### PR TITLE
Don't automatically add reviewers

### DIFF
--- a/.github/workflows/deploy-all-providers.yml
+++ b/.github/workflows/deploy-all-providers.yml
@@ -52,7 +52,6 @@ jobs:
           commit-message: "[internal] Update GitHub Actions workflow files"
           labels: "impact/no-changelog-required, automation/merge"
           title: "Update GitHub Actions workflows."
-          team-reviewers: "platform-integrations"
           path: pulumi-${{ matrix.provider }}
           token: ${{ secrets.PULUMI_BOT_TOKEN }}
       # See: https://docs.github.com/en/rest/guides/best-practices-for-integrators#dealing-with-secondary-rate-limits


### PR DESCRIPTION
This turns out to generate too much noise, we should perhaps set up a lambda webhook listener to notify our alert channel when a check suite in a repo fails instead.