### PR TITLE
Ensure that ONLY release workflows tag the Go SDK

### DIFF
--- a/provider-ci/lib/steps.js
+++ b/provider-ci/lib/steps.js
@@ -483,9 +483,8 @@ export class TagSDKTag extends step.Step {
     constructor() {
         super();
         return {
-            if: 'success() && github.event_name == \'push\'',
             name: 'Add SDK version tag',
-            run: 'git tag sdk/${{ github.ref_name }} && git push origin sdk/${{ github.ref_name }}',
+            run: 'git tag sdk/$(pulumictl get version --language generic) && git push origin sdk/$(pulumictl get version --language generic)',
         };
     }
 }

--- a/provider-ci/providers/aws/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/aws/repo/.github/workflows/main.yml
@@ -350,10 +350,6 @@ jobs:
         author_name: Failure in publishing SDK
         fields: repo,commit,author,action
         status: ${{ job.status }}
-    - if: success() && github.event_name == 'push'
-      name: Add SDK version tag
-      run: git tag sdk/${{ github.ref_name }} && git push origin sdk/${{ github.ref_name
-        }}
     strategy:
       fail-fast: true
       matrix:

--- a/provider-ci/providers/aws/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/aws/repo/.github/workflows/master.yml
@@ -350,10 +350,6 @@ jobs:
         author_name: Failure in publishing SDK
         fields: repo,commit,author,action
         status: ${{ job.status }}
-    - if: success() && github.event_name == 'push'
-      name: Add SDK version tag
-      run: git tag sdk/${{ github.ref_name }} && git push origin sdk/${{ github.ref_name
-        }}
     strategy:
       fail-fast: true
       matrix:

--- a/provider-ci/providers/aws/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/aws/repo/.github/workflows/prerelease.yml
@@ -296,10 +296,6 @@ jobs:
         author_name: Failure in publishing SDK
         fields: repo,commit,author,action
         status: ${{ job.status }}
-    - if: success() && github.event_name == 'push'
-      name: Add SDK version tag
-      run: git tag sdk/${{ github.ref_name }} && git push origin sdk/${{ github.ref_name
-        }}
     strategy:
       fail-fast: true
       matrix:

--- a/provider-ci/providers/aws/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/aws/repo/.github/workflows/release.yml
@@ -100,7 +100,7 @@ jobs:
         - "3.7"
   create_docs_build:
     name: create_docs_build
-    needs: publish_sdk
+    needs: tag_sdk
     runs-on: ubuntu-latest
     steps:
     - name: Install pulumictl
@@ -308,10 +308,6 @@ jobs:
         author_name: Failure in publishing SDK
         fields: repo,commit,author,action
         status: ${{ job.status }}
-    - if: success() && github.event_name == 'push'
-      name: Add SDK version tag
-      run: git tag sdk/${{ github.ref_name }} && git push origin sdk/${{ github.ref_name
-        }}
     strategy:
       fail-fast: true
       matrix:
@@ -323,6 +319,20 @@ jobs:
         - 14.x
         pythonversion:
         - "3.7"
+  tag_sdk:
+    name: tag_sdk
+    needs: publish_sdk
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout Repo
+      uses: actions/checkout@v2
+    - name: Install pulumictl
+      uses: jaxxstorm/action-install-gh-release@v1.2.0
+      with:
+        repo: pulumi/pulumictl
+    - name: Add SDK version tag
+      run: git tag sdk/$(pulumictl get version --language generic) && git push origin
+        sdk/$(pulumictl get version --language generic)
   test:
     name: test
     needs: build_sdk

--- a/provider-ci/src/steps.ts
+++ b/provider-ci/src/steps.ts
@@ -527,9 +527,8 @@ export class TagSDKTag extends step.Step {
     constructor() {
         super();
         return {
-            if: 'success() && github.event_name == \'push\'',
             name: 'Add SDK version tag',
-            run: 'git tag sdk/${{ github.ref_name }} && git push origin sdk/${{ github.ref_name }}',
+            run: 'git tag sdk/$(pulumictl get version --language generic) && git push origin sdk/$(pulumictl get version --language generic)',
         };
     }
 }


### PR DESCRIPTION
This is not needed for anything other than the release workflow
and we should not use the ref name - we should calculate it like
we do during build time

Without this change ALL master builds would create a tag and push that tag to the repo - even more - master builds would be being tagged as sdk/master and pushing those tags