### PR TITLE
Use built in GH automerge

### DIFF
--- a/.github/workflows/deploy-all-providers.yml
+++ b/.github/workflows/deploy-all-providers.yml
@@ -55,9 +55,6 @@ jobs:
           title: "Update GitHub Actions workflows."
           path: pulumi-${{ matrix.provider }}
           token: ${{ secrets.PULUMI_BOT_TOKEN }}
-      # See: https://docs.github.com/en/rest/guides/best-practices-for-integrators#dealing-with-secondary-rate-limits
-      - name: Sleep to prevent hitting secondary rate limits
-        run: sleep 1
       - name: Set PR to auto-merge
         if: steps.create-pr.outputs.pull-request-operation == 'created'
         uses: peter-evans/enable-pull-request-automerge@v1
@@ -65,5 +62,6 @@ jobs:
           token: ${{ secrets.PULUMI_BOT_TOKEN }}
           pull-request-number: ${{ steps.create-pr.outputs.pull-request-number }}
           merge-method: squash
-      - name: Sleep again to prevent hitting secondary rate limits
+        # See: https://docs.github.com/en/rest/guides/best-practices-for-integrators#dealing-with-secondary-rate-limits
+      - name: Sleep to prevent hitting secondary rate limits
         run: sleep 1

--- a/.github/workflows/deploy-all-providers.yml
+++ b/.github/workflows/deploy-all-providers.yml
@@ -43,6 +43,7 @@ jobs:
         run: |
           cp -r ci-mgmt/provider-ci/providers/${{ matrix.provider }}/repo/. pulumi-${{ matrix.provider }}/.
       - name: Create PR
+        id: create-pr
         uses: peter-evans/create-pull-request@v3
         with:
           author: Pulumi Bot <bot@pulumi.com>
@@ -50,10 +51,19 @@ jobs:
           branch: "update-github-actions-workflows-${{ github.run_number }}"
           committer: Pulumi Bot <bot@pulumi.com>
           commit-message: "[internal] Update GitHub Actions workflow files"
-          labels: "impact/no-changelog-required, automation/merge"
+          labels: "impact/no-changelog-required"
           title: "Update GitHub Actions workflows."
           path: pulumi-${{ matrix.provider }}
           token: ${{ secrets.PULUMI_BOT_TOKEN }}
       # See: https://docs.github.com/en/rest/guides/best-practices-for-integrators#dealing-with-secondary-rate-limits
       - name: Sleep to prevent hitting secondary rate limits
+        run: sleep 1
+      - name: Set PR to auto-merge
+        if: steps.create-pr.outputs.pull-request-operation == 'created'
+        uses: peter-evans/enable-pull-request-automerge@v1
+        with:
+          token: ${{ secrets.PULUMI_BOT_TOKEN }}
+          pull-request-number: ${{ steps.create-pr.outputs.pull-request-number }}
+          merge-method: squash
+      - name: Sleep again to prevent hitting secondary rate limits
         run: sleep 1

--- a/.github/workflows/deploy-single-provider.yml
+++ b/.github/workflows/deploy-single-provider.yml
@@ -29,6 +29,7 @@ jobs:
         run: |
           cp -r ci-mgmt/provider-ci/providers/${{ github.event.inputs.provider_name }}/repo/. pulumi-${{ github.event.inputs.provider_name }}/.
       - name: Create PR
+        id: create-pr
         uses: peter-evans/create-pull-request@v3
         with:
           author: Pulumi Bot <bot@pulumi.com>
@@ -36,8 +37,14 @@ jobs:
           branch: "update-github-actions-workflows-${{ github.run_number }}"
           committer: Pulumi Bot <bot@pulumi.com>
           commit-message: "[internal] Update GitHub Actions workflow files"
-          labels: "impact/no-changelog-required, automation/merge"
+          labels: "impact/no-changelog-required"
           title: "Update GitHub Actions workflows."
-          team-reviewers: "platform-integrations"
           path: pulumi-${{ github.event.inputs.provider_name }}
           token: ${{ secrets.PULUMI_BOT_TOKEN }}
+      - name: Set PR to auto-merge
+        if: steps.create-pr.outputs.pull-request-operation == 'created'
+        uses: peter-evans/enable-pull-request-automerge@v1
+        with:
+          token: ${{ secrets.PULUMI_BOT_TOKEN }}
+          pull-request-number: ${{ steps.create-pr.outputs.pull-request-number }}
+          merge-method: squash


### PR DESCRIPTION
Add a step to deploy-all-providers.yml that will enable automerge via squash on all created prs.  Automerge will only happen if all required checks pass, but it will not time out and will remove our need to run our own automerge job.

related #153 
fixes #144
resolves #155