### PR TITLE
[internal] Add the ability to be able to skip windows arm64 builds

### DIFF
--- a/provider-ci/lib/goreleaser.js
+++ b/provider-ci/lib/goreleaser.js
@@ -2,6 +2,7 @@ import * as param from '@jkcfg/std/param';
 const majVersion = param.Number('major-version', 2);
 const skipTfGen = param.Boolean('skipTfGen', false);
 const customLdFlag = param.String('customLdFlag') || "";
+const skipWindowsArmBuild = param.Boolean('skipWindowsArmBuild', false);
 export class GoreleaserConfig {
     constructor(params) {
         Object.assign(this, params);
@@ -11,6 +12,10 @@ export class PulumiGoreleaserPreConfig extends GoreleaserConfig {
     constructor(name) {
         super();
         let ldflags;
+        let ignores = [];
+        if (skipWindowsArmBuild) {
+            ignores.push({ goos: "windows", goarch: "arm64" });
+        }
         if (majVersion > 1) {
             ldflags = [`-X github.com/pulumi/pulumi-${name}/provider/v${majVersion}/pkg/version.Version={{.Tag}}`];
         }
@@ -42,6 +47,7 @@ export class PulumiGoreleaserPreConfig extends GoreleaserConfig {
                     'amd64',
                     'arm64',
                 ],
+                ignore: ignores,
                 main: `./cmd/pulumi-resource-${name}/`,
                 ldflags: ldflags,
                 binary: `pulumi-resource-${name}`
@@ -80,7 +86,10 @@ export class PulumiGoreleaserConfig extends PulumiGoreleaserPreConfig {
             filters: {
                 exclude: [
                     "Merge branch",
-                    "Merge pull request"
+                    "Merge pull request",
+                    "[internal]",
+                    "[ci]",
+                    "[chore]",
                 ],
             },
         };

--- a/provider-ci/providers/aiven/repo/.goreleaser.prerelease.yml
+++ b/provider-ci/providers/aiven/repo/.goreleaser.prerelease.yml
@@ -24,6 +24,7 @@ builds:
   - darwin
   - windows
   - linux
+  ignore: []
   ldflags:
   - -X github.com/pulumi/pulumi-aiven/provider/v4/pkg/version.Version={{.Tag}}
   main: ./cmd/pulumi-resource-aiven/

--- a/provider-ci/providers/aiven/repo/.goreleaser.yml
+++ b/provider-ci/providers/aiven/repo/.goreleaser.yml
@@ -24,6 +24,7 @@ builds:
   - darwin
   - windows
   - linux
+  ignore: []
   ldflags:
   - -X github.com/pulumi/pulumi-aiven/provider/v4/pkg/version.Version={{.Tag}}
   main: ./cmd/pulumi-resource-aiven/
@@ -32,6 +33,9 @@ changelog:
     exclude:
     - Merge branch
     - Merge pull request
+    - '[internal]'
+    - '[ci]'
+    - '[chore]'
   sort: asc
   use: git
 release:

--- a/provider-ci/providers/akamai/repo/.goreleaser.prerelease.yml
+++ b/provider-ci/providers/akamai/repo/.goreleaser.prerelease.yml
@@ -24,6 +24,7 @@ builds:
   - darwin
   - windows
   - linux
+  ignore: []
   ldflags:
   - -X github.com/pulumi/pulumi-akamai/provider/v2/pkg/version.Version={{.Tag}}
   main: ./cmd/pulumi-resource-akamai/

--- a/provider-ci/providers/akamai/repo/.goreleaser.yml
+++ b/provider-ci/providers/akamai/repo/.goreleaser.yml
@@ -24,6 +24,7 @@ builds:
   - darwin
   - windows
   - linux
+  ignore: []
   ldflags:
   - -X github.com/pulumi/pulumi-akamai/provider/v2/pkg/version.Version={{.Tag}}
   main: ./cmd/pulumi-resource-akamai/
@@ -32,6 +33,9 @@ changelog:
     exclude:
     - Merge branch
     - Merge pull request
+    - '[internal]'
+    - '[ci]'
+    - '[chore]'
   sort: asc
   use: git
 release:

--- a/provider-ci/providers/alicloud/repo/.goreleaser.prerelease.yml
+++ b/provider-ci/providers/alicloud/repo/.goreleaser.prerelease.yml
@@ -24,6 +24,7 @@ builds:
   - darwin
   - windows
   - linux
+  ignore: []
   ldflags:
   - -X github.com/pulumi/pulumi-alicloud/provider/v3/pkg/version.Version={{.Tag}}
   main: ./cmd/pulumi-resource-alicloud/

--- a/provider-ci/providers/alicloud/repo/.goreleaser.yml
+++ b/provider-ci/providers/alicloud/repo/.goreleaser.yml
@@ -24,6 +24,7 @@ builds:
   - darwin
   - windows
   - linux
+  ignore: []
   ldflags:
   - -X github.com/pulumi/pulumi-alicloud/provider/v3/pkg/version.Version={{.Tag}}
   main: ./cmd/pulumi-resource-alicloud/
@@ -32,6 +33,9 @@ changelog:
     exclude:
     - Merge branch
     - Merge pull request
+    - '[internal]'
+    - '[ci]'
+    - '[chore]'
   sort: asc
   use: git
 release:

--- a/provider-ci/providers/artifactory/repo/.goreleaser.prerelease.yml
+++ b/provider-ci/providers/artifactory/repo/.goreleaser.prerelease.yml
@@ -24,6 +24,7 @@ builds:
   - darwin
   - windows
   - linux
+  ignore: []
   ldflags:
   - -X github.com/pulumi/pulumi-artifactory/provider/pkg/version.Version={{.Tag}}
   main: ./cmd/pulumi-resource-artifactory/

--- a/provider-ci/providers/artifactory/repo/.goreleaser.yml
+++ b/provider-ci/providers/artifactory/repo/.goreleaser.yml
@@ -24,6 +24,7 @@ builds:
   - darwin
   - windows
   - linux
+  ignore: []
   ldflags:
   - -X github.com/pulumi/pulumi-artifactory/provider/pkg/version.Version={{.Tag}}
   main: ./cmd/pulumi-resource-artifactory/
@@ -32,6 +33,9 @@ changelog:
     exclude:
     - Merge branch
     - Merge pull request
+    - '[internal]'
+    - '[ci]'
+    - '[chore]'
   sort: asc
   use: git
 release:

--- a/provider-ci/providers/auth0/repo/.goreleaser.prerelease.yml
+++ b/provider-ci/providers/auth0/repo/.goreleaser.prerelease.yml
@@ -24,6 +24,7 @@ builds:
   - darwin
   - windows
   - linux
+  ignore: []
   ldflags:
   - -X github.com/pulumi/pulumi-auth0/provider/v2/pkg/version.Version={{.Tag}}
   main: ./cmd/pulumi-resource-auth0/

--- a/provider-ci/providers/auth0/repo/.goreleaser.yml
+++ b/provider-ci/providers/auth0/repo/.goreleaser.yml
@@ -24,6 +24,7 @@ builds:
   - darwin
   - windows
   - linux
+  ignore: []
   ldflags:
   - -X github.com/pulumi/pulumi-auth0/provider/v2/pkg/version.Version={{.Tag}}
   main: ./cmd/pulumi-resource-auth0/
@@ -32,6 +33,9 @@ changelog:
     exclude:
     - Merge branch
     - Merge pull request
+    - '[internal]'
+    - '[ci]'
+    - '[chore]'
   sort: asc
   use: git
 release:

--- a/provider-ci/providers/aws/repo/.goreleaser.prerelease.yml
+++ b/provider-ci/providers/aws/repo/.goreleaser.prerelease.yml
@@ -24,6 +24,7 @@ builds:
   - darwin
   - windows
   - linux
+  ignore: []
   ldflags:
   - -X github.com/pulumi/pulumi-aws/provider/v4/pkg/version.Version={{.Tag}}
   - -X github.com/terraform-providers/terraform-provider-aws/version.ProviderVersion={{.Tag}}

--- a/provider-ci/providers/aws/repo/.goreleaser.yml
+++ b/provider-ci/providers/aws/repo/.goreleaser.yml
@@ -24,6 +24,7 @@ builds:
   - darwin
   - windows
   - linux
+  ignore: []
   ldflags:
   - -X github.com/pulumi/pulumi-aws/provider/v4/pkg/version.Version={{.Tag}}
   - -X github.com/terraform-providers/terraform-provider-aws/version.ProviderVersion={{.Tag}}
@@ -33,6 +34,9 @@ changelog:
     exclude:
     - Merge branch
     - Merge pull request
+    - '[internal]'
+    - '[ci]'
+    - '[chore]'
   sort: asc
   use: git
 release:

--- a/provider-ci/providers/azure/repo/.goreleaser.prerelease.yml
+++ b/provider-ci/providers/azure/repo/.goreleaser.prerelease.yml
@@ -24,6 +24,7 @@ builds:
   - darwin
   - windows
   - linux
+  ignore: []
   ldflags:
   - -X github.com/pulumi/pulumi-azure/provider/v4/pkg/version.Version={{.Tag}}
   - -X github.com/hashicorp/terraform-provider-azurerm/version.ProviderVersion={{.Tag}}

--- a/provider-ci/providers/azure/repo/.goreleaser.yml
+++ b/provider-ci/providers/azure/repo/.goreleaser.yml
@@ -24,6 +24,7 @@ builds:
   - darwin
   - windows
   - linux
+  ignore: []
   ldflags:
   - -X github.com/pulumi/pulumi-azure/provider/v4/pkg/version.Version={{.Tag}}
   - -X github.com/hashicorp/terraform-provider-azurerm/version.ProviderVersion={{.Tag}}
@@ -33,6 +34,9 @@ changelog:
     exclude:
     - Merge branch
     - Merge pull request
+    - '[internal]'
+    - '[ci]'
+    - '[chore]'
   sort: asc
   use: git
 release:

--- a/provider-ci/providers/azuread/repo/.goreleaser.prerelease.yml
+++ b/provider-ci/providers/azuread/repo/.goreleaser.prerelease.yml
@@ -24,6 +24,7 @@ builds:
   - darwin
   - windows
   - linux
+  ignore: []
   ldflags:
   - -X github.com/pulumi/pulumi-azuread/provider/v5/pkg/version.Version={{.Tag}}
   main: ./cmd/pulumi-resource-azuread/

--- a/provider-ci/providers/azuread/repo/.goreleaser.yml
+++ b/provider-ci/providers/azuread/repo/.goreleaser.yml
@@ -24,6 +24,7 @@ builds:
   - darwin
   - windows
   - linux
+  ignore: []
   ldflags:
   - -X github.com/pulumi/pulumi-azuread/provider/v5/pkg/version.Version={{.Tag}}
   main: ./cmd/pulumi-resource-azuread/
@@ -32,6 +33,9 @@ changelog:
     exclude:
     - Merge branch
     - Merge pull request
+    - '[internal]'
+    - '[ci]'
+    - '[chore]'
   sort: asc
   use: git
 release:

--- a/provider-ci/providers/azuredevops/repo/.goreleaser.prerelease.yml
+++ b/provider-ci/providers/azuredevops/repo/.goreleaser.prerelease.yml
@@ -24,6 +24,7 @@ builds:
   - darwin
   - windows
   - linux
+  ignore: []
   ldflags:
   - -X github.com/pulumi/pulumi-azuredevops/provider/v2/pkg/version.Version={{.Tag}}
   main: ./cmd/pulumi-resource-azuredevops/

--- a/provider-ci/providers/azuredevops/repo/.goreleaser.yml
+++ b/provider-ci/providers/azuredevops/repo/.goreleaser.yml
@@ -24,6 +24,7 @@ builds:
   - darwin
   - windows
   - linux
+  ignore: []
   ldflags:
   - -X github.com/pulumi/pulumi-azuredevops/provider/v2/pkg/version.Version={{.Tag}}
   main: ./cmd/pulumi-resource-azuredevops/
@@ -32,6 +33,9 @@ changelog:
     exclude:
     - Merge branch
     - Merge pull request
+    - '[internal]'
+    - '[ci]'
+    - '[chore]'
   sort: asc
   use: git
 release:

--- a/provider-ci/providers/civo/repo/.goreleaser.prerelease.yml
+++ b/provider-ci/providers/civo/repo/.goreleaser.prerelease.yml
@@ -24,6 +24,7 @@ builds:
   - darwin
   - windows
   - linux
+  ignore: []
   ldflags:
   - -X github.com/pulumi/pulumi-civo/provider/v2/pkg/version.Version={{.Tag}}
   main: ./cmd/pulumi-resource-civo/

--- a/provider-ci/providers/civo/repo/.goreleaser.yml
+++ b/provider-ci/providers/civo/repo/.goreleaser.yml
@@ -24,6 +24,7 @@ builds:
   - darwin
   - windows
   - linux
+  ignore: []
   ldflags:
   - -X github.com/pulumi/pulumi-civo/provider/v2/pkg/version.Version={{.Tag}}
   main: ./cmd/pulumi-resource-civo/
@@ -32,6 +33,9 @@ changelog:
     exclude:
     - Merge branch
     - Merge pull request
+    - '[internal]'
+    - '[ci]'
+    - '[chore]'
   sort: asc
   use: git
 release:

--- a/provider-ci/providers/cloudamqp/repo/.goreleaser.prerelease.yml
+++ b/provider-ci/providers/cloudamqp/repo/.goreleaser.prerelease.yml
@@ -24,6 +24,7 @@ builds:
   - darwin
   - windows
   - linux
+  ignore: []
   ldflags:
   - -X github.com/pulumi/pulumi-cloudamqp/provider/v3/pkg/version.Version={{.Tag}}
   main: ./cmd/pulumi-resource-cloudamqp/

--- a/provider-ci/providers/cloudamqp/repo/.goreleaser.yml
+++ b/provider-ci/providers/cloudamqp/repo/.goreleaser.yml
@@ -24,6 +24,7 @@ builds:
   - darwin
   - windows
   - linux
+  ignore: []
   ldflags:
   - -X github.com/pulumi/pulumi-cloudamqp/provider/v3/pkg/version.Version={{.Tag}}
   main: ./cmd/pulumi-resource-cloudamqp/
@@ -32,6 +33,9 @@ changelog:
     exclude:
     - Merge branch
     - Merge pull request
+    - '[internal]'
+    - '[ci]'
+    - '[chore]'
   sort: asc
   use: git
 release:

--- a/provider-ci/providers/cloudflare/repo/.goreleaser.prerelease.yml
+++ b/provider-ci/providers/cloudflare/repo/.goreleaser.prerelease.yml
@@ -24,6 +24,7 @@ builds:
   - darwin
   - windows
   - linux
+  ignore: []
   ldflags:
   - -X github.com/pulumi/pulumi-cloudflare/provider/v4/pkg/version.Version={{.Tag}}
   main: ./cmd/pulumi-resource-cloudflare/

--- a/provider-ci/providers/cloudflare/repo/.goreleaser.yml
+++ b/provider-ci/providers/cloudflare/repo/.goreleaser.yml
@@ -24,6 +24,7 @@ builds:
   - darwin
   - windows
   - linux
+  ignore: []
   ldflags:
   - -X github.com/pulumi/pulumi-cloudflare/provider/v4/pkg/version.Version={{.Tag}}
   main: ./cmd/pulumi-resource-cloudflare/
@@ -32,6 +33,9 @@ changelog:
     exclude:
     - Merge branch
     - Merge pull request
+    - '[internal]'
+    - '[ci]'
+    - '[chore]'
   sort: asc
   use: git
 release:

--- a/provider-ci/providers/cloudinit/repo/.goreleaser.prerelease.yml
+++ b/provider-ci/providers/cloudinit/repo/.goreleaser.prerelease.yml
@@ -24,6 +24,7 @@ builds:
   - darwin
   - windows
   - linux
+  ignore: []
   ldflags:
   - -X github.com/pulumi/pulumi-cloudinit/provider/pkg/version.Version={{.Tag}}
   main: ./cmd/pulumi-resource-cloudinit/

--- a/provider-ci/providers/cloudinit/repo/.goreleaser.yml
+++ b/provider-ci/providers/cloudinit/repo/.goreleaser.yml
@@ -24,6 +24,7 @@ builds:
   - darwin
   - windows
   - linux
+  ignore: []
   ldflags:
   - -X github.com/pulumi/pulumi-cloudinit/provider/pkg/version.Version={{.Tag}}
   main: ./cmd/pulumi-resource-cloudinit/
@@ -32,6 +33,9 @@ changelog:
     exclude:
     - Merge branch
     - Merge pull request
+    - '[internal]'
+    - '[ci]'
+    - '[chore]'
   sort: asc
   use: git
 release:

--- a/provider-ci/providers/confluent/repo/.goreleaser.prerelease.yml
+++ b/provider-ci/providers/confluent/repo/.goreleaser.prerelease.yml
@@ -24,6 +24,7 @@ builds:
   - darwin
   - windows
   - linux
+  ignore: []
   ldflags:
   - -X github.com/pulumi/pulumi-confluent/provider/pkg/version.Version={{.Tag}}
   main: ./cmd/pulumi-resource-confluent/

--- a/provider-ci/providers/confluent/repo/.goreleaser.yml
+++ b/provider-ci/providers/confluent/repo/.goreleaser.yml
@@ -24,6 +24,7 @@ builds:
   - darwin
   - windows
   - linux
+  ignore: []
   ldflags:
   - -X github.com/pulumi/pulumi-confluent/provider/pkg/version.Version={{.Tag}}
   main: ./cmd/pulumi-resource-confluent/
@@ -32,6 +33,9 @@ changelog:
     exclude:
     - Merge branch
     - Merge pull request
+    - '[internal]'
+    - '[ci]'
+    - '[chore]'
   sort: asc
   use: git
 release:

--- a/provider-ci/providers/consul/repo/.goreleaser.prerelease.yml
+++ b/provider-ci/providers/consul/repo/.goreleaser.prerelease.yml
@@ -24,6 +24,7 @@ builds:
   - darwin
   - windows
   - linux
+  ignore: []
   ldflags:
   - -X github.com/pulumi/pulumi-consul/provider/v3/pkg/version.Version={{.Tag}}
   main: ./cmd/pulumi-resource-consul/

--- a/provider-ci/providers/consul/repo/.goreleaser.yml
+++ b/provider-ci/providers/consul/repo/.goreleaser.yml
@@ -24,6 +24,7 @@ builds:
   - darwin
   - windows
   - linux
+  ignore: []
   ldflags:
   - -X github.com/pulumi/pulumi-consul/provider/v3/pkg/version.Version={{.Tag}}
   main: ./cmd/pulumi-resource-consul/
@@ -32,6 +33,9 @@ changelog:
     exclude:
     - Merge branch
     - Merge pull request
+    - '[internal]'
+    - '[ci]'
+    - '[chore]'
   sort: asc
   use: git
 release:

--- a/provider-ci/providers/datadog/repo/.goreleaser.prerelease.yml
+++ b/provider-ci/providers/datadog/repo/.goreleaser.prerelease.yml
@@ -24,6 +24,7 @@ builds:
   - darwin
   - windows
   - linux
+  ignore: []
   ldflags:
   - -X github.com/pulumi/pulumi-datadog/provider/v4/pkg/version.Version={{.Tag}}
   main: ./cmd/pulumi-resource-datadog/

--- a/provider-ci/providers/datadog/repo/.goreleaser.yml
+++ b/provider-ci/providers/datadog/repo/.goreleaser.yml
@@ -24,6 +24,7 @@ builds:
   - darwin
   - windows
   - linux
+  ignore: []
   ldflags:
   - -X github.com/pulumi/pulumi-datadog/provider/v4/pkg/version.Version={{.Tag}}
   main: ./cmd/pulumi-resource-datadog/
@@ -32,6 +33,9 @@ changelog:
     exclude:
     - Merge branch
     - Merge pull request
+    - '[internal]'
+    - '[ci]'
+    - '[chore]'
   sort: asc
   use: git
 release:

--- a/provider-ci/providers/digitalocean/repo/.goreleaser.prerelease.yml
+++ b/provider-ci/providers/digitalocean/repo/.goreleaser.prerelease.yml
@@ -24,6 +24,7 @@ builds:
   - darwin
   - windows
   - linux
+  ignore: []
   ldflags:
   - -X github.com/pulumi/pulumi-digitalocean/provider/v4/pkg/version.Version={{.Tag}}
   main: ./cmd/pulumi-resource-digitalocean/

--- a/provider-ci/providers/digitalocean/repo/.goreleaser.yml
+++ b/provider-ci/providers/digitalocean/repo/.goreleaser.yml
@@ -24,6 +24,7 @@ builds:
   - darwin
   - windows
   - linux
+  ignore: []
   ldflags:
   - -X github.com/pulumi/pulumi-digitalocean/provider/v4/pkg/version.Version={{.Tag}}
   main: ./cmd/pulumi-resource-digitalocean/
@@ -32,6 +33,9 @@ changelog:
     exclude:
     - Merge branch
     - Merge pull request
+    - '[internal]'
+    - '[ci]'
+    - '[chore]'
   sort: asc
   use: git
 release:

--- a/provider-ci/providers/dnsimple/repo/.goreleaser.prerelease.yml
+++ b/provider-ci/providers/dnsimple/repo/.goreleaser.prerelease.yml
@@ -24,6 +24,7 @@ builds:
   - darwin
   - windows
   - linux
+  ignore: []
   ldflags:
   - -X github.com/pulumi/pulumi-dnsimple/provider/v3/pkg/version.Version={{.Tag}}
   main: ./cmd/pulumi-resource-dnsimple/

--- a/provider-ci/providers/dnsimple/repo/.goreleaser.yml
+++ b/provider-ci/providers/dnsimple/repo/.goreleaser.yml
@@ -24,6 +24,7 @@ builds:
   - darwin
   - windows
   - linux
+  ignore: []
   ldflags:
   - -X github.com/pulumi/pulumi-dnsimple/provider/v3/pkg/version.Version={{.Tag}}
   main: ./cmd/pulumi-resource-dnsimple/
@@ -32,6 +33,9 @@ changelog:
     exclude:
     - Merge branch
     - Merge pull request
+    - '[internal]'
+    - '[ci]'
+    - '[chore]'
   sort: asc
   use: git
 release:

--- a/provider-ci/providers/docker/repo/.goreleaser.prerelease.yml
+++ b/provider-ci/providers/docker/repo/.goreleaser.prerelease.yml
@@ -24,6 +24,7 @@ builds:
   - darwin
   - windows
   - linux
+  ignore: []
   ldflags:
   - -X github.com/pulumi/pulumi-docker/provider/v3/pkg/version.Version={{.Tag}}
   main: ./cmd/pulumi-resource-docker/

--- a/provider-ci/providers/docker/repo/.goreleaser.yml
+++ b/provider-ci/providers/docker/repo/.goreleaser.yml
@@ -24,6 +24,7 @@ builds:
   - darwin
   - windows
   - linux
+  ignore: []
   ldflags:
   - -X github.com/pulumi/pulumi-docker/provider/v3/pkg/version.Version={{.Tag}}
   main: ./cmd/pulumi-resource-docker/
@@ -32,6 +33,9 @@ changelog:
     exclude:
     - Merge branch
     - Merge pull request
+    - '[internal]'
+    - '[ci]'
+    - '[chore]'
   sort: asc
   use: git
 release:

--- a/provider-ci/providers/ec/repo/.goreleaser.prerelease.yml
+++ b/provider-ci/providers/ec/repo/.goreleaser.prerelease.yml
@@ -24,6 +24,7 @@ builds:
   - darwin
   - windows
   - linux
+  ignore: []
   ldflags:
   - -X github.com/pulumi/pulumi-ec/provider/pkg/version.Version={{.Tag}}
   main: ./cmd/pulumi-resource-ec/

--- a/provider-ci/providers/ec/repo/.goreleaser.yml
+++ b/provider-ci/providers/ec/repo/.goreleaser.yml
@@ -24,6 +24,7 @@ builds:
   - darwin
   - windows
   - linux
+  ignore: []
   ldflags:
   - -X github.com/pulumi/pulumi-ec/provider/pkg/version.Version={{.Tag}}
   main: ./cmd/pulumi-resource-ec/
@@ -32,6 +33,9 @@ changelog:
     exclude:
     - Merge branch
     - Merge pull request
+    - '[internal]'
+    - '[ci]'
+    - '[chore]'
   sort: asc
   use: git
 release:

--- a/provider-ci/providers/equinix-metal/repo/.goreleaser.prerelease.yml
+++ b/provider-ci/providers/equinix-metal/repo/.goreleaser.prerelease.yml
@@ -24,6 +24,7 @@ builds:
   - darwin
   - windows
   - linux
+  ignore: []
   ldflags:
   - -X github.com/pulumi/pulumi-equinix-metal/provider/v3/pkg/version.Version={{.Tag}}
   main: ./cmd/pulumi-resource-equinix-metal/

--- a/provider-ci/providers/equinix-metal/repo/.goreleaser.yml
+++ b/provider-ci/providers/equinix-metal/repo/.goreleaser.yml
@@ -24,6 +24,7 @@ builds:
   - darwin
   - windows
   - linux
+  ignore: []
   ldflags:
   - -X github.com/pulumi/pulumi-equinix-metal/provider/v3/pkg/version.Version={{.Tag}}
   main: ./cmd/pulumi-resource-equinix-metal/
@@ -32,6 +33,9 @@ changelog:
     exclude:
     - Merge branch
     - Merge pull request
+    - '[internal]'
+    - '[ci]'
+    - '[chore]'
   sort: asc
   use: git
 release:

--- a/provider-ci/providers/f5bigip/repo/.goreleaser.prerelease.yml
+++ b/provider-ci/providers/f5bigip/repo/.goreleaser.prerelease.yml
@@ -24,6 +24,7 @@ builds:
   - darwin
   - windows
   - linux
+  ignore: []
   ldflags:
   - -X github.com/pulumi/pulumi-f5bigip/provider/v3/pkg/version.Version={{.Tag}}
   main: ./cmd/pulumi-resource-f5bigip/

--- a/provider-ci/providers/f5bigip/repo/.goreleaser.yml
+++ b/provider-ci/providers/f5bigip/repo/.goreleaser.yml
@@ -24,6 +24,7 @@ builds:
   - darwin
   - windows
   - linux
+  ignore: []
   ldflags:
   - -X github.com/pulumi/pulumi-f5bigip/provider/v3/pkg/version.Version={{.Tag}}
   main: ./cmd/pulumi-resource-f5bigip/
@@ -32,6 +33,9 @@ changelog:
     exclude:
     - Merge branch
     - Merge pull request
+    - '[internal]'
+    - '[ci]'
+    - '[chore]'
   sort: asc
   use: git
 release:

--- a/provider-ci/providers/fastly/repo/.goreleaser.prerelease.yml
+++ b/provider-ci/providers/fastly/repo/.goreleaser.prerelease.yml
@@ -24,6 +24,7 @@ builds:
   - darwin
   - windows
   - linux
+  ignore: []
   ldflags:
   - -X github.com/pulumi/pulumi-fastly/provider/v3/pkg/version.Version={{.Tag}}
   main: ./cmd/pulumi-resource-fastly/

--- a/provider-ci/providers/fastly/repo/.goreleaser.yml
+++ b/provider-ci/providers/fastly/repo/.goreleaser.yml
@@ -24,6 +24,7 @@ builds:
   - darwin
   - windows
   - linux
+  ignore: []
   ldflags:
   - -X github.com/pulumi/pulumi-fastly/provider/v3/pkg/version.Version={{.Tag}}
   main: ./cmd/pulumi-resource-fastly/
@@ -32,6 +33,9 @@ changelog:
     exclude:
     - Merge branch
     - Merge pull request
+    - '[internal]'
+    - '[ci]'
+    - '[chore]'
   sort: asc
   use: git
 release:

--- a/provider-ci/providers/gcp/repo/.goreleaser.prerelease.yml
+++ b/provider-ci/providers/gcp/repo/.goreleaser.prerelease.yml
@@ -24,6 +24,7 @@ builds:
   - darwin
   - windows
   - linux
+  ignore: []
   ldflags:
   - -X github.com/pulumi/pulumi-gcp/provider/v6/pkg/version.Version={{.Tag}}
   - -X github.com/hashicorp/terraform-provider-google-beta/version.ProviderVersion={{.Tag}}

--- a/provider-ci/providers/gcp/repo/.goreleaser.yml
+++ b/provider-ci/providers/gcp/repo/.goreleaser.yml
@@ -24,6 +24,7 @@ builds:
   - darwin
   - windows
   - linux
+  ignore: []
   ldflags:
   - -X github.com/pulumi/pulumi-gcp/provider/v6/pkg/version.Version={{.Tag}}
   - -X github.com/hashicorp/terraform-provider-google-beta/version.ProviderVersion={{.Tag}}
@@ -33,6 +34,9 @@ changelog:
     exclude:
     - Merge branch
     - Merge pull request
+    - '[internal]'
+    - '[ci]'
+    - '[chore]'
   sort: asc
   use: git
 release:

--- a/provider-ci/providers/github/repo/.goreleaser.prerelease.yml
+++ b/provider-ci/providers/github/repo/.goreleaser.prerelease.yml
@@ -24,6 +24,7 @@ builds:
   - darwin
   - windows
   - linux
+  ignore: []
   ldflags:
   - -X github.com/pulumi/pulumi-github/provider/v4/pkg/version.Version={{.Tag}}
   main: ./cmd/pulumi-resource-github/

--- a/provider-ci/providers/github/repo/.goreleaser.yml
+++ b/provider-ci/providers/github/repo/.goreleaser.yml
@@ -24,6 +24,7 @@ builds:
   - darwin
   - windows
   - linux
+  ignore: []
   ldflags:
   - -X github.com/pulumi/pulumi-github/provider/v4/pkg/version.Version={{.Tag}}
   main: ./cmd/pulumi-resource-github/
@@ -32,6 +33,9 @@ changelog:
     exclude:
     - Merge branch
     - Merge pull request
+    - '[internal]'
+    - '[ci]'
+    - '[chore]'
   sort: asc
   use: git
 release:

--- a/provider-ci/providers/gitlab/repo/.goreleaser.prerelease.yml
+++ b/provider-ci/providers/gitlab/repo/.goreleaser.prerelease.yml
@@ -24,6 +24,7 @@ builds:
   - darwin
   - windows
   - linux
+  ignore: []
   ldflags:
   - -X github.com/pulumi/pulumi-gitlab/provider/v4/pkg/version.Version={{.Tag}}
   main: ./cmd/pulumi-resource-gitlab/

--- a/provider-ci/providers/gitlab/repo/.goreleaser.yml
+++ b/provider-ci/providers/gitlab/repo/.goreleaser.yml
@@ -24,6 +24,7 @@ builds:
   - darwin
   - windows
   - linux
+  ignore: []
   ldflags:
   - -X github.com/pulumi/pulumi-gitlab/provider/v4/pkg/version.Version={{.Tag}}
   main: ./cmd/pulumi-resource-gitlab/
@@ -32,6 +33,9 @@ changelog:
     exclude:
     - Merge branch
     - Merge pull request
+    - '[internal]'
+    - '[ci]'
+    - '[chore]'
   sort: asc
   use: git
 release:

--- a/provider-ci/providers/hcloud/repo/.goreleaser.prerelease.yml
+++ b/provider-ci/providers/hcloud/repo/.goreleaser.prerelease.yml
@@ -24,6 +24,7 @@ builds:
   - darwin
   - windows
   - linux
+  ignore: []
   ldflags:
   - -X github.com/pulumi/pulumi-hcloud/provider/pkg/version.Version={{.Tag}}
   main: ./cmd/pulumi-resource-hcloud/

--- a/provider-ci/providers/hcloud/repo/.goreleaser.yml
+++ b/provider-ci/providers/hcloud/repo/.goreleaser.yml
@@ -24,6 +24,7 @@ builds:
   - darwin
   - windows
   - linux
+  ignore: []
   ldflags:
   - -X github.com/pulumi/pulumi-hcloud/provider/pkg/version.Version={{.Tag}}
   main: ./cmd/pulumi-resource-hcloud/
@@ -32,6 +33,9 @@ changelog:
     exclude:
     - Merge branch
     - Merge pull request
+    - '[internal]'
+    - '[ci]'
+    - '[chore]'
   sort: asc
   use: git
 release:

--- a/provider-ci/providers/kafka/repo/.goreleaser.prerelease.yml
+++ b/provider-ci/providers/kafka/repo/.goreleaser.prerelease.yml
@@ -24,6 +24,7 @@ builds:
   - darwin
   - windows
   - linux
+  ignore: []
   ldflags:
   - -X github.com/pulumi/pulumi-kafka/provider/v3/pkg/version.Version={{.Tag}}
   main: ./cmd/pulumi-resource-kafka/

--- a/provider-ci/providers/kafka/repo/.goreleaser.yml
+++ b/provider-ci/providers/kafka/repo/.goreleaser.yml
@@ -24,6 +24,7 @@ builds:
   - darwin
   - windows
   - linux
+  ignore: []
   ldflags:
   - -X github.com/pulumi/pulumi-kafka/provider/v3/pkg/version.Version={{.Tag}}
   main: ./cmd/pulumi-resource-kafka/
@@ -32,6 +33,9 @@ changelog:
     exclude:
     - Merge branch
     - Merge pull request
+    - '[internal]'
+    - '[ci]'
+    - '[chore]'
   sort: asc
   use: git
 release:

--- a/provider-ci/providers/keycloak/repo/.goreleaser.prerelease.yml
+++ b/provider-ci/providers/keycloak/repo/.goreleaser.prerelease.yml
@@ -24,6 +24,7 @@ builds:
   - darwin
   - windows
   - linux
+  ignore: []
   ldflags:
   - -X github.com/pulumi/pulumi-keycloak/provider/v4/pkg/version.Version={{.Tag}}
   main: ./cmd/pulumi-resource-keycloak/

--- a/provider-ci/providers/keycloak/repo/.goreleaser.yml
+++ b/provider-ci/providers/keycloak/repo/.goreleaser.yml
@@ -24,6 +24,7 @@ builds:
   - darwin
   - windows
   - linux
+  ignore: []
   ldflags:
   - -X github.com/pulumi/pulumi-keycloak/provider/v4/pkg/version.Version={{.Tag}}
   main: ./cmd/pulumi-resource-keycloak/
@@ -32,6 +33,9 @@ changelog:
     exclude:
     - Merge branch
     - Merge pull request
+    - '[internal]'
+    - '[ci]'
+    - '[chore]'
   sort: asc
   use: git
 release:

--- a/provider-ci/providers/kong/repo/.goreleaser.prerelease.yml
+++ b/provider-ci/providers/kong/repo/.goreleaser.prerelease.yml
@@ -24,6 +24,7 @@ builds:
   - darwin
   - windows
   - linux
+  ignore: []
   ldflags:
   - -X github.com/pulumi/pulumi-kong/provider/v4/pkg/version.Version={{.Tag}}
   main: ./cmd/pulumi-resource-kong/

--- a/provider-ci/providers/kong/repo/.goreleaser.yml
+++ b/provider-ci/providers/kong/repo/.goreleaser.yml
@@ -24,6 +24,7 @@ builds:
   - darwin
   - windows
   - linux
+  ignore: []
   ldflags:
   - -X github.com/pulumi/pulumi-kong/provider/v4/pkg/version.Version={{.Tag}}
   main: ./cmd/pulumi-resource-kong/
@@ -32,6 +33,9 @@ changelog:
     exclude:
     - Merge branch
     - Merge pull request
+    - '[internal]'
+    - '[ci]'
+    - '[chore]'
   sort: asc
   use: git
 release:

--- a/provider-ci/providers/libvirt/repo/.goreleaser.prerelease.yml
+++ b/provider-ci/providers/libvirt/repo/.goreleaser.prerelease.yml
@@ -24,6 +24,7 @@ builds:
   - darwin
   - windows
   - linux
+  ignore: []
   ldflags:
   - -X github.com/pulumi/pulumi-libvirt/provider/pkg/version.Version={{.Tag}}
   main: ./cmd/pulumi-resource-libvirt/

--- a/provider-ci/providers/libvirt/repo/.goreleaser.yml
+++ b/provider-ci/providers/libvirt/repo/.goreleaser.yml
@@ -24,6 +24,7 @@ builds:
   - darwin
   - windows
   - linux
+  ignore: []
   ldflags:
   - -X github.com/pulumi/pulumi-libvirt/provider/pkg/version.Version={{.Tag}}
   main: ./cmd/pulumi-resource-libvirt/
@@ -32,6 +33,9 @@ changelog:
     exclude:
     - Merge branch
     - Merge pull request
+    - '[internal]'
+    - '[ci]'
+    - '[chore]'
   sort: asc
   use: git
 release:

--- a/provider-ci/providers/linode/repo/.goreleaser.prerelease.yml
+++ b/provider-ci/providers/linode/repo/.goreleaser.prerelease.yml
@@ -24,6 +24,7 @@ builds:
   - darwin
   - windows
   - linux
+  ignore: []
   ldflags:
   - -X github.com/pulumi/pulumi-linode/provider/v3/pkg/version.Version={{.Tag}}
   main: ./cmd/pulumi-resource-linode/

--- a/provider-ci/providers/linode/repo/.goreleaser.yml
+++ b/provider-ci/providers/linode/repo/.goreleaser.yml
@@ -24,6 +24,7 @@ builds:
   - darwin
   - windows
   - linux
+  ignore: []
   ldflags:
   - -X github.com/pulumi/pulumi-linode/provider/v3/pkg/version.Version={{.Tag}}
   main: ./cmd/pulumi-resource-linode/
@@ -32,6 +33,9 @@ changelog:
     exclude:
     - Merge branch
     - Merge pull request
+    - '[internal]'
+    - '[ci]'
+    - '[chore]'
   sort: asc
   use: git
 release:

--- a/provider-ci/providers/mailgun/repo/.goreleaser.prerelease.yml
+++ b/provider-ci/providers/mailgun/repo/.goreleaser.prerelease.yml
@@ -24,6 +24,7 @@ builds:
   - darwin
   - windows
   - linux
+  ignore: []
   ldflags:
   - -X github.com/pulumi/pulumi-mailgun/provider/v3/pkg/version.Version={{.Tag}}
   main: ./cmd/pulumi-resource-mailgun/

--- a/provider-ci/providers/mailgun/repo/.goreleaser.yml
+++ b/provider-ci/providers/mailgun/repo/.goreleaser.yml
@@ -24,6 +24,7 @@ builds:
   - darwin
   - windows
   - linux
+  ignore: []
   ldflags:
   - -X github.com/pulumi/pulumi-mailgun/provider/v3/pkg/version.Version={{.Tag}}
   main: ./cmd/pulumi-resource-mailgun/
@@ -32,6 +33,9 @@ changelog:
     exclude:
     - Merge branch
     - Merge pull request
+    - '[internal]'
+    - '[ci]'
+    - '[chore]'
   sort: asc
   use: git
 release:

--- a/provider-ci/providers/minio/config.yaml
+++ b/provider-ci/providers/minio/config.yaml
@@ -7,3 +7,4 @@ env:
   MINIO_SECRET_KEY: minio123
   MINIO_ENABLE_HTTPS: false
 upstream-provider-org: pulumi
+skipWindowsArmBuild: true

--- a/provider-ci/providers/minio/repo/.goreleaser.prerelease.yml
+++ b/provider-ci/providers/minio/repo/.goreleaser.prerelease.yml
@@ -24,6 +24,9 @@ builds:
   - darwin
   - windows
   - linux
+  ignore:
+  - goarch: arm64
+    goos: windows
   ldflags:
   - -X github.com/pulumi/pulumi-minio/provider/pkg/version.Version={{.Tag}}
   main: ./cmd/pulumi-resource-minio/

--- a/provider-ci/providers/minio/repo/.goreleaser.yml
+++ b/provider-ci/providers/minio/repo/.goreleaser.yml
@@ -24,6 +24,9 @@ builds:
   - darwin
   - windows
   - linux
+  ignore:
+  - goarch: arm64
+    goos: windows
   ldflags:
   - -X github.com/pulumi/pulumi-minio/provider/pkg/version.Version={{.Tag}}
   main: ./cmd/pulumi-resource-minio/
@@ -32,6 +35,9 @@ changelog:
     exclude:
     - Merge branch
     - Merge pull request
+    - '[internal]'
+    - '[ci]'
+    - '[chore]'
   sort: asc
   use: git
 release:

--- a/provider-ci/providers/mongodbatlas/repo/.goreleaser.prerelease.yml
+++ b/provider-ci/providers/mongodbatlas/repo/.goreleaser.prerelease.yml
@@ -24,6 +24,7 @@ builds:
   - darwin
   - windows
   - linux
+  ignore: []
   ldflags:
   - -X github.com/pulumi/pulumi-mongodbatlas/provider/v3/pkg/version.Version={{.Tag}}
   main: ./cmd/pulumi-resource-mongodbatlas/

--- a/provider-ci/providers/mongodbatlas/repo/.goreleaser.yml
+++ b/provider-ci/providers/mongodbatlas/repo/.goreleaser.yml
@@ -24,6 +24,7 @@ builds:
   - darwin
   - windows
   - linux
+  ignore: []
   ldflags:
   - -X github.com/pulumi/pulumi-mongodbatlas/provider/v3/pkg/version.Version={{.Tag}}
   main: ./cmd/pulumi-resource-mongodbatlas/
@@ -32,6 +33,9 @@ changelog:
     exclude:
     - Merge branch
     - Merge pull request
+    - '[internal]'
+    - '[ci]'
+    - '[chore]'
   sort: asc
   use: git
 release:

--- a/provider-ci/providers/mysql/repo/.goreleaser.prerelease.yml
+++ b/provider-ci/providers/mysql/repo/.goreleaser.prerelease.yml
@@ -24,6 +24,7 @@ builds:
   - darwin
   - windows
   - linux
+  ignore: []
   ldflags:
   - -X github.com/pulumi/pulumi-mysql/provider/v3/pkg/version.Version={{.Tag}}
   main: ./cmd/pulumi-resource-mysql/

--- a/provider-ci/providers/mysql/repo/.goreleaser.yml
+++ b/provider-ci/providers/mysql/repo/.goreleaser.yml
@@ -24,6 +24,7 @@ builds:
   - darwin
   - windows
   - linux
+  ignore: []
   ldflags:
   - -X github.com/pulumi/pulumi-mysql/provider/v3/pkg/version.Version={{.Tag}}
   main: ./cmd/pulumi-resource-mysql/
@@ -32,6 +33,9 @@ changelog:
     exclude:
     - Merge branch
     - Merge pull request
+    - '[internal]'
+    - '[ci]'
+    - '[chore]'
   sort: asc
   use: git
 release:

--- a/provider-ci/providers/newrelic/repo/.goreleaser.prerelease.yml
+++ b/provider-ci/providers/newrelic/repo/.goreleaser.prerelease.yml
@@ -24,6 +24,7 @@ builds:
   - darwin
   - windows
   - linux
+  ignore: []
   ldflags:
   - -X github.com/pulumi/pulumi-newrelic/provider/v4/pkg/version.Version={{.Tag}}
   main: ./cmd/pulumi-resource-newrelic/

--- a/provider-ci/providers/newrelic/repo/.goreleaser.yml
+++ b/provider-ci/providers/newrelic/repo/.goreleaser.yml
@@ -24,6 +24,7 @@ builds:
   - darwin
   - windows
   - linux
+  ignore: []
   ldflags:
   - -X github.com/pulumi/pulumi-newrelic/provider/v4/pkg/version.Version={{.Tag}}
   main: ./cmd/pulumi-resource-newrelic/
@@ -32,6 +33,9 @@ changelog:
     exclude:
     - Merge branch
     - Merge pull request
+    - '[internal]'
+    - '[ci]'
+    - '[chore]'
   sort: asc
   use: git
 release:

--- a/provider-ci/providers/nomad/repo/.goreleaser.prerelease.yml
+++ b/provider-ci/providers/nomad/repo/.goreleaser.prerelease.yml
@@ -24,6 +24,7 @@ builds:
   - darwin
   - windows
   - linux
+  ignore: []
   ldflags:
   - -X github.com/pulumi/pulumi-nomad/provider/pkg/version.Version={{.Tag}}
   main: ./cmd/pulumi-resource-nomad/

--- a/provider-ci/providers/nomad/repo/.goreleaser.yml
+++ b/provider-ci/providers/nomad/repo/.goreleaser.yml
@@ -24,6 +24,7 @@ builds:
   - darwin
   - windows
   - linux
+  ignore: []
   ldflags:
   - -X github.com/pulumi/pulumi-nomad/provider/pkg/version.Version={{.Tag}}
   main: ./cmd/pulumi-resource-nomad/
@@ -32,6 +33,9 @@ changelog:
     exclude:
     - Merge branch
     - Merge pull request
+    - '[internal]'
+    - '[ci]'
+    - '[chore]'
   sort: asc
   use: git
 release:

--- a/provider-ci/providers/ns1/repo/.goreleaser.prerelease.yml
+++ b/provider-ci/providers/ns1/repo/.goreleaser.prerelease.yml
@@ -24,6 +24,7 @@ builds:
   - darwin
   - windows
   - linux
+  ignore: []
   ldflags:
   - -X github.com/pulumi/pulumi-ns1/provider/v2/pkg/version.Version={{.Tag}}
   main: ./cmd/pulumi-resource-ns1/

--- a/provider-ci/providers/ns1/repo/.goreleaser.yml
+++ b/provider-ci/providers/ns1/repo/.goreleaser.yml
@@ -24,6 +24,7 @@ builds:
   - darwin
   - windows
   - linux
+  ignore: []
   ldflags:
   - -X github.com/pulumi/pulumi-ns1/provider/v2/pkg/version.Version={{.Tag}}
   main: ./cmd/pulumi-resource-ns1/
@@ -32,6 +33,9 @@ changelog:
     exclude:
     - Merge branch
     - Merge pull request
+    - '[internal]'
+    - '[ci]'
+    - '[chore]'
   sort: asc
   use: git
 release:

--- a/provider-ci/providers/okta/repo/.goreleaser.prerelease.yml
+++ b/provider-ci/providers/okta/repo/.goreleaser.prerelease.yml
@@ -24,6 +24,7 @@ builds:
   - darwin
   - windows
   - linux
+  ignore: []
   ldflags:
   - -X github.com/pulumi/pulumi-okta/provider/v3/pkg/version.Version={{.Tag}}
   main: ./cmd/pulumi-resource-okta/

--- a/provider-ci/providers/okta/repo/.goreleaser.yml
+++ b/provider-ci/providers/okta/repo/.goreleaser.yml
@@ -24,6 +24,7 @@ builds:
   - darwin
   - windows
   - linux
+  ignore: []
   ldflags:
   - -X github.com/pulumi/pulumi-okta/provider/v3/pkg/version.Version={{.Tag}}
   main: ./cmd/pulumi-resource-okta/
@@ -32,6 +33,9 @@ changelog:
     exclude:
     - Merge branch
     - Merge pull request
+    - '[internal]'
+    - '[ci]'
+    - '[chore]'
   sort: asc
   use: git
 release:

--- a/provider-ci/providers/openstack/repo/.goreleaser.prerelease.yml
+++ b/provider-ci/providers/openstack/repo/.goreleaser.prerelease.yml
@@ -24,6 +24,7 @@ builds:
   - darwin
   - windows
   - linux
+  ignore: []
   ldflags:
   - -X github.com/pulumi/pulumi-openstack/provider/v3/pkg/version.Version={{.Tag}}
   main: ./cmd/pulumi-resource-openstack/

--- a/provider-ci/providers/openstack/repo/.goreleaser.yml
+++ b/provider-ci/providers/openstack/repo/.goreleaser.yml
@@ -24,6 +24,7 @@ builds:
   - darwin
   - windows
   - linux
+  ignore: []
   ldflags:
   - -X github.com/pulumi/pulumi-openstack/provider/v3/pkg/version.Version={{.Tag}}
   main: ./cmd/pulumi-resource-openstack/
@@ -32,6 +33,9 @@ changelog:
     exclude:
     - Merge branch
     - Merge pull request
+    - '[internal]'
+    - '[ci]'
+    - '[chore]'
   sort: asc
   use: git
 release:

--- a/provider-ci/providers/opsgenie/repo/.goreleaser.prerelease.yml
+++ b/provider-ci/providers/opsgenie/repo/.goreleaser.prerelease.yml
@@ -24,6 +24,7 @@ builds:
   - darwin
   - windows
   - linux
+  ignore: []
   ldflags:
   - -X github.com/pulumi/pulumi-opsgenie/provider/pkg/version.Version={{.Tag}}
   main: ./cmd/pulumi-resource-opsgenie/

--- a/provider-ci/providers/opsgenie/repo/.goreleaser.yml
+++ b/provider-ci/providers/opsgenie/repo/.goreleaser.yml
@@ -24,6 +24,7 @@ builds:
   - darwin
   - windows
   - linux
+  ignore: []
   ldflags:
   - -X github.com/pulumi/pulumi-opsgenie/provider/pkg/version.Version={{.Tag}}
   main: ./cmd/pulumi-resource-opsgenie/
@@ -32,6 +33,9 @@ changelog:
     exclude:
     - Merge branch
     - Merge pull request
+    - '[internal]'
+    - '[ci]'
+    - '[chore]'
   sort: asc
   use: git
 release:

--- a/provider-ci/providers/pagerduty/repo/.goreleaser.prerelease.yml
+++ b/provider-ci/providers/pagerduty/repo/.goreleaser.prerelease.yml
@@ -24,6 +24,7 @@ builds:
   - darwin
   - windows
   - linux
+  ignore: []
   ldflags:
   - -X github.com/pulumi/pulumi-pagerduty/provider/v3/pkg/version.Version={{.Tag}}
   main: ./cmd/pulumi-resource-pagerduty/

--- a/provider-ci/providers/pagerduty/repo/.goreleaser.yml
+++ b/provider-ci/providers/pagerduty/repo/.goreleaser.yml
@@ -24,6 +24,7 @@ builds:
   - darwin
   - windows
   - linux
+  ignore: []
   ldflags:
   - -X github.com/pulumi/pulumi-pagerduty/provider/v3/pkg/version.Version={{.Tag}}
   main: ./cmd/pulumi-resource-pagerduty/
@@ -32,6 +33,9 @@ changelog:
     exclude:
     - Merge branch
     - Merge pull request
+    - '[internal]'
+    - '[ci]'
+    - '[chore]'
   sort: asc
   use: git
 release:

--- a/provider-ci/providers/postgresql/repo/.goreleaser.prerelease.yml
+++ b/provider-ci/providers/postgresql/repo/.goreleaser.prerelease.yml
@@ -24,6 +24,7 @@ builds:
   - darwin
   - windows
   - linux
+  ignore: []
   ldflags:
   - -X github.com/pulumi/pulumi-postgresql/provider/v3/pkg/version.Version={{.Tag}}
   main: ./cmd/pulumi-resource-postgresql/

--- a/provider-ci/providers/postgresql/repo/.goreleaser.yml
+++ b/provider-ci/providers/postgresql/repo/.goreleaser.yml
@@ -24,6 +24,7 @@ builds:
   - darwin
   - windows
   - linux
+  ignore: []
   ldflags:
   - -X github.com/pulumi/pulumi-postgresql/provider/v3/pkg/version.Version={{.Tag}}
   main: ./cmd/pulumi-resource-postgresql/
@@ -32,6 +33,9 @@ changelog:
     exclude:
     - Merge branch
     - Merge pull request
+    - '[internal]'
+    - '[ci]'
+    - '[chore]'
   sort: asc
   use: git
 release:

--- a/provider-ci/providers/rabbitmq/repo/.goreleaser.prerelease.yml
+++ b/provider-ci/providers/rabbitmq/repo/.goreleaser.prerelease.yml
@@ -24,6 +24,7 @@ builds:
   - darwin
   - windows
   - linux
+  ignore: []
   ldflags:
   - -X github.com/pulumi/pulumi-rabbitmq/provider/v3/pkg/version.Version={{.Tag}}
   main: ./cmd/pulumi-resource-rabbitmq/

--- a/provider-ci/providers/rabbitmq/repo/.goreleaser.yml
+++ b/provider-ci/providers/rabbitmq/repo/.goreleaser.yml
@@ -24,6 +24,7 @@ builds:
   - darwin
   - windows
   - linux
+  ignore: []
   ldflags:
   - -X github.com/pulumi/pulumi-rabbitmq/provider/v3/pkg/version.Version={{.Tag}}
   main: ./cmd/pulumi-resource-rabbitmq/
@@ -32,6 +33,9 @@ changelog:
     exclude:
     - Merge branch
     - Merge pull request
+    - '[internal]'
+    - '[ci]'
+    - '[chore]'
   sort: asc
   use: git
 release:

--- a/provider-ci/providers/rancher2/repo/.goreleaser.prerelease.yml
+++ b/provider-ci/providers/rancher2/repo/.goreleaser.prerelease.yml
@@ -24,6 +24,7 @@ builds:
   - darwin
   - windows
   - linux
+  ignore: []
   ldflags:
   - -X github.com/pulumi/pulumi-rancher2/provider/v3/pkg/version.Version={{.Tag}}
   main: ./cmd/pulumi-resource-rancher2/

--- a/provider-ci/providers/rancher2/repo/.goreleaser.yml
+++ b/provider-ci/providers/rancher2/repo/.goreleaser.yml
@@ -24,6 +24,7 @@ builds:
   - darwin
   - windows
   - linux
+  ignore: []
   ldflags:
   - -X github.com/pulumi/pulumi-rancher2/provider/v3/pkg/version.Version={{.Tag}}
   main: ./cmd/pulumi-resource-rancher2/
@@ -32,6 +33,9 @@ changelog:
     exclude:
     - Merge branch
     - Merge pull request
+    - '[internal]'
+    - '[ci]'
+    - '[chore]'
   sort: asc
   use: git
 release:

--- a/provider-ci/providers/random/repo/.goreleaser.prerelease.yml
+++ b/provider-ci/providers/random/repo/.goreleaser.prerelease.yml
@@ -24,6 +24,7 @@ builds:
   - darwin
   - windows
   - linux
+  ignore: []
   ldflags:
   - -X github.com/pulumi/pulumi-random/provider/v4/pkg/version.Version={{.Tag}}
   main: ./cmd/pulumi-resource-random/

--- a/provider-ci/providers/random/repo/.goreleaser.yml
+++ b/provider-ci/providers/random/repo/.goreleaser.yml
@@ -24,6 +24,7 @@ builds:
   - darwin
   - windows
   - linux
+  ignore: []
   ldflags:
   - -X github.com/pulumi/pulumi-random/provider/v4/pkg/version.Version={{.Tag}}
   main: ./cmd/pulumi-resource-random/
@@ -32,6 +33,9 @@ changelog:
     exclude:
     - Merge branch
     - Merge pull request
+    - '[internal]'
+    - '[ci]'
+    - '[chore]'
   sort: asc
   use: git
 release:

--- a/provider-ci/providers/rke/repo/.goreleaser.prerelease.yml
+++ b/provider-ci/providers/rke/repo/.goreleaser.prerelease.yml
@@ -24,6 +24,7 @@ builds:
   - darwin
   - windows
   - linux
+  ignore: []
   ldflags:
   - -X github.com/pulumi/pulumi-rke/provider/v3/pkg/version.Version={{.Tag}}
   main: ./cmd/pulumi-resource-rke/

--- a/provider-ci/providers/rke/repo/.goreleaser.yml
+++ b/provider-ci/providers/rke/repo/.goreleaser.yml
@@ -24,6 +24,7 @@ builds:
   - darwin
   - windows
   - linux
+  ignore: []
   ldflags:
   - -X github.com/pulumi/pulumi-rke/provider/v3/pkg/version.Version={{.Tag}}
   main: ./cmd/pulumi-resource-rke/
@@ -32,6 +33,9 @@ changelog:
     exclude:
     - Merge branch
     - Merge pull request
+    - '[internal]'
+    - '[ci]'
+    - '[chore]'
   sort: asc
   use: git
 release:

--- a/provider-ci/providers/signalfx/repo/.goreleaser.prerelease.yml
+++ b/provider-ci/providers/signalfx/repo/.goreleaser.prerelease.yml
@@ -24,6 +24,7 @@ builds:
   - darwin
   - windows
   - linux
+  ignore: []
   ldflags:
   - -X github.com/pulumi/pulumi-signalfx/provider/v5/pkg/version.Version={{.Tag}}
   main: ./cmd/pulumi-resource-signalfx/

--- a/provider-ci/providers/signalfx/repo/.goreleaser.yml
+++ b/provider-ci/providers/signalfx/repo/.goreleaser.yml
@@ -24,6 +24,7 @@ builds:
   - darwin
   - windows
   - linux
+  ignore: []
   ldflags:
   - -X github.com/pulumi/pulumi-signalfx/provider/v5/pkg/version.Version={{.Tag}}
   main: ./cmd/pulumi-resource-signalfx/
@@ -32,6 +33,9 @@ changelog:
     exclude:
     - Merge branch
     - Merge pull request
+    - '[internal]'
+    - '[ci]'
+    - '[chore]'
   sort: asc
   use: git
 release:

--- a/provider-ci/providers/snowflake/repo/.goreleaser.prerelease.yml
+++ b/provider-ci/providers/snowflake/repo/.goreleaser.prerelease.yml
@@ -24,6 +24,7 @@ builds:
   - darwin
   - windows
   - linux
+  ignore: []
   ldflags:
   - -X github.com/pulumi/pulumi-snowflake/provider/pkg/version.Version={{.Tag}}
   main: ./cmd/pulumi-resource-snowflake/

--- a/provider-ci/providers/snowflake/repo/.goreleaser.yml
+++ b/provider-ci/providers/snowflake/repo/.goreleaser.yml
@@ -24,6 +24,7 @@ builds:
   - darwin
   - windows
   - linux
+  ignore: []
   ldflags:
   - -X github.com/pulumi/pulumi-snowflake/provider/pkg/version.Version={{.Tag}}
   main: ./cmd/pulumi-resource-snowflake/
@@ -32,6 +33,9 @@ changelog:
     exclude:
     - Merge branch
     - Merge pull request
+    - '[internal]'
+    - '[ci]'
+    - '[chore]'
   sort: asc
   use: git
 release:

--- a/provider-ci/providers/splunk/repo/.goreleaser.prerelease.yml
+++ b/provider-ci/providers/splunk/repo/.goreleaser.prerelease.yml
@@ -24,6 +24,7 @@ builds:
   - darwin
   - windows
   - linux
+  ignore: []
   ldflags:
   - -X github.com/pulumi/pulumi-splunk/provider/pkg/version.Version={{.Tag}}
   main: ./cmd/pulumi-resource-splunk/

--- a/provider-ci/providers/splunk/repo/.goreleaser.yml
+++ b/provider-ci/providers/splunk/repo/.goreleaser.yml
@@ -24,6 +24,7 @@ builds:
   - darwin
   - windows
   - linux
+  ignore: []
   ldflags:
   - -X github.com/pulumi/pulumi-splunk/provider/pkg/version.Version={{.Tag}}
   main: ./cmd/pulumi-resource-splunk/
@@ -32,6 +33,9 @@ changelog:
     exclude:
     - Merge branch
     - Merge pull request
+    - '[internal]'
+    - '[ci]'
+    - '[chore]'
   sort: asc
   use: git
 release:

--- a/provider-ci/providers/spotinst/repo/.goreleaser.prerelease.yml
+++ b/provider-ci/providers/spotinst/repo/.goreleaser.prerelease.yml
@@ -24,6 +24,7 @@ builds:
   - darwin
   - windows
   - linux
+  ignore: []
   ldflags:
   - -X github.com/pulumi/pulumi-spotinst/provider/v3/pkg/version.Version={{.Tag}}
   main: ./cmd/pulumi-resource-spotinst/

--- a/provider-ci/providers/spotinst/repo/.goreleaser.yml
+++ b/provider-ci/providers/spotinst/repo/.goreleaser.yml
@@ -24,6 +24,7 @@ builds:
   - darwin
   - windows
   - linux
+  ignore: []
   ldflags:
   - -X github.com/pulumi/pulumi-spotinst/provider/v3/pkg/version.Version={{.Tag}}
   main: ./cmd/pulumi-resource-spotinst/
@@ -32,6 +33,9 @@ changelog:
     exclude:
     - Merge branch
     - Merge pull request
+    - '[internal]'
+    - '[ci]'
+    - '[chore]'
   sort: asc
   use: git
 release:

--- a/provider-ci/providers/sumologic/repo/.goreleaser.prerelease.yml
+++ b/provider-ci/providers/sumologic/repo/.goreleaser.prerelease.yml
@@ -24,6 +24,7 @@ builds:
   - darwin
   - windows
   - linux
+  ignore: []
   ldflags:
   - -X github.com/pulumi/pulumi-sumologic/provider/pkg/version.Version={{.Tag}}
   main: ./cmd/pulumi-resource-sumologic/

--- a/provider-ci/providers/sumologic/repo/.goreleaser.yml
+++ b/provider-ci/providers/sumologic/repo/.goreleaser.yml
@@ -24,6 +24,7 @@ builds:
   - darwin
   - windows
   - linux
+  ignore: []
   ldflags:
   - -X github.com/pulumi/pulumi-sumologic/provider/pkg/version.Version={{.Tag}}
   main: ./cmd/pulumi-resource-sumologic/
@@ -32,6 +33,9 @@ changelog:
     exclude:
     - Merge branch
     - Merge pull request
+    - '[internal]'
+    - '[ci]'
+    - '[chore]'
   sort: asc
   use: git
 release:

--- a/provider-ci/providers/tailscale/repo/.goreleaser.prerelease.yml
+++ b/provider-ci/providers/tailscale/repo/.goreleaser.prerelease.yml
@@ -24,6 +24,7 @@ builds:
   - darwin
   - windows
   - linux
+  ignore: []
   ldflags:
   - -X github.com/pulumi/pulumi-tailscale/provider/pkg/version.Version={{.Tag}}
   main: ./cmd/pulumi-resource-tailscale/

--- a/provider-ci/providers/tailscale/repo/.goreleaser.yml
+++ b/provider-ci/providers/tailscale/repo/.goreleaser.yml
@@ -24,6 +24,7 @@ builds:
   - darwin
   - windows
   - linux
+  ignore: []
   ldflags:
   - -X github.com/pulumi/pulumi-tailscale/provider/pkg/version.Version={{.Tag}}
   main: ./cmd/pulumi-resource-tailscale/
@@ -32,6 +33,9 @@ changelog:
     exclude:
     - Merge branch
     - Merge pull request
+    - '[internal]'
+    - '[ci]'
+    - '[chore]'
   sort: asc
   use: git
 release:

--- a/provider-ci/providers/terraform/repo/.goreleaser.prerelease.yml
+++ b/provider-ci/providers/terraform/repo/.goreleaser.prerelease.yml
@@ -21,6 +21,7 @@ builds:
   - darwin
   - windows
   - linux
+  ignore: []
   ldflags:
   - -X github.com/pulumi/pulumi-terraform/provider/v5/pkg/version.Version={{.Tag}}
   main: ./cmd/pulumi-resource-terraform/

--- a/provider-ci/providers/terraform/repo/.goreleaser.yml
+++ b/provider-ci/providers/terraform/repo/.goreleaser.yml
@@ -21,6 +21,7 @@ builds:
   - darwin
   - windows
   - linux
+  ignore: []
   ldflags:
   - -X github.com/pulumi/pulumi-terraform/provider/v5/pkg/version.Version={{.Tag}}
   main: ./cmd/pulumi-resource-terraform/
@@ -29,6 +30,9 @@ changelog:
     exclude:
     - Merge branch
     - Merge pull request
+    - '[internal]'
+    - '[ci]'
+    - '[chore]'
   sort: asc
   use: git
 release:

--- a/provider-ci/providers/tls/repo/.goreleaser.prerelease.yml
+++ b/provider-ci/providers/tls/repo/.goreleaser.prerelease.yml
@@ -24,6 +24,7 @@ builds:
   - darwin
   - windows
   - linux
+  ignore: []
   ldflags:
   - -X github.com/pulumi/pulumi-tls/provider/v4/pkg/version.Version={{.Tag}}
   main: ./cmd/pulumi-resource-tls/

--- a/provider-ci/providers/tls/repo/.goreleaser.yml
+++ b/provider-ci/providers/tls/repo/.goreleaser.yml
@@ -24,6 +24,7 @@ builds:
   - darwin
   - windows
   - linux
+  ignore: []
   ldflags:
   - -X github.com/pulumi/pulumi-tls/provider/v4/pkg/version.Version={{.Tag}}
   main: ./cmd/pulumi-resource-tls/
@@ -32,6 +33,9 @@ changelog:
     exclude:
     - Merge branch
     - Merge pull request
+    - '[internal]'
+    - '[ci]'
+    - '[chore]'
   sort: asc
   use: git
 release:

--- a/provider-ci/providers/vault/repo/.goreleaser.prerelease.yml
+++ b/provider-ci/providers/vault/repo/.goreleaser.prerelease.yml
@@ -24,6 +24,7 @@ builds:
   - darwin
   - windows
   - linux
+  ignore: []
   ldflags:
   - -X github.com/pulumi/pulumi-vault/provider/v5/pkg/version.Version={{.Tag}}
   main: ./cmd/pulumi-resource-vault/

--- a/provider-ci/providers/vault/repo/.goreleaser.yml
+++ b/provider-ci/providers/vault/repo/.goreleaser.yml
@@ -24,6 +24,7 @@ builds:
   - darwin
   - windows
   - linux
+  ignore: []
   ldflags:
   - -X github.com/pulumi/pulumi-vault/provider/v5/pkg/version.Version={{.Tag}}
   main: ./cmd/pulumi-resource-vault/
@@ -32,6 +33,9 @@ changelog:
     exclude:
     - Merge branch
     - Merge pull request
+    - '[internal]'
+    - '[ci]'
+    - '[chore]'
   sort: asc
   use: git
 release:

--- a/provider-ci/providers/venafi/repo/.goreleaser.prerelease.yml
+++ b/provider-ci/providers/venafi/repo/.goreleaser.prerelease.yml
@@ -24,6 +24,7 @@ builds:
   - darwin
   - windows
   - linux
+  ignore: []
   ldflags:
   - -X github.com/pulumi/pulumi-venafi/provider/pkg/version.Version={{.Tag}}
   main: ./cmd/pulumi-resource-venafi/

--- a/provider-ci/providers/venafi/repo/.goreleaser.yml
+++ b/provider-ci/providers/venafi/repo/.goreleaser.yml
@@ -24,6 +24,7 @@ builds:
   - darwin
   - windows
   - linux
+  ignore: []
   ldflags:
   - -X github.com/pulumi/pulumi-venafi/provider/pkg/version.Version={{.Tag}}
   main: ./cmd/pulumi-resource-venafi/
@@ -32,6 +33,9 @@ changelog:
     exclude:
     - Merge branch
     - Merge pull request
+    - '[internal]'
+    - '[ci]'
+    - '[chore]'
   sort: asc
   use: git
 release:

--- a/provider-ci/providers/vsphere/repo/.goreleaser.prerelease.yml
+++ b/provider-ci/providers/vsphere/repo/.goreleaser.prerelease.yml
@@ -24,6 +24,7 @@ builds:
   - darwin
   - windows
   - linux
+  ignore: []
   ldflags:
   - -X github.com/pulumi/pulumi-vsphere/provider/v4/pkg/version.Version={{.Tag}}
   main: ./cmd/pulumi-resource-vsphere/

--- a/provider-ci/providers/vsphere/repo/.goreleaser.yml
+++ b/provider-ci/providers/vsphere/repo/.goreleaser.yml
@@ -24,6 +24,7 @@ builds:
   - darwin
   - windows
   - linux
+  ignore: []
   ldflags:
   - -X github.com/pulumi/pulumi-vsphere/provider/v4/pkg/version.Version={{.Tag}}
   main: ./cmd/pulumi-resource-vsphere/
@@ -32,6 +33,9 @@ changelog:
     exclude:
     - Merge branch
     - Merge pull request
+    - '[internal]'
+    - '[ci]'
+    - '[chore]'
   sort: asc
   use: git
 release:

--- a/provider-ci/providers/wavefront/repo/.goreleaser.prerelease.yml
+++ b/provider-ci/providers/wavefront/repo/.goreleaser.prerelease.yml
@@ -24,6 +24,7 @@ builds:
   - darwin
   - windows
   - linux
+  ignore: []
   ldflags:
   - -X github.com/pulumi/pulumi-wavefront/provider/pkg/version.Version={{.Tag}}
   main: ./cmd/pulumi-resource-wavefront/

--- a/provider-ci/providers/wavefront/repo/.goreleaser.yml
+++ b/provider-ci/providers/wavefront/repo/.goreleaser.yml
@@ -24,6 +24,7 @@ builds:
   - darwin
   - windows
   - linux
+  ignore: []
   ldflags:
   - -X github.com/pulumi/pulumi-wavefront/provider/pkg/version.Version={{.Tag}}
   main: ./cmd/pulumi-resource-wavefront/
@@ -32,6 +33,9 @@ changelog:
     exclude:
     - Merge branch
     - Merge pull request
+    - '[internal]'
+    - '[ci]'
+    - '[chore]'
   sort: asc
   use: git
 release:

--- a/provider-ci/providers/yandex/repo/.goreleaser.prerelease.yml
+++ b/provider-ci/providers/yandex/repo/.goreleaser.prerelease.yml
@@ -24,6 +24,7 @@ builds:
   - darwin
   - windows
   - linux
+  ignore: []
   ldflags:
   - -X github.com/pulumi/pulumi-yandex/provider/pkg/version.Version={{.Tag}}
   main: ./cmd/pulumi-resource-yandex/

--- a/provider-ci/providers/yandex/repo/.goreleaser.yml
+++ b/provider-ci/providers/yandex/repo/.goreleaser.yml
@@ -24,6 +24,7 @@ builds:
   - darwin
   - windows
   - linux
+  ignore: []
   ldflags:
   - -X github.com/pulumi/pulumi-yandex/provider/pkg/version.Version={{.Tag}}
   main: ./cmd/pulumi-resource-yandex/
@@ -32,6 +33,9 @@ changelog:
     exclude:
     - Merge branch
     - Merge pull request
+    - '[internal]'
+    - '[ci]'
+    - '[chore]'
   sort: asc
   use: git
 release:


### PR DESCRIPTION
Starting in Go 1.17, Windows ARM64 builds will happen by default in
goreleaser due to our GOOS / GOARCH matrix. We want the ability to
exclude these builds where downstream dependencies are broken for
windows arm64 (e.g. pulumi-minio)