### PR TITLE
Bump Azure to be a v5 provider

### DIFF
--- a/provider-ci/providers/azure/config.yaml
+++ b/provider-ci/providers/azure/config.yaml
@@ -1,6 +1,6 @@
 provider: azure
 lint: false
-major-version: 4
+major-version: 5
 parallel: 2
 customLdFlag: "-X github.com/hashicorp/terraform-provider-azurerm/version.ProviderVersion={{.Tag}}"
 env:

--- a/provider-ci/providers/azure/repo/.goreleaser.prerelease.yml
+++ b/provider-ci/providers/azure/repo/.goreleaser.prerelease.yml
@@ -26,7 +26,7 @@ builds:
   - linux
   ignore: []
   ldflags:
-  - -X github.com/pulumi/pulumi-azure/provider/v4/pkg/version.Version={{.Tag}}
+  - -X github.com/pulumi/pulumi-azure/provider/v5/pkg/version.Version={{.Tag}}
   - -X
     github.com/hashicorp/terraform-provider-azurerm/version.ProviderVersion={{.Tag}}
   main: ./cmd/pulumi-resource-azure/

--- a/provider-ci/providers/azure/repo/.goreleaser.yml
+++ b/provider-ci/providers/azure/repo/.goreleaser.yml
@@ -26,7 +26,7 @@ builds:
   - linux
   ignore: []
   ldflags:
-  - -X github.com/pulumi/pulumi-azure/provider/v4/pkg/version.Version={{.Tag}}
+  - -X github.com/pulumi/pulumi-azure/provider/v5/pkg/version.Version={{.Tag}}
   - -X
     github.com/hashicorp/terraform-provider-azurerm/version.ProviderVersion={{.Tag}}
   main: ./cmd/pulumi-resource-azure/


### PR DESCRIPTION
This is back porting the changes to the CI Mgmt repo as per our convention