### PR TITLE
Include the logic to tar gz the provider binaires

### DIFF
--- a/actions/lib/workflow.js
+++ b/actions/lib/workflow.js
@@ -169,10 +169,14 @@ export class MultilangJob extends BaseJob {
                 uses: 'actions/download-artifact@v2',
                 with: {
                     // eslint-disable-next-line no-template-curly-in-string
-                    name: 'pulumi-${{ env.PROVIDER }}',
+                    name: '${{ env.PROVIDER }}-provider.tar.gz',
                     // eslint-disable-next-line no-template-curly-in-string
                     path: '${{ github.workspace }}/bin',
                 },
+            },
+            {
+                name: 'Untar provider binaries',
+                run: 'tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace }}/bin'
             },
             {
                 name: 'Restore binary perms',
@@ -196,13 +200,17 @@ export class PulumiBaseWorkflow extends g.GithubWorkflow {
                 run: 'make provider',
             })
                 .addStep({
+                name: 'Tar provider binaries',
+                run: 'tar -zcf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace }}/bin/ pulumi-resource-${{ env.PROVIDER }} pulumi-tfgen-${{ env.PROVIDER }}',
+            })
+                .addStep({
                 name: 'Upload artifacts',
                 uses: 'actions/upload-artifact@v2',
                 with: {
                     // eslint-disable-next-line no-template-curly-in-string
-                    name: 'pulumi-${{ env.PROVIDER }}',
+                    name: '${{ env.PROVIDER }}-provider.tar.gz',
                     // eslint-disable-next-line no-template-curly-in-string
-                    path: '${{ github.workspace }}/bin',
+                    path: '${{ github.workspace }}/bin/provider.tar.gz',
                 },
             })
                 .addStep({

--- a/actions/providers/aiven/repo/.github/workflows/master.yml
+++ b/actions/providers/aiven/repo/.github/workflows/master.yml
@@ -54,8 +54,11 @@ jobs:
     - name: Download provider + tfgen binaries
       uses: actions/download-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
+        name: ${{ env.PROVIDER }}-provider.tar.gz
         path: ${{ github.workspace }}/bin
+    - name: Untar provider binaries
+      run: tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin
     - name: Restore binary perms
       run: find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print
         -exec chmod +x {} \;
@@ -186,11 +189,15 @@ jobs:
       uses: pulumi/action-install-pulumi-cli@releases/v1
     - name: Build tfgen & provider binaries
       run: make provider
+    - name: Tar provider binaries
+      run: tar -zcf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin/ pulumi-resource-${{ env.PROVIDER }} pulumi-tfgen-${{ env.PROVIDER
+        }}
     - name: Upload artifacts
       uses: actions/upload-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
-        path: ${{ github.workspace }}/bin
+        name: ${{ env.PROVIDER }}-provider.tar.gz
+        path: ${{ github.workspace }}/bin/provider.tar.gz
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3
@@ -347,8 +354,11 @@ jobs:
     - name: Download provider + tfgen binaries
       uses: actions/download-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
+        name: ${{ env.PROVIDER }}-provider.tar.gz
         path: ${{ github.workspace }}/bin
+    - name: Untar provider binaries
+      run: tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin
     - name: Restore binary perms
       run: find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print
         -exec chmod +x {} \;

--- a/actions/providers/aiven/repo/.github/workflows/prerelease.yml
+++ b/actions/providers/aiven/repo/.github/workflows/prerelease.yml
@@ -54,8 +54,11 @@ jobs:
     - name: Download provider + tfgen binaries
       uses: actions/download-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
+        name: ${{ env.PROVIDER }}-provider.tar.gz
         path: ${{ github.workspace }}/bin
+    - name: Untar provider binaries
+      run: tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin
     - name: Restore binary perms
       run: find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print
         -exec chmod +x {} \;
@@ -186,11 +189,15 @@ jobs:
       uses: pulumi/action-install-pulumi-cli@releases/v1
     - name: Build tfgen & provider binaries
       run: make provider
+    - name: Tar provider binaries
+      run: tar -zcf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin/ pulumi-resource-${{ env.PROVIDER }} pulumi-tfgen-${{ env.PROVIDER
+        }}
     - name: Upload artifacts
       uses: actions/upload-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
-        path: ${{ github.workspace }}/bin
+        name: ${{ env.PROVIDER }}-provider.tar.gz
+        path: ${{ github.workspace }}/bin/provider.tar.gz
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3
@@ -335,8 +342,11 @@ jobs:
     - name: Download provider + tfgen binaries
       uses: actions/download-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
+        name: ${{ env.PROVIDER }}-provider.tar.gz
         path: ${{ github.workspace }}/bin
+    - name: Untar provider binaries
+      run: tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin
     - name: Restore binary perms
       run: find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print
         -exec chmod +x {} \;

--- a/actions/providers/aiven/repo/.github/workflows/pull-request.yml
+++ b/actions/providers/aiven/repo/.github/workflows/pull-request.yml
@@ -54,8 +54,11 @@ jobs:
     - name: Download provider + tfgen binaries
       uses: actions/download-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
+        name: ${{ env.PROVIDER }}-provider.tar.gz
         path: ${{ github.workspace }}/bin
+    - name: Untar provider binaries
+      run: tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin
     - name: Restore binary perms
       run: find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print
         -exec chmod +x {} \;
@@ -186,11 +189,15 @@ jobs:
       uses: pulumi/action-install-pulumi-cli@releases/v1
     - name: Build tfgen & provider binaries
       run: make provider
+    - name: Tar provider binaries
+      run: tar -zcf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin/ pulumi-resource-${{ env.PROVIDER }} pulumi-tfgen-${{ env.PROVIDER
+        }}
     - name: Upload artifacts
       uses: actions/upload-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
-        path: ${{ github.workspace }}/bin
+        name: ${{ env.PROVIDER }}-provider.tar.gz
+        path: ${{ github.workspace }}/bin/provider.tar.gz
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3
@@ -238,8 +245,11 @@ jobs:
     - name: Download provider + tfgen binaries
       uses: actions/download-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
+        name: ${{ env.PROVIDER }}-provider.tar.gz
         path: ${{ github.workspace }}/bin
+    - name: Untar provider binaries
+      run: tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin
     - name: Restore binary perms
       run: find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print
         -exec chmod +x {} \;

--- a/actions/providers/aiven/repo/.github/workflows/release.yml
+++ b/actions/providers/aiven/repo/.github/workflows/release.yml
@@ -54,8 +54,11 @@ jobs:
     - name: Download provider + tfgen binaries
       uses: actions/download-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
+        name: ${{ env.PROVIDER }}-provider.tar.gz
         path: ${{ github.workspace }}/bin
+    - name: Untar provider binaries
+      run: tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin
     - name: Restore binary perms
       run: find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print
         -exec chmod +x {} \;
@@ -199,11 +202,15 @@ jobs:
       uses: pulumi/action-install-pulumi-cli@releases/v1
     - name: Build tfgen & provider binaries
       run: make provider
+    - name: Tar provider binaries
+      run: tar -zcf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin/ pulumi-resource-${{ env.PROVIDER }} pulumi-tfgen-${{ env.PROVIDER
+        }}
     - name: Upload artifacts
       uses: actions/upload-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
-        path: ${{ github.workspace }}/bin
+        name: ${{ env.PROVIDER }}-provider.tar.gz
+        path: ${{ github.workspace }}/bin/provider.tar.gz
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3
@@ -355,8 +362,11 @@ jobs:
     - name: Download provider + tfgen binaries
       uses: actions/download-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
+        name: ${{ env.PROVIDER }}-provider.tar.gz
         path: ${{ github.workspace }}/bin
+    - name: Untar provider binaries
+      run: tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin
     - name: Restore binary perms
       run: find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print
         -exec chmod +x {} \;

--- a/actions/providers/akamai/repo/.github/workflows/master.yml
+++ b/actions/providers/akamai/repo/.github/workflows/master.yml
@@ -56,8 +56,11 @@ jobs:
     - name: Download provider + tfgen binaries
       uses: actions/download-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
+        name: ${{ env.PROVIDER }}-provider.tar.gz
         path: ${{ github.workspace }}/bin
+    - name: Untar provider binaries
+      run: tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin
     - name: Restore binary perms
       run: find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print
         -exec chmod +x {} \;
@@ -188,11 +191,15 @@ jobs:
       uses: pulumi/action-install-pulumi-cli@releases/v1
     - name: Build tfgen & provider binaries
       run: make provider
+    - name: Tar provider binaries
+      run: tar -zcf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin/ pulumi-resource-${{ env.PROVIDER }} pulumi-tfgen-${{ env.PROVIDER
+        }}
     - name: Upload artifacts
       uses: actions/upload-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
-        path: ${{ github.workspace }}/bin
+        name: ${{ env.PROVIDER }}-provider.tar.gz
+        path: ${{ github.workspace }}/bin/provider.tar.gz
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3
@@ -349,8 +356,11 @@ jobs:
     - name: Download provider + tfgen binaries
       uses: actions/download-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
+        name: ${{ env.PROVIDER }}-provider.tar.gz
         path: ${{ github.workspace }}/bin
+    - name: Untar provider binaries
+      run: tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin
     - name: Restore binary perms
       run: find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print
         -exec chmod +x {} \;

--- a/actions/providers/akamai/repo/.github/workflows/prerelease.yml
+++ b/actions/providers/akamai/repo/.github/workflows/prerelease.yml
@@ -56,8 +56,11 @@ jobs:
     - name: Download provider + tfgen binaries
       uses: actions/download-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
+        name: ${{ env.PROVIDER }}-provider.tar.gz
         path: ${{ github.workspace }}/bin
+    - name: Untar provider binaries
+      run: tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin
     - name: Restore binary perms
       run: find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print
         -exec chmod +x {} \;
@@ -188,11 +191,15 @@ jobs:
       uses: pulumi/action-install-pulumi-cli@releases/v1
     - name: Build tfgen & provider binaries
       run: make provider
+    - name: Tar provider binaries
+      run: tar -zcf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin/ pulumi-resource-${{ env.PROVIDER }} pulumi-tfgen-${{ env.PROVIDER
+        }}
     - name: Upload artifacts
       uses: actions/upload-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
-        path: ${{ github.workspace }}/bin
+        name: ${{ env.PROVIDER }}-provider.tar.gz
+        path: ${{ github.workspace }}/bin/provider.tar.gz
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3
@@ -337,8 +344,11 @@ jobs:
     - name: Download provider + tfgen binaries
       uses: actions/download-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
+        name: ${{ env.PROVIDER }}-provider.tar.gz
         path: ${{ github.workspace }}/bin
+    - name: Untar provider binaries
+      run: tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin
     - name: Restore binary perms
       run: find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print
         -exec chmod +x {} \;

--- a/actions/providers/akamai/repo/.github/workflows/pull-request.yml
+++ b/actions/providers/akamai/repo/.github/workflows/pull-request.yml
@@ -56,8 +56,11 @@ jobs:
     - name: Download provider + tfgen binaries
       uses: actions/download-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
+        name: ${{ env.PROVIDER }}-provider.tar.gz
         path: ${{ github.workspace }}/bin
+    - name: Untar provider binaries
+      run: tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin
     - name: Restore binary perms
       run: find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print
         -exec chmod +x {} \;
@@ -188,11 +191,15 @@ jobs:
       uses: pulumi/action-install-pulumi-cli@releases/v1
     - name: Build tfgen & provider binaries
       run: make provider
+    - name: Tar provider binaries
+      run: tar -zcf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin/ pulumi-resource-${{ env.PROVIDER }} pulumi-tfgen-${{ env.PROVIDER
+        }}
     - name: Upload artifacts
       uses: actions/upload-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
-        path: ${{ github.workspace }}/bin
+        name: ${{ env.PROVIDER }}-provider.tar.gz
+        path: ${{ github.workspace }}/bin/provider.tar.gz
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3
@@ -240,8 +247,11 @@ jobs:
     - name: Download provider + tfgen binaries
       uses: actions/download-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
+        name: ${{ env.PROVIDER }}-provider.tar.gz
         path: ${{ github.workspace }}/bin
+    - name: Untar provider binaries
+      run: tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin
     - name: Restore binary perms
       run: find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print
         -exec chmod +x {} \;

--- a/actions/providers/akamai/repo/.github/workflows/release.yml
+++ b/actions/providers/akamai/repo/.github/workflows/release.yml
@@ -56,8 +56,11 @@ jobs:
     - name: Download provider + tfgen binaries
       uses: actions/download-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
+        name: ${{ env.PROVIDER }}-provider.tar.gz
         path: ${{ github.workspace }}/bin
+    - name: Untar provider binaries
+      run: tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin
     - name: Restore binary perms
       run: find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print
         -exec chmod +x {} \;
@@ -201,11 +204,15 @@ jobs:
       uses: pulumi/action-install-pulumi-cli@releases/v1
     - name: Build tfgen & provider binaries
       run: make provider
+    - name: Tar provider binaries
+      run: tar -zcf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin/ pulumi-resource-${{ env.PROVIDER }} pulumi-tfgen-${{ env.PROVIDER
+        }}
     - name: Upload artifacts
       uses: actions/upload-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
-        path: ${{ github.workspace }}/bin
+        name: ${{ env.PROVIDER }}-provider.tar.gz
+        path: ${{ github.workspace }}/bin/provider.tar.gz
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3
@@ -357,8 +364,11 @@ jobs:
     - name: Download provider + tfgen binaries
       uses: actions/download-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
+        name: ${{ env.PROVIDER }}-provider.tar.gz
         path: ${{ github.workspace }}/bin
+    - name: Untar provider binaries
+      run: tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin
     - name: Restore binary perms
       run: find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print
         -exec chmod +x {} \;

--- a/actions/providers/alicloud/repo/.github/workflows/master.yml
+++ b/actions/providers/alicloud/repo/.github/workflows/master.yml
@@ -55,8 +55,11 @@ jobs:
     - name: Download provider + tfgen binaries
       uses: actions/download-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
+        name: ${{ env.PROVIDER }}-provider.tar.gz
         path: ${{ github.workspace }}/bin
+    - name: Untar provider binaries
+      run: tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin
     - name: Restore binary perms
       run: find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print
         -exec chmod +x {} \;
@@ -187,11 +190,15 @@ jobs:
       uses: pulumi/action-install-pulumi-cli@releases/v1
     - name: Build tfgen & provider binaries
       run: make provider
+    - name: Tar provider binaries
+      run: tar -zcf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin/ pulumi-resource-${{ env.PROVIDER }} pulumi-tfgen-${{ env.PROVIDER
+        }}
     - name: Upload artifacts
       uses: actions/upload-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
-        path: ${{ github.workspace }}/bin
+        name: ${{ env.PROVIDER }}-provider.tar.gz
+        path: ${{ github.workspace }}/bin/provider.tar.gz
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3
@@ -348,8 +355,11 @@ jobs:
     - name: Download provider + tfgen binaries
       uses: actions/download-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
+        name: ${{ env.PROVIDER }}-provider.tar.gz
         path: ${{ github.workspace }}/bin
+    - name: Untar provider binaries
+      run: tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin
     - name: Restore binary perms
       run: find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print
         -exec chmod +x {} \;

--- a/actions/providers/alicloud/repo/.github/workflows/prerelease.yml
+++ b/actions/providers/alicloud/repo/.github/workflows/prerelease.yml
@@ -55,8 +55,11 @@ jobs:
     - name: Download provider + tfgen binaries
       uses: actions/download-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
+        name: ${{ env.PROVIDER }}-provider.tar.gz
         path: ${{ github.workspace }}/bin
+    - name: Untar provider binaries
+      run: tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin
     - name: Restore binary perms
       run: find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print
         -exec chmod +x {} \;
@@ -187,11 +190,15 @@ jobs:
       uses: pulumi/action-install-pulumi-cli@releases/v1
     - name: Build tfgen & provider binaries
       run: make provider
+    - name: Tar provider binaries
+      run: tar -zcf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin/ pulumi-resource-${{ env.PROVIDER }} pulumi-tfgen-${{ env.PROVIDER
+        }}
     - name: Upload artifacts
       uses: actions/upload-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
-        path: ${{ github.workspace }}/bin
+        name: ${{ env.PROVIDER }}-provider.tar.gz
+        path: ${{ github.workspace }}/bin/provider.tar.gz
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3
@@ -336,8 +343,11 @@ jobs:
     - name: Download provider + tfgen binaries
       uses: actions/download-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
+        name: ${{ env.PROVIDER }}-provider.tar.gz
         path: ${{ github.workspace }}/bin
+    - name: Untar provider binaries
+      run: tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin
     - name: Restore binary perms
       run: find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print
         -exec chmod +x {} \;

--- a/actions/providers/alicloud/repo/.github/workflows/pull-request.yml
+++ b/actions/providers/alicloud/repo/.github/workflows/pull-request.yml
@@ -55,8 +55,11 @@ jobs:
     - name: Download provider + tfgen binaries
       uses: actions/download-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
+        name: ${{ env.PROVIDER }}-provider.tar.gz
         path: ${{ github.workspace }}/bin
+    - name: Untar provider binaries
+      run: tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin
     - name: Restore binary perms
       run: find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print
         -exec chmod +x {} \;
@@ -187,11 +190,15 @@ jobs:
       uses: pulumi/action-install-pulumi-cli@releases/v1
     - name: Build tfgen & provider binaries
       run: make provider
+    - name: Tar provider binaries
+      run: tar -zcf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin/ pulumi-resource-${{ env.PROVIDER }} pulumi-tfgen-${{ env.PROVIDER
+        }}
     - name: Upload artifacts
       uses: actions/upload-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
-        path: ${{ github.workspace }}/bin
+        name: ${{ env.PROVIDER }}-provider.tar.gz
+        path: ${{ github.workspace }}/bin/provider.tar.gz
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3
@@ -239,8 +246,11 @@ jobs:
     - name: Download provider + tfgen binaries
       uses: actions/download-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
+        name: ${{ env.PROVIDER }}-provider.tar.gz
         path: ${{ github.workspace }}/bin
+    - name: Untar provider binaries
+      run: tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin
     - name: Restore binary perms
       run: find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print
         -exec chmod +x {} \;

--- a/actions/providers/alicloud/repo/.github/workflows/release.yml
+++ b/actions/providers/alicloud/repo/.github/workflows/release.yml
@@ -55,8 +55,11 @@ jobs:
     - name: Download provider + tfgen binaries
       uses: actions/download-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
+        name: ${{ env.PROVIDER }}-provider.tar.gz
         path: ${{ github.workspace }}/bin
+    - name: Untar provider binaries
+      run: tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin
     - name: Restore binary perms
       run: find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print
         -exec chmod +x {} \;
@@ -200,11 +203,15 @@ jobs:
       uses: pulumi/action-install-pulumi-cli@releases/v1
     - name: Build tfgen & provider binaries
       run: make provider
+    - name: Tar provider binaries
+      run: tar -zcf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin/ pulumi-resource-${{ env.PROVIDER }} pulumi-tfgen-${{ env.PROVIDER
+        }}
     - name: Upload artifacts
       uses: actions/upload-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
-        path: ${{ github.workspace }}/bin
+        name: ${{ env.PROVIDER }}-provider.tar.gz
+        path: ${{ github.workspace }}/bin/provider.tar.gz
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3
@@ -356,8 +363,11 @@ jobs:
     - name: Download provider + tfgen binaries
       uses: actions/download-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
+        name: ${{ env.PROVIDER }}-provider.tar.gz
         path: ${{ github.workspace }}/bin
+    - name: Untar provider binaries
+      run: tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin
     - name: Restore binary perms
       run: find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print
         -exec chmod +x {} \;

--- a/actions/providers/auth0/repo/.github/workflows/master.yml
+++ b/actions/providers/auth0/repo/.github/workflows/master.yml
@@ -55,8 +55,11 @@ jobs:
     - name: Download provider + tfgen binaries
       uses: actions/download-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
+        name: ${{ env.PROVIDER }}-provider.tar.gz
         path: ${{ github.workspace }}/bin
+    - name: Untar provider binaries
+      run: tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin
     - name: Restore binary perms
       run: find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print
         -exec chmod +x {} \;
@@ -187,11 +190,15 @@ jobs:
       uses: pulumi/action-install-pulumi-cli@releases/v1
     - name: Build tfgen & provider binaries
       run: make provider
+    - name: Tar provider binaries
+      run: tar -zcf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin/ pulumi-resource-${{ env.PROVIDER }} pulumi-tfgen-${{ env.PROVIDER
+        }}
     - name: Upload artifacts
       uses: actions/upload-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
-        path: ${{ github.workspace }}/bin
+        name: ${{ env.PROVIDER }}-provider.tar.gz
+        path: ${{ github.workspace }}/bin/provider.tar.gz
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3
@@ -348,8 +355,11 @@ jobs:
     - name: Download provider + tfgen binaries
       uses: actions/download-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
+        name: ${{ env.PROVIDER }}-provider.tar.gz
         path: ${{ github.workspace }}/bin
+    - name: Untar provider binaries
+      run: tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin
     - name: Restore binary perms
       run: find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print
         -exec chmod +x {} \;

--- a/actions/providers/auth0/repo/.github/workflows/prerelease.yml
+++ b/actions/providers/auth0/repo/.github/workflows/prerelease.yml
@@ -55,8 +55,11 @@ jobs:
     - name: Download provider + tfgen binaries
       uses: actions/download-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
+        name: ${{ env.PROVIDER }}-provider.tar.gz
         path: ${{ github.workspace }}/bin
+    - name: Untar provider binaries
+      run: tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin
     - name: Restore binary perms
       run: find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print
         -exec chmod +x {} \;
@@ -187,11 +190,15 @@ jobs:
       uses: pulumi/action-install-pulumi-cli@releases/v1
     - name: Build tfgen & provider binaries
       run: make provider
+    - name: Tar provider binaries
+      run: tar -zcf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin/ pulumi-resource-${{ env.PROVIDER }} pulumi-tfgen-${{ env.PROVIDER
+        }}
     - name: Upload artifacts
       uses: actions/upload-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
-        path: ${{ github.workspace }}/bin
+        name: ${{ env.PROVIDER }}-provider.tar.gz
+        path: ${{ github.workspace }}/bin/provider.tar.gz
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3
@@ -336,8 +343,11 @@ jobs:
     - name: Download provider + tfgen binaries
       uses: actions/download-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
+        name: ${{ env.PROVIDER }}-provider.tar.gz
         path: ${{ github.workspace }}/bin
+    - name: Untar provider binaries
+      run: tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin
     - name: Restore binary perms
       run: find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print
         -exec chmod +x {} \;

--- a/actions/providers/auth0/repo/.github/workflows/pull-request.yml
+++ b/actions/providers/auth0/repo/.github/workflows/pull-request.yml
@@ -55,8 +55,11 @@ jobs:
     - name: Download provider + tfgen binaries
       uses: actions/download-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
+        name: ${{ env.PROVIDER }}-provider.tar.gz
         path: ${{ github.workspace }}/bin
+    - name: Untar provider binaries
+      run: tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin
     - name: Restore binary perms
       run: find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print
         -exec chmod +x {} \;
@@ -187,11 +190,15 @@ jobs:
       uses: pulumi/action-install-pulumi-cli@releases/v1
     - name: Build tfgen & provider binaries
       run: make provider
+    - name: Tar provider binaries
+      run: tar -zcf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin/ pulumi-resource-${{ env.PROVIDER }} pulumi-tfgen-${{ env.PROVIDER
+        }}
     - name: Upload artifacts
       uses: actions/upload-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
-        path: ${{ github.workspace }}/bin
+        name: ${{ env.PROVIDER }}-provider.tar.gz
+        path: ${{ github.workspace }}/bin/provider.tar.gz
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3
@@ -239,8 +246,11 @@ jobs:
     - name: Download provider + tfgen binaries
       uses: actions/download-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
+        name: ${{ env.PROVIDER }}-provider.tar.gz
         path: ${{ github.workspace }}/bin
+    - name: Untar provider binaries
+      run: tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin
     - name: Restore binary perms
       run: find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print
         -exec chmod +x {} \;

--- a/actions/providers/auth0/repo/.github/workflows/release.yml
+++ b/actions/providers/auth0/repo/.github/workflows/release.yml
@@ -55,8 +55,11 @@ jobs:
     - name: Download provider + tfgen binaries
       uses: actions/download-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
+        name: ${{ env.PROVIDER }}-provider.tar.gz
         path: ${{ github.workspace }}/bin
+    - name: Untar provider binaries
+      run: tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin
     - name: Restore binary perms
       run: find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print
         -exec chmod +x {} \;
@@ -200,11 +203,15 @@ jobs:
       uses: pulumi/action-install-pulumi-cli@releases/v1
     - name: Build tfgen & provider binaries
       run: make provider
+    - name: Tar provider binaries
+      run: tar -zcf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin/ pulumi-resource-${{ env.PROVIDER }} pulumi-tfgen-${{ env.PROVIDER
+        }}
     - name: Upload artifacts
       uses: actions/upload-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
-        path: ${{ github.workspace }}/bin
+        name: ${{ env.PROVIDER }}-provider.tar.gz
+        path: ${{ github.workspace }}/bin/provider.tar.gz
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3
@@ -356,8 +363,11 @@ jobs:
     - name: Download provider + tfgen binaries
       uses: actions/download-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
+        name: ${{ env.PROVIDER }}-provider.tar.gz
         path: ${{ github.workspace }}/bin
+    - name: Untar provider binaries
+      run: tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin
     - name: Restore binary perms
       run: find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print
         -exec chmod +x {} \;

--- a/actions/providers/aws/repo/.github/workflows/master.yml
+++ b/actions/providers/aws/repo/.github/workflows/master.yml
@@ -53,8 +53,11 @@ jobs:
     - name: Download provider + tfgen binaries
       uses: actions/download-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
+        name: ${{ env.PROVIDER }}-provider.tar.gz
         path: ${{ github.workspace }}/bin
+    - name: Untar provider binaries
+      run: tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin
     - name: Restore binary perms
       run: find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print
         -exec chmod +x {} \;
@@ -118,11 +121,15 @@ jobs:
       uses: pulumi/action-install-pulumi-cli@releases/v1
     - name: Build tfgen & provider binaries
       run: make provider
+    - name: Tar provider binaries
+      run: tar -zcf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin/ pulumi-resource-${{ env.PROVIDER }} pulumi-tfgen-${{ env.PROVIDER
+        }}
     - name: Upload artifacts
       uses: actions/upload-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
-        path: ${{ github.workspace }}/bin
+        name: ${{ env.PROVIDER }}-provider.tar.gz
+        path: ${{ github.workspace }}/bin/provider.tar.gz
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3
@@ -279,8 +286,11 @@ jobs:
     - name: Download provider + tfgen binaries
       uses: actions/download-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
+        name: ${{ env.PROVIDER }}-provider.tar.gz
         path: ${{ github.workspace }}/bin
+    - name: Untar provider binaries
+      run: tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin
     - name: Restore binary perms
       run: find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print
         -exec chmod +x {} \;

--- a/actions/providers/aws/repo/.github/workflows/prerelease.yml
+++ b/actions/providers/aws/repo/.github/workflows/prerelease.yml
@@ -53,8 +53,11 @@ jobs:
     - name: Download provider + tfgen binaries
       uses: actions/download-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
+        name: ${{ env.PROVIDER }}-provider.tar.gz
         path: ${{ github.workspace }}/bin
+    - name: Untar provider binaries
+      run: tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin
     - name: Restore binary perms
       run: find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print
         -exec chmod +x {} \;
@@ -118,11 +121,15 @@ jobs:
       uses: pulumi/action-install-pulumi-cli@releases/v1
     - name: Build tfgen & provider binaries
       run: make provider
+    - name: Tar provider binaries
+      run: tar -zcf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin/ pulumi-resource-${{ env.PROVIDER }} pulumi-tfgen-${{ env.PROVIDER
+        }}
     - name: Upload artifacts
       uses: actions/upload-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
-        path: ${{ github.workspace }}/bin
+        name: ${{ env.PROVIDER }}-provider.tar.gz
+        path: ${{ github.workspace }}/bin/provider.tar.gz
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3
@@ -267,8 +274,11 @@ jobs:
     - name: Download provider + tfgen binaries
       uses: actions/download-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
+        name: ${{ env.PROVIDER }}-provider.tar.gz
         path: ${{ github.workspace }}/bin
+    - name: Untar provider binaries
+      run: tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin
     - name: Restore binary perms
       run: find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print
         -exec chmod +x {} \;

--- a/actions/providers/aws/repo/.github/workflows/pull-request.yml
+++ b/actions/providers/aws/repo/.github/workflows/pull-request.yml
@@ -53,8 +53,11 @@ jobs:
     - name: Download provider + tfgen binaries
       uses: actions/download-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
+        name: ${{ env.PROVIDER }}-provider.tar.gz
         path: ${{ github.workspace }}/bin
+    - name: Untar provider binaries
+      run: tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin
     - name: Restore binary perms
       run: find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print
         -exec chmod +x {} \;
@@ -118,11 +121,15 @@ jobs:
       uses: pulumi/action-install-pulumi-cli@releases/v1
     - name: Build tfgen & provider binaries
       run: make provider
+    - name: Tar provider binaries
+      run: tar -zcf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin/ pulumi-resource-${{ env.PROVIDER }} pulumi-tfgen-${{ env.PROVIDER
+        }}
     - name: Upload artifacts
       uses: actions/upload-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
-        path: ${{ github.workspace }}/bin
+        name: ${{ env.PROVIDER }}-provider.tar.gz
+        path: ${{ github.workspace }}/bin/provider.tar.gz
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3
@@ -170,8 +177,11 @@ jobs:
     - name: Download provider + tfgen binaries
       uses: actions/download-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
+        name: ${{ env.PROVIDER }}-provider.tar.gz
         path: ${{ github.workspace }}/bin
+    - name: Untar provider binaries
+      run: tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin
     - name: Restore binary perms
       run: find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print
         -exec chmod +x {} \;

--- a/actions/providers/aws/repo/.github/workflows/release.yml
+++ b/actions/providers/aws/repo/.github/workflows/release.yml
@@ -53,8 +53,11 @@ jobs:
     - name: Download provider + tfgen binaries
       uses: actions/download-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
+        name: ${{ env.PROVIDER }}-provider.tar.gz
         path: ${{ github.workspace }}/bin
+    - name: Untar provider binaries
+      run: tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin
     - name: Restore binary perms
       run: find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print
         -exec chmod +x {} \;
@@ -131,11 +134,15 @@ jobs:
       uses: pulumi/action-install-pulumi-cli@releases/v1
     - name: Build tfgen & provider binaries
       run: make provider
+    - name: Tar provider binaries
+      run: tar -zcf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin/ pulumi-resource-${{ env.PROVIDER }} pulumi-tfgen-${{ env.PROVIDER
+        }}
     - name: Upload artifacts
       uses: actions/upload-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
-        path: ${{ github.workspace }}/bin
+        name: ${{ env.PROVIDER }}-provider.tar.gz
+        path: ${{ github.workspace }}/bin/provider.tar.gz
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3
@@ -287,8 +294,11 @@ jobs:
     - name: Download provider + tfgen binaries
       uses: actions/download-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
+        name: ${{ env.PROVIDER }}-provider.tar.gz
         path: ${{ github.workspace }}/bin
+    - name: Untar provider binaries
+      run: tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin
     - name: Restore binary perms
       run: find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print
         -exec chmod +x {} \;

--- a/actions/providers/azure/repo/.github/workflows/master.yml
+++ b/actions/providers/azure/repo/.github/workflows/master.yml
@@ -58,8 +58,11 @@ jobs:
     - name: Download provider + tfgen binaries
       uses: actions/download-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
+        name: ${{ env.PROVIDER }}-provider.tar.gz
         path: ${{ github.workspace }}/bin
+    - name: Untar provider binaries
+      run: tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin
     - name: Restore binary perms
       run: find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print
         -exec chmod +x {} \;
@@ -123,11 +126,15 @@ jobs:
       uses: pulumi/action-install-pulumi-cli@releases/v1
     - name: Build tfgen & provider binaries
       run: make provider
+    - name: Tar provider binaries
+      run: tar -zcf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin/ pulumi-resource-${{ env.PROVIDER }} pulumi-tfgen-${{ env.PROVIDER
+        }}
     - name: Upload artifacts
       uses: actions/upload-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
-        path: ${{ github.workspace }}/bin
+        name: ${{ env.PROVIDER }}-provider.tar.gz
+        path: ${{ github.workspace }}/bin/provider.tar.gz
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3
@@ -284,8 +291,11 @@ jobs:
     - name: Download provider + tfgen binaries
       uses: actions/download-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
+        name: ${{ env.PROVIDER }}-provider.tar.gz
         path: ${{ github.workspace }}/bin
+    - name: Untar provider binaries
+      run: tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin
     - name: Restore binary perms
       run: find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print
         -exec chmod +x {} \;

--- a/actions/providers/azure/repo/.github/workflows/prerelease.yml
+++ b/actions/providers/azure/repo/.github/workflows/prerelease.yml
@@ -58,8 +58,11 @@ jobs:
     - name: Download provider + tfgen binaries
       uses: actions/download-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
+        name: ${{ env.PROVIDER }}-provider.tar.gz
         path: ${{ github.workspace }}/bin
+    - name: Untar provider binaries
+      run: tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin
     - name: Restore binary perms
       run: find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print
         -exec chmod +x {} \;
@@ -123,11 +126,15 @@ jobs:
       uses: pulumi/action-install-pulumi-cli@releases/v1
     - name: Build tfgen & provider binaries
       run: make provider
+    - name: Tar provider binaries
+      run: tar -zcf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin/ pulumi-resource-${{ env.PROVIDER }} pulumi-tfgen-${{ env.PROVIDER
+        }}
     - name: Upload artifacts
       uses: actions/upload-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
-        path: ${{ github.workspace }}/bin
+        name: ${{ env.PROVIDER }}-provider.tar.gz
+        path: ${{ github.workspace }}/bin/provider.tar.gz
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3
@@ -272,8 +279,11 @@ jobs:
     - name: Download provider + tfgen binaries
       uses: actions/download-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
+        name: ${{ env.PROVIDER }}-provider.tar.gz
         path: ${{ github.workspace }}/bin
+    - name: Untar provider binaries
+      run: tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin
     - name: Restore binary perms
       run: find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print
         -exec chmod +x {} \;

--- a/actions/providers/azure/repo/.github/workflows/pull-request.yml
+++ b/actions/providers/azure/repo/.github/workflows/pull-request.yml
@@ -58,8 +58,11 @@ jobs:
     - name: Download provider + tfgen binaries
       uses: actions/download-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
+        name: ${{ env.PROVIDER }}-provider.tar.gz
         path: ${{ github.workspace }}/bin
+    - name: Untar provider binaries
+      run: tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin
     - name: Restore binary perms
       run: find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print
         -exec chmod +x {} \;
@@ -123,11 +126,15 @@ jobs:
       uses: pulumi/action-install-pulumi-cli@releases/v1
     - name: Build tfgen & provider binaries
       run: make provider
+    - name: Tar provider binaries
+      run: tar -zcf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin/ pulumi-resource-${{ env.PROVIDER }} pulumi-tfgen-${{ env.PROVIDER
+        }}
     - name: Upload artifacts
       uses: actions/upload-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
-        path: ${{ github.workspace }}/bin
+        name: ${{ env.PROVIDER }}-provider.tar.gz
+        path: ${{ github.workspace }}/bin/provider.tar.gz
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3
@@ -175,8 +182,11 @@ jobs:
     - name: Download provider + tfgen binaries
       uses: actions/download-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
+        name: ${{ env.PROVIDER }}-provider.tar.gz
         path: ${{ github.workspace }}/bin
+    - name: Untar provider binaries
+      run: tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin
     - name: Restore binary perms
       run: find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print
         -exec chmod +x {} \;

--- a/actions/providers/azure/repo/.github/workflows/release.yml
+++ b/actions/providers/azure/repo/.github/workflows/release.yml
@@ -58,8 +58,11 @@ jobs:
     - name: Download provider + tfgen binaries
       uses: actions/download-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
+        name: ${{ env.PROVIDER }}-provider.tar.gz
         path: ${{ github.workspace }}/bin
+    - name: Untar provider binaries
+      run: tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin
     - name: Restore binary perms
       run: find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print
         -exec chmod +x {} \;
@@ -136,11 +139,15 @@ jobs:
       uses: pulumi/action-install-pulumi-cli@releases/v1
     - name: Build tfgen & provider binaries
       run: make provider
+    - name: Tar provider binaries
+      run: tar -zcf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin/ pulumi-resource-${{ env.PROVIDER }} pulumi-tfgen-${{ env.PROVIDER
+        }}
     - name: Upload artifacts
       uses: actions/upload-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
-        path: ${{ github.workspace }}/bin
+        name: ${{ env.PROVIDER }}-provider.tar.gz
+        path: ${{ github.workspace }}/bin/provider.tar.gz
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3
@@ -292,8 +299,11 @@ jobs:
     - name: Download provider + tfgen binaries
       uses: actions/download-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
+        name: ${{ env.PROVIDER }}-provider.tar.gz
         path: ${{ github.workspace }}/bin
+    - name: Untar provider binaries
+      run: tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin
     - name: Restore binary perms
       run: find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print
         -exec chmod +x {} \;

--- a/actions/providers/azuread/repo/.github/workflows/master.yml
+++ b/actions/providers/azuread/repo/.github/workflows/master.yml
@@ -57,8 +57,11 @@ jobs:
     - name: Download provider + tfgen binaries
       uses: actions/download-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
+        name: ${{ env.PROVIDER }}-provider.tar.gz
         path: ${{ github.workspace }}/bin
+    - name: Untar provider binaries
+      run: tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin
     - name: Restore binary perms
       run: find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print
         -exec chmod +x {} \;
@@ -189,11 +192,15 @@ jobs:
       uses: pulumi/action-install-pulumi-cli@releases/v1
     - name: Build tfgen & provider binaries
       run: make provider
+    - name: Tar provider binaries
+      run: tar -zcf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin/ pulumi-resource-${{ env.PROVIDER }} pulumi-tfgen-${{ env.PROVIDER
+        }}
     - name: Upload artifacts
       uses: actions/upload-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
-        path: ${{ github.workspace }}/bin
+        name: ${{ env.PROVIDER }}-provider.tar.gz
+        path: ${{ github.workspace }}/bin/provider.tar.gz
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3
@@ -350,8 +357,11 @@ jobs:
     - name: Download provider + tfgen binaries
       uses: actions/download-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
+        name: ${{ env.PROVIDER }}-provider.tar.gz
         path: ${{ github.workspace }}/bin
+    - name: Untar provider binaries
+      run: tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin
     - name: Restore binary perms
       run: find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print
         -exec chmod +x {} \;

--- a/actions/providers/azuread/repo/.github/workflows/prerelease.yml
+++ b/actions/providers/azuread/repo/.github/workflows/prerelease.yml
@@ -57,8 +57,11 @@ jobs:
     - name: Download provider + tfgen binaries
       uses: actions/download-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
+        name: ${{ env.PROVIDER }}-provider.tar.gz
         path: ${{ github.workspace }}/bin
+    - name: Untar provider binaries
+      run: tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin
     - name: Restore binary perms
       run: find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print
         -exec chmod +x {} \;
@@ -189,11 +192,15 @@ jobs:
       uses: pulumi/action-install-pulumi-cli@releases/v1
     - name: Build tfgen & provider binaries
       run: make provider
+    - name: Tar provider binaries
+      run: tar -zcf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin/ pulumi-resource-${{ env.PROVIDER }} pulumi-tfgen-${{ env.PROVIDER
+        }}
     - name: Upload artifacts
       uses: actions/upload-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
-        path: ${{ github.workspace }}/bin
+        name: ${{ env.PROVIDER }}-provider.tar.gz
+        path: ${{ github.workspace }}/bin/provider.tar.gz
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3
@@ -338,8 +345,11 @@ jobs:
     - name: Download provider + tfgen binaries
       uses: actions/download-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
+        name: ${{ env.PROVIDER }}-provider.tar.gz
         path: ${{ github.workspace }}/bin
+    - name: Untar provider binaries
+      run: tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin
     - name: Restore binary perms
       run: find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print
         -exec chmod +x {} \;

--- a/actions/providers/azuread/repo/.github/workflows/pull-request.yml
+++ b/actions/providers/azuread/repo/.github/workflows/pull-request.yml
@@ -57,8 +57,11 @@ jobs:
     - name: Download provider + tfgen binaries
       uses: actions/download-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
+        name: ${{ env.PROVIDER }}-provider.tar.gz
         path: ${{ github.workspace }}/bin
+    - name: Untar provider binaries
+      run: tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin
     - name: Restore binary perms
       run: find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print
         -exec chmod +x {} \;
@@ -189,11 +192,15 @@ jobs:
       uses: pulumi/action-install-pulumi-cli@releases/v1
     - name: Build tfgen & provider binaries
       run: make provider
+    - name: Tar provider binaries
+      run: tar -zcf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin/ pulumi-resource-${{ env.PROVIDER }} pulumi-tfgen-${{ env.PROVIDER
+        }}
     - name: Upload artifacts
       uses: actions/upload-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
-        path: ${{ github.workspace }}/bin
+        name: ${{ env.PROVIDER }}-provider.tar.gz
+        path: ${{ github.workspace }}/bin/provider.tar.gz
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3
@@ -241,8 +248,11 @@ jobs:
     - name: Download provider + tfgen binaries
       uses: actions/download-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
+        name: ${{ env.PROVIDER }}-provider.tar.gz
         path: ${{ github.workspace }}/bin
+    - name: Untar provider binaries
+      run: tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin
     - name: Restore binary perms
       run: find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print
         -exec chmod +x {} \;

--- a/actions/providers/azuread/repo/.github/workflows/release.yml
+++ b/actions/providers/azuread/repo/.github/workflows/release.yml
@@ -57,8 +57,11 @@ jobs:
     - name: Download provider + tfgen binaries
       uses: actions/download-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
+        name: ${{ env.PROVIDER }}-provider.tar.gz
         path: ${{ github.workspace }}/bin
+    - name: Untar provider binaries
+      run: tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin
     - name: Restore binary perms
       run: find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print
         -exec chmod +x {} \;
@@ -202,11 +205,15 @@ jobs:
       uses: pulumi/action-install-pulumi-cli@releases/v1
     - name: Build tfgen & provider binaries
       run: make provider
+    - name: Tar provider binaries
+      run: tar -zcf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin/ pulumi-resource-${{ env.PROVIDER }} pulumi-tfgen-${{ env.PROVIDER
+        }}
     - name: Upload artifacts
       uses: actions/upload-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
-        path: ${{ github.workspace }}/bin
+        name: ${{ env.PROVIDER }}-provider.tar.gz
+        path: ${{ github.workspace }}/bin/provider.tar.gz
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3
@@ -358,8 +365,11 @@ jobs:
     - name: Download provider + tfgen binaries
       uses: actions/download-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
+        name: ${{ env.PROVIDER }}-provider.tar.gz
         path: ${{ github.workspace }}/bin
+    - name: Untar provider binaries
+      run: tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin
     - name: Restore binary perms
       run: find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print
         -exec chmod +x {} \;

--- a/actions/providers/azuredevops/repo/.github/workflows/master.yml
+++ b/actions/providers/azuredevops/repo/.github/workflows/master.yml
@@ -54,8 +54,11 @@ jobs:
     - name: Download provider + tfgen binaries
       uses: actions/download-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
+        name: ${{ env.PROVIDER }}-provider.tar.gz
         path: ${{ github.workspace }}/bin
+    - name: Untar provider binaries
+      run: tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin
     - name: Restore binary perms
       run: find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print
         -exec chmod +x {} \;
@@ -119,11 +122,15 @@ jobs:
       uses: pulumi/action-install-pulumi-cli@releases/v1
     - name: Build tfgen & provider binaries
       run: make provider
+    - name: Tar provider binaries
+      run: tar -zcf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin/ pulumi-resource-${{ env.PROVIDER }} pulumi-tfgen-${{ env.PROVIDER
+        }}
     - name: Upload artifacts
       uses: actions/upload-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
-        path: ${{ github.workspace }}/bin
+        name: ${{ env.PROVIDER }}-provider.tar.gz
+        path: ${{ github.workspace }}/bin/provider.tar.gz
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3
@@ -280,8 +287,11 @@ jobs:
     - name: Download provider + tfgen binaries
       uses: actions/download-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
+        name: ${{ env.PROVIDER }}-provider.tar.gz
         path: ${{ github.workspace }}/bin
+    - name: Untar provider binaries
+      run: tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin
     - name: Restore binary perms
       run: find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print
         -exec chmod +x {} \;

--- a/actions/providers/azuredevops/repo/.github/workflows/prerelease.yml
+++ b/actions/providers/azuredevops/repo/.github/workflows/prerelease.yml
@@ -54,8 +54,11 @@ jobs:
     - name: Download provider + tfgen binaries
       uses: actions/download-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
+        name: ${{ env.PROVIDER }}-provider.tar.gz
         path: ${{ github.workspace }}/bin
+    - name: Untar provider binaries
+      run: tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin
     - name: Restore binary perms
       run: find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print
         -exec chmod +x {} \;
@@ -119,11 +122,15 @@ jobs:
       uses: pulumi/action-install-pulumi-cli@releases/v1
     - name: Build tfgen & provider binaries
       run: make provider
+    - name: Tar provider binaries
+      run: tar -zcf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin/ pulumi-resource-${{ env.PROVIDER }} pulumi-tfgen-${{ env.PROVIDER
+        }}
     - name: Upload artifacts
       uses: actions/upload-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
-        path: ${{ github.workspace }}/bin
+        name: ${{ env.PROVIDER }}-provider.tar.gz
+        path: ${{ github.workspace }}/bin/provider.tar.gz
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3
@@ -268,8 +275,11 @@ jobs:
     - name: Download provider + tfgen binaries
       uses: actions/download-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
+        name: ${{ env.PROVIDER }}-provider.tar.gz
         path: ${{ github.workspace }}/bin
+    - name: Untar provider binaries
+      run: tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin
     - name: Restore binary perms
       run: find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print
         -exec chmod +x {} \;

--- a/actions/providers/azuredevops/repo/.github/workflows/pull-request.yml
+++ b/actions/providers/azuredevops/repo/.github/workflows/pull-request.yml
@@ -54,8 +54,11 @@ jobs:
     - name: Download provider + tfgen binaries
       uses: actions/download-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
+        name: ${{ env.PROVIDER }}-provider.tar.gz
         path: ${{ github.workspace }}/bin
+    - name: Untar provider binaries
+      run: tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin
     - name: Restore binary perms
       run: find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print
         -exec chmod +x {} \;
@@ -119,11 +122,15 @@ jobs:
       uses: pulumi/action-install-pulumi-cli@releases/v1
     - name: Build tfgen & provider binaries
       run: make provider
+    - name: Tar provider binaries
+      run: tar -zcf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin/ pulumi-resource-${{ env.PROVIDER }} pulumi-tfgen-${{ env.PROVIDER
+        }}
     - name: Upload artifacts
       uses: actions/upload-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
-        path: ${{ github.workspace }}/bin
+        name: ${{ env.PROVIDER }}-provider.tar.gz
+        path: ${{ github.workspace }}/bin/provider.tar.gz
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3
@@ -171,8 +178,11 @@ jobs:
     - name: Download provider + tfgen binaries
       uses: actions/download-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
+        name: ${{ env.PROVIDER }}-provider.tar.gz
         path: ${{ github.workspace }}/bin
+    - name: Untar provider binaries
+      run: tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin
     - name: Restore binary perms
       run: find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print
         -exec chmod +x {} \;

--- a/actions/providers/azuredevops/repo/.github/workflows/release.yml
+++ b/actions/providers/azuredevops/repo/.github/workflows/release.yml
@@ -54,8 +54,11 @@ jobs:
     - name: Download provider + tfgen binaries
       uses: actions/download-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
+        name: ${{ env.PROVIDER }}-provider.tar.gz
         path: ${{ github.workspace }}/bin
+    - name: Untar provider binaries
+      run: tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin
     - name: Restore binary perms
       run: find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print
         -exec chmod +x {} \;
@@ -132,11 +135,15 @@ jobs:
       uses: pulumi/action-install-pulumi-cli@releases/v1
     - name: Build tfgen & provider binaries
       run: make provider
+    - name: Tar provider binaries
+      run: tar -zcf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin/ pulumi-resource-${{ env.PROVIDER }} pulumi-tfgen-${{ env.PROVIDER
+        }}
     - name: Upload artifacts
       uses: actions/upload-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
-        path: ${{ github.workspace }}/bin
+        name: ${{ env.PROVIDER }}-provider.tar.gz
+        path: ${{ github.workspace }}/bin/provider.tar.gz
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3
@@ -288,8 +295,11 @@ jobs:
     - name: Download provider + tfgen binaries
       uses: actions/download-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
+        name: ${{ env.PROVIDER }}-provider.tar.gz
         path: ${{ github.workspace }}/bin
+    - name: Untar provider binaries
+      run: tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin
     - name: Restore binary perms
       run: find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print
         -exec chmod +x {} \;

--- a/actions/providers/civo/repo/.github/workflows/master.yml
+++ b/actions/providers/civo/repo/.github/workflows/master.yml
@@ -53,8 +53,11 @@ jobs:
     - name: Download provider + tfgen binaries
       uses: actions/download-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
+        name: ${{ env.PROVIDER }}-provider.tar.gz
         path: ${{ github.workspace }}/bin
+    - name: Untar provider binaries
+      run: tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin
     - name: Restore binary perms
       run: find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print
         -exec chmod +x {} \;
@@ -185,11 +188,15 @@ jobs:
       uses: pulumi/action-install-pulumi-cli@releases/v1
     - name: Build tfgen & provider binaries
       run: make provider
+    - name: Tar provider binaries
+      run: tar -zcf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin/ pulumi-resource-${{ env.PROVIDER }} pulumi-tfgen-${{ env.PROVIDER
+        }}
     - name: Upload artifacts
       uses: actions/upload-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
-        path: ${{ github.workspace }}/bin
+        name: ${{ env.PROVIDER }}-provider.tar.gz
+        path: ${{ github.workspace }}/bin/provider.tar.gz
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3
@@ -346,8 +353,11 @@ jobs:
     - name: Download provider + tfgen binaries
       uses: actions/download-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
+        name: ${{ env.PROVIDER }}-provider.tar.gz
         path: ${{ github.workspace }}/bin
+    - name: Untar provider binaries
+      run: tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin
     - name: Restore binary perms
       run: find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print
         -exec chmod +x {} \;

--- a/actions/providers/civo/repo/.github/workflows/prerelease.yml
+++ b/actions/providers/civo/repo/.github/workflows/prerelease.yml
@@ -53,8 +53,11 @@ jobs:
     - name: Download provider + tfgen binaries
       uses: actions/download-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
+        name: ${{ env.PROVIDER }}-provider.tar.gz
         path: ${{ github.workspace }}/bin
+    - name: Untar provider binaries
+      run: tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin
     - name: Restore binary perms
       run: find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print
         -exec chmod +x {} \;
@@ -185,11 +188,15 @@ jobs:
       uses: pulumi/action-install-pulumi-cli@releases/v1
     - name: Build tfgen & provider binaries
       run: make provider
+    - name: Tar provider binaries
+      run: tar -zcf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin/ pulumi-resource-${{ env.PROVIDER }} pulumi-tfgen-${{ env.PROVIDER
+        }}
     - name: Upload artifacts
       uses: actions/upload-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
-        path: ${{ github.workspace }}/bin
+        name: ${{ env.PROVIDER }}-provider.tar.gz
+        path: ${{ github.workspace }}/bin/provider.tar.gz
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3
@@ -334,8 +341,11 @@ jobs:
     - name: Download provider + tfgen binaries
       uses: actions/download-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
+        name: ${{ env.PROVIDER }}-provider.tar.gz
         path: ${{ github.workspace }}/bin
+    - name: Untar provider binaries
+      run: tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin
     - name: Restore binary perms
       run: find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print
         -exec chmod +x {} \;

--- a/actions/providers/civo/repo/.github/workflows/pull-request.yml
+++ b/actions/providers/civo/repo/.github/workflows/pull-request.yml
@@ -53,8 +53,11 @@ jobs:
     - name: Download provider + tfgen binaries
       uses: actions/download-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
+        name: ${{ env.PROVIDER }}-provider.tar.gz
         path: ${{ github.workspace }}/bin
+    - name: Untar provider binaries
+      run: tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin
     - name: Restore binary perms
       run: find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print
         -exec chmod +x {} \;
@@ -185,11 +188,15 @@ jobs:
       uses: pulumi/action-install-pulumi-cli@releases/v1
     - name: Build tfgen & provider binaries
       run: make provider
+    - name: Tar provider binaries
+      run: tar -zcf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin/ pulumi-resource-${{ env.PROVIDER }} pulumi-tfgen-${{ env.PROVIDER
+        }}
     - name: Upload artifacts
       uses: actions/upload-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
-        path: ${{ github.workspace }}/bin
+        name: ${{ env.PROVIDER }}-provider.tar.gz
+        path: ${{ github.workspace }}/bin/provider.tar.gz
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3
@@ -237,8 +244,11 @@ jobs:
     - name: Download provider + tfgen binaries
       uses: actions/download-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
+        name: ${{ env.PROVIDER }}-provider.tar.gz
         path: ${{ github.workspace }}/bin
+    - name: Untar provider binaries
+      run: tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin
     - name: Restore binary perms
       run: find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print
         -exec chmod +x {} \;

--- a/actions/providers/civo/repo/.github/workflows/release.yml
+++ b/actions/providers/civo/repo/.github/workflows/release.yml
@@ -53,8 +53,11 @@ jobs:
     - name: Download provider + tfgen binaries
       uses: actions/download-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
+        name: ${{ env.PROVIDER }}-provider.tar.gz
         path: ${{ github.workspace }}/bin
+    - name: Untar provider binaries
+      run: tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin
     - name: Restore binary perms
       run: find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print
         -exec chmod +x {} \;
@@ -198,11 +201,15 @@ jobs:
       uses: pulumi/action-install-pulumi-cli@releases/v1
     - name: Build tfgen & provider binaries
       run: make provider
+    - name: Tar provider binaries
+      run: tar -zcf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin/ pulumi-resource-${{ env.PROVIDER }} pulumi-tfgen-${{ env.PROVIDER
+        }}
     - name: Upload artifacts
       uses: actions/upload-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
-        path: ${{ github.workspace }}/bin
+        name: ${{ env.PROVIDER }}-provider.tar.gz
+        path: ${{ github.workspace }}/bin/provider.tar.gz
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3
@@ -354,8 +361,11 @@ jobs:
     - name: Download provider + tfgen binaries
       uses: actions/download-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
+        name: ${{ env.PROVIDER }}-provider.tar.gz
         path: ${{ github.workspace }}/bin
+    - name: Untar provider binaries
+      run: tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin
     - name: Restore binary perms
       run: find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print
         -exec chmod +x {} \;

--- a/actions/providers/cloudamqp/repo/.github/workflows/master.yml
+++ b/actions/providers/cloudamqp/repo/.github/workflows/master.yml
@@ -52,8 +52,11 @@ jobs:
     - name: Download provider + tfgen binaries
       uses: actions/download-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
+        name: ${{ env.PROVIDER }}-provider.tar.gz
         path: ${{ github.workspace }}/bin
+    - name: Untar provider binaries
+      run: tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin
     - name: Restore binary perms
       run: find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print
         -exec chmod +x {} \;
@@ -184,11 +187,15 @@ jobs:
       uses: pulumi/action-install-pulumi-cli@releases/v1
     - name: Build tfgen & provider binaries
       run: make provider
+    - name: Tar provider binaries
+      run: tar -zcf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin/ pulumi-resource-${{ env.PROVIDER }} pulumi-tfgen-${{ env.PROVIDER
+        }}
     - name: Upload artifacts
       uses: actions/upload-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
-        path: ${{ github.workspace }}/bin
+        name: ${{ env.PROVIDER }}-provider.tar.gz
+        path: ${{ github.workspace }}/bin/provider.tar.gz
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3
@@ -345,8 +352,11 @@ jobs:
     - name: Download provider + tfgen binaries
       uses: actions/download-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
+        name: ${{ env.PROVIDER }}-provider.tar.gz
         path: ${{ github.workspace }}/bin
+    - name: Untar provider binaries
+      run: tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin
     - name: Restore binary perms
       run: find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print
         -exec chmod +x {} \;

--- a/actions/providers/cloudamqp/repo/.github/workflows/prerelease.yml
+++ b/actions/providers/cloudamqp/repo/.github/workflows/prerelease.yml
@@ -52,8 +52,11 @@ jobs:
     - name: Download provider + tfgen binaries
       uses: actions/download-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
+        name: ${{ env.PROVIDER }}-provider.tar.gz
         path: ${{ github.workspace }}/bin
+    - name: Untar provider binaries
+      run: tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin
     - name: Restore binary perms
       run: find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print
         -exec chmod +x {} \;
@@ -184,11 +187,15 @@ jobs:
       uses: pulumi/action-install-pulumi-cli@releases/v1
     - name: Build tfgen & provider binaries
       run: make provider
+    - name: Tar provider binaries
+      run: tar -zcf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin/ pulumi-resource-${{ env.PROVIDER }} pulumi-tfgen-${{ env.PROVIDER
+        }}
     - name: Upload artifacts
       uses: actions/upload-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
-        path: ${{ github.workspace }}/bin
+        name: ${{ env.PROVIDER }}-provider.tar.gz
+        path: ${{ github.workspace }}/bin/provider.tar.gz
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3
@@ -333,8 +340,11 @@ jobs:
     - name: Download provider + tfgen binaries
       uses: actions/download-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
+        name: ${{ env.PROVIDER }}-provider.tar.gz
         path: ${{ github.workspace }}/bin
+    - name: Untar provider binaries
+      run: tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin
     - name: Restore binary perms
       run: find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print
         -exec chmod +x {} \;

--- a/actions/providers/cloudamqp/repo/.github/workflows/pull-request.yml
+++ b/actions/providers/cloudamqp/repo/.github/workflows/pull-request.yml
@@ -52,8 +52,11 @@ jobs:
     - name: Download provider + tfgen binaries
       uses: actions/download-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
+        name: ${{ env.PROVIDER }}-provider.tar.gz
         path: ${{ github.workspace }}/bin
+    - name: Untar provider binaries
+      run: tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin
     - name: Restore binary perms
       run: find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print
         -exec chmod +x {} \;
@@ -184,11 +187,15 @@ jobs:
       uses: pulumi/action-install-pulumi-cli@releases/v1
     - name: Build tfgen & provider binaries
       run: make provider
+    - name: Tar provider binaries
+      run: tar -zcf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin/ pulumi-resource-${{ env.PROVIDER }} pulumi-tfgen-${{ env.PROVIDER
+        }}
     - name: Upload artifacts
       uses: actions/upload-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
-        path: ${{ github.workspace }}/bin
+        name: ${{ env.PROVIDER }}-provider.tar.gz
+        path: ${{ github.workspace }}/bin/provider.tar.gz
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3
@@ -236,8 +243,11 @@ jobs:
     - name: Download provider + tfgen binaries
       uses: actions/download-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
+        name: ${{ env.PROVIDER }}-provider.tar.gz
         path: ${{ github.workspace }}/bin
+    - name: Untar provider binaries
+      run: tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin
     - name: Restore binary perms
       run: find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print
         -exec chmod +x {} \;

--- a/actions/providers/cloudamqp/repo/.github/workflows/release.yml
+++ b/actions/providers/cloudamqp/repo/.github/workflows/release.yml
@@ -52,8 +52,11 @@ jobs:
     - name: Download provider + tfgen binaries
       uses: actions/download-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
+        name: ${{ env.PROVIDER }}-provider.tar.gz
         path: ${{ github.workspace }}/bin
+    - name: Untar provider binaries
+      run: tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin
     - name: Restore binary perms
       run: find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print
         -exec chmod +x {} \;
@@ -197,11 +200,15 @@ jobs:
       uses: pulumi/action-install-pulumi-cli@releases/v1
     - name: Build tfgen & provider binaries
       run: make provider
+    - name: Tar provider binaries
+      run: tar -zcf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin/ pulumi-resource-${{ env.PROVIDER }} pulumi-tfgen-${{ env.PROVIDER
+        }}
     - name: Upload artifacts
       uses: actions/upload-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
-        path: ${{ github.workspace }}/bin
+        name: ${{ env.PROVIDER }}-provider.tar.gz
+        path: ${{ github.workspace }}/bin/provider.tar.gz
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3
@@ -353,8 +360,11 @@ jobs:
     - name: Download provider + tfgen binaries
       uses: actions/download-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
+        name: ${{ env.PROVIDER }}-provider.tar.gz
         path: ${{ github.workspace }}/bin
+    - name: Untar provider binaries
+      run: tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin
     - name: Restore binary perms
       run: find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print
         -exec chmod +x {} \;

--- a/actions/providers/cloudflare/repo/.github/workflows/master.yml
+++ b/actions/providers/cloudflare/repo/.github/workflows/master.yml
@@ -52,8 +52,11 @@ jobs:
     - name: Download provider + tfgen binaries
       uses: actions/download-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
+        name: ${{ env.PROVIDER }}-provider.tar.gz
         path: ${{ github.workspace }}/bin
+    - name: Untar provider binaries
+      run: tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin
     - name: Restore binary perms
       run: find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print
         -exec chmod +x {} \;
@@ -184,11 +187,15 @@ jobs:
       uses: pulumi/action-install-pulumi-cli@releases/v1
     - name: Build tfgen & provider binaries
       run: make provider
+    - name: Tar provider binaries
+      run: tar -zcf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin/ pulumi-resource-${{ env.PROVIDER }} pulumi-tfgen-${{ env.PROVIDER
+        }}
     - name: Upload artifacts
       uses: actions/upload-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
-        path: ${{ github.workspace }}/bin
+        name: ${{ env.PROVIDER }}-provider.tar.gz
+        path: ${{ github.workspace }}/bin/provider.tar.gz
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3
@@ -345,8 +352,11 @@ jobs:
     - name: Download provider + tfgen binaries
       uses: actions/download-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
+        name: ${{ env.PROVIDER }}-provider.tar.gz
         path: ${{ github.workspace }}/bin
+    - name: Untar provider binaries
+      run: tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin
     - name: Restore binary perms
       run: find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print
         -exec chmod +x {} \;

--- a/actions/providers/cloudflare/repo/.github/workflows/prerelease.yml
+++ b/actions/providers/cloudflare/repo/.github/workflows/prerelease.yml
@@ -52,8 +52,11 @@ jobs:
     - name: Download provider + tfgen binaries
       uses: actions/download-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
+        name: ${{ env.PROVIDER }}-provider.tar.gz
         path: ${{ github.workspace }}/bin
+    - name: Untar provider binaries
+      run: tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin
     - name: Restore binary perms
       run: find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print
         -exec chmod +x {} \;
@@ -184,11 +187,15 @@ jobs:
       uses: pulumi/action-install-pulumi-cli@releases/v1
     - name: Build tfgen & provider binaries
       run: make provider
+    - name: Tar provider binaries
+      run: tar -zcf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin/ pulumi-resource-${{ env.PROVIDER }} pulumi-tfgen-${{ env.PROVIDER
+        }}
     - name: Upload artifacts
       uses: actions/upload-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
-        path: ${{ github.workspace }}/bin
+        name: ${{ env.PROVIDER }}-provider.tar.gz
+        path: ${{ github.workspace }}/bin/provider.tar.gz
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3
@@ -333,8 +340,11 @@ jobs:
     - name: Download provider + tfgen binaries
       uses: actions/download-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
+        name: ${{ env.PROVIDER }}-provider.tar.gz
         path: ${{ github.workspace }}/bin
+    - name: Untar provider binaries
+      run: tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin
     - name: Restore binary perms
       run: find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print
         -exec chmod +x {} \;

--- a/actions/providers/cloudflare/repo/.github/workflows/pull-request.yml
+++ b/actions/providers/cloudflare/repo/.github/workflows/pull-request.yml
@@ -52,8 +52,11 @@ jobs:
     - name: Download provider + tfgen binaries
       uses: actions/download-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
+        name: ${{ env.PROVIDER }}-provider.tar.gz
         path: ${{ github.workspace }}/bin
+    - name: Untar provider binaries
+      run: tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin
     - name: Restore binary perms
       run: find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print
         -exec chmod +x {} \;
@@ -184,11 +187,15 @@ jobs:
       uses: pulumi/action-install-pulumi-cli@releases/v1
     - name: Build tfgen & provider binaries
       run: make provider
+    - name: Tar provider binaries
+      run: tar -zcf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin/ pulumi-resource-${{ env.PROVIDER }} pulumi-tfgen-${{ env.PROVIDER
+        }}
     - name: Upload artifacts
       uses: actions/upload-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
-        path: ${{ github.workspace }}/bin
+        name: ${{ env.PROVIDER }}-provider.tar.gz
+        path: ${{ github.workspace }}/bin/provider.tar.gz
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3
@@ -236,8 +243,11 @@ jobs:
     - name: Download provider + tfgen binaries
       uses: actions/download-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
+        name: ${{ env.PROVIDER }}-provider.tar.gz
         path: ${{ github.workspace }}/bin
+    - name: Untar provider binaries
+      run: tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin
     - name: Restore binary perms
       run: find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print
         -exec chmod +x {} \;

--- a/actions/providers/cloudflare/repo/.github/workflows/release.yml
+++ b/actions/providers/cloudflare/repo/.github/workflows/release.yml
@@ -52,8 +52,11 @@ jobs:
     - name: Download provider + tfgen binaries
       uses: actions/download-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
+        name: ${{ env.PROVIDER }}-provider.tar.gz
         path: ${{ github.workspace }}/bin
+    - name: Untar provider binaries
+      run: tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin
     - name: Restore binary perms
       run: find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print
         -exec chmod +x {} \;
@@ -197,11 +200,15 @@ jobs:
       uses: pulumi/action-install-pulumi-cli@releases/v1
     - name: Build tfgen & provider binaries
       run: make provider
+    - name: Tar provider binaries
+      run: tar -zcf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin/ pulumi-resource-${{ env.PROVIDER }} pulumi-tfgen-${{ env.PROVIDER
+        }}
     - name: Upload artifacts
       uses: actions/upload-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
-        path: ${{ github.workspace }}/bin
+        name: ${{ env.PROVIDER }}-provider.tar.gz
+        path: ${{ github.workspace }}/bin/provider.tar.gz
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3
@@ -353,8 +360,11 @@ jobs:
     - name: Download provider + tfgen binaries
       uses: actions/download-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
+        name: ${{ env.PROVIDER }}-provider.tar.gz
         path: ${{ github.workspace }}/bin
+    - name: Untar provider binaries
+      run: tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin
     - name: Restore binary perms
       run: find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print
         -exec chmod +x {} \;

--- a/actions/providers/consul/repo/.github/workflows/master.yml
+++ b/actions/providers/consul/repo/.github/workflows/master.yml
@@ -52,8 +52,11 @@ jobs:
     - name: Download provider + tfgen binaries
       uses: actions/download-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
+        name: ${{ env.PROVIDER }}-provider.tar.gz
         path: ${{ github.workspace }}/bin
+    - name: Untar provider binaries
+      run: tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin
     - name: Restore binary perms
       run: find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print
         -exec chmod +x {} \;
@@ -184,11 +187,15 @@ jobs:
       uses: pulumi/action-install-pulumi-cli@releases/v1
     - name: Build tfgen & provider binaries
       run: make provider
+    - name: Tar provider binaries
+      run: tar -zcf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin/ pulumi-resource-${{ env.PROVIDER }} pulumi-tfgen-${{ env.PROVIDER
+        }}
     - name: Upload artifacts
       uses: actions/upload-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
-        path: ${{ github.workspace }}/bin
+        name: ${{ env.PROVIDER }}-provider.tar.gz
+        path: ${{ github.workspace }}/bin/provider.tar.gz
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3
@@ -345,8 +352,11 @@ jobs:
     - name: Download provider + tfgen binaries
       uses: actions/download-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
+        name: ${{ env.PROVIDER }}-provider.tar.gz
         path: ${{ github.workspace }}/bin
+    - name: Untar provider binaries
+      run: tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin
     - name: Restore binary perms
       run: find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print
         -exec chmod +x {} \;

--- a/actions/providers/consul/repo/.github/workflows/prerelease.yml
+++ b/actions/providers/consul/repo/.github/workflows/prerelease.yml
@@ -52,8 +52,11 @@ jobs:
     - name: Download provider + tfgen binaries
       uses: actions/download-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
+        name: ${{ env.PROVIDER }}-provider.tar.gz
         path: ${{ github.workspace }}/bin
+    - name: Untar provider binaries
+      run: tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin
     - name: Restore binary perms
       run: find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print
         -exec chmod +x {} \;
@@ -184,11 +187,15 @@ jobs:
       uses: pulumi/action-install-pulumi-cli@releases/v1
     - name: Build tfgen & provider binaries
       run: make provider
+    - name: Tar provider binaries
+      run: tar -zcf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin/ pulumi-resource-${{ env.PROVIDER }} pulumi-tfgen-${{ env.PROVIDER
+        }}
     - name: Upload artifacts
       uses: actions/upload-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
-        path: ${{ github.workspace }}/bin
+        name: ${{ env.PROVIDER }}-provider.tar.gz
+        path: ${{ github.workspace }}/bin/provider.tar.gz
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3
@@ -333,8 +340,11 @@ jobs:
     - name: Download provider + tfgen binaries
       uses: actions/download-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
+        name: ${{ env.PROVIDER }}-provider.tar.gz
         path: ${{ github.workspace }}/bin
+    - name: Untar provider binaries
+      run: tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin
     - name: Restore binary perms
       run: find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print
         -exec chmod +x {} \;

--- a/actions/providers/consul/repo/.github/workflows/pull-request.yml
+++ b/actions/providers/consul/repo/.github/workflows/pull-request.yml
@@ -52,8 +52,11 @@ jobs:
     - name: Download provider + tfgen binaries
       uses: actions/download-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
+        name: ${{ env.PROVIDER }}-provider.tar.gz
         path: ${{ github.workspace }}/bin
+    - name: Untar provider binaries
+      run: tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin
     - name: Restore binary perms
       run: find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print
         -exec chmod +x {} \;
@@ -184,11 +187,15 @@ jobs:
       uses: pulumi/action-install-pulumi-cli@releases/v1
     - name: Build tfgen & provider binaries
       run: make provider
+    - name: Tar provider binaries
+      run: tar -zcf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin/ pulumi-resource-${{ env.PROVIDER }} pulumi-tfgen-${{ env.PROVIDER
+        }}
     - name: Upload artifacts
       uses: actions/upload-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
-        path: ${{ github.workspace }}/bin
+        name: ${{ env.PROVIDER }}-provider.tar.gz
+        path: ${{ github.workspace }}/bin/provider.tar.gz
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3
@@ -236,8 +243,11 @@ jobs:
     - name: Download provider + tfgen binaries
       uses: actions/download-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
+        name: ${{ env.PROVIDER }}-provider.tar.gz
         path: ${{ github.workspace }}/bin
+    - name: Untar provider binaries
+      run: tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin
     - name: Restore binary perms
       run: find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print
         -exec chmod +x {} \;

--- a/actions/providers/consul/repo/.github/workflows/release.yml
+++ b/actions/providers/consul/repo/.github/workflows/release.yml
@@ -52,8 +52,11 @@ jobs:
     - name: Download provider + tfgen binaries
       uses: actions/download-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
+        name: ${{ env.PROVIDER }}-provider.tar.gz
         path: ${{ github.workspace }}/bin
+    - name: Untar provider binaries
+      run: tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin
     - name: Restore binary perms
       run: find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print
         -exec chmod +x {} \;
@@ -197,11 +200,15 @@ jobs:
       uses: pulumi/action-install-pulumi-cli@releases/v1
     - name: Build tfgen & provider binaries
       run: make provider
+    - name: Tar provider binaries
+      run: tar -zcf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin/ pulumi-resource-${{ env.PROVIDER }} pulumi-tfgen-${{ env.PROVIDER
+        }}
     - name: Upload artifacts
       uses: actions/upload-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
-        path: ${{ github.workspace }}/bin
+        name: ${{ env.PROVIDER }}-provider.tar.gz
+        path: ${{ github.workspace }}/bin/provider.tar.gz
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3
@@ -353,8 +360,11 @@ jobs:
     - name: Download provider + tfgen binaries
       uses: actions/download-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
+        name: ${{ env.PROVIDER }}-provider.tar.gz
         path: ${{ github.workspace }}/bin
+    - name: Untar provider binaries
+      run: tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin
     - name: Restore binary perms
       run: find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print
         -exec chmod +x {} \;

--- a/actions/providers/datadog/repo/.github/workflows/master.yml
+++ b/actions/providers/datadog/repo/.github/workflows/master.yml
@@ -52,8 +52,11 @@ jobs:
     - name: Download provider + tfgen binaries
       uses: actions/download-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
+        name: ${{ env.PROVIDER }}-provider.tar.gz
         path: ${{ github.workspace }}/bin
+    - name: Untar provider binaries
+      run: tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin
     - name: Restore binary perms
       run: find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print
         -exec chmod +x {} \;
@@ -117,11 +120,15 @@ jobs:
       uses: pulumi/action-install-pulumi-cli@releases/v1
     - name: Build tfgen & provider binaries
       run: make provider
+    - name: Tar provider binaries
+      run: tar -zcf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin/ pulumi-resource-${{ env.PROVIDER }} pulumi-tfgen-${{ env.PROVIDER
+        }}
     - name: Upload artifacts
       uses: actions/upload-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
-        path: ${{ github.workspace }}/bin
+        name: ${{ env.PROVIDER }}-provider.tar.gz
+        path: ${{ github.workspace }}/bin/provider.tar.gz
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3
@@ -278,8 +285,11 @@ jobs:
     - name: Download provider + tfgen binaries
       uses: actions/download-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
+        name: ${{ env.PROVIDER }}-provider.tar.gz
         path: ${{ github.workspace }}/bin
+    - name: Untar provider binaries
+      run: tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin
     - name: Restore binary perms
       run: find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print
         -exec chmod +x {} \;

--- a/actions/providers/datadog/repo/.github/workflows/prerelease.yml
+++ b/actions/providers/datadog/repo/.github/workflows/prerelease.yml
@@ -52,8 +52,11 @@ jobs:
     - name: Download provider + tfgen binaries
       uses: actions/download-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
+        name: ${{ env.PROVIDER }}-provider.tar.gz
         path: ${{ github.workspace }}/bin
+    - name: Untar provider binaries
+      run: tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin
     - name: Restore binary perms
       run: find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print
         -exec chmod +x {} \;
@@ -117,11 +120,15 @@ jobs:
       uses: pulumi/action-install-pulumi-cli@releases/v1
     - name: Build tfgen & provider binaries
       run: make provider
+    - name: Tar provider binaries
+      run: tar -zcf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin/ pulumi-resource-${{ env.PROVIDER }} pulumi-tfgen-${{ env.PROVIDER
+        }}
     - name: Upload artifacts
       uses: actions/upload-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
-        path: ${{ github.workspace }}/bin
+        name: ${{ env.PROVIDER }}-provider.tar.gz
+        path: ${{ github.workspace }}/bin/provider.tar.gz
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3
@@ -266,8 +273,11 @@ jobs:
     - name: Download provider + tfgen binaries
       uses: actions/download-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
+        name: ${{ env.PROVIDER }}-provider.tar.gz
         path: ${{ github.workspace }}/bin
+    - name: Untar provider binaries
+      run: tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin
     - name: Restore binary perms
       run: find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print
         -exec chmod +x {} \;

--- a/actions/providers/datadog/repo/.github/workflows/pull-request.yml
+++ b/actions/providers/datadog/repo/.github/workflows/pull-request.yml
@@ -52,8 +52,11 @@ jobs:
     - name: Download provider + tfgen binaries
       uses: actions/download-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
+        name: ${{ env.PROVIDER }}-provider.tar.gz
         path: ${{ github.workspace }}/bin
+    - name: Untar provider binaries
+      run: tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin
     - name: Restore binary perms
       run: find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print
         -exec chmod +x {} \;
@@ -117,11 +120,15 @@ jobs:
       uses: pulumi/action-install-pulumi-cli@releases/v1
     - name: Build tfgen & provider binaries
       run: make provider
+    - name: Tar provider binaries
+      run: tar -zcf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin/ pulumi-resource-${{ env.PROVIDER }} pulumi-tfgen-${{ env.PROVIDER
+        }}
     - name: Upload artifacts
       uses: actions/upload-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
-        path: ${{ github.workspace }}/bin
+        name: ${{ env.PROVIDER }}-provider.tar.gz
+        path: ${{ github.workspace }}/bin/provider.tar.gz
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3
@@ -169,8 +176,11 @@ jobs:
     - name: Download provider + tfgen binaries
       uses: actions/download-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
+        name: ${{ env.PROVIDER }}-provider.tar.gz
         path: ${{ github.workspace }}/bin
+    - name: Untar provider binaries
+      run: tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin
     - name: Restore binary perms
       run: find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print
         -exec chmod +x {} \;

--- a/actions/providers/datadog/repo/.github/workflows/release.yml
+++ b/actions/providers/datadog/repo/.github/workflows/release.yml
@@ -52,8 +52,11 @@ jobs:
     - name: Download provider + tfgen binaries
       uses: actions/download-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
+        name: ${{ env.PROVIDER }}-provider.tar.gz
         path: ${{ github.workspace }}/bin
+    - name: Untar provider binaries
+      run: tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin
     - name: Restore binary perms
       run: find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print
         -exec chmod +x {} \;
@@ -130,11 +133,15 @@ jobs:
       uses: pulumi/action-install-pulumi-cli@releases/v1
     - name: Build tfgen & provider binaries
       run: make provider
+    - name: Tar provider binaries
+      run: tar -zcf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin/ pulumi-resource-${{ env.PROVIDER }} pulumi-tfgen-${{ env.PROVIDER
+        }}
     - name: Upload artifacts
       uses: actions/upload-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
-        path: ${{ github.workspace }}/bin
+        name: ${{ env.PROVIDER }}-provider.tar.gz
+        path: ${{ github.workspace }}/bin/provider.tar.gz
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3
@@ -286,8 +293,11 @@ jobs:
     - name: Download provider + tfgen binaries
       uses: actions/download-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
+        name: ${{ env.PROVIDER }}-provider.tar.gz
         path: ${{ github.workspace }}/bin
+    - name: Untar provider binaries
+      run: tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin
     - name: Restore binary perms
       run: find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print
         -exec chmod +x {} \;

--- a/actions/providers/digitalocean/repo/.github/workflows/master.yml
+++ b/actions/providers/digitalocean/repo/.github/workflows/master.yml
@@ -53,8 +53,11 @@ jobs:
     - name: Download provider + tfgen binaries
       uses: actions/download-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
+        name: ${{ env.PROVIDER }}-provider.tar.gz
         path: ${{ github.workspace }}/bin
+    - name: Untar provider binaries
+      run: tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin
     - name: Restore binary perms
       run: find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print
         -exec chmod +x {} \;
@@ -185,11 +188,15 @@ jobs:
       uses: pulumi/action-install-pulumi-cli@releases/v1
     - name: Build tfgen & provider binaries
       run: make provider
+    - name: Tar provider binaries
+      run: tar -zcf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin/ pulumi-resource-${{ env.PROVIDER }} pulumi-tfgen-${{ env.PROVIDER
+        }}
     - name: Upload artifacts
       uses: actions/upload-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
-        path: ${{ github.workspace }}/bin
+        name: ${{ env.PROVIDER }}-provider.tar.gz
+        path: ${{ github.workspace }}/bin/provider.tar.gz
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3
@@ -346,8 +353,11 @@ jobs:
     - name: Download provider + tfgen binaries
       uses: actions/download-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
+        name: ${{ env.PROVIDER }}-provider.tar.gz
         path: ${{ github.workspace }}/bin
+    - name: Untar provider binaries
+      run: tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin
     - name: Restore binary perms
       run: find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print
         -exec chmod +x {} \;

--- a/actions/providers/digitalocean/repo/.github/workflows/prerelease.yml
+++ b/actions/providers/digitalocean/repo/.github/workflows/prerelease.yml
@@ -53,8 +53,11 @@ jobs:
     - name: Download provider + tfgen binaries
       uses: actions/download-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
+        name: ${{ env.PROVIDER }}-provider.tar.gz
         path: ${{ github.workspace }}/bin
+    - name: Untar provider binaries
+      run: tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin
     - name: Restore binary perms
       run: find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print
         -exec chmod +x {} \;
@@ -185,11 +188,15 @@ jobs:
       uses: pulumi/action-install-pulumi-cli@releases/v1
     - name: Build tfgen & provider binaries
       run: make provider
+    - name: Tar provider binaries
+      run: tar -zcf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin/ pulumi-resource-${{ env.PROVIDER }} pulumi-tfgen-${{ env.PROVIDER
+        }}
     - name: Upload artifacts
       uses: actions/upload-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
-        path: ${{ github.workspace }}/bin
+        name: ${{ env.PROVIDER }}-provider.tar.gz
+        path: ${{ github.workspace }}/bin/provider.tar.gz
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3
@@ -334,8 +341,11 @@ jobs:
     - name: Download provider + tfgen binaries
       uses: actions/download-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
+        name: ${{ env.PROVIDER }}-provider.tar.gz
         path: ${{ github.workspace }}/bin
+    - name: Untar provider binaries
+      run: tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin
     - name: Restore binary perms
       run: find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print
         -exec chmod +x {} \;

--- a/actions/providers/digitalocean/repo/.github/workflows/pull-request.yml
+++ b/actions/providers/digitalocean/repo/.github/workflows/pull-request.yml
@@ -53,8 +53,11 @@ jobs:
     - name: Download provider + tfgen binaries
       uses: actions/download-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
+        name: ${{ env.PROVIDER }}-provider.tar.gz
         path: ${{ github.workspace }}/bin
+    - name: Untar provider binaries
+      run: tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin
     - name: Restore binary perms
       run: find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print
         -exec chmod +x {} \;
@@ -185,11 +188,15 @@ jobs:
       uses: pulumi/action-install-pulumi-cli@releases/v1
     - name: Build tfgen & provider binaries
       run: make provider
+    - name: Tar provider binaries
+      run: tar -zcf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin/ pulumi-resource-${{ env.PROVIDER }} pulumi-tfgen-${{ env.PROVIDER
+        }}
     - name: Upload artifacts
       uses: actions/upload-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
-        path: ${{ github.workspace }}/bin
+        name: ${{ env.PROVIDER }}-provider.tar.gz
+        path: ${{ github.workspace }}/bin/provider.tar.gz
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3
@@ -237,8 +244,11 @@ jobs:
     - name: Download provider + tfgen binaries
       uses: actions/download-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
+        name: ${{ env.PROVIDER }}-provider.tar.gz
         path: ${{ github.workspace }}/bin
+    - name: Untar provider binaries
+      run: tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin
     - name: Restore binary perms
       run: find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print
         -exec chmod +x {} \;

--- a/actions/providers/digitalocean/repo/.github/workflows/release.yml
+++ b/actions/providers/digitalocean/repo/.github/workflows/release.yml
@@ -53,8 +53,11 @@ jobs:
     - name: Download provider + tfgen binaries
       uses: actions/download-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
+        name: ${{ env.PROVIDER }}-provider.tar.gz
         path: ${{ github.workspace }}/bin
+    - name: Untar provider binaries
+      run: tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin
     - name: Restore binary perms
       run: find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print
         -exec chmod +x {} \;
@@ -198,11 +201,15 @@ jobs:
       uses: pulumi/action-install-pulumi-cli@releases/v1
     - name: Build tfgen & provider binaries
       run: make provider
+    - name: Tar provider binaries
+      run: tar -zcf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin/ pulumi-resource-${{ env.PROVIDER }} pulumi-tfgen-${{ env.PROVIDER
+        }}
     - name: Upload artifacts
       uses: actions/upload-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
-        path: ${{ github.workspace }}/bin
+        name: ${{ env.PROVIDER }}-provider.tar.gz
+        path: ${{ github.workspace }}/bin/provider.tar.gz
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3
@@ -354,8 +361,11 @@ jobs:
     - name: Download provider + tfgen binaries
       uses: actions/download-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
+        name: ${{ env.PROVIDER }}-provider.tar.gz
         path: ${{ github.workspace }}/bin
+    - name: Untar provider binaries
+      run: tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin
     - name: Restore binary perms
       run: find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print
         -exec chmod +x {} \;

--- a/actions/providers/dnsimple/repo/.github/workflows/master.yml
+++ b/actions/providers/dnsimple/repo/.github/workflows/master.yml
@@ -54,8 +54,11 @@ jobs:
     - name: Download provider + tfgen binaries
       uses: actions/download-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
+        name: ${{ env.PROVIDER }}-provider.tar.gz
         path: ${{ github.workspace }}/bin
+    - name: Untar provider binaries
+      run: tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin
     - name: Restore binary perms
       run: find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print
         -exec chmod +x {} \;
@@ -186,11 +189,15 @@ jobs:
       uses: pulumi/action-install-pulumi-cli@releases/v1
     - name: Build tfgen & provider binaries
       run: make provider
+    - name: Tar provider binaries
+      run: tar -zcf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin/ pulumi-resource-${{ env.PROVIDER }} pulumi-tfgen-${{ env.PROVIDER
+        }}
     - name: Upload artifacts
       uses: actions/upload-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
-        path: ${{ github.workspace }}/bin
+        name: ${{ env.PROVIDER }}-provider.tar.gz
+        path: ${{ github.workspace }}/bin/provider.tar.gz
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3
@@ -347,8 +354,11 @@ jobs:
     - name: Download provider + tfgen binaries
       uses: actions/download-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
+        name: ${{ env.PROVIDER }}-provider.tar.gz
         path: ${{ github.workspace }}/bin
+    - name: Untar provider binaries
+      run: tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin
     - name: Restore binary perms
       run: find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print
         -exec chmod +x {} \;

--- a/actions/providers/dnsimple/repo/.github/workflows/prerelease.yml
+++ b/actions/providers/dnsimple/repo/.github/workflows/prerelease.yml
@@ -54,8 +54,11 @@ jobs:
     - name: Download provider + tfgen binaries
       uses: actions/download-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
+        name: ${{ env.PROVIDER }}-provider.tar.gz
         path: ${{ github.workspace }}/bin
+    - name: Untar provider binaries
+      run: tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin
     - name: Restore binary perms
       run: find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print
         -exec chmod +x {} \;
@@ -186,11 +189,15 @@ jobs:
       uses: pulumi/action-install-pulumi-cli@releases/v1
     - name: Build tfgen & provider binaries
       run: make provider
+    - name: Tar provider binaries
+      run: tar -zcf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin/ pulumi-resource-${{ env.PROVIDER }} pulumi-tfgen-${{ env.PROVIDER
+        }}
     - name: Upload artifacts
       uses: actions/upload-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
-        path: ${{ github.workspace }}/bin
+        name: ${{ env.PROVIDER }}-provider.tar.gz
+        path: ${{ github.workspace }}/bin/provider.tar.gz
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3
@@ -335,8 +342,11 @@ jobs:
     - name: Download provider + tfgen binaries
       uses: actions/download-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
+        name: ${{ env.PROVIDER }}-provider.tar.gz
         path: ${{ github.workspace }}/bin
+    - name: Untar provider binaries
+      run: tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin
     - name: Restore binary perms
       run: find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print
         -exec chmod +x {} \;

--- a/actions/providers/dnsimple/repo/.github/workflows/pull-request.yml
+++ b/actions/providers/dnsimple/repo/.github/workflows/pull-request.yml
@@ -54,8 +54,11 @@ jobs:
     - name: Download provider + tfgen binaries
       uses: actions/download-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
+        name: ${{ env.PROVIDER }}-provider.tar.gz
         path: ${{ github.workspace }}/bin
+    - name: Untar provider binaries
+      run: tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin
     - name: Restore binary perms
       run: find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print
         -exec chmod +x {} \;
@@ -186,11 +189,15 @@ jobs:
       uses: pulumi/action-install-pulumi-cli@releases/v1
     - name: Build tfgen & provider binaries
       run: make provider
+    - name: Tar provider binaries
+      run: tar -zcf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin/ pulumi-resource-${{ env.PROVIDER }} pulumi-tfgen-${{ env.PROVIDER
+        }}
     - name: Upload artifacts
       uses: actions/upload-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
-        path: ${{ github.workspace }}/bin
+        name: ${{ env.PROVIDER }}-provider.tar.gz
+        path: ${{ github.workspace }}/bin/provider.tar.gz
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3
@@ -238,8 +245,11 @@ jobs:
     - name: Download provider + tfgen binaries
       uses: actions/download-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
+        name: ${{ env.PROVIDER }}-provider.tar.gz
         path: ${{ github.workspace }}/bin
+    - name: Untar provider binaries
+      run: tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin
     - name: Restore binary perms
       run: find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print
         -exec chmod +x {} \;

--- a/actions/providers/dnsimple/repo/.github/workflows/release.yml
+++ b/actions/providers/dnsimple/repo/.github/workflows/release.yml
@@ -54,8 +54,11 @@ jobs:
     - name: Download provider + tfgen binaries
       uses: actions/download-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
+        name: ${{ env.PROVIDER }}-provider.tar.gz
         path: ${{ github.workspace }}/bin
+    - name: Untar provider binaries
+      run: tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin
     - name: Restore binary perms
       run: find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print
         -exec chmod +x {} \;
@@ -199,11 +202,15 @@ jobs:
       uses: pulumi/action-install-pulumi-cli@releases/v1
     - name: Build tfgen & provider binaries
       run: make provider
+    - name: Tar provider binaries
+      run: tar -zcf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin/ pulumi-resource-${{ env.PROVIDER }} pulumi-tfgen-${{ env.PROVIDER
+        }}
     - name: Upload artifacts
       uses: actions/upload-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
-        path: ${{ github.workspace }}/bin
+        name: ${{ env.PROVIDER }}-provider.tar.gz
+        path: ${{ github.workspace }}/bin/provider.tar.gz
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3
@@ -355,8 +362,11 @@ jobs:
     - name: Download provider + tfgen binaries
       uses: actions/download-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
+        name: ${{ env.PROVIDER }}-provider.tar.gz
         path: ${{ github.workspace }}/bin
+    - name: Untar provider binaries
+      run: tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin
     - name: Restore binary perms
       run: find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print
         -exec chmod +x {} \;

--- a/actions/providers/docker/repo/.github/workflows/master.yml
+++ b/actions/providers/docker/repo/.github/workflows/master.yml
@@ -58,8 +58,11 @@ jobs:
     - name: Download provider + tfgen binaries
       uses: actions/download-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
+        name: ${{ env.PROVIDER }}-provider.tar.gz
         path: ${{ github.workspace }}/bin
+    - name: Untar provider binaries
+      run: tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin
     - name: Restore binary perms
       run: find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print
         -exec chmod +x {} \;
@@ -190,11 +193,15 @@ jobs:
       uses: pulumi/action-install-pulumi-cli@releases/v1
     - name: Build tfgen & provider binaries
       run: make provider
+    - name: Tar provider binaries
+      run: tar -zcf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin/ pulumi-resource-${{ env.PROVIDER }} pulumi-tfgen-${{ env.PROVIDER
+        }}
     - name: Upload artifacts
       uses: actions/upload-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
-        path: ${{ github.workspace }}/bin
+        name: ${{ env.PROVIDER }}-provider.tar.gz
+        path: ${{ github.workspace }}/bin/provider.tar.gz
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3
@@ -351,8 +358,11 @@ jobs:
     - name: Download provider + tfgen binaries
       uses: actions/download-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
+        name: ${{ env.PROVIDER }}-provider.tar.gz
         path: ${{ github.workspace }}/bin
+    - name: Untar provider binaries
+      run: tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin
     - name: Restore binary perms
       run: find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print
         -exec chmod +x {} \;

--- a/actions/providers/docker/repo/.github/workflows/prerelease.yml
+++ b/actions/providers/docker/repo/.github/workflows/prerelease.yml
@@ -58,8 +58,11 @@ jobs:
     - name: Download provider + tfgen binaries
       uses: actions/download-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
+        name: ${{ env.PROVIDER }}-provider.tar.gz
         path: ${{ github.workspace }}/bin
+    - name: Untar provider binaries
+      run: tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin
     - name: Restore binary perms
       run: find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print
         -exec chmod +x {} \;
@@ -190,11 +193,15 @@ jobs:
       uses: pulumi/action-install-pulumi-cli@releases/v1
     - name: Build tfgen & provider binaries
       run: make provider
+    - name: Tar provider binaries
+      run: tar -zcf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin/ pulumi-resource-${{ env.PROVIDER }} pulumi-tfgen-${{ env.PROVIDER
+        }}
     - name: Upload artifacts
       uses: actions/upload-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
-        path: ${{ github.workspace }}/bin
+        name: ${{ env.PROVIDER }}-provider.tar.gz
+        path: ${{ github.workspace }}/bin/provider.tar.gz
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3
@@ -339,8 +346,11 @@ jobs:
     - name: Download provider + tfgen binaries
       uses: actions/download-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
+        name: ${{ env.PROVIDER }}-provider.tar.gz
         path: ${{ github.workspace }}/bin
+    - name: Untar provider binaries
+      run: tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin
     - name: Restore binary perms
       run: find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print
         -exec chmod +x {} \;

--- a/actions/providers/docker/repo/.github/workflows/pull-request.yml
+++ b/actions/providers/docker/repo/.github/workflows/pull-request.yml
@@ -58,8 +58,11 @@ jobs:
     - name: Download provider + tfgen binaries
       uses: actions/download-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
+        name: ${{ env.PROVIDER }}-provider.tar.gz
         path: ${{ github.workspace }}/bin
+    - name: Untar provider binaries
+      run: tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin
     - name: Restore binary perms
       run: find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print
         -exec chmod +x {} \;
@@ -190,11 +193,15 @@ jobs:
       uses: pulumi/action-install-pulumi-cli@releases/v1
     - name: Build tfgen & provider binaries
       run: make provider
+    - name: Tar provider binaries
+      run: tar -zcf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin/ pulumi-resource-${{ env.PROVIDER }} pulumi-tfgen-${{ env.PROVIDER
+        }}
     - name: Upload artifacts
       uses: actions/upload-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
-        path: ${{ github.workspace }}/bin
+        name: ${{ env.PROVIDER }}-provider.tar.gz
+        path: ${{ github.workspace }}/bin/provider.tar.gz
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3
@@ -242,8 +249,11 @@ jobs:
     - name: Download provider + tfgen binaries
       uses: actions/download-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
+        name: ${{ env.PROVIDER }}-provider.tar.gz
         path: ${{ github.workspace }}/bin
+    - name: Untar provider binaries
+      run: tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin
     - name: Restore binary perms
       run: find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print
         -exec chmod +x {} \;

--- a/actions/providers/docker/repo/.github/workflows/release.yml
+++ b/actions/providers/docker/repo/.github/workflows/release.yml
@@ -58,8 +58,11 @@ jobs:
     - name: Download provider + tfgen binaries
       uses: actions/download-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
+        name: ${{ env.PROVIDER }}-provider.tar.gz
         path: ${{ github.workspace }}/bin
+    - name: Untar provider binaries
+      run: tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin
     - name: Restore binary perms
       run: find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print
         -exec chmod +x {} \;
@@ -203,11 +206,15 @@ jobs:
       uses: pulumi/action-install-pulumi-cli@releases/v1
     - name: Build tfgen & provider binaries
       run: make provider
+    - name: Tar provider binaries
+      run: tar -zcf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin/ pulumi-resource-${{ env.PROVIDER }} pulumi-tfgen-${{ env.PROVIDER
+        }}
     - name: Upload artifacts
       uses: actions/upload-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
-        path: ${{ github.workspace }}/bin
+        name: ${{ env.PROVIDER }}-provider.tar.gz
+        path: ${{ github.workspace }}/bin/provider.tar.gz
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3
@@ -359,8 +366,11 @@ jobs:
     - name: Download provider + tfgen binaries
       uses: actions/download-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
+        name: ${{ env.PROVIDER }}-provider.tar.gz
         path: ${{ github.workspace }}/bin
+    - name: Untar provider binaries
+      run: tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin
     - name: Restore binary perms
       run: find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print
         -exec chmod +x {} \;

--- a/actions/providers/f5bigip/repo/.github/workflows/master.yml
+++ b/actions/providers/f5bigip/repo/.github/workflows/master.yml
@@ -56,8 +56,11 @@ jobs:
     - name: Download provider + tfgen binaries
       uses: actions/download-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
+        name: ${{ env.PROVIDER }}-provider.tar.gz
         path: ${{ github.workspace }}/bin
+    - name: Untar provider binaries
+      run: tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin
     - name: Restore binary perms
       run: find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print
         -exec chmod +x {} \;
@@ -188,11 +191,15 @@ jobs:
       uses: pulumi/action-install-pulumi-cli@releases/v1
     - name: Build tfgen & provider binaries
       run: make provider
+    - name: Tar provider binaries
+      run: tar -zcf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin/ pulumi-resource-${{ env.PROVIDER }} pulumi-tfgen-${{ env.PROVIDER
+        }}
     - name: Upload artifacts
       uses: actions/upload-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
-        path: ${{ github.workspace }}/bin
+        name: ${{ env.PROVIDER }}-provider.tar.gz
+        path: ${{ github.workspace }}/bin/provider.tar.gz
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3
@@ -349,8 +356,11 @@ jobs:
     - name: Download provider + tfgen binaries
       uses: actions/download-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
+        name: ${{ env.PROVIDER }}-provider.tar.gz
         path: ${{ github.workspace }}/bin
+    - name: Untar provider binaries
+      run: tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin
     - name: Restore binary perms
       run: find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print
         -exec chmod +x {} \;

--- a/actions/providers/f5bigip/repo/.github/workflows/prerelease.yml
+++ b/actions/providers/f5bigip/repo/.github/workflows/prerelease.yml
@@ -56,8 +56,11 @@ jobs:
     - name: Download provider + tfgen binaries
       uses: actions/download-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
+        name: ${{ env.PROVIDER }}-provider.tar.gz
         path: ${{ github.workspace }}/bin
+    - name: Untar provider binaries
+      run: tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin
     - name: Restore binary perms
       run: find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print
         -exec chmod +x {} \;
@@ -188,11 +191,15 @@ jobs:
       uses: pulumi/action-install-pulumi-cli@releases/v1
     - name: Build tfgen & provider binaries
       run: make provider
+    - name: Tar provider binaries
+      run: tar -zcf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin/ pulumi-resource-${{ env.PROVIDER }} pulumi-tfgen-${{ env.PROVIDER
+        }}
     - name: Upload artifacts
       uses: actions/upload-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
-        path: ${{ github.workspace }}/bin
+        name: ${{ env.PROVIDER }}-provider.tar.gz
+        path: ${{ github.workspace }}/bin/provider.tar.gz
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3
@@ -337,8 +344,11 @@ jobs:
     - name: Download provider + tfgen binaries
       uses: actions/download-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
+        name: ${{ env.PROVIDER }}-provider.tar.gz
         path: ${{ github.workspace }}/bin
+    - name: Untar provider binaries
+      run: tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin
     - name: Restore binary perms
       run: find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print
         -exec chmod +x {} \;

--- a/actions/providers/f5bigip/repo/.github/workflows/pull-request.yml
+++ b/actions/providers/f5bigip/repo/.github/workflows/pull-request.yml
@@ -56,8 +56,11 @@ jobs:
     - name: Download provider + tfgen binaries
       uses: actions/download-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
+        name: ${{ env.PROVIDER }}-provider.tar.gz
         path: ${{ github.workspace }}/bin
+    - name: Untar provider binaries
+      run: tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin
     - name: Restore binary perms
       run: find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print
         -exec chmod +x {} \;
@@ -188,11 +191,15 @@ jobs:
       uses: pulumi/action-install-pulumi-cli@releases/v1
     - name: Build tfgen & provider binaries
       run: make provider
+    - name: Tar provider binaries
+      run: tar -zcf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin/ pulumi-resource-${{ env.PROVIDER }} pulumi-tfgen-${{ env.PROVIDER
+        }}
     - name: Upload artifacts
       uses: actions/upload-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
-        path: ${{ github.workspace }}/bin
+        name: ${{ env.PROVIDER }}-provider.tar.gz
+        path: ${{ github.workspace }}/bin/provider.tar.gz
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3
@@ -240,8 +247,11 @@ jobs:
     - name: Download provider + tfgen binaries
       uses: actions/download-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
+        name: ${{ env.PROVIDER }}-provider.tar.gz
         path: ${{ github.workspace }}/bin
+    - name: Untar provider binaries
+      run: tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin
     - name: Restore binary perms
       run: find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print
         -exec chmod +x {} \;

--- a/actions/providers/f5bigip/repo/.github/workflows/release.yml
+++ b/actions/providers/f5bigip/repo/.github/workflows/release.yml
@@ -56,8 +56,11 @@ jobs:
     - name: Download provider + tfgen binaries
       uses: actions/download-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
+        name: ${{ env.PROVIDER }}-provider.tar.gz
         path: ${{ github.workspace }}/bin
+    - name: Untar provider binaries
+      run: tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin
     - name: Restore binary perms
       run: find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print
         -exec chmod +x {} \;
@@ -201,11 +204,15 @@ jobs:
       uses: pulumi/action-install-pulumi-cli@releases/v1
     - name: Build tfgen & provider binaries
       run: make provider
+    - name: Tar provider binaries
+      run: tar -zcf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin/ pulumi-resource-${{ env.PROVIDER }} pulumi-tfgen-${{ env.PROVIDER
+        }}
     - name: Upload artifacts
       uses: actions/upload-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
-        path: ${{ github.workspace }}/bin
+        name: ${{ env.PROVIDER }}-provider.tar.gz
+        path: ${{ github.workspace }}/bin/provider.tar.gz
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3
@@ -357,8 +364,11 @@ jobs:
     - name: Download provider + tfgen binaries
       uses: actions/download-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
+        name: ${{ env.PROVIDER }}-provider.tar.gz
         path: ${{ github.workspace }}/bin
+    - name: Untar provider binaries
+      run: tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin
     - name: Restore binary perms
       run: find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print
         -exec chmod +x {} \;

--- a/actions/providers/fastly/repo/.github/workflows/master.yml
+++ b/actions/providers/fastly/repo/.github/workflows/master.yml
@@ -53,8 +53,11 @@ jobs:
     - name: Download provider + tfgen binaries
       uses: actions/download-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
+        name: ${{ env.PROVIDER }}-provider.tar.gz
         path: ${{ github.workspace }}/bin
+    - name: Untar provider binaries
+      run: tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin
     - name: Restore binary perms
       run: find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print
         -exec chmod +x {} \;
@@ -185,11 +188,15 @@ jobs:
       uses: pulumi/action-install-pulumi-cli@releases/v1
     - name: Build tfgen & provider binaries
       run: make provider
+    - name: Tar provider binaries
+      run: tar -zcf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin/ pulumi-resource-${{ env.PROVIDER }} pulumi-tfgen-${{ env.PROVIDER
+        }}
     - name: Upload artifacts
       uses: actions/upload-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
-        path: ${{ github.workspace }}/bin
+        name: ${{ env.PROVIDER }}-provider.tar.gz
+        path: ${{ github.workspace }}/bin/provider.tar.gz
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3
@@ -346,8 +353,11 @@ jobs:
     - name: Download provider + tfgen binaries
       uses: actions/download-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
+        name: ${{ env.PROVIDER }}-provider.tar.gz
         path: ${{ github.workspace }}/bin
+    - name: Untar provider binaries
+      run: tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin
     - name: Restore binary perms
       run: find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print
         -exec chmod +x {} \;

--- a/actions/providers/fastly/repo/.github/workflows/prerelease.yml
+++ b/actions/providers/fastly/repo/.github/workflows/prerelease.yml
@@ -53,8 +53,11 @@ jobs:
     - name: Download provider + tfgen binaries
       uses: actions/download-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
+        name: ${{ env.PROVIDER }}-provider.tar.gz
         path: ${{ github.workspace }}/bin
+    - name: Untar provider binaries
+      run: tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin
     - name: Restore binary perms
       run: find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print
         -exec chmod +x {} \;
@@ -185,11 +188,15 @@ jobs:
       uses: pulumi/action-install-pulumi-cli@releases/v1
     - name: Build tfgen & provider binaries
       run: make provider
+    - name: Tar provider binaries
+      run: tar -zcf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin/ pulumi-resource-${{ env.PROVIDER }} pulumi-tfgen-${{ env.PROVIDER
+        }}
     - name: Upload artifacts
       uses: actions/upload-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
-        path: ${{ github.workspace }}/bin
+        name: ${{ env.PROVIDER }}-provider.tar.gz
+        path: ${{ github.workspace }}/bin/provider.tar.gz
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3
@@ -334,8 +341,11 @@ jobs:
     - name: Download provider + tfgen binaries
       uses: actions/download-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
+        name: ${{ env.PROVIDER }}-provider.tar.gz
         path: ${{ github.workspace }}/bin
+    - name: Untar provider binaries
+      run: tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin
     - name: Restore binary perms
       run: find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print
         -exec chmod +x {} \;

--- a/actions/providers/fastly/repo/.github/workflows/pull-request.yml
+++ b/actions/providers/fastly/repo/.github/workflows/pull-request.yml
@@ -53,8 +53,11 @@ jobs:
     - name: Download provider + tfgen binaries
       uses: actions/download-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
+        name: ${{ env.PROVIDER }}-provider.tar.gz
         path: ${{ github.workspace }}/bin
+    - name: Untar provider binaries
+      run: tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin
     - name: Restore binary perms
       run: find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print
         -exec chmod +x {} \;
@@ -185,11 +188,15 @@ jobs:
       uses: pulumi/action-install-pulumi-cli@releases/v1
     - name: Build tfgen & provider binaries
       run: make provider
+    - name: Tar provider binaries
+      run: tar -zcf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin/ pulumi-resource-${{ env.PROVIDER }} pulumi-tfgen-${{ env.PROVIDER
+        }}
     - name: Upload artifacts
       uses: actions/upload-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
-        path: ${{ github.workspace }}/bin
+        name: ${{ env.PROVIDER }}-provider.tar.gz
+        path: ${{ github.workspace }}/bin/provider.tar.gz
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3
@@ -237,8 +244,11 @@ jobs:
     - name: Download provider + tfgen binaries
       uses: actions/download-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
+        name: ${{ env.PROVIDER }}-provider.tar.gz
         path: ${{ github.workspace }}/bin
+    - name: Untar provider binaries
+      run: tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin
     - name: Restore binary perms
       run: find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print
         -exec chmod +x {} \;

--- a/actions/providers/fastly/repo/.github/workflows/release.yml
+++ b/actions/providers/fastly/repo/.github/workflows/release.yml
@@ -53,8 +53,11 @@ jobs:
     - name: Download provider + tfgen binaries
       uses: actions/download-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
+        name: ${{ env.PROVIDER }}-provider.tar.gz
         path: ${{ github.workspace }}/bin
+    - name: Untar provider binaries
+      run: tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin
     - name: Restore binary perms
       run: find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print
         -exec chmod +x {} \;
@@ -198,11 +201,15 @@ jobs:
       uses: pulumi/action-install-pulumi-cli@releases/v1
     - name: Build tfgen & provider binaries
       run: make provider
+    - name: Tar provider binaries
+      run: tar -zcf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin/ pulumi-resource-${{ env.PROVIDER }} pulumi-tfgen-${{ env.PROVIDER
+        }}
     - name: Upload artifacts
       uses: actions/upload-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
-        path: ${{ github.workspace }}/bin
+        name: ${{ env.PROVIDER }}-provider.tar.gz
+        path: ${{ github.workspace }}/bin/provider.tar.gz
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3
@@ -354,8 +361,11 @@ jobs:
     - name: Download provider + tfgen binaries
       uses: actions/download-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
+        name: ${{ env.PROVIDER }}-provider.tar.gz
         path: ${{ github.workspace }}/bin
+    - name: Untar provider binaries
+      run: tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin
     - name: Restore binary perms
       run: find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print
         -exec chmod +x {} \;

--- a/actions/providers/gcp/repo/.github/workflows/master.yml
+++ b/actions/providers/gcp/repo/.github/workflows/master.yml
@@ -55,8 +55,11 @@ jobs:
     - name: Download provider + tfgen binaries
       uses: actions/download-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
+        name: ${{ env.PROVIDER }}-provider.tar.gz
         path: ${{ github.workspace }}/bin
+    - name: Untar provider binaries
+      run: tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin
     - name: Restore binary perms
       run: find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print
         -exec chmod +x {} \;
@@ -120,11 +123,15 @@ jobs:
       uses: pulumi/action-install-pulumi-cli@releases/v1
     - name: Build tfgen & provider binaries
       run: make provider
+    - name: Tar provider binaries
+      run: tar -zcf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin/ pulumi-resource-${{ env.PROVIDER }} pulumi-tfgen-${{ env.PROVIDER
+        }}
     - name: Upload artifacts
       uses: actions/upload-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
-        path: ${{ github.workspace }}/bin
+        name: ${{ env.PROVIDER }}-provider.tar.gz
+        path: ${{ github.workspace }}/bin/provider.tar.gz
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3
@@ -281,8 +288,11 @@ jobs:
     - name: Download provider + tfgen binaries
       uses: actions/download-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
+        name: ${{ env.PROVIDER }}-provider.tar.gz
         path: ${{ github.workspace }}/bin
+    - name: Untar provider binaries
+      run: tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin
     - name: Restore binary perms
       run: find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print
         -exec chmod +x {} \;

--- a/actions/providers/gcp/repo/.github/workflows/prerelease.yml
+++ b/actions/providers/gcp/repo/.github/workflows/prerelease.yml
@@ -55,8 +55,11 @@ jobs:
     - name: Download provider + tfgen binaries
       uses: actions/download-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
+        name: ${{ env.PROVIDER }}-provider.tar.gz
         path: ${{ github.workspace }}/bin
+    - name: Untar provider binaries
+      run: tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin
     - name: Restore binary perms
       run: find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print
         -exec chmod +x {} \;
@@ -120,11 +123,15 @@ jobs:
       uses: pulumi/action-install-pulumi-cli@releases/v1
     - name: Build tfgen & provider binaries
       run: make provider
+    - name: Tar provider binaries
+      run: tar -zcf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin/ pulumi-resource-${{ env.PROVIDER }} pulumi-tfgen-${{ env.PROVIDER
+        }}
     - name: Upload artifacts
       uses: actions/upload-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
-        path: ${{ github.workspace }}/bin
+        name: ${{ env.PROVIDER }}-provider.tar.gz
+        path: ${{ github.workspace }}/bin/provider.tar.gz
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3
@@ -269,8 +276,11 @@ jobs:
     - name: Download provider + tfgen binaries
       uses: actions/download-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
+        name: ${{ env.PROVIDER }}-provider.tar.gz
         path: ${{ github.workspace }}/bin
+    - name: Untar provider binaries
+      run: tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin
     - name: Restore binary perms
       run: find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print
         -exec chmod +x {} \;

--- a/actions/providers/gcp/repo/.github/workflows/pull-request.yml
+++ b/actions/providers/gcp/repo/.github/workflows/pull-request.yml
@@ -55,8 +55,11 @@ jobs:
     - name: Download provider + tfgen binaries
       uses: actions/download-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
+        name: ${{ env.PROVIDER }}-provider.tar.gz
         path: ${{ github.workspace }}/bin
+    - name: Untar provider binaries
+      run: tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin
     - name: Restore binary perms
       run: find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print
         -exec chmod +x {} \;
@@ -120,11 +123,15 @@ jobs:
       uses: pulumi/action-install-pulumi-cli@releases/v1
     - name: Build tfgen & provider binaries
       run: make provider
+    - name: Tar provider binaries
+      run: tar -zcf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin/ pulumi-resource-${{ env.PROVIDER }} pulumi-tfgen-${{ env.PROVIDER
+        }}
     - name: Upload artifacts
       uses: actions/upload-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
-        path: ${{ github.workspace }}/bin
+        name: ${{ env.PROVIDER }}-provider.tar.gz
+        path: ${{ github.workspace }}/bin/provider.tar.gz
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3
@@ -172,8 +179,11 @@ jobs:
     - name: Download provider + tfgen binaries
       uses: actions/download-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
+        name: ${{ env.PROVIDER }}-provider.tar.gz
         path: ${{ github.workspace }}/bin
+    - name: Untar provider binaries
+      run: tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin
     - name: Restore binary perms
       run: find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print
         -exec chmod +x {} \;

--- a/actions/providers/gcp/repo/.github/workflows/release.yml
+++ b/actions/providers/gcp/repo/.github/workflows/release.yml
@@ -55,8 +55,11 @@ jobs:
     - name: Download provider + tfgen binaries
       uses: actions/download-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
+        name: ${{ env.PROVIDER }}-provider.tar.gz
         path: ${{ github.workspace }}/bin
+    - name: Untar provider binaries
+      run: tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin
     - name: Restore binary perms
       run: find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print
         -exec chmod +x {} \;
@@ -133,11 +136,15 @@ jobs:
       uses: pulumi/action-install-pulumi-cli@releases/v1
     - name: Build tfgen & provider binaries
       run: make provider
+    - name: Tar provider binaries
+      run: tar -zcf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin/ pulumi-resource-${{ env.PROVIDER }} pulumi-tfgen-${{ env.PROVIDER
+        }}
     - name: Upload artifacts
       uses: actions/upload-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
-        path: ${{ github.workspace }}/bin
+        name: ${{ env.PROVIDER }}-provider.tar.gz
+        path: ${{ github.workspace }}/bin/provider.tar.gz
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3
@@ -289,8 +296,11 @@ jobs:
     - name: Download provider + tfgen binaries
       uses: actions/download-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
+        name: ${{ env.PROVIDER }}-provider.tar.gz
         path: ${{ github.workspace }}/bin
+    - name: Untar provider binaries
+      run: tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin
     - name: Restore binary perms
       run: find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print
         -exec chmod +x {} \;

--- a/actions/providers/github/repo/.github/workflows/master.yml
+++ b/actions/providers/github/repo/.github/workflows/master.yml
@@ -54,8 +54,11 @@ jobs:
     - name: Download provider + tfgen binaries
       uses: actions/download-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
+        name: ${{ env.PROVIDER }}-provider.tar.gz
         path: ${{ github.workspace }}/bin
+    - name: Untar provider binaries
+      run: tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin
     - name: Restore binary perms
       run: find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print
         -exec chmod +x {} \;
@@ -186,11 +189,15 @@ jobs:
       uses: pulumi/action-install-pulumi-cli@releases/v1
     - name: Build tfgen & provider binaries
       run: make provider
+    - name: Tar provider binaries
+      run: tar -zcf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin/ pulumi-resource-${{ env.PROVIDER }} pulumi-tfgen-${{ env.PROVIDER
+        }}
     - name: Upload artifacts
       uses: actions/upload-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
-        path: ${{ github.workspace }}/bin
+        name: ${{ env.PROVIDER }}-provider.tar.gz
+        path: ${{ github.workspace }}/bin/provider.tar.gz
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3
@@ -347,8 +354,11 @@ jobs:
     - name: Download provider + tfgen binaries
       uses: actions/download-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
+        name: ${{ env.PROVIDER }}-provider.tar.gz
         path: ${{ github.workspace }}/bin
+    - name: Untar provider binaries
+      run: tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin
     - name: Restore binary perms
       run: find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print
         -exec chmod +x {} \;

--- a/actions/providers/github/repo/.github/workflows/prerelease.yml
+++ b/actions/providers/github/repo/.github/workflows/prerelease.yml
@@ -54,8 +54,11 @@ jobs:
     - name: Download provider + tfgen binaries
       uses: actions/download-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
+        name: ${{ env.PROVIDER }}-provider.tar.gz
         path: ${{ github.workspace }}/bin
+    - name: Untar provider binaries
+      run: tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin
     - name: Restore binary perms
       run: find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print
         -exec chmod +x {} \;
@@ -186,11 +189,15 @@ jobs:
       uses: pulumi/action-install-pulumi-cli@releases/v1
     - name: Build tfgen & provider binaries
       run: make provider
+    - name: Tar provider binaries
+      run: tar -zcf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin/ pulumi-resource-${{ env.PROVIDER }} pulumi-tfgen-${{ env.PROVIDER
+        }}
     - name: Upload artifacts
       uses: actions/upload-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
-        path: ${{ github.workspace }}/bin
+        name: ${{ env.PROVIDER }}-provider.tar.gz
+        path: ${{ github.workspace }}/bin/provider.tar.gz
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3
@@ -335,8 +342,11 @@ jobs:
     - name: Download provider + tfgen binaries
       uses: actions/download-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
+        name: ${{ env.PROVIDER }}-provider.tar.gz
         path: ${{ github.workspace }}/bin
+    - name: Untar provider binaries
+      run: tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin
     - name: Restore binary perms
       run: find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print
         -exec chmod +x {} \;

--- a/actions/providers/github/repo/.github/workflows/pull-request.yml
+++ b/actions/providers/github/repo/.github/workflows/pull-request.yml
@@ -54,8 +54,11 @@ jobs:
     - name: Download provider + tfgen binaries
       uses: actions/download-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
+        name: ${{ env.PROVIDER }}-provider.tar.gz
         path: ${{ github.workspace }}/bin
+    - name: Untar provider binaries
+      run: tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin
     - name: Restore binary perms
       run: find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print
         -exec chmod +x {} \;
@@ -186,11 +189,15 @@ jobs:
       uses: pulumi/action-install-pulumi-cli@releases/v1
     - name: Build tfgen & provider binaries
       run: make provider
+    - name: Tar provider binaries
+      run: tar -zcf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin/ pulumi-resource-${{ env.PROVIDER }} pulumi-tfgen-${{ env.PROVIDER
+        }}
     - name: Upload artifacts
       uses: actions/upload-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
-        path: ${{ github.workspace }}/bin
+        name: ${{ env.PROVIDER }}-provider.tar.gz
+        path: ${{ github.workspace }}/bin/provider.tar.gz
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3
@@ -238,8 +245,11 @@ jobs:
     - name: Download provider + tfgen binaries
       uses: actions/download-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
+        name: ${{ env.PROVIDER }}-provider.tar.gz
         path: ${{ github.workspace }}/bin
+    - name: Untar provider binaries
+      run: tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin
     - name: Restore binary perms
       run: find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print
         -exec chmod +x {} \;

--- a/actions/providers/github/repo/.github/workflows/release.yml
+++ b/actions/providers/github/repo/.github/workflows/release.yml
@@ -54,8 +54,11 @@ jobs:
     - name: Download provider + tfgen binaries
       uses: actions/download-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
+        name: ${{ env.PROVIDER }}-provider.tar.gz
         path: ${{ github.workspace }}/bin
+    - name: Untar provider binaries
+      run: tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin
     - name: Restore binary perms
       run: find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print
         -exec chmod +x {} \;
@@ -199,11 +202,15 @@ jobs:
       uses: pulumi/action-install-pulumi-cli@releases/v1
     - name: Build tfgen & provider binaries
       run: make provider
+    - name: Tar provider binaries
+      run: tar -zcf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin/ pulumi-resource-${{ env.PROVIDER }} pulumi-tfgen-${{ env.PROVIDER
+        }}
     - name: Upload artifacts
       uses: actions/upload-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
-        path: ${{ github.workspace }}/bin
+        name: ${{ env.PROVIDER }}-provider.tar.gz
+        path: ${{ github.workspace }}/bin/provider.tar.gz
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3
@@ -355,8 +362,11 @@ jobs:
     - name: Download provider + tfgen binaries
       uses: actions/download-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
+        name: ${{ env.PROVIDER }}-provider.tar.gz
         path: ${{ github.workspace }}/bin
+    - name: Untar provider binaries
+      run: tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin
     - name: Restore binary perms
       run: find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print
         -exec chmod +x {} \;

--- a/actions/providers/gitlab/repo/.github/workflows/master.yml
+++ b/actions/providers/gitlab/repo/.github/workflows/master.yml
@@ -53,8 +53,11 @@ jobs:
     - name: Download provider + tfgen binaries
       uses: actions/download-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
+        name: ${{ env.PROVIDER }}-provider.tar.gz
         path: ${{ github.workspace }}/bin
+    - name: Untar provider binaries
+      run: tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin
     - name: Restore binary perms
       run: find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print
         -exec chmod +x {} \;
@@ -185,11 +188,15 @@ jobs:
       uses: pulumi/action-install-pulumi-cli@releases/v1
     - name: Build tfgen & provider binaries
       run: make provider
+    - name: Tar provider binaries
+      run: tar -zcf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin/ pulumi-resource-${{ env.PROVIDER }} pulumi-tfgen-${{ env.PROVIDER
+        }}
     - name: Upload artifacts
       uses: actions/upload-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
-        path: ${{ github.workspace }}/bin
+        name: ${{ env.PROVIDER }}-provider.tar.gz
+        path: ${{ github.workspace }}/bin/provider.tar.gz
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3
@@ -346,8 +353,11 @@ jobs:
     - name: Download provider + tfgen binaries
       uses: actions/download-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
+        name: ${{ env.PROVIDER }}-provider.tar.gz
         path: ${{ github.workspace }}/bin
+    - name: Untar provider binaries
+      run: tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin
     - name: Restore binary perms
       run: find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print
         -exec chmod +x {} \;

--- a/actions/providers/gitlab/repo/.github/workflows/prerelease.yml
+++ b/actions/providers/gitlab/repo/.github/workflows/prerelease.yml
@@ -53,8 +53,11 @@ jobs:
     - name: Download provider + tfgen binaries
       uses: actions/download-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
+        name: ${{ env.PROVIDER }}-provider.tar.gz
         path: ${{ github.workspace }}/bin
+    - name: Untar provider binaries
+      run: tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin
     - name: Restore binary perms
       run: find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print
         -exec chmod +x {} \;
@@ -185,11 +188,15 @@ jobs:
       uses: pulumi/action-install-pulumi-cli@releases/v1
     - name: Build tfgen & provider binaries
       run: make provider
+    - name: Tar provider binaries
+      run: tar -zcf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin/ pulumi-resource-${{ env.PROVIDER }} pulumi-tfgen-${{ env.PROVIDER
+        }}
     - name: Upload artifacts
       uses: actions/upload-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
-        path: ${{ github.workspace }}/bin
+        name: ${{ env.PROVIDER }}-provider.tar.gz
+        path: ${{ github.workspace }}/bin/provider.tar.gz
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3
@@ -334,8 +341,11 @@ jobs:
     - name: Download provider + tfgen binaries
       uses: actions/download-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
+        name: ${{ env.PROVIDER }}-provider.tar.gz
         path: ${{ github.workspace }}/bin
+    - name: Untar provider binaries
+      run: tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin
     - name: Restore binary perms
       run: find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print
         -exec chmod +x {} \;

--- a/actions/providers/gitlab/repo/.github/workflows/pull-request.yml
+++ b/actions/providers/gitlab/repo/.github/workflows/pull-request.yml
@@ -53,8 +53,11 @@ jobs:
     - name: Download provider + tfgen binaries
       uses: actions/download-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
+        name: ${{ env.PROVIDER }}-provider.tar.gz
         path: ${{ github.workspace }}/bin
+    - name: Untar provider binaries
+      run: tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin
     - name: Restore binary perms
       run: find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print
         -exec chmod +x {} \;
@@ -185,11 +188,15 @@ jobs:
       uses: pulumi/action-install-pulumi-cli@releases/v1
     - name: Build tfgen & provider binaries
       run: make provider
+    - name: Tar provider binaries
+      run: tar -zcf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin/ pulumi-resource-${{ env.PROVIDER }} pulumi-tfgen-${{ env.PROVIDER
+        }}
     - name: Upload artifacts
       uses: actions/upload-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
-        path: ${{ github.workspace }}/bin
+        name: ${{ env.PROVIDER }}-provider.tar.gz
+        path: ${{ github.workspace }}/bin/provider.tar.gz
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3
@@ -237,8 +244,11 @@ jobs:
     - name: Download provider + tfgen binaries
       uses: actions/download-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
+        name: ${{ env.PROVIDER }}-provider.tar.gz
         path: ${{ github.workspace }}/bin
+    - name: Untar provider binaries
+      run: tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin
     - name: Restore binary perms
       run: find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print
         -exec chmod +x {} \;

--- a/actions/providers/gitlab/repo/.github/workflows/release.yml
+++ b/actions/providers/gitlab/repo/.github/workflows/release.yml
@@ -53,8 +53,11 @@ jobs:
     - name: Download provider + tfgen binaries
       uses: actions/download-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
+        name: ${{ env.PROVIDER }}-provider.tar.gz
         path: ${{ github.workspace }}/bin
+    - name: Untar provider binaries
+      run: tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin
     - name: Restore binary perms
       run: find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print
         -exec chmod +x {} \;
@@ -198,11 +201,15 @@ jobs:
       uses: pulumi/action-install-pulumi-cli@releases/v1
     - name: Build tfgen & provider binaries
       run: make provider
+    - name: Tar provider binaries
+      run: tar -zcf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin/ pulumi-resource-${{ env.PROVIDER }} pulumi-tfgen-${{ env.PROVIDER
+        }}
     - name: Upload artifacts
       uses: actions/upload-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
-        path: ${{ github.workspace }}/bin
+        name: ${{ env.PROVIDER }}-provider.tar.gz
+        path: ${{ github.workspace }}/bin/provider.tar.gz
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3
@@ -354,8 +361,11 @@ jobs:
     - name: Download provider + tfgen binaries
       uses: actions/download-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
+        name: ${{ env.PROVIDER }}-provider.tar.gz
         path: ${{ github.workspace }}/bin
+    - name: Untar provider binaries
+      run: tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin
     - name: Restore binary perms
       run: find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print
         -exec chmod +x {} \;

--- a/actions/providers/hcloud/repo/.github/workflows/master.yml
+++ b/actions/providers/hcloud/repo/.github/workflows/master.yml
@@ -53,8 +53,11 @@ jobs:
     - name: Download provider + tfgen binaries
       uses: actions/download-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
+        name: ${{ env.PROVIDER }}-provider.tar.gz
         path: ${{ github.workspace }}/bin
+    - name: Untar provider binaries
+      run: tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin
     - name: Restore binary perms
       run: find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print
         -exec chmod +x {} \;
@@ -185,11 +188,15 @@ jobs:
       uses: pulumi/action-install-pulumi-cli@releases/v1
     - name: Build tfgen & provider binaries
       run: make provider
+    - name: Tar provider binaries
+      run: tar -zcf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin/ pulumi-resource-${{ env.PROVIDER }} pulumi-tfgen-${{ env.PROVIDER
+        }}
     - name: Upload artifacts
       uses: actions/upload-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
-        path: ${{ github.workspace }}/bin
+        name: ${{ env.PROVIDER }}-provider.tar.gz
+        path: ${{ github.workspace }}/bin/provider.tar.gz
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3
@@ -346,8 +353,11 @@ jobs:
     - name: Download provider + tfgen binaries
       uses: actions/download-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
+        name: ${{ env.PROVIDER }}-provider.tar.gz
         path: ${{ github.workspace }}/bin
+    - name: Untar provider binaries
+      run: tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin
     - name: Restore binary perms
       run: find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print
         -exec chmod +x {} \;

--- a/actions/providers/hcloud/repo/.github/workflows/prerelease.yml
+++ b/actions/providers/hcloud/repo/.github/workflows/prerelease.yml
@@ -53,8 +53,11 @@ jobs:
     - name: Download provider + tfgen binaries
       uses: actions/download-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
+        name: ${{ env.PROVIDER }}-provider.tar.gz
         path: ${{ github.workspace }}/bin
+    - name: Untar provider binaries
+      run: tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin
     - name: Restore binary perms
       run: find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print
         -exec chmod +x {} \;
@@ -185,11 +188,15 @@ jobs:
       uses: pulumi/action-install-pulumi-cli@releases/v1
     - name: Build tfgen & provider binaries
       run: make provider
+    - name: Tar provider binaries
+      run: tar -zcf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin/ pulumi-resource-${{ env.PROVIDER }} pulumi-tfgen-${{ env.PROVIDER
+        }}
     - name: Upload artifacts
       uses: actions/upload-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
-        path: ${{ github.workspace }}/bin
+        name: ${{ env.PROVIDER }}-provider.tar.gz
+        path: ${{ github.workspace }}/bin/provider.tar.gz
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3
@@ -334,8 +341,11 @@ jobs:
     - name: Download provider + tfgen binaries
       uses: actions/download-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
+        name: ${{ env.PROVIDER }}-provider.tar.gz
         path: ${{ github.workspace }}/bin
+    - name: Untar provider binaries
+      run: tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin
     - name: Restore binary perms
       run: find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print
         -exec chmod +x {} \;

--- a/actions/providers/hcloud/repo/.github/workflows/pull-request.yml
+++ b/actions/providers/hcloud/repo/.github/workflows/pull-request.yml
@@ -53,8 +53,11 @@ jobs:
     - name: Download provider + tfgen binaries
       uses: actions/download-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
+        name: ${{ env.PROVIDER }}-provider.tar.gz
         path: ${{ github.workspace }}/bin
+    - name: Untar provider binaries
+      run: tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin
     - name: Restore binary perms
       run: find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print
         -exec chmod +x {} \;
@@ -185,11 +188,15 @@ jobs:
       uses: pulumi/action-install-pulumi-cli@releases/v1
     - name: Build tfgen & provider binaries
       run: make provider
+    - name: Tar provider binaries
+      run: tar -zcf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin/ pulumi-resource-${{ env.PROVIDER }} pulumi-tfgen-${{ env.PROVIDER
+        }}
     - name: Upload artifacts
       uses: actions/upload-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
-        path: ${{ github.workspace }}/bin
+        name: ${{ env.PROVIDER }}-provider.tar.gz
+        path: ${{ github.workspace }}/bin/provider.tar.gz
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3
@@ -237,8 +244,11 @@ jobs:
     - name: Download provider + tfgen binaries
       uses: actions/download-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
+        name: ${{ env.PROVIDER }}-provider.tar.gz
         path: ${{ github.workspace }}/bin
+    - name: Untar provider binaries
+      run: tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin
     - name: Restore binary perms
       run: find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print
         -exec chmod +x {} \;

--- a/actions/providers/hcloud/repo/.github/workflows/release.yml
+++ b/actions/providers/hcloud/repo/.github/workflows/release.yml
@@ -53,8 +53,11 @@ jobs:
     - name: Download provider + tfgen binaries
       uses: actions/download-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
+        name: ${{ env.PROVIDER }}-provider.tar.gz
         path: ${{ github.workspace }}/bin
+    - name: Untar provider binaries
+      run: tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin
     - name: Restore binary perms
       run: find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print
         -exec chmod +x {} \;
@@ -198,11 +201,15 @@ jobs:
       uses: pulumi/action-install-pulumi-cli@releases/v1
     - name: Build tfgen & provider binaries
       run: make provider
+    - name: Tar provider binaries
+      run: tar -zcf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin/ pulumi-resource-${{ env.PROVIDER }} pulumi-tfgen-${{ env.PROVIDER
+        }}
     - name: Upload artifacts
       uses: actions/upload-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
-        path: ${{ github.workspace }}/bin
+        name: ${{ env.PROVIDER }}-provider.tar.gz
+        path: ${{ github.workspace }}/bin/provider.tar.gz
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3
@@ -354,8 +361,11 @@ jobs:
     - name: Download provider + tfgen binaries
       uses: actions/download-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
+        name: ${{ env.PROVIDER }}-provider.tar.gz
         path: ${{ github.workspace }}/bin
+    - name: Untar provider binaries
+      run: tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin
     - name: Restore binary perms
       run: find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print
         -exec chmod +x {} \;

--- a/actions/providers/kafka/repo/.github/workflows/master.yml
+++ b/actions/providers/kafka/repo/.github/workflows/master.yml
@@ -52,8 +52,11 @@ jobs:
     - name: Download provider + tfgen binaries
       uses: actions/download-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
+        name: ${{ env.PROVIDER }}-provider.tar.gz
         path: ${{ github.workspace }}/bin
+    - name: Untar provider binaries
+      run: tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin
     - name: Restore binary perms
       run: find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print
         -exec chmod +x {} \;
@@ -184,11 +187,15 @@ jobs:
       uses: pulumi/action-install-pulumi-cli@releases/v1
     - name: Build tfgen & provider binaries
       run: make provider
+    - name: Tar provider binaries
+      run: tar -zcf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin/ pulumi-resource-${{ env.PROVIDER }} pulumi-tfgen-${{ env.PROVIDER
+        }}
     - name: Upload artifacts
       uses: actions/upload-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
-        path: ${{ github.workspace }}/bin
+        name: ${{ env.PROVIDER }}-provider.tar.gz
+        path: ${{ github.workspace }}/bin/provider.tar.gz
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3
@@ -345,8 +352,11 @@ jobs:
     - name: Download provider + tfgen binaries
       uses: actions/download-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
+        name: ${{ env.PROVIDER }}-provider.tar.gz
         path: ${{ github.workspace }}/bin
+    - name: Untar provider binaries
+      run: tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin
     - name: Restore binary perms
       run: find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print
         -exec chmod +x {} \;

--- a/actions/providers/kafka/repo/.github/workflows/prerelease.yml
+++ b/actions/providers/kafka/repo/.github/workflows/prerelease.yml
@@ -52,8 +52,11 @@ jobs:
     - name: Download provider + tfgen binaries
       uses: actions/download-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
+        name: ${{ env.PROVIDER }}-provider.tar.gz
         path: ${{ github.workspace }}/bin
+    - name: Untar provider binaries
+      run: tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin
     - name: Restore binary perms
       run: find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print
         -exec chmod +x {} \;
@@ -184,11 +187,15 @@ jobs:
       uses: pulumi/action-install-pulumi-cli@releases/v1
     - name: Build tfgen & provider binaries
       run: make provider
+    - name: Tar provider binaries
+      run: tar -zcf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin/ pulumi-resource-${{ env.PROVIDER }} pulumi-tfgen-${{ env.PROVIDER
+        }}
     - name: Upload artifacts
       uses: actions/upload-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
-        path: ${{ github.workspace }}/bin
+        name: ${{ env.PROVIDER }}-provider.tar.gz
+        path: ${{ github.workspace }}/bin/provider.tar.gz
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3
@@ -333,8 +340,11 @@ jobs:
     - name: Download provider + tfgen binaries
       uses: actions/download-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
+        name: ${{ env.PROVIDER }}-provider.tar.gz
         path: ${{ github.workspace }}/bin
+    - name: Untar provider binaries
+      run: tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin
     - name: Restore binary perms
       run: find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print
         -exec chmod +x {} \;

--- a/actions/providers/kafka/repo/.github/workflows/pull-request.yml
+++ b/actions/providers/kafka/repo/.github/workflows/pull-request.yml
@@ -52,8 +52,11 @@ jobs:
     - name: Download provider + tfgen binaries
       uses: actions/download-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
+        name: ${{ env.PROVIDER }}-provider.tar.gz
         path: ${{ github.workspace }}/bin
+    - name: Untar provider binaries
+      run: tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin
     - name: Restore binary perms
       run: find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print
         -exec chmod +x {} \;
@@ -184,11 +187,15 @@ jobs:
       uses: pulumi/action-install-pulumi-cli@releases/v1
     - name: Build tfgen & provider binaries
       run: make provider
+    - name: Tar provider binaries
+      run: tar -zcf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin/ pulumi-resource-${{ env.PROVIDER }} pulumi-tfgen-${{ env.PROVIDER
+        }}
     - name: Upload artifacts
       uses: actions/upload-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
-        path: ${{ github.workspace }}/bin
+        name: ${{ env.PROVIDER }}-provider.tar.gz
+        path: ${{ github.workspace }}/bin/provider.tar.gz
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3
@@ -236,8 +243,11 @@ jobs:
     - name: Download provider + tfgen binaries
       uses: actions/download-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
+        name: ${{ env.PROVIDER }}-provider.tar.gz
         path: ${{ github.workspace }}/bin
+    - name: Untar provider binaries
+      run: tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin
     - name: Restore binary perms
       run: find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print
         -exec chmod +x {} \;

--- a/actions/providers/kafka/repo/.github/workflows/release.yml
+++ b/actions/providers/kafka/repo/.github/workflows/release.yml
@@ -52,8 +52,11 @@ jobs:
     - name: Download provider + tfgen binaries
       uses: actions/download-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
+        name: ${{ env.PROVIDER }}-provider.tar.gz
         path: ${{ github.workspace }}/bin
+    - name: Untar provider binaries
+      run: tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin
     - name: Restore binary perms
       run: find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print
         -exec chmod +x {} \;
@@ -197,11 +200,15 @@ jobs:
       uses: pulumi/action-install-pulumi-cli@releases/v1
     - name: Build tfgen & provider binaries
       run: make provider
+    - name: Tar provider binaries
+      run: tar -zcf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin/ pulumi-resource-${{ env.PROVIDER }} pulumi-tfgen-${{ env.PROVIDER
+        }}
     - name: Upload artifacts
       uses: actions/upload-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
-        path: ${{ github.workspace }}/bin
+        name: ${{ env.PROVIDER }}-provider.tar.gz
+        path: ${{ github.workspace }}/bin/provider.tar.gz
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3
@@ -353,8 +360,11 @@ jobs:
     - name: Download provider + tfgen binaries
       uses: actions/download-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
+        name: ${{ env.PROVIDER }}-provider.tar.gz
         path: ${{ github.workspace }}/bin
+    - name: Untar provider binaries
+      run: tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin
     - name: Restore binary perms
       run: find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print
         -exec chmod +x {} \;

--- a/actions/providers/keycloak/repo/.github/workflows/master.yml
+++ b/actions/providers/keycloak/repo/.github/workflows/master.yml
@@ -57,8 +57,11 @@ jobs:
     - name: Download provider + tfgen binaries
       uses: actions/download-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
+        name: ${{ env.PROVIDER }}-provider.tar.gz
         path: ${{ github.workspace }}/bin
+    - name: Untar provider binaries
+      run: tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin
     - name: Restore binary perms
       run: find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print
         -exec chmod +x {} \;
@@ -189,11 +192,15 @@ jobs:
       uses: pulumi/action-install-pulumi-cli@releases/v1
     - name: Build tfgen & provider binaries
       run: make provider
+    - name: Tar provider binaries
+      run: tar -zcf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin/ pulumi-resource-${{ env.PROVIDER }} pulumi-tfgen-${{ env.PROVIDER
+        }}
     - name: Upload artifacts
       uses: actions/upload-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
-        path: ${{ github.workspace }}/bin
+        name: ${{ env.PROVIDER }}-provider.tar.gz
+        path: ${{ github.workspace }}/bin/provider.tar.gz
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3
@@ -350,8 +357,11 @@ jobs:
     - name: Download provider + tfgen binaries
       uses: actions/download-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
+        name: ${{ env.PROVIDER }}-provider.tar.gz
         path: ${{ github.workspace }}/bin
+    - name: Untar provider binaries
+      run: tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin
     - name: Restore binary perms
       run: find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print
         -exec chmod +x {} \;

--- a/actions/providers/keycloak/repo/.github/workflows/prerelease.yml
+++ b/actions/providers/keycloak/repo/.github/workflows/prerelease.yml
@@ -57,8 +57,11 @@ jobs:
     - name: Download provider + tfgen binaries
       uses: actions/download-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
+        name: ${{ env.PROVIDER }}-provider.tar.gz
         path: ${{ github.workspace }}/bin
+    - name: Untar provider binaries
+      run: tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin
     - name: Restore binary perms
       run: find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print
         -exec chmod +x {} \;
@@ -189,11 +192,15 @@ jobs:
       uses: pulumi/action-install-pulumi-cli@releases/v1
     - name: Build tfgen & provider binaries
       run: make provider
+    - name: Tar provider binaries
+      run: tar -zcf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin/ pulumi-resource-${{ env.PROVIDER }} pulumi-tfgen-${{ env.PROVIDER
+        }}
     - name: Upload artifacts
       uses: actions/upload-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
-        path: ${{ github.workspace }}/bin
+        name: ${{ env.PROVIDER }}-provider.tar.gz
+        path: ${{ github.workspace }}/bin/provider.tar.gz
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3
@@ -338,8 +345,11 @@ jobs:
     - name: Download provider + tfgen binaries
       uses: actions/download-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
+        name: ${{ env.PROVIDER }}-provider.tar.gz
         path: ${{ github.workspace }}/bin
+    - name: Untar provider binaries
+      run: tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin
     - name: Restore binary perms
       run: find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print
         -exec chmod +x {} \;

--- a/actions/providers/keycloak/repo/.github/workflows/pull-request.yml
+++ b/actions/providers/keycloak/repo/.github/workflows/pull-request.yml
@@ -57,8 +57,11 @@ jobs:
     - name: Download provider + tfgen binaries
       uses: actions/download-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
+        name: ${{ env.PROVIDER }}-provider.tar.gz
         path: ${{ github.workspace }}/bin
+    - name: Untar provider binaries
+      run: tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin
     - name: Restore binary perms
       run: find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print
         -exec chmod +x {} \;
@@ -189,11 +192,15 @@ jobs:
       uses: pulumi/action-install-pulumi-cli@releases/v1
     - name: Build tfgen & provider binaries
       run: make provider
+    - name: Tar provider binaries
+      run: tar -zcf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin/ pulumi-resource-${{ env.PROVIDER }} pulumi-tfgen-${{ env.PROVIDER
+        }}
     - name: Upload artifacts
       uses: actions/upload-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
-        path: ${{ github.workspace }}/bin
+        name: ${{ env.PROVIDER }}-provider.tar.gz
+        path: ${{ github.workspace }}/bin/provider.tar.gz
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3
@@ -241,8 +248,11 @@ jobs:
     - name: Download provider + tfgen binaries
       uses: actions/download-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
+        name: ${{ env.PROVIDER }}-provider.tar.gz
         path: ${{ github.workspace }}/bin
+    - name: Untar provider binaries
+      run: tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin
     - name: Restore binary perms
       run: find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print
         -exec chmod +x {} \;

--- a/actions/providers/keycloak/repo/.github/workflows/release.yml
+++ b/actions/providers/keycloak/repo/.github/workflows/release.yml
@@ -57,8 +57,11 @@ jobs:
     - name: Download provider + tfgen binaries
       uses: actions/download-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
+        name: ${{ env.PROVIDER }}-provider.tar.gz
         path: ${{ github.workspace }}/bin
+    - name: Untar provider binaries
+      run: tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin
     - name: Restore binary perms
       run: find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print
         -exec chmod +x {} \;
@@ -202,11 +205,15 @@ jobs:
       uses: pulumi/action-install-pulumi-cli@releases/v1
     - name: Build tfgen & provider binaries
       run: make provider
+    - name: Tar provider binaries
+      run: tar -zcf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin/ pulumi-resource-${{ env.PROVIDER }} pulumi-tfgen-${{ env.PROVIDER
+        }}
     - name: Upload artifacts
       uses: actions/upload-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
-        path: ${{ github.workspace }}/bin
+        name: ${{ env.PROVIDER }}-provider.tar.gz
+        path: ${{ github.workspace }}/bin/provider.tar.gz
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3
@@ -358,8 +365,11 @@ jobs:
     - name: Download provider + tfgen binaries
       uses: actions/download-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
+        name: ${{ env.PROVIDER }}-provider.tar.gz
         path: ${{ github.workspace }}/bin
+    - name: Untar provider binaries
+      run: tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin
     - name: Restore binary perms
       run: find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print
         -exec chmod +x {} \;

--- a/actions/providers/kong/repo/.github/workflows/master.yml
+++ b/actions/providers/kong/repo/.github/workflows/master.yml
@@ -52,8 +52,11 @@ jobs:
     - name: Download provider + tfgen binaries
       uses: actions/download-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
+        name: ${{ env.PROVIDER }}-provider.tar.gz
         path: ${{ github.workspace }}/bin
+    - name: Untar provider binaries
+      run: tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin
     - name: Restore binary perms
       run: find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print
         -exec chmod +x {} \;
@@ -184,11 +187,15 @@ jobs:
       uses: pulumi/action-install-pulumi-cli@releases/v1
     - name: Build tfgen & provider binaries
       run: make provider
+    - name: Tar provider binaries
+      run: tar -zcf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin/ pulumi-resource-${{ env.PROVIDER }} pulumi-tfgen-${{ env.PROVIDER
+        }}
     - name: Upload artifacts
       uses: actions/upload-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
-        path: ${{ github.workspace }}/bin
+        name: ${{ env.PROVIDER }}-provider.tar.gz
+        path: ${{ github.workspace }}/bin/provider.tar.gz
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3
@@ -345,8 +352,11 @@ jobs:
     - name: Download provider + tfgen binaries
       uses: actions/download-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
+        name: ${{ env.PROVIDER }}-provider.tar.gz
         path: ${{ github.workspace }}/bin
+    - name: Untar provider binaries
+      run: tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin
     - name: Restore binary perms
       run: find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print
         -exec chmod +x {} \;

--- a/actions/providers/kong/repo/.github/workflows/prerelease.yml
+++ b/actions/providers/kong/repo/.github/workflows/prerelease.yml
@@ -52,8 +52,11 @@ jobs:
     - name: Download provider + tfgen binaries
       uses: actions/download-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
+        name: ${{ env.PROVIDER }}-provider.tar.gz
         path: ${{ github.workspace }}/bin
+    - name: Untar provider binaries
+      run: tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin
     - name: Restore binary perms
       run: find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print
         -exec chmod +x {} \;
@@ -184,11 +187,15 @@ jobs:
       uses: pulumi/action-install-pulumi-cli@releases/v1
     - name: Build tfgen & provider binaries
       run: make provider
+    - name: Tar provider binaries
+      run: tar -zcf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin/ pulumi-resource-${{ env.PROVIDER }} pulumi-tfgen-${{ env.PROVIDER
+        }}
     - name: Upload artifacts
       uses: actions/upload-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
-        path: ${{ github.workspace }}/bin
+        name: ${{ env.PROVIDER }}-provider.tar.gz
+        path: ${{ github.workspace }}/bin/provider.tar.gz
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3
@@ -333,8 +340,11 @@ jobs:
     - name: Download provider + tfgen binaries
       uses: actions/download-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
+        name: ${{ env.PROVIDER }}-provider.tar.gz
         path: ${{ github.workspace }}/bin
+    - name: Untar provider binaries
+      run: tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin
     - name: Restore binary perms
       run: find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print
         -exec chmod +x {} \;

--- a/actions/providers/kong/repo/.github/workflows/pull-request.yml
+++ b/actions/providers/kong/repo/.github/workflows/pull-request.yml
@@ -52,8 +52,11 @@ jobs:
     - name: Download provider + tfgen binaries
       uses: actions/download-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
+        name: ${{ env.PROVIDER }}-provider.tar.gz
         path: ${{ github.workspace }}/bin
+    - name: Untar provider binaries
+      run: tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin
     - name: Restore binary perms
       run: find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print
         -exec chmod +x {} \;
@@ -184,11 +187,15 @@ jobs:
       uses: pulumi/action-install-pulumi-cli@releases/v1
     - name: Build tfgen & provider binaries
       run: make provider
+    - name: Tar provider binaries
+      run: tar -zcf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin/ pulumi-resource-${{ env.PROVIDER }} pulumi-tfgen-${{ env.PROVIDER
+        }}
     - name: Upload artifacts
       uses: actions/upload-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
-        path: ${{ github.workspace }}/bin
+        name: ${{ env.PROVIDER }}-provider.tar.gz
+        path: ${{ github.workspace }}/bin/provider.tar.gz
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3
@@ -236,8 +243,11 @@ jobs:
     - name: Download provider + tfgen binaries
       uses: actions/download-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
+        name: ${{ env.PROVIDER }}-provider.tar.gz
         path: ${{ github.workspace }}/bin
+    - name: Untar provider binaries
+      run: tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin
     - name: Restore binary perms
       run: find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print
         -exec chmod +x {} \;

--- a/actions/providers/kong/repo/.github/workflows/release.yml
+++ b/actions/providers/kong/repo/.github/workflows/release.yml
@@ -52,8 +52,11 @@ jobs:
     - name: Download provider + tfgen binaries
       uses: actions/download-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
+        name: ${{ env.PROVIDER }}-provider.tar.gz
         path: ${{ github.workspace }}/bin
+    - name: Untar provider binaries
+      run: tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin
     - name: Restore binary perms
       run: find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print
         -exec chmod +x {} \;
@@ -197,11 +200,15 @@ jobs:
       uses: pulumi/action-install-pulumi-cli@releases/v1
     - name: Build tfgen & provider binaries
       run: make provider
+    - name: Tar provider binaries
+      run: tar -zcf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin/ pulumi-resource-${{ env.PROVIDER }} pulumi-tfgen-${{ env.PROVIDER
+        }}
     - name: Upload artifacts
       uses: actions/upload-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
-        path: ${{ github.workspace }}/bin
+        name: ${{ env.PROVIDER }}-provider.tar.gz
+        path: ${{ github.workspace }}/bin/provider.tar.gz
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3
@@ -353,8 +360,11 @@ jobs:
     - name: Download provider + tfgen binaries
       uses: actions/download-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
+        name: ${{ env.PROVIDER }}-provider.tar.gz
         path: ${{ github.workspace }}/bin
+    - name: Untar provider binaries
+      run: tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin
     - name: Restore binary perms
       run: find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print
         -exec chmod +x {} \;

--- a/actions/providers/linode/repo/.github/workflows/master.yml
+++ b/actions/providers/linode/repo/.github/workflows/master.yml
@@ -53,8 +53,11 @@ jobs:
     - name: Download provider + tfgen binaries
       uses: actions/download-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
+        name: ${{ env.PROVIDER }}-provider.tar.gz
         path: ${{ github.workspace }}/bin
+    - name: Untar provider binaries
+      run: tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin
     - name: Restore binary perms
       run: find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print
         -exec chmod +x {} \;
@@ -185,11 +188,15 @@ jobs:
       uses: pulumi/action-install-pulumi-cli@releases/v1
     - name: Build tfgen & provider binaries
       run: make provider
+    - name: Tar provider binaries
+      run: tar -zcf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin/ pulumi-resource-${{ env.PROVIDER }} pulumi-tfgen-${{ env.PROVIDER
+        }}
     - name: Upload artifacts
       uses: actions/upload-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
-        path: ${{ github.workspace }}/bin
+        name: ${{ env.PROVIDER }}-provider.tar.gz
+        path: ${{ github.workspace }}/bin/provider.tar.gz
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3
@@ -346,8 +353,11 @@ jobs:
     - name: Download provider + tfgen binaries
       uses: actions/download-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
+        name: ${{ env.PROVIDER }}-provider.tar.gz
         path: ${{ github.workspace }}/bin
+    - name: Untar provider binaries
+      run: tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin
     - name: Restore binary perms
       run: find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print
         -exec chmod +x {} \;

--- a/actions/providers/linode/repo/.github/workflows/prerelease.yml
+++ b/actions/providers/linode/repo/.github/workflows/prerelease.yml
@@ -53,8 +53,11 @@ jobs:
     - name: Download provider + tfgen binaries
       uses: actions/download-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
+        name: ${{ env.PROVIDER }}-provider.tar.gz
         path: ${{ github.workspace }}/bin
+    - name: Untar provider binaries
+      run: tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin
     - name: Restore binary perms
       run: find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print
         -exec chmod +x {} \;
@@ -185,11 +188,15 @@ jobs:
       uses: pulumi/action-install-pulumi-cli@releases/v1
     - name: Build tfgen & provider binaries
       run: make provider
+    - name: Tar provider binaries
+      run: tar -zcf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin/ pulumi-resource-${{ env.PROVIDER }} pulumi-tfgen-${{ env.PROVIDER
+        }}
     - name: Upload artifacts
       uses: actions/upload-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
-        path: ${{ github.workspace }}/bin
+        name: ${{ env.PROVIDER }}-provider.tar.gz
+        path: ${{ github.workspace }}/bin/provider.tar.gz
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3
@@ -334,8 +341,11 @@ jobs:
     - name: Download provider + tfgen binaries
       uses: actions/download-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
+        name: ${{ env.PROVIDER }}-provider.tar.gz
         path: ${{ github.workspace }}/bin
+    - name: Untar provider binaries
+      run: tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin
     - name: Restore binary perms
       run: find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print
         -exec chmod +x {} \;

--- a/actions/providers/linode/repo/.github/workflows/pull-request.yml
+++ b/actions/providers/linode/repo/.github/workflows/pull-request.yml
@@ -53,8 +53,11 @@ jobs:
     - name: Download provider + tfgen binaries
       uses: actions/download-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
+        name: ${{ env.PROVIDER }}-provider.tar.gz
         path: ${{ github.workspace }}/bin
+    - name: Untar provider binaries
+      run: tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin
     - name: Restore binary perms
       run: find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print
         -exec chmod +x {} \;
@@ -185,11 +188,15 @@ jobs:
       uses: pulumi/action-install-pulumi-cli@releases/v1
     - name: Build tfgen & provider binaries
       run: make provider
+    - name: Tar provider binaries
+      run: tar -zcf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin/ pulumi-resource-${{ env.PROVIDER }} pulumi-tfgen-${{ env.PROVIDER
+        }}
     - name: Upload artifacts
       uses: actions/upload-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
-        path: ${{ github.workspace }}/bin
+        name: ${{ env.PROVIDER }}-provider.tar.gz
+        path: ${{ github.workspace }}/bin/provider.tar.gz
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3
@@ -237,8 +244,11 @@ jobs:
     - name: Download provider + tfgen binaries
       uses: actions/download-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
+        name: ${{ env.PROVIDER }}-provider.tar.gz
         path: ${{ github.workspace }}/bin
+    - name: Untar provider binaries
+      run: tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin
     - name: Restore binary perms
       run: find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print
         -exec chmod +x {} \;

--- a/actions/providers/linode/repo/.github/workflows/release.yml
+++ b/actions/providers/linode/repo/.github/workflows/release.yml
@@ -53,8 +53,11 @@ jobs:
     - name: Download provider + tfgen binaries
       uses: actions/download-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
+        name: ${{ env.PROVIDER }}-provider.tar.gz
         path: ${{ github.workspace }}/bin
+    - name: Untar provider binaries
+      run: tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin
     - name: Restore binary perms
       run: find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print
         -exec chmod +x {} \;
@@ -198,11 +201,15 @@ jobs:
       uses: pulumi/action-install-pulumi-cli@releases/v1
     - name: Build tfgen & provider binaries
       run: make provider
+    - name: Tar provider binaries
+      run: tar -zcf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin/ pulumi-resource-${{ env.PROVIDER }} pulumi-tfgen-${{ env.PROVIDER
+        }}
     - name: Upload artifacts
       uses: actions/upload-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
-        path: ${{ github.workspace }}/bin
+        name: ${{ env.PROVIDER }}-provider.tar.gz
+        path: ${{ github.workspace }}/bin/provider.tar.gz
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3
@@ -354,8 +361,11 @@ jobs:
     - name: Download provider + tfgen binaries
       uses: actions/download-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
+        name: ${{ env.PROVIDER }}-provider.tar.gz
         path: ${{ github.workspace }}/bin
+    - name: Untar provider binaries
+      run: tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin
     - name: Restore binary perms
       run: find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print
         -exec chmod +x {} \;

--- a/actions/providers/mailgun/repo/.github/workflows/master.yml
+++ b/actions/providers/mailgun/repo/.github/workflows/master.yml
@@ -53,8 +53,11 @@ jobs:
     - name: Download provider + tfgen binaries
       uses: actions/download-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
+        name: ${{ env.PROVIDER }}-provider.tar.gz
         path: ${{ github.workspace }}/bin
+    - name: Untar provider binaries
+      run: tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin
     - name: Restore binary perms
       run: find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print
         -exec chmod +x {} \;
@@ -185,11 +188,15 @@ jobs:
       uses: pulumi/action-install-pulumi-cli@releases/v1
     - name: Build tfgen & provider binaries
       run: make provider
+    - name: Tar provider binaries
+      run: tar -zcf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin/ pulumi-resource-${{ env.PROVIDER }} pulumi-tfgen-${{ env.PROVIDER
+        }}
     - name: Upload artifacts
       uses: actions/upload-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
-        path: ${{ github.workspace }}/bin
+        name: ${{ env.PROVIDER }}-provider.tar.gz
+        path: ${{ github.workspace }}/bin/provider.tar.gz
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3
@@ -346,8 +353,11 @@ jobs:
     - name: Download provider + tfgen binaries
       uses: actions/download-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
+        name: ${{ env.PROVIDER }}-provider.tar.gz
         path: ${{ github.workspace }}/bin
+    - name: Untar provider binaries
+      run: tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin
     - name: Restore binary perms
       run: find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print
         -exec chmod +x {} \;

--- a/actions/providers/mailgun/repo/.github/workflows/prerelease.yml
+++ b/actions/providers/mailgun/repo/.github/workflows/prerelease.yml
@@ -53,8 +53,11 @@ jobs:
     - name: Download provider + tfgen binaries
       uses: actions/download-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
+        name: ${{ env.PROVIDER }}-provider.tar.gz
         path: ${{ github.workspace }}/bin
+    - name: Untar provider binaries
+      run: tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin
     - name: Restore binary perms
       run: find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print
         -exec chmod +x {} \;
@@ -185,11 +188,15 @@ jobs:
       uses: pulumi/action-install-pulumi-cli@releases/v1
     - name: Build tfgen & provider binaries
       run: make provider
+    - name: Tar provider binaries
+      run: tar -zcf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin/ pulumi-resource-${{ env.PROVIDER }} pulumi-tfgen-${{ env.PROVIDER
+        }}
     - name: Upload artifacts
       uses: actions/upload-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
-        path: ${{ github.workspace }}/bin
+        name: ${{ env.PROVIDER }}-provider.tar.gz
+        path: ${{ github.workspace }}/bin/provider.tar.gz
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3
@@ -334,8 +341,11 @@ jobs:
     - name: Download provider + tfgen binaries
       uses: actions/download-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
+        name: ${{ env.PROVIDER }}-provider.tar.gz
         path: ${{ github.workspace }}/bin
+    - name: Untar provider binaries
+      run: tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin
     - name: Restore binary perms
       run: find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print
         -exec chmod +x {} \;

--- a/actions/providers/mailgun/repo/.github/workflows/pull-request.yml
+++ b/actions/providers/mailgun/repo/.github/workflows/pull-request.yml
@@ -53,8 +53,11 @@ jobs:
     - name: Download provider + tfgen binaries
       uses: actions/download-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
+        name: ${{ env.PROVIDER }}-provider.tar.gz
         path: ${{ github.workspace }}/bin
+    - name: Untar provider binaries
+      run: tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin
     - name: Restore binary perms
       run: find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print
         -exec chmod +x {} \;
@@ -185,11 +188,15 @@ jobs:
       uses: pulumi/action-install-pulumi-cli@releases/v1
     - name: Build tfgen & provider binaries
       run: make provider
+    - name: Tar provider binaries
+      run: tar -zcf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin/ pulumi-resource-${{ env.PROVIDER }} pulumi-tfgen-${{ env.PROVIDER
+        }}
     - name: Upload artifacts
       uses: actions/upload-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
-        path: ${{ github.workspace }}/bin
+        name: ${{ env.PROVIDER }}-provider.tar.gz
+        path: ${{ github.workspace }}/bin/provider.tar.gz
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3
@@ -237,8 +244,11 @@ jobs:
     - name: Download provider + tfgen binaries
       uses: actions/download-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
+        name: ${{ env.PROVIDER }}-provider.tar.gz
         path: ${{ github.workspace }}/bin
+    - name: Untar provider binaries
+      run: tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin
     - name: Restore binary perms
       run: find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print
         -exec chmod +x {} \;

--- a/actions/providers/mailgun/repo/.github/workflows/release.yml
+++ b/actions/providers/mailgun/repo/.github/workflows/release.yml
@@ -53,8 +53,11 @@ jobs:
     - name: Download provider + tfgen binaries
       uses: actions/download-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
+        name: ${{ env.PROVIDER }}-provider.tar.gz
         path: ${{ github.workspace }}/bin
+    - name: Untar provider binaries
+      run: tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin
     - name: Restore binary perms
       run: find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print
         -exec chmod +x {} \;
@@ -198,11 +201,15 @@ jobs:
       uses: pulumi/action-install-pulumi-cli@releases/v1
     - name: Build tfgen & provider binaries
       run: make provider
+    - name: Tar provider binaries
+      run: tar -zcf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin/ pulumi-resource-${{ env.PROVIDER }} pulumi-tfgen-${{ env.PROVIDER
+        }}
     - name: Upload artifacts
       uses: actions/upload-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
-        path: ${{ github.workspace }}/bin
+        name: ${{ env.PROVIDER }}-provider.tar.gz
+        path: ${{ github.workspace }}/bin/provider.tar.gz
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3
@@ -354,8 +361,11 @@ jobs:
     - name: Download provider + tfgen binaries
       uses: actions/download-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
+        name: ${{ env.PROVIDER }}-provider.tar.gz
         path: ${{ github.workspace }}/bin
+    - name: Untar provider binaries
+      run: tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin
     - name: Restore binary perms
       run: find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print
         -exec chmod +x {} \;

--- a/actions/providers/mongodbatlas/repo/.github/workflows/master.yml
+++ b/actions/providers/mongodbatlas/repo/.github/workflows/master.yml
@@ -55,8 +55,11 @@ jobs:
     - name: Download provider + tfgen binaries
       uses: actions/download-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
+        name: ${{ env.PROVIDER }}-provider.tar.gz
         path: ${{ github.workspace }}/bin
+    - name: Untar provider binaries
+      run: tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin
     - name: Restore binary perms
       run: find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print
         -exec chmod +x {} \;
@@ -187,11 +190,15 @@ jobs:
       uses: pulumi/action-install-pulumi-cli@releases/v1
     - name: Build tfgen & provider binaries
       run: make provider
+    - name: Tar provider binaries
+      run: tar -zcf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin/ pulumi-resource-${{ env.PROVIDER }} pulumi-tfgen-${{ env.PROVIDER
+        }}
     - name: Upload artifacts
       uses: actions/upload-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
-        path: ${{ github.workspace }}/bin
+        name: ${{ env.PROVIDER }}-provider.tar.gz
+        path: ${{ github.workspace }}/bin/provider.tar.gz
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3
@@ -348,8 +355,11 @@ jobs:
     - name: Download provider + tfgen binaries
       uses: actions/download-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
+        name: ${{ env.PROVIDER }}-provider.tar.gz
         path: ${{ github.workspace }}/bin
+    - name: Untar provider binaries
+      run: tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin
     - name: Restore binary perms
       run: find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print
         -exec chmod +x {} \;

--- a/actions/providers/mongodbatlas/repo/.github/workflows/prerelease.yml
+++ b/actions/providers/mongodbatlas/repo/.github/workflows/prerelease.yml
@@ -55,8 +55,11 @@ jobs:
     - name: Download provider + tfgen binaries
       uses: actions/download-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
+        name: ${{ env.PROVIDER }}-provider.tar.gz
         path: ${{ github.workspace }}/bin
+    - name: Untar provider binaries
+      run: tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin
     - name: Restore binary perms
       run: find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print
         -exec chmod +x {} \;
@@ -187,11 +190,15 @@ jobs:
       uses: pulumi/action-install-pulumi-cli@releases/v1
     - name: Build tfgen & provider binaries
       run: make provider
+    - name: Tar provider binaries
+      run: tar -zcf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin/ pulumi-resource-${{ env.PROVIDER }} pulumi-tfgen-${{ env.PROVIDER
+        }}
     - name: Upload artifacts
       uses: actions/upload-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
-        path: ${{ github.workspace }}/bin
+        name: ${{ env.PROVIDER }}-provider.tar.gz
+        path: ${{ github.workspace }}/bin/provider.tar.gz
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3
@@ -336,8 +343,11 @@ jobs:
     - name: Download provider + tfgen binaries
       uses: actions/download-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
+        name: ${{ env.PROVIDER }}-provider.tar.gz
         path: ${{ github.workspace }}/bin
+    - name: Untar provider binaries
+      run: tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin
     - name: Restore binary perms
       run: find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print
         -exec chmod +x {} \;

--- a/actions/providers/mongodbatlas/repo/.github/workflows/pull-request.yml
+++ b/actions/providers/mongodbatlas/repo/.github/workflows/pull-request.yml
@@ -55,8 +55,11 @@ jobs:
     - name: Download provider + tfgen binaries
       uses: actions/download-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
+        name: ${{ env.PROVIDER }}-provider.tar.gz
         path: ${{ github.workspace }}/bin
+    - name: Untar provider binaries
+      run: tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin
     - name: Restore binary perms
       run: find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print
         -exec chmod +x {} \;
@@ -187,11 +190,15 @@ jobs:
       uses: pulumi/action-install-pulumi-cli@releases/v1
     - name: Build tfgen & provider binaries
       run: make provider
+    - name: Tar provider binaries
+      run: tar -zcf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin/ pulumi-resource-${{ env.PROVIDER }} pulumi-tfgen-${{ env.PROVIDER
+        }}
     - name: Upload artifacts
       uses: actions/upload-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
-        path: ${{ github.workspace }}/bin
+        name: ${{ env.PROVIDER }}-provider.tar.gz
+        path: ${{ github.workspace }}/bin/provider.tar.gz
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3
@@ -239,8 +246,11 @@ jobs:
     - name: Download provider + tfgen binaries
       uses: actions/download-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
+        name: ${{ env.PROVIDER }}-provider.tar.gz
         path: ${{ github.workspace }}/bin
+    - name: Untar provider binaries
+      run: tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin
     - name: Restore binary perms
       run: find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print
         -exec chmod +x {} \;

--- a/actions/providers/mongodbatlas/repo/.github/workflows/release.yml
+++ b/actions/providers/mongodbatlas/repo/.github/workflows/release.yml
@@ -55,8 +55,11 @@ jobs:
     - name: Download provider + tfgen binaries
       uses: actions/download-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
+        name: ${{ env.PROVIDER }}-provider.tar.gz
         path: ${{ github.workspace }}/bin
+    - name: Untar provider binaries
+      run: tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin
     - name: Restore binary perms
       run: find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print
         -exec chmod +x {} \;
@@ -200,11 +203,15 @@ jobs:
       uses: pulumi/action-install-pulumi-cli@releases/v1
     - name: Build tfgen & provider binaries
       run: make provider
+    - name: Tar provider binaries
+      run: tar -zcf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin/ pulumi-resource-${{ env.PROVIDER }} pulumi-tfgen-${{ env.PROVIDER
+        }}
     - name: Upload artifacts
       uses: actions/upload-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
-        path: ${{ github.workspace }}/bin
+        name: ${{ env.PROVIDER }}-provider.tar.gz
+        path: ${{ github.workspace }}/bin/provider.tar.gz
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3
@@ -356,8 +363,11 @@ jobs:
     - name: Download provider + tfgen binaries
       uses: actions/download-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
+        name: ${{ env.PROVIDER }}-provider.tar.gz
         path: ${{ github.workspace }}/bin
+    - name: Untar provider binaries
+      run: tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin
     - name: Restore binary perms
       run: find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print
         -exec chmod +x {} \;

--- a/actions/providers/mysql/repo/.github/workflows/master.yml
+++ b/actions/providers/mysql/repo/.github/workflows/master.yml
@@ -52,8 +52,11 @@ jobs:
     - name: Download provider + tfgen binaries
       uses: actions/download-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
+        name: ${{ env.PROVIDER }}-provider.tar.gz
         path: ${{ github.workspace }}/bin
+    - name: Untar provider binaries
+      run: tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin
     - name: Restore binary perms
       run: find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print
         -exec chmod +x {} \;
@@ -184,11 +187,15 @@ jobs:
       uses: pulumi/action-install-pulumi-cli@releases/v1
     - name: Build tfgen & provider binaries
       run: make provider
+    - name: Tar provider binaries
+      run: tar -zcf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin/ pulumi-resource-${{ env.PROVIDER }} pulumi-tfgen-${{ env.PROVIDER
+        }}
     - name: Upload artifacts
       uses: actions/upload-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
-        path: ${{ github.workspace }}/bin
+        name: ${{ env.PROVIDER }}-provider.tar.gz
+        path: ${{ github.workspace }}/bin/provider.tar.gz
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3
@@ -345,8 +352,11 @@ jobs:
     - name: Download provider + tfgen binaries
       uses: actions/download-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
+        name: ${{ env.PROVIDER }}-provider.tar.gz
         path: ${{ github.workspace }}/bin
+    - name: Untar provider binaries
+      run: tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin
     - name: Restore binary perms
       run: find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print
         -exec chmod +x {} \;

--- a/actions/providers/mysql/repo/.github/workflows/prerelease.yml
+++ b/actions/providers/mysql/repo/.github/workflows/prerelease.yml
@@ -52,8 +52,11 @@ jobs:
     - name: Download provider + tfgen binaries
       uses: actions/download-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
+        name: ${{ env.PROVIDER }}-provider.tar.gz
         path: ${{ github.workspace }}/bin
+    - name: Untar provider binaries
+      run: tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin
     - name: Restore binary perms
       run: find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print
         -exec chmod +x {} \;
@@ -184,11 +187,15 @@ jobs:
       uses: pulumi/action-install-pulumi-cli@releases/v1
     - name: Build tfgen & provider binaries
       run: make provider
+    - name: Tar provider binaries
+      run: tar -zcf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin/ pulumi-resource-${{ env.PROVIDER }} pulumi-tfgen-${{ env.PROVIDER
+        }}
     - name: Upload artifacts
       uses: actions/upload-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
-        path: ${{ github.workspace }}/bin
+        name: ${{ env.PROVIDER }}-provider.tar.gz
+        path: ${{ github.workspace }}/bin/provider.tar.gz
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3
@@ -333,8 +340,11 @@ jobs:
     - name: Download provider + tfgen binaries
       uses: actions/download-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
+        name: ${{ env.PROVIDER }}-provider.tar.gz
         path: ${{ github.workspace }}/bin
+    - name: Untar provider binaries
+      run: tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin
     - name: Restore binary perms
       run: find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print
         -exec chmod +x {} \;

--- a/actions/providers/mysql/repo/.github/workflows/pull-request.yml
+++ b/actions/providers/mysql/repo/.github/workflows/pull-request.yml
@@ -52,8 +52,11 @@ jobs:
     - name: Download provider + tfgen binaries
       uses: actions/download-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
+        name: ${{ env.PROVIDER }}-provider.tar.gz
         path: ${{ github.workspace }}/bin
+    - name: Untar provider binaries
+      run: tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin
     - name: Restore binary perms
       run: find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print
         -exec chmod +x {} \;
@@ -184,11 +187,15 @@ jobs:
       uses: pulumi/action-install-pulumi-cli@releases/v1
     - name: Build tfgen & provider binaries
       run: make provider
+    - name: Tar provider binaries
+      run: tar -zcf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin/ pulumi-resource-${{ env.PROVIDER }} pulumi-tfgen-${{ env.PROVIDER
+        }}
     - name: Upload artifacts
       uses: actions/upload-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
-        path: ${{ github.workspace }}/bin
+        name: ${{ env.PROVIDER }}-provider.tar.gz
+        path: ${{ github.workspace }}/bin/provider.tar.gz
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3
@@ -236,8 +243,11 @@ jobs:
     - name: Download provider + tfgen binaries
       uses: actions/download-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
+        name: ${{ env.PROVIDER }}-provider.tar.gz
         path: ${{ github.workspace }}/bin
+    - name: Untar provider binaries
+      run: tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin
     - name: Restore binary perms
       run: find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print
         -exec chmod +x {} \;

--- a/actions/providers/mysql/repo/.github/workflows/release.yml
+++ b/actions/providers/mysql/repo/.github/workflows/release.yml
@@ -52,8 +52,11 @@ jobs:
     - name: Download provider + tfgen binaries
       uses: actions/download-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
+        name: ${{ env.PROVIDER }}-provider.tar.gz
         path: ${{ github.workspace }}/bin
+    - name: Untar provider binaries
+      run: tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin
     - name: Restore binary perms
       run: find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print
         -exec chmod +x {} \;
@@ -197,11 +200,15 @@ jobs:
       uses: pulumi/action-install-pulumi-cli@releases/v1
     - name: Build tfgen & provider binaries
       run: make provider
+    - name: Tar provider binaries
+      run: tar -zcf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin/ pulumi-resource-${{ env.PROVIDER }} pulumi-tfgen-${{ env.PROVIDER
+        }}
     - name: Upload artifacts
       uses: actions/upload-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
-        path: ${{ github.workspace }}/bin
+        name: ${{ env.PROVIDER }}-provider.tar.gz
+        path: ${{ github.workspace }}/bin/provider.tar.gz
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3
@@ -353,8 +360,11 @@ jobs:
     - name: Download provider + tfgen binaries
       uses: actions/download-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
+        name: ${{ env.PROVIDER }}-provider.tar.gz
         path: ${{ github.workspace }}/bin
+    - name: Untar provider binaries
+      run: tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin
     - name: Restore binary perms
       run: find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print
         -exec chmod +x {} \;

--- a/actions/providers/newrelic/repo/.github/workflows/master.yml
+++ b/actions/providers/newrelic/repo/.github/workflows/master.yml
@@ -54,8 +54,11 @@ jobs:
     - name: Download provider + tfgen binaries
       uses: actions/download-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
+        name: ${{ env.PROVIDER }}-provider.tar.gz
         path: ${{ github.workspace }}/bin
+    - name: Untar provider binaries
+      run: tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin
     - name: Restore binary perms
       run: find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print
         -exec chmod +x {} \;
@@ -186,11 +189,15 @@ jobs:
       uses: pulumi/action-install-pulumi-cli@releases/v1
     - name: Build tfgen & provider binaries
       run: make provider
+    - name: Tar provider binaries
+      run: tar -zcf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin/ pulumi-resource-${{ env.PROVIDER }} pulumi-tfgen-${{ env.PROVIDER
+        }}
     - name: Upload artifacts
       uses: actions/upload-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
-        path: ${{ github.workspace }}/bin
+        name: ${{ env.PROVIDER }}-provider.tar.gz
+        path: ${{ github.workspace }}/bin/provider.tar.gz
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3
@@ -347,8 +354,11 @@ jobs:
     - name: Download provider + tfgen binaries
       uses: actions/download-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
+        name: ${{ env.PROVIDER }}-provider.tar.gz
         path: ${{ github.workspace }}/bin
+    - name: Untar provider binaries
+      run: tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin
     - name: Restore binary perms
       run: find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print
         -exec chmod +x {} \;

--- a/actions/providers/newrelic/repo/.github/workflows/prerelease.yml
+++ b/actions/providers/newrelic/repo/.github/workflows/prerelease.yml
@@ -54,8 +54,11 @@ jobs:
     - name: Download provider + tfgen binaries
       uses: actions/download-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
+        name: ${{ env.PROVIDER }}-provider.tar.gz
         path: ${{ github.workspace }}/bin
+    - name: Untar provider binaries
+      run: tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin
     - name: Restore binary perms
       run: find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print
         -exec chmod +x {} \;
@@ -186,11 +189,15 @@ jobs:
       uses: pulumi/action-install-pulumi-cli@releases/v1
     - name: Build tfgen & provider binaries
       run: make provider
+    - name: Tar provider binaries
+      run: tar -zcf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin/ pulumi-resource-${{ env.PROVIDER }} pulumi-tfgen-${{ env.PROVIDER
+        }}
     - name: Upload artifacts
       uses: actions/upload-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
-        path: ${{ github.workspace }}/bin
+        name: ${{ env.PROVIDER }}-provider.tar.gz
+        path: ${{ github.workspace }}/bin/provider.tar.gz
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3
@@ -335,8 +342,11 @@ jobs:
     - name: Download provider + tfgen binaries
       uses: actions/download-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
+        name: ${{ env.PROVIDER }}-provider.tar.gz
         path: ${{ github.workspace }}/bin
+    - name: Untar provider binaries
+      run: tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin
     - name: Restore binary perms
       run: find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print
         -exec chmod +x {} \;

--- a/actions/providers/newrelic/repo/.github/workflows/pull-request.yml
+++ b/actions/providers/newrelic/repo/.github/workflows/pull-request.yml
@@ -54,8 +54,11 @@ jobs:
     - name: Download provider + tfgen binaries
       uses: actions/download-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
+        name: ${{ env.PROVIDER }}-provider.tar.gz
         path: ${{ github.workspace }}/bin
+    - name: Untar provider binaries
+      run: tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin
     - name: Restore binary perms
       run: find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print
         -exec chmod +x {} \;
@@ -186,11 +189,15 @@ jobs:
       uses: pulumi/action-install-pulumi-cli@releases/v1
     - name: Build tfgen & provider binaries
       run: make provider
+    - name: Tar provider binaries
+      run: tar -zcf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin/ pulumi-resource-${{ env.PROVIDER }} pulumi-tfgen-${{ env.PROVIDER
+        }}
     - name: Upload artifacts
       uses: actions/upload-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
-        path: ${{ github.workspace }}/bin
+        name: ${{ env.PROVIDER }}-provider.tar.gz
+        path: ${{ github.workspace }}/bin/provider.tar.gz
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3
@@ -238,8 +245,11 @@ jobs:
     - name: Download provider + tfgen binaries
       uses: actions/download-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
+        name: ${{ env.PROVIDER }}-provider.tar.gz
         path: ${{ github.workspace }}/bin
+    - name: Untar provider binaries
+      run: tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin
     - name: Restore binary perms
       run: find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print
         -exec chmod +x {} \;

--- a/actions/providers/newrelic/repo/.github/workflows/release.yml
+++ b/actions/providers/newrelic/repo/.github/workflows/release.yml
@@ -54,8 +54,11 @@ jobs:
     - name: Download provider + tfgen binaries
       uses: actions/download-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
+        name: ${{ env.PROVIDER }}-provider.tar.gz
         path: ${{ github.workspace }}/bin
+    - name: Untar provider binaries
+      run: tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin
     - name: Restore binary perms
       run: find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print
         -exec chmod +x {} \;
@@ -199,11 +202,15 @@ jobs:
       uses: pulumi/action-install-pulumi-cli@releases/v1
     - name: Build tfgen & provider binaries
       run: make provider
+    - name: Tar provider binaries
+      run: tar -zcf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin/ pulumi-resource-${{ env.PROVIDER }} pulumi-tfgen-${{ env.PROVIDER
+        }}
     - name: Upload artifacts
       uses: actions/upload-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
-        path: ${{ github.workspace }}/bin
+        name: ${{ env.PROVIDER }}-provider.tar.gz
+        path: ${{ github.workspace }}/bin/provider.tar.gz
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3
@@ -355,8 +362,11 @@ jobs:
     - name: Download provider + tfgen binaries
       uses: actions/download-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
+        name: ${{ env.PROVIDER }}-provider.tar.gz
         path: ${{ github.workspace }}/bin
+    - name: Untar provider binaries
+      run: tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin
     - name: Restore binary perms
       run: find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print
         -exec chmod +x {} \;

--- a/actions/providers/ns1/repo/.github/workflows/master.yml
+++ b/actions/providers/ns1/repo/.github/workflows/master.yml
@@ -53,8 +53,11 @@ jobs:
     - name: Download provider + tfgen binaries
       uses: actions/download-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
+        name: ${{ env.PROVIDER }}-provider.tar.gz
         path: ${{ github.workspace }}/bin
+    - name: Untar provider binaries
+      run: tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin
     - name: Restore binary perms
       run: find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print
         -exec chmod +x {} \;
@@ -185,11 +188,15 @@ jobs:
       uses: pulumi/action-install-pulumi-cli@releases/v1
     - name: Build tfgen & provider binaries
       run: make provider
+    - name: Tar provider binaries
+      run: tar -zcf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin/ pulumi-resource-${{ env.PROVIDER }} pulumi-tfgen-${{ env.PROVIDER
+        }}
     - name: Upload artifacts
       uses: actions/upload-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
-        path: ${{ github.workspace }}/bin
+        name: ${{ env.PROVIDER }}-provider.tar.gz
+        path: ${{ github.workspace }}/bin/provider.tar.gz
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3
@@ -346,8 +353,11 @@ jobs:
     - name: Download provider + tfgen binaries
       uses: actions/download-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
+        name: ${{ env.PROVIDER }}-provider.tar.gz
         path: ${{ github.workspace }}/bin
+    - name: Untar provider binaries
+      run: tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin
     - name: Restore binary perms
       run: find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print
         -exec chmod +x {} \;

--- a/actions/providers/ns1/repo/.github/workflows/prerelease.yml
+++ b/actions/providers/ns1/repo/.github/workflows/prerelease.yml
@@ -53,8 +53,11 @@ jobs:
     - name: Download provider + tfgen binaries
       uses: actions/download-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
+        name: ${{ env.PROVIDER }}-provider.tar.gz
         path: ${{ github.workspace }}/bin
+    - name: Untar provider binaries
+      run: tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin
     - name: Restore binary perms
       run: find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print
         -exec chmod +x {} \;
@@ -185,11 +188,15 @@ jobs:
       uses: pulumi/action-install-pulumi-cli@releases/v1
     - name: Build tfgen & provider binaries
       run: make provider
+    - name: Tar provider binaries
+      run: tar -zcf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin/ pulumi-resource-${{ env.PROVIDER }} pulumi-tfgen-${{ env.PROVIDER
+        }}
     - name: Upload artifacts
       uses: actions/upload-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
-        path: ${{ github.workspace }}/bin
+        name: ${{ env.PROVIDER }}-provider.tar.gz
+        path: ${{ github.workspace }}/bin/provider.tar.gz
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3
@@ -334,8 +341,11 @@ jobs:
     - name: Download provider + tfgen binaries
       uses: actions/download-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
+        name: ${{ env.PROVIDER }}-provider.tar.gz
         path: ${{ github.workspace }}/bin
+    - name: Untar provider binaries
+      run: tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin
     - name: Restore binary perms
       run: find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print
         -exec chmod +x {} \;

--- a/actions/providers/ns1/repo/.github/workflows/pull-request.yml
+++ b/actions/providers/ns1/repo/.github/workflows/pull-request.yml
@@ -53,8 +53,11 @@ jobs:
     - name: Download provider + tfgen binaries
       uses: actions/download-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
+        name: ${{ env.PROVIDER }}-provider.tar.gz
         path: ${{ github.workspace }}/bin
+    - name: Untar provider binaries
+      run: tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin
     - name: Restore binary perms
       run: find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print
         -exec chmod +x {} \;
@@ -185,11 +188,15 @@ jobs:
       uses: pulumi/action-install-pulumi-cli@releases/v1
     - name: Build tfgen & provider binaries
       run: make provider
+    - name: Tar provider binaries
+      run: tar -zcf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin/ pulumi-resource-${{ env.PROVIDER }} pulumi-tfgen-${{ env.PROVIDER
+        }}
     - name: Upload artifacts
       uses: actions/upload-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
-        path: ${{ github.workspace }}/bin
+        name: ${{ env.PROVIDER }}-provider.tar.gz
+        path: ${{ github.workspace }}/bin/provider.tar.gz
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3
@@ -237,8 +244,11 @@ jobs:
     - name: Download provider + tfgen binaries
       uses: actions/download-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
+        name: ${{ env.PROVIDER }}-provider.tar.gz
         path: ${{ github.workspace }}/bin
+    - name: Untar provider binaries
+      run: tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin
     - name: Restore binary perms
       run: find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print
         -exec chmod +x {} \;

--- a/actions/providers/ns1/repo/.github/workflows/release.yml
+++ b/actions/providers/ns1/repo/.github/workflows/release.yml
@@ -53,8 +53,11 @@ jobs:
     - name: Download provider + tfgen binaries
       uses: actions/download-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
+        name: ${{ env.PROVIDER }}-provider.tar.gz
         path: ${{ github.workspace }}/bin
+    - name: Untar provider binaries
+      run: tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin
     - name: Restore binary perms
       run: find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print
         -exec chmod +x {} \;
@@ -198,11 +201,15 @@ jobs:
       uses: pulumi/action-install-pulumi-cli@releases/v1
     - name: Build tfgen & provider binaries
       run: make provider
+    - name: Tar provider binaries
+      run: tar -zcf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin/ pulumi-resource-${{ env.PROVIDER }} pulumi-tfgen-${{ env.PROVIDER
+        }}
     - name: Upload artifacts
       uses: actions/upload-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
-        path: ${{ github.workspace }}/bin
+        name: ${{ env.PROVIDER }}-provider.tar.gz
+        path: ${{ github.workspace }}/bin/provider.tar.gz
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3
@@ -354,8 +361,11 @@ jobs:
     - name: Download provider + tfgen binaries
       uses: actions/download-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
+        name: ${{ env.PROVIDER }}-provider.tar.gz
         path: ${{ github.workspace }}/bin
+    - name: Untar provider binaries
+      run: tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin
     - name: Restore binary perms
       run: find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print
         -exec chmod +x {} \;

--- a/actions/providers/okta/repo/.github/workflows/master.yml
+++ b/actions/providers/okta/repo/.github/workflows/master.yml
@@ -55,8 +55,11 @@ jobs:
     - name: Download provider + tfgen binaries
       uses: actions/download-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
+        name: ${{ env.PROVIDER }}-provider.tar.gz
         path: ${{ github.workspace }}/bin
+    - name: Untar provider binaries
+      run: tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin
     - name: Restore binary perms
       run: find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print
         -exec chmod +x {} \;
@@ -187,11 +190,15 @@ jobs:
       uses: pulumi/action-install-pulumi-cli@releases/v1
     - name: Build tfgen & provider binaries
       run: make provider
+    - name: Tar provider binaries
+      run: tar -zcf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin/ pulumi-resource-${{ env.PROVIDER }} pulumi-tfgen-${{ env.PROVIDER
+        }}
     - name: Upload artifacts
       uses: actions/upload-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
-        path: ${{ github.workspace }}/bin
+        name: ${{ env.PROVIDER }}-provider.tar.gz
+        path: ${{ github.workspace }}/bin/provider.tar.gz
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3
@@ -348,8 +355,11 @@ jobs:
     - name: Download provider + tfgen binaries
       uses: actions/download-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
+        name: ${{ env.PROVIDER }}-provider.tar.gz
         path: ${{ github.workspace }}/bin
+    - name: Untar provider binaries
+      run: tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin
     - name: Restore binary perms
       run: find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print
         -exec chmod +x {} \;

--- a/actions/providers/okta/repo/.github/workflows/prerelease.yml
+++ b/actions/providers/okta/repo/.github/workflows/prerelease.yml
@@ -55,8 +55,11 @@ jobs:
     - name: Download provider + tfgen binaries
       uses: actions/download-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
+        name: ${{ env.PROVIDER }}-provider.tar.gz
         path: ${{ github.workspace }}/bin
+    - name: Untar provider binaries
+      run: tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin
     - name: Restore binary perms
       run: find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print
         -exec chmod +x {} \;
@@ -187,11 +190,15 @@ jobs:
       uses: pulumi/action-install-pulumi-cli@releases/v1
     - name: Build tfgen & provider binaries
       run: make provider
+    - name: Tar provider binaries
+      run: tar -zcf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin/ pulumi-resource-${{ env.PROVIDER }} pulumi-tfgen-${{ env.PROVIDER
+        }}
     - name: Upload artifacts
       uses: actions/upload-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
-        path: ${{ github.workspace }}/bin
+        name: ${{ env.PROVIDER }}-provider.tar.gz
+        path: ${{ github.workspace }}/bin/provider.tar.gz
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3
@@ -336,8 +343,11 @@ jobs:
     - name: Download provider + tfgen binaries
       uses: actions/download-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
+        name: ${{ env.PROVIDER }}-provider.tar.gz
         path: ${{ github.workspace }}/bin
+    - name: Untar provider binaries
+      run: tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin
     - name: Restore binary perms
       run: find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print
         -exec chmod +x {} \;

--- a/actions/providers/okta/repo/.github/workflows/pull-request.yml
+++ b/actions/providers/okta/repo/.github/workflows/pull-request.yml
@@ -55,8 +55,11 @@ jobs:
     - name: Download provider + tfgen binaries
       uses: actions/download-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
+        name: ${{ env.PROVIDER }}-provider.tar.gz
         path: ${{ github.workspace }}/bin
+    - name: Untar provider binaries
+      run: tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin
     - name: Restore binary perms
       run: find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print
         -exec chmod +x {} \;
@@ -187,11 +190,15 @@ jobs:
       uses: pulumi/action-install-pulumi-cli@releases/v1
     - name: Build tfgen & provider binaries
       run: make provider
+    - name: Tar provider binaries
+      run: tar -zcf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin/ pulumi-resource-${{ env.PROVIDER }} pulumi-tfgen-${{ env.PROVIDER
+        }}
     - name: Upload artifacts
       uses: actions/upload-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
-        path: ${{ github.workspace }}/bin
+        name: ${{ env.PROVIDER }}-provider.tar.gz
+        path: ${{ github.workspace }}/bin/provider.tar.gz
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3
@@ -239,8 +246,11 @@ jobs:
     - name: Download provider + tfgen binaries
       uses: actions/download-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
+        name: ${{ env.PROVIDER }}-provider.tar.gz
         path: ${{ github.workspace }}/bin
+    - name: Untar provider binaries
+      run: tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin
     - name: Restore binary perms
       run: find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print
         -exec chmod +x {} \;

--- a/actions/providers/okta/repo/.github/workflows/release.yml
+++ b/actions/providers/okta/repo/.github/workflows/release.yml
@@ -55,8 +55,11 @@ jobs:
     - name: Download provider + tfgen binaries
       uses: actions/download-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
+        name: ${{ env.PROVIDER }}-provider.tar.gz
         path: ${{ github.workspace }}/bin
+    - name: Untar provider binaries
+      run: tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin
     - name: Restore binary perms
       run: find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print
         -exec chmod +x {} \;
@@ -200,11 +203,15 @@ jobs:
       uses: pulumi/action-install-pulumi-cli@releases/v1
     - name: Build tfgen & provider binaries
       run: make provider
+    - name: Tar provider binaries
+      run: tar -zcf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin/ pulumi-resource-${{ env.PROVIDER }} pulumi-tfgen-${{ env.PROVIDER
+        }}
     - name: Upload artifacts
       uses: actions/upload-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
-        path: ${{ github.workspace }}/bin
+        name: ${{ env.PROVIDER }}-provider.tar.gz
+        path: ${{ github.workspace }}/bin/provider.tar.gz
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3
@@ -356,8 +363,11 @@ jobs:
     - name: Download provider + tfgen binaries
       uses: actions/download-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
+        name: ${{ env.PROVIDER }}-provider.tar.gz
         path: ${{ github.workspace }}/bin
+    - name: Untar provider binaries
+      run: tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin
     - name: Restore binary perms
       run: find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print
         -exec chmod +x {} \;

--- a/actions/providers/openstack/repo/.github/workflows/master.yml
+++ b/actions/providers/openstack/repo/.github/workflows/master.yml
@@ -61,8 +61,11 @@ jobs:
     - name: Download provider + tfgen binaries
       uses: actions/download-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
+        name: ${{ env.PROVIDER }}-provider.tar.gz
         path: ${{ github.workspace }}/bin
+    - name: Untar provider binaries
+      run: tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin
     - name: Restore binary perms
       run: find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print
         -exec chmod +x {} \;
@@ -193,11 +196,15 @@ jobs:
       uses: pulumi/action-install-pulumi-cli@releases/v1
     - name: Build tfgen & provider binaries
       run: make provider
+    - name: Tar provider binaries
+      run: tar -zcf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin/ pulumi-resource-${{ env.PROVIDER }} pulumi-tfgen-${{ env.PROVIDER
+        }}
     - name: Upload artifacts
       uses: actions/upload-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
-        path: ${{ github.workspace }}/bin
+        name: ${{ env.PROVIDER }}-provider.tar.gz
+        path: ${{ github.workspace }}/bin/provider.tar.gz
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3
@@ -354,8 +361,11 @@ jobs:
     - name: Download provider + tfgen binaries
       uses: actions/download-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
+        name: ${{ env.PROVIDER }}-provider.tar.gz
         path: ${{ github.workspace }}/bin
+    - name: Untar provider binaries
+      run: tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin
     - name: Restore binary perms
       run: find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print
         -exec chmod +x {} \;

--- a/actions/providers/openstack/repo/.github/workflows/prerelease.yml
+++ b/actions/providers/openstack/repo/.github/workflows/prerelease.yml
@@ -61,8 +61,11 @@ jobs:
     - name: Download provider + tfgen binaries
       uses: actions/download-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
+        name: ${{ env.PROVIDER }}-provider.tar.gz
         path: ${{ github.workspace }}/bin
+    - name: Untar provider binaries
+      run: tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin
     - name: Restore binary perms
       run: find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print
         -exec chmod +x {} \;
@@ -193,11 +196,15 @@ jobs:
       uses: pulumi/action-install-pulumi-cli@releases/v1
     - name: Build tfgen & provider binaries
       run: make provider
+    - name: Tar provider binaries
+      run: tar -zcf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin/ pulumi-resource-${{ env.PROVIDER }} pulumi-tfgen-${{ env.PROVIDER
+        }}
     - name: Upload artifacts
       uses: actions/upload-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
-        path: ${{ github.workspace }}/bin
+        name: ${{ env.PROVIDER }}-provider.tar.gz
+        path: ${{ github.workspace }}/bin/provider.tar.gz
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3
@@ -342,8 +349,11 @@ jobs:
     - name: Download provider + tfgen binaries
       uses: actions/download-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
+        name: ${{ env.PROVIDER }}-provider.tar.gz
         path: ${{ github.workspace }}/bin
+    - name: Untar provider binaries
+      run: tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin
     - name: Restore binary perms
       run: find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print
         -exec chmod +x {} \;

--- a/actions/providers/openstack/repo/.github/workflows/pull-request.yml
+++ b/actions/providers/openstack/repo/.github/workflows/pull-request.yml
@@ -61,8 +61,11 @@ jobs:
     - name: Download provider + tfgen binaries
       uses: actions/download-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
+        name: ${{ env.PROVIDER }}-provider.tar.gz
         path: ${{ github.workspace }}/bin
+    - name: Untar provider binaries
+      run: tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin
     - name: Restore binary perms
       run: find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print
         -exec chmod +x {} \;
@@ -193,11 +196,15 @@ jobs:
       uses: pulumi/action-install-pulumi-cli@releases/v1
     - name: Build tfgen & provider binaries
       run: make provider
+    - name: Tar provider binaries
+      run: tar -zcf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin/ pulumi-resource-${{ env.PROVIDER }} pulumi-tfgen-${{ env.PROVIDER
+        }}
     - name: Upload artifacts
       uses: actions/upload-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
-        path: ${{ github.workspace }}/bin
+        name: ${{ env.PROVIDER }}-provider.tar.gz
+        path: ${{ github.workspace }}/bin/provider.tar.gz
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3
@@ -245,8 +252,11 @@ jobs:
     - name: Download provider + tfgen binaries
       uses: actions/download-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
+        name: ${{ env.PROVIDER }}-provider.tar.gz
         path: ${{ github.workspace }}/bin
+    - name: Untar provider binaries
+      run: tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin
     - name: Restore binary perms
       run: find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print
         -exec chmod +x {} \;

--- a/actions/providers/openstack/repo/.github/workflows/release.yml
+++ b/actions/providers/openstack/repo/.github/workflows/release.yml
@@ -61,8 +61,11 @@ jobs:
     - name: Download provider + tfgen binaries
       uses: actions/download-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
+        name: ${{ env.PROVIDER }}-provider.tar.gz
         path: ${{ github.workspace }}/bin
+    - name: Untar provider binaries
+      run: tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin
     - name: Restore binary perms
       run: find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print
         -exec chmod +x {} \;
@@ -206,11 +209,15 @@ jobs:
       uses: pulumi/action-install-pulumi-cli@releases/v1
     - name: Build tfgen & provider binaries
       run: make provider
+    - name: Tar provider binaries
+      run: tar -zcf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin/ pulumi-resource-${{ env.PROVIDER }} pulumi-tfgen-${{ env.PROVIDER
+        }}
     - name: Upload artifacts
       uses: actions/upload-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
-        path: ${{ github.workspace }}/bin
+        name: ${{ env.PROVIDER }}-provider.tar.gz
+        path: ${{ github.workspace }}/bin/provider.tar.gz
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3
@@ -362,8 +369,11 @@ jobs:
     - name: Download provider + tfgen binaries
       uses: actions/download-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
+        name: ${{ env.PROVIDER }}-provider.tar.gz
         path: ${{ github.workspace }}/bin
+    - name: Untar provider binaries
+      run: tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin
     - name: Restore binary perms
       run: find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print
         -exec chmod +x {} \;

--- a/actions/providers/packet/repo/.github/workflows/master.yml
+++ b/actions/providers/packet/repo/.github/workflows/master.yml
@@ -53,8 +53,11 @@ jobs:
     - name: Download provider + tfgen binaries
       uses: actions/download-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
+        name: ${{ env.PROVIDER }}-provider.tar.gz
         path: ${{ github.workspace }}/bin
+    - name: Untar provider binaries
+      run: tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin
     - name: Restore binary perms
       run: find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print
         -exec chmod +x {} \;
@@ -185,11 +188,15 @@ jobs:
       uses: pulumi/action-install-pulumi-cli@releases/v1
     - name: Build tfgen & provider binaries
       run: make provider
+    - name: Tar provider binaries
+      run: tar -zcf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin/ pulumi-resource-${{ env.PROVIDER }} pulumi-tfgen-${{ env.PROVIDER
+        }}
     - name: Upload artifacts
       uses: actions/upload-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
-        path: ${{ github.workspace }}/bin
+        name: ${{ env.PROVIDER }}-provider.tar.gz
+        path: ${{ github.workspace }}/bin/provider.tar.gz
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3
@@ -346,8 +353,11 @@ jobs:
     - name: Download provider + tfgen binaries
       uses: actions/download-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
+        name: ${{ env.PROVIDER }}-provider.tar.gz
         path: ${{ github.workspace }}/bin
+    - name: Untar provider binaries
+      run: tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin
     - name: Restore binary perms
       run: find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print
         -exec chmod +x {} \;

--- a/actions/providers/packet/repo/.github/workflows/prerelease.yml
+++ b/actions/providers/packet/repo/.github/workflows/prerelease.yml
@@ -53,8 +53,11 @@ jobs:
     - name: Download provider + tfgen binaries
       uses: actions/download-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
+        name: ${{ env.PROVIDER }}-provider.tar.gz
         path: ${{ github.workspace }}/bin
+    - name: Untar provider binaries
+      run: tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin
     - name: Restore binary perms
       run: find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print
         -exec chmod +x {} \;
@@ -185,11 +188,15 @@ jobs:
       uses: pulumi/action-install-pulumi-cli@releases/v1
     - name: Build tfgen & provider binaries
       run: make provider
+    - name: Tar provider binaries
+      run: tar -zcf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin/ pulumi-resource-${{ env.PROVIDER }} pulumi-tfgen-${{ env.PROVIDER
+        }}
     - name: Upload artifacts
       uses: actions/upload-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
-        path: ${{ github.workspace }}/bin
+        name: ${{ env.PROVIDER }}-provider.tar.gz
+        path: ${{ github.workspace }}/bin/provider.tar.gz
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3
@@ -334,8 +341,11 @@ jobs:
     - name: Download provider + tfgen binaries
       uses: actions/download-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
+        name: ${{ env.PROVIDER }}-provider.tar.gz
         path: ${{ github.workspace }}/bin
+    - name: Untar provider binaries
+      run: tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin
     - name: Restore binary perms
       run: find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print
         -exec chmod +x {} \;

--- a/actions/providers/packet/repo/.github/workflows/pull-request.yml
+++ b/actions/providers/packet/repo/.github/workflows/pull-request.yml
@@ -53,8 +53,11 @@ jobs:
     - name: Download provider + tfgen binaries
       uses: actions/download-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
+        name: ${{ env.PROVIDER }}-provider.tar.gz
         path: ${{ github.workspace }}/bin
+    - name: Untar provider binaries
+      run: tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin
     - name: Restore binary perms
       run: find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print
         -exec chmod +x {} \;
@@ -185,11 +188,15 @@ jobs:
       uses: pulumi/action-install-pulumi-cli@releases/v1
     - name: Build tfgen & provider binaries
       run: make provider
+    - name: Tar provider binaries
+      run: tar -zcf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin/ pulumi-resource-${{ env.PROVIDER }} pulumi-tfgen-${{ env.PROVIDER
+        }}
     - name: Upload artifacts
       uses: actions/upload-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
-        path: ${{ github.workspace }}/bin
+        name: ${{ env.PROVIDER }}-provider.tar.gz
+        path: ${{ github.workspace }}/bin/provider.tar.gz
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3
@@ -237,8 +244,11 @@ jobs:
     - name: Download provider + tfgen binaries
       uses: actions/download-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
+        name: ${{ env.PROVIDER }}-provider.tar.gz
         path: ${{ github.workspace }}/bin
+    - name: Untar provider binaries
+      run: tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin
     - name: Restore binary perms
       run: find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print
         -exec chmod +x {} \;

--- a/actions/providers/packet/repo/.github/workflows/release.yml
+++ b/actions/providers/packet/repo/.github/workflows/release.yml
@@ -53,8 +53,11 @@ jobs:
     - name: Download provider + tfgen binaries
       uses: actions/download-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
+        name: ${{ env.PROVIDER }}-provider.tar.gz
         path: ${{ github.workspace }}/bin
+    - name: Untar provider binaries
+      run: tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin
     - name: Restore binary perms
       run: find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print
         -exec chmod +x {} \;
@@ -198,11 +201,15 @@ jobs:
       uses: pulumi/action-install-pulumi-cli@releases/v1
     - name: Build tfgen & provider binaries
       run: make provider
+    - name: Tar provider binaries
+      run: tar -zcf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin/ pulumi-resource-${{ env.PROVIDER }} pulumi-tfgen-${{ env.PROVIDER
+        }}
     - name: Upload artifacts
       uses: actions/upload-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
-        path: ${{ github.workspace }}/bin
+        name: ${{ env.PROVIDER }}-provider.tar.gz
+        path: ${{ github.workspace }}/bin/provider.tar.gz
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3
@@ -354,8 +361,11 @@ jobs:
     - name: Download provider + tfgen binaries
       uses: actions/download-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
+        name: ${{ env.PROVIDER }}-provider.tar.gz
         path: ${{ github.workspace }}/bin
+    - name: Untar provider binaries
+      run: tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin
     - name: Restore binary perms
       run: find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print
         -exec chmod +x {} \;

--- a/actions/providers/pagerduty/repo/.github/workflows/master.yml
+++ b/actions/providers/pagerduty/repo/.github/workflows/master.yml
@@ -53,8 +53,11 @@ jobs:
     - name: Download provider + tfgen binaries
       uses: actions/download-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
+        name: ${{ env.PROVIDER }}-provider.tar.gz
         path: ${{ github.workspace }}/bin
+    - name: Untar provider binaries
+      run: tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin
     - name: Restore binary perms
       run: find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print
         -exec chmod +x {} \;
@@ -185,11 +188,15 @@ jobs:
       uses: pulumi/action-install-pulumi-cli@releases/v1
     - name: Build tfgen & provider binaries
       run: make provider
+    - name: Tar provider binaries
+      run: tar -zcf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin/ pulumi-resource-${{ env.PROVIDER }} pulumi-tfgen-${{ env.PROVIDER
+        }}
     - name: Upload artifacts
       uses: actions/upload-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
-        path: ${{ github.workspace }}/bin
+        name: ${{ env.PROVIDER }}-provider.tar.gz
+        path: ${{ github.workspace }}/bin/provider.tar.gz
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3
@@ -346,8 +353,11 @@ jobs:
     - name: Download provider + tfgen binaries
       uses: actions/download-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
+        name: ${{ env.PROVIDER }}-provider.tar.gz
         path: ${{ github.workspace }}/bin
+    - name: Untar provider binaries
+      run: tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin
     - name: Restore binary perms
       run: find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print
         -exec chmod +x {} \;

--- a/actions/providers/pagerduty/repo/.github/workflows/prerelease.yml
+++ b/actions/providers/pagerduty/repo/.github/workflows/prerelease.yml
@@ -53,8 +53,11 @@ jobs:
     - name: Download provider + tfgen binaries
       uses: actions/download-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
+        name: ${{ env.PROVIDER }}-provider.tar.gz
         path: ${{ github.workspace }}/bin
+    - name: Untar provider binaries
+      run: tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin
     - name: Restore binary perms
       run: find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print
         -exec chmod +x {} \;
@@ -185,11 +188,15 @@ jobs:
       uses: pulumi/action-install-pulumi-cli@releases/v1
     - name: Build tfgen & provider binaries
       run: make provider
+    - name: Tar provider binaries
+      run: tar -zcf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin/ pulumi-resource-${{ env.PROVIDER }} pulumi-tfgen-${{ env.PROVIDER
+        }}
     - name: Upload artifacts
       uses: actions/upload-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
-        path: ${{ github.workspace }}/bin
+        name: ${{ env.PROVIDER }}-provider.tar.gz
+        path: ${{ github.workspace }}/bin/provider.tar.gz
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3
@@ -334,8 +341,11 @@ jobs:
     - name: Download provider + tfgen binaries
       uses: actions/download-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
+        name: ${{ env.PROVIDER }}-provider.tar.gz
         path: ${{ github.workspace }}/bin
+    - name: Untar provider binaries
+      run: tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin
     - name: Restore binary perms
       run: find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print
         -exec chmod +x {} \;

--- a/actions/providers/pagerduty/repo/.github/workflows/pull-request.yml
+++ b/actions/providers/pagerduty/repo/.github/workflows/pull-request.yml
@@ -53,8 +53,11 @@ jobs:
     - name: Download provider + tfgen binaries
       uses: actions/download-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
+        name: ${{ env.PROVIDER }}-provider.tar.gz
         path: ${{ github.workspace }}/bin
+    - name: Untar provider binaries
+      run: tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin
     - name: Restore binary perms
       run: find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print
         -exec chmod +x {} \;
@@ -185,11 +188,15 @@ jobs:
       uses: pulumi/action-install-pulumi-cli@releases/v1
     - name: Build tfgen & provider binaries
       run: make provider
+    - name: Tar provider binaries
+      run: tar -zcf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin/ pulumi-resource-${{ env.PROVIDER }} pulumi-tfgen-${{ env.PROVIDER
+        }}
     - name: Upload artifacts
       uses: actions/upload-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
-        path: ${{ github.workspace }}/bin
+        name: ${{ env.PROVIDER }}-provider.tar.gz
+        path: ${{ github.workspace }}/bin/provider.tar.gz
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3
@@ -237,8 +244,11 @@ jobs:
     - name: Download provider + tfgen binaries
       uses: actions/download-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
+        name: ${{ env.PROVIDER }}-provider.tar.gz
         path: ${{ github.workspace }}/bin
+    - name: Untar provider binaries
+      run: tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin
     - name: Restore binary perms
       run: find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print
         -exec chmod +x {} \;

--- a/actions/providers/pagerduty/repo/.github/workflows/release.yml
+++ b/actions/providers/pagerduty/repo/.github/workflows/release.yml
@@ -53,8 +53,11 @@ jobs:
     - name: Download provider + tfgen binaries
       uses: actions/download-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
+        name: ${{ env.PROVIDER }}-provider.tar.gz
         path: ${{ github.workspace }}/bin
+    - name: Untar provider binaries
+      run: tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin
     - name: Restore binary perms
       run: find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print
         -exec chmod +x {} \;
@@ -198,11 +201,15 @@ jobs:
       uses: pulumi/action-install-pulumi-cli@releases/v1
     - name: Build tfgen & provider binaries
       run: make provider
+    - name: Tar provider binaries
+      run: tar -zcf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin/ pulumi-resource-${{ env.PROVIDER }} pulumi-tfgen-${{ env.PROVIDER
+        }}
     - name: Upload artifacts
       uses: actions/upload-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
-        path: ${{ github.workspace }}/bin
+        name: ${{ env.PROVIDER }}-provider.tar.gz
+        path: ${{ github.workspace }}/bin/provider.tar.gz
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3
@@ -354,8 +361,11 @@ jobs:
     - name: Download provider + tfgen binaries
       uses: actions/download-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
+        name: ${{ env.PROVIDER }}-provider.tar.gz
         path: ${{ github.workspace }}/bin
+    - name: Untar provider binaries
+      run: tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin
     - name: Restore binary perms
       run: find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print
         -exec chmod +x {} \;

--- a/actions/providers/postgresql/repo/.github/workflows/master.yml
+++ b/actions/providers/postgresql/repo/.github/workflows/master.yml
@@ -52,8 +52,11 @@ jobs:
     - name: Download provider + tfgen binaries
       uses: actions/download-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
+        name: ${{ env.PROVIDER }}-provider.tar.gz
         path: ${{ github.workspace }}/bin
+    - name: Untar provider binaries
+      run: tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin
     - name: Restore binary perms
       run: find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print
         -exec chmod +x {} \;
@@ -184,11 +187,15 @@ jobs:
       uses: pulumi/action-install-pulumi-cli@releases/v1
     - name: Build tfgen & provider binaries
       run: make provider
+    - name: Tar provider binaries
+      run: tar -zcf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin/ pulumi-resource-${{ env.PROVIDER }} pulumi-tfgen-${{ env.PROVIDER
+        }}
     - name: Upload artifacts
       uses: actions/upload-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
-        path: ${{ github.workspace }}/bin
+        name: ${{ env.PROVIDER }}-provider.tar.gz
+        path: ${{ github.workspace }}/bin/provider.tar.gz
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3
@@ -345,8 +352,11 @@ jobs:
     - name: Download provider + tfgen binaries
       uses: actions/download-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
+        name: ${{ env.PROVIDER }}-provider.tar.gz
         path: ${{ github.workspace }}/bin
+    - name: Untar provider binaries
+      run: tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin
     - name: Restore binary perms
       run: find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print
         -exec chmod +x {} \;

--- a/actions/providers/postgresql/repo/.github/workflows/prerelease.yml
+++ b/actions/providers/postgresql/repo/.github/workflows/prerelease.yml
@@ -52,8 +52,11 @@ jobs:
     - name: Download provider + tfgen binaries
       uses: actions/download-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
+        name: ${{ env.PROVIDER }}-provider.tar.gz
         path: ${{ github.workspace }}/bin
+    - name: Untar provider binaries
+      run: tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin
     - name: Restore binary perms
       run: find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print
         -exec chmod +x {} \;
@@ -184,11 +187,15 @@ jobs:
       uses: pulumi/action-install-pulumi-cli@releases/v1
     - name: Build tfgen & provider binaries
       run: make provider
+    - name: Tar provider binaries
+      run: tar -zcf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin/ pulumi-resource-${{ env.PROVIDER }} pulumi-tfgen-${{ env.PROVIDER
+        }}
     - name: Upload artifacts
       uses: actions/upload-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
-        path: ${{ github.workspace }}/bin
+        name: ${{ env.PROVIDER }}-provider.tar.gz
+        path: ${{ github.workspace }}/bin/provider.tar.gz
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3
@@ -333,8 +340,11 @@ jobs:
     - name: Download provider + tfgen binaries
       uses: actions/download-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
+        name: ${{ env.PROVIDER }}-provider.tar.gz
         path: ${{ github.workspace }}/bin
+    - name: Untar provider binaries
+      run: tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin
     - name: Restore binary perms
       run: find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print
         -exec chmod +x {} \;

--- a/actions/providers/postgresql/repo/.github/workflows/pull-request.yml
+++ b/actions/providers/postgresql/repo/.github/workflows/pull-request.yml
@@ -52,8 +52,11 @@ jobs:
     - name: Download provider + tfgen binaries
       uses: actions/download-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
+        name: ${{ env.PROVIDER }}-provider.tar.gz
         path: ${{ github.workspace }}/bin
+    - name: Untar provider binaries
+      run: tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin
     - name: Restore binary perms
       run: find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print
         -exec chmod +x {} \;
@@ -184,11 +187,15 @@ jobs:
       uses: pulumi/action-install-pulumi-cli@releases/v1
     - name: Build tfgen & provider binaries
       run: make provider
+    - name: Tar provider binaries
+      run: tar -zcf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin/ pulumi-resource-${{ env.PROVIDER }} pulumi-tfgen-${{ env.PROVIDER
+        }}
     - name: Upload artifacts
       uses: actions/upload-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
-        path: ${{ github.workspace }}/bin
+        name: ${{ env.PROVIDER }}-provider.tar.gz
+        path: ${{ github.workspace }}/bin/provider.tar.gz
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3
@@ -236,8 +243,11 @@ jobs:
     - name: Download provider + tfgen binaries
       uses: actions/download-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
+        name: ${{ env.PROVIDER }}-provider.tar.gz
         path: ${{ github.workspace }}/bin
+    - name: Untar provider binaries
+      run: tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin
     - name: Restore binary perms
       run: find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print
         -exec chmod +x {} \;

--- a/actions/providers/postgresql/repo/.github/workflows/release.yml
+++ b/actions/providers/postgresql/repo/.github/workflows/release.yml
@@ -52,8 +52,11 @@ jobs:
     - name: Download provider + tfgen binaries
       uses: actions/download-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
+        name: ${{ env.PROVIDER }}-provider.tar.gz
         path: ${{ github.workspace }}/bin
+    - name: Untar provider binaries
+      run: tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin
     - name: Restore binary perms
       run: find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print
         -exec chmod +x {} \;
@@ -197,11 +200,15 @@ jobs:
       uses: pulumi/action-install-pulumi-cli@releases/v1
     - name: Build tfgen & provider binaries
       run: make provider
+    - name: Tar provider binaries
+      run: tar -zcf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin/ pulumi-resource-${{ env.PROVIDER }} pulumi-tfgen-${{ env.PROVIDER
+        }}
     - name: Upload artifacts
       uses: actions/upload-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
-        path: ${{ github.workspace }}/bin
+        name: ${{ env.PROVIDER }}-provider.tar.gz
+        path: ${{ github.workspace }}/bin/provider.tar.gz
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3
@@ -353,8 +360,11 @@ jobs:
     - name: Download provider + tfgen binaries
       uses: actions/download-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
+        name: ${{ env.PROVIDER }}-provider.tar.gz
         path: ${{ github.workspace }}/bin
+    - name: Untar provider binaries
+      run: tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin
     - name: Restore binary perms
       run: find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print
         -exec chmod +x {} \;

--- a/actions/providers/rabbitmq/repo/.github/workflows/master.yml
+++ b/actions/providers/rabbitmq/repo/.github/workflows/master.yml
@@ -52,8 +52,11 @@ jobs:
     - name: Download provider + tfgen binaries
       uses: actions/download-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
+        name: ${{ env.PROVIDER }}-provider.tar.gz
         path: ${{ github.workspace }}/bin
+    - name: Untar provider binaries
+      run: tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin
     - name: Restore binary perms
       run: find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print
         -exec chmod +x {} \;
@@ -184,11 +187,15 @@ jobs:
       uses: pulumi/action-install-pulumi-cli@releases/v1
     - name: Build tfgen & provider binaries
       run: make provider
+    - name: Tar provider binaries
+      run: tar -zcf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin/ pulumi-resource-${{ env.PROVIDER }} pulumi-tfgen-${{ env.PROVIDER
+        }}
     - name: Upload artifacts
       uses: actions/upload-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
-        path: ${{ github.workspace }}/bin
+        name: ${{ env.PROVIDER }}-provider.tar.gz
+        path: ${{ github.workspace }}/bin/provider.tar.gz
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3
@@ -345,8 +352,11 @@ jobs:
     - name: Download provider + tfgen binaries
       uses: actions/download-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
+        name: ${{ env.PROVIDER }}-provider.tar.gz
         path: ${{ github.workspace }}/bin
+    - name: Untar provider binaries
+      run: tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin
     - name: Restore binary perms
       run: find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print
         -exec chmod +x {} \;

--- a/actions/providers/rabbitmq/repo/.github/workflows/prerelease.yml
+++ b/actions/providers/rabbitmq/repo/.github/workflows/prerelease.yml
@@ -52,8 +52,11 @@ jobs:
     - name: Download provider + tfgen binaries
       uses: actions/download-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
+        name: ${{ env.PROVIDER }}-provider.tar.gz
         path: ${{ github.workspace }}/bin
+    - name: Untar provider binaries
+      run: tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin
     - name: Restore binary perms
       run: find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print
         -exec chmod +x {} \;
@@ -184,11 +187,15 @@ jobs:
       uses: pulumi/action-install-pulumi-cli@releases/v1
     - name: Build tfgen & provider binaries
       run: make provider
+    - name: Tar provider binaries
+      run: tar -zcf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin/ pulumi-resource-${{ env.PROVIDER }} pulumi-tfgen-${{ env.PROVIDER
+        }}
     - name: Upload artifacts
       uses: actions/upload-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
-        path: ${{ github.workspace }}/bin
+        name: ${{ env.PROVIDER }}-provider.tar.gz
+        path: ${{ github.workspace }}/bin/provider.tar.gz
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3
@@ -333,8 +340,11 @@ jobs:
     - name: Download provider + tfgen binaries
       uses: actions/download-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
+        name: ${{ env.PROVIDER }}-provider.tar.gz
         path: ${{ github.workspace }}/bin
+    - name: Untar provider binaries
+      run: tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin
     - name: Restore binary perms
       run: find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print
         -exec chmod +x {} \;

--- a/actions/providers/rabbitmq/repo/.github/workflows/pull-request.yml
+++ b/actions/providers/rabbitmq/repo/.github/workflows/pull-request.yml
@@ -52,8 +52,11 @@ jobs:
     - name: Download provider + tfgen binaries
       uses: actions/download-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
+        name: ${{ env.PROVIDER }}-provider.tar.gz
         path: ${{ github.workspace }}/bin
+    - name: Untar provider binaries
+      run: tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin
     - name: Restore binary perms
       run: find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print
         -exec chmod +x {} \;
@@ -184,11 +187,15 @@ jobs:
       uses: pulumi/action-install-pulumi-cli@releases/v1
     - name: Build tfgen & provider binaries
       run: make provider
+    - name: Tar provider binaries
+      run: tar -zcf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin/ pulumi-resource-${{ env.PROVIDER }} pulumi-tfgen-${{ env.PROVIDER
+        }}
     - name: Upload artifacts
       uses: actions/upload-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
-        path: ${{ github.workspace }}/bin
+        name: ${{ env.PROVIDER }}-provider.tar.gz
+        path: ${{ github.workspace }}/bin/provider.tar.gz
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3
@@ -236,8 +243,11 @@ jobs:
     - name: Download provider + tfgen binaries
       uses: actions/download-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
+        name: ${{ env.PROVIDER }}-provider.tar.gz
         path: ${{ github.workspace }}/bin
+    - name: Untar provider binaries
+      run: tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin
     - name: Restore binary perms
       run: find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print
         -exec chmod +x {} \;

--- a/actions/providers/rabbitmq/repo/.github/workflows/release.yml
+++ b/actions/providers/rabbitmq/repo/.github/workflows/release.yml
@@ -52,8 +52,11 @@ jobs:
     - name: Download provider + tfgen binaries
       uses: actions/download-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
+        name: ${{ env.PROVIDER }}-provider.tar.gz
         path: ${{ github.workspace }}/bin
+    - name: Untar provider binaries
+      run: tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin
     - name: Restore binary perms
       run: find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print
         -exec chmod +x {} \;
@@ -197,11 +200,15 @@ jobs:
       uses: pulumi/action-install-pulumi-cli@releases/v1
     - name: Build tfgen & provider binaries
       run: make provider
+    - name: Tar provider binaries
+      run: tar -zcf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin/ pulumi-resource-${{ env.PROVIDER }} pulumi-tfgen-${{ env.PROVIDER
+        }}
     - name: Upload artifacts
       uses: actions/upload-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
-        path: ${{ github.workspace }}/bin
+        name: ${{ env.PROVIDER }}-provider.tar.gz
+        path: ${{ github.workspace }}/bin/provider.tar.gz
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3
@@ -353,8 +360,11 @@ jobs:
     - name: Download provider + tfgen binaries
       uses: actions/download-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
+        name: ${{ env.PROVIDER }}-provider.tar.gz
         path: ${{ github.workspace }}/bin
+    - name: Untar provider binaries
+      run: tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin
     - name: Restore binary perms
       run: find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print
         -exec chmod +x {} \;

--- a/actions/providers/rancher2/repo/.github/workflows/master.yml
+++ b/actions/providers/rancher2/repo/.github/workflows/master.yml
@@ -54,8 +54,11 @@ jobs:
     - name: Download provider + tfgen binaries
       uses: actions/download-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
+        name: ${{ env.PROVIDER }}-provider.tar.gz
         path: ${{ github.workspace }}/bin
+    - name: Untar provider binaries
+      run: tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin
     - name: Restore binary perms
       run: find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print
         -exec chmod +x {} \;
@@ -186,11 +189,15 @@ jobs:
       uses: pulumi/action-install-pulumi-cli@releases/v1
     - name: Build tfgen & provider binaries
       run: make provider
+    - name: Tar provider binaries
+      run: tar -zcf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin/ pulumi-resource-${{ env.PROVIDER }} pulumi-tfgen-${{ env.PROVIDER
+        }}
     - name: Upload artifacts
       uses: actions/upload-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
-        path: ${{ github.workspace }}/bin
+        name: ${{ env.PROVIDER }}-provider.tar.gz
+        path: ${{ github.workspace }}/bin/provider.tar.gz
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3
@@ -347,8 +354,11 @@ jobs:
     - name: Download provider + tfgen binaries
       uses: actions/download-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
+        name: ${{ env.PROVIDER }}-provider.tar.gz
         path: ${{ github.workspace }}/bin
+    - name: Untar provider binaries
+      run: tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin
     - name: Restore binary perms
       run: find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print
         -exec chmod +x {} \;

--- a/actions/providers/rancher2/repo/.github/workflows/prerelease.yml
+++ b/actions/providers/rancher2/repo/.github/workflows/prerelease.yml
@@ -54,8 +54,11 @@ jobs:
     - name: Download provider + tfgen binaries
       uses: actions/download-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
+        name: ${{ env.PROVIDER }}-provider.tar.gz
         path: ${{ github.workspace }}/bin
+    - name: Untar provider binaries
+      run: tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin
     - name: Restore binary perms
       run: find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print
         -exec chmod +x {} \;
@@ -186,11 +189,15 @@ jobs:
       uses: pulumi/action-install-pulumi-cli@releases/v1
     - name: Build tfgen & provider binaries
       run: make provider
+    - name: Tar provider binaries
+      run: tar -zcf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin/ pulumi-resource-${{ env.PROVIDER }} pulumi-tfgen-${{ env.PROVIDER
+        }}
     - name: Upload artifacts
       uses: actions/upload-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
-        path: ${{ github.workspace }}/bin
+        name: ${{ env.PROVIDER }}-provider.tar.gz
+        path: ${{ github.workspace }}/bin/provider.tar.gz
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3
@@ -335,8 +342,11 @@ jobs:
     - name: Download provider + tfgen binaries
       uses: actions/download-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
+        name: ${{ env.PROVIDER }}-provider.tar.gz
         path: ${{ github.workspace }}/bin
+    - name: Untar provider binaries
+      run: tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin
     - name: Restore binary perms
       run: find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print
         -exec chmod +x {} \;

--- a/actions/providers/rancher2/repo/.github/workflows/pull-request.yml
+++ b/actions/providers/rancher2/repo/.github/workflows/pull-request.yml
@@ -54,8 +54,11 @@ jobs:
     - name: Download provider + tfgen binaries
       uses: actions/download-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
+        name: ${{ env.PROVIDER }}-provider.tar.gz
         path: ${{ github.workspace }}/bin
+    - name: Untar provider binaries
+      run: tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin
     - name: Restore binary perms
       run: find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print
         -exec chmod +x {} \;
@@ -186,11 +189,15 @@ jobs:
       uses: pulumi/action-install-pulumi-cli@releases/v1
     - name: Build tfgen & provider binaries
       run: make provider
+    - name: Tar provider binaries
+      run: tar -zcf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin/ pulumi-resource-${{ env.PROVIDER }} pulumi-tfgen-${{ env.PROVIDER
+        }}
     - name: Upload artifacts
       uses: actions/upload-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
-        path: ${{ github.workspace }}/bin
+        name: ${{ env.PROVIDER }}-provider.tar.gz
+        path: ${{ github.workspace }}/bin/provider.tar.gz
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3
@@ -238,8 +245,11 @@ jobs:
     - name: Download provider + tfgen binaries
       uses: actions/download-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
+        name: ${{ env.PROVIDER }}-provider.tar.gz
         path: ${{ github.workspace }}/bin
+    - name: Untar provider binaries
+      run: tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin
     - name: Restore binary perms
       run: find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print
         -exec chmod +x {} \;

--- a/actions/providers/rancher2/repo/.github/workflows/release.yml
+++ b/actions/providers/rancher2/repo/.github/workflows/release.yml
@@ -54,8 +54,11 @@ jobs:
     - name: Download provider + tfgen binaries
       uses: actions/download-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
+        name: ${{ env.PROVIDER }}-provider.tar.gz
         path: ${{ github.workspace }}/bin
+    - name: Untar provider binaries
+      run: tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin
     - name: Restore binary perms
       run: find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print
         -exec chmod +x {} \;
@@ -199,11 +202,15 @@ jobs:
       uses: pulumi/action-install-pulumi-cli@releases/v1
     - name: Build tfgen & provider binaries
       run: make provider
+    - name: Tar provider binaries
+      run: tar -zcf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin/ pulumi-resource-${{ env.PROVIDER }} pulumi-tfgen-${{ env.PROVIDER
+        }}
     - name: Upload artifacts
       uses: actions/upload-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
-        path: ${{ github.workspace }}/bin
+        name: ${{ env.PROVIDER }}-provider.tar.gz
+        path: ${{ github.workspace }}/bin/provider.tar.gz
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3
@@ -355,8 +362,11 @@ jobs:
     - name: Download provider + tfgen binaries
       uses: actions/download-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
+        name: ${{ env.PROVIDER }}-provider.tar.gz
         path: ${{ github.workspace }}/bin
+    - name: Untar provider binaries
+      run: tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin
     - name: Restore binary perms
       run: find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print
         -exec chmod +x {} \;

--- a/actions/providers/random/repo/.github/workflows/master.yml
+++ b/actions/providers/random/repo/.github/workflows/master.yml
@@ -52,8 +52,11 @@ jobs:
     - name: Download provider + tfgen binaries
       uses: actions/download-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
+        name: ${{ env.PROVIDER }}-provider.tar.gz
         path: ${{ github.workspace }}/bin
+    - name: Untar provider binaries
+      run: tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin
     - name: Restore binary perms
       run: find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print
         -exec chmod +x {} \;
@@ -184,11 +187,15 @@ jobs:
       uses: pulumi/action-install-pulumi-cli@releases/v1
     - name: Build tfgen & provider binaries
       run: make provider
+    - name: Tar provider binaries
+      run: tar -zcf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin/ pulumi-resource-${{ env.PROVIDER }} pulumi-tfgen-${{ env.PROVIDER
+        }}
     - name: Upload artifacts
       uses: actions/upload-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
-        path: ${{ github.workspace }}/bin
+        name: ${{ env.PROVIDER }}-provider.tar.gz
+        path: ${{ github.workspace }}/bin/provider.tar.gz
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3
@@ -345,8 +352,11 @@ jobs:
     - name: Download provider + tfgen binaries
       uses: actions/download-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
+        name: ${{ env.PROVIDER }}-provider.tar.gz
         path: ${{ github.workspace }}/bin
+    - name: Untar provider binaries
+      run: tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin
     - name: Restore binary perms
       run: find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print
         -exec chmod +x {} \;

--- a/actions/providers/random/repo/.github/workflows/prerelease.yml
+++ b/actions/providers/random/repo/.github/workflows/prerelease.yml
@@ -52,8 +52,11 @@ jobs:
     - name: Download provider + tfgen binaries
       uses: actions/download-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
+        name: ${{ env.PROVIDER }}-provider.tar.gz
         path: ${{ github.workspace }}/bin
+    - name: Untar provider binaries
+      run: tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin
     - name: Restore binary perms
       run: find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print
         -exec chmod +x {} \;
@@ -184,11 +187,15 @@ jobs:
       uses: pulumi/action-install-pulumi-cli@releases/v1
     - name: Build tfgen & provider binaries
       run: make provider
+    - name: Tar provider binaries
+      run: tar -zcf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin/ pulumi-resource-${{ env.PROVIDER }} pulumi-tfgen-${{ env.PROVIDER
+        }}
     - name: Upload artifacts
       uses: actions/upload-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
-        path: ${{ github.workspace }}/bin
+        name: ${{ env.PROVIDER }}-provider.tar.gz
+        path: ${{ github.workspace }}/bin/provider.tar.gz
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3
@@ -333,8 +340,11 @@ jobs:
     - name: Download provider + tfgen binaries
       uses: actions/download-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
+        name: ${{ env.PROVIDER }}-provider.tar.gz
         path: ${{ github.workspace }}/bin
+    - name: Untar provider binaries
+      run: tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin
     - name: Restore binary perms
       run: find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print
         -exec chmod +x {} \;

--- a/actions/providers/random/repo/.github/workflows/pull-request.yml
+++ b/actions/providers/random/repo/.github/workflows/pull-request.yml
@@ -52,8 +52,11 @@ jobs:
     - name: Download provider + tfgen binaries
       uses: actions/download-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
+        name: ${{ env.PROVIDER }}-provider.tar.gz
         path: ${{ github.workspace }}/bin
+    - name: Untar provider binaries
+      run: tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin
     - name: Restore binary perms
       run: find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print
         -exec chmod +x {} \;
@@ -184,11 +187,15 @@ jobs:
       uses: pulumi/action-install-pulumi-cli@releases/v1
     - name: Build tfgen & provider binaries
       run: make provider
+    - name: Tar provider binaries
+      run: tar -zcf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin/ pulumi-resource-${{ env.PROVIDER }} pulumi-tfgen-${{ env.PROVIDER
+        }}
     - name: Upload artifacts
       uses: actions/upload-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
-        path: ${{ github.workspace }}/bin
+        name: ${{ env.PROVIDER }}-provider.tar.gz
+        path: ${{ github.workspace }}/bin/provider.tar.gz
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3
@@ -236,8 +243,11 @@ jobs:
     - name: Download provider + tfgen binaries
       uses: actions/download-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
+        name: ${{ env.PROVIDER }}-provider.tar.gz
         path: ${{ github.workspace }}/bin
+    - name: Untar provider binaries
+      run: tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin
     - name: Restore binary perms
       run: find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print
         -exec chmod +x {} \;

--- a/actions/providers/random/repo/.github/workflows/release.yml
+++ b/actions/providers/random/repo/.github/workflows/release.yml
@@ -52,8 +52,11 @@ jobs:
     - name: Download provider + tfgen binaries
       uses: actions/download-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
+        name: ${{ env.PROVIDER }}-provider.tar.gz
         path: ${{ github.workspace }}/bin
+    - name: Untar provider binaries
+      run: tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin
     - name: Restore binary perms
       run: find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print
         -exec chmod +x {} \;
@@ -197,11 +200,15 @@ jobs:
       uses: pulumi/action-install-pulumi-cli@releases/v1
     - name: Build tfgen & provider binaries
       run: make provider
+    - name: Tar provider binaries
+      run: tar -zcf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin/ pulumi-resource-${{ env.PROVIDER }} pulumi-tfgen-${{ env.PROVIDER
+        }}
     - name: Upload artifacts
       uses: actions/upload-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
-        path: ${{ github.workspace }}/bin
+        name: ${{ env.PROVIDER }}-provider.tar.gz
+        path: ${{ github.workspace }}/bin/provider.tar.gz
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3
@@ -353,8 +360,11 @@ jobs:
     - name: Download provider + tfgen binaries
       uses: actions/download-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
+        name: ${{ env.PROVIDER }}-provider.tar.gz
         path: ${{ github.workspace }}/bin
+    - name: Untar provider binaries
+      run: tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin
     - name: Restore binary perms
       run: find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print
         -exec chmod +x {} \;

--- a/actions/providers/signalfx/repo/.github/workflows/master.yml
+++ b/actions/providers/signalfx/repo/.github/workflows/master.yml
@@ -52,8 +52,11 @@ jobs:
     - name: Download provider + tfgen binaries
       uses: actions/download-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
+        name: ${{ env.PROVIDER }}-provider.tar.gz
         path: ${{ github.workspace }}/bin
+    - name: Untar provider binaries
+      run: tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin
     - name: Restore binary perms
       run: find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print
         -exec chmod +x {} \;
@@ -184,11 +187,15 @@ jobs:
       uses: pulumi/action-install-pulumi-cli@releases/v1
     - name: Build tfgen & provider binaries
       run: make provider
+    - name: Tar provider binaries
+      run: tar -zcf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin/ pulumi-resource-${{ env.PROVIDER }} pulumi-tfgen-${{ env.PROVIDER
+        }}
     - name: Upload artifacts
       uses: actions/upload-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
-        path: ${{ github.workspace }}/bin
+        name: ${{ env.PROVIDER }}-provider.tar.gz
+        path: ${{ github.workspace }}/bin/provider.tar.gz
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3
@@ -345,8 +352,11 @@ jobs:
     - name: Download provider + tfgen binaries
       uses: actions/download-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
+        name: ${{ env.PROVIDER }}-provider.tar.gz
         path: ${{ github.workspace }}/bin
+    - name: Untar provider binaries
+      run: tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin
     - name: Restore binary perms
       run: find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print
         -exec chmod +x {} \;

--- a/actions/providers/signalfx/repo/.github/workflows/prerelease.yml
+++ b/actions/providers/signalfx/repo/.github/workflows/prerelease.yml
@@ -52,8 +52,11 @@ jobs:
     - name: Download provider + tfgen binaries
       uses: actions/download-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
+        name: ${{ env.PROVIDER }}-provider.tar.gz
         path: ${{ github.workspace }}/bin
+    - name: Untar provider binaries
+      run: tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin
     - name: Restore binary perms
       run: find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print
         -exec chmod +x {} \;
@@ -184,11 +187,15 @@ jobs:
       uses: pulumi/action-install-pulumi-cli@releases/v1
     - name: Build tfgen & provider binaries
       run: make provider
+    - name: Tar provider binaries
+      run: tar -zcf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin/ pulumi-resource-${{ env.PROVIDER }} pulumi-tfgen-${{ env.PROVIDER
+        }}
     - name: Upload artifacts
       uses: actions/upload-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
-        path: ${{ github.workspace }}/bin
+        name: ${{ env.PROVIDER }}-provider.tar.gz
+        path: ${{ github.workspace }}/bin/provider.tar.gz
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3
@@ -333,8 +340,11 @@ jobs:
     - name: Download provider + tfgen binaries
       uses: actions/download-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
+        name: ${{ env.PROVIDER }}-provider.tar.gz
         path: ${{ github.workspace }}/bin
+    - name: Untar provider binaries
+      run: tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin
     - name: Restore binary perms
       run: find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print
         -exec chmod +x {} \;

--- a/actions/providers/signalfx/repo/.github/workflows/pull-request.yml
+++ b/actions/providers/signalfx/repo/.github/workflows/pull-request.yml
@@ -52,8 +52,11 @@ jobs:
     - name: Download provider + tfgen binaries
       uses: actions/download-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
+        name: ${{ env.PROVIDER }}-provider.tar.gz
         path: ${{ github.workspace }}/bin
+    - name: Untar provider binaries
+      run: tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin
     - name: Restore binary perms
       run: find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print
         -exec chmod +x {} \;
@@ -184,11 +187,15 @@ jobs:
       uses: pulumi/action-install-pulumi-cli@releases/v1
     - name: Build tfgen & provider binaries
       run: make provider
+    - name: Tar provider binaries
+      run: tar -zcf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin/ pulumi-resource-${{ env.PROVIDER }} pulumi-tfgen-${{ env.PROVIDER
+        }}
     - name: Upload artifacts
       uses: actions/upload-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
-        path: ${{ github.workspace }}/bin
+        name: ${{ env.PROVIDER }}-provider.tar.gz
+        path: ${{ github.workspace }}/bin/provider.tar.gz
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3
@@ -236,8 +243,11 @@ jobs:
     - name: Download provider + tfgen binaries
       uses: actions/download-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
+        name: ${{ env.PROVIDER }}-provider.tar.gz
         path: ${{ github.workspace }}/bin
+    - name: Untar provider binaries
+      run: tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin
     - name: Restore binary perms
       run: find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print
         -exec chmod +x {} \;

--- a/actions/providers/signalfx/repo/.github/workflows/release.yml
+++ b/actions/providers/signalfx/repo/.github/workflows/release.yml
@@ -52,8 +52,11 @@ jobs:
     - name: Download provider + tfgen binaries
       uses: actions/download-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
+        name: ${{ env.PROVIDER }}-provider.tar.gz
         path: ${{ github.workspace }}/bin
+    - name: Untar provider binaries
+      run: tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin
     - name: Restore binary perms
       run: find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print
         -exec chmod +x {} \;
@@ -197,11 +200,15 @@ jobs:
       uses: pulumi/action-install-pulumi-cli@releases/v1
     - name: Build tfgen & provider binaries
       run: make provider
+    - name: Tar provider binaries
+      run: tar -zcf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin/ pulumi-resource-${{ env.PROVIDER }} pulumi-tfgen-${{ env.PROVIDER
+        }}
     - name: Upload artifacts
       uses: actions/upload-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
-        path: ${{ github.workspace }}/bin
+        name: ${{ env.PROVIDER }}-provider.tar.gz
+        path: ${{ github.workspace }}/bin/provider.tar.gz
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3
@@ -353,8 +360,11 @@ jobs:
     - name: Download provider + tfgen binaries
       uses: actions/download-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
+        name: ${{ env.PROVIDER }}-provider.tar.gz
         path: ${{ github.workspace }}/bin
+    - name: Untar provider binaries
+      run: tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin
     - name: Restore binary perms
       run: find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print
         -exec chmod +x {} \;

--- a/actions/providers/spotinst/repo/.github/workflows/master.yml
+++ b/actions/providers/spotinst/repo/.github/workflows/master.yml
@@ -55,8 +55,11 @@ jobs:
     - name: Download provider + tfgen binaries
       uses: actions/download-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
+        name: ${{ env.PROVIDER }}-provider.tar.gz
         path: ${{ github.workspace }}/bin
+    - name: Untar provider binaries
+      run: tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin
     - name: Restore binary perms
       run: find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print
         -exec chmod +x {} \;
@@ -187,11 +190,15 @@ jobs:
       uses: pulumi/action-install-pulumi-cli@releases/v1
     - name: Build tfgen & provider binaries
       run: make provider
+    - name: Tar provider binaries
+      run: tar -zcf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin/ pulumi-resource-${{ env.PROVIDER }} pulumi-tfgen-${{ env.PROVIDER
+        }}
     - name: Upload artifacts
       uses: actions/upload-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
-        path: ${{ github.workspace }}/bin
+        name: ${{ env.PROVIDER }}-provider.tar.gz
+        path: ${{ github.workspace }}/bin/provider.tar.gz
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3
@@ -348,8 +355,11 @@ jobs:
     - name: Download provider + tfgen binaries
       uses: actions/download-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
+        name: ${{ env.PROVIDER }}-provider.tar.gz
         path: ${{ github.workspace }}/bin
+    - name: Untar provider binaries
+      run: tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin
     - name: Restore binary perms
       run: find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print
         -exec chmod +x {} \;

--- a/actions/providers/spotinst/repo/.github/workflows/prerelease.yml
+++ b/actions/providers/spotinst/repo/.github/workflows/prerelease.yml
@@ -55,8 +55,11 @@ jobs:
     - name: Download provider + tfgen binaries
       uses: actions/download-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
+        name: ${{ env.PROVIDER }}-provider.tar.gz
         path: ${{ github.workspace }}/bin
+    - name: Untar provider binaries
+      run: tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin
     - name: Restore binary perms
       run: find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print
         -exec chmod +x {} \;
@@ -187,11 +190,15 @@ jobs:
       uses: pulumi/action-install-pulumi-cli@releases/v1
     - name: Build tfgen & provider binaries
       run: make provider
+    - name: Tar provider binaries
+      run: tar -zcf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin/ pulumi-resource-${{ env.PROVIDER }} pulumi-tfgen-${{ env.PROVIDER
+        }}
     - name: Upload artifacts
       uses: actions/upload-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
-        path: ${{ github.workspace }}/bin
+        name: ${{ env.PROVIDER }}-provider.tar.gz
+        path: ${{ github.workspace }}/bin/provider.tar.gz
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3
@@ -336,8 +343,11 @@ jobs:
     - name: Download provider + tfgen binaries
       uses: actions/download-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
+        name: ${{ env.PROVIDER }}-provider.tar.gz
         path: ${{ github.workspace }}/bin
+    - name: Untar provider binaries
+      run: tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin
     - name: Restore binary perms
       run: find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print
         -exec chmod +x {} \;

--- a/actions/providers/spotinst/repo/.github/workflows/pull-request.yml
+++ b/actions/providers/spotinst/repo/.github/workflows/pull-request.yml
@@ -55,8 +55,11 @@ jobs:
     - name: Download provider + tfgen binaries
       uses: actions/download-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
+        name: ${{ env.PROVIDER }}-provider.tar.gz
         path: ${{ github.workspace }}/bin
+    - name: Untar provider binaries
+      run: tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin
     - name: Restore binary perms
       run: find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print
         -exec chmod +x {} \;
@@ -187,11 +190,15 @@ jobs:
       uses: pulumi/action-install-pulumi-cli@releases/v1
     - name: Build tfgen & provider binaries
       run: make provider
+    - name: Tar provider binaries
+      run: tar -zcf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin/ pulumi-resource-${{ env.PROVIDER }} pulumi-tfgen-${{ env.PROVIDER
+        }}
     - name: Upload artifacts
       uses: actions/upload-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
-        path: ${{ github.workspace }}/bin
+        name: ${{ env.PROVIDER }}-provider.tar.gz
+        path: ${{ github.workspace }}/bin/provider.tar.gz
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3
@@ -239,8 +246,11 @@ jobs:
     - name: Download provider + tfgen binaries
       uses: actions/download-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
+        name: ${{ env.PROVIDER }}-provider.tar.gz
         path: ${{ github.workspace }}/bin
+    - name: Untar provider binaries
+      run: tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin
     - name: Restore binary perms
       run: find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print
         -exec chmod +x {} \;

--- a/actions/providers/spotinst/repo/.github/workflows/release.yml
+++ b/actions/providers/spotinst/repo/.github/workflows/release.yml
@@ -55,8 +55,11 @@ jobs:
     - name: Download provider + tfgen binaries
       uses: actions/download-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
+        name: ${{ env.PROVIDER }}-provider.tar.gz
         path: ${{ github.workspace }}/bin
+    - name: Untar provider binaries
+      run: tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin
     - name: Restore binary perms
       run: find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print
         -exec chmod +x {} \;
@@ -200,11 +203,15 @@ jobs:
       uses: pulumi/action-install-pulumi-cli@releases/v1
     - name: Build tfgen & provider binaries
       run: make provider
+    - name: Tar provider binaries
+      run: tar -zcf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin/ pulumi-resource-${{ env.PROVIDER }} pulumi-tfgen-${{ env.PROVIDER
+        }}
     - name: Upload artifacts
       uses: actions/upload-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
-        path: ${{ github.workspace }}/bin
+        name: ${{ env.PROVIDER }}-provider.tar.gz
+        path: ${{ github.workspace }}/bin/provider.tar.gz
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3
@@ -356,8 +363,11 @@ jobs:
     - name: Download provider + tfgen binaries
       uses: actions/download-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
+        name: ${{ env.PROVIDER }}-provider.tar.gz
         path: ${{ github.workspace }}/bin
+    - name: Untar provider binaries
+      run: tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin
     - name: Restore binary perms
       run: find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print
         -exec chmod +x {} \;

--- a/actions/providers/terraform/repo/.github/workflows/master.yml
+++ b/actions/providers/terraform/repo/.github/workflows/master.yml
@@ -55,8 +55,11 @@ jobs:
     - name: Download provider + tfgen binaries
       uses: actions/download-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
+        name: ${{ env.PROVIDER }}-provider.tar.gz
         path: ${{ github.workspace }}/bin
+    - name: Untar provider binaries
+      run: tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin
     - name: Restore binary perms
       run: find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print
         -exec chmod +x {} \;
@@ -120,11 +123,15 @@ jobs:
       uses: pulumi/action-install-pulumi-cli@releases/v1
     - name: Build tfgen & provider binaries
       run: make provider
+    - name: Tar provider binaries
+      run: tar -zcf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin/ pulumi-resource-${{ env.PROVIDER }} pulumi-tfgen-${{ env.PROVIDER
+        }}
     - name: Upload artifacts
       uses: actions/upload-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
-        path: ${{ github.workspace }}/bin
+        name: ${{ env.PROVIDER }}-provider.tar.gz
+        path: ${{ github.workspace }}/bin/provider.tar.gz
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3
@@ -281,8 +288,11 @@ jobs:
     - name: Download provider + tfgen binaries
       uses: actions/download-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
+        name: ${{ env.PROVIDER }}-provider.tar.gz
         path: ${{ github.workspace }}/bin
+    - name: Untar provider binaries
+      run: tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin
     - name: Restore binary perms
       run: find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print
         -exec chmod +x {} \;

--- a/actions/providers/terraform/repo/.github/workflows/prerelease.yml
+++ b/actions/providers/terraform/repo/.github/workflows/prerelease.yml
@@ -55,8 +55,11 @@ jobs:
     - name: Download provider + tfgen binaries
       uses: actions/download-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
+        name: ${{ env.PROVIDER }}-provider.tar.gz
         path: ${{ github.workspace }}/bin
+    - name: Untar provider binaries
+      run: tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin
     - name: Restore binary perms
       run: find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print
         -exec chmod +x {} \;
@@ -120,11 +123,15 @@ jobs:
       uses: pulumi/action-install-pulumi-cli@releases/v1
     - name: Build tfgen & provider binaries
       run: make provider
+    - name: Tar provider binaries
+      run: tar -zcf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin/ pulumi-resource-${{ env.PROVIDER }} pulumi-tfgen-${{ env.PROVIDER
+        }}
     - name: Upload artifacts
       uses: actions/upload-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
-        path: ${{ github.workspace }}/bin
+        name: ${{ env.PROVIDER }}-provider.tar.gz
+        path: ${{ github.workspace }}/bin/provider.tar.gz
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3
@@ -269,8 +276,11 @@ jobs:
     - name: Download provider + tfgen binaries
       uses: actions/download-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
+        name: ${{ env.PROVIDER }}-provider.tar.gz
         path: ${{ github.workspace }}/bin
+    - name: Untar provider binaries
+      run: tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin
     - name: Restore binary perms
       run: find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print
         -exec chmod +x {} \;

--- a/actions/providers/terraform/repo/.github/workflows/pull-request.yml
+++ b/actions/providers/terraform/repo/.github/workflows/pull-request.yml
@@ -55,8 +55,11 @@ jobs:
     - name: Download provider + tfgen binaries
       uses: actions/download-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
+        name: ${{ env.PROVIDER }}-provider.tar.gz
         path: ${{ github.workspace }}/bin
+    - name: Untar provider binaries
+      run: tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin
     - name: Restore binary perms
       run: find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print
         -exec chmod +x {} \;
@@ -120,11 +123,15 @@ jobs:
       uses: pulumi/action-install-pulumi-cli@releases/v1
     - name: Build tfgen & provider binaries
       run: make provider
+    - name: Tar provider binaries
+      run: tar -zcf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin/ pulumi-resource-${{ env.PROVIDER }} pulumi-tfgen-${{ env.PROVIDER
+        }}
     - name: Upload artifacts
       uses: actions/upload-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
-        path: ${{ github.workspace }}/bin
+        name: ${{ env.PROVIDER }}-provider.tar.gz
+        path: ${{ github.workspace }}/bin/provider.tar.gz
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3
@@ -172,8 +179,11 @@ jobs:
     - name: Download provider + tfgen binaries
       uses: actions/download-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
+        name: ${{ env.PROVIDER }}-provider.tar.gz
         path: ${{ github.workspace }}/bin
+    - name: Untar provider binaries
+      run: tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin
     - name: Restore binary perms
       run: find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print
         -exec chmod +x {} \;

--- a/actions/providers/terraform/repo/.github/workflows/release.yml
+++ b/actions/providers/terraform/repo/.github/workflows/release.yml
@@ -55,8 +55,11 @@ jobs:
     - name: Download provider + tfgen binaries
       uses: actions/download-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
+        name: ${{ env.PROVIDER }}-provider.tar.gz
         path: ${{ github.workspace }}/bin
+    - name: Untar provider binaries
+      run: tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin
     - name: Restore binary perms
       run: find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print
         -exec chmod +x {} \;
@@ -133,11 +136,15 @@ jobs:
       uses: pulumi/action-install-pulumi-cli@releases/v1
     - name: Build tfgen & provider binaries
       run: make provider
+    - name: Tar provider binaries
+      run: tar -zcf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin/ pulumi-resource-${{ env.PROVIDER }} pulumi-tfgen-${{ env.PROVIDER
+        }}
     - name: Upload artifacts
       uses: actions/upload-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
-        path: ${{ github.workspace }}/bin
+        name: ${{ env.PROVIDER }}-provider.tar.gz
+        path: ${{ github.workspace }}/bin/provider.tar.gz
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3
@@ -289,8 +296,11 @@ jobs:
     - name: Download provider + tfgen binaries
       uses: actions/download-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
+        name: ${{ env.PROVIDER }}-provider.tar.gz
         path: ${{ github.workspace }}/bin
+    - name: Untar provider binaries
+      run: tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin
     - name: Restore binary perms
       run: find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print
         -exec chmod +x {} \;

--- a/actions/providers/tls/repo/.github/workflows/master.yml
+++ b/actions/providers/tls/repo/.github/workflows/master.yml
@@ -52,8 +52,11 @@ jobs:
     - name: Download provider + tfgen binaries
       uses: actions/download-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
+        name: ${{ env.PROVIDER }}-provider.tar.gz
         path: ${{ github.workspace }}/bin
+    - name: Untar provider binaries
+      run: tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin
     - name: Restore binary perms
       run: find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print
         -exec chmod +x {} \;
@@ -184,11 +187,15 @@ jobs:
       uses: pulumi/action-install-pulumi-cli@releases/v1
     - name: Build tfgen & provider binaries
       run: make provider
+    - name: Tar provider binaries
+      run: tar -zcf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin/ pulumi-resource-${{ env.PROVIDER }} pulumi-tfgen-${{ env.PROVIDER
+        }}
     - name: Upload artifacts
       uses: actions/upload-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
-        path: ${{ github.workspace }}/bin
+        name: ${{ env.PROVIDER }}-provider.tar.gz
+        path: ${{ github.workspace }}/bin/provider.tar.gz
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3
@@ -345,8 +352,11 @@ jobs:
     - name: Download provider + tfgen binaries
       uses: actions/download-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
+        name: ${{ env.PROVIDER }}-provider.tar.gz
         path: ${{ github.workspace }}/bin
+    - name: Untar provider binaries
+      run: tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin
     - name: Restore binary perms
       run: find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print
         -exec chmod +x {} \;

--- a/actions/providers/tls/repo/.github/workflows/prerelease.yml
+++ b/actions/providers/tls/repo/.github/workflows/prerelease.yml
@@ -52,8 +52,11 @@ jobs:
     - name: Download provider + tfgen binaries
       uses: actions/download-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
+        name: ${{ env.PROVIDER }}-provider.tar.gz
         path: ${{ github.workspace }}/bin
+    - name: Untar provider binaries
+      run: tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin
     - name: Restore binary perms
       run: find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print
         -exec chmod +x {} \;
@@ -184,11 +187,15 @@ jobs:
       uses: pulumi/action-install-pulumi-cli@releases/v1
     - name: Build tfgen & provider binaries
       run: make provider
+    - name: Tar provider binaries
+      run: tar -zcf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin/ pulumi-resource-${{ env.PROVIDER }} pulumi-tfgen-${{ env.PROVIDER
+        }}
     - name: Upload artifacts
       uses: actions/upload-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
-        path: ${{ github.workspace }}/bin
+        name: ${{ env.PROVIDER }}-provider.tar.gz
+        path: ${{ github.workspace }}/bin/provider.tar.gz
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3
@@ -333,8 +340,11 @@ jobs:
     - name: Download provider + tfgen binaries
       uses: actions/download-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
+        name: ${{ env.PROVIDER }}-provider.tar.gz
         path: ${{ github.workspace }}/bin
+    - name: Untar provider binaries
+      run: tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin
     - name: Restore binary perms
       run: find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print
         -exec chmod +x {} \;

--- a/actions/providers/tls/repo/.github/workflows/pull-request.yml
+++ b/actions/providers/tls/repo/.github/workflows/pull-request.yml
@@ -52,8 +52,11 @@ jobs:
     - name: Download provider + tfgen binaries
       uses: actions/download-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
+        name: ${{ env.PROVIDER }}-provider.tar.gz
         path: ${{ github.workspace }}/bin
+    - name: Untar provider binaries
+      run: tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin
     - name: Restore binary perms
       run: find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print
         -exec chmod +x {} \;
@@ -184,11 +187,15 @@ jobs:
       uses: pulumi/action-install-pulumi-cli@releases/v1
     - name: Build tfgen & provider binaries
       run: make provider
+    - name: Tar provider binaries
+      run: tar -zcf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin/ pulumi-resource-${{ env.PROVIDER }} pulumi-tfgen-${{ env.PROVIDER
+        }}
     - name: Upload artifacts
       uses: actions/upload-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
-        path: ${{ github.workspace }}/bin
+        name: ${{ env.PROVIDER }}-provider.tar.gz
+        path: ${{ github.workspace }}/bin/provider.tar.gz
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3
@@ -236,8 +243,11 @@ jobs:
     - name: Download provider + tfgen binaries
       uses: actions/download-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
+        name: ${{ env.PROVIDER }}-provider.tar.gz
         path: ${{ github.workspace }}/bin
+    - name: Untar provider binaries
+      run: tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin
     - name: Restore binary perms
       run: find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print
         -exec chmod +x {} \;

--- a/actions/providers/tls/repo/.github/workflows/release.yml
+++ b/actions/providers/tls/repo/.github/workflows/release.yml
@@ -52,8 +52,11 @@ jobs:
     - name: Download provider + tfgen binaries
       uses: actions/download-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
+        name: ${{ env.PROVIDER }}-provider.tar.gz
         path: ${{ github.workspace }}/bin
+    - name: Untar provider binaries
+      run: tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin
     - name: Restore binary perms
       run: find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print
         -exec chmod +x {} \;
@@ -197,11 +200,15 @@ jobs:
       uses: pulumi/action-install-pulumi-cli@releases/v1
     - name: Build tfgen & provider binaries
       run: make provider
+    - name: Tar provider binaries
+      run: tar -zcf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin/ pulumi-resource-${{ env.PROVIDER }} pulumi-tfgen-${{ env.PROVIDER
+        }}
     - name: Upload artifacts
       uses: actions/upload-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
-        path: ${{ github.workspace }}/bin
+        name: ${{ env.PROVIDER }}-provider.tar.gz
+        path: ${{ github.workspace }}/bin/provider.tar.gz
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3
@@ -353,8 +360,11 @@ jobs:
     - name: Download provider + tfgen binaries
       uses: actions/download-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
+        name: ${{ env.PROVIDER }}-provider.tar.gz
         path: ${{ github.workspace }}/bin
+    - name: Untar provider binaries
+      run: tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin
     - name: Restore binary perms
       run: find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print
         -exec chmod +x {} \;

--- a/actions/providers/vault/repo/.github/workflows/master.yml
+++ b/actions/providers/vault/repo/.github/workflows/master.yml
@@ -52,8 +52,11 @@ jobs:
     - name: Download provider + tfgen binaries
       uses: actions/download-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
+        name: ${{ env.PROVIDER }}-provider.tar.gz
         path: ${{ github.workspace }}/bin
+    - name: Untar provider binaries
+      run: tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin
     - name: Restore binary perms
       run: find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print
         -exec chmod +x {} \;
@@ -184,11 +187,15 @@ jobs:
       uses: pulumi/action-install-pulumi-cli@releases/v1
     - name: Build tfgen & provider binaries
       run: make provider
+    - name: Tar provider binaries
+      run: tar -zcf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin/ pulumi-resource-${{ env.PROVIDER }} pulumi-tfgen-${{ env.PROVIDER
+        }}
     - name: Upload artifacts
       uses: actions/upload-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
-        path: ${{ github.workspace }}/bin
+        name: ${{ env.PROVIDER }}-provider.tar.gz
+        path: ${{ github.workspace }}/bin/provider.tar.gz
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3
@@ -345,8 +352,11 @@ jobs:
     - name: Download provider + tfgen binaries
       uses: actions/download-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
+        name: ${{ env.PROVIDER }}-provider.tar.gz
         path: ${{ github.workspace }}/bin
+    - name: Untar provider binaries
+      run: tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin
     - name: Restore binary perms
       run: find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print
         -exec chmod +x {} \;

--- a/actions/providers/vault/repo/.github/workflows/prerelease.yml
+++ b/actions/providers/vault/repo/.github/workflows/prerelease.yml
@@ -52,8 +52,11 @@ jobs:
     - name: Download provider + tfgen binaries
       uses: actions/download-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
+        name: ${{ env.PROVIDER }}-provider.tar.gz
         path: ${{ github.workspace }}/bin
+    - name: Untar provider binaries
+      run: tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin
     - name: Restore binary perms
       run: find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print
         -exec chmod +x {} \;
@@ -184,11 +187,15 @@ jobs:
       uses: pulumi/action-install-pulumi-cli@releases/v1
     - name: Build tfgen & provider binaries
       run: make provider
+    - name: Tar provider binaries
+      run: tar -zcf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin/ pulumi-resource-${{ env.PROVIDER }} pulumi-tfgen-${{ env.PROVIDER
+        }}
     - name: Upload artifacts
       uses: actions/upload-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
-        path: ${{ github.workspace }}/bin
+        name: ${{ env.PROVIDER }}-provider.tar.gz
+        path: ${{ github.workspace }}/bin/provider.tar.gz
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3
@@ -333,8 +340,11 @@ jobs:
     - name: Download provider + tfgen binaries
       uses: actions/download-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
+        name: ${{ env.PROVIDER }}-provider.tar.gz
         path: ${{ github.workspace }}/bin
+    - name: Untar provider binaries
+      run: tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin
     - name: Restore binary perms
       run: find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print
         -exec chmod +x {} \;

--- a/actions/providers/vault/repo/.github/workflows/pull-request.yml
+++ b/actions/providers/vault/repo/.github/workflows/pull-request.yml
@@ -52,8 +52,11 @@ jobs:
     - name: Download provider + tfgen binaries
       uses: actions/download-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
+        name: ${{ env.PROVIDER }}-provider.tar.gz
         path: ${{ github.workspace }}/bin
+    - name: Untar provider binaries
+      run: tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin
     - name: Restore binary perms
       run: find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print
         -exec chmod +x {} \;
@@ -184,11 +187,15 @@ jobs:
       uses: pulumi/action-install-pulumi-cli@releases/v1
     - name: Build tfgen & provider binaries
       run: make provider
+    - name: Tar provider binaries
+      run: tar -zcf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin/ pulumi-resource-${{ env.PROVIDER }} pulumi-tfgen-${{ env.PROVIDER
+        }}
     - name: Upload artifacts
       uses: actions/upload-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
-        path: ${{ github.workspace }}/bin
+        name: ${{ env.PROVIDER }}-provider.tar.gz
+        path: ${{ github.workspace }}/bin/provider.tar.gz
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3
@@ -236,8 +243,11 @@ jobs:
     - name: Download provider + tfgen binaries
       uses: actions/download-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
+        name: ${{ env.PROVIDER }}-provider.tar.gz
         path: ${{ github.workspace }}/bin
+    - name: Untar provider binaries
+      run: tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin
     - name: Restore binary perms
       run: find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print
         -exec chmod +x {} \;

--- a/actions/providers/vault/repo/.github/workflows/release.yml
+++ b/actions/providers/vault/repo/.github/workflows/release.yml
@@ -52,8 +52,11 @@ jobs:
     - name: Download provider + tfgen binaries
       uses: actions/download-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
+        name: ${{ env.PROVIDER }}-provider.tar.gz
         path: ${{ github.workspace }}/bin
+    - name: Untar provider binaries
+      run: tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin
     - name: Restore binary perms
       run: find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print
         -exec chmod +x {} \;
@@ -197,11 +200,15 @@ jobs:
       uses: pulumi/action-install-pulumi-cli@releases/v1
     - name: Build tfgen & provider binaries
       run: make provider
+    - name: Tar provider binaries
+      run: tar -zcf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin/ pulumi-resource-${{ env.PROVIDER }} pulumi-tfgen-${{ env.PROVIDER
+        }}
     - name: Upload artifacts
       uses: actions/upload-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
-        path: ${{ github.workspace }}/bin
+        name: ${{ env.PROVIDER }}-provider.tar.gz
+        path: ${{ github.workspace }}/bin/provider.tar.gz
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3
@@ -353,8 +360,11 @@ jobs:
     - name: Download provider + tfgen binaries
       uses: actions/download-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
+        name: ${{ env.PROVIDER }}-provider.tar.gz
         path: ${{ github.workspace }}/bin
+    - name: Untar provider binaries
+      run: tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin
     - name: Restore binary perms
       run: find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print
         -exec chmod +x {} \;

--- a/actions/providers/vsphere/repo/.github/workflows/master.yml
+++ b/actions/providers/vsphere/repo/.github/workflows/master.yml
@@ -52,8 +52,11 @@ jobs:
     - name: Download provider + tfgen binaries
       uses: actions/download-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
+        name: ${{ env.PROVIDER }}-provider.tar.gz
         path: ${{ github.workspace }}/bin
+    - name: Untar provider binaries
+      run: tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin
     - name: Restore binary perms
       run: find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print
         -exec chmod +x {} \;
@@ -184,11 +187,15 @@ jobs:
       uses: pulumi/action-install-pulumi-cli@releases/v1
     - name: Build tfgen & provider binaries
       run: make provider
+    - name: Tar provider binaries
+      run: tar -zcf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin/ pulumi-resource-${{ env.PROVIDER }} pulumi-tfgen-${{ env.PROVIDER
+        }}
     - name: Upload artifacts
       uses: actions/upload-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
-        path: ${{ github.workspace }}/bin
+        name: ${{ env.PROVIDER }}-provider.tar.gz
+        path: ${{ github.workspace }}/bin/provider.tar.gz
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3
@@ -345,8 +352,11 @@ jobs:
     - name: Download provider + tfgen binaries
       uses: actions/download-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
+        name: ${{ env.PROVIDER }}-provider.tar.gz
         path: ${{ github.workspace }}/bin
+    - name: Untar provider binaries
+      run: tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin
     - name: Restore binary perms
       run: find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print
         -exec chmod +x {} \;

--- a/actions/providers/vsphere/repo/.github/workflows/prerelease.yml
+++ b/actions/providers/vsphere/repo/.github/workflows/prerelease.yml
@@ -52,8 +52,11 @@ jobs:
     - name: Download provider + tfgen binaries
       uses: actions/download-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
+        name: ${{ env.PROVIDER }}-provider.tar.gz
         path: ${{ github.workspace }}/bin
+    - name: Untar provider binaries
+      run: tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin
     - name: Restore binary perms
       run: find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print
         -exec chmod +x {} \;
@@ -184,11 +187,15 @@ jobs:
       uses: pulumi/action-install-pulumi-cli@releases/v1
     - name: Build tfgen & provider binaries
       run: make provider
+    - name: Tar provider binaries
+      run: tar -zcf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin/ pulumi-resource-${{ env.PROVIDER }} pulumi-tfgen-${{ env.PROVIDER
+        }}
     - name: Upload artifacts
       uses: actions/upload-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
-        path: ${{ github.workspace }}/bin
+        name: ${{ env.PROVIDER }}-provider.tar.gz
+        path: ${{ github.workspace }}/bin/provider.tar.gz
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3
@@ -333,8 +340,11 @@ jobs:
     - name: Download provider + tfgen binaries
       uses: actions/download-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
+        name: ${{ env.PROVIDER }}-provider.tar.gz
         path: ${{ github.workspace }}/bin
+    - name: Untar provider binaries
+      run: tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin
     - name: Restore binary perms
       run: find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print
         -exec chmod +x {} \;

--- a/actions/providers/vsphere/repo/.github/workflows/pull-request.yml
+++ b/actions/providers/vsphere/repo/.github/workflows/pull-request.yml
@@ -52,8 +52,11 @@ jobs:
     - name: Download provider + tfgen binaries
       uses: actions/download-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
+        name: ${{ env.PROVIDER }}-provider.tar.gz
         path: ${{ github.workspace }}/bin
+    - name: Untar provider binaries
+      run: tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin
     - name: Restore binary perms
       run: find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print
         -exec chmod +x {} \;
@@ -184,11 +187,15 @@ jobs:
       uses: pulumi/action-install-pulumi-cli@releases/v1
     - name: Build tfgen & provider binaries
       run: make provider
+    - name: Tar provider binaries
+      run: tar -zcf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin/ pulumi-resource-${{ env.PROVIDER }} pulumi-tfgen-${{ env.PROVIDER
+        }}
     - name: Upload artifacts
       uses: actions/upload-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
-        path: ${{ github.workspace }}/bin
+        name: ${{ env.PROVIDER }}-provider.tar.gz
+        path: ${{ github.workspace }}/bin/provider.tar.gz
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3
@@ -236,8 +243,11 @@ jobs:
     - name: Download provider + tfgen binaries
       uses: actions/download-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
+        name: ${{ env.PROVIDER }}-provider.tar.gz
         path: ${{ github.workspace }}/bin
+    - name: Untar provider binaries
+      run: tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin
     - name: Restore binary perms
       run: find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print
         -exec chmod +x {} \;

--- a/actions/providers/vsphere/repo/.github/workflows/release.yml
+++ b/actions/providers/vsphere/repo/.github/workflows/release.yml
@@ -52,8 +52,11 @@ jobs:
     - name: Download provider + tfgen binaries
       uses: actions/download-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
+        name: ${{ env.PROVIDER }}-provider.tar.gz
         path: ${{ github.workspace }}/bin
+    - name: Untar provider binaries
+      run: tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin
     - name: Restore binary perms
       run: find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print
         -exec chmod +x {} \;
@@ -197,11 +200,15 @@ jobs:
       uses: pulumi/action-install-pulumi-cli@releases/v1
     - name: Build tfgen & provider binaries
       run: make provider
+    - name: Tar provider binaries
+      run: tar -zcf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin/ pulumi-resource-${{ env.PROVIDER }} pulumi-tfgen-${{ env.PROVIDER
+        }}
     - name: Upload artifacts
       uses: actions/upload-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
-        path: ${{ github.workspace }}/bin
+        name: ${{ env.PROVIDER }}-provider.tar.gz
+        path: ${{ github.workspace }}/bin/provider.tar.gz
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3
@@ -353,8 +360,11 @@ jobs:
     - name: Download provider + tfgen binaries
       uses: actions/download-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
+        name: ${{ env.PROVIDER }}-provider.tar.gz
         path: ${{ github.workspace }}/bin
+    - name: Untar provider binaries
+      run: tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin
     - name: Restore binary perms
       run: find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print
         -exec chmod +x {} \;

--- a/actions/providers/wavefront/repo/.github/workflows/master.yml
+++ b/actions/providers/wavefront/repo/.github/workflows/master.yml
@@ -54,8 +54,11 @@ jobs:
     - name: Download provider + tfgen binaries
       uses: actions/download-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
+        name: ${{ env.PROVIDER }}-provider.tar.gz
         path: ${{ github.workspace }}/bin
+    - name: Untar provider binaries
+      run: tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin
     - name: Restore binary perms
       run: find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print
         -exec chmod +x {} \;
@@ -186,11 +189,15 @@ jobs:
       uses: pulumi/action-install-pulumi-cli@releases/v1
     - name: Build tfgen & provider binaries
       run: make provider
+    - name: Tar provider binaries
+      run: tar -zcf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin/ pulumi-resource-${{ env.PROVIDER }} pulumi-tfgen-${{ env.PROVIDER
+        }}
     - name: Upload artifacts
       uses: actions/upload-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
-        path: ${{ github.workspace }}/bin
+        name: ${{ env.PROVIDER }}-provider.tar.gz
+        path: ${{ github.workspace }}/bin/provider.tar.gz
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3
@@ -347,8 +354,11 @@ jobs:
     - name: Download provider + tfgen binaries
       uses: actions/download-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
+        name: ${{ env.PROVIDER }}-provider.tar.gz
         path: ${{ github.workspace }}/bin
+    - name: Untar provider binaries
+      run: tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin
     - name: Restore binary perms
       run: find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print
         -exec chmod +x {} \;

--- a/actions/providers/wavefront/repo/.github/workflows/prerelease.yml
+++ b/actions/providers/wavefront/repo/.github/workflows/prerelease.yml
@@ -54,8 +54,11 @@ jobs:
     - name: Download provider + tfgen binaries
       uses: actions/download-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
+        name: ${{ env.PROVIDER }}-provider.tar.gz
         path: ${{ github.workspace }}/bin
+    - name: Untar provider binaries
+      run: tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin
     - name: Restore binary perms
       run: find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print
         -exec chmod +x {} \;
@@ -186,11 +189,15 @@ jobs:
       uses: pulumi/action-install-pulumi-cli@releases/v1
     - name: Build tfgen & provider binaries
       run: make provider
+    - name: Tar provider binaries
+      run: tar -zcf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin/ pulumi-resource-${{ env.PROVIDER }} pulumi-tfgen-${{ env.PROVIDER
+        }}
     - name: Upload artifacts
       uses: actions/upload-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
-        path: ${{ github.workspace }}/bin
+        name: ${{ env.PROVIDER }}-provider.tar.gz
+        path: ${{ github.workspace }}/bin/provider.tar.gz
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3
@@ -335,8 +342,11 @@ jobs:
     - name: Download provider + tfgen binaries
       uses: actions/download-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
+        name: ${{ env.PROVIDER }}-provider.tar.gz
         path: ${{ github.workspace }}/bin
+    - name: Untar provider binaries
+      run: tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin
     - name: Restore binary perms
       run: find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print
         -exec chmod +x {} \;

--- a/actions/providers/wavefront/repo/.github/workflows/pull-request.yml
+++ b/actions/providers/wavefront/repo/.github/workflows/pull-request.yml
@@ -54,8 +54,11 @@ jobs:
     - name: Download provider + tfgen binaries
       uses: actions/download-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
+        name: ${{ env.PROVIDER }}-provider.tar.gz
         path: ${{ github.workspace }}/bin
+    - name: Untar provider binaries
+      run: tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin
     - name: Restore binary perms
       run: find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print
         -exec chmod +x {} \;
@@ -186,11 +189,15 @@ jobs:
       uses: pulumi/action-install-pulumi-cli@releases/v1
     - name: Build tfgen & provider binaries
       run: make provider
+    - name: Tar provider binaries
+      run: tar -zcf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin/ pulumi-resource-${{ env.PROVIDER }} pulumi-tfgen-${{ env.PROVIDER
+        }}
     - name: Upload artifacts
       uses: actions/upload-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
-        path: ${{ github.workspace }}/bin
+        name: ${{ env.PROVIDER }}-provider.tar.gz
+        path: ${{ github.workspace }}/bin/provider.tar.gz
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3
@@ -238,8 +245,11 @@ jobs:
     - name: Download provider + tfgen binaries
       uses: actions/download-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
+        name: ${{ env.PROVIDER }}-provider.tar.gz
         path: ${{ github.workspace }}/bin
+    - name: Untar provider binaries
+      run: tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin
     - name: Restore binary perms
       run: find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print
         -exec chmod +x {} \;

--- a/actions/providers/wavefront/repo/.github/workflows/release.yml
+++ b/actions/providers/wavefront/repo/.github/workflows/release.yml
@@ -54,8 +54,11 @@ jobs:
     - name: Download provider + tfgen binaries
       uses: actions/download-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
+        name: ${{ env.PROVIDER }}-provider.tar.gz
         path: ${{ github.workspace }}/bin
+    - name: Untar provider binaries
+      run: tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin
     - name: Restore binary perms
       run: find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print
         -exec chmod +x {} \;
@@ -199,11 +202,15 @@ jobs:
       uses: pulumi/action-install-pulumi-cli@releases/v1
     - name: Build tfgen & provider binaries
       run: make provider
+    - name: Tar provider binaries
+      run: tar -zcf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin/ pulumi-resource-${{ env.PROVIDER }} pulumi-tfgen-${{ env.PROVIDER
+        }}
     - name: Upload artifacts
       uses: actions/upload-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
-        path: ${{ github.workspace }}/bin
+        name: ${{ env.PROVIDER }}-provider.tar.gz
+        path: ${{ github.workspace }}/bin/provider.tar.gz
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3
@@ -355,8 +362,11 @@ jobs:
     - name: Download provider + tfgen binaries
       uses: actions/download-artifact@v2
       with:
-        name: pulumi-${{ env.PROVIDER }}
+        name: ${{ env.PROVIDER }}-provider.tar.gz
         path: ${{ github.workspace }}/bin
+    - name: Untar provider binaries
+      run: tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        }}/bin
     - name: Restore binary perms
       run: find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print
         -exec chmod +x {} \;

--- a/actions/src/workflow.ts
+++ b/actions/src/workflow.ts
@@ -177,10 +177,14 @@ export class MultilangJob extends BaseJob {
             uses: 'actions/download-artifact@v2',
             with: {
                 // eslint-disable-next-line no-template-curly-in-string
-                name: 'pulumi-${{ env.PROVIDER }}',
+                name: '${{ env.PROVIDER }}-provider.tar.gz',
                 // eslint-disable-next-line no-template-curly-in-string
                 path: '${{ github.workspace }}/bin',
             },
+        },
+        {
+            name: 'Untar provider binaries',
+            run: 'tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace }}/bin'
         },
         {
             name: 'Restore binary perms',
@@ -208,15 +212,19 @@ export class PulumiBaseWorkflow extends g.GithubWorkflow {
                         run: 'make provider',
                     },
                 )
+                .addStep({
+                    name: 'Tar provider binaries',
+                    run: 'tar -zcf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace }}/bin/ pulumi-resource-${{ env.PROVIDER }} pulumi-tfgen-${{ env.PROVIDER }}',
+                })
                 .addStep(
                     {
                         name: 'Upload artifacts',
                         uses: 'actions/upload-artifact@v2',
                         with: {
                             // eslint-disable-next-line no-template-curly-in-string
-                            name: 'pulumi-${{ env.PROVIDER }}',
+                            name: '${{ env.PROVIDER }}-provider.tar.gz',
                             // eslint-disable-next-line no-template-curly-in-string
-                            path: '${{ github.workspace }}/bin',
+                            path: '${{ github.workspace }}/bin/provider.tar.gz',
                         },
                     },
                 )


### PR DESCRIPTION
The binaries can easily be zipped to save space. The example
was vsphere went from 129MB to 50MB

We will get similar savings or more for the other providers. AWS
will go from 472 to 129MB

Fixes: #42 