### PR TITLE
Update install of gotestfmt to use jaxxstorm/action-install-gh-release

### DIFF
--- a/provider-ci/lib/steps.js
+++ b/provider-ci/lib/steps.js
@@ -650,11 +650,11 @@ export class SetupGotestfmt extends step.Step {
     constructor() {
         super();
         return {
-            name: 'Set up gotestfmt',
-            uses: 'haveyoudebuggedit/gotestfmt-action@v2',
+            name: 'Install gotestfmt',
+            uses: action.installGhRelease,
             with: {
-                token: "${{ secrets.GITHUB_TOKEN }}"
-            }
+                repo: 'haveyoudebuggedit/gotestfmt',
+            },
         };
     }
 }

--- a/provider-ci/providers/aiven/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/aiven/repo/.github/workflows/main.yml
@@ -418,10 +418,10 @@ jobs:
         pip3 install pipenv
     - name: Install dependencies
       run: make install_${{ matrix.language}}_sdk
-    - name: Set up gotestfmt
-      uses: haveyoudebuggedit/gotestfmt-action@v2
+    - name: Install gotestfmt
+      uses: jaxxstorm/action-install-gh-release@v1.2.0
       with:
-        token: ${{ secrets.GITHUB_TOKEN }}
+        repo: haveyoudebuggedit/gotestfmt
     - name: Run tests
       run: cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language
         }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt

--- a/provider-ci/providers/aiven/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/aiven/repo/.github/workflows/master.yml
@@ -418,10 +418,10 @@ jobs:
         pip3 install pipenv
     - name: Install dependencies
       run: make install_${{ matrix.language}}_sdk
-    - name: Set up gotestfmt
-      uses: haveyoudebuggedit/gotestfmt-action@v2
+    - name: Install gotestfmt
+      uses: jaxxstorm/action-install-gh-release@v1.2.0
       with:
-        token: ${{ secrets.GITHUB_TOKEN }}
+        repo: haveyoudebuggedit/gotestfmt
     - name: Run tests
       run: cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language
         }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt

--- a/provider-ci/providers/aiven/repo/.github/workflows/nightly-test.yml
+++ b/provider-ci/providers/aiven/repo/.github/workflows/nightly-test.yml
@@ -234,10 +234,10 @@ jobs:
         pip3 install pipenv
     - name: Install dependencies
       run: make install_${{ matrix.language}}_sdk
-    - name: Set up gotestfmt
-      uses: haveyoudebuggedit/gotestfmt-action@v2
+    - name: Install gotestfmt
+      uses: jaxxstorm/action-install-gh-release@v1.2.0
       with:
-        token: ${{ secrets.GITHUB_TOKEN }}
+        repo: haveyoudebuggedit/gotestfmt
     - name: Run tests
       run: cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language
         }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt

--- a/provider-ci/providers/aiven/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/aiven/repo/.github/workflows/prerelease.yml
@@ -364,10 +364,10 @@ jobs:
         pip3 install pipenv
     - name: Install dependencies
       run: make install_${{ matrix.language}}_sdk
-    - name: Set up gotestfmt
-      uses: haveyoudebuggedit/gotestfmt-action@v2
+    - name: Install gotestfmt
+      uses: jaxxstorm/action-install-gh-release@v1.2.0
       with:
-        token: ${{ secrets.GITHUB_TOKEN }}
+        repo: haveyoudebuggedit/gotestfmt
     - name: Run tests
       run: cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language
         }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt

--- a/provider-ci/providers/aiven/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/aiven/repo/.github/workflows/release.yml
@@ -376,10 +376,10 @@ jobs:
         pip3 install pipenv
     - name: Install dependencies
       run: make install_${{ matrix.language}}_sdk
-    - name: Set up gotestfmt
-      uses: haveyoudebuggedit/gotestfmt-action@v2
+    - name: Install gotestfmt
+      uses: jaxxstorm/action-install-gh-release@v1.2.0
       with:
-        token: ${{ secrets.GITHUB_TOKEN }}
+        repo: haveyoudebuggedit/gotestfmt
     - name: Run tests
       run: cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language
         }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt

--- a/provider-ci/providers/aiven/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/aiven/repo/.github/workflows/run-acceptance-tests.yml
@@ -265,10 +265,10 @@ jobs:
         pip3 install pipenv
     - name: Install dependencies
       run: make install_${{ matrix.language}}_sdk
-    - name: Set up gotestfmt
-      uses: haveyoudebuggedit/gotestfmt-action@v2
+    - name: Install gotestfmt
+      uses: jaxxstorm/action-install-gh-release@v1.2.0
       with:
-        token: ${{ secrets.GITHUB_TOKEN }}
+        repo: haveyoudebuggedit/gotestfmt
     - name: Run tests
       run: cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language
         }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt

--- a/provider-ci/providers/akamai/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/akamai/repo/.github/workflows/main.yml
@@ -420,10 +420,10 @@ jobs:
         pip3 install pipenv
     - name: Install dependencies
       run: make install_${{ matrix.language}}_sdk
-    - name: Set up gotestfmt
-      uses: haveyoudebuggedit/gotestfmt-action@v2
+    - name: Install gotestfmt
+      uses: jaxxstorm/action-install-gh-release@v1.2.0
       with:
-        token: ${{ secrets.GITHUB_TOKEN }}
+        repo: haveyoudebuggedit/gotestfmt
     - name: Run tests
       run: cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language
         }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt

--- a/provider-ci/providers/akamai/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/akamai/repo/.github/workflows/master.yml
@@ -420,10 +420,10 @@ jobs:
         pip3 install pipenv
     - name: Install dependencies
       run: make install_${{ matrix.language}}_sdk
-    - name: Set up gotestfmt
-      uses: haveyoudebuggedit/gotestfmt-action@v2
+    - name: Install gotestfmt
+      uses: jaxxstorm/action-install-gh-release@v1.2.0
       with:
-        token: ${{ secrets.GITHUB_TOKEN }}
+        repo: haveyoudebuggedit/gotestfmt
     - name: Run tests
       run: cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language
         }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt

--- a/provider-ci/providers/akamai/repo/.github/workflows/nightly-test.yml
+++ b/provider-ci/providers/akamai/repo/.github/workflows/nightly-test.yml
@@ -236,10 +236,10 @@ jobs:
         pip3 install pipenv
     - name: Install dependencies
       run: make install_${{ matrix.language}}_sdk
-    - name: Set up gotestfmt
-      uses: haveyoudebuggedit/gotestfmt-action@v2
+    - name: Install gotestfmt
+      uses: jaxxstorm/action-install-gh-release@v1.2.0
       with:
-        token: ${{ secrets.GITHUB_TOKEN }}
+        repo: haveyoudebuggedit/gotestfmt
     - name: Run tests
       run: cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language
         }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt

--- a/provider-ci/providers/akamai/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/akamai/repo/.github/workflows/prerelease.yml
@@ -366,10 +366,10 @@ jobs:
         pip3 install pipenv
     - name: Install dependencies
       run: make install_${{ matrix.language}}_sdk
-    - name: Set up gotestfmt
-      uses: haveyoudebuggedit/gotestfmt-action@v2
+    - name: Install gotestfmt
+      uses: jaxxstorm/action-install-gh-release@v1.2.0
       with:
-        token: ${{ secrets.GITHUB_TOKEN }}
+        repo: haveyoudebuggedit/gotestfmt
     - name: Run tests
       run: cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language
         }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt

--- a/provider-ci/providers/akamai/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/akamai/repo/.github/workflows/release.yml
@@ -378,10 +378,10 @@ jobs:
         pip3 install pipenv
     - name: Install dependencies
       run: make install_${{ matrix.language}}_sdk
-    - name: Set up gotestfmt
-      uses: haveyoudebuggedit/gotestfmt-action@v2
+    - name: Install gotestfmt
+      uses: jaxxstorm/action-install-gh-release@v1.2.0
       with:
-        token: ${{ secrets.GITHUB_TOKEN }}
+        repo: haveyoudebuggedit/gotestfmt
     - name: Run tests
       run: cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language
         }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt

--- a/provider-ci/providers/akamai/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/akamai/repo/.github/workflows/run-acceptance-tests.yml
@@ -267,10 +267,10 @@ jobs:
         pip3 install pipenv
     - name: Install dependencies
       run: make install_${{ matrix.language}}_sdk
-    - name: Set up gotestfmt
-      uses: haveyoudebuggedit/gotestfmt-action@v2
+    - name: Install gotestfmt
+      uses: jaxxstorm/action-install-gh-release@v1.2.0
       with:
-        token: ${{ secrets.GITHUB_TOKEN }}
+        repo: haveyoudebuggedit/gotestfmt
     - name: Run tests
       run: cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language
         }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt

--- a/provider-ci/providers/alicloud/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/alicloud/repo/.github/workflows/main.yml
@@ -419,10 +419,10 @@ jobs:
         pip3 install pipenv
     - name: Install dependencies
       run: make install_${{ matrix.language}}_sdk
-    - name: Set up gotestfmt
-      uses: haveyoudebuggedit/gotestfmt-action@v2
+    - name: Install gotestfmt
+      uses: jaxxstorm/action-install-gh-release@v1.2.0
       with:
-        token: ${{ secrets.GITHUB_TOKEN }}
+        repo: haveyoudebuggedit/gotestfmt
     - name: Run tests
       run: cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language
         }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt

--- a/provider-ci/providers/alicloud/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/alicloud/repo/.github/workflows/master.yml
@@ -419,10 +419,10 @@ jobs:
         pip3 install pipenv
     - name: Install dependencies
       run: make install_${{ matrix.language}}_sdk
-    - name: Set up gotestfmt
-      uses: haveyoudebuggedit/gotestfmt-action@v2
+    - name: Install gotestfmt
+      uses: jaxxstorm/action-install-gh-release@v1.2.0
       with:
-        token: ${{ secrets.GITHUB_TOKEN }}
+        repo: haveyoudebuggedit/gotestfmt
     - name: Run tests
       run: cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language
         }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt

--- a/provider-ci/providers/alicloud/repo/.github/workflows/nightly-test.yml
+++ b/provider-ci/providers/alicloud/repo/.github/workflows/nightly-test.yml
@@ -235,10 +235,10 @@ jobs:
         pip3 install pipenv
     - name: Install dependencies
       run: make install_${{ matrix.language}}_sdk
-    - name: Set up gotestfmt
-      uses: haveyoudebuggedit/gotestfmt-action@v2
+    - name: Install gotestfmt
+      uses: jaxxstorm/action-install-gh-release@v1.2.0
       with:
-        token: ${{ secrets.GITHUB_TOKEN }}
+        repo: haveyoudebuggedit/gotestfmt
     - name: Run tests
       run: cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language
         }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt

--- a/provider-ci/providers/alicloud/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/alicloud/repo/.github/workflows/prerelease.yml
@@ -365,10 +365,10 @@ jobs:
         pip3 install pipenv
     - name: Install dependencies
       run: make install_${{ matrix.language}}_sdk
-    - name: Set up gotestfmt
-      uses: haveyoudebuggedit/gotestfmt-action@v2
+    - name: Install gotestfmt
+      uses: jaxxstorm/action-install-gh-release@v1.2.0
       with:
-        token: ${{ secrets.GITHUB_TOKEN }}
+        repo: haveyoudebuggedit/gotestfmt
     - name: Run tests
       run: cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language
         }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt

--- a/provider-ci/providers/alicloud/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/alicloud/repo/.github/workflows/release.yml
@@ -377,10 +377,10 @@ jobs:
         pip3 install pipenv
     - name: Install dependencies
       run: make install_${{ matrix.language}}_sdk
-    - name: Set up gotestfmt
-      uses: haveyoudebuggedit/gotestfmt-action@v2
+    - name: Install gotestfmt
+      uses: jaxxstorm/action-install-gh-release@v1.2.0
       with:
-        token: ${{ secrets.GITHUB_TOKEN }}
+        repo: haveyoudebuggedit/gotestfmt
     - name: Run tests
       run: cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language
         }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt

--- a/provider-ci/providers/alicloud/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/alicloud/repo/.github/workflows/run-acceptance-tests.yml
@@ -266,10 +266,10 @@ jobs:
         pip3 install pipenv
     - name: Install dependencies
       run: make install_${{ matrix.language}}_sdk
-    - name: Set up gotestfmt
-      uses: haveyoudebuggedit/gotestfmt-action@v2
+    - name: Install gotestfmt
+      uses: jaxxstorm/action-install-gh-release@v1.2.0
       with:
-        token: ${{ secrets.GITHUB_TOKEN }}
+        repo: haveyoudebuggedit/gotestfmt
     - name: Run tests
       run: cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language
         }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt

--- a/provider-ci/providers/artifactory/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/artifactory/repo/.github/workflows/main.yml
@@ -493,10 +493,10 @@ jobs:
         pip3 install pipenv
     - name: Install dependencies
       run: make install_${{ matrix.language}}_sdk
-    - name: Set up gotestfmt
-      uses: haveyoudebuggedit/gotestfmt-action@v2
+    - name: Install gotestfmt
+      uses: jaxxstorm/action-install-gh-release@v1.2.0
       with:
-        token: ${{ secrets.GITHUB_TOKEN }}
+        repo: haveyoudebuggedit/gotestfmt
     - name: Run tests
       run: cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language
         }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt

--- a/provider-ci/providers/artifactory/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/artifactory/repo/.github/workflows/master.yml
@@ -493,10 +493,10 @@ jobs:
         pip3 install pipenv
     - name: Install dependencies
       run: make install_${{ matrix.language}}_sdk
-    - name: Set up gotestfmt
-      uses: haveyoudebuggedit/gotestfmt-action@v2
+    - name: Install gotestfmt
+      uses: jaxxstorm/action-install-gh-release@v1.2.0
       with:
-        token: ${{ secrets.GITHUB_TOKEN }}
+        repo: haveyoudebuggedit/gotestfmt
     - name: Run tests
       run: cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language
         }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt

--- a/provider-ci/providers/artifactory/repo/.github/workflows/nightly-test.yml
+++ b/provider-ci/providers/artifactory/repo/.github/workflows/nightly-test.yml
@@ -234,10 +234,10 @@ jobs:
         pip3 install pipenv
     - name: Install dependencies
       run: make install_${{ matrix.language}}_sdk
-    - name: Set up gotestfmt
-      uses: haveyoudebuggedit/gotestfmt-action@v2
+    - name: Install gotestfmt
+      uses: jaxxstorm/action-install-gh-release@v1.2.0
       with:
-        token: ${{ secrets.GITHUB_TOKEN }}
+        repo: haveyoudebuggedit/gotestfmt
     - name: Run tests
       run: cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language
         }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt

--- a/provider-ci/providers/artifactory/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/artifactory/repo/.github/workflows/prerelease.yml
@@ -439,10 +439,10 @@ jobs:
         pip3 install pipenv
     - name: Install dependencies
       run: make install_${{ matrix.language}}_sdk
-    - name: Set up gotestfmt
-      uses: haveyoudebuggedit/gotestfmt-action@v2
+    - name: Install gotestfmt
+      uses: jaxxstorm/action-install-gh-release@v1.2.0
       with:
-        token: ${{ secrets.GITHUB_TOKEN }}
+        repo: haveyoudebuggedit/gotestfmt
     - name: Run tests
       run: cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language
         }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt

--- a/provider-ci/providers/artifactory/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/artifactory/repo/.github/workflows/release.yml
@@ -451,10 +451,10 @@ jobs:
         pip3 install pipenv
     - name: Install dependencies
       run: make install_${{ matrix.language}}_sdk
-    - name: Set up gotestfmt
-      uses: haveyoudebuggedit/gotestfmt-action@v2
+    - name: Install gotestfmt
+      uses: jaxxstorm/action-install-gh-release@v1.2.0
       with:
-        token: ${{ secrets.GITHUB_TOKEN }}
+        repo: haveyoudebuggedit/gotestfmt
     - name: Run tests
       run: cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language
         }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt

--- a/provider-ci/providers/artifactory/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/artifactory/repo/.github/workflows/run-acceptance-tests.yml
@@ -348,10 +348,10 @@ jobs:
         pip3 install pipenv
     - name: Install dependencies
       run: make install_${{ matrix.language}}_sdk
-    - name: Set up gotestfmt
-      uses: haveyoudebuggedit/gotestfmt-action@v2
+    - name: Install gotestfmt
+      uses: jaxxstorm/action-install-gh-release@v1.2.0
       with:
-        token: ${{ secrets.GITHUB_TOKEN }}
+        repo: haveyoudebuggedit/gotestfmt
     - name: Run tests
       run: cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language
         }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt

--- a/provider-ci/providers/auth0/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/auth0/repo/.github/workflows/main.yml
@@ -494,10 +494,10 @@ jobs:
         pip3 install pipenv
     - name: Install dependencies
       run: make install_${{ matrix.language}}_sdk
-    - name: Set up gotestfmt
-      uses: haveyoudebuggedit/gotestfmt-action@v2
+    - name: Install gotestfmt
+      uses: jaxxstorm/action-install-gh-release@v1.2.0
       with:
-        token: ${{ secrets.GITHUB_TOKEN }}
+        repo: haveyoudebuggedit/gotestfmt
     - name: Run tests
       run: cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language
         }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt

--- a/provider-ci/providers/auth0/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/auth0/repo/.github/workflows/master.yml
@@ -494,10 +494,10 @@ jobs:
         pip3 install pipenv
     - name: Install dependencies
       run: make install_${{ matrix.language}}_sdk
-    - name: Set up gotestfmt
-      uses: haveyoudebuggedit/gotestfmt-action@v2
+    - name: Install gotestfmt
+      uses: jaxxstorm/action-install-gh-release@v1.2.0
       with:
-        token: ${{ secrets.GITHUB_TOKEN }}
+        repo: haveyoudebuggedit/gotestfmt
     - name: Run tests
       run: cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language
         }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt

--- a/provider-ci/providers/auth0/repo/.github/workflows/nightly-test.yml
+++ b/provider-ci/providers/auth0/repo/.github/workflows/nightly-test.yml
@@ -235,10 +235,10 @@ jobs:
         pip3 install pipenv
     - name: Install dependencies
       run: make install_${{ matrix.language}}_sdk
-    - name: Set up gotestfmt
-      uses: haveyoudebuggedit/gotestfmt-action@v2
+    - name: Install gotestfmt
+      uses: jaxxstorm/action-install-gh-release@v1.2.0
       with:
-        token: ${{ secrets.GITHUB_TOKEN }}
+        repo: haveyoudebuggedit/gotestfmt
     - name: Run tests
       run: cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language
         }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt

--- a/provider-ci/providers/auth0/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/auth0/repo/.github/workflows/prerelease.yml
@@ -440,10 +440,10 @@ jobs:
         pip3 install pipenv
     - name: Install dependencies
       run: make install_${{ matrix.language}}_sdk
-    - name: Set up gotestfmt
-      uses: haveyoudebuggedit/gotestfmt-action@v2
+    - name: Install gotestfmt
+      uses: jaxxstorm/action-install-gh-release@v1.2.0
       with:
-        token: ${{ secrets.GITHUB_TOKEN }}
+        repo: haveyoudebuggedit/gotestfmt
     - name: Run tests
       run: cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language
         }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt

--- a/provider-ci/providers/auth0/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/auth0/repo/.github/workflows/release.yml
@@ -452,10 +452,10 @@ jobs:
         pip3 install pipenv
     - name: Install dependencies
       run: make install_${{ matrix.language}}_sdk
-    - name: Set up gotestfmt
-      uses: haveyoudebuggedit/gotestfmt-action@v2
+    - name: Install gotestfmt
+      uses: jaxxstorm/action-install-gh-release@v1.2.0
       with:
-        token: ${{ secrets.GITHUB_TOKEN }}
+        repo: haveyoudebuggedit/gotestfmt
     - name: Run tests
       run: cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language
         }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt

--- a/provider-ci/providers/auth0/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/auth0/repo/.github/workflows/run-acceptance-tests.yml
@@ -349,10 +349,10 @@ jobs:
         pip3 install pipenv
     - name: Install dependencies
       run: make install_${{ matrix.language}}_sdk
-    - name: Set up gotestfmt
-      uses: haveyoudebuggedit/gotestfmt-action@v2
+    - name: Install gotestfmt
+      uses: jaxxstorm/action-install-gh-release@v1.2.0
       with:
-        token: ${{ secrets.GITHUB_TOKEN }}
+        repo: haveyoudebuggedit/gotestfmt
     - name: Run tests
       run: cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language
         }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt

--- a/provider-ci/providers/aws/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/aws/repo/.github/workflows/main.yml
@@ -426,10 +426,10 @@ jobs:
         role-to-assume: ${{ secrets.AWS_CI_ROLE_ARN }}
     - name: Install dependencies
       run: make install_${{ matrix.language}}_sdk
-    - name: Set up gotestfmt
-      uses: haveyoudebuggedit/gotestfmt-action@v2
+    - name: Install gotestfmt
+      uses: jaxxstorm/action-install-gh-release@v1.2.0
       with:
-        token: ${{ secrets.GITHUB_TOKEN }}
+        repo: haveyoudebuggedit/gotestfmt
     - name: Run tests
       run: cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language
         }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt

--- a/provider-ci/providers/aws/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/aws/repo/.github/workflows/master.yml
@@ -426,10 +426,10 @@ jobs:
         role-to-assume: ${{ secrets.AWS_CI_ROLE_ARN }}
     - name: Install dependencies
       run: make install_${{ matrix.language}}_sdk
-    - name: Set up gotestfmt
-      uses: haveyoudebuggedit/gotestfmt-action@v2
+    - name: Install gotestfmt
+      uses: jaxxstorm/action-install-gh-release@v1.2.0
       with:
-        token: ${{ secrets.GITHUB_TOKEN }}
+        repo: haveyoudebuggedit/gotestfmt
     - name: Run tests
       run: cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language
         }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt

--- a/provider-ci/providers/aws/repo/.github/workflows/nightly-test.yml
+++ b/provider-ci/providers/aws/repo/.github/workflows/nightly-test.yml
@@ -242,10 +242,10 @@ jobs:
         role-to-assume: ${{ secrets.AWS_CI_ROLE_ARN }}
     - name: Install dependencies
       run: make install_${{ matrix.language}}_sdk
-    - name: Set up gotestfmt
-      uses: haveyoudebuggedit/gotestfmt-action@v2
+    - name: Install gotestfmt
+      uses: jaxxstorm/action-install-gh-release@v1.2.0
       with:
-        token: ${{ secrets.GITHUB_TOKEN }}
+        repo: haveyoudebuggedit/gotestfmt
     - name: Run tests
       run: cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language
         }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt

--- a/provider-ci/providers/aws/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/aws/repo/.github/workflows/prerelease.yml
@@ -372,10 +372,10 @@ jobs:
         role-to-assume: ${{ secrets.AWS_CI_ROLE_ARN }}
     - name: Install dependencies
       run: make install_${{ matrix.language}}_sdk
-    - name: Set up gotestfmt
-      uses: haveyoudebuggedit/gotestfmt-action@v2
+    - name: Install gotestfmt
+      uses: jaxxstorm/action-install-gh-release@v1.2.0
       with:
-        token: ${{ secrets.GITHUB_TOKEN }}
+        repo: haveyoudebuggedit/gotestfmt
     - name: Run tests
       run: cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language
         }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt

--- a/provider-ci/providers/aws/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/aws/repo/.github/workflows/release.yml
@@ -384,10 +384,10 @@ jobs:
         role-to-assume: ${{ secrets.AWS_CI_ROLE_ARN }}
     - name: Install dependencies
       run: make install_${{ matrix.language}}_sdk
-    - name: Set up gotestfmt
-      uses: haveyoudebuggedit/gotestfmt-action@v2
+    - name: Install gotestfmt
+      uses: jaxxstorm/action-install-gh-release@v1.2.0
       with:
-        token: ${{ secrets.GITHUB_TOKEN }}
+        repo: haveyoudebuggedit/gotestfmt
     - name: Run tests
       run: cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language
         }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt

--- a/provider-ci/providers/aws/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/aws/repo/.github/workflows/run-acceptance-tests.yml
@@ -273,10 +273,10 @@ jobs:
         role-to-assume: ${{ secrets.AWS_CI_ROLE_ARN }}
     - name: Install dependencies
       run: make install_${{ matrix.language}}_sdk
-    - name: Set up gotestfmt
-      uses: haveyoudebuggedit/gotestfmt-action@v2
+    - name: Install gotestfmt
+      uses: jaxxstorm/action-install-gh-release@v1.2.0
       with:
-        token: ${{ secrets.GITHUB_TOKEN }}
+        repo: haveyoudebuggedit/gotestfmt
     - name: Run tests
       run: cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language
         }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt

--- a/provider-ci/providers/azure/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/azure/repo/.github/workflows/main.yml
@@ -422,10 +422,10 @@ jobs:
         pip3 install pipenv
     - name: Install dependencies
       run: make install_${{ matrix.language}}_sdk
-    - name: Set up gotestfmt
-      uses: haveyoudebuggedit/gotestfmt-action@v2
+    - name: Install gotestfmt
+      uses: jaxxstorm/action-install-gh-release@v1.2.0
       with:
-        token: ${{ secrets.GITHUB_TOKEN }}
+        repo: haveyoudebuggedit/gotestfmt
     - name: Run tests
       run: cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language
         }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt

--- a/provider-ci/providers/azure/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/azure/repo/.github/workflows/master.yml
@@ -422,10 +422,10 @@ jobs:
         pip3 install pipenv
     - name: Install dependencies
       run: make install_${{ matrix.language}}_sdk
-    - name: Set up gotestfmt
-      uses: haveyoudebuggedit/gotestfmt-action@v2
+    - name: Install gotestfmt
+      uses: jaxxstorm/action-install-gh-release@v1.2.0
       with:
-        token: ${{ secrets.GITHUB_TOKEN }}
+        repo: haveyoudebuggedit/gotestfmt
     - name: Run tests
       run: cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language
         }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt

--- a/provider-ci/providers/azure/repo/.github/workflows/nightly-test.yml
+++ b/provider-ci/providers/azure/repo/.github/workflows/nightly-test.yml
@@ -238,10 +238,10 @@ jobs:
         pip3 install pipenv
     - name: Install dependencies
       run: make install_${{ matrix.language}}_sdk
-    - name: Set up gotestfmt
-      uses: haveyoudebuggedit/gotestfmt-action@v2
+    - name: Install gotestfmt
+      uses: jaxxstorm/action-install-gh-release@v1.2.0
       with:
-        token: ${{ secrets.GITHUB_TOKEN }}
+        repo: haveyoudebuggedit/gotestfmt
     - name: Run tests
       run: cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language
         }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt

--- a/provider-ci/providers/azure/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/azure/repo/.github/workflows/prerelease.yml
@@ -368,10 +368,10 @@ jobs:
         pip3 install pipenv
     - name: Install dependencies
       run: make install_${{ matrix.language}}_sdk
-    - name: Set up gotestfmt
-      uses: haveyoudebuggedit/gotestfmt-action@v2
+    - name: Install gotestfmt
+      uses: jaxxstorm/action-install-gh-release@v1.2.0
       with:
-        token: ${{ secrets.GITHUB_TOKEN }}
+        repo: haveyoudebuggedit/gotestfmt
     - name: Run tests
       run: cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language
         }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt

--- a/provider-ci/providers/azure/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/azure/repo/.github/workflows/release.yml
@@ -380,10 +380,10 @@ jobs:
         pip3 install pipenv
     - name: Install dependencies
       run: make install_${{ matrix.language}}_sdk
-    - name: Set up gotestfmt
-      uses: haveyoudebuggedit/gotestfmt-action@v2
+    - name: Install gotestfmt
+      uses: jaxxstorm/action-install-gh-release@v1.2.0
       with:
-        token: ${{ secrets.GITHUB_TOKEN }}
+        repo: haveyoudebuggedit/gotestfmt
     - name: Run tests
       run: cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language
         }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt

--- a/provider-ci/providers/azure/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/azure/repo/.github/workflows/run-acceptance-tests.yml
@@ -269,10 +269,10 @@ jobs:
         pip3 install pipenv
     - name: Install dependencies
       run: make install_${{ matrix.language}}_sdk
-    - name: Set up gotestfmt
-      uses: haveyoudebuggedit/gotestfmt-action@v2
+    - name: Install gotestfmt
+      uses: jaxxstorm/action-install-gh-release@v1.2.0
       with:
-        token: ${{ secrets.GITHUB_TOKEN }}
+        repo: haveyoudebuggedit/gotestfmt
     - name: Run tests
       run: cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language
         }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt

--- a/provider-ci/providers/azuread/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/azuread/repo/.github/workflows/main.yml
@@ -496,10 +496,10 @@ jobs:
         pip3 install pipenv
     - name: Install dependencies
       run: make install_${{ matrix.language}}_sdk
-    - name: Set up gotestfmt
-      uses: haveyoudebuggedit/gotestfmt-action@v2
+    - name: Install gotestfmt
+      uses: jaxxstorm/action-install-gh-release@v1.2.0
       with:
-        token: ${{ secrets.GITHUB_TOKEN }}
+        repo: haveyoudebuggedit/gotestfmt
     - name: Run tests
       run: cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language
         }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt

--- a/provider-ci/providers/azuread/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/azuread/repo/.github/workflows/master.yml
@@ -496,10 +496,10 @@ jobs:
         pip3 install pipenv
     - name: Install dependencies
       run: make install_${{ matrix.language}}_sdk
-    - name: Set up gotestfmt
-      uses: haveyoudebuggedit/gotestfmt-action@v2
+    - name: Install gotestfmt
+      uses: jaxxstorm/action-install-gh-release@v1.2.0
       with:
-        token: ${{ secrets.GITHUB_TOKEN }}
+        repo: haveyoudebuggedit/gotestfmt
     - name: Run tests
       run: cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language
         }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt

--- a/provider-ci/providers/azuread/repo/.github/workflows/nightly-test.yml
+++ b/provider-ci/providers/azuread/repo/.github/workflows/nightly-test.yml
@@ -237,10 +237,10 @@ jobs:
         pip3 install pipenv
     - name: Install dependencies
       run: make install_${{ matrix.language}}_sdk
-    - name: Set up gotestfmt
-      uses: haveyoudebuggedit/gotestfmt-action@v2
+    - name: Install gotestfmt
+      uses: jaxxstorm/action-install-gh-release@v1.2.0
       with:
-        token: ${{ secrets.GITHUB_TOKEN }}
+        repo: haveyoudebuggedit/gotestfmt
     - name: Run tests
       run: cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language
         }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt

--- a/provider-ci/providers/azuread/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/azuread/repo/.github/workflows/prerelease.yml
@@ -442,10 +442,10 @@ jobs:
         pip3 install pipenv
     - name: Install dependencies
       run: make install_${{ matrix.language}}_sdk
-    - name: Set up gotestfmt
-      uses: haveyoudebuggedit/gotestfmt-action@v2
+    - name: Install gotestfmt
+      uses: jaxxstorm/action-install-gh-release@v1.2.0
       with:
-        token: ${{ secrets.GITHUB_TOKEN }}
+        repo: haveyoudebuggedit/gotestfmt
     - name: Run tests
       run: cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language
         }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt

--- a/provider-ci/providers/azuread/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/azuread/repo/.github/workflows/release.yml
@@ -454,10 +454,10 @@ jobs:
         pip3 install pipenv
     - name: Install dependencies
       run: make install_${{ matrix.language}}_sdk
-    - name: Set up gotestfmt
-      uses: haveyoudebuggedit/gotestfmt-action@v2
+    - name: Install gotestfmt
+      uses: jaxxstorm/action-install-gh-release@v1.2.0
       with:
-        token: ${{ secrets.GITHUB_TOKEN }}
+        repo: haveyoudebuggedit/gotestfmt
     - name: Run tests
       run: cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language
         }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt

--- a/provider-ci/providers/azuread/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/azuread/repo/.github/workflows/run-acceptance-tests.yml
@@ -351,10 +351,10 @@ jobs:
         pip3 install pipenv
     - name: Install dependencies
       run: make install_${{ matrix.language}}_sdk
-    - name: Set up gotestfmt
-      uses: haveyoudebuggedit/gotestfmt-action@v2
+    - name: Install gotestfmt
+      uses: jaxxstorm/action-install-gh-release@v1.2.0
       with:
-        token: ${{ secrets.GITHUB_TOKEN }}
+        repo: haveyoudebuggedit/gotestfmt
     - name: Run tests
       run: cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language
         }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt

--- a/provider-ci/providers/azuredevops/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/azuredevops/repo/.github/workflows/main.yml
@@ -418,10 +418,10 @@ jobs:
         pip3 install pipenv
     - name: Install dependencies
       run: make install_${{ matrix.language}}_sdk
-    - name: Set up gotestfmt
-      uses: haveyoudebuggedit/gotestfmt-action@v2
+    - name: Install gotestfmt
+      uses: jaxxstorm/action-install-gh-release@v1.2.0
       with:
-        token: ${{ secrets.GITHUB_TOKEN }}
+        repo: haveyoudebuggedit/gotestfmt
     - name: Run tests
       run: cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language
         }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt

--- a/provider-ci/providers/azuredevops/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/azuredevops/repo/.github/workflows/master.yml
@@ -418,10 +418,10 @@ jobs:
         pip3 install pipenv
     - name: Install dependencies
       run: make install_${{ matrix.language}}_sdk
-    - name: Set up gotestfmt
-      uses: haveyoudebuggedit/gotestfmt-action@v2
+    - name: Install gotestfmt
+      uses: jaxxstorm/action-install-gh-release@v1.2.0
       with:
-        token: ${{ secrets.GITHUB_TOKEN }}
+        repo: haveyoudebuggedit/gotestfmt
     - name: Run tests
       run: cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language
         }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt

--- a/provider-ci/providers/azuredevops/repo/.github/workflows/nightly-test.yml
+++ b/provider-ci/providers/azuredevops/repo/.github/workflows/nightly-test.yml
@@ -234,10 +234,10 @@ jobs:
         pip3 install pipenv
     - name: Install dependencies
       run: make install_${{ matrix.language}}_sdk
-    - name: Set up gotestfmt
-      uses: haveyoudebuggedit/gotestfmt-action@v2
+    - name: Install gotestfmt
+      uses: jaxxstorm/action-install-gh-release@v1.2.0
       with:
-        token: ${{ secrets.GITHUB_TOKEN }}
+        repo: haveyoudebuggedit/gotestfmt
     - name: Run tests
       run: cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language
         }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt

--- a/provider-ci/providers/azuredevops/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/azuredevops/repo/.github/workflows/prerelease.yml
@@ -364,10 +364,10 @@ jobs:
         pip3 install pipenv
     - name: Install dependencies
       run: make install_${{ matrix.language}}_sdk
-    - name: Set up gotestfmt
-      uses: haveyoudebuggedit/gotestfmt-action@v2
+    - name: Install gotestfmt
+      uses: jaxxstorm/action-install-gh-release@v1.2.0
       with:
-        token: ${{ secrets.GITHUB_TOKEN }}
+        repo: haveyoudebuggedit/gotestfmt
     - name: Run tests
       run: cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language
         }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt

--- a/provider-ci/providers/azuredevops/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/azuredevops/repo/.github/workflows/release.yml
@@ -376,10 +376,10 @@ jobs:
         pip3 install pipenv
     - name: Install dependencies
       run: make install_${{ matrix.language}}_sdk
-    - name: Set up gotestfmt
-      uses: haveyoudebuggedit/gotestfmt-action@v2
+    - name: Install gotestfmt
+      uses: jaxxstorm/action-install-gh-release@v1.2.0
       with:
-        token: ${{ secrets.GITHUB_TOKEN }}
+        repo: haveyoudebuggedit/gotestfmt
     - name: Run tests
       run: cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language
         }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt

--- a/provider-ci/providers/azuredevops/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/azuredevops/repo/.github/workflows/run-acceptance-tests.yml
@@ -265,10 +265,10 @@ jobs:
         pip3 install pipenv
     - name: Install dependencies
       run: make install_${{ matrix.language}}_sdk
-    - name: Set up gotestfmt
-      uses: haveyoudebuggedit/gotestfmt-action@v2
+    - name: Install gotestfmt
+      uses: jaxxstorm/action-install-gh-release@v1.2.0
       with:
-        token: ${{ secrets.GITHUB_TOKEN }}
+        repo: haveyoudebuggedit/gotestfmt
     - name: Run tests
       run: cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language
         }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt

--- a/provider-ci/providers/civo/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/civo/repo/.github/workflows/main.yml
@@ -492,10 +492,10 @@ jobs:
         pip3 install pipenv
     - name: Install dependencies
       run: make install_${{ matrix.language}}_sdk
-    - name: Set up gotestfmt
-      uses: haveyoudebuggedit/gotestfmt-action@v2
+    - name: Install gotestfmt
+      uses: jaxxstorm/action-install-gh-release@v1.2.0
       with:
-        token: ${{ secrets.GITHUB_TOKEN }}
+        repo: haveyoudebuggedit/gotestfmt
     - name: Run tests
       run: cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language
         }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt

--- a/provider-ci/providers/civo/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/civo/repo/.github/workflows/master.yml
@@ -492,10 +492,10 @@ jobs:
         pip3 install pipenv
     - name: Install dependencies
       run: make install_${{ matrix.language}}_sdk
-    - name: Set up gotestfmt
-      uses: haveyoudebuggedit/gotestfmt-action@v2
+    - name: Install gotestfmt
+      uses: jaxxstorm/action-install-gh-release@v1.2.0
       with:
-        token: ${{ secrets.GITHUB_TOKEN }}
+        repo: haveyoudebuggedit/gotestfmt
     - name: Run tests
       run: cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language
         }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt

--- a/provider-ci/providers/civo/repo/.github/workflows/nightly-test.yml
+++ b/provider-ci/providers/civo/repo/.github/workflows/nightly-test.yml
@@ -233,10 +233,10 @@ jobs:
         pip3 install pipenv
     - name: Install dependencies
       run: make install_${{ matrix.language}}_sdk
-    - name: Set up gotestfmt
-      uses: haveyoudebuggedit/gotestfmt-action@v2
+    - name: Install gotestfmt
+      uses: jaxxstorm/action-install-gh-release@v1.2.0
       with:
-        token: ${{ secrets.GITHUB_TOKEN }}
+        repo: haveyoudebuggedit/gotestfmt
     - name: Run tests
       run: cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language
         }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt

--- a/provider-ci/providers/civo/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/civo/repo/.github/workflows/prerelease.yml
@@ -438,10 +438,10 @@ jobs:
         pip3 install pipenv
     - name: Install dependencies
       run: make install_${{ matrix.language}}_sdk
-    - name: Set up gotestfmt
-      uses: haveyoudebuggedit/gotestfmt-action@v2
+    - name: Install gotestfmt
+      uses: jaxxstorm/action-install-gh-release@v1.2.0
       with:
-        token: ${{ secrets.GITHUB_TOKEN }}
+        repo: haveyoudebuggedit/gotestfmt
     - name: Run tests
       run: cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language
         }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt

--- a/provider-ci/providers/civo/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/civo/repo/.github/workflows/release.yml
@@ -450,10 +450,10 @@ jobs:
         pip3 install pipenv
     - name: Install dependencies
       run: make install_${{ matrix.language}}_sdk
-    - name: Set up gotestfmt
-      uses: haveyoudebuggedit/gotestfmt-action@v2
+    - name: Install gotestfmt
+      uses: jaxxstorm/action-install-gh-release@v1.2.0
       with:
-        token: ${{ secrets.GITHUB_TOKEN }}
+        repo: haveyoudebuggedit/gotestfmt
     - name: Run tests
       run: cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language
         }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt

--- a/provider-ci/providers/civo/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/civo/repo/.github/workflows/run-acceptance-tests.yml
@@ -347,10 +347,10 @@ jobs:
         pip3 install pipenv
     - name: Install dependencies
       run: make install_${{ matrix.language}}_sdk
-    - name: Set up gotestfmt
-      uses: haveyoudebuggedit/gotestfmt-action@v2
+    - name: Install gotestfmt
+      uses: jaxxstorm/action-install-gh-release@v1.2.0
       with:
-        token: ${{ secrets.GITHUB_TOKEN }}
+        repo: haveyoudebuggedit/gotestfmt
     - name: Run tests
       run: cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language
         }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt

--- a/provider-ci/providers/cloudamqp/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/cloudamqp/repo/.github/workflows/main.yml
@@ -491,10 +491,10 @@ jobs:
         pip3 install pipenv
     - name: Install dependencies
       run: make install_${{ matrix.language}}_sdk
-    - name: Set up gotestfmt
-      uses: haveyoudebuggedit/gotestfmt-action@v2
+    - name: Install gotestfmt
+      uses: jaxxstorm/action-install-gh-release@v1.2.0
       with:
-        token: ${{ secrets.GITHUB_TOKEN }}
+        repo: haveyoudebuggedit/gotestfmt
     - name: Run tests
       run: cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language
         }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt

--- a/provider-ci/providers/cloudamqp/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/cloudamqp/repo/.github/workflows/master.yml
@@ -491,10 +491,10 @@ jobs:
         pip3 install pipenv
     - name: Install dependencies
       run: make install_${{ matrix.language}}_sdk
-    - name: Set up gotestfmt
-      uses: haveyoudebuggedit/gotestfmt-action@v2
+    - name: Install gotestfmt
+      uses: jaxxstorm/action-install-gh-release@v1.2.0
       with:
-        token: ${{ secrets.GITHUB_TOKEN }}
+        repo: haveyoudebuggedit/gotestfmt
     - name: Run tests
       run: cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language
         }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt

--- a/provider-ci/providers/cloudamqp/repo/.github/workflows/nightly-test.yml
+++ b/provider-ci/providers/cloudamqp/repo/.github/workflows/nightly-test.yml
@@ -232,10 +232,10 @@ jobs:
         pip3 install pipenv
     - name: Install dependencies
       run: make install_${{ matrix.language}}_sdk
-    - name: Set up gotestfmt
-      uses: haveyoudebuggedit/gotestfmt-action@v2
+    - name: Install gotestfmt
+      uses: jaxxstorm/action-install-gh-release@v1.2.0
       with:
-        token: ${{ secrets.GITHUB_TOKEN }}
+        repo: haveyoudebuggedit/gotestfmt
     - name: Run tests
       run: cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language
         }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt

--- a/provider-ci/providers/cloudamqp/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/cloudamqp/repo/.github/workflows/prerelease.yml
@@ -437,10 +437,10 @@ jobs:
         pip3 install pipenv
     - name: Install dependencies
       run: make install_${{ matrix.language}}_sdk
-    - name: Set up gotestfmt
-      uses: haveyoudebuggedit/gotestfmt-action@v2
+    - name: Install gotestfmt
+      uses: jaxxstorm/action-install-gh-release@v1.2.0
       with:
-        token: ${{ secrets.GITHUB_TOKEN }}
+        repo: haveyoudebuggedit/gotestfmt
     - name: Run tests
       run: cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language
         }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt

--- a/provider-ci/providers/cloudamqp/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/cloudamqp/repo/.github/workflows/release.yml
@@ -449,10 +449,10 @@ jobs:
         pip3 install pipenv
     - name: Install dependencies
       run: make install_${{ matrix.language}}_sdk
-    - name: Set up gotestfmt
-      uses: haveyoudebuggedit/gotestfmt-action@v2
+    - name: Install gotestfmt
+      uses: jaxxstorm/action-install-gh-release@v1.2.0
       with:
-        token: ${{ secrets.GITHUB_TOKEN }}
+        repo: haveyoudebuggedit/gotestfmt
     - name: Run tests
       run: cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language
         }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt

--- a/provider-ci/providers/cloudamqp/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/cloudamqp/repo/.github/workflows/run-acceptance-tests.yml
@@ -346,10 +346,10 @@ jobs:
         pip3 install pipenv
     - name: Install dependencies
       run: make install_${{ matrix.language}}_sdk
-    - name: Set up gotestfmt
-      uses: haveyoudebuggedit/gotestfmt-action@v2
+    - name: Install gotestfmt
+      uses: jaxxstorm/action-install-gh-release@v1.2.0
       with:
-        token: ${{ secrets.GITHUB_TOKEN }}
+        repo: haveyoudebuggedit/gotestfmt
     - name: Run tests
       run: cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language
         }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt

--- a/provider-ci/providers/cloudflare/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/cloudflare/repo/.github/workflows/main.yml
@@ -491,10 +491,10 @@ jobs:
         pip3 install pipenv
     - name: Install dependencies
       run: make install_${{ matrix.language}}_sdk
-    - name: Set up gotestfmt
-      uses: haveyoudebuggedit/gotestfmt-action@v2
+    - name: Install gotestfmt
+      uses: jaxxstorm/action-install-gh-release@v1.2.0
       with:
-        token: ${{ secrets.GITHUB_TOKEN }}
+        repo: haveyoudebuggedit/gotestfmt
     - name: Run tests
       run: cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language
         }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt

--- a/provider-ci/providers/cloudflare/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/cloudflare/repo/.github/workflows/master.yml
@@ -491,10 +491,10 @@ jobs:
         pip3 install pipenv
     - name: Install dependencies
       run: make install_${{ matrix.language}}_sdk
-    - name: Set up gotestfmt
-      uses: haveyoudebuggedit/gotestfmt-action@v2
+    - name: Install gotestfmt
+      uses: jaxxstorm/action-install-gh-release@v1.2.0
       with:
-        token: ${{ secrets.GITHUB_TOKEN }}
+        repo: haveyoudebuggedit/gotestfmt
     - name: Run tests
       run: cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language
         }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt

--- a/provider-ci/providers/cloudflare/repo/.github/workflows/nightly-test.yml
+++ b/provider-ci/providers/cloudflare/repo/.github/workflows/nightly-test.yml
@@ -232,10 +232,10 @@ jobs:
         pip3 install pipenv
     - name: Install dependencies
       run: make install_${{ matrix.language}}_sdk
-    - name: Set up gotestfmt
-      uses: haveyoudebuggedit/gotestfmt-action@v2
+    - name: Install gotestfmt
+      uses: jaxxstorm/action-install-gh-release@v1.2.0
       with:
-        token: ${{ secrets.GITHUB_TOKEN }}
+        repo: haveyoudebuggedit/gotestfmt
     - name: Run tests
       run: cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language
         }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt

--- a/provider-ci/providers/cloudflare/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/cloudflare/repo/.github/workflows/prerelease.yml
@@ -437,10 +437,10 @@ jobs:
         pip3 install pipenv
     - name: Install dependencies
       run: make install_${{ matrix.language}}_sdk
-    - name: Set up gotestfmt
-      uses: haveyoudebuggedit/gotestfmt-action@v2
+    - name: Install gotestfmt
+      uses: jaxxstorm/action-install-gh-release@v1.2.0
       with:
-        token: ${{ secrets.GITHUB_TOKEN }}
+        repo: haveyoudebuggedit/gotestfmt
     - name: Run tests
       run: cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language
         }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt

--- a/provider-ci/providers/cloudflare/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/cloudflare/repo/.github/workflows/release.yml
@@ -449,10 +449,10 @@ jobs:
         pip3 install pipenv
     - name: Install dependencies
       run: make install_${{ matrix.language}}_sdk
-    - name: Set up gotestfmt
-      uses: haveyoudebuggedit/gotestfmt-action@v2
+    - name: Install gotestfmt
+      uses: jaxxstorm/action-install-gh-release@v1.2.0
       with:
-        token: ${{ secrets.GITHUB_TOKEN }}
+        repo: haveyoudebuggedit/gotestfmt
     - name: Run tests
       run: cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language
         }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt

--- a/provider-ci/providers/cloudflare/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/cloudflare/repo/.github/workflows/run-acceptance-tests.yml
@@ -346,10 +346,10 @@ jobs:
         pip3 install pipenv
     - name: Install dependencies
       run: make install_${{ matrix.language}}_sdk
-    - name: Set up gotestfmt
-      uses: haveyoudebuggedit/gotestfmt-action@v2
+    - name: Install gotestfmt
+      uses: jaxxstorm/action-install-gh-release@v1.2.0
       with:
-        token: ${{ secrets.GITHUB_TOKEN }}
+        repo: haveyoudebuggedit/gotestfmt
     - name: Run tests
       run: cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language
         }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt

--- a/provider-ci/providers/cloudinit/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/cloudinit/repo/.github/workflows/main.yml
@@ -416,10 +416,10 @@ jobs:
         pip3 install pipenv
     - name: Install dependencies
       run: make install_${{ matrix.language}}_sdk
-    - name: Set up gotestfmt
-      uses: haveyoudebuggedit/gotestfmt-action@v2
+    - name: Install gotestfmt
+      uses: jaxxstorm/action-install-gh-release@v1.2.0
       with:
-        token: ${{ secrets.GITHUB_TOKEN }}
+        repo: haveyoudebuggedit/gotestfmt
     - name: Run tests
       run: cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language
         }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt

--- a/provider-ci/providers/cloudinit/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/cloudinit/repo/.github/workflows/master.yml
@@ -416,10 +416,10 @@ jobs:
         pip3 install pipenv
     - name: Install dependencies
       run: make install_${{ matrix.language}}_sdk
-    - name: Set up gotestfmt
-      uses: haveyoudebuggedit/gotestfmt-action@v2
+    - name: Install gotestfmt
+      uses: jaxxstorm/action-install-gh-release@v1.2.0
       with:
-        token: ${{ secrets.GITHUB_TOKEN }}
+        repo: haveyoudebuggedit/gotestfmt
     - name: Run tests
       run: cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language
         }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt

--- a/provider-ci/providers/cloudinit/repo/.github/workflows/nightly-test.yml
+++ b/provider-ci/providers/cloudinit/repo/.github/workflows/nightly-test.yml
@@ -232,10 +232,10 @@ jobs:
         pip3 install pipenv
     - name: Install dependencies
       run: make install_${{ matrix.language}}_sdk
-    - name: Set up gotestfmt
-      uses: haveyoudebuggedit/gotestfmt-action@v2
+    - name: Install gotestfmt
+      uses: jaxxstorm/action-install-gh-release@v1.2.0
       with:
-        token: ${{ secrets.GITHUB_TOKEN }}
+        repo: haveyoudebuggedit/gotestfmt
     - name: Run tests
       run: cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language
         }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt

--- a/provider-ci/providers/cloudinit/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/cloudinit/repo/.github/workflows/prerelease.yml
@@ -362,10 +362,10 @@ jobs:
         pip3 install pipenv
     - name: Install dependencies
       run: make install_${{ matrix.language}}_sdk
-    - name: Set up gotestfmt
-      uses: haveyoudebuggedit/gotestfmt-action@v2
+    - name: Install gotestfmt
+      uses: jaxxstorm/action-install-gh-release@v1.2.0
       with:
-        token: ${{ secrets.GITHUB_TOKEN }}
+        repo: haveyoudebuggedit/gotestfmt
     - name: Run tests
       run: cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language
         }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt

--- a/provider-ci/providers/cloudinit/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/cloudinit/repo/.github/workflows/release.yml
@@ -374,10 +374,10 @@ jobs:
         pip3 install pipenv
     - name: Install dependencies
       run: make install_${{ matrix.language}}_sdk
-    - name: Set up gotestfmt
-      uses: haveyoudebuggedit/gotestfmt-action@v2
+    - name: Install gotestfmt
+      uses: jaxxstorm/action-install-gh-release@v1.2.0
       with:
-        token: ${{ secrets.GITHUB_TOKEN }}
+        repo: haveyoudebuggedit/gotestfmt
     - name: Run tests
       run: cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language
         }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt

--- a/provider-ci/providers/cloudinit/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/cloudinit/repo/.github/workflows/run-acceptance-tests.yml
@@ -263,10 +263,10 @@ jobs:
         pip3 install pipenv
     - name: Install dependencies
       run: make install_${{ matrix.language}}_sdk
-    - name: Set up gotestfmt
-      uses: haveyoudebuggedit/gotestfmt-action@v2
+    - name: Install gotestfmt
+      uses: jaxxstorm/action-install-gh-release@v1.2.0
       with:
-        token: ${{ secrets.GITHUB_TOKEN }}
+        repo: haveyoudebuggedit/gotestfmt
     - name: Run tests
       run: cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language
         }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt

--- a/provider-ci/providers/confluent/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/confluent/repo/.github/workflows/main.yml
@@ -493,10 +493,10 @@ jobs:
         pip3 install pipenv
     - name: Install dependencies
       run: make install_${{ matrix.language}}_sdk
-    - name: Set up gotestfmt
-      uses: haveyoudebuggedit/gotestfmt-action@v2
+    - name: Install gotestfmt
+      uses: jaxxstorm/action-install-gh-release@v1.2.0
       with:
-        token: ${{ secrets.GITHUB_TOKEN }}
+        repo: haveyoudebuggedit/gotestfmt
     - name: Run tests
       run: cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language
         }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt

--- a/provider-ci/providers/confluent/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/confluent/repo/.github/workflows/master.yml
@@ -493,10 +493,10 @@ jobs:
         pip3 install pipenv
     - name: Install dependencies
       run: make install_${{ matrix.language}}_sdk
-    - name: Set up gotestfmt
-      uses: haveyoudebuggedit/gotestfmt-action@v2
+    - name: Install gotestfmt
+      uses: jaxxstorm/action-install-gh-release@v1.2.0
       with:
-        token: ${{ secrets.GITHUB_TOKEN }}
+        repo: haveyoudebuggedit/gotestfmt
     - name: Run tests
       run: cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language
         }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt

--- a/provider-ci/providers/confluent/repo/.github/workflows/nightly-test.yml
+++ b/provider-ci/providers/confluent/repo/.github/workflows/nightly-test.yml
@@ -234,10 +234,10 @@ jobs:
         pip3 install pipenv
     - name: Install dependencies
       run: make install_${{ matrix.language}}_sdk
-    - name: Set up gotestfmt
-      uses: haveyoudebuggedit/gotestfmt-action@v2
+    - name: Install gotestfmt
+      uses: jaxxstorm/action-install-gh-release@v1.2.0
       with:
-        token: ${{ secrets.GITHUB_TOKEN }}
+        repo: haveyoudebuggedit/gotestfmt
     - name: Run tests
       run: cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language
         }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt

--- a/provider-ci/providers/confluent/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/confluent/repo/.github/workflows/prerelease.yml
@@ -439,10 +439,10 @@ jobs:
         pip3 install pipenv
     - name: Install dependencies
       run: make install_${{ matrix.language}}_sdk
-    - name: Set up gotestfmt
-      uses: haveyoudebuggedit/gotestfmt-action@v2
+    - name: Install gotestfmt
+      uses: jaxxstorm/action-install-gh-release@v1.2.0
       with:
-        token: ${{ secrets.GITHUB_TOKEN }}
+        repo: haveyoudebuggedit/gotestfmt
     - name: Run tests
       run: cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language
         }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt

--- a/provider-ci/providers/confluent/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/confluent/repo/.github/workflows/release.yml
@@ -451,10 +451,10 @@ jobs:
         pip3 install pipenv
     - name: Install dependencies
       run: make install_${{ matrix.language}}_sdk
-    - name: Set up gotestfmt
-      uses: haveyoudebuggedit/gotestfmt-action@v2
+    - name: Install gotestfmt
+      uses: jaxxstorm/action-install-gh-release@v1.2.0
       with:
-        token: ${{ secrets.GITHUB_TOKEN }}
+        repo: haveyoudebuggedit/gotestfmt
     - name: Run tests
       run: cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language
         }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt

--- a/provider-ci/providers/confluent/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/confluent/repo/.github/workflows/run-acceptance-tests.yml
@@ -348,10 +348,10 @@ jobs:
         pip3 install pipenv
     - name: Install dependencies
       run: make install_${{ matrix.language}}_sdk
-    - name: Set up gotestfmt
-      uses: haveyoudebuggedit/gotestfmt-action@v2
+    - name: Install gotestfmt
+      uses: jaxxstorm/action-install-gh-release@v1.2.0
       with:
-        token: ${{ secrets.GITHUB_TOKEN }}
+        repo: haveyoudebuggedit/gotestfmt
     - name: Run tests
       run: cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language
         }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt

--- a/provider-ci/providers/consul/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/consul/repo/.github/workflows/main.yml
@@ -493,10 +493,10 @@ jobs:
       run: docker-compose -f testing/docker-compose.yml up --build -d
     - name: Install dependencies
       run: make install_${{ matrix.language}}_sdk
-    - name: Set up gotestfmt
-      uses: haveyoudebuggedit/gotestfmt-action@v2
+    - name: Install gotestfmt
+      uses: jaxxstorm/action-install-gh-release@v1.2.0
       with:
-        token: ${{ secrets.GITHUB_TOKEN }}
+        repo: haveyoudebuggedit/gotestfmt
     - name: Run tests
       run: cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language
         }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt

--- a/provider-ci/providers/consul/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/consul/repo/.github/workflows/master.yml
@@ -493,10 +493,10 @@ jobs:
       run: docker-compose -f testing/docker-compose.yml up --build -d
     - name: Install dependencies
       run: make install_${{ matrix.language}}_sdk
-    - name: Set up gotestfmt
-      uses: haveyoudebuggedit/gotestfmt-action@v2
+    - name: Install gotestfmt
+      uses: jaxxstorm/action-install-gh-release@v1.2.0
       with:
-        token: ${{ secrets.GITHUB_TOKEN }}
+        repo: haveyoudebuggedit/gotestfmt
     - name: Run tests
       run: cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language
         }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt

--- a/provider-ci/providers/consul/repo/.github/workflows/nightly-test.yml
+++ b/provider-ci/providers/consul/repo/.github/workflows/nightly-test.yml
@@ -234,10 +234,10 @@ jobs:
       run: docker-compose -f testing/docker-compose.yml up --build -d
     - name: Install dependencies
       run: make install_${{ matrix.language}}_sdk
-    - name: Set up gotestfmt
-      uses: haveyoudebuggedit/gotestfmt-action@v2
+    - name: Install gotestfmt
+      uses: jaxxstorm/action-install-gh-release@v1.2.0
       with:
-        token: ${{ secrets.GITHUB_TOKEN }}
+        repo: haveyoudebuggedit/gotestfmt
     - name: Run tests
       run: cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language
         }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt

--- a/provider-ci/providers/consul/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/consul/repo/.github/workflows/prerelease.yml
@@ -439,10 +439,10 @@ jobs:
       run: docker-compose -f testing/docker-compose.yml up --build -d
     - name: Install dependencies
       run: make install_${{ matrix.language}}_sdk
-    - name: Set up gotestfmt
-      uses: haveyoudebuggedit/gotestfmt-action@v2
+    - name: Install gotestfmt
+      uses: jaxxstorm/action-install-gh-release@v1.2.0
       with:
-        token: ${{ secrets.GITHUB_TOKEN }}
+        repo: haveyoudebuggedit/gotestfmt
     - name: Run tests
       run: cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language
         }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt

--- a/provider-ci/providers/consul/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/consul/repo/.github/workflows/release.yml
@@ -451,10 +451,10 @@ jobs:
       run: docker-compose -f testing/docker-compose.yml up --build -d
     - name: Install dependencies
       run: make install_${{ matrix.language}}_sdk
-    - name: Set up gotestfmt
-      uses: haveyoudebuggedit/gotestfmt-action@v2
+    - name: Install gotestfmt
+      uses: jaxxstorm/action-install-gh-release@v1.2.0
       with:
-        token: ${{ secrets.GITHUB_TOKEN }}
+        repo: haveyoudebuggedit/gotestfmt
     - name: Run tests
       run: cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language
         }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt

--- a/provider-ci/providers/consul/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/consul/repo/.github/workflows/run-acceptance-tests.yml
@@ -348,10 +348,10 @@ jobs:
       run: docker-compose -f testing/docker-compose.yml up --build -d
     - name: Install dependencies
       run: make install_${{ matrix.language}}_sdk
-    - name: Set up gotestfmt
-      uses: haveyoudebuggedit/gotestfmt-action@v2
+    - name: Install gotestfmt
+      uses: jaxxstorm/action-install-gh-release@v1.2.0
       with:
-        token: ${{ secrets.GITHUB_TOKEN }}
+        repo: haveyoudebuggedit/gotestfmt
     - name: Run tests
       run: cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language
         }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt

--- a/provider-ci/providers/datadog/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/datadog/repo/.github/workflows/main.yml
@@ -416,10 +416,10 @@ jobs:
         pip3 install pipenv
     - name: Install dependencies
       run: make install_${{ matrix.language}}_sdk
-    - name: Set up gotestfmt
-      uses: haveyoudebuggedit/gotestfmt-action@v2
+    - name: Install gotestfmt
+      uses: jaxxstorm/action-install-gh-release@v1.2.0
       with:
-        token: ${{ secrets.GITHUB_TOKEN }}
+        repo: haveyoudebuggedit/gotestfmt
     - name: Run tests
       run: cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language
         }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt

--- a/provider-ci/providers/datadog/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/datadog/repo/.github/workflows/master.yml
@@ -416,10 +416,10 @@ jobs:
         pip3 install pipenv
     - name: Install dependencies
       run: make install_${{ matrix.language}}_sdk
-    - name: Set up gotestfmt
-      uses: haveyoudebuggedit/gotestfmt-action@v2
+    - name: Install gotestfmt
+      uses: jaxxstorm/action-install-gh-release@v1.2.0
       with:
-        token: ${{ secrets.GITHUB_TOKEN }}
+        repo: haveyoudebuggedit/gotestfmt
     - name: Run tests
       run: cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language
         }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt

--- a/provider-ci/providers/datadog/repo/.github/workflows/nightly-test.yml
+++ b/provider-ci/providers/datadog/repo/.github/workflows/nightly-test.yml
@@ -232,10 +232,10 @@ jobs:
         pip3 install pipenv
     - name: Install dependencies
       run: make install_${{ matrix.language}}_sdk
-    - name: Set up gotestfmt
-      uses: haveyoudebuggedit/gotestfmt-action@v2
+    - name: Install gotestfmt
+      uses: jaxxstorm/action-install-gh-release@v1.2.0
       with:
-        token: ${{ secrets.GITHUB_TOKEN }}
+        repo: haveyoudebuggedit/gotestfmt
     - name: Run tests
       run: cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language
         }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt

--- a/provider-ci/providers/datadog/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/datadog/repo/.github/workflows/prerelease.yml
@@ -362,10 +362,10 @@ jobs:
         pip3 install pipenv
     - name: Install dependencies
       run: make install_${{ matrix.language}}_sdk
-    - name: Set up gotestfmt
-      uses: haveyoudebuggedit/gotestfmt-action@v2
+    - name: Install gotestfmt
+      uses: jaxxstorm/action-install-gh-release@v1.2.0
       with:
-        token: ${{ secrets.GITHUB_TOKEN }}
+        repo: haveyoudebuggedit/gotestfmt
     - name: Run tests
       run: cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language
         }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt

--- a/provider-ci/providers/datadog/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/datadog/repo/.github/workflows/release.yml
@@ -374,10 +374,10 @@ jobs:
         pip3 install pipenv
     - name: Install dependencies
       run: make install_${{ matrix.language}}_sdk
-    - name: Set up gotestfmt
-      uses: haveyoudebuggedit/gotestfmt-action@v2
+    - name: Install gotestfmt
+      uses: jaxxstorm/action-install-gh-release@v1.2.0
       with:
-        token: ${{ secrets.GITHUB_TOKEN }}
+        repo: haveyoudebuggedit/gotestfmt
     - name: Run tests
       run: cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language
         }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt

--- a/provider-ci/providers/datadog/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/datadog/repo/.github/workflows/run-acceptance-tests.yml
@@ -263,10 +263,10 @@ jobs:
         pip3 install pipenv
     - name: Install dependencies
       run: make install_${{ matrix.language}}_sdk
-    - name: Set up gotestfmt
-      uses: haveyoudebuggedit/gotestfmt-action@v2
+    - name: Install gotestfmt
+      uses: jaxxstorm/action-install-gh-release@v1.2.0
       with:
-        token: ${{ secrets.GITHUB_TOKEN }}
+        repo: haveyoudebuggedit/gotestfmt
     - name: Run tests
       run: cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language
         }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt

--- a/provider-ci/providers/digitalocean/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/digitalocean/repo/.github/workflows/main.yml
@@ -492,10 +492,10 @@ jobs:
         pip3 install pipenv
     - name: Install dependencies
       run: make install_${{ matrix.language}}_sdk
-    - name: Set up gotestfmt
-      uses: haveyoudebuggedit/gotestfmt-action@v2
+    - name: Install gotestfmt
+      uses: jaxxstorm/action-install-gh-release@v1.2.0
       with:
-        token: ${{ secrets.GITHUB_TOKEN }}
+        repo: haveyoudebuggedit/gotestfmt
     - name: Run tests
       run: cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language
         }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt

--- a/provider-ci/providers/digitalocean/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/digitalocean/repo/.github/workflows/master.yml
@@ -492,10 +492,10 @@ jobs:
         pip3 install pipenv
     - name: Install dependencies
       run: make install_${{ matrix.language}}_sdk
-    - name: Set up gotestfmt
-      uses: haveyoudebuggedit/gotestfmt-action@v2
+    - name: Install gotestfmt
+      uses: jaxxstorm/action-install-gh-release@v1.2.0
       with:
-        token: ${{ secrets.GITHUB_TOKEN }}
+        repo: haveyoudebuggedit/gotestfmt
     - name: Run tests
       run: cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language
         }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt

--- a/provider-ci/providers/digitalocean/repo/.github/workflows/nightly-test.yml
+++ b/provider-ci/providers/digitalocean/repo/.github/workflows/nightly-test.yml
@@ -233,10 +233,10 @@ jobs:
         pip3 install pipenv
     - name: Install dependencies
       run: make install_${{ matrix.language}}_sdk
-    - name: Set up gotestfmt
-      uses: haveyoudebuggedit/gotestfmt-action@v2
+    - name: Install gotestfmt
+      uses: jaxxstorm/action-install-gh-release@v1.2.0
       with:
-        token: ${{ secrets.GITHUB_TOKEN }}
+        repo: haveyoudebuggedit/gotestfmt
     - name: Run tests
       run: cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language
         }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt

--- a/provider-ci/providers/digitalocean/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/digitalocean/repo/.github/workflows/prerelease.yml
@@ -438,10 +438,10 @@ jobs:
         pip3 install pipenv
     - name: Install dependencies
       run: make install_${{ matrix.language}}_sdk
-    - name: Set up gotestfmt
-      uses: haveyoudebuggedit/gotestfmt-action@v2
+    - name: Install gotestfmt
+      uses: jaxxstorm/action-install-gh-release@v1.2.0
       with:
-        token: ${{ secrets.GITHUB_TOKEN }}
+        repo: haveyoudebuggedit/gotestfmt
     - name: Run tests
       run: cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language
         }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt

--- a/provider-ci/providers/digitalocean/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/digitalocean/repo/.github/workflows/release.yml
@@ -450,10 +450,10 @@ jobs:
         pip3 install pipenv
     - name: Install dependencies
       run: make install_${{ matrix.language}}_sdk
-    - name: Set up gotestfmt
-      uses: haveyoudebuggedit/gotestfmt-action@v2
+    - name: Install gotestfmt
+      uses: jaxxstorm/action-install-gh-release@v1.2.0
       with:
-        token: ${{ secrets.GITHUB_TOKEN }}
+        repo: haveyoudebuggedit/gotestfmt
     - name: Run tests
       run: cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language
         }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt

--- a/provider-ci/providers/digitalocean/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/digitalocean/repo/.github/workflows/run-acceptance-tests.yml
@@ -347,10 +347,10 @@ jobs:
         pip3 install pipenv
     - name: Install dependencies
       run: make install_${{ matrix.language}}_sdk
-    - name: Set up gotestfmt
-      uses: haveyoudebuggedit/gotestfmt-action@v2
+    - name: Install gotestfmt
+      uses: jaxxstorm/action-install-gh-release@v1.2.0
       with:
-        token: ${{ secrets.GITHUB_TOKEN }}
+        repo: haveyoudebuggedit/gotestfmt
     - name: Run tests
       run: cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language
         }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt

--- a/provider-ci/providers/dnsimple/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/dnsimple/repo/.github/workflows/main.yml
@@ -493,10 +493,10 @@ jobs:
         pip3 install pipenv
     - name: Install dependencies
       run: make install_${{ matrix.language}}_sdk
-    - name: Set up gotestfmt
-      uses: haveyoudebuggedit/gotestfmt-action@v2
+    - name: Install gotestfmt
+      uses: jaxxstorm/action-install-gh-release@v1.2.0
       with:
-        token: ${{ secrets.GITHUB_TOKEN }}
+        repo: haveyoudebuggedit/gotestfmt
     - name: Run tests
       run: cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language
         }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt

--- a/provider-ci/providers/dnsimple/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/dnsimple/repo/.github/workflows/master.yml
@@ -493,10 +493,10 @@ jobs:
         pip3 install pipenv
     - name: Install dependencies
       run: make install_${{ matrix.language}}_sdk
-    - name: Set up gotestfmt
-      uses: haveyoudebuggedit/gotestfmt-action@v2
+    - name: Install gotestfmt
+      uses: jaxxstorm/action-install-gh-release@v1.2.0
       with:
-        token: ${{ secrets.GITHUB_TOKEN }}
+        repo: haveyoudebuggedit/gotestfmt
     - name: Run tests
       run: cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language
         }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt

--- a/provider-ci/providers/dnsimple/repo/.github/workflows/nightly-test.yml
+++ b/provider-ci/providers/dnsimple/repo/.github/workflows/nightly-test.yml
@@ -234,10 +234,10 @@ jobs:
         pip3 install pipenv
     - name: Install dependencies
       run: make install_${{ matrix.language}}_sdk
-    - name: Set up gotestfmt
-      uses: haveyoudebuggedit/gotestfmt-action@v2
+    - name: Install gotestfmt
+      uses: jaxxstorm/action-install-gh-release@v1.2.0
       with:
-        token: ${{ secrets.GITHUB_TOKEN }}
+        repo: haveyoudebuggedit/gotestfmt
     - name: Run tests
       run: cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language
         }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt

--- a/provider-ci/providers/dnsimple/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/dnsimple/repo/.github/workflows/prerelease.yml
@@ -439,10 +439,10 @@ jobs:
         pip3 install pipenv
     - name: Install dependencies
       run: make install_${{ matrix.language}}_sdk
-    - name: Set up gotestfmt
-      uses: haveyoudebuggedit/gotestfmt-action@v2
+    - name: Install gotestfmt
+      uses: jaxxstorm/action-install-gh-release@v1.2.0
       with:
-        token: ${{ secrets.GITHUB_TOKEN }}
+        repo: haveyoudebuggedit/gotestfmt
     - name: Run tests
       run: cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language
         }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt

--- a/provider-ci/providers/dnsimple/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/dnsimple/repo/.github/workflows/release.yml
@@ -451,10 +451,10 @@ jobs:
         pip3 install pipenv
     - name: Install dependencies
       run: make install_${{ matrix.language}}_sdk
-    - name: Set up gotestfmt
-      uses: haveyoudebuggedit/gotestfmt-action@v2
+    - name: Install gotestfmt
+      uses: jaxxstorm/action-install-gh-release@v1.2.0
       with:
-        token: ${{ secrets.GITHUB_TOKEN }}
+        repo: haveyoudebuggedit/gotestfmt
     - name: Run tests
       run: cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language
         }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt

--- a/provider-ci/providers/dnsimple/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/dnsimple/repo/.github/workflows/run-acceptance-tests.yml
@@ -348,10 +348,10 @@ jobs:
         pip3 install pipenv
     - name: Install dependencies
       run: make install_${{ matrix.language}}_sdk
-    - name: Set up gotestfmt
-      uses: haveyoudebuggedit/gotestfmt-action@v2
+    - name: Install gotestfmt
+      uses: jaxxstorm/action-install-gh-release@v1.2.0
       with:
-        token: ${{ secrets.GITHUB_TOKEN }}
+        repo: haveyoudebuggedit/gotestfmt
     - name: Run tests
       run: cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language
         }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt

--- a/provider-ci/providers/docker/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/docker/repo/.github/workflows/main.yml
@@ -506,10 +506,10 @@ jobs:
         role-to-assume: ${{ secrets.AWS_CI_ROLE_ARN }}
     - name: Install dependencies
       run: make install_${{ matrix.language}}_sdk
-    - name: Set up gotestfmt
-      uses: haveyoudebuggedit/gotestfmt-action@v2
+    - name: Install gotestfmt
+      uses: jaxxstorm/action-install-gh-release@v1.2.0
       with:
-        token: ${{ secrets.GITHUB_TOKEN }}
+        repo: haveyoudebuggedit/gotestfmt
     - name: Run tests
       run: cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language
         }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt

--- a/provider-ci/providers/docker/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/docker/repo/.github/workflows/master.yml
@@ -506,10 +506,10 @@ jobs:
         role-to-assume: ${{ secrets.AWS_CI_ROLE_ARN }}
     - name: Install dependencies
       run: make install_${{ matrix.language}}_sdk
-    - name: Set up gotestfmt
-      uses: haveyoudebuggedit/gotestfmt-action@v2
+    - name: Install gotestfmt
+      uses: jaxxstorm/action-install-gh-release@v1.2.0
       with:
-        token: ${{ secrets.GITHUB_TOKEN }}
+        repo: haveyoudebuggedit/gotestfmt
     - name: Run tests
       run: cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language
         }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt

--- a/provider-ci/providers/docker/repo/.github/workflows/nightly-test.yml
+++ b/provider-ci/providers/docker/repo/.github/workflows/nightly-test.yml
@@ -247,10 +247,10 @@ jobs:
         role-to-assume: ${{ secrets.AWS_CI_ROLE_ARN }}
     - name: Install dependencies
       run: make install_${{ matrix.language}}_sdk
-    - name: Set up gotestfmt
-      uses: haveyoudebuggedit/gotestfmt-action@v2
+    - name: Install gotestfmt
+      uses: jaxxstorm/action-install-gh-release@v1.2.0
       with:
-        token: ${{ secrets.GITHUB_TOKEN }}
+        repo: haveyoudebuggedit/gotestfmt
     - name: Run tests
       run: cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language
         }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt

--- a/provider-ci/providers/docker/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/docker/repo/.github/workflows/prerelease.yml
@@ -452,10 +452,10 @@ jobs:
         role-to-assume: ${{ secrets.AWS_CI_ROLE_ARN }}
     - name: Install dependencies
       run: make install_${{ matrix.language}}_sdk
-    - name: Set up gotestfmt
-      uses: haveyoudebuggedit/gotestfmt-action@v2
+    - name: Install gotestfmt
+      uses: jaxxstorm/action-install-gh-release@v1.2.0
       with:
-        token: ${{ secrets.GITHUB_TOKEN }}
+        repo: haveyoudebuggedit/gotestfmt
     - name: Run tests
       run: cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language
         }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt

--- a/provider-ci/providers/docker/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/docker/repo/.github/workflows/release.yml
@@ -464,10 +464,10 @@ jobs:
         role-to-assume: ${{ secrets.AWS_CI_ROLE_ARN }}
     - name: Install dependencies
       run: make install_${{ matrix.language}}_sdk
-    - name: Set up gotestfmt
-      uses: haveyoudebuggedit/gotestfmt-action@v2
+    - name: Install gotestfmt
+      uses: jaxxstorm/action-install-gh-release@v1.2.0
       with:
-        token: ${{ secrets.GITHUB_TOKEN }}
+        repo: haveyoudebuggedit/gotestfmt
     - name: Run tests
       run: cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language
         }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt

--- a/provider-ci/providers/docker/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/docker/repo/.github/workflows/run-acceptance-tests.yml
@@ -361,10 +361,10 @@ jobs:
         role-to-assume: ${{ secrets.AWS_CI_ROLE_ARN }}
     - name: Install dependencies
       run: make install_${{ matrix.language}}_sdk
-    - name: Set up gotestfmt
-      uses: haveyoudebuggedit/gotestfmt-action@v2
+    - name: Install gotestfmt
+      uses: jaxxstorm/action-install-gh-release@v1.2.0
       with:
-        token: ${{ secrets.GITHUB_TOKEN }}
+        repo: haveyoudebuggedit/gotestfmt
     - name: Run tests
       run: cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language
         }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt

--- a/provider-ci/providers/ec/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/ec/repo/.github/workflows/main.yml
@@ -492,10 +492,10 @@ jobs:
         pip3 install pipenv
     - name: Install dependencies
       run: make install_${{ matrix.language}}_sdk
-    - name: Set up gotestfmt
-      uses: haveyoudebuggedit/gotestfmt-action@v2
+    - name: Install gotestfmt
+      uses: jaxxstorm/action-install-gh-release@v1.2.0
       with:
-        token: ${{ secrets.GITHUB_TOKEN }}
+        repo: haveyoudebuggedit/gotestfmt
     - name: Run tests
       run: cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language
         }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt

--- a/provider-ci/providers/ec/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/ec/repo/.github/workflows/master.yml
@@ -492,10 +492,10 @@ jobs:
         pip3 install pipenv
     - name: Install dependencies
       run: make install_${{ matrix.language}}_sdk
-    - name: Set up gotestfmt
-      uses: haveyoudebuggedit/gotestfmt-action@v2
+    - name: Install gotestfmt
+      uses: jaxxstorm/action-install-gh-release@v1.2.0
       with:
-        token: ${{ secrets.GITHUB_TOKEN }}
+        repo: haveyoudebuggedit/gotestfmt
     - name: Run tests
       run: cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language
         }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt

--- a/provider-ci/providers/ec/repo/.github/workflows/nightly-test.yml
+++ b/provider-ci/providers/ec/repo/.github/workflows/nightly-test.yml
@@ -233,10 +233,10 @@ jobs:
         pip3 install pipenv
     - name: Install dependencies
       run: make install_${{ matrix.language}}_sdk
-    - name: Set up gotestfmt
-      uses: haveyoudebuggedit/gotestfmt-action@v2
+    - name: Install gotestfmt
+      uses: jaxxstorm/action-install-gh-release@v1.2.0
       with:
-        token: ${{ secrets.GITHUB_TOKEN }}
+        repo: haveyoudebuggedit/gotestfmt
     - name: Run tests
       run: cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language
         }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt

--- a/provider-ci/providers/ec/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/ec/repo/.github/workflows/prerelease.yml
@@ -438,10 +438,10 @@ jobs:
         pip3 install pipenv
     - name: Install dependencies
       run: make install_${{ matrix.language}}_sdk
-    - name: Set up gotestfmt
-      uses: haveyoudebuggedit/gotestfmt-action@v2
+    - name: Install gotestfmt
+      uses: jaxxstorm/action-install-gh-release@v1.2.0
       with:
-        token: ${{ secrets.GITHUB_TOKEN }}
+        repo: haveyoudebuggedit/gotestfmt
     - name: Run tests
       run: cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language
         }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt

--- a/provider-ci/providers/ec/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/ec/repo/.github/workflows/release.yml
@@ -450,10 +450,10 @@ jobs:
         pip3 install pipenv
     - name: Install dependencies
       run: make install_${{ matrix.language}}_sdk
-    - name: Set up gotestfmt
-      uses: haveyoudebuggedit/gotestfmt-action@v2
+    - name: Install gotestfmt
+      uses: jaxxstorm/action-install-gh-release@v1.2.0
       with:
-        token: ${{ secrets.GITHUB_TOKEN }}
+        repo: haveyoudebuggedit/gotestfmt
     - name: Run tests
       run: cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language
         }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt

--- a/provider-ci/providers/ec/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/ec/repo/.github/workflows/run-acceptance-tests.yml
@@ -347,10 +347,10 @@ jobs:
         pip3 install pipenv
     - name: Install dependencies
       run: make install_${{ matrix.language}}_sdk
-    - name: Set up gotestfmt
-      uses: haveyoudebuggedit/gotestfmt-action@v2
+    - name: Install gotestfmt
+      uses: jaxxstorm/action-install-gh-release@v1.2.0
       with:
-        token: ${{ secrets.GITHUB_TOKEN }}
+        repo: haveyoudebuggedit/gotestfmt
     - name: Run tests
       run: cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language
         }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt

--- a/provider-ci/providers/equinix-metal/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/equinix-metal/repo/.github/workflows/main.yml
@@ -417,10 +417,10 @@ jobs:
         pip3 install pipenv
     - name: Install dependencies
       run: make install_${{ matrix.language}}_sdk
-    - name: Set up gotestfmt
-      uses: haveyoudebuggedit/gotestfmt-action@v2
+    - name: Install gotestfmt
+      uses: jaxxstorm/action-install-gh-release@v1.2.0
       with:
-        token: ${{ secrets.GITHUB_TOKEN }}
+        repo: haveyoudebuggedit/gotestfmt
     - name: Run tests
       run: cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language
         }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt

--- a/provider-ci/providers/equinix-metal/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/equinix-metal/repo/.github/workflows/master.yml
@@ -417,10 +417,10 @@ jobs:
         pip3 install pipenv
     - name: Install dependencies
       run: make install_${{ matrix.language}}_sdk
-    - name: Set up gotestfmt
-      uses: haveyoudebuggedit/gotestfmt-action@v2
+    - name: Install gotestfmt
+      uses: jaxxstorm/action-install-gh-release@v1.2.0
       with:
-        token: ${{ secrets.GITHUB_TOKEN }}
+        repo: haveyoudebuggedit/gotestfmt
     - name: Run tests
       run: cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language
         }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt

--- a/provider-ci/providers/equinix-metal/repo/.github/workflows/nightly-test.yml
+++ b/provider-ci/providers/equinix-metal/repo/.github/workflows/nightly-test.yml
@@ -233,10 +233,10 @@ jobs:
         pip3 install pipenv
     - name: Install dependencies
       run: make install_${{ matrix.language}}_sdk
-    - name: Set up gotestfmt
-      uses: haveyoudebuggedit/gotestfmt-action@v2
+    - name: Install gotestfmt
+      uses: jaxxstorm/action-install-gh-release@v1.2.0
       with:
-        token: ${{ secrets.GITHUB_TOKEN }}
+        repo: haveyoudebuggedit/gotestfmt
     - name: Run tests
       run: cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language
         }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt

--- a/provider-ci/providers/equinix-metal/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/equinix-metal/repo/.github/workflows/prerelease.yml
@@ -363,10 +363,10 @@ jobs:
         pip3 install pipenv
     - name: Install dependencies
       run: make install_${{ matrix.language}}_sdk
-    - name: Set up gotestfmt
-      uses: haveyoudebuggedit/gotestfmt-action@v2
+    - name: Install gotestfmt
+      uses: jaxxstorm/action-install-gh-release@v1.2.0
       with:
-        token: ${{ secrets.GITHUB_TOKEN }}
+        repo: haveyoudebuggedit/gotestfmt
     - name: Run tests
       run: cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language
         }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt

--- a/provider-ci/providers/equinix-metal/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/equinix-metal/repo/.github/workflows/release.yml
@@ -375,10 +375,10 @@ jobs:
         pip3 install pipenv
     - name: Install dependencies
       run: make install_${{ matrix.language}}_sdk
-    - name: Set up gotestfmt
-      uses: haveyoudebuggedit/gotestfmt-action@v2
+    - name: Install gotestfmt
+      uses: jaxxstorm/action-install-gh-release@v1.2.0
       with:
-        token: ${{ secrets.GITHUB_TOKEN }}
+        repo: haveyoudebuggedit/gotestfmt
     - name: Run tests
       run: cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language
         }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt

--- a/provider-ci/providers/equinix-metal/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/equinix-metal/repo/.github/workflows/run-acceptance-tests.yml
@@ -264,10 +264,10 @@ jobs:
         pip3 install pipenv
     - name: Install dependencies
       run: make install_${{ matrix.language}}_sdk
-    - name: Set up gotestfmt
-      uses: haveyoudebuggedit/gotestfmt-action@v2
+    - name: Install gotestfmt
+      uses: jaxxstorm/action-install-gh-release@v1.2.0
       with:
-        token: ${{ secrets.GITHUB_TOKEN }}
+        repo: haveyoudebuggedit/gotestfmt
     - name: Run tests
       run: cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language
         }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt

--- a/provider-ci/providers/f5bigip/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/f5bigip/repo/.github/workflows/main.yml
@@ -504,10 +504,10 @@ jobs:
         role-to-assume: ${{ secrets.AWS_CI_ROLE_ARN }}
     - name: Install dependencies
       run: make install_${{ matrix.language}}_sdk
-    - name: Set up gotestfmt
-      uses: haveyoudebuggedit/gotestfmt-action@v2
+    - name: Install gotestfmt
+      uses: jaxxstorm/action-install-gh-release@v1.2.0
       with:
-        token: ${{ secrets.GITHUB_TOKEN }}
+        repo: haveyoudebuggedit/gotestfmt
     - name: Run tests
       run: cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language
         }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt

--- a/provider-ci/providers/f5bigip/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/f5bigip/repo/.github/workflows/master.yml
@@ -504,10 +504,10 @@ jobs:
         role-to-assume: ${{ secrets.AWS_CI_ROLE_ARN }}
     - name: Install dependencies
       run: make install_${{ matrix.language}}_sdk
-    - name: Set up gotestfmt
-      uses: haveyoudebuggedit/gotestfmt-action@v2
+    - name: Install gotestfmt
+      uses: jaxxstorm/action-install-gh-release@v1.2.0
       with:
-        token: ${{ secrets.GITHUB_TOKEN }}
+        repo: haveyoudebuggedit/gotestfmt
     - name: Run tests
       run: cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language
         }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt

--- a/provider-ci/providers/f5bigip/repo/.github/workflows/nightly-test.yml
+++ b/provider-ci/providers/f5bigip/repo/.github/workflows/nightly-test.yml
@@ -245,10 +245,10 @@ jobs:
         role-to-assume: ${{ secrets.AWS_CI_ROLE_ARN }}
     - name: Install dependencies
       run: make install_${{ matrix.language}}_sdk
-    - name: Set up gotestfmt
-      uses: haveyoudebuggedit/gotestfmt-action@v2
+    - name: Install gotestfmt
+      uses: jaxxstorm/action-install-gh-release@v1.2.0
       with:
-        token: ${{ secrets.GITHUB_TOKEN }}
+        repo: haveyoudebuggedit/gotestfmt
     - name: Run tests
       run: cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language
         }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt

--- a/provider-ci/providers/f5bigip/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/f5bigip/repo/.github/workflows/prerelease.yml
@@ -450,10 +450,10 @@ jobs:
         role-to-assume: ${{ secrets.AWS_CI_ROLE_ARN }}
     - name: Install dependencies
       run: make install_${{ matrix.language}}_sdk
-    - name: Set up gotestfmt
-      uses: haveyoudebuggedit/gotestfmt-action@v2
+    - name: Install gotestfmt
+      uses: jaxxstorm/action-install-gh-release@v1.2.0
       with:
-        token: ${{ secrets.GITHUB_TOKEN }}
+        repo: haveyoudebuggedit/gotestfmt
     - name: Run tests
       run: cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language
         }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt

--- a/provider-ci/providers/f5bigip/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/f5bigip/repo/.github/workflows/release.yml
@@ -462,10 +462,10 @@ jobs:
         role-to-assume: ${{ secrets.AWS_CI_ROLE_ARN }}
     - name: Install dependencies
       run: make install_${{ matrix.language}}_sdk
-    - name: Set up gotestfmt
-      uses: haveyoudebuggedit/gotestfmt-action@v2
+    - name: Install gotestfmt
+      uses: jaxxstorm/action-install-gh-release@v1.2.0
       with:
-        token: ${{ secrets.GITHUB_TOKEN }}
+        repo: haveyoudebuggedit/gotestfmt
     - name: Run tests
       run: cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language
         }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt

--- a/provider-ci/providers/f5bigip/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/f5bigip/repo/.github/workflows/run-acceptance-tests.yml
@@ -359,10 +359,10 @@ jobs:
         role-to-assume: ${{ secrets.AWS_CI_ROLE_ARN }}
     - name: Install dependencies
       run: make install_${{ matrix.language}}_sdk
-    - name: Set up gotestfmt
-      uses: haveyoudebuggedit/gotestfmt-action@v2
+    - name: Install gotestfmt
+      uses: jaxxstorm/action-install-gh-release@v1.2.0
       with:
-        token: ${{ secrets.GITHUB_TOKEN }}
+        repo: haveyoudebuggedit/gotestfmt
     - name: Run tests
       run: cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language
         }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt

--- a/provider-ci/providers/fastly/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/fastly/repo/.github/workflows/main.yml
@@ -492,10 +492,10 @@ jobs:
         pip3 install pipenv
     - name: Install dependencies
       run: make install_${{ matrix.language}}_sdk
-    - name: Set up gotestfmt
-      uses: haveyoudebuggedit/gotestfmt-action@v2
+    - name: Install gotestfmt
+      uses: jaxxstorm/action-install-gh-release@v1.2.0
       with:
-        token: ${{ secrets.GITHUB_TOKEN }}
+        repo: haveyoudebuggedit/gotestfmt
     - name: Run tests
       run: cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language
         }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt

--- a/provider-ci/providers/fastly/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/fastly/repo/.github/workflows/master.yml
@@ -492,10 +492,10 @@ jobs:
         pip3 install pipenv
     - name: Install dependencies
       run: make install_${{ matrix.language}}_sdk
-    - name: Set up gotestfmt
-      uses: haveyoudebuggedit/gotestfmt-action@v2
+    - name: Install gotestfmt
+      uses: jaxxstorm/action-install-gh-release@v1.2.0
       with:
-        token: ${{ secrets.GITHUB_TOKEN }}
+        repo: haveyoudebuggedit/gotestfmt
     - name: Run tests
       run: cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language
         }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt

--- a/provider-ci/providers/fastly/repo/.github/workflows/nightly-test.yml
+++ b/provider-ci/providers/fastly/repo/.github/workflows/nightly-test.yml
@@ -233,10 +233,10 @@ jobs:
         pip3 install pipenv
     - name: Install dependencies
       run: make install_${{ matrix.language}}_sdk
-    - name: Set up gotestfmt
-      uses: haveyoudebuggedit/gotestfmt-action@v2
+    - name: Install gotestfmt
+      uses: jaxxstorm/action-install-gh-release@v1.2.0
       with:
-        token: ${{ secrets.GITHUB_TOKEN }}
+        repo: haveyoudebuggedit/gotestfmt
     - name: Run tests
       run: cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language
         }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt

--- a/provider-ci/providers/fastly/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/fastly/repo/.github/workflows/prerelease.yml
@@ -438,10 +438,10 @@ jobs:
         pip3 install pipenv
     - name: Install dependencies
       run: make install_${{ matrix.language}}_sdk
-    - name: Set up gotestfmt
-      uses: haveyoudebuggedit/gotestfmt-action@v2
+    - name: Install gotestfmt
+      uses: jaxxstorm/action-install-gh-release@v1.2.0
       with:
-        token: ${{ secrets.GITHUB_TOKEN }}
+        repo: haveyoudebuggedit/gotestfmt
     - name: Run tests
       run: cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language
         }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt

--- a/provider-ci/providers/fastly/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/fastly/repo/.github/workflows/release.yml
@@ -450,10 +450,10 @@ jobs:
         pip3 install pipenv
     - name: Install dependencies
       run: make install_${{ matrix.language}}_sdk
-    - name: Set up gotestfmt
-      uses: haveyoudebuggedit/gotestfmt-action@v2
+    - name: Install gotestfmt
+      uses: jaxxstorm/action-install-gh-release@v1.2.0
       with:
-        token: ${{ secrets.GITHUB_TOKEN }}
+        repo: haveyoudebuggedit/gotestfmt
     - name: Run tests
       run: cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language
         }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt

--- a/provider-ci/providers/fastly/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/fastly/repo/.github/workflows/run-acceptance-tests.yml
@@ -347,10 +347,10 @@ jobs:
         pip3 install pipenv
     - name: Install dependencies
       run: make install_${{ matrix.language}}_sdk
-    - name: Set up gotestfmt
-      uses: haveyoudebuggedit/gotestfmt-action@v2
+    - name: Install gotestfmt
+      uses: jaxxstorm/action-install-gh-release@v1.2.0
       with:
-        token: ${{ secrets.GITHUB_TOKEN }}
+        repo: haveyoudebuggedit/gotestfmt
     - name: Run tests
       run: cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language
         }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt

--- a/provider-ci/providers/gcp/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/gcp/repo/.github/workflows/main.yml
@@ -427,10 +427,10 @@ jobs:
         version: 285.0.0
     - name: Install dependencies
       run: make install_${{ matrix.language}}_sdk
-    - name: Set up gotestfmt
-      uses: haveyoudebuggedit/gotestfmt-action@v2
+    - name: Install gotestfmt
+      uses: jaxxstorm/action-install-gh-release@v1.2.0
       with:
-        token: ${{ secrets.GITHUB_TOKEN }}
+        repo: haveyoudebuggedit/gotestfmt
     - name: Run tests
       run: cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language
         }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt

--- a/provider-ci/providers/gcp/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/gcp/repo/.github/workflows/master.yml
@@ -427,10 +427,10 @@ jobs:
         version: 285.0.0
     - name: Install dependencies
       run: make install_${{ matrix.language}}_sdk
-    - name: Set up gotestfmt
-      uses: haveyoudebuggedit/gotestfmt-action@v2
+    - name: Install gotestfmt
+      uses: jaxxstorm/action-install-gh-release@v1.2.0
       with:
-        token: ${{ secrets.GITHUB_TOKEN }}
+        repo: haveyoudebuggedit/gotestfmt
     - name: Run tests
       run: cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language
         }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt

--- a/provider-ci/providers/gcp/repo/.github/workflows/nightly-test.yml
+++ b/provider-ci/providers/gcp/repo/.github/workflows/nightly-test.yml
@@ -243,10 +243,10 @@ jobs:
         version: 285.0.0
     - name: Install dependencies
       run: make install_${{ matrix.language}}_sdk
-    - name: Set up gotestfmt
-      uses: haveyoudebuggedit/gotestfmt-action@v2
+    - name: Install gotestfmt
+      uses: jaxxstorm/action-install-gh-release@v1.2.0
       with:
-        token: ${{ secrets.GITHUB_TOKEN }}
+        repo: haveyoudebuggedit/gotestfmt
     - name: Run tests
       run: cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language
         }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt

--- a/provider-ci/providers/gcp/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/gcp/repo/.github/workflows/prerelease.yml
@@ -373,10 +373,10 @@ jobs:
         version: 285.0.0
     - name: Install dependencies
       run: make install_${{ matrix.language}}_sdk
-    - name: Set up gotestfmt
-      uses: haveyoudebuggedit/gotestfmt-action@v2
+    - name: Install gotestfmt
+      uses: jaxxstorm/action-install-gh-release@v1.2.0
       with:
-        token: ${{ secrets.GITHUB_TOKEN }}
+        repo: haveyoudebuggedit/gotestfmt
     - name: Run tests
       run: cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language
         }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt

--- a/provider-ci/providers/gcp/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/gcp/repo/.github/workflows/release.yml
@@ -385,10 +385,10 @@ jobs:
         version: 285.0.0
     - name: Install dependencies
       run: make install_${{ matrix.language}}_sdk
-    - name: Set up gotestfmt
-      uses: haveyoudebuggedit/gotestfmt-action@v2
+    - name: Install gotestfmt
+      uses: jaxxstorm/action-install-gh-release@v1.2.0
       with:
-        token: ${{ secrets.GITHUB_TOKEN }}
+        repo: haveyoudebuggedit/gotestfmt
     - name: Run tests
       run: cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language
         }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt

--- a/provider-ci/providers/gcp/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/gcp/repo/.github/workflows/run-acceptance-tests.yml
@@ -274,10 +274,10 @@ jobs:
         version: 285.0.0
     - name: Install dependencies
       run: make install_${{ matrix.language}}_sdk
-    - name: Set up gotestfmt
-      uses: haveyoudebuggedit/gotestfmt-action@v2
+    - name: Install gotestfmt
+      uses: jaxxstorm/action-install-gh-release@v1.2.0
       with:
-        token: ${{ secrets.GITHUB_TOKEN }}
+        repo: haveyoudebuggedit/gotestfmt
     - name: Run tests
       run: cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language
         }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt

--- a/provider-ci/providers/github/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/github/repo/.github/workflows/main.yml
@@ -493,10 +493,10 @@ jobs:
         pip3 install pipenv
     - name: Install dependencies
       run: make install_${{ matrix.language}}_sdk
-    - name: Set up gotestfmt
-      uses: haveyoudebuggedit/gotestfmt-action@v2
+    - name: Install gotestfmt
+      uses: jaxxstorm/action-install-gh-release@v1.2.0
       with:
-        token: ${{ secrets.GITHUB_TOKEN }}
+        repo: haveyoudebuggedit/gotestfmt
     - name: Run tests
       run: cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language
         }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt

--- a/provider-ci/providers/github/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/github/repo/.github/workflows/master.yml
@@ -493,10 +493,10 @@ jobs:
         pip3 install pipenv
     - name: Install dependencies
       run: make install_${{ matrix.language}}_sdk
-    - name: Set up gotestfmt
-      uses: haveyoudebuggedit/gotestfmt-action@v2
+    - name: Install gotestfmt
+      uses: jaxxstorm/action-install-gh-release@v1.2.0
       with:
-        token: ${{ secrets.GITHUB_TOKEN }}
+        repo: haveyoudebuggedit/gotestfmt
     - name: Run tests
       run: cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language
         }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt

--- a/provider-ci/providers/github/repo/.github/workflows/nightly-test.yml
+++ b/provider-ci/providers/github/repo/.github/workflows/nightly-test.yml
@@ -234,10 +234,10 @@ jobs:
         pip3 install pipenv
     - name: Install dependencies
       run: make install_${{ matrix.language}}_sdk
-    - name: Set up gotestfmt
-      uses: haveyoudebuggedit/gotestfmt-action@v2
+    - name: Install gotestfmt
+      uses: jaxxstorm/action-install-gh-release@v1.2.0
       with:
-        token: ${{ secrets.GITHUB_TOKEN }}
+        repo: haveyoudebuggedit/gotestfmt
     - name: Run tests
       run: cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language
         }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt

--- a/provider-ci/providers/github/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/github/repo/.github/workflows/prerelease.yml
@@ -439,10 +439,10 @@ jobs:
         pip3 install pipenv
     - name: Install dependencies
       run: make install_${{ matrix.language}}_sdk
-    - name: Set up gotestfmt
-      uses: haveyoudebuggedit/gotestfmt-action@v2
+    - name: Install gotestfmt
+      uses: jaxxstorm/action-install-gh-release@v1.2.0
       with:
-        token: ${{ secrets.GITHUB_TOKEN }}
+        repo: haveyoudebuggedit/gotestfmt
     - name: Run tests
       run: cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language
         }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt

--- a/provider-ci/providers/github/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/github/repo/.github/workflows/release.yml
@@ -451,10 +451,10 @@ jobs:
         pip3 install pipenv
     - name: Install dependencies
       run: make install_${{ matrix.language}}_sdk
-    - name: Set up gotestfmt
-      uses: haveyoudebuggedit/gotestfmt-action@v2
+    - name: Install gotestfmt
+      uses: jaxxstorm/action-install-gh-release@v1.2.0
       with:
-        token: ${{ secrets.GITHUB_TOKEN }}
+        repo: haveyoudebuggedit/gotestfmt
     - name: Run tests
       run: cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language
         }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt

--- a/provider-ci/providers/github/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/github/repo/.github/workflows/run-acceptance-tests.yml
@@ -348,10 +348,10 @@ jobs:
         pip3 install pipenv
     - name: Install dependencies
       run: make install_${{ matrix.language}}_sdk
-    - name: Set up gotestfmt
-      uses: haveyoudebuggedit/gotestfmt-action@v2
+    - name: Install gotestfmt
+      uses: jaxxstorm/action-install-gh-release@v1.2.0
       with:
-        token: ${{ secrets.GITHUB_TOKEN }}
+        repo: haveyoudebuggedit/gotestfmt
     - name: Run tests
       run: cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language
         }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt

--- a/provider-ci/providers/gitlab/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/gitlab/repo/.github/workflows/main.yml
@@ -492,10 +492,10 @@ jobs:
         pip3 install pipenv
     - name: Install dependencies
       run: make install_${{ matrix.language}}_sdk
-    - name: Set up gotestfmt
-      uses: haveyoudebuggedit/gotestfmt-action@v2
+    - name: Install gotestfmt
+      uses: jaxxstorm/action-install-gh-release@v1.2.0
       with:
-        token: ${{ secrets.GITHUB_TOKEN }}
+        repo: haveyoudebuggedit/gotestfmt
     - name: Run tests
       run: cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language
         }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt

--- a/provider-ci/providers/gitlab/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/gitlab/repo/.github/workflows/master.yml
@@ -492,10 +492,10 @@ jobs:
         pip3 install pipenv
     - name: Install dependencies
       run: make install_${{ matrix.language}}_sdk
-    - name: Set up gotestfmt
-      uses: haveyoudebuggedit/gotestfmt-action@v2
+    - name: Install gotestfmt
+      uses: jaxxstorm/action-install-gh-release@v1.2.0
       with:
-        token: ${{ secrets.GITHUB_TOKEN }}
+        repo: haveyoudebuggedit/gotestfmt
     - name: Run tests
       run: cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language
         }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt

--- a/provider-ci/providers/gitlab/repo/.github/workflows/nightly-test.yml
+++ b/provider-ci/providers/gitlab/repo/.github/workflows/nightly-test.yml
@@ -233,10 +233,10 @@ jobs:
         pip3 install pipenv
     - name: Install dependencies
       run: make install_${{ matrix.language}}_sdk
-    - name: Set up gotestfmt
-      uses: haveyoudebuggedit/gotestfmt-action@v2
+    - name: Install gotestfmt
+      uses: jaxxstorm/action-install-gh-release@v1.2.0
       with:
-        token: ${{ secrets.GITHUB_TOKEN }}
+        repo: haveyoudebuggedit/gotestfmt
     - name: Run tests
       run: cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language
         }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt

--- a/provider-ci/providers/gitlab/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/gitlab/repo/.github/workflows/prerelease.yml
@@ -438,10 +438,10 @@ jobs:
         pip3 install pipenv
     - name: Install dependencies
       run: make install_${{ matrix.language}}_sdk
-    - name: Set up gotestfmt
-      uses: haveyoudebuggedit/gotestfmt-action@v2
+    - name: Install gotestfmt
+      uses: jaxxstorm/action-install-gh-release@v1.2.0
       with:
-        token: ${{ secrets.GITHUB_TOKEN }}
+        repo: haveyoudebuggedit/gotestfmt
     - name: Run tests
       run: cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language
         }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt

--- a/provider-ci/providers/gitlab/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/gitlab/repo/.github/workflows/release.yml
@@ -450,10 +450,10 @@ jobs:
         pip3 install pipenv
     - name: Install dependencies
       run: make install_${{ matrix.language}}_sdk
-    - name: Set up gotestfmt
-      uses: haveyoudebuggedit/gotestfmt-action@v2
+    - name: Install gotestfmt
+      uses: jaxxstorm/action-install-gh-release@v1.2.0
       with:
-        token: ${{ secrets.GITHUB_TOKEN }}
+        repo: haveyoudebuggedit/gotestfmt
     - name: Run tests
       run: cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language
         }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt

--- a/provider-ci/providers/gitlab/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/gitlab/repo/.github/workflows/run-acceptance-tests.yml
@@ -347,10 +347,10 @@ jobs:
         pip3 install pipenv
     - name: Install dependencies
       run: make install_${{ matrix.language}}_sdk
-    - name: Set up gotestfmt
-      uses: haveyoudebuggedit/gotestfmt-action@v2
+    - name: Install gotestfmt
+      uses: jaxxstorm/action-install-gh-release@v1.2.0
       with:
-        token: ${{ secrets.GITHUB_TOKEN }}
+        repo: haveyoudebuggedit/gotestfmt
     - name: Run tests
       run: cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language
         }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt

--- a/provider-ci/providers/hcloud/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/hcloud/repo/.github/workflows/main.yml
@@ -492,10 +492,10 @@ jobs:
         pip3 install pipenv
     - name: Install dependencies
       run: make install_${{ matrix.language}}_sdk
-    - name: Set up gotestfmt
-      uses: haveyoudebuggedit/gotestfmt-action@v2
+    - name: Install gotestfmt
+      uses: jaxxstorm/action-install-gh-release@v1.2.0
       with:
-        token: ${{ secrets.GITHUB_TOKEN }}
+        repo: haveyoudebuggedit/gotestfmt
     - name: Run tests
       run: cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language
         }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt

--- a/provider-ci/providers/hcloud/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/hcloud/repo/.github/workflows/master.yml
@@ -492,10 +492,10 @@ jobs:
         pip3 install pipenv
     - name: Install dependencies
       run: make install_${{ matrix.language}}_sdk
-    - name: Set up gotestfmt
-      uses: haveyoudebuggedit/gotestfmt-action@v2
+    - name: Install gotestfmt
+      uses: jaxxstorm/action-install-gh-release@v1.2.0
       with:
-        token: ${{ secrets.GITHUB_TOKEN }}
+        repo: haveyoudebuggedit/gotestfmt
     - name: Run tests
       run: cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language
         }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt

--- a/provider-ci/providers/hcloud/repo/.github/workflows/nightly-test.yml
+++ b/provider-ci/providers/hcloud/repo/.github/workflows/nightly-test.yml
@@ -233,10 +233,10 @@ jobs:
         pip3 install pipenv
     - name: Install dependencies
       run: make install_${{ matrix.language}}_sdk
-    - name: Set up gotestfmt
-      uses: haveyoudebuggedit/gotestfmt-action@v2
+    - name: Install gotestfmt
+      uses: jaxxstorm/action-install-gh-release@v1.2.0
       with:
-        token: ${{ secrets.GITHUB_TOKEN }}
+        repo: haveyoudebuggedit/gotestfmt
     - name: Run tests
       run: cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language
         }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt

--- a/provider-ci/providers/hcloud/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/hcloud/repo/.github/workflows/prerelease.yml
@@ -438,10 +438,10 @@ jobs:
         pip3 install pipenv
     - name: Install dependencies
       run: make install_${{ matrix.language}}_sdk
-    - name: Set up gotestfmt
-      uses: haveyoudebuggedit/gotestfmt-action@v2
+    - name: Install gotestfmt
+      uses: jaxxstorm/action-install-gh-release@v1.2.0
       with:
-        token: ${{ secrets.GITHUB_TOKEN }}
+        repo: haveyoudebuggedit/gotestfmt
     - name: Run tests
       run: cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language
         }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt

--- a/provider-ci/providers/hcloud/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/hcloud/repo/.github/workflows/release.yml
@@ -450,10 +450,10 @@ jobs:
         pip3 install pipenv
     - name: Install dependencies
       run: make install_${{ matrix.language}}_sdk
-    - name: Set up gotestfmt
-      uses: haveyoudebuggedit/gotestfmt-action@v2
+    - name: Install gotestfmt
+      uses: jaxxstorm/action-install-gh-release@v1.2.0
       with:
-        token: ${{ secrets.GITHUB_TOKEN }}
+        repo: haveyoudebuggedit/gotestfmt
     - name: Run tests
       run: cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language
         }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt

--- a/provider-ci/providers/hcloud/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/hcloud/repo/.github/workflows/run-acceptance-tests.yml
@@ -347,10 +347,10 @@ jobs:
         pip3 install pipenv
     - name: Install dependencies
       run: make install_${{ matrix.language}}_sdk
-    - name: Set up gotestfmt
-      uses: haveyoudebuggedit/gotestfmt-action@v2
+    - name: Install gotestfmt
+      uses: jaxxstorm/action-install-gh-release@v1.2.0
       with:
-        token: ${{ secrets.GITHUB_TOKEN }}
+        repo: haveyoudebuggedit/gotestfmt
     - name: Run tests
       run: cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language
         }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt

--- a/provider-ci/providers/kafka/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/kafka/repo/.github/workflows/main.yml
@@ -493,10 +493,10 @@ jobs:
       run: docker-compose -f testing/docker-compose.yml up --build -d
     - name: Install dependencies
       run: make install_${{ matrix.language}}_sdk
-    - name: Set up gotestfmt
-      uses: haveyoudebuggedit/gotestfmt-action@v2
+    - name: Install gotestfmt
+      uses: jaxxstorm/action-install-gh-release@v1.2.0
       with:
-        token: ${{ secrets.GITHUB_TOKEN }}
+        repo: haveyoudebuggedit/gotestfmt
     - name: Run tests
       run: cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language
         }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt

--- a/provider-ci/providers/kafka/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/kafka/repo/.github/workflows/master.yml
@@ -493,10 +493,10 @@ jobs:
       run: docker-compose -f testing/docker-compose.yml up --build -d
     - name: Install dependencies
       run: make install_${{ matrix.language}}_sdk
-    - name: Set up gotestfmt
-      uses: haveyoudebuggedit/gotestfmt-action@v2
+    - name: Install gotestfmt
+      uses: jaxxstorm/action-install-gh-release@v1.2.0
       with:
-        token: ${{ secrets.GITHUB_TOKEN }}
+        repo: haveyoudebuggedit/gotestfmt
     - name: Run tests
       run: cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language
         }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt

--- a/provider-ci/providers/kafka/repo/.github/workflows/nightly-test.yml
+++ b/provider-ci/providers/kafka/repo/.github/workflows/nightly-test.yml
@@ -234,10 +234,10 @@ jobs:
       run: docker-compose -f testing/docker-compose.yml up --build -d
     - name: Install dependencies
       run: make install_${{ matrix.language}}_sdk
-    - name: Set up gotestfmt
-      uses: haveyoudebuggedit/gotestfmt-action@v2
+    - name: Install gotestfmt
+      uses: jaxxstorm/action-install-gh-release@v1.2.0
       with:
-        token: ${{ secrets.GITHUB_TOKEN }}
+        repo: haveyoudebuggedit/gotestfmt
     - name: Run tests
       run: cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language
         }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt

--- a/provider-ci/providers/kafka/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/kafka/repo/.github/workflows/prerelease.yml
@@ -439,10 +439,10 @@ jobs:
       run: docker-compose -f testing/docker-compose.yml up --build -d
     - name: Install dependencies
       run: make install_${{ matrix.language}}_sdk
-    - name: Set up gotestfmt
-      uses: haveyoudebuggedit/gotestfmt-action@v2
+    - name: Install gotestfmt
+      uses: jaxxstorm/action-install-gh-release@v1.2.0
       with:
-        token: ${{ secrets.GITHUB_TOKEN }}
+        repo: haveyoudebuggedit/gotestfmt
     - name: Run tests
       run: cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language
         }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt

--- a/provider-ci/providers/kafka/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/kafka/repo/.github/workflows/release.yml
@@ -451,10 +451,10 @@ jobs:
       run: docker-compose -f testing/docker-compose.yml up --build -d
     - name: Install dependencies
       run: make install_${{ matrix.language}}_sdk
-    - name: Set up gotestfmt
-      uses: haveyoudebuggedit/gotestfmt-action@v2
+    - name: Install gotestfmt
+      uses: jaxxstorm/action-install-gh-release@v1.2.0
       with:
-        token: ${{ secrets.GITHUB_TOKEN }}
+        repo: haveyoudebuggedit/gotestfmt
     - name: Run tests
       run: cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language
         }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt

--- a/provider-ci/providers/kafka/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/kafka/repo/.github/workflows/run-acceptance-tests.yml
@@ -348,10 +348,10 @@ jobs:
       run: docker-compose -f testing/docker-compose.yml up --build -d
     - name: Install dependencies
       run: make install_${{ matrix.language}}_sdk
-    - name: Set up gotestfmt
-      uses: haveyoudebuggedit/gotestfmt-action@v2
+    - name: Install gotestfmt
+      uses: jaxxstorm/action-install-gh-release@v1.2.0
       with:
-        token: ${{ secrets.GITHUB_TOKEN }}
+        repo: haveyoudebuggedit/gotestfmt
     - name: Run tests
       run: cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language
         }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt

--- a/provider-ci/providers/keycloak/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/keycloak/repo/.github/workflows/main.yml
@@ -500,10 +500,10 @@ jobs:
       run: testing/setup.sh
     - name: Install dependencies
       run: make install_${{ matrix.language}}_sdk
-    - name: Set up gotestfmt
-      uses: haveyoudebuggedit/gotestfmt-action@v2
+    - name: Install gotestfmt
+      uses: jaxxstorm/action-install-gh-release@v1.2.0
       with:
-        token: ${{ secrets.GITHUB_TOKEN }}
+        repo: haveyoudebuggedit/gotestfmt
     - name: Run tests
       run: cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language
         }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt

--- a/provider-ci/providers/keycloak/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/keycloak/repo/.github/workflows/master.yml
@@ -500,10 +500,10 @@ jobs:
       run: testing/setup.sh
     - name: Install dependencies
       run: make install_${{ matrix.language}}_sdk
-    - name: Set up gotestfmt
-      uses: haveyoudebuggedit/gotestfmt-action@v2
+    - name: Install gotestfmt
+      uses: jaxxstorm/action-install-gh-release@v1.2.0
       with:
-        token: ${{ secrets.GITHUB_TOKEN }}
+        repo: haveyoudebuggedit/gotestfmt
     - name: Run tests
       run: cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language
         }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt

--- a/provider-ci/providers/keycloak/repo/.github/workflows/nightly-test.yml
+++ b/provider-ci/providers/keycloak/repo/.github/workflows/nightly-test.yml
@@ -241,10 +241,10 @@ jobs:
       run: testing/setup.sh
     - name: Install dependencies
       run: make install_${{ matrix.language}}_sdk
-    - name: Set up gotestfmt
-      uses: haveyoudebuggedit/gotestfmt-action@v2
+    - name: Install gotestfmt
+      uses: jaxxstorm/action-install-gh-release@v1.2.0
       with:
-        token: ${{ secrets.GITHUB_TOKEN }}
+        repo: haveyoudebuggedit/gotestfmt
     - name: Run tests
       run: cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language
         }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt

--- a/provider-ci/providers/keycloak/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/keycloak/repo/.github/workflows/prerelease.yml
@@ -446,10 +446,10 @@ jobs:
       run: testing/setup.sh
     - name: Install dependencies
       run: make install_${{ matrix.language}}_sdk
-    - name: Set up gotestfmt
-      uses: haveyoudebuggedit/gotestfmt-action@v2
+    - name: Install gotestfmt
+      uses: jaxxstorm/action-install-gh-release@v1.2.0
       with:
-        token: ${{ secrets.GITHUB_TOKEN }}
+        repo: haveyoudebuggedit/gotestfmt
     - name: Run tests
       run: cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language
         }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt

--- a/provider-ci/providers/keycloak/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/keycloak/repo/.github/workflows/release.yml
@@ -458,10 +458,10 @@ jobs:
       run: testing/setup.sh
     - name: Install dependencies
       run: make install_${{ matrix.language}}_sdk
-    - name: Set up gotestfmt
-      uses: haveyoudebuggedit/gotestfmt-action@v2
+    - name: Install gotestfmt
+      uses: jaxxstorm/action-install-gh-release@v1.2.0
       with:
-        token: ${{ secrets.GITHUB_TOKEN }}
+        repo: haveyoudebuggedit/gotestfmt
     - name: Run tests
       run: cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language
         }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt

--- a/provider-ci/providers/keycloak/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/keycloak/repo/.github/workflows/run-acceptance-tests.yml
@@ -355,10 +355,10 @@ jobs:
       run: testing/setup.sh
     - name: Install dependencies
       run: make install_${{ matrix.language}}_sdk
-    - name: Set up gotestfmt
-      uses: haveyoudebuggedit/gotestfmt-action@v2
+    - name: Install gotestfmt
+      uses: jaxxstorm/action-install-gh-release@v1.2.0
       with:
-        token: ${{ secrets.GITHUB_TOKEN }}
+        repo: haveyoudebuggedit/gotestfmt
     - name: Run tests
       run: cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language
         }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt

--- a/provider-ci/providers/kong/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/kong/repo/.github/workflows/main.yml
@@ -493,10 +493,10 @@ jobs:
       run: docker-compose -f testing/docker-compose.yml up --build -d
     - name: Install dependencies
       run: make install_${{ matrix.language}}_sdk
-    - name: Set up gotestfmt
-      uses: haveyoudebuggedit/gotestfmt-action@v2
+    - name: Install gotestfmt
+      uses: jaxxstorm/action-install-gh-release@v1.2.0
       with:
-        token: ${{ secrets.GITHUB_TOKEN }}
+        repo: haveyoudebuggedit/gotestfmt
     - name: Run tests
       run: cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language
         }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt

--- a/provider-ci/providers/kong/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/kong/repo/.github/workflows/master.yml
@@ -493,10 +493,10 @@ jobs:
       run: docker-compose -f testing/docker-compose.yml up --build -d
     - name: Install dependencies
       run: make install_${{ matrix.language}}_sdk
-    - name: Set up gotestfmt
-      uses: haveyoudebuggedit/gotestfmt-action@v2
+    - name: Install gotestfmt
+      uses: jaxxstorm/action-install-gh-release@v1.2.0
       with:
-        token: ${{ secrets.GITHUB_TOKEN }}
+        repo: haveyoudebuggedit/gotestfmt
     - name: Run tests
       run: cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language
         }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt

--- a/provider-ci/providers/kong/repo/.github/workflows/nightly-test.yml
+++ b/provider-ci/providers/kong/repo/.github/workflows/nightly-test.yml
@@ -234,10 +234,10 @@ jobs:
       run: docker-compose -f testing/docker-compose.yml up --build -d
     - name: Install dependencies
       run: make install_${{ matrix.language}}_sdk
-    - name: Set up gotestfmt
-      uses: haveyoudebuggedit/gotestfmt-action@v2
+    - name: Install gotestfmt
+      uses: jaxxstorm/action-install-gh-release@v1.2.0
       with:
-        token: ${{ secrets.GITHUB_TOKEN }}
+        repo: haveyoudebuggedit/gotestfmt
     - name: Run tests
       run: cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language
         }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt

--- a/provider-ci/providers/kong/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/kong/repo/.github/workflows/prerelease.yml
@@ -439,10 +439,10 @@ jobs:
       run: docker-compose -f testing/docker-compose.yml up --build -d
     - name: Install dependencies
       run: make install_${{ matrix.language}}_sdk
-    - name: Set up gotestfmt
-      uses: haveyoudebuggedit/gotestfmt-action@v2
+    - name: Install gotestfmt
+      uses: jaxxstorm/action-install-gh-release@v1.2.0
       with:
-        token: ${{ secrets.GITHUB_TOKEN }}
+        repo: haveyoudebuggedit/gotestfmt
     - name: Run tests
       run: cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language
         }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt

--- a/provider-ci/providers/kong/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/kong/repo/.github/workflows/release.yml
@@ -451,10 +451,10 @@ jobs:
       run: docker-compose -f testing/docker-compose.yml up --build -d
     - name: Install dependencies
       run: make install_${{ matrix.language}}_sdk
-    - name: Set up gotestfmt
-      uses: haveyoudebuggedit/gotestfmt-action@v2
+    - name: Install gotestfmt
+      uses: jaxxstorm/action-install-gh-release@v1.2.0
       with:
-        token: ${{ secrets.GITHUB_TOKEN }}
+        repo: haveyoudebuggedit/gotestfmt
     - name: Run tests
       run: cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language
         }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt

--- a/provider-ci/providers/kong/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/kong/repo/.github/workflows/run-acceptance-tests.yml
@@ -348,10 +348,10 @@ jobs:
       run: docker-compose -f testing/docker-compose.yml up --build -d
     - name: Install dependencies
       run: make install_${{ matrix.language}}_sdk
-    - name: Set up gotestfmt
-      uses: haveyoudebuggedit/gotestfmt-action@v2
+    - name: Install gotestfmt
+      uses: jaxxstorm/action-install-gh-release@v1.2.0
       with:
-        token: ${{ secrets.GITHUB_TOKEN }}
+        repo: haveyoudebuggedit/gotestfmt
     - name: Run tests
       run: cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language
         }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt

--- a/provider-ci/providers/libvirt/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/libvirt/repo/.github/workflows/main.yml
@@ -494,10 +494,10 @@ jobs:
       run: testing/setup.sh
     - name: Install dependencies
       run: make install_${{ matrix.language}}_sdk
-    - name: Set up gotestfmt
-      uses: haveyoudebuggedit/gotestfmt-action@v2
+    - name: Install gotestfmt
+      uses: jaxxstorm/action-install-gh-release@v1.2.0
       with:
-        token: ${{ secrets.GITHUB_TOKEN }}
+        repo: haveyoudebuggedit/gotestfmt
     - name: Run tests
       run: cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language
         }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt

--- a/provider-ci/providers/libvirt/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/libvirt/repo/.github/workflows/master.yml
@@ -494,10 +494,10 @@ jobs:
       run: testing/setup.sh
     - name: Install dependencies
       run: make install_${{ matrix.language}}_sdk
-    - name: Set up gotestfmt
-      uses: haveyoudebuggedit/gotestfmt-action@v2
+    - name: Install gotestfmt
+      uses: jaxxstorm/action-install-gh-release@v1.2.0
       with:
-        token: ${{ secrets.GITHUB_TOKEN }}
+        repo: haveyoudebuggedit/gotestfmt
     - name: Run tests
       run: cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language
         }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt

--- a/provider-ci/providers/libvirt/repo/.github/workflows/nightly-test.yml
+++ b/provider-ci/providers/libvirt/repo/.github/workflows/nightly-test.yml
@@ -235,10 +235,10 @@ jobs:
       run: testing/setup.sh
     - name: Install dependencies
       run: make install_${{ matrix.language}}_sdk
-    - name: Set up gotestfmt
-      uses: haveyoudebuggedit/gotestfmt-action@v2
+    - name: Install gotestfmt
+      uses: jaxxstorm/action-install-gh-release@v1.2.0
       with:
-        token: ${{ secrets.GITHUB_TOKEN }}
+        repo: haveyoudebuggedit/gotestfmt
     - name: Run tests
       run: cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language
         }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt

--- a/provider-ci/providers/libvirt/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/libvirt/repo/.github/workflows/prerelease.yml
@@ -440,10 +440,10 @@ jobs:
       run: testing/setup.sh
     - name: Install dependencies
       run: make install_${{ matrix.language}}_sdk
-    - name: Set up gotestfmt
-      uses: haveyoudebuggedit/gotestfmt-action@v2
+    - name: Install gotestfmt
+      uses: jaxxstorm/action-install-gh-release@v1.2.0
       with:
-        token: ${{ secrets.GITHUB_TOKEN }}
+        repo: haveyoudebuggedit/gotestfmt
     - name: Run tests
       run: cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language
         }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt

--- a/provider-ci/providers/libvirt/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/libvirt/repo/.github/workflows/release.yml
@@ -452,10 +452,10 @@ jobs:
       run: testing/setup.sh
     - name: Install dependencies
       run: make install_${{ matrix.language}}_sdk
-    - name: Set up gotestfmt
-      uses: haveyoudebuggedit/gotestfmt-action@v2
+    - name: Install gotestfmt
+      uses: jaxxstorm/action-install-gh-release@v1.2.0
       with:
-        token: ${{ secrets.GITHUB_TOKEN }}
+        repo: haveyoudebuggedit/gotestfmt
     - name: Run tests
       run: cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language
         }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt

--- a/provider-ci/providers/libvirt/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/libvirt/repo/.github/workflows/run-acceptance-tests.yml
@@ -349,10 +349,10 @@ jobs:
       run: testing/setup.sh
     - name: Install dependencies
       run: make install_${{ matrix.language}}_sdk
-    - name: Set up gotestfmt
-      uses: haveyoudebuggedit/gotestfmt-action@v2
+    - name: Install gotestfmt
+      uses: jaxxstorm/action-install-gh-release@v1.2.0
       with:
-        token: ${{ secrets.GITHUB_TOKEN }}
+        repo: haveyoudebuggedit/gotestfmt
     - name: Run tests
       run: cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language
         }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt

--- a/provider-ci/providers/linode/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/linode/repo/.github/workflows/main.yml
@@ -492,10 +492,10 @@ jobs:
         pip3 install pipenv
     - name: Install dependencies
       run: make install_${{ matrix.language}}_sdk
-    - name: Set up gotestfmt
-      uses: haveyoudebuggedit/gotestfmt-action@v2
+    - name: Install gotestfmt
+      uses: jaxxstorm/action-install-gh-release@v1.2.0
       with:
-        token: ${{ secrets.GITHUB_TOKEN }}
+        repo: haveyoudebuggedit/gotestfmt
     - name: Run tests
       run: cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language
         }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt

--- a/provider-ci/providers/linode/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/linode/repo/.github/workflows/master.yml
@@ -492,10 +492,10 @@ jobs:
         pip3 install pipenv
     - name: Install dependencies
       run: make install_${{ matrix.language}}_sdk
-    - name: Set up gotestfmt
-      uses: haveyoudebuggedit/gotestfmt-action@v2
+    - name: Install gotestfmt
+      uses: jaxxstorm/action-install-gh-release@v1.2.0
       with:
-        token: ${{ secrets.GITHUB_TOKEN }}
+        repo: haveyoudebuggedit/gotestfmt
     - name: Run tests
       run: cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language
         }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt

--- a/provider-ci/providers/linode/repo/.github/workflows/nightly-test.yml
+++ b/provider-ci/providers/linode/repo/.github/workflows/nightly-test.yml
@@ -233,10 +233,10 @@ jobs:
         pip3 install pipenv
     - name: Install dependencies
       run: make install_${{ matrix.language}}_sdk
-    - name: Set up gotestfmt
-      uses: haveyoudebuggedit/gotestfmt-action@v2
+    - name: Install gotestfmt
+      uses: jaxxstorm/action-install-gh-release@v1.2.0
       with:
-        token: ${{ secrets.GITHUB_TOKEN }}
+        repo: haveyoudebuggedit/gotestfmt
     - name: Run tests
       run: cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language
         }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt

--- a/provider-ci/providers/linode/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/linode/repo/.github/workflows/prerelease.yml
@@ -438,10 +438,10 @@ jobs:
         pip3 install pipenv
     - name: Install dependencies
       run: make install_${{ matrix.language}}_sdk
-    - name: Set up gotestfmt
-      uses: haveyoudebuggedit/gotestfmt-action@v2
+    - name: Install gotestfmt
+      uses: jaxxstorm/action-install-gh-release@v1.2.0
       with:
-        token: ${{ secrets.GITHUB_TOKEN }}
+        repo: haveyoudebuggedit/gotestfmt
     - name: Run tests
       run: cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language
         }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt

--- a/provider-ci/providers/linode/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/linode/repo/.github/workflows/release.yml
@@ -450,10 +450,10 @@ jobs:
         pip3 install pipenv
     - name: Install dependencies
       run: make install_${{ matrix.language}}_sdk
-    - name: Set up gotestfmt
-      uses: haveyoudebuggedit/gotestfmt-action@v2
+    - name: Install gotestfmt
+      uses: jaxxstorm/action-install-gh-release@v1.2.0
       with:
-        token: ${{ secrets.GITHUB_TOKEN }}
+        repo: haveyoudebuggedit/gotestfmt
     - name: Run tests
       run: cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language
         }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt

--- a/provider-ci/providers/linode/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/linode/repo/.github/workflows/run-acceptance-tests.yml
@@ -347,10 +347,10 @@ jobs:
         pip3 install pipenv
     - name: Install dependencies
       run: make install_${{ matrix.language}}_sdk
-    - name: Set up gotestfmt
-      uses: haveyoudebuggedit/gotestfmt-action@v2
+    - name: Install gotestfmt
+      uses: jaxxstorm/action-install-gh-release@v1.2.0
       with:
-        token: ${{ secrets.GITHUB_TOKEN }}
+        repo: haveyoudebuggedit/gotestfmt
     - name: Run tests
       run: cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language
         }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt

--- a/provider-ci/providers/mailgun/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/mailgun/repo/.github/workflows/main.yml
@@ -492,10 +492,10 @@ jobs:
         pip3 install pipenv
     - name: Install dependencies
       run: make install_${{ matrix.language}}_sdk
-    - name: Set up gotestfmt
-      uses: haveyoudebuggedit/gotestfmt-action@v2
+    - name: Install gotestfmt
+      uses: jaxxstorm/action-install-gh-release@v1.2.0
       with:
-        token: ${{ secrets.GITHUB_TOKEN }}
+        repo: haveyoudebuggedit/gotestfmt
     - name: Run tests
       run: cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language
         }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt

--- a/provider-ci/providers/mailgun/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/mailgun/repo/.github/workflows/master.yml
@@ -492,10 +492,10 @@ jobs:
         pip3 install pipenv
     - name: Install dependencies
       run: make install_${{ matrix.language}}_sdk
-    - name: Set up gotestfmt
-      uses: haveyoudebuggedit/gotestfmt-action@v2
+    - name: Install gotestfmt
+      uses: jaxxstorm/action-install-gh-release@v1.2.0
       with:
-        token: ${{ secrets.GITHUB_TOKEN }}
+        repo: haveyoudebuggedit/gotestfmt
     - name: Run tests
       run: cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language
         }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt

--- a/provider-ci/providers/mailgun/repo/.github/workflows/nightly-test.yml
+++ b/provider-ci/providers/mailgun/repo/.github/workflows/nightly-test.yml
@@ -233,10 +233,10 @@ jobs:
         pip3 install pipenv
     - name: Install dependencies
       run: make install_${{ matrix.language}}_sdk
-    - name: Set up gotestfmt
-      uses: haveyoudebuggedit/gotestfmt-action@v2
+    - name: Install gotestfmt
+      uses: jaxxstorm/action-install-gh-release@v1.2.0
       with:
-        token: ${{ secrets.GITHUB_TOKEN }}
+        repo: haveyoudebuggedit/gotestfmt
     - name: Run tests
       run: cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language
         }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt

--- a/provider-ci/providers/mailgun/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/mailgun/repo/.github/workflows/prerelease.yml
@@ -438,10 +438,10 @@ jobs:
         pip3 install pipenv
     - name: Install dependencies
       run: make install_${{ matrix.language}}_sdk
-    - name: Set up gotestfmt
-      uses: haveyoudebuggedit/gotestfmt-action@v2
+    - name: Install gotestfmt
+      uses: jaxxstorm/action-install-gh-release@v1.2.0
       with:
-        token: ${{ secrets.GITHUB_TOKEN }}
+        repo: haveyoudebuggedit/gotestfmt
     - name: Run tests
       run: cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language
         }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt

--- a/provider-ci/providers/mailgun/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/mailgun/repo/.github/workflows/release.yml
@@ -450,10 +450,10 @@ jobs:
         pip3 install pipenv
     - name: Install dependencies
       run: make install_${{ matrix.language}}_sdk
-    - name: Set up gotestfmt
-      uses: haveyoudebuggedit/gotestfmt-action@v2
+    - name: Install gotestfmt
+      uses: jaxxstorm/action-install-gh-release@v1.2.0
       with:
-        token: ${{ secrets.GITHUB_TOKEN }}
+        repo: haveyoudebuggedit/gotestfmt
     - name: Run tests
       run: cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language
         }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt

--- a/provider-ci/providers/mailgun/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/mailgun/repo/.github/workflows/run-acceptance-tests.yml
@@ -347,10 +347,10 @@ jobs:
         pip3 install pipenv
     - name: Install dependencies
       run: make install_${{ matrix.language}}_sdk
-    - name: Set up gotestfmt
-      uses: haveyoudebuggedit/gotestfmt-action@v2
+    - name: Install gotestfmt
+      uses: jaxxstorm/action-install-gh-release@v1.2.0
       with:
-        token: ${{ secrets.GITHUB_TOKEN }}
+        repo: haveyoudebuggedit/gotestfmt
     - name: Run tests
       run: cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language
         }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt

--- a/provider-ci/providers/minio/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/minio/repo/.github/workflows/main.yml
@@ -497,10 +497,10 @@ jobs:
       run: docker-compose -f testing/docker-compose.yml up --build -d
     - name: Install dependencies
       run: make install_${{ matrix.language}}_sdk
-    - name: Set up gotestfmt
-      uses: haveyoudebuggedit/gotestfmt-action@v2
+    - name: Install gotestfmt
+      uses: jaxxstorm/action-install-gh-release@v1.2.0
       with:
-        token: ${{ secrets.GITHUB_TOKEN }}
+        repo: haveyoudebuggedit/gotestfmt
     - name: Run tests
       run: cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language
         }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt

--- a/provider-ci/providers/minio/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/minio/repo/.github/workflows/master.yml
@@ -497,10 +497,10 @@ jobs:
       run: docker-compose -f testing/docker-compose.yml up --build -d
     - name: Install dependencies
       run: make install_${{ matrix.language}}_sdk
-    - name: Set up gotestfmt
-      uses: haveyoudebuggedit/gotestfmt-action@v2
+    - name: Install gotestfmt
+      uses: jaxxstorm/action-install-gh-release@v1.2.0
       with:
-        token: ${{ secrets.GITHUB_TOKEN }}
+        repo: haveyoudebuggedit/gotestfmt
     - name: Run tests
       run: cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language
         }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt

--- a/provider-ci/providers/minio/repo/.github/workflows/nightly-test.yml
+++ b/provider-ci/providers/minio/repo/.github/workflows/nightly-test.yml
@@ -238,10 +238,10 @@ jobs:
       run: docker-compose -f testing/docker-compose.yml up --build -d
     - name: Install dependencies
       run: make install_${{ matrix.language}}_sdk
-    - name: Set up gotestfmt
-      uses: haveyoudebuggedit/gotestfmt-action@v2
+    - name: Install gotestfmt
+      uses: jaxxstorm/action-install-gh-release@v1.2.0
       with:
-        token: ${{ secrets.GITHUB_TOKEN }}
+        repo: haveyoudebuggedit/gotestfmt
     - name: Run tests
       run: cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language
         }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt

--- a/provider-ci/providers/minio/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/minio/repo/.github/workflows/prerelease.yml
@@ -443,10 +443,10 @@ jobs:
       run: docker-compose -f testing/docker-compose.yml up --build -d
     - name: Install dependencies
       run: make install_${{ matrix.language}}_sdk
-    - name: Set up gotestfmt
-      uses: haveyoudebuggedit/gotestfmt-action@v2
+    - name: Install gotestfmt
+      uses: jaxxstorm/action-install-gh-release@v1.2.0
       with:
-        token: ${{ secrets.GITHUB_TOKEN }}
+        repo: haveyoudebuggedit/gotestfmt
     - name: Run tests
       run: cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language
         }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt

--- a/provider-ci/providers/minio/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/minio/repo/.github/workflows/release.yml
@@ -455,10 +455,10 @@ jobs:
       run: docker-compose -f testing/docker-compose.yml up --build -d
     - name: Install dependencies
       run: make install_${{ matrix.language}}_sdk
-    - name: Set up gotestfmt
-      uses: haveyoudebuggedit/gotestfmt-action@v2
+    - name: Install gotestfmt
+      uses: jaxxstorm/action-install-gh-release@v1.2.0
       with:
-        token: ${{ secrets.GITHUB_TOKEN }}
+        repo: haveyoudebuggedit/gotestfmt
     - name: Run tests
       run: cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language
         }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt

--- a/provider-ci/providers/minio/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/minio/repo/.github/workflows/run-acceptance-tests.yml
@@ -352,10 +352,10 @@ jobs:
       run: docker-compose -f testing/docker-compose.yml up --build -d
     - name: Install dependencies
       run: make install_${{ matrix.language}}_sdk
-    - name: Set up gotestfmt
-      uses: haveyoudebuggedit/gotestfmt-action@v2
+    - name: Install gotestfmt
+      uses: jaxxstorm/action-install-gh-release@v1.2.0
       with:
-        token: ${{ secrets.GITHUB_TOKEN }}
+        repo: haveyoudebuggedit/gotestfmt
     - name: Run tests
       run: cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language
         }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt

--- a/provider-ci/providers/mongodbatlas/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/mongodbatlas/repo/.github/workflows/main.yml
@@ -494,10 +494,10 @@ jobs:
         pip3 install pipenv
     - name: Install dependencies
       run: make install_${{ matrix.language}}_sdk
-    - name: Set up gotestfmt
-      uses: haveyoudebuggedit/gotestfmt-action@v2
+    - name: Install gotestfmt
+      uses: jaxxstorm/action-install-gh-release@v1.2.0
       with:
-        token: ${{ secrets.GITHUB_TOKEN }}
+        repo: haveyoudebuggedit/gotestfmt
     - name: Run tests
       run: cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language
         }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt

--- a/provider-ci/providers/mongodbatlas/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/mongodbatlas/repo/.github/workflows/master.yml
@@ -494,10 +494,10 @@ jobs:
         pip3 install pipenv
     - name: Install dependencies
       run: make install_${{ matrix.language}}_sdk
-    - name: Set up gotestfmt
-      uses: haveyoudebuggedit/gotestfmt-action@v2
+    - name: Install gotestfmt
+      uses: jaxxstorm/action-install-gh-release@v1.2.0
       with:
-        token: ${{ secrets.GITHUB_TOKEN }}
+        repo: haveyoudebuggedit/gotestfmt
     - name: Run tests
       run: cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language
         }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt

--- a/provider-ci/providers/mongodbatlas/repo/.github/workflows/nightly-test.yml
+++ b/provider-ci/providers/mongodbatlas/repo/.github/workflows/nightly-test.yml
@@ -235,10 +235,10 @@ jobs:
         pip3 install pipenv
     - name: Install dependencies
       run: make install_${{ matrix.language}}_sdk
-    - name: Set up gotestfmt
-      uses: haveyoudebuggedit/gotestfmt-action@v2
+    - name: Install gotestfmt
+      uses: jaxxstorm/action-install-gh-release@v1.2.0
       with:
-        token: ${{ secrets.GITHUB_TOKEN }}
+        repo: haveyoudebuggedit/gotestfmt
     - name: Run tests
       run: cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language
         }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt

--- a/provider-ci/providers/mongodbatlas/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/mongodbatlas/repo/.github/workflows/prerelease.yml
@@ -440,10 +440,10 @@ jobs:
         pip3 install pipenv
     - name: Install dependencies
       run: make install_${{ matrix.language}}_sdk
-    - name: Set up gotestfmt
-      uses: haveyoudebuggedit/gotestfmt-action@v2
+    - name: Install gotestfmt
+      uses: jaxxstorm/action-install-gh-release@v1.2.0
       with:
-        token: ${{ secrets.GITHUB_TOKEN }}
+        repo: haveyoudebuggedit/gotestfmt
     - name: Run tests
       run: cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language
         }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt

--- a/provider-ci/providers/mongodbatlas/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/mongodbatlas/repo/.github/workflows/release.yml
@@ -452,10 +452,10 @@ jobs:
         pip3 install pipenv
     - name: Install dependencies
       run: make install_${{ matrix.language}}_sdk
-    - name: Set up gotestfmt
-      uses: haveyoudebuggedit/gotestfmt-action@v2
+    - name: Install gotestfmt
+      uses: jaxxstorm/action-install-gh-release@v1.2.0
       with:
-        token: ${{ secrets.GITHUB_TOKEN }}
+        repo: haveyoudebuggedit/gotestfmt
     - name: Run tests
       run: cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language
         }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt

--- a/provider-ci/providers/mongodbatlas/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/mongodbatlas/repo/.github/workflows/run-acceptance-tests.yml
@@ -349,10 +349,10 @@ jobs:
         pip3 install pipenv
     - name: Install dependencies
       run: make install_${{ matrix.language}}_sdk
-    - name: Set up gotestfmt
-      uses: haveyoudebuggedit/gotestfmt-action@v2
+    - name: Install gotestfmt
+      uses: jaxxstorm/action-install-gh-release@v1.2.0
       with:
-        token: ${{ secrets.GITHUB_TOKEN }}
+        repo: haveyoudebuggedit/gotestfmt
     - name: Run tests
       run: cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language
         }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt

--- a/provider-ci/providers/mysql/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/mysql/repo/.github/workflows/main.yml
@@ -493,10 +493,10 @@ jobs:
       run: docker-compose -f testing/docker-compose.yml up --build -d
     - name: Install dependencies
       run: make install_${{ matrix.language}}_sdk
-    - name: Set up gotestfmt
-      uses: haveyoudebuggedit/gotestfmt-action@v2
+    - name: Install gotestfmt
+      uses: jaxxstorm/action-install-gh-release@v1.2.0
       with:
-        token: ${{ secrets.GITHUB_TOKEN }}
+        repo: haveyoudebuggedit/gotestfmt
     - name: Run tests
       run: cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language
         }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt

--- a/provider-ci/providers/mysql/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/mysql/repo/.github/workflows/master.yml
@@ -493,10 +493,10 @@ jobs:
       run: docker-compose -f testing/docker-compose.yml up --build -d
     - name: Install dependencies
       run: make install_${{ matrix.language}}_sdk
-    - name: Set up gotestfmt
-      uses: haveyoudebuggedit/gotestfmt-action@v2
+    - name: Install gotestfmt
+      uses: jaxxstorm/action-install-gh-release@v1.2.0
       with:
-        token: ${{ secrets.GITHUB_TOKEN }}
+        repo: haveyoudebuggedit/gotestfmt
     - name: Run tests
       run: cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language
         }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt

--- a/provider-ci/providers/mysql/repo/.github/workflows/nightly-test.yml
+++ b/provider-ci/providers/mysql/repo/.github/workflows/nightly-test.yml
@@ -234,10 +234,10 @@ jobs:
       run: docker-compose -f testing/docker-compose.yml up --build -d
     - name: Install dependencies
       run: make install_${{ matrix.language}}_sdk
-    - name: Set up gotestfmt
-      uses: haveyoudebuggedit/gotestfmt-action@v2
+    - name: Install gotestfmt
+      uses: jaxxstorm/action-install-gh-release@v1.2.0
       with:
-        token: ${{ secrets.GITHUB_TOKEN }}
+        repo: haveyoudebuggedit/gotestfmt
     - name: Run tests
       run: cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language
         }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt

--- a/provider-ci/providers/mysql/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/mysql/repo/.github/workflows/prerelease.yml
@@ -439,10 +439,10 @@ jobs:
       run: docker-compose -f testing/docker-compose.yml up --build -d
     - name: Install dependencies
       run: make install_${{ matrix.language}}_sdk
-    - name: Set up gotestfmt
-      uses: haveyoudebuggedit/gotestfmt-action@v2
+    - name: Install gotestfmt
+      uses: jaxxstorm/action-install-gh-release@v1.2.0
       with:
-        token: ${{ secrets.GITHUB_TOKEN }}
+        repo: haveyoudebuggedit/gotestfmt
     - name: Run tests
       run: cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language
         }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt

--- a/provider-ci/providers/mysql/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/mysql/repo/.github/workflows/release.yml
@@ -451,10 +451,10 @@ jobs:
       run: docker-compose -f testing/docker-compose.yml up --build -d
     - name: Install dependencies
       run: make install_${{ matrix.language}}_sdk
-    - name: Set up gotestfmt
-      uses: haveyoudebuggedit/gotestfmt-action@v2
+    - name: Install gotestfmt
+      uses: jaxxstorm/action-install-gh-release@v1.2.0
       with:
-        token: ${{ secrets.GITHUB_TOKEN }}
+        repo: haveyoudebuggedit/gotestfmt
     - name: Run tests
       run: cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language
         }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt

--- a/provider-ci/providers/mysql/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/mysql/repo/.github/workflows/run-acceptance-tests.yml
@@ -348,10 +348,10 @@ jobs:
       run: docker-compose -f testing/docker-compose.yml up --build -d
     - name: Install dependencies
       run: make install_${{ matrix.language}}_sdk
-    - name: Set up gotestfmt
-      uses: haveyoudebuggedit/gotestfmt-action@v2
+    - name: Install gotestfmt
+      uses: jaxxstorm/action-install-gh-release@v1.2.0
       with:
-        token: ${{ secrets.GITHUB_TOKEN }}
+        repo: haveyoudebuggedit/gotestfmt
     - name: Run tests
       run: cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language
         }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt

--- a/provider-ci/providers/newrelic/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/newrelic/repo/.github/workflows/main.yml
@@ -493,10 +493,10 @@ jobs:
         pip3 install pipenv
     - name: Install dependencies
       run: make install_${{ matrix.language}}_sdk
-    - name: Set up gotestfmt
-      uses: haveyoudebuggedit/gotestfmt-action@v2
+    - name: Install gotestfmt
+      uses: jaxxstorm/action-install-gh-release@v1.2.0
       with:
-        token: ${{ secrets.GITHUB_TOKEN }}
+        repo: haveyoudebuggedit/gotestfmt
     - name: Run tests
       run: cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language
         }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt

--- a/provider-ci/providers/newrelic/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/newrelic/repo/.github/workflows/master.yml
@@ -493,10 +493,10 @@ jobs:
         pip3 install pipenv
     - name: Install dependencies
       run: make install_${{ matrix.language}}_sdk
-    - name: Set up gotestfmt
-      uses: haveyoudebuggedit/gotestfmt-action@v2
+    - name: Install gotestfmt
+      uses: jaxxstorm/action-install-gh-release@v1.2.0
       with:
-        token: ${{ secrets.GITHUB_TOKEN }}
+        repo: haveyoudebuggedit/gotestfmt
     - name: Run tests
       run: cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language
         }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt

--- a/provider-ci/providers/newrelic/repo/.github/workflows/nightly-test.yml
+++ b/provider-ci/providers/newrelic/repo/.github/workflows/nightly-test.yml
@@ -234,10 +234,10 @@ jobs:
         pip3 install pipenv
     - name: Install dependencies
       run: make install_${{ matrix.language}}_sdk
-    - name: Set up gotestfmt
-      uses: haveyoudebuggedit/gotestfmt-action@v2
+    - name: Install gotestfmt
+      uses: jaxxstorm/action-install-gh-release@v1.2.0
       with:
-        token: ${{ secrets.GITHUB_TOKEN }}
+        repo: haveyoudebuggedit/gotestfmt
     - name: Run tests
       run: cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language
         }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt

--- a/provider-ci/providers/newrelic/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/newrelic/repo/.github/workflows/prerelease.yml
@@ -439,10 +439,10 @@ jobs:
         pip3 install pipenv
     - name: Install dependencies
       run: make install_${{ matrix.language}}_sdk
-    - name: Set up gotestfmt
-      uses: haveyoudebuggedit/gotestfmt-action@v2
+    - name: Install gotestfmt
+      uses: jaxxstorm/action-install-gh-release@v1.2.0
       with:
-        token: ${{ secrets.GITHUB_TOKEN }}
+        repo: haveyoudebuggedit/gotestfmt
     - name: Run tests
       run: cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language
         }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt

--- a/provider-ci/providers/newrelic/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/newrelic/repo/.github/workflows/release.yml
@@ -451,10 +451,10 @@ jobs:
         pip3 install pipenv
     - name: Install dependencies
       run: make install_${{ matrix.language}}_sdk
-    - name: Set up gotestfmt
-      uses: haveyoudebuggedit/gotestfmt-action@v2
+    - name: Install gotestfmt
+      uses: jaxxstorm/action-install-gh-release@v1.2.0
       with:
-        token: ${{ secrets.GITHUB_TOKEN }}
+        repo: haveyoudebuggedit/gotestfmt
     - name: Run tests
       run: cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language
         }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt

--- a/provider-ci/providers/newrelic/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/newrelic/repo/.github/workflows/run-acceptance-tests.yml
@@ -348,10 +348,10 @@ jobs:
         pip3 install pipenv
     - name: Install dependencies
       run: make install_${{ matrix.language}}_sdk
-    - name: Set up gotestfmt
-      uses: haveyoudebuggedit/gotestfmt-action@v2
+    - name: Install gotestfmt
+      uses: jaxxstorm/action-install-gh-release@v1.2.0
       with:
-        token: ${{ secrets.GITHUB_TOKEN }}
+        repo: haveyoudebuggedit/gotestfmt
     - name: Run tests
       run: cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language
         }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt

--- a/provider-ci/providers/nomad/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/nomad/repo/.github/workflows/main.yml
@@ -494,10 +494,10 @@ jobs:
       run: testing/setup.sh
     - name: Install dependencies
       run: make install_${{ matrix.language}}_sdk
-    - name: Set up gotestfmt
-      uses: haveyoudebuggedit/gotestfmt-action@v2
+    - name: Install gotestfmt
+      uses: jaxxstorm/action-install-gh-release@v1.2.0
       with:
-        token: ${{ secrets.GITHUB_TOKEN }}
+        repo: haveyoudebuggedit/gotestfmt
     - name: Run tests
       run: cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language
         }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt

--- a/provider-ci/providers/nomad/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/nomad/repo/.github/workflows/master.yml
@@ -494,10 +494,10 @@ jobs:
       run: testing/setup.sh
     - name: Install dependencies
       run: make install_${{ matrix.language}}_sdk
-    - name: Set up gotestfmt
-      uses: haveyoudebuggedit/gotestfmt-action@v2
+    - name: Install gotestfmt
+      uses: jaxxstorm/action-install-gh-release@v1.2.0
       with:
-        token: ${{ secrets.GITHUB_TOKEN }}
+        repo: haveyoudebuggedit/gotestfmt
     - name: Run tests
       run: cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language
         }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt

--- a/provider-ci/providers/nomad/repo/.github/workflows/nightly-test.yml
+++ b/provider-ci/providers/nomad/repo/.github/workflows/nightly-test.yml
@@ -235,10 +235,10 @@ jobs:
       run: testing/setup.sh
     - name: Install dependencies
       run: make install_${{ matrix.language}}_sdk
-    - name: Set up gotestfmt
-      uses: haveyoudebuggedit/gotestfmt-action@v2
+    - name: Install gotestfmt
+      uses: jaxxstorm/action-install-gh-release@v1.2.0
       with:
-        token: ${{ secrets.GITHUB_TOKEN }}
+        repo: haveyoudebuggedit/gotestfmt
     - name: Run tests
       run: cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language
         }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt

--- a/provider-ci/providers/nomad/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/nomad/repo/.github/workflows/prerelease.yml
@@ -440,10 +440,10 @@ jobs:
       run: testing/setup.sh
     - name: Install dependencies
       run: make install_${{ matrix.language}}_sdk
-    - name: Set up gotestfmt
-      uses: haveyoudebuggedit/gotestfmt-action@v2
+    - name: Install gotestfmt
+      uses: jaxxstorm/action-install-gh-release@v1.2.0
       with:
-        token: ${{ secrets.GITHUB_TOKEN }}
+        repo: haveyoudebuggedit/gotestfmt
     - name: Run tests
       run: cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language
         }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt

--- a/provider-ci/providers/nomad/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/nomad/repo/.github/workflows/release.yml
@@ -452,10 +452,10 @@ jobs:
       run: testing/setup.sh
     - name: Install dependencies
       run: make install_${{ matrix.language}}_sdk
-    - name: Set up gotestfmt
-      uses: haveyoudebuggedit/gotestfmt-action@v2
+    - name: Install gotestfmt
+      uses: jaxxstorm/action-install-gh-release@v1.2.0
       with:
-        token: ${{ secrets.GITHUB_TOKEN }}
+        repo: haveyoudebuggedit/gotestfmt
     - name: Run tests
       run: cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language
         }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt

--- a/provider-ci/providers/nomad/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/nomad/repo/.github/workflows/run-acceptance-tests.yml
@@ -349,10 +349,10 @@ jobs:
       run: testing/setup.sh
     - name: Install dependencies
       run: make install_${{ matrix.language}}_sdk
-    - name: Set up gotestfmt
-      uses: haveyoudebuggedit/gotestfmt-action@v2
+    - name: Install gotestfmt
+      uses: jaxxstorm/action-install-gh-release@v1.2.0
       with:
-        token: ${{ secrets.GITHUB_TOKEN }}
+        repo: haveyoudebuggedit/gotestfmt
     - name: Run tests
       run: cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language
         }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt

--- a/provider-ci/providers/ns1/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/ns1/repo/.github/workflows/main.yml
@@ -492,10 +492,10 @@ jobs:
         pip3 install pipenv
     - name: Install dependencies
       run: make install_${{ matrix.language}}_sdk
-    - name: Set up gotestfmt
-      uses: haveyoudebuggedit/gotestfmt-action@v2
+    - name: Install gotestfmt
+      uses: jaxxstorm/action-install-gh-release@v1.2.0
       with:
-        token: ${{ secrets.GITHUB_TOKEN }}
+        repo: haveyoudebuggedit/gotestfmt
     - name: Run tests
       run: cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language
         }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt

--- a/provider-ci/providers/ns1/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/ns1/repo/.github/workflows/master.yml
@@ -492,10 +492,10 @@ jobs:
         pip3 install pipenv
     - name: Install dependencies
       run: make install_${{ matrix.language}}_sdk
-    - name: Set up gotestfmt
-      uses: haveyoudebuggedit/gotestfmt-action@v2
+    - name: Install gotestfmt
+      uses: jaxxstorm/action-install-gh-release@v1.2.0
       with:
-        token: ${{ secrets.GITHUB_TOKEN }}
+        repo: haveyoudebuggedit/gotestfmt
     - name: Run tests
       run: cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language
         }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt

--- a/provider-ci/providers/ns1/repo/.github/workflows/nightly-test.yml
+++ b/provider-ci/providers/ns1/repo/.github/workflows/nightly-test.yml
@@ -233,10 +233,10 @@ jobs:
         pip3 install pipenv
     - name: Install dependencies
       run: make install_${{ matrix.language}}_sdk
-    - name: Set up gotestfmt
-      uses: haveyoudebuggedit/gotestfmt-action@v2
+    - name: Install gotestfmt
+      uses: jaxxstorm/action-install-gh-release@v1.2.0
       with:
-        token: ${{ secrets.GITHUB_TOKEN }}
+        repo: haveyoudebuggedit/gotestfmt
     - name: Run tests
       run: cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language
         }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt

--- a/provider-ci/providers/ns1/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/ns1/repo/.github/workflows/prerelease.yml
@@ -438,10 +438,10 @@ jobs:
         pip3 install pipenv
     - name: Install dependencies
       run: make install_${{ matrix.language}}_sdk
-    - name: Set up gotestfmt
-      uses: haveyoudebuggedit/gotestfmt-action@v2
+    - name: Install gotestfmt
+      uses: jaxxstorm/action-install-gh-release@v1.2.0
       with:
-        token: ${{ secrets.GITHUB_TOKEN }}
+        repo: haveyoudebuggedit/gotestfmt
     - name: Run tests
       run: cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language
         }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt

--- a/provider-ci/providers/ns1/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/ns1/repo/.github/workflows/release.yml
@@ -450,10 +450,10 @@ jobs:
         pip3 install pipenv
     - name: Install dependencies
       run: make install_${{ matrix.language}}_sdk
-    - name: Set up gotestfmt
-      uses: haveyoudebuggedit/gotestfmt-action@v2
+    - name: Install gotestfmt
+      uses: jaxxstorm/action-install-gh-release@v1.2.0
       with:
-        token: ${{ secrets.GITHUB_TOKEN }}
+        repo: haveyoudebuggedit/gotestfmt
     - name: Run tests
       run: cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language
         }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt

--- a/provider-ci/providers/ns1/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/ns1/repo/.github/workflows/run-acceptance-tests.yml
@@ -347,10 +347,10 @@ jobs:
         pip3 install pipenv
     - name: Install dependencies
       run: make install_${{ matrix.language}}_sdk
-    - name: Set up gotestfmt
-      uses: haveyoudebuggedit/gotestfmt-action@v2
+    - name: Install gotestfmt
+      uses: jaxxstorm/action-install-gh-release@v1.2.0
       with:
-        token: ${{ secrets.GITHUB_TOKEN }}
+        repo: haveyoudebuggedit/gotestfmt
     - name: Run tests
       run: cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language
         }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt

--- a/provider-ci/providers/okta/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/okta/repo/.github/workflows/main.yml
@@ -494,10 +494,10 @@ jobs:
         pip3 install pipenv
     - name: Install dependencies
       run: make install_${{ matrix.language}}_sdk
-    - name: Set up gotestfmt
-      uses: haveyoudebuggedit/gotestfmt-action@v2
+    - name: Install gotestfmt
+      uses: jaxxstorm/action-install-gh-release@v1.2.0
       with:
-        token: ${{ secrets.GITHUB_TOKEN }}
+        repo: haveyoudebuggedit/gotestfmt
     - name: Run tests
       run: cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language
         }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt

--- a/provider-ci/providers/okta/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/okta/repo/.github/workflows/master.yml
@@ -494,10 +494,10 @@ jobs:
         pip3 install pipenv
     - name: Install dependencies
       run: make install_${{ matrix.language}}_sdk
-    - name: Set up gotestfmt
-      uses: haveyoudebuggedit/gotestfmt-action@v2
+    - name: Install gotestfmt
+      uses: jaxxstorm/action-install-gh-release@v1.2.0
       with:
-        token: ${{ secrets.GITHUB_TOKEN }}
+        repo: haveyoudebuggedit/gotestfmt
     - name: Run tests
       run: cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language
         }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt

--- a/provider-ci/providers/okta/repo/.github/workflows/nightly-test.yml
+++ b/provider-ci/providers/okta/repo/.github/workflows/nightly-test.yml
@@ -235,10 +235,10 @@ jobs:
         pip3 install pipenv
     - name: Install dependencies
       run: make install_${{ matrix.language}}_sdk
-    - name: Set up gotestfmt
-      uses: haveyoudebuggedit/gotestfmt-action@v2
+    - name: Install gotestfmt
+      uses: jaxxstorm/action-install-gh-release@v1.2.0
       with:
-        token: ${{ secrets.GITHUB_TOKEN }}
+        repo: haveyoudebuggedit/gotestfmt
     - name: Run tests
       run: cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language
         }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt

--- a/provider-ci/providers/okta/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/okta/repo/.github/workflows/prerelease.yml
@@ -440,10 +440,10 @@ jobs:
         pip3 install pipenv
     - name: Install dependencies
       run: make install_${{ matrix.language}}_sdk
-    - name: Set up gotestfmt
-      uses: haveyoudebuggedit/gotestfmt-action@v2
+    - name: Install gotestfmt
+      uses: jaxxstorm/action-install-gh-release@v1.2.0
       with:
-        token: ${{ secrets.GITHUB_TOKEN }}
+        repo: haveyoudebuggedit/gotestfmt
     - name: Run tests
       run: cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language
         }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt

--- a/provider-ci/providers/okta/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/okta/repo/.github/workflows/release.yml
@@ -452,10 +452,10 @@ jobs:
         pip3 install pipenv
     - name: Install dependencies
       run: make install_${{ matrix.language}}_sdk
-    - name: Set up gotestfmt
-      uses: haveyoudebuggedit/gotestfmt-action@v2
+    - name: Install gotestfmt
+      uses: jaxxstorm/action-install-gh-release@v1.2.0
       with:
-        token: ${{ secrets.GITHUB_TOKEN }}
+        repo: haveyoudebuggedit/gotestfmt
     - name: Run tests
       run: cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language
         }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt

--- a/provider-ci/providers/okta/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/okta/repo/.github/workflows/run-acceptance-tests.yml
@@ -349,10 +349,10 @@ jobs:
         pip3 install pipenv
     - name: Install dependencies
       run: make install_${{ matrix.language}}_sdk
-    - name: Set up gotestfmt
-      uses: haveyoudebuggedit/gotestfmt-action@v2
+    - name: Install gotestfmt
+      uses: jaxxstorm/action-install-gh-release@v1.2.0
       with:
-        token: ${{ secrets.GITHUB_TOKEN }}
+        repo: haveyoudebuggedit/gotestfmt
     - name: Run tests
       run: cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language
         }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt

--- a/provider-ci/providers/openstack/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/openstack/repo/.github/workflows/main.yml
@@ -500,10 +500,10 @@ jobs:
         pip3 install pipenv
     - name: Install dependencies
       run: make install_${{ matrix.language}}_sdk
-    - name: Set up gotestfmt
-      uses: haveyoudebuggedit/gotestfmt-action@v2
+    - name: Install gotestfmt
+      uses: jaxxstorm/action-install-gh-release@v1.2.0
       with:
-        token: ${{ secrets.GITHUB_TOKEN }}
+        repo: haveyoudebuggedit/gotestfmt
     - name: Run tests
       run: cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language
         }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt

--- a/provider-ci/providers/openstack/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/openstack/repo/.github/workflows/master.yml
@@ -500,10 +500,10 @@ jobs:
         pip3 install pipenv
     - name: Install dependencies
       run: make install_${{ matrix.language}}_sdk
-    - name: Set up gotestfmt
-      uses: haveyoudebuggedit/gotestfmt-action@v2
+    - name: Install gotestfmt
+      uses: jaxxstorm/action-install-gh-release@v1.2.0
       with:
-        token: ${{ secrets.GITHUB_TOKEN }}
+        repo: haveyoudebuggedit/gotestfmt
     - name: Run tests
       run: cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language
         }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt

--- a/provider-ci/providers/openstack/repo/.github/workflows/nightly-test.yml
+++ b/provider-ci/providers/openstack/repo/.github/workflows/nightly-test.yml
@@ -241,10 +241,10 @@ jobs:
         pip3 install pipenv
     - name: Install dependencies
       run: make install_${{ matrix.language}}_sdk
-    - name: Set up gotestfmt
-      uses: haveyoudebuggedit/gotestfmt-action@v2
+    - name: Install gotestfmt
+      uses: jaxxstorm/action-install-gh-release@v1.2.0
       with:
-        token: ${{ secrets.GITHUB_TOKEN }}
+        repo: haveyoudebuggedit/gotestfmt
     - name: Run tests
       run: cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language
         }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt

--- a/provider-ci/providers/openstack/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/openstack/repo/.github/workflows/prerelease.yml
@@ -446,10 +446,10 @@ jobs:
         pip3 install pipenv
     - name: Install dependencies
       run: make install_${{ matrix.language}}_sdk
-    - name: Set up gotestfmt
-      uses: haveyoudebuggedit/gotestfmt-action@v2
+    - name: Install gotestfmt
+      uses: jaxxstorm/action-install-gh-release@v1.2.0
       with:
-        token: ${{ secrets.GITHUB_TOKEN }}
+        repo: haveyoudebuggedit/gotestfmt
     - name: Run tests
       run: cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language
         }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt

--- a/provider-ci/providers/openstack/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/openstack/repo/.github/workflows/release.yml
@@ -458,10 +458,10 @@ jobs:
         pip3 install pipenv
     - name: Install dependencies
       run: make install_${{ matrix.language}}_sdk
-    - name: Set up gotestfmt
-      uses: haveyoudebuggedit/gotestfmt-action@v2
+    - name: Install gotestfmt
+      uses: jaxxstorm/action-install-gh-release@v1.2.0
       with:
-        token: ${{ secrets.GITHUB_TOKEN }}
+        repo: haveyoudebuggedit/gotestfmt
     - name: Run tests
       run: cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language
         }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt

--- a/provider-ci/providers/openstack/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/openstack/repo/.github/workflows/run-acceptance-tests.yml
@@ -355,10 +355,10 @@ jobs:
         pip3 install pipenv
     - name: Install dependencies
       run: make install_${{ matrix.language}}_sdk
-    - name: Set up gotestfmt
-      uses: haveyoudebuggedit/gotestfmt-action@v2
+    - name: Install gotestfmt
+      uses: jaxxstorm/action-install-gh-release@v1.2.0
       with:
-        token: ${{ secrets.GITHUB_TOKEN }}
+        repo: haveyoudebuggedit/gotestfmt
     - name: Run tests
       run: cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language
         }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt

--- a/provider-ci/providers/opsgenie/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/opsgenie/repo/.github/workflows/main.yml
@@ -492,10 +492,10 @@ jobs:
         pip3 install pipenv
     - name: Install dependencies
       run: make install_${{ matrix.language}}_sdk
-    - name: Set up gotestfmt
-      uses: haveyoudebuggedit/gotestfmt-action@v2
+    - name: Install gotestfmt
+      uses: jaxxstorm/action-install-gh-release@v1.2.0
       with:
-        token: ${{ secrets.GITHUB_TOKEN }}
+        repo: haveyoudebuggedit/gotestfmt
     - name: Run tests
       run: cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language
         }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt

--- a/provider-ci/providers/opsgenie/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/opsgenie/repo/.github/workflows/master.yml
@@ -492,10 +492,10 @@ jobs:
         pip3 install pipenv
     - name: Install dependencies
       run: make install_${{ matrix.language}}_sdk
-    - name: Set up gotestfmt
-      uses: haveyoudebuggedit/gotestfmt-action@v2
+    - name: Install gotestfmt
+      uses: jaxxstorm/action-install-gh-release@v1.2.0
       with:
-        token: ${{ secrets.GITHUB_TOKEN }}
+        repo: haveyoudebuggedit/gotestfmt
     - name: Run tests
       run: cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language
         }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt

--- a/provider-ci/providers/opsgenie/repo/.github/workflows/nightly-test.yml
+++ b/provider-ci/providers/opsgenie/repo/.github/workflows/nightly-test.yml
@@ -233,10 +233,10 @@ jobs:
         pip3 install pipenv
     - name: Install dependencies
       run: make install_${{ matrix.language}}_sdk
-    - name: Set up gotestfmt
-      uses: haveyoudebuggedit/gotestfmt-action@v2
+    - name: Install gotestfmt
+      uses: jaxxstorm/action-install-gh-release@v1.2.0
       with:
-        token: ${{ secrets.GITHUB_TOKEN }}
+        repo: haveyoudebuggedit/gotestfmt
     - name: Run tests
       run: cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language
         }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt

--- a/provider-ci/providers/opsgenie/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/opsgenie/repo/.github/workflows/prerelease.yml
@@ -438,10 +438,10 @@ jobs:
         pip3 install pipenv
     - name: Install dependencies
       run: make install_${{ matrix.language}}_sdk
-    - name: Set up gotestfmt
-      uses: haveyoudebuggedit/gotestfmt-action@v2
+    - name: Install gotestfmt
+      uses: jaxxstorm/action-install-gh-release@v1.2.0
       with:
-        token: ${{ secrets.GITHUB_TOKEN }}
+        repo: haveyoudebuggedit/gotestfmt
     - name: Run tests
       run: cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language
         }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt

--- a/provider-ci/providers/opsgenie/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/opsgenie/repo/.github/workflows/release.yml
@@ -450,10 +450,10 @@ jobs:
         pip3 install pipenv
     - name: Install dependencies
       run: make install_${{ matrix.language}}_sdk
-    - name: Set up gotestfmt
-      uses: haveyoudebuggedit/gotestfmt-action@v2
+    - name: Install gotestfmt
+      uses: jaxxstorm/action-install-gh-release@v1.2.0
       with:
-        token: ${{ secrets.GITHUB_TOKEN }}
+        repo: haveyoudebuggedit/gotestfmt
     - name: Run tests
       run: cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language
         }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt

--- a/provider-ci/providers/opsgenie/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/opsgenie/repo/.github/workflows/run-acceptance-tests.yml
@@ -347,10 +347,10 @@ jobs:
         pip3 install pipenv
     - name: Install dependencies
       run: make install_${{ matrix.language}}_sdk
-    - name: Set up gotestfmt
-      uses: haveyoudebuggedit/gotestfmt-action@v2
+    - name: Install gotestfmt
+      uses: jaxxstorm/action-install-gh-release@v1.2.0
       with:
-        token: ${{ secrets.GITHUB_TOKEN }}
+        repo: haveyoudebuggedit/gotestfmt
     - name: Run tests
       run: cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language
         }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt

--- a/provider-ci/providers/pagerduty/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/pagerduty/repo/.github/workflows/main.yml
@@ -492,10 +492,10 @@ jobs:
         pip3 install pipenv
     - name: Install dependencies
       run: make install_${{ matrix.language}}_sdk
-    - name: Set up gotestfmt
-      uses: haveyoudebuggedit/gotestfmt-action@v2
+    - name: Install gotestfmt
+      uses: jaxxstorm/action-install-gh-release@v1.2.0
       with:
-        token: ${{ secrets.GITHUB_TOKEN }}
+        repo: haveyoudebuggedit/gotestfmt
     - name: Run tests
       run: cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language
         }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt

--- a/provider-ci/providers/pagerduty/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/pagerduty/repo/.github/workflows/master.yml
@@ -492,10 +492,10 @@ jobs:
         pip3 install pipenv
     - name: Install dependencies
       run: make install_${{ matrix.language}}_sdk
-    - name: Set up gotestfmt
-      uses: haveyoudebuggedit/gotestfmt-action@v2
+    - name: Install gotestfmt
+      uses: jaxxstorm/action-install-gh-release@v1.2.0
       with:
-        token: ${{ secrets.GITHUB_TOKEN }}
+        repo: haveyoudebuggedit/gotestfmt
     - name: Run tests
       run: cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language
         }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt

--- a/provider-ci/providers/pagerduty/repo/.github/workflows/nightly-test.yml
+++ b/provider-ci/providers/pagerduty/repo/.github/workflows/nightly-test.yml
@@ -233,10 +233,10 @@ jobs:
         pip3 install pipenv
     - name: Install dependencies
       run: make install_${{ matrix.language}}_sdk
-    - name: Set up gotestfmt
-      uses: haveyoudebuggedit/gotestfmt-action@v2
+    - name: Install gotestfmt
+      uses: jaxxstorm/action-install-gh-release@v1.2.0
       with:
-        token: ${{ secrets.GITHUB_TOKEN }}
+        repo: haveyoudebuggedit/gotestfmt
     - name: Run tests
       run: cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language
         }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt

--- a/provider-ci/providers/pagerduty/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/pagerduty/repo/.github/workflows/prerelease.yml
@@ -438,10 +438,10 @@ jobs:
         pip3 install pipenv
     - name: Install dependencies
       run: make install_${{ matrix.language}}_sdk
-    - name: Set up gotestfmt
-      uses: haveyoudebuggedit/gotestfmt-action@v2
+    - name: Install gotestfmt
+      uses: jaxxstorm/action-install-gh-release@v1.2.0
       with:
-        token: ${{ secrets.GITHUB_TOKEN }}
+        repo: haveyoudebuggedit/gotestfmt
     - name: Run tests
       run: cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language
         }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt

--- a/provider-ci/providers/pagerduty/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/pagerduty/repo/.github/workflows/release.yml
@@ -450,10 +450,10 @@ jobs:
         pip3 install pipenv
     - name: Install dependencies
       run: make install_${{ matrix.language}}_sdk
-    - name: Set up gotestfmt
-      uses: haveyoudebuggedit/gotestfmt-action@v2
+    - name: Install gotestfmt
+      uses: jaxxstorm/action-install-gh-release@v1.2.0
       with:
-        token: ${{ secrets.GITHUB_TOKEN }}
+        repo: haveyoudebuggedit/gotestfmt
     - name: Run tests
       run: cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language
         }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt

--- a/provider-ci/providers/pagerduty/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/pagerduty/repo/.github/workflows/run-acceptance-tests.yml
@@ -347,10 +347,10 @@ jobs:
         pip3 install pipenv
     - name: Install dependencies
       run: make install_${{ matrix.language}}_sdk
-    - name: Set up gotestfmt
-      uses: haveyoudebuggedit/gotestfmt-action@v2
+    - name: Install gotestfmt
+      uses: jaxxstorm/action-install-gh-release@v1.2.0
       with:
-        token: ${{ secrets.GITHUB_TOKEN }}
+        repo: haveyoudebuggedit/gotestfmt
     - name: Run tests
       run: cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language
         }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt

--- a/provider-ci/providers/postgresql/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/postgresql/repo/.github/workflows/main.yml
@@ -493,10 +493,10 @@ jobs:
       run: docker-compose -f testing/docker-compose.yml up --build -d
     - name: Install dependencies
       run: make install_${{ matrix.language}}_sdk
-    - name: Set up gotestfmt
-      uses: haveyoudebuggedit/gotestfmt-action@v2
+    - name: Install gotestfmt
+      uses: jaxxstorm/action-install-gh-release@v1.2.0
       with:
-        token: ${{ secrets.GITHUB_TOKEN }}
+        repo: haveyoudebuggedit/gotestfmt
     - name: Run tests
       run: cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language
         }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt

--- a/provider-ci/providers/postgresql/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/postgresql/repo/.github/workflows/master.yml
@@ -493,10 +493,10 @@ jobs:
       run: docker-compose -f testing/docker-compose.yml up --build -d
     - name: Install dependencies
       run: make install_${{ matrix.language}}_sdk
-    - name: Set up gotestfmt
-      uses: haveyoudebuggedit/gotestfmt-action@v2
+    - name: Install gotestfmt
+      uses: jaxxstorm/action-install-gh-release@v1.2.0
       with:
-        token: ${{ secrets.GITHUB_TOKEN }}
+        repo: haveyoudebuggedit/gotestfmt
     - name: Run tests
       run: cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language
         }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt

--- a/provider-ci/providers/postgresql/repo/.github/workflows/nightly-test.yml
+++ b/provider-ci/providers/postgresql/repo/.github/workflows/nightly-test.yml
@@ -234,10 +234,10 @@ jobs:
       run: docker-compose -f testing/docker-compose.yml up --build -d
     - name: Install dependencies
       run: make install_${{ matrix.language}}_sdk
-    - name: Set up gotestfmt
-      uses: haveyoudebuggedit/gotestfmt-action@v2
+    - name: Install gotestfmt
+      uses: jaxxstorm/action-install-gh-release@v1.2.0
       with:
-        token: ${{ secrets.GITHUB_TOKEN }}
+        repo: haveyoudebuggedit/gotestfmt
     - name: Run tests
       run: cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language
         }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt

--- a/provider-ci/providers/postgresql/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/postgresql/repo/.github/workflows/prerelease.yml
@@ -439,10 +439,10 @@ jobs:
       run: docker-compose -f testing/docker-compose.yml up --build -d
     - name: Install dependencies
       run: make install_${{ matrix.language}}_sdk
-    - name: Set up gotestfmt
-      uses: haveyoudebuggedit/gotestfmt-action@v2
+    - name: Install gotestfmt
+      uses: jaxxstorm/action-install-gh-release@v1.2.0
       with:
-        token: ${{ secrets.GITHUB_TOKEN }}
+        repo: haveyoudebuggedit/gotestfmt
     - name: Run tests
       run: cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language
         }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt

--- a/provider-ci/providers/postgresql/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/postgresql/repo/.github/workflows/release.yml
@@ -451,10 +451,10 @@ jobs:
       run: docker-compose -f testing/docker-compose.yml up --build -d
     - name: Install dependencies
       run: make install_${{ matrix.language}}_sdk
-    - name: Set up gotestfmt
-      uses: haveyoudebuggedit/gotestfmt-action@v2
+    - name: Install gotestfmt
+      uses: jaxxstorm/action-install-gh-release@v1.2.0
       with:
-        token: ${{ secrets.GITHUB_TOKEN }}
+        repo: haveyoudebuggedit/gotestfmt
     - name: Run tests
       run: cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language
         }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt

--- a/provider-ci/providers/postgresql/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/postgresql/repo/.github/workflows/run-acceptance-tests.yml
@@ -348,10 +348,10 @@ jobs:
       run: docker-compose -f testing/docker-compose.yml up --build -d
     - name: Install dependencies
       run: make install_${{ matrix.language}}_sdk
-    - name: Set up gotestfmt
-      uses: haveyoudebuggedit/gotestfmt-action@v2
+    - name: Install gotestfmt
+      uses: jaxxstorm/action-install-gh-release@v1.2.0
       with:
-        token: ${{ secrets.GITHUB_TOKEN }}
+        repo: haveyoudebuggedit/gotestfmt
     - name: Run tests
       run: cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language
         }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt

--- a/provider-ci/providers/rabbitmq/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/rabbitmq/repo/.github/workflows/main.yml
@@ -493,10 +493,10 @@ jobs:
       run: docker-compose -f testing/docker-compose.yml up --build -d
     - name: Install dependencies
       run: make install_${{ matrix.language}}_sdk
-    - name: Set up gotestfmt
-      uses: haveyoudebuggedit/gotestfmt-action@v2
+    - name: Install gotestfmt
+      uses: jaxxstorm/action-install-gh-release@v1.2.0
       with:
-        token: ${{ secrets.GITHUB_TOKEN }}
+        repo: haveyoudebuggedit/gotestfmt
     - name: Run tests
       run: cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language
         }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt

--- a/provider-ci/providers/rabbitmq/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/rabbitmq/repo/.github/workflows/master.yml
@@ -493,10 +493,10 @@ jobs:
       run: docker-compose -f testing/docker-compose.yml up --build -d
     - name: Install dependencies
       run: make install_${{ matrix.language}}_sdk
-    - name: Set up gotestfmt
-      uses: haveyoudebuggedit/gotestfmt-action@v2
+    - name: Install gotestfmt
+      uses: jaxxstorm/action-install-gh-release@v1.2.0
       with:
-        token: ${{ secrets.GITHUB_TOKEN }}
+        repo: haveyoudebuggedit/gotestfmt
     - name: Run tests
       run: cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language
         }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt

--- a/provider-ci/providers/rabbitmq/repo/.github/workflows/nightly-test.yml
+++ b/provider-ci/providers/rabbitmq/repo/.github/workflows/nightly-test.yml
@@ -234,10 +234,10 @@ jobs:
       run: docker-compose -f testing/docker-compose.yml up --build -d
     - name: Install dependencies
       run: make install_${{ matrix.language}}_sdk
-    - name: Set up gotestfmt
-      uses: haveyoudebuggedit/gotestfmt-action@v2
+    - name: Install gotestfmt
+      uses: jaxxstorm/action-install-gh-release@v1.2.0
       with:
-        token: ${{ secrets.GITHUB_TOKEN }}
+        repo: haveyoudebuggedit/gotestfmt
     - name: Run tests
       run: cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language
         }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt

--- a/provider-ci/providers/rabbitmq/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/rabbitmq/repo/.github/workflows/prerelease.yml
@@ -439,10 +439,10 @@ jobs:
       run: docker-compose -f testing/docker-compose.yml up --build -d
     - name: Install dependencies
       run: make install_${{ matrix.language}}_sdk
-    - name: Set up gotestfmt
-      uses: haveyoudebuggedit/gotestfmt-action@v2
+    - name: Install gotestfmt
+      uses: jaxxstorm/action-install-gh-release@v1.2.0
       with:
-        token: ${{ secrets.GITHUB_TOKEN }}
+        repo: haveyoudebuggedit/gotestfmt
     - name: Run tests
       run: cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language
         }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt

--- a/provider-ci/providers/rabbitmq/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/rabbitmq/repo/.github/workflows/release.yml
@@ -451,10 +451,10 @@ jobs:
       run: docker-compose -f testing/docker-compose.yml up --build -d
     - name: Install dependencies
       run: make install_${{ matrix.language}}_sdk
-    - name: Set up gotestfmt
-      uses: haveyoudebuggedit/gotestfmt-action@v2
+    - name: Install gotestfmt
+      uses: jaxxstorm/action-install-gh-release@v1.2.0
       with:
-        token: ${{ secrets.GITHUB_TOKEN }}
+        repo: haveyoudebuggedit/gotestfmt
     - name: Run tests
       run: cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language
         }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt

--- a/provider-ci/providers/rabbitmq/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/rabbitmq/repo/.github/workflows/run-acceptance-tests.yml
@@ -348,10 +348,10 @@ jobs:
       run: docker-compose -f testing/docker-compose.yml up --build -d
     - name: Install dependencies
       run: make install_${{ matrix.language}}_sdk
-    - name: Set up gotestfmt
-      uses: haveyoudebuggedit/gotestfmt-action@v2
+    - name: Install gotestfmt
+      uses: jaxxstorm/action-install-gh-release@v1.2.0
       with:
-        token: ${{ secrets.GITHUB_TOKEN }}
+        repo: haveyoudebuggedit/gotestfmt
     - name: Run tests
       run: cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language
         }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt

--- a/provider-ci/providers/rancher2/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/rancher2/repo/.github/workflows/main.yml
@@ -420,10 +420,10 @@ jobs:
       run: testing/setup.sh
     - name: Install dependencies
       run: make install_${{ matrix.language}}_sdk
-    - name: Set up gotestfmt
-      uses: haveyoudebuggedit/gotestfmt-action@v2
+    - name: Install gotestfmt
+      uses: jaxxstorm/action-install-gh-release@v1.2.0
       with:
-        token: ${{ secrets.GITHUB_TOKEN }}
+        repo: haveyoudebuggedit/gotestfmt
     - name: Run tests
       run: cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language
         }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt

--- a/provider-ci/providers/rancher2/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/rancher2/repo/.github/workflows/master.yml
@@ -420,10 +420,10 @@ jobs:
       run: testing/setup.sh
     - name: Install dependencies
       run: make install_${{ matrix.language}}_sdk
-    - name: Set up gotestfmt
-      uses: haveyoudebuggedit/gotestfmt-action@v2
+    - name: Install gotestfmt
+      uses: jaxxstorm/action-install-gh-release@v1.2.0
       with:
-        token: ${{ secrets.GITHUB_TOKEN }}
+        repo: haveyoudebuggedit/gotestfmt
     - name: Run tests
       run: cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language
         }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt

--- a/provider-ci/providers/rancher2/repo/.github/workflows/nightly-test.yml
+++ b/provider-ci/providers/rancher2/repo/.github/workflows/nightly-test.yml
@@ -236,10 +236,10 @@ jobs:
       run: testing/setup.sh
     - name: Install dependencies
       run: make install_${{ matrix.language}}_sdk
-    - name: Set up gotestfmt
-      uses: haveyoudebuggedit/gotestfmt-action@v2
+    - name: Install gotestfmt
+      uses: jaxxstorm/action-install-gh-release@v1.2.0
       with:
-        token: ${{ secrets.GITHUB_TOKEN }}
+        repo: haveyoudebuggedit/gotestfmt
     - name: Run tests
       run: cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language
         }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt

--- a/provider-ci/providers/rancher2/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/rancher2/repo/.github/workflows/prerelease.yml
@@ -366,10 +366,10 @@ jobs:
       run: testing/setup.sh
     - name: Install dependencies
       run: make install_${{ matrix.language}}_sdk
-    - name: Set up gotestfmt
-      uses: haveyoudebuggedit/gotestfmt-action@v2
+    - name: Install gotestfmt
+      uses: jaxxstorm/action-install-gh-release@v1.2.0
       with:
-        token: ${{ secrets.GITHUB_TOKEN }}
+        repo: haveyoudebuggedit/gotestfmt
     - name: Run tests
       run: cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language
         }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt

--- a/provider-ci/providers/rancher2/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/rancher2/repo/.github/workflows/release.yml
@@ -378,10 +378,10 @@ jobs:
       run: testing/setup.sh
     - name: Install dependencies
       run: make install_${{ matrix.language}}_sdk
-    - name: Set up gotestfmt
-      uses: haveyoudebuggedit/gotestfmt-action@v2
+    - name: Install gotestfmt
+      uses: jaxxstorm/action-install-gh-release@v1.2.0
       with:
-        token: ${{ secrets.GITHUB_TOKEN }}
+        repo: haveyoudebuggedit/gotestfmt
     - name: Run tests
       run: cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language
         }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt

--- a/provider-ci/providers/rancher2/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/rancher2/repo/.github/workflows/run-acceptance-tests.yml
@@ -267,10 +267,10 @@ jobs:
       run: testing/setup.sh
     - name: Install dependencies
       run: make install_${{ matrix.language}}_sdk
-    - name: Set up gotestfmt
-      uses: haveyoudebuggedit/gotestfmt-action@v2
+    - name: Install gotestfmt
+      uses: jaxxstorm/action-install-gh-release@v1.2.0
       with:
-        token: ${{ secrets.GITHUB_TOKEN }}
+        repo: haveyoudebuggedit/gotestfmt
     - name: Run tests
       run: cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language
         }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt

--- a/provider-ci/providers/random/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/random/repo/.github/workflows/main.yml
@@ -491,10 +491,10 @@ jobs:
         pip3 install pipenv
     - name: Install dependencies
       run: make install_${{ matrix.language}}_sdk
-    - name: Set up gotestfmt
-      uses: haveyoudebuggedit/gotestfmt-action@v2
+    - name: Install gotestfmt
+      uses: jaxxstorm/action-install-gh-release@v1.2.0
       with:
-        token: ${{ secrets.GITHUB_TOKEN }}
+        repo: haveyoudebuggedit/gotestfmt
     - name: Run tests
       run: cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language
         }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt

--- a/provider-ci/providers/random/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/random/repo/.github/workflows/master.yml
@@ -491,10 +491,10 @@ jobs:
         pip3 install pipenv
     - name: Install dependencies
       run: make install_${{ matrix.language}}_sdk
-    - name: Set up gotestfmt
-      uses: haveyoudebuggedit/gotestfmt-action@v2
+    - name: Install gotestfmt
+      uses: jaxxstorm/action-install-gh-release@v1.2.0
       with:
-        token: ${{ secrets.GITHUB_TOKEN }}
+        repo: haveyoudebuggedit/gotestfmt
     - name: Run tests
       run: cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language
         }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt

--- a/provider-ci/providers/random/repo/.github/workflows/nightly-test.yml
+++ b/provider-ci/providers/random/repo/.github/workflows/nightly-test.yml
@@ -232,10 +232,10 @@ jobs:
         pip3 install pipenv
     - name: Install dependencies
       run: make install_${{ matrix.language}}_sdk
-    - name: Set up gotestfmt
-      uses: haveyoudebuggedit/gotestfmt-action@v2
+    - name: Install gotestfmt
+      uses: jaxxstorm/action-install-gh-release@v1.2.0
       with:
-        token: ${{ secrets.GITHUB_TOKEN }}
+        repo: haveyoudebuggedit/gotestfmt
     - name: Run tests
       run: cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language
         }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt

--- a/provider-ci/providers/random/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/random/repo/.github/workflows/prerelease.yml
@@ -437,10 +437,10 @@ jobs:
         pip3 install pipenv
     - name: Install dependencies
       run: make install_${{ matrix.language}}_sdk
-    - name: Set up gotestfmt
-      uses: haveyoudebuggedit/gotestfmt-action@v2
+    - name: Install gotestfmt
+      uses: jaxxstorm/action-install-gh-release@v1.2.0
       with:
-        token: ${{ secrets.GITHUB_TOKEN }}
+        repo: haveyoudebuggedit/gotestfmt
     - name: Run tests
       run: cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language
         }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt

--- a/provider-ci/providers/random/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/random/repo/.github/workflows/release.yml
@@ -449,10 +449,10 @@ jobs:
         pip3 install pipenv
     - name: Install dependencies
       run: make install_${{ matrix.language}}_sdk
-    - name: Set up gotestfmt
-      uses: haveyoudebuggedit/gotestfmt-action@v2
+    - name: Install gotestfmt
+      uses: jaxxstorm/action-install-gh-release@v1.2.0
       with:
-        token: ${{ secrets.GITHUB_TOKEN }}
+        repo: haveyoudebuggedit/gotestfmt
     - name: Run tests
       run: cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language
         }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt

--- a/provider-ci/providers/random/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/random/repo/.github/workflows/run-acceptance-tests.yml
@@ -346,10 +346,10 @@ jobs:
         pip3 install pipenv
     - name: Install dependencies
       run: make install_${{ matrix.language}}_sdk
-    - name: Set up gotestfmt
-      uses: haveyoudebuggedit/gotestfmt-action@v2
+    - name: Install gotestfmt
+      uses: jaxxstorm/action-install-gh-release@v1.2.0
       with:
-        token: ${{ secrets.GITHUB_TOKEN }}
+        repo: haveyoudebuggedit/gotestfmt
     - name: Run tests
       run: cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language
         }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt

--- a/provider-ci/providers/rke/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/rke/repo/.github/workflows/main.yml
@@ -501,10 +501,10 @@ jobs:
         role-to-assume: ${{ secrets.AWS_CI_ROLE_ARN }}
     - name: Install dependencies
       run: make install_${{ matrix.language}}_sdk
-    - name: Set up gotestfmt
-      uses: haveyoudebuggedit/gotestfmt-action@v2
+    - name: Install gotestfmt
+      uses: jaxxstorm/action-install-gh-release@v1.2.0
       with:
-        token: ${{ secrets.GITHUB_TOKEN }}
+        repo: haveyoudebuggedit/gotestfmt
     - name: Run tests
       run: cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language
         }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt

--- a/provider-ci/providers/rke/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/rke/repo/.github/workflows/master.yml
@@ -501,10 +501,10 @@ jobs:
         role-to-assume: ${{ secrets.AWS_CI_ROLE_ARN }}
     - name: Install dependencies
       run: make install_${{ matrix.language}}_sdk
-    - name: Set up gotestfmt
-      uses: haveyoudebuggedit/gotestfmt-action@v2
+    - name: Install gotestfmt
+      uses: jaxxstorm/action-install-gh-release@v1.2.0
       with:
-        token: ${{ secrets.GITHUB_TOKEN }}
+        repo: haveyoudebuggedit/gotestfmt
     - name: Run tests
       run: cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language
         }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt

--- a/provider-ci/providers/rke/repo/.github/workflows/nightly-test.yml
+++ b/provider-ci/providers/rke/repo/.github/workflows/nightly-test.yml
@@ -242,10 +242,10 @@ jobs:
         role-to-assume: ${{ secrets.AWS_CI_ROLE_ARN }}
     - name: Install dependencies
       run: make install_${{ matrix.language}}_sdk
-    - name: Set up gotestfmt
-      uses: haveyoudebuggedit/gotestfmt-action@v2
+    - name: Install gotestfmt
+      uses: jaxxstorm/action-install-gh-release@v1.2.0
       with:
-        token: ${{ secrets.GITHUB_TOKEN }}
+        repo: haveyoudebuggedit/gotestfmt
     - name: Run tests
       run: cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language
         }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt

--- a/provider-ci/providers/rke/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/rke/repo/.github/workflows/prerelease.yml
@@ -447,10 +447,10 @@ jobs:
         role-to-assume: ${{ secrets.AWS_CI_ROLE_ARN }}
     - name: Install dependencies
       run: make install_${{ matrix.language}}_sdk
-    - name: Set up gotestfmt
-      uses: haveyoudebuggedit/gotestfmt-action@v2
+    - name: Install gotestfmt
+      uses: jaxxstorm/action-install-gh-release@v1.2.0
       with:
-        token: ${{ secrets.GITHUB_TOKEN }}
+        repo: haveyoudebuggedit/gotestfmt
     - name: Run tests
       run: cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language
         }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt

--- a/provider-ci/providers/rke/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/rke/repo/.github/workflows/release.yml
@@ -459,10 +459,10 @@ jobs:
         role-to-assume: ${{ secrets.AWS_CI_ROLE_ARN }}
     - name: Install dependencies
       run: make install_${{ matrix.language}}_sdk
-    - name: Set up gotestfmt
-      uses: haveyoudebuggedit/gotestfmt-action@v2
+    - name: Install gotestfmt
+      uses: jaxxstorm/action-install-gh-release@v1.2.0
       with:
-        token: ${{ secrets.GITHUB_TOKEN }}
+        repo: haveyoudebuggedit/gotestfmt
     - name: Run tests
       run: cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language
         }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt

--- a/provider-ci/providers/rke/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/rke/repo/.github/workflows/run-acceptance-tests.yml
@@ -356,10 +356,10 @@ jobs:
         role-to-assume: ${{ secrets.AWS_CI_ROLE_ARN }}
     - name: Install dependencies
       run: make install_${{ matrix.language}}_sdk
-    - name: Set up gotestfmt
-      uses: haveyoudebuggedit/gotestfmt-action@v2
+    - name: Install gotestfmt
+      uses: jaxxstorm/action-install-gh-release@v1.2.0
       with:
-        token: ${{ secrets.GITHUB_TOKEN }}
+        repo: haveyoudebuggedit/gotestfmt
     - name: Run tests
       run: cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language
         }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt

--- a/provider-ci/providers/signalfx/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/signalfx/repo/.github/workflows/main.yml
@@ -491,10 +491,10 @@ jobs:
         pip3 install pipenv
     - name: Install dependencies
       run: make install_${{ matrix.language}}_sdk
-    - name: Set up gotestfmt
-      uses: haveyoudebuggedit/gotestfmt-action@v2
+    - name: Install gotestfmt
+      uses: jaxxstorm/action-install-gh-release@v1.2.0
       with:
-        token: ${{ secrets.GITHUB_TOKEN }}
+        repo: haveyoudebuggedit/gotestfmt
     - name: Run tests
       run: cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language
         }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt

--- a/provider-ci/providers/signalfx/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/signalfx/repo/.github/workflows/master.yml
@@ -491,10 +491,10 @@ jobs:
         pip3 install pipenv
     - name: Install dependencies
       run: make install_${{ matrix.language}}_sdk
-    - name: Set up gotestfmt
-      uses: haveyoudebuggedit/gotestfmt-action@v2
+    - name: Install gotestfmt
+      uses: jaxxstorm/action-install-gh-release@v1.2.0
       with:
-        token: ${{ secrets.GITHUB_TOKEN }}
+        repo: haveyoudebuggedit/gotestfmt
     - name: Run tests
       run: cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language
         }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt

--- a/provider-ci/providers/signalfx/repo/.github/workflows/nightly-test.yml
+++ b/provider-ci/providers/signalfx/repo/.github/workflows/nightly-test.yml
@@ -232,10 +232,10 @@ jobs:
         pip3 install pipenv
     - name: Install dependencies
       run: make install_${{ matrix.language}}_sdk
-    - name: Set up gotestfmt
-      uses: haveyoudebuggedit/gotestfmt-action@v2
+    - name: Install gotestfmt
+      uses: jaxxstorm/action-install-gh-release@v1.2.0
       with:
-        token: ${{ secrets.GITHUB_TOKEN }}
+        repo: haveyoudebuggedit/gotestfmt
     - name: Run tests
       run: cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language
         }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt

--- a/provider-ci/providers/signalfx/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/signalfx/repo/.github/workflows/prerelease.yml
@@ -437,10 +437,10 @@ jobs:
         pip3 install pipenv
     - name: Install dependencies
       run: make install_${{ matrix.language}}_sdk
-    - name: Set up gotestfmt
-      uses: haveyoudebuggedit/gotestfmt-action@v2
+    - name: Install gotestfmt
+      uses: jaxxstorm/action-install-gh-release@v1.2.0
       with:
-        token: ${{ secrets.GITHUB_TOKEN }}
+        repo: haveyoudebuggedit/gotestfmt
     - name: Run tests
       run: cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language
         }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt

--- a/provider-ci/providers/signalfx/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/signalfx/repo/.github/workflows/release.yml
@@ -449,10 +449,10 @@ jobs:
         pip3 install pipenv
     - name: Install dependencies
       run: make install_${{ matrix.language}}_sdk
-    - name: Set up gotestfmt
-      uses: haveyoudebuggedit/gotestfmt-action@v2
+    - name: Install gotestfmt
+      uses: jaxxstorm/action-install-gh-release@v1.2.0
       with:
-        token: ${{ secrets.GITHUB_TOKEN }}
+        repo: haveyoudebuggedit/gotestfmt
     - name: Run tests
       run: cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language
         }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt

--- a/provider-ci/providers/signalfx/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/signalfx/repo/.github/workflows/run-acceptance-tests.yml
@@ -346,10 +346,10 @@ jobs:
         pip3 install pipenv
     - name: Install dependencies
       run: make install_${{ matrix.language}}_sdk
-    - name: Set up gotestfmt
-      uses: haveyoudebuggedit/gotestfmt-action@v2
+    - name: Install gotestfmt
+      uses: jaxxstorm/action-install-gh-release@v1.2.0
       with:
-        token: ${{ secrets.GITHUB_TOKEN }}
+        repo: haveyoudebuggedit/gotestfmt
     - name: Run tests
       run: cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language
         }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt

--- a/provider-ci/providers/snowflake/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/snowflake/repo/.github/workflows/main.yml
@@ -496,10 +496,10 @@ jobs:
         pip3 install pipenv
     - name: Install dependencies
       run: make install_${{ matrix.language}}_sdk
-    - name: Set up gotestfmt
-      uses: haveyoudebuggedit/gotestfmt-action@v2
+    - name: Install gotestfmt
+      uses: jaxxstorm/action-install-gh-release@v1.2.0
       with:
-        token: ${{ secrets.GITHUB_TOKEN }}
+        repo: haveyoudebuggedit/gotestfmt
     - name: Run tests
       run: cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language
         }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt

--- a/provider-ci/providers/snowflake/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/snowflake/repo/.github/workflows/master.yml
@@ -496,10 +496,10 @@ jobs:
         pip3 install pipenv
     - name: Install dependencies
       run: make install_${{ matrix.language}}_sdk
-    - name: Set up gotestfmt
-      uses: haveyoudebuggedit/gotestfmt-action@v2
+    - name: Install gotestfmt
+      uses: jaxxstorm/action-install-gh-release@v1.2.0
       with:
-        token: ${{ secrets.GITHUB_TOKEN }}
+        repo: haveyoudebuggedit/gotestfmt
     - name: Run tests
       run: cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language
         }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt

--- a/provider-ci/providers/snowflake/repo/.github/workflows/nightly-test.yml
+++ b/provider-ci/providers/snowflake/repo/.github/workflows/nightly-test.yml
@@ -237,10 +237,10 @@ jobs:
         pip3 install pipenv
     - name: Install dependencies
       run: make install_${{ matrix.language}}_sdk
-    - name: Set up gotestfmt
-      uses: haveyoudebuggedit/gotestfmt-action@v2
+    - name: Install gotestfmt
+      uses: jaxxstorm/action-install-gh-release@v1.2.0
       with:
-        token: ${{ secrets.GITHUB_TOKEN }}
+        repo: haveyoudebuggedit/gotestfmt
     - name: Run tests
       run: cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language
         }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt

--- a/provider-ci/providers/snowflake/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/snowflake/repo/.github/workflows/prerelease.yml
@@ -442,10 +442,10 @@ jobs:
         pip3 install pipenv
     - name: Install dependencies
       run: make install_${{ matrix.language}}_sdk
-    - name: Set up gotestfmt
-      uses: haveyoudebuggedit/gotestfmt-action@v2
+    - name: Install gotestfmt
+      uses: jaxxstorm/action-install-gh-release@v1.2.0
       with:
-        token: ${{ secrets.GITHUB_TOKEN }}
+        repo: haveyoudebuggedit/gotestfmt
     - name: Run tests
       run: cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language
         }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt

--- a/provider-ci/providers/snowflake/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/snowflake/repo/.github/workflows/release.yml
@@ -454,10 +454,10 @@ jobs:
         pip3 install pipenv
     - name: Install dependencies
       run: make install_${{ matrix.language}}_sdk
-    - name: Set up gotestfmt
-      uses: haveyoudebuggedit/gotestfmt-action@v2
+    - name: Install gotestfmt
+      uses: jaxxstorm/action-install-gh-release@v1.2.0
       with:
-        token: ${{ secrets.GITHUB_TOKEN }}
+        repo: haveyoudebuggedit/gotestfmt
     - name: Run tests
       run: cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language
         }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt

--- a/provider-ci/providers/snowflake/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/snowflake/repo/.github/workflows/run-acceptance-tests.yml
@@ -351,10 +351,10 @@ jobs:
         pip3 install pipenv
     - name: Install dependencies
       run: make install_${{ matrix.language}}_sdk
-    - name: Set up gotestfmt
-      uses: haveyoudebuggedit/gotestfmt-action@v2
+    - name: Install gotestfmt
+      uses: jaxxstorm/action-install-gh-release@v1.2.0
       with:
-        token: ${{ secrets.GITHUB_TOKEN }}
+        repo: haveyoudebuggedit/gotestfmt
     - name: Run tests
       run: cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language
         }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt

--- a/provider-ci/providers/splunk/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/splunk/repo/.github/workflows/main.yml
@@ -496,10 +496,10 @@ jobs:
       run: docker-compose -f testing/docker-compose.yml up --build -d
     - name: Install dependencies
       run: make install_${{ matrix.language}}_sdk
-    - name: Set up gotestfmt
-      uses: haveyoudebuggedit/gotestfmt-action@v2
+    - name: Install gotestfmt
+      uses: jaxxstorm/action-install-gh-release@v1.2.0
       with:
-        token: ${{ secrets.GITHUB_TOKEN }}
+        repo: haveyoudebuggedit/gotestfmt
     - name: Run tests
       run: cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language
         }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt

--- a/provider-ci/providers/splunk/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/splunk/repo/.github/workflows/master.yml
@@ -496,10 +496,10 @@ jobs:
       run: docker-compose -f testing/docker-compose.yml up --build -d
     - name: Install dependencies
       run: make install_${{ matrix.language}}_sdk
-    - name: Set up gotestfmt
-      uses: haveyoudebuggedit/gotestfmt-action@v2
+    - name: Install gotestfmt
+      uses: jaxxstorm/action-install-gh-release@v1.2.0
       with:
-        token: ${{ secrets.GITHUB_TOKEN }}
+        repo: haveyoudebuggedit/gotestfmt
     - name: Run tests
       run: cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language
         }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt

--- a/provider-ci/providers/splunk/repo/.github/workflows/nightly-test.yml
+++ b/provider-ci/providers/splunk/repo/.github/workflows/nightly-test.yml
@@ -237,10 +237,10 @@ jobs:
       run: docker-compose -f testing/docker-compose.yml up --build -d
     - name: Install dependencies
       run: make install_${{ matrix.language}}_sdk
-    - name: Set up gotestfmt
-      uses: haveyoudebuggedit/gotestfmt-action@v2
+    - name: Install gotestfmt
+      uses: jaxxstorm/action-install-gh-release@v1.2.0
       with:
-        token: ${{ secrets.GITHUB_TOKEN }}
+        repo: haveyoudebuggedit/gotestfmt
     - name: Run tests
       run: cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language
         }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt

--- a/provider-ci/providers/splunk/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/splunk/repo/.github/workflows/prerelease.yml
@@ -442,10 +442,10 @@ jobs:
       run: docker-compose -f testing/docker-compose.yml up --build -d
     - name: Install dependencies
       run: make install_${{ matrix.language}}_sdk
-    - name: Set up gotestfmt
-      uses: haveyoudebuggedit/gotestfmt-action@v2
+    - name: Install gotestfmt
+      uses: jaxxstorm/action-install-gh-release@v1.2.0
       with:
-        token: ${{ secrets.GITHUB_TOKEN }}
+        repo: haveyoudebuggedit/gotestfmt
     - name: Run tests
       run: cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language
         }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt

--- a/provider-ci/providers/splunk/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/splunk/repo/.github/workflows/release.yml
@@ -454,10 +454,10 @@ jobs:
       run: docker-compose -f testing/docker-compose.yml up --build -d
     - name: Install dependencies
       run: make install_${{ matrix.language}}_sdk
-    - name: Set up gotestfmt
-      uses: haveyoudebuggedit/gotestfmt-action@v2
+    - name: Install gotestfmt
+      uses: jaxxstorm/action-install-gh-release@v1.2.0
       with:
-        token: ${{ secrets.GITHUB_TOKEN }}
+        repo: haveyoudebuggedit/gotestfmt
     - name: Run tests
       run: cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language
         }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt

--- a/provider-ci/providers/splunk/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/splunk/repo/.github/workflows/run-acceptance-tests.yml
@@ -351,10 +351,10 @@ jobs:
       run: docker-compose -f testing/docker-compose.yml up --build -d
     - name: Install dependencies
       run: make install_${{ matrix.language}}_sdk
-    - name: Set up gotestfmt
-      uses: haveyoudebuggedit/gotestfmt-action@v2
+    - name: Install gotestfmt
+      uses: jaxxstorm/action-install-gh-release@v1.2.0
       with:
-        token: ${{ secrets.GITHUB_TOKEN }}
+        repo: haveyoudebuggedit/gotestfmt
     - name: Run tests
       run: cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language
         }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt

--- a/provider-ci/providers/spotinst/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/spotinst/repo/.github/workflows/main.yml
@@ -503,10 +503,10 @@ jobs:
         role-to-assume: ${{ secrets.AWS_CI_ROLE_ARN }}
     - name: Install dependencies
       run: make install_${{ matrix.language}}_sdk
-    - name: Set up gotestfmt
-      uses: haveyoudebuggedit/gotestfmt-action@v2
+    - name: Install gotestfmt
+      uses: jaxxstorm/action-install-gh-release@v1.2.0
       with:
-        token: ${{ secrets.GITHUB_TOKEN }}
+        repo: haveyoudebuggedit/gotestfmt
     - name: Run tests
       run: cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language
         }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt

--- a/provider-ci/providers/spotinst/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/spotinst/repo/.github/workflows/master.yml
@@ -503,10 +503,10 @@ jobs:
         role-to-assume: ${{ secrets.AWS_CI_ROLE_ARN }}
     - name: Install dependencies
       run: make install_${{ matrix.language}}_sdk
-    - name: Set up gotestfmt
-      uses: haveyoudebuggedit/gotestfmt-action@v2
+    - name: Install gotestfmt
+      uses: jaxxstorm/action-install-gh-release@v1.2.0
       with:
-        token: ${{ secrets.GITHUB_TOKEN }}
+        repo: haveyoudebuggedit/gotestfmt
     - name: Run tests
       run: cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language
         }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt

--- a/provider-ci/providers/spotinst/repo/.github/workflows/nightly-test.yml
+++ b/provider-ci/providers/spotinst/repo/.github/workflows/nightly-test.yml
@@ -244,10 +244,10 @@ jobs:
         role-to-assume: ${{ secrets.AWS_CI_ROLE_ARN }}
     - name: Install dependencies
       run: make install_${{ matrix.language}}_sdk
-    - name: Set up gotestfmt
-      uses: haveyoudebuggedit/gotestfmt-action@v2
+    - name: Install gotestfmt
+      uses: jaxxstorm/action-install-gh-release@v1.2.0
       with:
-        token: ${{ secrets.GITHUB_TOKEN }}
+        repo: haveyoudebuggedit/gotestfmt
     - name: Run tests
       run: cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language
         }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt

--- a/provider-ci/providers/spotinst/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/spotinst/repo/.github/workflows/prerelease.yml
@@ -449,10 +449,10 @@ jobs:
         role-to-assume: ${{ secrets.AWS_CI_ROLE_ARN }}
     - name: Install dependencies
       run: make install_${{ matrix.language}}_sdk
-    - name: Set up gotestfmt
-      uses: haveyoudebuggedit/gotestfmt-action@v2
+    - name: Install gotestfmt
+      uses: jaxxstorm/action-install-gh-release@v1.2.0
       with:
-        token: ${{ secrets.GITHUB_TOKEN }}
+        repo: haveyoudebuggedit/gotestfmt
     - name: Run tests
       run: cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language
         }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt

--- a/provider-ci/providers/spotinst/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/spotinst/repo/.github/workflows/release.yml
@@ -461,10 +461,10 @@ jobs:
         role-to-assume: ${{ secrets.AWS_CI_ROLE_ARN }}
     - name: Install dependencies
       run: make install_${{ matrix.language}}_sdk
-    - name: Set up gotestfmt
-      uses: haveyoudebuggedit/gotestfmt-action@v2
+    - name: Install gotestfmt
+      uses: jaxxstorm/action-install-gh-release@v1.2.0
       with:
-        token: ${{ secrets.GITHUB_TOKEN }}
+        repo: haveyoudebuggedit/gotestfmt
     - name: Run tests
       run: cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language
         }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt

--- a/provider-ci/providers/spotinst/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/spotinst/repo/.github/workflows/run-acceptance-tests.yml
@@ -358,10 +358,10 @@ jobs:
         role-to-assume: ${{ secrets.AWS_CI_ROLE_ARN }}
     - name: Install dependencies
       run: make install_${{ matrix.language}}_sdk
-    - name: Set up gotestfmt
-      uses: haveyoudebuggedit/gotestfmt-action@v2
+    - name: Install gotestfmt
+      uses: jaxxstorm/action-install-gh-release@v1.2.0
       with:
-        token: ${{ secrets.GITHUB_TOKEN }}
+        repo: haveyoudebuggedit/gotestfmt
     - name: Run tests
       run: cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language
         }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt

--- a/provider-ci/providers/sumologic/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/sumologic/repo/.github/workflows/main.yml
@@ -494,10 +494,10 @@ jobs:
         pip3 install pipenv
     - name: Install dependencies
       run: make install_${{ matrix.language}}_sdk
-    - name: Set up gotestfmt
-      uses: haveyoudebuggedit/gotestfmt-action@v2
+    - name: Install gotestfmt
+      uses: jaxxstorm/action-install-gh-release@v1.2.0
       with:
-        token: ${{ secrets.GITHUB_TOKEN }}
+        repo: haveyoudebuggedit/gotestfmt
     - name: Run tests
       run: cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language
         }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt

--- a/provider-ci/providers/sumologic/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/sumologic/repo/.github/workflows/master.yml
@@ -494,10 +494,10 @@ jobs:
         pip3 install pipenv
     - name: Install dependencies
       run: make install_${{ matrix.language}}_sdk
-    - name: Set up gotestfmt
-      uses: haveyoudebuggedit/gotestfmt-action@v2
+    - name: Install gotestfmt
+      uses: jaxxstorm/action-install-gh-release@v1.2.0
       with:
-        token: ${{ secrets.GITHUB_TOKEN }}
+        repo: haveyoudebuggedit/gotestfmt
     - name: Run tests
       run: cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language
         }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt

--- a/provider-ci/providers/sumologic/repo/.github/workflows/nightly-test.yml
+++ b/provider-ci/providers/sumologic/repo/.github/workflows/nightly-test.yml
@@ -235,10 +235,10 @@ jobs:
         pip3 install pipenv
     - name: Install dependencies
       run: make install_${{ matrix.language}}_sdk
-    - name: Set up gotestfmt
-      uses: haveyoudebuggedit/gotestfmt-action@v2
+    - name: Install gotestfmt
+      uses: jaxxstorm/action-install-gh-release@v1.2.0
       with:
-        token: ${{ secrets.GITHUB_TOKEN }}
+        repo: haveyoudebuggedit/gotestfmt
     - name: Run tests
       run: cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language
         }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt

--- a/provider-ci/providers/sumologic/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/sumologic/repo/.github/workflows/prerelease.yml
@@ -440,10 +440,10 @@ jobs:
         pip3 install pipenv
     - name: Install dependencies
       run: make install_${{ matrix.language}}_sdk
-    - name: Set up gotestfmt
-      uses: haveyoudebuggedit/gotestfmt-action@v2
+    - name: Install gotestfmt
+      uses: jaxxstorm/action-install-gh-release@v1.2.0
       with:
-        token: ${{ secrets.GITHUB_TOKEN }}
+        repo: haveyoudebuggedit/gotestfmt
     - name: Run tests
       run: cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language
         }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt

--- a/provider-ci/providers/sumologic/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/sumologic/repo/.github/workflows/release.yml
@@ -452,10 +452,10 @@ jobs:
         pip3 install pipenv
     - name: Install dependencies
       run: make install_${{ matrix.language}}_sdk
-    - name: Set up gotestfmt
-      uses: haveyoudebuggedit/gotestfmt-action@v2
+    - name: Install gotestfmt
+      uses: jaxxstorm/action-install-gh-release@v1.2.0
       with:
-        token: ${{ secrets.GITHUB_TOKEN }}
+        repo: haveyoudebuggedit/gotestfmt
     - name: Run tests
       run: cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language
         }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt

--- a/provider-ci/providers/sumologic/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/sumologic/repo/.github/workflows/run-acceptance-tests.yml
@@ -349,10 +349,10 @@ jobs:
         pip3 install pipenv
     - name: Install dependencies
       run: make install_${{ matrix.language}}_sdk
-    - name: Set up gotestfmt
-      uses: haveyoudebuggedit/gotestfmt-action@v2
+    - name: Install gotestfmt
+      uses: jaxxstorm/action-install-gh-release@v1.2.0
       with:
-        token: ${{ secrets.GITHUB_TOKEN }}
+        repo: haveyoudebuggedit/gotestfmt
     - name: Run tests
       run: cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language
         }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt

--- a/provider-ci/providers/tailscale/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/tailscale/repo/.github/workflows/main.yml
@@ -493,10 +493,10 @@ jobs:
         pip3 install pipenv
     - name: Install dependencies
       run: make install_${{ matrix.language}}_sdk
-    - name: Set up gotestfmt
-      uses: haveyoudebuggedit/gotestfmt-action@v2
+    - name: Install gotestfmt
+      uses: jaxxstorm/action-install-gh-release@v1.2.0
       with:
-        token: ${{ secrets.GITHUB_TOKEN }}
+        repo: haveyoudebuggedit/gotestfmt
     - name: Run tests
       run: cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language
         }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt

--- a/provider-ci/providers/tailscale/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/tailscale/repo/.github/workflows/master.yml
@@ -493,10 +493,10 @@ jobs:
         pip3 install pipenv
     - name: Install dependencies
       run: make install_${{ matrix.language}}_sdk
-    - name: Set up gotestfmt
-      uses: haveyoudebuggedit/gotestfmt-action@v2
+    - name: Install gotestfmt
+      uses: jaxxstorm/action-install-gh-release@v1.2.0
       with:
-        token: ${{ secrets.GITHUB_TOKEN }}
+        repo: haveyoudebuggedit/gotestfmt
     - name: Run tests
       run: cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language
         }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt

--- a/provider-ci/providers/tailscale/repo/.github/workflows/nightly-test.yml
+++ b/provider-ci/providers/tailscale/repo/.github/workflows/nightly-test.yml
@@ -234,10 +234,10 @@ jobs:
         pip3 install pipenv
     - name: Install dependencies
       run: make install_${{ matrix.language}}_sdk
-    - name: Set up gotestfmt
-      uses: haveyoudebuggedit/gotestfmt-action@v2
+    - name: Install gotestfmt
+      uses: jaxxstorm/action-install-gh-release@v1.2.0
       with:
-        token: ${{ secrets.GITHUB_TOKEN }}
+        repo: haveyoudebuggedit/gotestfmt
     - name: Run tests
       run: cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language
         }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt

--- a/provider-ci/providers/tailscale/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/tailscale/repo/.github/workflows/prerelease.yml
@@ -439,10 +439,10 @@ jobs:
         pip3 install pipenv
     - name: Install dependencies
       run: make install_${{ matrix.language}}_sdk
-    - name: Set up gotestfmt
-      uses: haveyoudebuggedit/gotestfmt-action@v2
+    - name: Install gotestfmt
+      uses: jaxxstorm/action-install-gh-release@v1.2.0
       with:
-        token: ${{ secrets.GITHUB_TOKEN }}
+        repo: haveyoudebuggedit/gotestfmt
     - name: Run tests
       run: cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language
         }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt

--- a/provider-ci/providers/tailscale/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/tailscale/repo/.github/workflows/release.yml
@@ -451,10 +451,10 @@ jobs:
         pip3 install pipenv
     - name: Install dependencies
       run: make install_${{ matrix.language}}_sdk
-    - name: Set up gotestfmt
-      uses: haveyoudebuggedit/gotestfmt-action@v2
+    - name: Install gotestfmt
+      uses: jaxxstorm/action-install-gh-release@v1.2.0
       with:
-        token: ${{ secrets.GITHUB_TOKEN }}
+        repo: haveyoudebuggedit/gotestfmt
     - name: Run tests
       run: cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language
         }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt

--- a/provider-ci/providers/tailscale/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/tailscale/repo/.github/workflows/run-acceptance-tests.yml
@@ -348,10 +348,10 @@ jobs:
         pip3 install pipenv
     - name: Install dependencies
       run: make install_${{ matrix.language}}_sdk
-    - name: Set up gotestfmt
-      uses: haveyoudebuggedit/gotestfmt-action@v2
+    - name: Install gotestfmt
+      uses: jaxxstorm/action-install-gh-release@v1.2.0
       with:
-        token: ${{ secrets.GITHUB_TOKEN }}
+        repo: haveyoudebuggedit/gotestfmt
     - name: Run tests
       run: cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language
         }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt

--- a/provider-ci/providers/terraform/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/terraform/repo/.github/workflows/main.yml
@@ -428,10 +428,10 @@ jobs:
         role-to-assume: ${{ secrets.AWS_CI_ROLE_ARN }}
     - name: Install dependencies
       run: make install_${{ matrix.language}}_sdk
-    - name: Set up gotestfmt
-      uses: haveyoudebuggedit/gotestfmt-action@v2
+    - name: Install gotestfmt
+      uses: jaxxstorm/action-install-gh-release@v1.2.0
       with:
-        token: ${{ secrets.GITHUB_TOKEN }}
+        repo: haveyoudebuggedit/gotestfmt
     - name: Run tests
       run: cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language
         }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt

--- a/provider-ci/providers/terraform/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/terraform/repo/.github/workflows/master.yml
@@ -428,10 +428,10 @@ jobs:
         role-to-assume: ${{ secrets.AWS_CI_ROLE_ARN }}
     - name: Install dependencies
       run: make install_${{ matrix.language}}_sdk
-    - name: Set up gotestfmt
-      uses: haveyoudebuggedit/gotestfmt-action@v2
+    - name: Install gotestfmt
+      uses: jaxxstorm/action-install-gh-release@v1.2.0
       with:
-        token: ${{ secrets.GITHUB_TOKEN }}
+        repo: haveyoudebuggedit/gotestfmt
     - name: Run tests
       run: cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language
         }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt

--- a/provider-ci/providers/terraform/repo/.github/workflows/nightly-test.yml
+++ b/provider-ci/providers/terraform/repo/.github/workflows/nightly-test.yml
@@ -244,10 +244,10 @@ jobs:
         role-to-assume: ${{ secrets.AWS_CI_ROLE_ARN }}
     - name: Install dependencies
       run: make install_${{ matrix.language}}_sdk
-    - name: Set up gotestfmt
-      uses: haveyoudebuggedit/gotestfmt-action@v2
+    - name: Install gotestfmt
+      uses: jaxxstorm/action-install-gh-release@v1.2.0
       with:
-        token: ${{ secrets.GITHUB_TOKEN }}
+        repo: haveyoudebuggedit/gotestfmt
     - name: Run tests
       run: cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language
         }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt

--- a/provider-ci/providers/terraform/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/terraform/repo/.github/workflows/prerelease.yml
@@ -374,10 +374,10 @@ jobs:
         role-to-assume: ${{ secrets.AWS_CI_ROLE_ARN }}
     - name: Install dependencies
       run: make install_${{ matrix.language}}_sdk
-    - name: Set up gotestfmt
-      uses: haveyoudebuggedit/gotestfmt-action@v2
+    - name: Install gotestfmt
+      uses: jaxxstorm/action-install-gh-release@v1.2.0
       with:
-        token: ${{ secrets.GITHUB_TOKEN }}
+        repo: haveyoudebuggedit/gotestfmt
     - name: Run tests
       run: cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language
         }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt

--- a/provider-ci/providers/terraform/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/terraform/repo/.github/workflows/release.yml
@@ -386,10 +386,10 @@ jobs:
         role-to-assume: ${{ secrets.AWS_CI_ROLE_ARN }}
     - name: Install dependencies
       run: make install_${{ matrix.language}}_sdk
-    - name: Set up gotestfmt
-      uses: haveyoudebuggedit/gotestfmt-action@v2
+    - name: Install gotestfmt
+      uses: jaxxstorm/action-install-gh-release@v1.2.0
       with:
-        token: ${{ secrets.GITHUB_TOKEN }}
+        repo: haveyoudebuggedit/gotestfmt
     - name: Run tests
       run: cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language
         }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt

--- a/provider-ci/providers/terraform/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/terraform/repo/.github/workflows/run-acceptance-tests.yml
@@ -275,10 +275,10 @@ jobs:
         role-to-assume: ${{ secrets.AWS_CI_ROLE_ARN }}
     - name: Install dependencies
       run: make install_${{ matrix.language}}_sdk
-    - name: Set up gotestfmt
-      uses: haveyoudebuggedit/gotestfmt-action@v2
+    - name: Install gotestfmt
+      uses: jaxxstorm/action-install-gh-release@v1.2.0
       with:
-        token: ${{ secrets.GITHUB_TOKEN }}
+        repo: haveyoudebuggedit/gotestfmt
     - name: Run tests
       run: cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language
         }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt

--- a/provider-ci/providers/tls/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/tls/repo/.github/workflows/main.yml
@@ -491,10 +491,10 @@ jobs:
         pip3 install pipenv
     - name: Install dependencies
       run: make install_${{ matrix.language}}_sdk
-    - name: Set up gotestfmt
-      uses: haveyoudebuggedit/gotestfmt-action@v2
+    - name: Install gotestfmt
+      uses: jaxxstorm/action-install-gh-release@v1.2.0
       with:
-        token: ${{ secrets.GITHUB_TOKEN }}
+        repo: haveyoudebuggedit/gotestfmt
     - name: Run tests
       run: cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language
         }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt

--- a/provider-ci/providers/tls/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/tls/repo/.github/workflows/master.yml
@@ -491,10 +491,10 @@ jobs:
         pip3 install pipenv
     - name: Install dependencies
       run: make install_${{ matrix.language}}_sdk
-    - name: Set up gotestfmt
-      uses: haveyoudebuggedit/gotestfmt-action@v2
+    - name: Install gotestfmt
+      uses: jaxxstorm/action-install-gh-release@v1.2.0
       with:
-        token: ${{ secrets.GITHUB_TOKEN }}
+        repo: haveyoudebuggedit/gotestfmt
     - name: Run tests
       run: cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language
         }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt

--- a/provider-ci/providers/tls/repo/.github/workflows/nightly-test.yml
+++ b/provider-ci/providers/tls/repo/.github/workflows/nightly-test.yml
@@ -232,10 +232,10 @@ jobs:
         pip3 install pipenv
     - name: Install dependencies
       run: make install_${{ matrix.language}}_sdk
-    - name: Set up gotestfmt
-      uses: haveyoudebuggedit/gotestfmt-action@v2
+    - name: Install gotestfmt
+      uses: jaxxstorm/action-install-gh-release@v1.2.0
       with:
-        token: ${{ secrets.GITHUB_TOKEN }}
+        repo: haveyoudebuggedit/gotestfmt
     - name: Run tests
       run: cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language
         }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt

--- a/provider-ci/providers/tls/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/tls/repo/.github/workflows/prerelease.yml
@@ -437,10 +437,10 @@ jobs:
         pip3 install pipenv
     - name: Install dependencies
       run: make install_${{ matrix.language}}_sdk
-    - name: Set up gotestfmt
-      uses: haveyoudebuggedit/gotestfmt-action@v2
+    - name: Install gotestfmt
+      uses: jaxxstorm/action-install-gh-release@v1.2.0
       with:
-        token: ${{ secrets.GITHUB_TOKEN }}
+        repo: haveyoudebuggedit/gotestfmt
     - name: Run tests
       run: cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language
         }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt

--- a/provider-ci/providers/tls/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/tls/repo/.github/workflows/release.yml
@@ -449,10 +449,10 @@ jobs:
         pip3 install pipenv
     - name: Install dependencies
       run: make install_${{ matrix.language}}_sdk
-    - name: Set up gotestfmt
-      uses: haveyoudebuggedit/gotestfmt-action@v2
+    - name: Install gotestfmt
+      uses: jaxxstorm/action-install-gh-release@v1.2.0
       with:
-        token: ${{ secrets.GITHUB_TOKEN }}
+        repo: haveyoudebuggedit/gotestfmt
     - name: Run tests
       run: cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language
         }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt

--- a/provider-ci/providers/tls/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/tls/repo/.github/workflows/run-acceptance-tests.yml
@@ -346,10 +346,10 @@ jobs:
         pip3 install pipenv
     - name: Install dependencies
       run: make install_${{ matrix.language}}_sdk
-    - name: Set up gotestfmt
-      uses: haveyoudebuggedit/gotestfmt-action@v2
+    - name: Install gotestfmt
+      uses: jaxxstorm/action-install-gh-release@v1.2.0
       with:
-        token: ${{ secrets.GITHUB_TOKEN }}
+        repo: haveyoudebuggedit/gotestfmt
     - name: Run tests
       run: cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language
         }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt

--- a/provider-ci/providers/vault/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/vault/repo/.github/workflows/main.yml
@@ -493,10 +493,10 @@ jobs:
       run: docker-compose -f testing/docker-compose.yml up --build -d
     - name: Install dependencies
       run: make install_${{ matrix.language}}_sdk
-    - name: Set up gotestfmt
-      uses: haveyoudebuggedit/gotestfmt-action@v2
+    - name: Install gotestfmt
+      uses: jaxxstorm/action-install-gh-release@v1.2.0
       with:
-        token: ${{ secrets.GITHUB_TOKEN }}
+        repo: haveyoudebuggedit/gotestfmt
     - name: Run tests
       run: cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language
         }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt

--- a/provider-ci/providers/vault/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/vault/repo/.github/workflows/master.yml
@@ -493,10 +493,10 @@ jobs:
       run: docker-compose -f testing/docker-compose.yml up --build -d
     - name: Install dependencies
       run: make install_${{ matrix.language}}_sdk
-    - name: Set up gotestfmt
-      uses: haveyoudebuggedit/gotestfmt-action@v2
+    - name: Install gotestfmt
+      uses: jaxxstorm/action-install-gh-release@v1.2.0
       with:
-        token: ${{ secrets.GITHUB_TOKEN }}
+        repo: haveyoudebuggedit/gotestfmt
     - name: Run tests
       run: cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language
         }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt

--- a/provider-ci/providers/vault/repo/.github/workflows/nightly-test.yml
+++ b/provider-ci/providers/vault/repo/.github/workflows/nightly-test.yml
@@ -234,10 +234,10 @@ jobs:
       run: docker-compose -f testing/docker-compose.yml up --build -d
     - name: Install dependencies
       run: make install_${{ matrix.language}}_sdk
-    - name: Set up gotestfmt
-      uses: haveyoudebuggedit/gotestfmt-action@v2
+    - name: Install gotestfmt
+      uses: jaxxstorm/action-install-gh-release@v1.2.0
       with:
-        token: ${{ secrets.GITHUB_TOKEN }}
+        repo: haveyoudebuggedit/gotestfmt
     - name: Run tests
       run: cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language
         }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt

--- a/provider-ci/providers/vault/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/vault/repo/.github/workflows/prerelease.yml
@@ -439,10 +439,10 @@ jobs:
       run: docker-compose -f testing/docker-compose.yml up --build -d
     - name: Install dependencies
       run: make install_${{ matrix.language}}_sdk
-    - name: Set up gotestfmt
-      uses: haveyoudebuggedit/gotestfmt-action@v2
+    - name: Install gotestfmt
+      uses: jaxxstorm/action-install-gh-release@v1.2.0
       with:
-        token: ${{ secrets.GITHUB_TOKEN }}
+        repo: haveyoudebuggedit/gotestfmt
     - name: Run tests
       run: cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language
         }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt

--- a/provider-ci/providers/vault/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/vault/repo/.github/workflows/release.yml
@@ -451,10 +451,10 @@ jobs:
       run: docker-compose -f testing/docker-compose.yml up --build -d
     - name: Install dependencies
       run: make install_${{ matrix.language}}_sdk
-    - name: Set up gotestfmt
-      uses: haveyoudebuggedit/gotestfmt-action@v2
+    - name: Install gotestfmt
+      uses: jaxxstorm/action-install-gh-release@v1.2.0
       with:
-        token: ${{ secrets.GITHUB_TOKEN }}
+        repo: haveyoudebuggedit/gotestfmt
     - name: Run tests
       run: cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language
         }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt

--- a/provider-ci/providers/vault/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/vault/repo/.github/workflows/run-acceptance-tests.yml
@@ -348,10 +348,10 @@ jobs:
       run: docker-compose -f testing/docker-compose.yml up --build -d
     - name: Install dependencies
       run: make install_${{ matrix.language}}_sdk
-    - name: Set up gotestfmt
-      uses: haveyoudebuggedit/gotestfmt-action@v2
+    - name: Install gotestfmt
+      uses: jaxxstorm/action-install-gh-release@v1.2.0
       with:
-        token: ${{ secrets.GITHUB_TOKEN }}
+        repo: haveyoudebuggedit/gotestfmt
     - name: Run tests
       run: cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language
         }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt

--- a/provider-ci/providers/venafi/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/venafi/repo/.github/workflows/main.yml
@@ -494,10 +494,10 @@ jobs:
         pip3 install pipenv
     - name: Install dependencies
       run: make install_${{ matrix.language}}_sdk
-    - name: Set up gotestfmt
-      uses: haveyoudebuggedit/gotestfmt-action@v2
+    - name: Install gotestfmt
+      uses: jaxxstorm/action-install-gh-release@v1.2.0
       with:
-        token: ${{ secrets.GITHUB_TOKEN }}
+        repo: haveyoudebuggedit/gotestfmt
     - name: Run tests
       run: cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language
         }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt

--- a/provider-ci/providers/venafi/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/venafi/repo/.github/workflows/master.yml
@@ -494,10 +494,10 @@ jobs:
         pip3 install pipenv
     - name: Install dependencies
       run: make install_${{ matrix.language}}_sdk
-    - name: Set up gotestfmt
-      uses: haveyoudebuggedit/gotestfmt-action@v2
+    - name: Install gotestfmt
+      uses: jaxxstorm/action-install-gh-release@v1.2.0
       with:
-        token: ${{ secrets.GITHUB_TOKEN }}
+        repo: haveyoudebuggedit/gotestfmt
     - name: Run tests
       run: cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language
         }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt

--- a/provider-ci/providers/venafi/repo/.github/workflows/nightly-test.yml
+++ b/provider-ci/providers/venafi/repo/.github/workflows/nightly-test.yml
@@ -235,10 +235,10 @@ jobs:
         pip3 install pipenv
     - name: Install dependencies
       run: make install_${{ matrix.language}}_sdk
-    - name: Set up gotestfmt
-      uses: haveyoudebuggedit/gotestfmt-action@v2
+    - name: Install gotestfmt
+      uses: jaxxstorm/action-install-gh-release@v1.2.0
       with:
-        token: ${{ secrets.GITHUB_TOKEN }}
+        repo: haveyoudebuggedit/gotestfmt
     - name: Run tests
       run: cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language
         }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt

--- a/provider-ci/providers/venafi/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/venafi/repo/.github/workflows/prerelease.yml
@@ -440,10 +440,10 @@ jobs:
         pip3 install pipenv
     - name: Install dependencies
       run: make install_${{ matrix.language}}_sdk
-    - name: Set up gotestfmt
-      uses: haveyoudebuggedit/gotestfmt-action@v2
+    - name: Install gotestfmt
+      uses: jaxxstorm/action-install-gh-release@v1.2.0
       with:
-        token: ${{ secrets.GITHUB_TOKEN }}
+        repo: haveyoudebuggedit/gotestfmt
     - name: Run tests
       run: cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language
         }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt

--- a/provider-ci/providers/venafi/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/venafi/repo/.github/workflows/release.yml
@@ -452,10 +452,10 @@ jobs:
         pip3 install pipenv
     - name: Install dependencies
       run: make install_${{ matrix.language}}_sdk
-    - name: Set up gotestfmt
-      uses: haveyoudebuggedit/gotestfmt-action@v2
+    - name: Install gotestfmt
+      uses: jaxxstorm/action-install-gh-release@v1.2.0
       with:
-        token: ${{ secrets.GITHUB_TOKEN }}
+        repo: haveyoudebuggedit/gotestfmt
     - name: Run tests
       run: cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language
         }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt

--- a/provider-ci/providers/venafi/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/venafi/repo/.github/workflows/run-acceptance-tests.yml
@@ -349,10 +349,10 @@ jobs:
         pip3 install pipenv
     - name: Install dependencies
       run: make install_${{ matrix.language}}_sdk
-    - name: Set up gotestfmt
-      uses: haveyoudebuggedit/gotestfmt-action@v2
+    - name: Install gotestfmt
+      uses: jaxxstorm/action-install-gh-release@v1.2.0
       with:
-        token: ${{ secrets.GITHUB_TOKEN }}
+        repo: haveyoudebuggedit/gotestfmt
     - name: Run tests
       run: cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language
         }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt

--- a/provider-ci/providers/vsphere/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/vsphere/repo/.github/workflows/main.yml
@@ -491,10 +491,10 @@ jobs:
         pip3 install pipenv
     - name: Install dependencies
       run: make install_${{ matrix.language}}_sdk
-    - name: Set up gotestfmt
-      uses: haveyoudebuggedit/gotestfmt-action@v2
+    - name: Install gotestfmt
+      uses: jaxxstorm/action-install-gh-release@v1.2.0
       with:
-        token: ${{ secrets.GITHUB_TOKEN }}
+        repo: haveyoudebuggedit/gotestfmt
     - name: Run tests
       run: cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language
         }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt

--- a/provider-ci/providers/vsphere/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/vsphere/repo/.github/workflows/master.yml
@@ -491,10 +491,10 @@ jobs:
         pip3 install pipenv
     - name: Install dependencies
       run: make install_${{ matrix.language}}_sdk
-    - name: Set up gotestfmt
-      uses: haveyoudebuggedit/gotestfmt-action@v2
+    - name: Install gotestfmt
+      uses: jaxxstorm/action-install-gh-release@v1.2.0
       with:
-        token: ${{ secrets.GITHUB_TOKEN }}
+        repo: haveyoudebuggedit/gotestfmt
     - name: Run tests
       run: cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language
         }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt

--- a/provider-ci/providers/vsphere/repo/.github/workflows/nightly-test.yml
+++ b/provider-ci/providers/vsphere/repo/.github/workflows/nightly-test.yml
@@ -232,10 +232,10 @@ jobs:
         pip3 install pipenv
     - name: Install dependencies
       run: make install_${{ matrix.language}}_sdk
-    - name: Set up gotestfmt
-      uses: haveyoudebuggedit/gotestfmt-action@v2
+    - name: Install gotestfmt
+      uses: jaxxstorm/action-install-gh-release@v1.2.0
       with:
-        token: ${{ secrets.GITHUB_TOKEN }}
+        repo: haveyoudebuggedit/gotestfmt
     - name: Run tests
       run: cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language
         }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt

--- a/provider-ci/providers/vsphere/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/vsphere/repo/.github/workflows/prerelease.yml
@@ -437,10 +437,10 @@ jobs:
         pip3 install pipenv
     - name: Install dependencies
       run: make install_${{ matrix.language}}_sdk
-    - name: Set up gotestfmt
-      uses: haveyoudebuggedit/gotestfmt-action@v2
+    - name: Install gotestfmt
+      uses: jaxxstorm/action-install-gh-release@v1.2.0
       with:
-        token: ${{ secrets.GITHUB_TOKEN }}
+        repo: haveyoudebuggedit/gotestfmt
     - name: Run tests
       run: cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language
         }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt

--- a/provider-ci/providers/vsphere/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/vsphere/repo/.github/workflows/release.yml
@@ -449,10 +449,10 @@ jobs:
         pip3 install pipenv
     - name: Install dependencies
       run: make install_${{ matrix.language}}_sdk
-    - name: Set up gotestfmt
-      uses: haveyoudebuggedit/gotestfmt-action@v2
+    - name: Install gotestfmt
+      uses: jaxxstorm/action-install-gh-release@v1.2.0
       with:
-        token: ${{ secrets.GITHUB_TOKEN }}
+        repo: haveyoudebuggedit/gotestfmt
     - name: Run tests
       run: cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language
         }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt

--- a/provider-ci/providers/vsphere/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/vsphere/repo/.github/workflows/run-acceptance-tests.yml
@@ -346,10 +346,10 @@ jobs:
         pip3 install pipenv
     - name: Install dependencies
       run: make install_${{ matrix.language}}_sdk
-    - name: Set up gotestfmt
-      uses: haveyoudebuggedit/gotestfmt-action@v2
+    - name: Install gotestfmt
+      uses: jaxxstorm/action-install-gh-release@v1.2.0
       with:
-        token: ${{ secrets.GITHUB_TOKEN }}
+        repo: haveyoudebuggedit/gotestfmt
     - name: Run tests
       run: cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language
         }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt

--- a/provider-ci/providers/wavefront/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/wavefront/repo/.github/workflows/main.yml
@@ -493,10 +493,10 @@ jobs:
         pip3 install pipenv
     - name: Install dependencies
       run: make install_${{ matrix.language}}_sdk
-    - name: Set up gotestfmt
-      uses: haveyoudebuggedit/gotestfmt-action@v2
+    - name: Install gotestfmt
+      uses: jaxxstorm/action-install-gh-release@v1.2.0
       with:
-        token: ${{ secrets.GITHUB_TOKEN }}
+        repo: haveyoudebuggedit/gotestfmt
     - name: Run tests
       run: cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language
         }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt

--- a/provider-ci/providers/wavefront/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/wavefront/repo/.github/workflows/master.yml
@@ -493,10 +493,10 @@ jobs:
         pip3 install pipenv
     - name: Install dependencies
       run: make install_${{ matrix.language}}_sdk
-    - name: Set up gotestfmt
-      uses: haveyoudebuggedit/gotestfmt-action@v2
+    - name: Install gotestfmt
+      uses: jaxxstorm/action-install-gh-release@v1.2.0
       with:
-        token: ${{ secrets.GITHUB_TOKEN }}
+        repo: haveyoudebuggedit/gotestfmt
     - name: Run tests
       run: cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language
         }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt

--- a/provider-ci/providers/wavefront/repo/.github/workflows/nightly-test.yml
+++ b/provider-ci/providers/wavefront/repo/.github/workflows/nightly-test.yml
@@ -234,10 +234,10 @@ jobs:
         pip3 install pipenv
     - name: Install dependencies
       run: make install_${{ matrix.language}}_sdk
-    - name: Set up gotestfmt
-      uses: haveyoudebuggedit/gotestfmt-action@v2
+    - name: Install gotestfmt
+      uses: jaxxstorm/action-install-gh-release@v1.2.0
       with:
-        token: ${{ secrets.GITHUB_TOKEN }}
+        repo: haveyoudebuggedit/gotestfmt
     - name: Run tests
       run: cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language
         }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt

--- a/provider-ci/providers/wavefront/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/wavefront/repo/.github/workflows/prerelease.yml
@@ -439,10 +439,10 @@ jobs:
         pip3 install pipenv
     - name: Install dependencies
       run: make install_${{ matrix.language}}_sdk
-    - name: Set up gotestfmt
-      uses: haveyoudebuggedit/gotestfmt-action@v2
+    - name: Install gotestfmt
+      uses: jaxxstorm/action-install-gh-release@v1.2.0
       with:
-        token: ${{ secrets.GITHUB_TOKEN }}
+        repo: haveyoudebuggedit/gotestfmt
     - name: Run tests
       run: cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language
         }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt

--- a/provider-ci/providers/wavefront/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/wavefront/repo/.github/workflows/release.yml
@@ -451,10 +451,10 @@ jobs:
         pip3 install pipenv
     - name: Install dependencies
       run: make install_${{ matrix.language}}_sdk
-    - name: Set up gotestfmt
-      uses: haveyoudebuggedit/gotestfmt-action@v2
+    - name: Install gotestfmt
+      uses: jaxxstorm/action-install-gh-release@v1.2.0
       with:
-        token: ${{ secrets.GITHUB_TOKEN }}
+        repo: haveyoudebuggedit/gotestfmt
     - name: Run tests
       run: cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language
         }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt

--- a/provider-ci/providers/wavefront/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/wavefront/repo/.github/workflows/run-acceptance-tests.yml
@@ -348,10 +348,10 @@ jobs:
         pip3 install pipenv
     - name: Install dependencies
       run: make install_${{ matrix.language}}_sdk
-    - name: Set up gotestfmt
-      uses: haveyoudebuggedit/gotestfmt-action@v2
+    - name: Install gotestfmt
+      uses: jaxxstorm/action-install-gh-release@v1.2.0
       with:
-        token: ${{ secrets.GITHUB_TOKEN }}
+        repo: haveyoudebuggedit/gotestfmt
     - name: Run tests
       run: cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language
         }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt

--- a/provider-ci/providers/yandex/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/yandex/repo/.github/workflows/main.yml
@@ -494,10 +494,10 @@ jobs:
         pip3 install pipenv
     - name: Install dependencies
       run: make install_${{ matrix.language}}_sdk
-    - name: Set up gotestfmt
-      uses: haveyoudebuggedit/gotestfmt-action@v2
+    - name: Install gotestfmt
+      uses: jaxxstorm/action-install-gh-release@v1.2.0
       with:
-        token: ${{ secrets.GITHUB_TOKEN }}
+        repo: haveyoudebuggedit/gotestfmt
     - name: Run tests
       run: cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language
         }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt

--- a/provider-ci/providers/yandex/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/yandex/repo/.github/workflows/master.yml
@@ -494,10 +494,10 @@ jobs:
         pip3 install pipenv
     - name: Install dependencies
       run: make install_${{ matrix.language}}_sdk
-    - name: Set up gotestfmt
-      uses: haveyoudebuggedit/gotestfmt-action@v2
+    - name: Install gotestfmt
+      uses: jaxxstorm/action-install-gh-release@v1.2.0
       with:
-        token: ${{ secrets.GITHUB_TOKEN }}
+        repo: haveyoudebuggedit/gotestfmt
     - name: Run tests
       run: cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language
         }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt

--- a/provider-ci/providers/yandex/repo/.github/workflows/nightly-test.yml
+++ b/provider-ci/providers/yandex/repo/.github/workflows/nightly-test.yml
@@ -235,10 +235,10 @@ jobs:
         pip3 install pipenv
     - name: Install dependencies
       run: make install_${{ matrix.language}}_sdk
-    - name: Set up gotestfmt
-      uses: haveyoudebuggedit/gotestfmt-action@v2
+    - name: Install gotestfmt
+      uses: jaxxstorm/action-install-gh-release@v1.2.0
       with:
-        token: ${{ secrets.GITHUB_TOKEN }}
+        repo: haveyoudebuggedit/gotestfmt
     - name: Run tests
       run: cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language
         }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt

--- a/provider-ci/providers/yandex/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/yandex/repo/.github/workflows/prerelease.yml
@@ -440,10 +440,10 @@ jobs:
         pip3 install pipenv
     - name: Install dependencies
       run: make install_${{ matrix.language}}_sdk
-    - name: Set up gotestfmt
-      uses: haveyoudebuggedit/gotestfmt-action@v2
+    - name: Install gotestfmt
+      uses: jaxxstorm/action-install-gh-release@v1.2.0
       with:
-        token: ${{ secrets.GITHUB_TOKEN }}
+        repo: haveyoudebuggedit/gotestfmt
     - name: Run tests
       run: cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language
         }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt

--- a/provider-ci/providers/yandex/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/yandex/repo/.github/workflows/release.yml
@@ -452,10 +452,10 @@ jobs:
         pip3 install pipenv
     - name: Install dependencies
       run: make install_${{ matrix.language}}_sdk
-    - name: Set up gotestfmt
-      uses: haveyoudebuggedit/gotestfmt-action@v2
+    - name: Install gotestfmt
+      uses: jaxxstorm/action-install-gh-release@v1.2.0
       with:
-        token: ${{ secrets.GITHUB_TOKEN }}
+        repo: haveyoudebuggedit/gotestfmt
     - name: Run tests
       run: cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language
         }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt

--- a/provider-ci/providers/yandex/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/yandex/repo/.github/workflows/run-acceptance-tests.yml
@@ -349,10 +349,10 @@ jobs:
         pip3 install pipenv
     - name: Install dependencies
       run: make install_${{ matrix.language}}_sdk
-    - name: Set up gotestfmt
-      uses: haveyoudebuggedit/gotestfmt-action@v2
+    - name: Install gotestfmt
+      uses: jaxxstorm/action-install-gh-release@v1.2.0
       with:
-        token: ${{ secrets.GITHUB_TOKEN }}
+        repo: haveyoudebuggedit/gotestfmt
     - name: Run tests
       run: cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language
         }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt

--- a/provider-ci/src/steps.ts
+++ b/provider-ci/src/steps.ts
@@ -707,11 +707,11 @@ export class SetupGotestfmt extends step.Step {
     constructor() {
         super();
         return {
-            name: 'Set up gotestfmt',
-            uses: 'haveyoudebuggedit/gotestfmt-action@v2',
+            name: 'Install gotestfmt',
+            uses: action.installGhRelease,
             with: {
-                token: "${{ secrets.GITHUB_TOKEN }}"
-            }
+                repo: 'haveyoudebuggedit/gotestfmt',
+            },
         }
     }
 }


### PR DESCRIPTION
The installation of gotestfmt doesn't really work on anything other
than linux. The new action will work on all platforms
