### PR TITLE
Allow for non-master default branch names

### DIFF
--- a/provider-ci/lib/workflows.js
+++ b/provider-ci/lib/workflows.js
@@ -238,7 +238,6 @@ export class UpdatePulumiTerraformBridgeWorkflow extends g.GithubWorkflow {
                     committer: "pulumi-bot <bot@pulumi.com>",
                     author: "pulumi-bot <bot@pulumi.com>",
                     branch: "pulumi-bot/bridge-v${{ github.event.inputs.bridge_version }}-${{ github.run_id}}",
-                    base: "master",
                     labels: "impact/no-changelog-required",
                     title: "Update pulumi-terraform-bridge to v${{ github.event.inputs.bridge_version }}",
                     body: "This pull request was generated automatically by the update-bridge workflow in this repository.",
@@ -276,7 +275,6 @@ export class UpdateUpstreamProviderWorkflow extends g.GithubWorkflow {
             committer: "pulumi-bot <bot@pulumi.com>",
             author: "pulumi-bot <bot@pulumi.com>",
             branch: "pulumi-bot/v${{ github.event.inputs.version }}-${{ github.run_id}}",
-            base: "master",
             // TODO: Add auto-merge.
             labels: "impact/no-changelog-required",
             title: "Update ${{ env.UPSTREAM_PROVIDER_REPO }} to v${{ github.event.inputs.version }}",

--- a/provider-ci/providers/aiven/repo/.github/workflows/update-bridge.yml
+++ b/provider-ci/providers/aiven/repo/.github/workflows/update-bridge.yml
@@ -49,7 +49,6 @@ jobs:
       uses: peter-evans/create-pull-request@v3.12.0
       with:
         author: pulumi-bot <bot@pulumi.com>
-        base: master
         body: This pull request was generated automatically by the update-bridge workflow
           in this repository.
         branch: pulumi-bot/bridge-v${{ github.event.inputs.bridge_version }}-${{ github.run_id}}

--- a/provider-ci/providers/aiven/repo/.github/workflows/update-upstream-provider.yml
+++ b/provider-ci/providers/aiven/repo/.github/workflows/update-upstream-provider.yml
@@ -70,7 +70,6 @@ jobs:
       uses: peter-evans/create-pull-request@v3.12.0
       with:
         author: pulumi-bot <bot@pulumi.com>
-        base: master
         body: This pull request was generated automatically by the update-upstream-provider
           workflow in this repository.
         branch: pulumi-bot/v${{ github.event.inputs.version }}-${{ github.run_id}}
@@ -87,7 +86,6 @@ jobs:
       uses: peter-evans/create-pull-request@v3.12.0
       with:
         author: pulumi-bot <bot@pulumi.com>
-        base: master
         body: |-
           Fixes #${{ github.event.inputs.linked_issue_number }}
 

--- a/provider-ci/providers/akamai/repo/.github/workflows/update-bridge.yml
+++ b/provider-ci/providers/akamai/repo/.github/workflows/update-bridge.yml
@@ -49,7 +49,6 @@ jobs:
       uses: peter-evans/create-pull-request@v3.12.0
       with:
         author: pulumi-bot <bot@pulumi.com>
-        base: master
         body: This pull request was generated automatically by the update-bridge workflow
           in this repository.
         branch: pulumi-bot/bridge-v${{ github.event.inputs.bridge_version }}-${{ github.run_id}}

--- a/provider-ci/providers/akamai/repo/.github/workflows/update-upstream-provider.yml
+++ b/provider-ci/providers/akamai/repo/.github/workflows/update-upstream-provider.yml
@@ -72,7 +72,6 @@ jobs:
       uses: peter-evans/create-pull-request@v3.12.0
       with:
         author: pulumi-bot <bot@pulumi.com>
-        base: master
         body: This pull request was generated automatically by the update-upstream-provider
           workflow in this repository.
         branch: pulumi-bot/v${{ github.event.inputs.version }}-${{ github.run_id}}
@@ -89,7 +88,6 @@ jobs:
       uses: peter-evans/create-pull-request@v3.12.0
       with:
         author: pulumi-bot <bot@pulumi.com>
-        base: master
         body: |-
           Fixes #${{ github.event.inputs.linked_issue_number }}
 

--- a/provider-ci/providers/alicloud/repo/.github/workflows/update-bridge.yml
+++ b/provider-ci/providers/alicloud/repo/.github/workflows/update-bridge.yml
@@ -49,7 +49,6 @@ jobs:
       uses: peter-evans/create-pull-request@v3.12.0
       with:
         author: pulumi-bot <bot@pulumi.com>
-        base: master
         body: This pull request was generated automatically by the update-bridge workflow
           in this repository.
         branch: pulumi-bot/bridge-v${{ github.event.inputs.bridge_version }}-${{ github.run_id}}

--- a/provider-ci/providers/alicloud/repo/.github/workflows/update-upstream-provider.yml
+++ b/provider-ci/providers/alicloud/repo/.github/workflows/update-upstream-provider.yml
@@ -71,7 +71,6 @@ jobs:
       uses: peter-evans/create-pull-request@v3.12.0
       with:
         author: pulumi-bot <bot@pulumi.com>
-        base: master
         body: This pull request was generated automatically by the update-upstream-provider
           workflow in this repository.
         branch: pulumi-bot/v${{ github.event.inputs.version }}-${{ github.run_id}}
@@ -88,7 +87,6 @@ jobs:
       uses: peter-evans/create-pull-request@v3.12.0
       with:
         author: pulumi-bot <bot@pulumi.com>
-        base: master
         body: |-
           Fixes #${{ github.event.inputs.linked_issue_number }}
 

--- a/provider-ci/providers/artifactory/repo/.github/workflows/update-bridge.yml
+++ b/provider-ci/providers/artifactory/repo/.github/workflows/update-bridge.yml
@@ -49,7 +49,6 @@ jobs:
       uses: peter-evans/create-pull-request@v3.12.0
       with:
         author: pulumi-bot <bot@pulumi.com>
-        base: master
         body: This pull request was generated automatically by the update-bridge workflow
           in this repository.
         branch: pulumi-bot/bridge-v${{ github.event.inputs.bridge_version }}-${{ github.run_id}}

--- a/provider-ci/providers/artifactory/repo/.github/workflows/update-upstream-provider.yml
+++ b/provider-ci/providers/artifactory/repo/.github/workflows/update-upstream-provider.yml
@@ -70,7 +70,6 @@ jobs:
       uses: peter-evans/create-pull-request@v3.12.0
       with:
         author: pulumi-bot <bot@pulumi.com>
-        base: master
         body: This pull request was generated automatically by the update-upstream-provider
           workflow in this repository.
         branch: pulumi-bot/v${{ github.event.inputs.version }}-${{ github.run_id}}
@@ -87,7 +86,6 @@ jobs:
       uses: peter-evans/create-pull-request@v3.12.0
       with:
         author: pulumi-bot <bot@pulumi.com>
-        base: master
         body: |-
           Fixes #${{ github.event.inputs.linked_issue_number }}
 

--- a/provider-ci/providers/auth0/repo/.github/workflows/update-bridge.yml
+++ b/provider-ci/providers/auth0/repo/.github/workflows/update-bridge.yml
@@ -49,7 +49,6 @@ jobs:
       uses: peter-evans/create-pull-request@v3.12.0
       with:
         author: pulumi-bot <bot@pulumi.com>
-        base: master
         body: This pull request was generated automatically by the update-bridge workflow
           in this repository.
         branch: pulumi-bot/bridge-v${{ github.event.inputs.bridge_version }}-${{ github.run_id}}

--- a/provider-ci/providers/auth0/repo/.github/workflows/update-upstream-provider.yml
+++ b/provider-ci/providers/auth0/repo/.github/workflows/update-upstream-provider.yml
@@ -71,7 +71,6 @@ jobs:
       uses: peter-evans/create-pull-request@v3.12.0
       with:
         author: pulumi-bot <bot@pulumi.com>
-        base: master
         body: This pull request was generated automatically by the update-upstream-provider
           workflow in this repository.
         branch: pulumi-bot/v${{ github.event.inputs.version }}-${{ github.run_id}}
@@ -88,7 +87,6 @@ jobs:
       uses: peter-evans/create-pull-request@v3.12.0
       with:
         author: pulumi-bot <bot@pulumi.com>
-        base: master
         body: |-
           Fixes #${{ github.event.inputs.linked_issue_number }}
 

--- a/provider-ci/providers/aws/repo/.github/workflows/update-bridge.yml
+++ b/provider-ci/providers/aws/repo/.github/workflows/update-bridge.yml
@@ -49,7 +49,6 @@ jobs:
       uses: peter-evans/create-pull-request@v3.12.0
       with:
         author: pulumi-bot <bot@pulumi.com>
-        base: master
         body: This pull request was generated automatically by the update-bridge workflow
           in this repository.
         branch: pulumi-bot/bridge-v${{ github.event.inputs.bridge_version }}-${{ github.run_id}}

--- a/provider-ci/providers/aws/repo/.github/workflows/update-upstream-provider.yml
+++ b/provider-ci/providers/aws/repo/.github/workflows/update-upstream-provider.yml
@@ -69,7 +69,6 @@ jobs:
       uses: peter-evans/create-pull-request@v3.12.0
       with:
         author: pulumi-bot <bot@pulumi.com>
-        base: master
         body: This pull request was generated automatically by the update-upstream-provider
           workflow in this repository.
         branch: pulumi-bot/v${{ github.event.inputs.version }}-${{ github.run_id}}
@@ -86,7 +85,6 @@ jobs:
       uses: peter-evans/create-pull-request@v3.12.0
       with:
         author: pulumi-bot <bot@pulumi.com>
-        base: master
         body: |-
           Fixes #${{ github.event.inputs.linked_issue_number }}
 

--- a/provider-ci/providers/azure/repo/.github/workflows/update-bridge.yml
+++ b/provider-ci/providers/azure/repo/.github/workflows/update-bridge.yml
@@ -49,7 +49,6 @@ jobs:
       uses: peter-evans/create-pull-request@v3.12.0
       with:
         author: pulumi-bot <bot@pulumi.com>
-        base: master
         body: This pull request was generated automatically by the update-bridge workflow
           in this repository.
         branch: pulumi-bot/bridge-v${{ github.event.inputs.bridge_version }}-${{ github.run_id}}

--- a/provider-ci/providers/azure/repo/.github/workflows/update-upstream-provider.yml
+++ b/provider-ci/providers/azure/repo/.github/workflows/update-upstream-provider.yml
@@ -74,7 +74,6 @@ jobs:
       uses: peter-evans/create-pull-request@v3.12.0
       with:
         author: pulumi-bot <bot@pulumi.com>
-        base: master
         body: This pull request was generated automatically by the update-upstream-provider
           workflow in this repository.
         branch: pulumi-bot/v${{ github.event.inputs.version }}-${{ github.run_id}}
@@ -91,7 +90,6 @@ jobs:
       uses: peter-evans/create-pull-request@v3.12.0
       with:
         author: pulumi-bot <bot@pulumi.com>
-        base: master
         body: |-
           Fixes #${{ github.event.inputs.linked_issue_number }}
 

--- a/provider-ci/providers/azuread/repo/.github/workflows/update-bridge.yml
+++ b/provider-ci/providers/azuread/repo/.github/workflows/update-bridge.yml
@@ -49,7 +49,6 @@ jobs:
       uses: peter-evans/create-pull-request@v3.12.0
       with:
         author: pulumi-bot <bot@pulumi.com>
-        base: master
         body: This pull request was generated automatically by the update-bridge workflow
           in this repository.
         branch: pulumi-bot/bridge-v${{ github.event.inputs.bridge_version }}-${{ github.run_id}}

--- a/provider-ci/providers/azuread/repo/.github/workflows/update-upstream-provider.yml
+++ b/provider-ci/providers/azuread/repo/.github/workflows/update-upstream-provider.yml
@@ -73,7 +73,6 @@ jobs:
       uses: peter-evans/create-pull-request@v3.12.0
       with:
         author: pulumi-bot <bot@pulumi.com>
-        base: master
         body: This pull request was generated automatically by the update-upstream-provider
           workflow in this repository.
         branch: pulumi-bot/v${{ github.event.inputs.version }}-${{ github.run_id}}
@@ -90,7 +89,6 @@ jobs:
       uses: peter-evans/create-pull-request@v3.12.0
       with:
         author: pulumi-bot <bot@pulumi.com>
-        base: master
         body: |-
           Fixes #${{ github.event.inputs.linked_issue_number }}
 

--- a/provider-ci/providers/azuredevops/repo/.github/workflows/update-bridge.yml
+++ b/provider-ci/providers/azuredevops/repo/.github/workflows/update-bridge.yml
@@ -49,7 +49,6 @@ jobs:
       uses: peter-evans/create-pull-request@v3.12.0
       with:
         author: pulumi-bot <bot@pulumi.com>
-        base: master
         body: This pull request was generated automatically by the update-bridge workflow
           in this repository.
         branch: pulumi-bot/bridge-v${{ github.event.inputs.bridge_version }}-${{ github.run_id}}

--- a/provider-ci/providers/azuredevops/repo/.github/workflows/update-upstream-provider.yml
+++ b/provider-ci/providers/azuredevops/repo/.github/workflows/update-upstream-provider.yml
@@ -70,7 +70,6 @@ jobs:
       uses: peter-evans/create-pull-request@v3.12.0
       with:
         author: pulumi-bot <bot@pulumi.com>
-        base: master
         body: This pull request was generated automatically by the update-upstream-provider
           workflow in this repository.
         branch: pulumi-bot/v${{ github.event.inputs.version }}-${{ github.run_id}}
@@ -87,7 +86,6 @@ jobs:
       uses: peter-evans/create-pull-request@v3.12.0
       with:
         author: pulumi-bot <bot@pulumi.com>
-        base: master
         body: |-
           Fixes #${{ github.event.inputs.linked_issue_number }}
 

--- a/provider-ci/providers/civo/repo/.github/workflows/update-bridge.yml
+++ b/provider-ci/providers/civo/repo/.github/workflows/update-bridge.yml
@@ -49,7 +49,6 @@ jobs:
       uses: peter-evans/create-pull-request@v3.12.0
       with:
         author: pulumi-bot <bot@pulumi.com>
-        base: master
         body: This pull request was generated automatically by the update-bridge workflow
           in this repository.
         branch: pulumi-bot/bridge-v${{ github.event.inputs.bridge_version }}-${{ github.run_id}}

--- a/provider-ci/providers/civo/repo/.github/workflows/update-upstream-provider.yml
+++ b/provider-ci/providers/civo/repo/.github/workflows/update-upstream-provider.yml
@@ -69,7 +69,6 @@ jobs:
       uses: peter-evans/create-pull-request@v3.12.0
       with:
         author: pulumi-bot <bot@pulumi.com>
-        base: master
         body: This pull request was generated automatically by the update-upstream-provider
           workflow in this repository.
         branch: pulumi-bot/v${{ github.event.inputs.version }}-${{ github.run_id}}
@@ -86,7 +85,6 @@ jobs:
       uses: peter-evans/create-pull-request@v3.12.0
       with:
         author: pulumi-bot <bot@pulumi.com>
-        base: master
         body: |-
           Fixes #${{ github.event.inputs.linked_issue_number }}
 

--- a/provider-ci/providers/cloudamqp/repo/.github/workflows/update-bridge.yml
+++ b/provider-ci/providers/cloudamqp/repo/.github/workflows/update-bridge.yml
@@ -49,7 +49,6 @@ jobs:
       uses: peter-evans/create-pull-request@v3.12.0
       with:
         author: pulumi-bot <bot@pulumi.com>
-        base: master
         body: This pull request was generated automatically by the update-bridge workflow
           in this repository.
         branch: pulumi-bot/bridge-v${{ github.event.inputs.bridge_version }}-${{ github.run_id}}

--- a/provider-ci/providers/cloudamqp/repo/.github/workflows/update-upstream-provider.yml
+++ b/provider-ci/providers/cloudamqp/repo/.github/workflows/update-upstream-provider.yml
@@ -68,7 +68,6 @@ jobs:
       uses: peter-evans/create-pull-request@v3.12.0
       with:
         author: pulumi-bot <bot@pulumi.com>
-        base: master
         body: This pull request was generated automatically by the update-upstream-provider
           workflow in this repository.
         branch: pulumi-bot/v${{ github.event.inputs.version }}-${{ github.run_id}}
@@ -85,7 +84,6 @@ jobs:
       uses: peter-evans/create-pull-request@v3.12.0
       with:
         author: pulumi-bot <bot@pulumi.com>
-        base: master
         body: |-
           Fixes #${{ github.event.inputs.linked_issue_number }}
 

--- a/provider-ci/providers/cloudflare/repo/.github/workflows/update-bridge.yml
+++ b/provider-ci/providers/cloudflare/repo/.github/workflows/update-bridge.yml
@@ -49,7 +49,6 @@ jobs:
       uses: peter-evans/create-pull-request@v3.12.0
       with:
         author: pulumi-bot <bot@pulumi.com>
-        base: master
         body: This pull request was generated automatically by the update-bridge workflow
           in this repository.
         branch: pulumi-bot/bridge-v${{ github.event.inputs.bridge_version }}-${{ github.run_id}}

--- a/provider-ci/providers/cloudflare/repo/.github/workflows/update-upstream-provider.yml
+++ b/provider-ci/providers/cloudflare/repo/.github/workflows/update-upstream-provider.yml
@@ -68,7 +68,6 @@ jobs:
       uses: peter-evans/create-pull-request@v3.12.0
       with:
         author: pulumi-bot <bot@pulumi.com>
-        base: master
         body: This pull request was generated automatically by the update-upstream-provider
           workflow in this repository.
         branch: pulumi-bot/v${{ github.event.inputs.version }}-${{ github.run_id}}
@@ -85,7 +84,6 @@ jobs:
       uses: peter-evans/create-pull-request@v3.12.0
       with:
         author: pulumi-bot <bot@pulumi.com>
-        base: master
         body: |-
           Fixes #${{ github.event.inputs.linked_issue_number }}
 

--- a/provider-ci/providers/cloudinit/repo/.github/workflows/update-bridge.yml
+++ b/provider-ci/providers/cloudinit/repo/.github/workflows/update-bridge.yml
@@ -49,7 +49,6 @@ jobs:
       uses: peter-evans/create-pull-request@v3.12.0
       with:
         author: pulumi-bot <bot@pulumi.com>
-        base: master
         body: This pull request was generated automatically by the update-bridge workflow
           in this repository.
         branch: pulumi-bot/bridge-v${{ github.event.inputs.bridge_version }}-${{ github.run_id}}

--- a/provider-ci/providers/cloudinit/repo/.github/workflows/update-upstream-provider.yml
+++ b/provider-ci/providers/cloudinit/repo/.github/workflows/update-upstream-provider.yml
@@ -68,7 +68,6 @@ jobs:
       uses: peter-evans/create-pull-request@v3.12.0
       with:
         author: pulumi-bot <bot@pulumi.com>
-        base: master
         body: This pull request was generated automatically by the update-upstream-provider
           workflow in this repository.
         branch: pulumi-bot/v${{ github.event.inputs.version }}-${{ github.run_id}}
@@ -85,7 +84,6 @@ jobs:
       uses: peter-evans/create-pull-request@v3.12.0
       with:
         author: pulumi-bot <bot@pulumi.com>
-        base: master
         body: |-
           Fixes #${{ github.event.inputs.linked_issue_number }}
 

--- a/provider-ci/providers/confluent/repo/.github/workflows/update-bridge.yml
+++ b/provider-ci/providers/confluent/repo/.github/workflows/update-bridge.yml
@@ -49,7 +49,6 @@ jobs:
       uses: peter-evans/create-pull-request@v3.12.0
       with:
         author: pulumi-bot <bot@pulumi.com>
-        base: master
         body: This pull request was generated automatically by the update-bridge workflow
           in this repository.
         branch: pulumi-bot/bridge-v${{ github.event.inputs.bridge_version }}-${{ github.run_id}}

--- a/provider-ci/providers/confluent/repo/.github/workflows/update-upstream-provider.yml
+++ b/provider-ci/providers/confluent/repo/.github/workflows/update-upstream-provider.yml
@@ -70,7 +70,6 @@ jobs:
       uses: peter-evans/create-pull-request@v3.12.0
       with:
         author: pulumi-bot <bot@pulumi.com>
-        base: master
         body: This pull request was generated automatically by the update-upstream-provider
           workflow in this repository.
         branch: pulumi-bot/v${{ github.event.inputs.version }}-${{ github.run_id}}
@@ -87,7 +86,6 @@ jobs:
       uses: peter-evans/create-pull-request@v3.12.0
       with:
         author: pulumi-bot <bot@pulumi.com>
-        base: master
         body: |-
           Fixes #${{ github.event.inputs.linked_issue_number }}
 

--- a/provider-ci/providers/consul/repo/.github/workflows/update-bridge.yml
+++ b/provider-ci/providers/consul/repo/.github/workflows/update-bridge.yml
@@ -49,7 +49,6 @@ jobs:
       uses: peter-evans/create-pull-request@v3.12.0
       with:
         author: pulumi-bot <bot@pulumi.com>
-        base: master
         body: This pull request was generated automatically by the update-bridge workflow
           in this repository.
         branch: pulumi-bot/bridge-v${{ github.event.inputs.bridge_version }}-${{ github.run_id}}

--- a/provider-ci/providers/consul/repo/.github/workflows/update-upstream-provider.yml
+++ b/provider-ci/providers/consul/repo/.github/workflows/update-upstream-provider.yml
@@ -68,7 +68,6 @@ jobs:
       uses: peter-evans/create-pull-request@v3.12.0
       with:
         author: pulumi-bot <bot@pulumi.com>
-        base: master
         body: This pull request was generated automatically by the update-upstream-provider
           workflow in this repository.
         branch: pulumi-bot/v${{ github.event.inputs.version }}-${{ github.run_id}}
@@ -85,7 +84,6 @@ jobs:
       uses: peter-evans/create-pull-request@v3.12.0
       with:
         author: pulumi-bot <bot@pulumi.com>
-        base: master
         body: |-
           Fixes #${{ github.event.inputs.linked_issue_number }}
 

--- a/provider-ci/providers/datadog/repo/.github/workflows/update-bridge.yml
+++ b/provider-ci/providers/datadog/repo/.github/workflows/update-bridge.yml
@@ -49,7 +49,6 @@ jobs:
       uses: peter-evans/create-pull-request@v3.12.0
       with:
         author: pulumi-bot <bot@pulumi.com>
-        base: master
         body: This pull request was generated automatically by the update-bridge workflow
           in this repository.
         branch: pulumi-bot/bridge-v${{ github.event.inputs.bridge_version }}-${{ github.run_id}}

--- a/provider-ci/providers/datadog/repo/.github/workflows/update-upstream-provider.yml
+++ b/provider-ci/providers/datadog/repo/.github/workflows/update-upstream-provider.yml
@@ -68,7 +68,6 @@ jobs:
       uses: peter-evans/create-pull-request@v3.12.0
       with:
         author: pulumi-bot <bot@pulumi.com>
-        base: master
         body: This pull request was generated automatically by the update-upstream-provider
           workflow in this repository.
         branch: pulumi-bot/v${{ github.event.inputs.version }}-${{ github.run_id}}
@@ -85,7 +84,6 @@ jobs:
       uses: peter-evans/create-pull-request@v3.12.0
       with:
         author: pulumi-bot <bot@pulumi.com>
-        base: master
         body: |-
           Fixes #${{ github.event.inputs.linked_issue_number }}
 

--- a/provider-ci/providers/digitalocean/repo/.github/workflows/update-bridge.yml
+++ b/provider-ci/providers/digitalocean/repo/.github/workflows/update-bridge.yml
@@ -49,7 +49,6 @@ jobs:
       uses: peter-evans/create-pull-request@v3.12.0
       with:
         author: pulumi-bot <bot@pulumi.com>
-        base: master
         body: This pull request was generated automatically by the update-bridge workflow
           in this repository.
         branch: pulumi-bot/bridge-v${{ github.event.inputs.bridge_version }}-${{ github.run_id}}

--- a/provider-ci/providers/digitalocean/repo/.github/workflows/update-upstream-provider.yml
+++ b/provider-ci/providers/digitalocean/repo/.github/workflows/update-upstream-provider.yml
@@ -69,7 +69,6 @@ jobs:
       uses: peter-evans/create-pull-request@v3.12.0
       with:
         author: pulumi-bot <bot@pulumi.com>
-        base: master
         body: This pull request was generated automatically by the update-upstream-provider
           workflow in this repository.
         branch: pulumi-bot/v${{ github.event.inputs.version }}-${{ github.run_id}}
@@ -86,7 +85,6 @@ jobs:
       uses: peter-evans/create-pull-request@v3.12.0
       with:
         author: pulumi-bot <bot@pulumi.com>
-        base: master
         body: |-
           Fixes #${{ github.event.inputs.linked_issue_number }}
 

--- a/provider-ci/providers/dnsimple/repo/.github/workflows/update-bridge.yml
+++ b/provider-ci/providers/dnsimple/repo/.github/workflows/update-bridge.yml
@@ -49,7 +49,6 @@ jobs:
       uses: peter-evans/create-pull-request@v3.12.0
       with:
         author: pulumi-bot <bot@pulumi.com>
-        base: master
         body: This pull request was generated automatically by the update-bridge workflow
           in this repository.
         branch: pulumi-bot/bridge-v${{ github.event.inputs.bridge_version }}-${{ github.run_id}}

--- a/provider-ci/providers/dnsimple/repo/.github/workflows/update-upstream-provider.yml
+++ b/provider-ci/providers/dnsimple/repo/.github/workflows/update-upstream-provider.yml
@@ -70,7 +70,6 @@ jobs:
       uses: peter-evans/create-pull-request@v3.12.0
       with:
         author: pulumi-bot <bot@pulumi.com>
-        base: master
         body: This pull request was generated automatically by the update-upstream-provider
           workflow in this repository.
         branch: pulumi-bot/v${{ github.event.inputs.version }}-${{ github.run_id}}
@@ -87,7 +86,6 @@ jobs:
       uses: peter-evans/create-pull-request@v3.12.0
       with:
         author: pulumi-bot <bot@pulumi.com>
-        base: master
         body: |-
           Fixes #${{ github.event.inputs.linked_issue_number }}
 

--- a/provider-ci/providers/docker/repo/.github/workflows/update-bridge.yml
+++ b/provider-ci/providers/docker/repo/.github/workflows/update-bridge.yml
@@ -49,7 +49,6 @@ jobs:
       uses: peter-evans/create-pull-request@v3.12.0
       with:
         author: pulumi-bot <bot@pulumi.com>
-        base: master
         body: This pull request was generated automatically by the update-bridge workflow
           in this repository.
         branch: pulumi-bot/bridge-v${{ github.event.inputs.bridge_version }}-${{ github.run_id}}

--- a/provider-ci/providers/docker/repo/.github/workflows/update-upstream-provider.yml
+++ b/provider-ci/providers/docker/repo/.github/workflows/update-upstream-provider.yml
@@ -74,7 +74,6 @@ jobs:
       uses: peter-evans/create-pull-request@v3.12.0
       with:
         author: pulumi-bot <bot@pulumi.com>
-        base: master
         body: This pull request was generated automatically by the update-upstream-provider
           workflow in this repository.
         branch: pulumi-bot/v${{ github.event.inputs.version }}-${{ github.run_id}}
@@ -91,7 +90,6 @@ jobs:
       uses: peter-evans/create-pull-request@v3.12.0
       with:
         author: pulumi-bot <bot@pulumi.com>
-        base: master
         body: |-
           Fixes #${{ github.event.inputs.linked_issue_number }}
 

--- a/provider-ci/providers/ec/repo/.github/workflows/update-bridge.yml
+++ b/provider-ci/providers/ec/repo/.github/workflows/update-bridge.yml
@@ -49,7 +49,6 @@ jobs:
       uses: peter-evans/create-pull-request@v3.12.0
       with:
         author: pulumi-bot <bot@pulumi.com>
-        base: master
         body: This pull request was generated automatically by the update-bridge workflow
           in this repository.
         branch: pulumi-bot/bridge-v${{ github.event.inputs.bridge_version }}-${{ github.run_id}}

--- a/provider-ci/providers/ec/repo/.github/workflows/update-upstream-provider.yml
+++ b/provider-ci/providers/ec/repo/.github/workflows/update-upstream-provider.yml
@@ -69,7 +69,6 @@ jobs:
       uses: peter-evans/create-pull-request@v3.12.0
       with:
         author: pulumi-bot <bot@pulumi.com>
-        base: master
         body: This pull request was generated automatically by the update-upstream-provider
           workflow in this repository.
         branch: pulumi-bot/v${{ github.event.inputs.version }}-${{ github.run_id}}
@@ -86,7 +85,6 @@ jobs:
       uses: peter-evans/create-pull-request@v3.12.0
       with:
         author: pulumi-bot <bot@pulumi.com>
-        base: master
         body: |-
           Fixes #${{ github.event.inputs.linked_issue_number }}
 

--- a/provider-ci/providers/equinix-metal/repo/.github/workflows/update-bridge.yml
+++ b/provider-ci/providers/equinix-metal/repo/.github/workflows/update-bridge.yml
@@ -49,7 +49,6 @@ jobs:
       uses: peter-evans/create-pull-request@v3.12.0
       with:
         author: pulumi-bot <bot@pulumi.com>
-        base: master
         body: This pull request was generated automatically by the update-bridge workflow
           in this repository.
         branch: pulumi-bot/bridge-v${{ github.event.inputs.bridge_version }}-${{ github.run_id}}

--- a/provider-ci/providers/equinix-metal/repo/.github/workflows/update-upstream-provider.yml
+++ b/provider-ci/providers/equinix-metal/repo/.github/workflows/update-upstream-provider.yml
@@ -69,7 +69,6 @@ jobs:
       uses: peter-evans/create-pull-request@v3.12.0
       with:
         author: pulumi-bot <bot@pulumi.com>
-        base: master
         body: This pull request was generated automatically by the update-upstream-provider
           workflow in this repository.
         branch: pulumi-bot/v${{ github.event.inputs.version }}-${{ github.run_id}}
@@ -86,7 +85,6 @@ jobs:
       uses: peter-evans/create-pull-request@v3.12.0
       with:
         author: pulumi-bot <bot@pulumi.com>
-        base: master
         body: |-
           Fixes #${{ github.event.inputs.linked_issue_number }}
 

--- a/provider-ci/providers/f5bigip/repo/.github/workflows/update-bridge.yml
+++ b/provider-ci/providers/f5bigip/repo/.github/workflows/update-bridge.yml
@@ -49,7 +49,6 @@ jobs:
       uses: peter-evans/create-pull-request@v3.12.0
       with:
         author: pulumi-bot <bot@pulumi.com>
-        base: master
         body: This pull request was generated automatically by the update-bridge workflow
           in this repository.
         branch: pulumi-bot/bridge-v${{ github.event.inputs.bridge_version }}-${{ github.run_id}}

--- a/provider-ci/providers/f5bigip/repo/.github/workflows/update-upstream-provider.yml
+++ b/provider-ci/providers/f5bigip/repo/.github/workflows/update-upstream-provider.yml
@@ -72,7 +72,6 @@ jobs:
       uses: peter-evans/create-pull-request@v3.12.0
       with:
         author: pulumi-bot <bot@pulumi.com>
-        base: master
         body: This pull request was generated automatically by the update-upstream-provider
           workflow in this repository.
         branch: pulumi-bot/v${{ github.event.inputs.version }}-${{ github.run_id}}
@@ -89,7 +88,6 @@ jobs:
       uses: peter-evans/create-pull-request@v3.12.0
       with:
         author: pulumi-bot <bot@pulumi.com>
-        base: master
         body: |-
           Fixes #${{ github.event.inputs.linked_issue_number }}
 

--- a/provider-ci/providers/fastly/repo/.github/workflows/update-bridge.yml
+++ b/provider-ci/providers/fastly/repo/.github/workflows/update-bridge.yml
@@ -49,7 +49,6 @@ jobs:
       uses: peter-evans/create-pull-request@v3.12.0
       with:
         author: pulumi-bot <bot@pulumi.com>
-        base: master
         body: This pull request was generated automatically by the update-bridge workflow
           in this repository.
         branch: pulumi-bot/bridge-v${{ github.event.inputs.bridge_version }}-${{ github.run_id}}

--- a/provider-ci/providers/fastly/repo/.github/workflows/update-upstream-provider.yml
+++ b/provider-ci/providers/fastly/repo/.github/workflows/update-upstream-provider.yml
@@ -69,7 +69,6 @@ jobs:
       uses: peter-evans/create-pull-request@v3.12.0
       with:
         author: pulumi-bot <bot@pulumi.com>
-        base: master
         body: This pull request was generated automatically by the update-upstream-provider
           workflow in this repository.
         branch: pulumi-bot/v${{ github.event.inputs.version }}-${{ github.run_id}}
@@ -86,7 +85,6 @@ jobs:
       uses: peter-evans/create-pull-request@v3.12.0
       with:
         author: pulumi-bot <bot@pulumi.com>
-        base: master
         body: |-
           Fixes #${{ github.event.inputs.linked_issue_number }}
 

--- a/provider-ci/providers/gcp/repo/.github/workflows/update-bridge.yml
+++ b/provider-ci/providers/gcp/repo/.github/workflows/update-bridge.yml
@@ -49,7 +49,6 @@ jobs:
       uses: peter-evans/create-pull-request@v3.12.0
       with:
         author: pulumi-bot <bot@pulumi.com>
-        base: master
         body: This pull request was generated automatically by the update-bridge workflow
           in this repository.
         branch: pulumi-bot/bridge-v${{ github.event.inputs.bridge_version }}-${{ github.run_id}}

--- a/provider-ci/providers/gcp/repo/.github/workflows/update-upstream-provider.yml
+++ b/provider-ci/providers/gcp/repo/.github/workflows/update-upstream-provider.yml
@@ -71,7 +71,6 @@ jobs:
       uses: peter-evans/create-pull-request@v3.12.0
       with:
         author: pulumi-bot <bot@pulumi.com>
-        base: master
         body: This pull request was generated automatically by the update-upstream-provider
           workflow in this repository.
         branch: pulumi-bot/v${{ github.event.inputs.version }}-${{ github.run_id}}
@@ -88,7 +87,6 @@ jobs:
       uses: peter-evans/create-pull-request@v3.12.0
       with:
         author: pulumi-bot <bot@pulumi.com>
-        base: master
         body: |-
           Fixes #${{ github.event.inputs.linked_issue_number }}
 

--- a/provider-ci/providers/github/repo/.github/workflows/update-bridge.yml
+++ b/provider-ci/providers/github/repo/.github/workflows/update-bridge.yml
@@ -49,7 +49,6 @@ jobs:
       uses: peter-evans/create-pull-request@v3.12.0
       with:
         author: pulumi-bot <bot@pulumi.com>
-        base: master
         body: This pull request was generated automatically by the update-bridge workflow
           in this repository.
         branch: pulumi-bot/bridge-v${{ github.event.inputs.bridge_version }}-${{ github.run_id}}

--- a/provider-ci/providers/github/repo/.github/workflows/update-upstream-provider.yml
+++ b/provider-ci/providers/github/repo/.github/workflows/update-upstream-provider.yml
@@ -70,7 +70,6 @@ jobs:
       uses: peter-evans/create-pull-request@v3.12.0
       with:
         author: pulumi-bot <bot@pulumi.com>
-        base: master
         body: This pull request was generated automatically by the update-upstream-provider
           workflow in this repository.
         branch: pulumi-bot/v${{ github.event.inputs.version }}-${{ github.run_id}}
@@ -87,7 +86,6 @@ jobs:
       uses: peter-evans/create-pull-request@v3.12.0
       with:
         author: pulumi-bot <bot@pulumi.com>
-        base: master
         body: |-
           Fixes #${{ github.event.inputs.linked_issue_number }}
 

--- a/provider-ci/providers/gitlab/repo/.github/workflows/update-bridge.yml
+++ b/provider-ci/providers/gitlab/repo/.github/workflows/update-bridge.yml
@@ -49,7 +49,6 @@ jobs:
       uses: peter-evans/create-pull-request@v3.12.0
       with:
         author: pulumi-bot <bot@pulumi.com>
-        base: master
         body: This pull request was generated automatically by the update-bridge workflow
           in this repository.
         branch: pulumi-bot/bridge-v${{ github.event.inputs.bridge_version }}-${{ github.run_id}}

--- a/provider-ci/providers/gitlab/repo/.github/workflows/update-upstream-provider.yml
+++ b/provider-ci/providers/gitlab/repo/.github/workflows/update-upstream-provider.yml
@@ -69,7 +69,6 @@ jobs:
       uses: peter-evans/create-pull-request@v3.12.0
       with:
         author: pulumi-bot <bot@pulumi.com>
-        base: master
         body: This pull request was generated automatically by the update-upstream-provider
           workflow in this repository.
         branch: pulumi-bot/v${{ github.event.inputs.version }}-${{ github.run_id}}
@@ -86,7 +85,6 @@ jobs:
       uses: peter-evans/create-pull-request@v3.12.0
       with:
         author: pulumi-bot <bot@pulumi.com>
-        base: master
         body: |-
           Fixes #${{ github.event.inputs.linked_issue_number }}
 

--- a/provider-ci/providers/hcloud/repo/.github/workflows/update-bridge.yml
+++ b/provider-ci/providers/hcloud/repo/.github/workflows/update-bridge.yml
@@ -49,7 +49,6 @@ jobs:
       uses: peter-evans/create-pull-request@v3.12.0
       with:
         author: pulumi-bot <bot@pulumi.com>
-        base: master
         body: This pull request was generated automatically by the update-bridge workflow
           in this repository.
         branch: pulumi-bot/bridge-v${{ github.event.inputs.bridge_version }}-${{ github.run_id}}

--- a/provider-ci/providers/hcloud/repo/.github/workflows/update-upstream-provider.yml
+++ b/provider-ci/providers/hcloud/repo/.github/workflows/update-upstream-provider.yml
@@ -69,7 +69,6 @@ jobs:
       uses: peter-evans/create-pull-request@v3.12.0
       with:
         author: pulumi-bot <bot@pulumi.com>
-        base: master
         body: This pull request was generated automatically by the update-upstream-provider
           workflow in this repository.
         branch: pulumi-bot/v${{ github.event.inputs.version }}-${{ github.run_id}}
@@ -86,7 +85,6 @@ jobs:
       uses: peter-evans/create-pull-request@v3.12.0
       with:
         author: pulumi-bot <bot@pulumi.com>
-        base: master
         body: |-
           Fixes #${{ github.event.inputs.linked_issue_number }}
 

--- a/provider-ci/providers/kafka/repo/.github/workflows/update-bridge.yml
+++ b/provider-ci/providers/kafka/repo/.github/workflows/update-bridge.yml
@@ -49,7 +49,6 @@ jobs:
       uses: peter-evans/create-pull-request@v3.12.0
       with:
         author: pulumi-bot <bot@pulumi.com>
-        base: master
         body: This pull request was generated automatically by the update-bridge workflow
           in this repository.
         branch: pulumi-bot/bridge-v${{ github.event.inputs.bridge_version }}-${{ github.run_id}}

--- a/provider-ci/providers/kafka/repo/.github/workflows/update-upstream-provider.yml
+++ b/provider-ci/providers/kafka/repo/.github/workflows/update-upstream-provider.yml
@@ -68,7 +68,6 @@ jobs:
       uses: peter-evans/create-pull-request@v3.12.0
       with:
         author: pulumi-bot <bot@pulumi.com>
-        base: master
         body: This pull request was generated automatically by the update-upstream-provider
           workflow in this repository.
         branch: pulumi-bot/v${{ github.event.inputs.version }}-${{ github.run_id}}
@@ -85,7 +84,6 @@ jobs:
       uses: peter-evans/create-pull-request@v3.12.0
       with:
         author: pulumi-bot <bot@pulumi.com>
-        base: master
         body: |-
           Fixes #${{ github.event.inputs.linked_issue_number }}
 

--- a/provider-ci/providers/keycloak/repo/.github/workflows/update-bridge.yml
+++ b/provider-ci/providers/keycloak/repo/.github/workflows/update-bridge.yml
@@ -49,7 +49,6 @@ jobs:
       uses: peter-evans/create-pull-request@v3.12.0
       with:
         author: pulumi-bot <bot@pulumi.com>
-        base: master
         body: This pull request was generated automatically by the update-bridge workflow
           in this repository.
         branch: pulumi-bot/bridge-v${{ github.event.inputs.bridge_version }}-${{ github.run_id}}

--- a/provider-ci/providers/keycloak/repo/.github/workflows/update-upstream-provider.yml
+++ b/provider-ci/providers/keycloak/repo/.github/workflows/update-upstream-provider.yml
@@ -73,7 +73,6 @@ jobs:
       uses: peter-evans/create-pull-request@v3.12.0
       with:
         author: pulumi-bot <bot@pulumi.com>
-        base: master
         body: This pull request was generated automatically by the update-upstream-provider
           workflow in this repository.
         branch: pulumi-bot/v${{ github.event.inputs.version }}-${{ github.run_id}}
@@ -90,7 +89,6 @@ jobs:
       uses: peter-evans/create-pull-request@v3.12.0
       with:
         author: pulumi-bot <bot@pulumi.com>
-        base: master
         body: |-
           Fixes #${{ github.event.inputs.linked_issue_number }}
 

--- a/provider-ci/providers/kong/repo/.github/workflows/update-bridge.yml
+++ b/provider-ci/providers/kong/repo/.github/workflows/update-bridge.yml
@@ -49,7 +49,6 @@ jobs:
       uses: peter-evans/create-pull-request@v3.12.0
       with:
         author: pulumi-bot <bot@pulumi.com>
-        base: master
         body: This pull request was generated automatically by the update-bridge workflow
           in this repository.
         branch: pulumi-bot/bridge-v${{ github.event.inputs.bridge_version }}-${{ github.run_id}}

--- a/provider-ci/providers/kong/repo/.github/workflows/update-upstream-provider.yml
+++ b/provider-ci/providers/kong/repo/.github/workflows/update-upstream-provider.yml
@@ -68,7 +68,6 @@ jobs:
       uses: peter-evans/create-pull-request@v3.12.0
       with:
         author: pulumi-bot <bot@pulumi.com>
-        base: master
         body: This pull request was generated automatically by the update-upstream-provider
           workflow in this repository.
         branch: pulumi-bot/v${{ github.event.inputs.version }}-${{ github.run_id}}
@@ -85,7 +84,6 @@ jobs:
       uses: peter-evans/create-pull-request@v3.12.0
       with:
         author: pulumi-bot <bot@pulumi.com>
-        base: master
         body: |-
           Fixes #${{ github.event.inputs.linked_issue_number }}
 

--- a/provider-ci/providers/libvirt/repo/.github/workflows/update-bridge.yml
+++ b/provider-ci/providers/libvirt/repo/.github/workflows/update-bridge.yml
@@ -49,7 +49,6 @@ jobs:
       uses: peter-evans/create-pull-request@v3.12.0
       with:
         author: pulumi-bot <bot@pulumi.com>
-        base: master
         body: This pull request was generated automatically by the update-bridge workflow
           in this repository.
         branch: pulumi-bot/bridge-v${{ github.event.inputs.bridge_version }}-${{ github.run_id}}

--- a/provider-ci/providers/libvirt/repo/.github/workflows/update-upstream-provider.yml
+++ b/provider-ci/providers/libvirt/repo/.github/workflows/update-upstream-provider.yml
@@ -69,7 +69,6 @@ jobs:
       uses: peter-evans/create-pull-request@v3.12.0
       with:
         author: pulumi-bot <bot@pulumi.com>
-        base: master
         body: This pull request was generated automatically by the update-upstream-provider
           workflow in this repository.
         branch: pulumi-bot/v${{ github.event.inputs.version }}-${{ github.run_id}}
@@ -86,7 +85,6 @@ jobs:
       uses: peter-evans/create-pull-request@v3.12.0
       with:
         author: pulumi-bot <bot@pulumi.com>
-        base: master
         body: |-
           Fixes #${{ github.event.inputs.linked_issue_number }}
 

--- a/provider-ci/providers/linode/repo/.github/workflows/update-bridge.yml
+++ b/provider-ci/providers/linode/repo/.github/workflows/update-bridge.yml
@@ -49,7 +49,6 @@ jobs:
       uses: peter-evans/create-pull-request@v3.12.0
       with:
         author: pulumi-bot <bot@pulumi.com>
-        base: master
         body: This pull request was generated automatically by the update-bridge workflow
           in this repository.
         branch: pulumi-bot/bridge-v${{ github.event.inputs.bridge_version }}-${{ github.run_id}}

--- a/provider-ci/providers/linode/repo/.github/workflows/update-upstream-provider.yml
+++ b/provider-ci/providers/linode/repo/.github/workflows/update-upstream-provider.yml
@@ -69,7 +69,6 @@ jobs:
       uses: peter-evans/create-pull-request@v3.12.0
       with:
         author: pulumi-bot <bot@pulumi.com>
-        base: master
         body: This pull request was generated automatically by the update-upstream-provider
           workflow in this repository.
         branch: pulumi-bot/v${{ github.event.inputs.version }}-${{ github.run_id}}
@@ -86,7 +85,6 @@ jobs:
       uses: peter-evans/create-pull-request@v3.12.0
       with:
         author: pulumi-bot <bot@pulumi.com>
-        base: master
         body: |-
           Fixes #${{ github.event.inputs.linked_issue_number }}
 

--- a/provider-ci/providers/mailgun/repo/.github/workflows/update-bridge.yml
+++ b/provider-ci/providers/mailgun/repo/.github/workflows/update-bridge.yml
@@ -49,7 +49,6 @@ jobs:
       uses: peter-evans/create-pull-request@v3.12.0
       with:
         author: pulumi-bot <bot@pulumi.com>
-        base: master
         body: This pull request was generated automatically by the update-bridge workflow
           in this repository.
         branch: pulumi-bot/bridge-v${{ github.event.inputs.bridge_version }}-${{ github.run_id}}

--- a/provider-ci/providers/mailgun/repo/.github/workflows/update-upstream-provider.yml
+++ b/provider-ci/providers/mailgun/repo/.github/workflows/update-upstream-provider.yml
@@ -69,7 +69,6 @@ jobs:
       uses: peter-evans/create-pull-request@v3.12.0
       with:
         author: pulumi-bot <bot@pulumi.com>
-        base: master
         body: This pull request was generated automatically by the update-upstream-provider
           workflow in this repository.
         branch: pulumi-bot/v${{ github.event.inputs.version }}-${{ github.run_id}}
@@ -86,7 +85,6 @@ jobs:
       uses: peter-evans/create-pull-request@v3.12.0
       with:
         author: pulumi-bot <bot@pulumi.com>
-        base: master
         body: |-
           Fixes #${{ github.event.inputs.linked_issue_number }}
 

--- a/provider-ci/providers/minio/repo/.github/workflows/update-bridge.yml
+++ b/provider-ci/providers/minio/repo/.github/workflows/update-bridge.yml
@@ -49,7 +49,6 @@ jobs:
       uses: peter-evans/create-pull-request@v3.12.0
       with:
         author: pulumi-bot <bot@pulumi.com>
-        base: master
         body: This pull request was generated automatically by the update-bridge workflow
           in this repository.
         branch: pulumi-bot/bridge-v${{ github.event.inputs.bridge_version }}-${{ github.run_id}}

--- a/provider-ci/providers/minio/repo/.github/workflows/update-upstream-provider.yml
+++ b/provider-ci/providers/minio/repo/.github/workflows/update-upstream-provider.yml
@@ -72,7 +72,6 @@ jobs:
       uses: peter-evans/create-pull-request@v3.12.0
       with:
         author: pulumi-bot <bot@pulumi.com>
-        base: master
         body: This pull request was generated automatically by the update-upstream-provider
           workflow in this repository.
         branch: pulumi-bot/v${{ github.event.inputs.version }}-${{ github.run_id}}
@@ -89,7 +88,6 @@ jobs:
       uses: peter-evans/create-pull-request@v3.12.0
       with:
         author: pulumi-bot <bot@pulumi.com>
-        base: master
         body: |-
           Fixes #${{ github.event.inputs.linked_issue_number }}
 

--- a/provider-ci/providers/mongodbatlas/repo/.github/workflows/update-bridge.yml
+++ b/provider-ci/providers/mongodbatlas/repo/.github/workflows/update-bridge.yml
@@ -49,7 +49,6 @@ jobs:
       uses: peter-evans/create-pull-request@v3.12.0
       with:
         author: pulumi-bot <bot@pulumi.com>
-        base: master
         body: This pull request was generated automatically by the update-bridge workflow
           in this repository.
         branch: pulumi-bot/bridge-v${{ github.event.inputs.bridge_version }}-${{ github.run_id}}

--- a/provider-ci/providers/mongodbatlas/repo/.github/workflows/update-upstream-provider.yml
+++ b/provider-ci/providers/mongodbatlas/repo/.github/workflows/update-upstream-provider.yml
@@ -71,7 +71,6 @@ jobs:
       uses: peter-evans/create-pull-request@v3.12.0
       with:
         author: pulumi-bot <bot@pulumi.com>
-        base: master
         body: This pull request was generated automatically by the update-upstream-provider
           workflow in this repository.
         branch: pulumi-bot/v${{ github.event.inputs.version }}-${{ github.run_id}}
@@ -88,7 +87,6 @@ jobs:
       uses: peter-evans/create-pull-request@v3.12.0
       with:
         author: pulumi-bot <bot@pulumi.com>
-        base: master
         body: |-
           Fixes #${{ github.event.inputs.linked_issue_number }}
 

--- a/provider-ci/providers/mysql/repo/.github/workflows/update-bridge.yml
+++ b/provider-ci/providers/mysql/repo/.github/workflows/update-bridge.yml
@@ -49,7 +49,6 @@ jobs:
       uses: peter-evans/create-pull-request@v3.12.0
       with:
         author: pulumi-bot <bot@pulumi.com>
-        base: master
         body: This pull request was generated automatically by the update-bridge workflow
           in this repository.
         branch: pulumi-bot/bridge-v${{ github.event.inputs.bridge_version }}-${{ github.run_id}}

--- a/provider-ci/providers/mysql/repo/.github/workflows/update-upstream-provider.yml
+++ b/provider-ci/providers/mysql/repo/.github/workflows/update-upstream-provider.yml
@@ -68,7 +68,6 @@ jobs:
       uses: peter-evans/create-pull-request@v3.12.0
       with:
         author: pulumi-bot <bot@pulumi.com>
-        base: master
         body: This pull request was generated automatically by the update-upstream-provider
           workflow in this repository.
         branch: pulumi-bot/v${{ github.event.inputs.version }}-${{ github.run_id}}
@@ -85,7 +84,6 @@ jobs:
       uses: peter-evans/create-pull-request@v3.12.0
       with:
         author: pulumi-bot <bot@pulumi.com>
-        base: master
         body: |-
           Fixes #${{ github.event.inputs.linked_issue_number }}
 

--- a/provider-ci/providers/newrelic/repo/.github/workflows/update-bridge.yml
+++ b/provider-ci/providers/newrelic/repo/.github/workflows/update-bridge.yml
@@ -49,7 +49,6 @@ jobs:
       uses: peter-evans/create-pull-request@v3.12.0
       with:
         author: pulumi-bot <bot@pulumi.com>
-        base: master
         body: This pull request was generated automatically by the update-bridge workflow
           in this repository.
         branch: pulumi-bot/bridge-v${{ github.event.inputs.bridge_version }}-${{ github.run_id}}

--- a/provider-ci/providers/newrelic/repo/.github/workflows/update-upstream-provider.yml
+++ b/provider-ci/providers/newrelic/repo/.github/workflows/update-upstream-provider.yml
@@ -70,7 +70,6 @@ jobs:
       uses: peter-evans/create-pull-request@v3.12.0
       with:
         author: pulumi-bot <bot@pulumi.com>
-        base: master
         body: This pull request was generated automatically by the update-upstream-provider
           workflow in this repository.
         branch: pulumi-bot/v${{ github.event.inputs.version }}-${{ github.run_id}}
@@ -87,7 +86,6 @@ jobs:
       uses: peter-evans/create-pull-request@v3.12.0
       with:
         author: pulumi-bot <bot@pulumi.com>
-        base: master
         body: |-
           Fixes #${{ github.event.inputs.linked_issue_number }}
 

--- a/provider-ci/providers/nomad/repo/.github/workflows/update-bridge.yml
+++ b/provider-ci/providers/nomad/repo/.github/workflows/update-bridge.yml
@@ -49,7 +49,6 @@ jobs:
       uses: peter-evans/create-pull-request@v3.12.0
       with:
         author: pulumi-bot <bot@pulumi.com>
-        base: master
         body: This pull request was generated automatically by the update-bridge workflow
           in this repository.
         branch: pulumi-bot/bridge-v${{ github.event.inputs.bridge_version }}-${{ github.run_id}}

--- a/provider-ci/providers/nomad/repo/.github/workflows/update-upstream-provider.yml
+++ b/provider-ci/providers/nomad/repo/.github/workflows/update-upstream-provider.yml
@@ -69,7 +69,6 @@ jobs:
       uses: peter-evans/create-pull-request@v3.12.0
       with:
         author: pulumi-bot <bot@pulumi.com>
-        base: master
         body: This pull request was generated automatically by the update-upstream-provider
           workflow in this repository.
         branch: pulumi-bot/v${{ github.event.inputs.version }}-${{ github.run_id}}
@@ -86,7 +85,6 @@ jobs:
       uses: peter-evans/create-pull-request@v3.12.0
       with:
         author: pulumi-bot <bot@pulumi.com>
-        base: master
         body: |-
           Fixes #${{ github.event.inputs.linked_issue_number }}
 

--- a/provider-ci/providers/ns1/repo/.github/workflows/update-bridge.yml
+++ b/provider-ci/providers/ns1/repo/.github/workflows/update-bridge.yml
@@ -49,7 +49,6 @@ jobs:
       uses: peter-evans/create-pull-request@v3.12.0
       with:
         author: pulumi-bot <bot@pulumi.com>
-        base: master
         body: This pull request was generated automatically by the update-bridge workflow
           in this repository.
         branch: pulumi-bot/bridge-v${{ github.event.inputs.bridge_version }}-${{ github.run_id}}

--- a/provider-ci/providers/ns1/repo/.github/workflows/update-upstream-provider.yml
+++ b/provider-ci/providers/ns1/repo/.github/workflows/update-upstream-provider.yml
@@ -69,7 +69,6 @@ jobs:
       uses: peter-evans/create-pull-request@v3.12.0
       with:
         author: pulumi-bot <bot@pulumi.com>
-        base: master
         body: This pull request was generated automatically by the update-upstream-provider
           workflow in this repository.
         branch: pulumi-bot/v${{ github.event.inputs.version }}-${{ github.run_id}}
@@ -86,7 +85,6 @@ jobs:
       uses: peter-evans/create-pull-request@v3.12.0
       with:
         author: pulumi-bot <bot@pulumi.com>
-        base: master
         body: |-
           Fixes #${{ github.event.inputs.linked_issue_number }}
 

--- a/provider-ci/providers/okta/repo/.github/workflows/update-bridge.yml
+++ b/provider-ci/providers/okta/repo/.github/workflows/update-bridge.yml
@@ -49,7 +49,6 @@ jobs:
       uses: peter-evans/create-pull-request@v3.12.0
       with:
         author: pulumi-bot <bot@pulumi.com>
-        base: master
         body: This pull request was generated automatically by the update-bridge workflow
           in this repository.
         branch: pulumi-bot/bridge-v${{ github.event.inputs.bridge_version }}-${{ github.run_id}}

--- a/provider-ci/providers/okta/repo/.github/workflows/update-upstream-provider.yml
+++ b/provider-ci/providers/okta/repo/.github/workflows/update-upstream-provider.yml
@@ -71,7 +71,6 @@ jobs:
       uses: peter-evans/create-pull-request@v3.12.0
       with:
         author: pulumi-bot <bot@pulumi.com>
-        base: master
         body: This pull request was generated automatically by the update-upstream-provider
           workflow in this repository.
         branch: pulumi-bot/v${{ github.event.inputs.version }}-${{ github.run_id}}
@@ -88,7 +87,6 @@ jobs:
       uses: peter-evans/create-pull-request@v3.12.0
       with:
         author: pulumi-bot <bot@pulumi.com>
-        base: master
         body: |-
           Fixes #${{ github.event.inputs.linked_issue_number }}
 

--- a/provider-ci/providers/openstack/repo/.github/workflows/update-bridge.yml
+++ b/provider-ci/providers/openstack/repo/.github/workflows/update-bridge.yml
@@ -49,7 +49,6 @@ jobs:
       uses: peter-evans/create-pull-request@v3.12.0
       with:
         author: pulumi-bot <bot@pulumi.com>
-        base: master
         body: This pull request was generated automatically by the update-bridge workflow
           in this repository.
         branch: pulumi-bot/bridge-v${{ github.event.inputs.bridge_version }}-${{ github.run_id}}

--- a/provider-ci/providers/openstack/repo/.github/workflows/update-upstream-provider.yml
+++ b/provider-ci/providers/openstack/repo/.github/workflows/update-upstream-provider.yml
@@ -77,7 +77,6 @@ jobs:
       uses: peter-evans/create-pull-request@v3.12.0
       with:
         author: pulumi-bot <bot@pulumi.com>
-        base: master
         body: This pull request was generated automatically by the update-upstream-provider
           workflow in this repository.
         branch: pulumi-bot/v${{ github.event.inputs.version }}-${{ github.run_id}}
@@ -94,7 +93,6 @@ jobs:
       uses: peter-evans/create-pull-request@v3.12.0
       with:
         author: pulumi-bot <bot@pulumi.com>
-        base: master
         body: |-
           Fixes #${{ github.event.inputs.linked_issue_number }}
 

--- a/provider-ci/providers/opsgenie/repo/.github/workflows/update-bridge.yml
+++ b/provider-ci/providers/opsgenie/repo/.github/workflows/update-bridge.yml
@@ -49,7 +49,6 @@ jobs:
       uses: peter-evans/create-pull-request@v3.12.0
       with:
         author: pulumi-bot <bot@pulumi.com>
-        base: master
         body: This pull request was generated automatically by the update-bridge workflow
           in this repository.
         branch: pulumi-bot/bridge-v${{ github.event.inputs.bridge_version }}-${{ github.run_id}}

--- a/provider-ci/providers/opsgenie/repo/.github/workflows/update-upstream-provider.yml
+++ b/provider-ci/providers/opsgenie/repo/.github/workflows/update-upstream-provider.yml
@@ -69,7 +69,6 @@ jobs:
       uses: peter-evans/create-pull-request@v3.12.0
       with:
         author: pulumi-bot <bot@pulumi.com>
-        base: master
         body: This pull request was generated automatically by the update-upstream-provider
           workflow in this repository.
         branch: pulumi-bot/v${{ github.event.inputs.version }}-${{ github.run_id}}
@@ -86,7 +85,6 @@ jobs:
       uses: peter-evans/create-pull-request@v3.12.0
       with:
         author: pulumi-bot <bot@pulumi.com>
-        base: master
         body: |-
           Fixes #${{ github.event.inputs.linked_issue_number }}
 

--- a/provider-ci/providers/pagerduty/repo/.github/workflows/update-bridge.yml
+++ b/provider-ci/providers/pagerduty/repo/.github/workflows/update-bridge.yml
@@ -49,7 +49,6 @@ jobs:
       uses: peter-evans/create-pull-request@v3.12.0
       with:
         author: pulumi-bot <bot@pulumi.com>
-        base: master
         body: This pull request was generated automatically by the update-bridge workflow
           in this repository.
         branch: pulumi-bot/bridge-v${{ github.event.inputs.bridge_version }}-${{ github.run_id}}

--- a/provider-ci/providers/pagerduty/repo/.github/workflows/update-upstream-provider.yml
+++ b/provider-ci/providers/pagerduty/repo/.github/workflows/update-upstream-provider.yml
@@ -69,7 +69,6 @@ jobs:
       uses: peter-evans/create-pull-request@v3.12.0
       with:
         author: pulumi-bot <bot@pulumi.com>
-        base: master
         body: This pull request was generated automatically by the update-upstream-provider
           workflow in this repository.
         branch: pulumi-bot/v${{ github.event.inputs.version }}-${{ github.run_id}}
@@ -86,7 +85,6 @@ jobs:
       uses: peter-evans/create-pull-request@v3.12.0
       with:
         author: pulumi-bot <bot@pulumi.com>
-        base: master
         body: |-
           Fixes #${{ github.event.inputs.linked_issue_number }}
 

--- a/provider-ci/providers/postgresql/repo/.github/workflows/update-bridge.yml
+++ b/provider-ci/providers/postgresql/repo/.github/workflows/update-bridge.yml
@@ -49,7 +49,6 @@ jobs:
       uses: peter-evans/create-pull-request@v3.12.0
       with:
         author: pulumi-bot <bot@pulumi.com>
-        base: master
         body: This pull request was generated automatically by the update-bridge workflow
           in this repository.
         branch: pulumi-bot/bridge-v${{ github.event.inputs.bridge_version }}-${{ github.run_id}}

--- a/provider-ci/providers/postgresql/repo/.github/workflows/update-upstream-provider.yml
+++ b/provider-ci/providers/postgresql/repo/.github/workflows/update-upstream-provider.yml
@@ -68,7 +68,6 @@ jobs:
       uses: peter-evans/create-pull-request@v3.12.0
       with:
         author: pulumi-bot <bot@pulumi.com>
-        base: master
         body: This pull request was generated automatically by the update-upstream-provider
           workflow in this repository.
         branch: pulumi-bot/v${{ github.event.inputs.version }}-${{ github.run_id}}
@@ -85,7 +84,6 @@ jobs:
       uses: peter-evans/create-pull-request@v3.12.0
       with:
         author: pulumi-bot <bot@pulumi.com>
-        base: master
         body: |-
           Fixes #${{ github.event.inputs.linked_issue_number }}
 

--- a/provider-ci/providers/rabbitmq/repo/.github/workflows/update-bridge.yml
+++ b/provider-ci/providers/rabbitmq/repo/.github/workflows/update-bridge.yml
@@ -49,7 +49,6 @@ jobs:
       uses: peter-evans/create-pull-request@v3.12.0
       with:
         author: pulumi-bot <bot@pulumi.com>
-        base: master
         body: This pull request was generated automatically by the update-bridge workflow
           in this repository.
         branch: pulumi-bot/bridge-v${{ github.event.inputs.bridge_version }}-${{ github.run_id}}

--- a/provider-ci/providers/rabbitmq/repo/.github/workflows/update-upstream-provider.yml
+++ b/provider-ci/providers/rabbitmq/repo/.github/workflows/update-upstream-provider.yml
@@ -68,7 +68,6 @@ jobs:
       uses: peter-evans/create-pull-request@v3.12.0
       with:
         author: pulumi-bot <bot@pulumi.com>
-        base: master
         body: This pull request was generated automatically by the update-upstream-provider
           workflow in this repository.
         branch: pulumi-bot/v${{ github.event.inputs.version }}-${{ github.run_id}}
@@ -85,7 +84,6 @@ jobs:
       uses: peter-evans/create-pull-request@v3.12.0
       with:
         author: pulumi-bot <bot@pulumi.com>
-        base: master
         body: |-
           Fixes #${{ github.event.inputs.linked_issue_number }}
 

--- a/provider-ci/providers/rancher2/repo/.github/workflows/update-bridge.yml
+++ b/provider-ci/providers/rancher2/repo/.github/workflows/update-bridge.yml
@@ -49,7 +49,6 @@ jobs:
       uses: peter-evans/create-pull-request@v3.12.0
       with:
         author: pulumi-bot <bot@pulumi.com>
-        base: master
         body: This pull request was generated automatically by the update-bridge workflow
           in this repository.
         branch: pulumi-bot/bridge-v${{ github.event.inputs.bridge_version }}-${{ github.run_id}}

--- a/provider-ci/providers/rancher2/repo/.github/workflows/update-upstream-provider.yml
+++ b/provider-ci/providers/rancher2/repo/.github/workflows/update-upstream-provider.yml
@@ -70,7 +70,6 @@ jobs:
       uses: peter-evans/create-pull-request@v3.12.0
       with:
         author: pulumi-bot <bot@pulumi.com>
-        base: master
         body: This pull request was generated automatically by the update-upstream-provider
           workflow in this repository.
         branch: pulumi-bot/v${{ github.event.inputs.version }}-${{ github.run_id}}
@@ -87,7 +86,6 @@ jobs:
       uses: peter-evans/create-pull-request@v3.12.0
       with:
         author: pulumi-bot <bot@pulumi.com>
-        base: master
         body: |-
           Fixes #${{ github.event.inputs.linked_issue_number }}
 

--- a/provider-ci/providers/random/repo/.github/workflows/update-bridge.yml
+++ b/provider-ci/providers/random/repo/.github/workflows/update-bridge.yml
@@ -49,7 +49,6 @@ jobs:
       uses: peter-evans/create-pull-request@v3.12.0
       with:
         author: pulumi-bot <bot@pulumi.com>
-        base: master
         body: This pull request was generated automatically by the update-bridge workflow
           in this repository.
         branch: pulumi-bot/bridge-v${{ github.event.inputs.bridge_version }}-${{ github.run_id}}

--- a/provider-ci/providers/random/repo/.github/workflows/update-upstream-provider.yml
+++ b/provider-ci/providers/random/repo/.github/workflows/update-upstream-provider.yml
@@ -68,7 +68,6 @@ jobs:
       uses: peter-evans/create-pull-request@v3.12.0
       with:
         author: pulumi-bot <bot@pulumi.com>
-        base: master
         body: This pull request was generated automatically by the update-upstream-provider
           workflow in this repository.
         branch: pulumi-bot/v${{ github.event.inputs.version }}-${{ github.run_id}}
@@ -85,7 +84,6 @@ jobs:
       uses: peter-evans/create-pull-request@v3.12.0
       with:
         author: pulumi-bot <bot@pulumi.com>
-        base: master
         body: |-
           Fixes #${{ github.event.inputs.linked_issue_number }}
 

--- a/provider-ci/providers/rke/repo/.github/workflows/update-bridge.yml
+++ b/provider-ci/providers/rke/repo/.github/workflows/update-bridge.yml
@@ -49,7 +49,6 @@ jobs:
       uses: peter-evans/create-pull-request@v3.12.0
       with:
         author: pulumi-bot <bot@pulumi.com>
-        base: master
         body: This pull request was generated automatically by the update-bridge workflow
           in this repository.
         branch: pulumi-bot/bridge-v${{ github.event.inputs.bridge_version }}-${{ github.run_id}}

--- a/provider-ci/providers/rke/repo/.github/workflows/update-upstream-provider.yml
+++ b/provider-ci/providers/rke/repo/.github/workflows/update-upstream-provider.yml
@@ -69,7 +69,6 @@ jobs:
       uses: peter-evans/create-pull-request@v3.12.0
       with:
         author: pulumi-bot <bot@pulumi.com>
-        base: master
         body: This pull request was generated automatically by the update-upstream-provider
           workflow in this repository.
         branch: pulumi-bot/v${{ github.event.inputs.version }}-${{ github.run_id}}
@@ -86,7 +85,6 @@ jobs:
       uses: peter-evans/create-pull-request@v3.12.0
       with:
         author: pulumi-bot <bot@pulumi.com>
-        base: master
         body: |-
           Fixes #${{ github.event.inputs.linked_issue_number }}
 

--- a/provider-ci/providers/signalfx/repo/.github/workflows/update-bridge.yml
+++ b/provider-ci/providers/signalfx/repo/.github/workflows/update-bridge.yml
@@ -49,7 +49,6 @@ jobs:
       uses: peter-evans/create-pull-request@v3.12.0
       with:
         author: pulumi-bot <bot@pulumi.com>
-        base: master
         body: This pull request was generated automatically by the update-bridge workflow
           in this repository.
         branch: pulumi-bot/bridge-v${{ github.event.inputs.bridge_version }}-${{ github.run_id}}

--- a/provider-ci/providers/signalfx/repo/.github/workflows/update-upstream-provider.yml
+++ b/provider-ci/providers/signalfx/repo/.github/workflows/update-upstream-provider.yml
@@ -68,7 +68,6 @@ jobs:
       uses: peter-evans/create-pull-request@v3.12.0
       with:
         author: pulumi-bot <bot@pulumi.com>
-        base: master
         body: This pull request was generated automatically by the update-upstream-provider
           workflow in this repository.
         branch: pulumi-bot/v${{ github.event.inputs.version }}-${{ github.run_id}}
@@ -85,7 +84,6 @@ jobs:
       uses: peter-evans/create-pull-request@v3.12.0
       with:
         author: pulumi-bot <bot@pulumi.com>
-        base: master
         body: |-
           Fixes #${{ github.event.inputs.linked_issue_number }}
 

--- a/provider-ci/providers/snowflake/repo/.github/workflows/update-bridge.yml
+++ b/provider-ci/providers/snowflake/repo/.github/workflows/update-bridge.yml
@@ -49,7 +49,6 @@ jobs:
       uses: peter-evans/create-pull-request@v3.12.0
       with:
         author: pulumi-bot <bot@pulumi.com>
-        base: master
         body: This pull request was generated automatically by the update-bridge workflow
           in this repository.
         branch: pulumi-bot/bridge-v${{ github.event.inputs.bridge_version }}-${{ github.run_id}}

--- a/provider-ci/providers/snowflake/repo/.github/workflows/update-upstream-provider.yml
+++ b/provider-ci/providers/snowflake/repo/.github/workflows/update-upstream-provider.yml
@@ -73,7 +73,6 @@ jobs:
       uses: peter-evans/create-pull-request@v3.12.0
       with:
         author: pulumi-bot <bot@pulumi.com>
-        base: master
         body: This pull request was generated automatically by the update-upstream-provider
           workflow in this repository.
         branch: pulumi-bot/v${{ github.event.inputs.version }}-${{ github.run_id}}
@@ -90,7 +89,6 @@ jobs:
       uses: peter-evans/create-pull-request@v3.12.0
       with:
         author: pulumi-bot <bot@pulumi.com>
-        base: master
         body: |-
           Fixes #${{ github.event.inputs.linked_issue_number }}
 

--- a/provider-ci/providers/splunk/repo/.github/workflows/update-bridge.yml
+++ b/provider-ci/providers/splunk/repo/.github/workflows/update-bridge.yml
@@ -49,7 +49,6 @@ jobs:
       uses: peter-evans/create-pull-request@v3.12.0
       with:
         author: pulumi-bot <bot@pulumi.com>
-        base: master
         body: This pull request was generated automatically by the update-bridge workflow
           in this repository.
         branch: pulumi-bot/bridge-v${{ github.event.inputs.bridge_version }}-${{ github.run_id}}

--- a/provider-ci/providers/splunk/repo/.github/workflows/update-upstream-provider.yml
+++ b/provider-ci/providers/splunk/repo/.github/workflows/update-upstream-provider.yml
@@ -71,7 +71,6 @@ jobs:
       uses: peter-evans/create-pull-request@v3.12.0
       with:
         author: pulumi-bot <bot@pulumi.com>
-        base: master
         body: This pull request was generated automatically by the update-upstream-provider
           workflow in this repository.
         branch: pulumi-bot/v${{ github.event.inputs.version }}-${{ github.run_id}}
@@ -88,7 +87,6 @@ jobs:
       uses: peter-evans/create-pull-request@v3.12.0
       with:
         author: pulumi-bot <bot@pulumi.com>
-        base: master
         body: |-
           Fixes #${{ github.event.inputs.linked_issue_number }}
 

--- a/provider-ci/providers/spotinst/repo/.github/workflows/update-bridge.yml
+++ b/provider-ci/providers/spotinst/repo/.github/workflows/update-bridge.yml
@@ -49,7 +49,6 @@ jobs:
       uses: peter-evans/create-pull-request@v3.12.0
       with:
         author: pulumi-bot <bot@pulumi.com>
-        base: master
         body: This pull request was generated automatically by the update-bridge workflow
           in this repository.
         branch: pulumi-bot/bridge-v${{ github.event.inputs.bridge_version }}-${{ github.run_id}}

--- a/provider-ci/providers/spotinst/repo/.github/workflows/update-upstream-provider.yml
+++ b/provider-ci/providers/spotinst/repo/.github/workflows/update-upstream-provider.yml
@@ -71,7 +71,6 @@ jobs:
       uses: peter-evans/create-pull-request@v3.12.0
       with:
         author: pulumi-bot <bot@pulumi.com>
-        base: master
         body: This pull request was generated automatically by the update-upstream-provider
           workflow in this repository.
         branch: pulumi-bot/v${{ github.event.inputs.version }}-${{ github.run_id}}
@@ -88,7 +87,6 @@ jobs:
       uses: peter-evans/create-pull-request@v3.12.0
       with:
         author: pulumi-bot <bot@pulumi.com>
-        base: master
         body: |-
           Fixes #${{ github.event.inputs.linked_issue_number }}
 

--- a/provider-ci/providers/sumologic/repo/.github/workflows/update-bridge.yml
+++ b/provider-ci/providers/sumologic/repo/.github/workflows/update-bridge.yml
@@ -49,7 +49,6 @@ jobs:
       uses: peter-evans/create-pull-request@v3.12.0
       with:
         author: pulumi-bot <bot@pulumi.com>
-        base: master
         body: This pull request was generated automatically by the update-bridge workflow
           in this repository.
         branch: pulumi-bot/bridge-v${{ github.event.inputs.bridge_version }}-${{ github.run_id}}

--- a/provider-ci/providers/sumologic/repo/.github/workflows/update-upstream-provider.yml
+++ b/provider-ci/providers/sumologic/repo/.github/workflows/update-upstream-provider.yml
@@ -71,7 +71,6 @@ jobs:
       uses: peter-evans/create-pull-request@v3.12.0
       with:
         author: pulumi-bot <bot@pulumi.com>
-        base: master
         body: This pull request was generated automatically by the update-upstream-provider
           workflow in this repository.
         branch: pulumi-bot/v${{ github.event.inputs.version }}-${{ github.run_id}}
@@ -88,7 +87,6 @@ jobs:
       uses: peter-evans/create-pull-request@v3.12.0
       with:
         author: pulumi-bot <bot@pulumi.com>
-        base: master
         body: |-
           Fixes #${{ github.event.inputs.linked_issue_number }}
 

--- a/provider-ci/providers/tailscale/repo/.github/workflows/update-bridge.yml
+++ b/provider-ci/providers/tailscale/repo/.github/workflows/update-bridge.yml
@@ -49,7 +49,6 @@ jobs:
       uses: peter-evans/create-pull-request@v3.12.0
       with:
         author: pulumi-bot <bot@pulumi.com>
-        base: master
         body: This pull request was generated automatically by the update-bridge workflow
           in this repository.
         branch: pulumi-bot/bridge-v${{ github.event.inputs.bridge_version }}-${{ github.run_id}}

--- a/provider-ci/providers/tailscale/repo/.github/workflows/update-upstream-provider.yml
+++ b/provider-ci/providers/tailscale/repo/.github/workflows/update-upstream-provider.yml
@@ -70,7 +70,6 @@ jobs:
       uses: peter-evans/create-pull-request@v3.12.0
       with:
         author: pulumi-bot <bot@pulumi.com>
-        base: master
         body: This pull request was generated automatically by the update-upstream-provider
           workflow in this repository.
         branch: pulumi-bot/v${{ github.event.inputs.version }}-${{ github.run_id}}
@@ -87,7 +86,6 @@ jobs:
       uses: peter-evans/create-pull-request@v3.12.0
       with:
         author: pulumi-bot <bot@pulumi.com>
-        base: master
         body: |-
           Fixes #${{ github.event.inputs.linked_issue_number }}
 

--- a/provider-ci/providers/terraform/repo/.github/workflows/update-bridge.yml
+++ b/provider-ci/providers/terraform/repo/.github/workflows/update-bridge.yml
@@ -49,7 +49,6 @@ jobs:
       uses: peter-evans/create-pull-request@v3.12.0
       with:
         author: pulumi-bot <bot@pulumi.com>
-        base: master
         body: This pull request was generated automatically by the update-bridge workflow
           in this repository.
         branch: pulumi-bot/bridge-v${{ github.event.inputs.bridge_version }}-${{ github.run_id}}

--- a/provider-ci/providers/terraform/repo/.github/workflows/update-upstream-provider.yml
+++ b/provider-ci/providers/terraform/repo/.github/workflows/update-upstream-provider.yml
@@ -71,7 +71,6 @@ jobs:
       uses: peter-evans/create-pull-request@v3.12.0
       with:
         author: pulumi-bot <bot@pulumi.com>
-        base: master
         body: This pull request was generated automatically by the update-upstream-provider
           workflow in this repository.
         branch: pulumi-bot/v${{ github.event.inputs.version }}-${{ github.run_id}}
@@ -88,7 +87,6 @@ jobs:
       uses: peter-evans/create-pull-request@v3.12.0
       with:
         author: pulumi-bot <bot@pulumi.com>
-        base: master
         body: |-
           Fixes #${{ github.event.inputs.linked_issue_number }}
 

--- a/provider-ci/providers/tls/repo/.github/workflows/update-bridge.yml
+++ b/provider-ci/providers/tls/repo/.github/workflows/update-bridge.yml
@@ -49,7 +49,6 @@ jobs:
       uses: peter-evans/create-pull-request@v3.12.0
       with:
         author: pulumi-bot <bot@pulumi.com>
-        base: master
         body: This pull request was generated automatically by the update-bridge workflow
           in this repository.
         branch: pulumi-bot/bridge-v${{ github.event.inputs.bridge_version }}-${{ github.run_id}}

--- a/provider-ci/providers/tls/repo/.github/workflows/update-upstream-provider.yml
+++ b/provider-ci/providers/tls/repo/.github/workflows/update-upstream-provider.yml
@@ -68,7 +68,6 @@ jobs:
       uses: peter-evans/create-pull-request@v3.12.0
       with:
         author: pulumi-bot <bot@pulumi.com>
-        base: master
         body: This pull request was generated automatically by the update-upstream-provider
           workflow in this repository.
         branch: pulumi-bot/v${{ github.event.inputs.version }}-${{ github.run_id}}
@@ -85,7 +84,6 @@ jobs:
       uses: peter-evans/create-pull-request@v3.12.0
       with:
         author: pulumi-bot <bot@pulumi.com>
-        base: master
         body: |-
           Fixes #${{ github.event.inputs.linked_issue_number }}
 

--- a/provider-ci/providers/vault/repo/.github/workflows/update-bridge.yml
+++ b/provider-ci/providers/vault/repo/.github/workflows/update-bridge.yml
@@ -49,7 +49,6 @@ jobs:
       uses: peter-evans/create-pull-request@v3.12.0
       with:
         author: pulumi-bot <bot@pulumi.com>
-        base: master
         body: This pull request was generated automatically by the update-bridge workflow
           in this repository.
         branch: pulumi-bot/bridge-v${{ github.event.inputs.bridge_version }}-${{ github.run_id}}

--- a/provider-ci/providers/vault/repo/.github/workflows/update-upstream-provider.yml
+++ b/provider-ci/providers/vault/repo/.github/workflows/update-upstream-provider.yml
@@ -68,7 +68,6 @@ jobs:
       uses: peter-evans/create-pull-request@v3.12.0
       with:
         author: pulumi-bot <bot@pulumi.com>
-        base: master
         body: This pull request was generated automatically by the update-upstream-provider
           workflow in this repository.
         branch: pulumi-bot/v${{ github.event.inputs.version }}-${{ github.run_id}}
@@ -85,7 +84,6 @@ jobs:
       uses: peter-evans/create-pull-request@v3.12.0
       with:
         author: pulumi-bot <bot@pulumi.com>
-        base: master
         body: |-
           Fixes #${{ github.event.inputs.linked_issue_number }}
 

--- a/provider-ci/providers/venafi/repo/.github/workflows/update-bridge.yml
+++ b/provider-ci/providers/venafi/repo/.github/workflows/update-bridge.yml
@@ -49,7 +49,6 @@ jobs:
       uses: peter-evans/create-pull-request@v3.12.0
       with:
         author: pulumi-bot <bot@pulumi.com>
-        base: master
         body: This pull request was generated automatically by the update-bridge workflow
           in this repository.
         branch: pulumi-bot/bridge-v${{ github.event.inputs.bridge_version }}-${{ github.run_id}}

--- a/provider-ci/providers/venafi/repo/.github/workflows/update-upstream-provider.yml
+++ b/provider-ci/providers/venafi/repo/.github/workflows/update-upstream-provider.yml
@@ -71,7 +71,6 @@ jobs:
       uses: peter-evans/create-pull-request@v3.12.0
       with:
         author: pulumi-bot <bot@pulumi.com>
-        base: master
         body: This pull request was generated automatically by the update-upstream-provider
           workflow in this repository.
         branch: pulumi-bot/v${{ github.event.inputs.version }}-${{ github.run_id}}
@@ -88,7 +87,6 @@ jobs:
       uses: peter-evans/create-pull-request@v3.12.0
       with:
         author: pulumi-bot <bot@pulumi.com>
-        base: master
         body: |-
           Fixes #${{ github.event.inputs.linked_issue_number }}
 

--- a/provider-ci/providers/vsphere/repo/.github/workflows/update-bridge.yml
+++ b/provider-ci/providers/vsphere/repo/.github/workflows/update-bridge.yml
@@ -49,7 +49,6 @@ jobs:
       uses: peter-evans/create-pull-request@v3.12.0
       with:
         author: pulumi-bot <bot@pulumi.com>
-        base: master
         body: This pull request was generated automatically by the update-bridge workflow
           in this repository.
         branch: pulumi-bot/bridge-v${{ github.event.inputs.bridge_version }}-${{ github.run_id}}

--- a/provider-ci/providers/vsphere/repo/.github/workflows/update-upstream-provider.yml
+++ b/provider-ci/providers/vsphere/repo/.github/workflows/update-upstream-provider.yml
@@ -68,7 +68,6 @@ jobs:
       uses: peter-evans/create-pull-request@v3.12.0
       with:
         author: pulumi-bot <bot@pulumi.com>
-        base: master
         body: This pull request was generated automatically by the update-upstream-provider
           workflow in this repository.
         branch: pulumi-bot/v${{ github.event.inputs.version }}-${{ github.run_id}}
@@ -85,7 +84,6 @@ jobs:
       uses: peter-evans/create-pull-request@v3.12.0
       with:
         author: pulumi-bot <bot@pulumi.com>
-        base: master
         body: |-
           Fixes #${{ github.event.inputs.linked_issue_number }}
 

--- a/provider-ci/providers/wavefront/repo/.github/workflows/update-bridge.yml
+++ b/provider-ci/providers/wavefront/repo/.github/workflows/update-bridge.yml
@@ -49,7 +49,6 @@ jobs:
       uses: peter-evans/create-pull-request@v3.12.0
       with:
         author: pulumi-bot <bot@pulumi.com>
-        base: master
         body: This pull request was generated automatically by the update-bridge workflow
           in this repository.
         branch: pulumi-bot/bridge-v${{ github.event.inputs.bridge_version }}-${{ github.run_id}}

--- a/provider-ci/providers/wavefront/repo/.github/workflows/update-upstream-provider.yml
+++ b/provider-ci/providers/wavefront/repo/.github/workflows/update-upstream-provider.yml
@@ -70,7 +70,6 @@ jobs:
       uses: peter-evans/create-pull-request@v3.12.0
       with:
         author: pulumi-bot <bot@pulumi.com>
-        base: master
         body: This pull request was generated automatically by the update-upstream-provider
           workflow in this repository.
         branch: pulumi-bot/v${{ github.event.inputs.version }}-${{ github.run_id}}
@@ -87,7 +86,6 @@ jobs:
       uses: peter-evans/create-pull-request@v3.12.0
       with:
         author: pulumi-bot <bot@pulumi.com>
-        base: master
         body: |-
           Fixes #${{ github.event.inputs.linked_issue_number }}
 

--- a/provider-ci/providers/yandex/repo/.github/workflows/update-bridge.yml
+++ b/provider-ci/providers/yandex/repo/.github/workflows/update-bridge.yml
@@ -49,7 +49,6 @@ jobs:
       uses: peter-evans/create-pull-request@v3.12.0
       with:
         author: pulumi-bot <bot@pulumi.com>
-        base: master
         body: This pull request was generated automatically by the update-bridge workflow
           in this repository.
         branch: pulumi-bot/bridge-v${{ github.event.inputs.bridge_version }}-${{ github.run_id}}

--- a/provider-ci/providers/yandex/repo/.github/workflows/update-upstream-provider.yml
+++ b/provider-ci/providers/yandex/repo/.github/workflows/update-upstream-provider.yml
@@ -71,7 +71,6 @@ jobs:
       uses: peter-evans/create-pull-request@v3.12.0
       with:
         author: pulumi-bot <bot@pulumi.com>
-        base: master
         body: This pull request was generated automatically by the update-upstream-provider
           workflow in this repository.
         branch: pulumi-bot/v${{ github.event.inputs.version }}-${{ github.run_id}}
@@ -88,7 +87,6 @@ jobs:
       uses: peter-evans/create-pull-request@v3.12.0
       with:
         author: pulumi-bot <bot@pulumi.com>
-        base: master
         body: |-
           Fixes #${{ github.event.inputs.linked_issue_number }}
 

--- a/provider-ci/src/workflows.ts
+++ b/provider-ci/src/workflows.ts
@@ -269,7 +269,6 @@ export class UpdatePulumiTerraformBridgeWorkflow extends g.GithubWorkflow {
                         committer: "pulumi-bot <bot@pulumi.com>",
                         author: "pulumi-bot <bot@pulumi.com>",
                         branch: "pulumi-bot/bridge-v${{ github.event.inputs.bridge_version }}-${{ github.run_id}}",
-                        base: "master",
                         labels: "impact/no-changelog-required",
                         title: "Update pulumi-terraform-bridge to v${{ github.event.inputs.bridge_version }}",
                         body: "This pull request was generated automatically by the update-bridge workflow in this repository.",
@@ -324,7 +323,6 @@ export class UpdateUpstreamProviderWorkflow extends g.GithubWorkflow {
             committer: "pulumi-bot <bot@pulumi.com>",
             author: "pulumi-bot <bot@pulumi.com>",
             branch: "pulumi-bot/v${{ github.event.inputs.version }}-${{ github.run_id}}",
-            base: "master",
             // TODO: Add auto-merge.
             labels: "impact/no-changelog-required",
             title: "Update ${{ env.UPSTREAM_PROVIDER_REPO }} to v${{ github.event.inputs.version }}",


### PR DESCRIPTION
Removed the unnecessary "base" option when creating PRs for updating the
bridge or the upstream provider. The create-pull-request action defaults
to the branch that is checked out in actions/checkout, which is the
default branch anyway.

Tested both the bridge and upstream provider workflows with pulumi-artifactory, which was has a default branch named "main".