### PR TITLE
Remove old automerge action

### DIFF
--- a/.github/workflows/update-workflows-all-providers.yml
+++ b/.github/workflows/update-workflows-all-providers.yml
@@ -39,6 +39,8 @@ jobs:
         with:
           repository: pulumi/pulumi-${{ matrix.provider }}
           path: pulumi-${{ matrix.provider }}
+      - name: Delete old automerge
+        run: rm pulumi-${{ matrix.provider }}/.github/workflows/pr-automation.yml
       - name: Copy files from ci-mgmt to pulumi-${{ matrix.provider }}
         run: |
           cp -r ci-mgmt/provider-ci/providers/${{ matrix.provider }}/repo/. pulumi-${{ matrix.provider }}/.

--- a/.github/workflows/update-workflows-all-providers.yml
+++ b/.github/workflows/update-workflows-all-providers.yml
@@ -39,8 +39,8 @@ jobs:
         with:
           repository: pulumi/pulumi-${{ matrix.provider }}
           path: pulumi-${{ matrix.provider }}
-      - name: Delete old automerge
-        run: rm pulumi-${{ matrix.provider }}/.github/workflows/pr-automation.yml
+      - name: Delete existing workflows
+        run: rm pulumi-${{ matrix.provider }}/.github/workflows/*.yml
       - name: Copy files from ci-mgmt to pulumi-${{ matrix.provider }}
         run: |
           cp -r ci-mgmt/provider-ci/providers/${{ matrix.provider }}/repo/. pulumi-${{ matrix.provider }}/.

--- a/.github/workflows/update-workflows-single-provider.yml
+++ b/.github/workflows/update-workflows-single-provider.yml
@@ -25,8 +25,8 @@ jobs:
         with:
           repository: pulumi/pulumi-${{ github.event.inputs.provider_name }}
           path: pulumi-${{ github.event.inputs.provider_name }}
-      - name: Delete old automerge
-        run: rm pulumi-${{ github.event.inputs.provider_name }}/.github/workflows/pr-automation.yml
+      - name: Delete existing workflows
+        run: rm pulumi-${{ github.event.inputs.provider_name }}/.github/workflows/*.yml
       - name: Copy files from ci-mgmt to pulumi-${{ github.event.inputs.provider_name }}
         run: |
           cp -r ci-mgmt/provider-ci/providers/${{ github.event.inputs.provider_name }}/repo/. pulumi-${{ github.event.inputs.provider_name }}/.

--- a/.github/workflows/update-workflows-single-provider.yml
+++ b/.github/workflows/update-workflows-single-provider.yml
@@ -25,6 +25,8 @@ jobs:
         with:
           repository: pulumi/pulumi-${{ github.event.inputs.provider_name }}
           path: pulumi-${{ github.event.inputs.provider_name }}
+      - name: Delete old automerge
+        run: rm pulumi-pulumi-${{ github.event.inputs.provider_name }}/.github/workflows/pr-automation.yml
       - name: Copy files from ci-mgmt to pulumi-${{ github.event.inputs.provider_name }}
         run: |
           cp -r ci-mgmt/provider-ci/providers/${{ github.event.inputs.provider_name }}/repo/. pulumi-${{ github.event.inputs.provider_name }}/.

--- a/.github/workflows/update-workflows-single-provider.yml
+++ b/.github/workflows/update-workflows-single-provider.yml
@@ -26,7 +26,7 @@ jobs:
           repository: pulumi/pulumi-${{ github.event.inputs.provider_name }}
           path: pulumi-${{ github.event.inputs.provider_name }}
       - name: Delete old automerge
-        run: rm pulumi-pulumi-${{ github.event.inputs.provider_name }}/.github/workflows/pr-automation.yml
+        run: rm pulumi-${{ github.event.inputs.provider_name }}/.github/workflows/pr-automation.yml
       - name: Copy files from ci-mgmt to pulumi-${{ github.event.inputs.provider_name }}
         run: |
           cp -r ci-mgmt/provider-ci/providers/${{ github.event.inputs.provider_name }}/repo/. pulumi-${{ github.event.inputs.provider_name }}/.


### PR DESCRIPTION
This change will add removing all existing workflows as a step before we copy in new ones, to ensure cruft is not left behind as we go.