### PR TITLE
Generate makefiles

### DIFF
--- a/provider-ci/cmd/generate-providers.ts
+++ b/provider-ci/cmd/generate-providers.ts
@@ -59,16 +59,19 @@ const writeProviderFiles = (provider: Provider) => {
   fs.mkdirSync(providerRepoPath, { recursive: true });
   for (const file of provider.files) {
     const filePath = path.join(providerRepoPath, file.path);
-    const yamlContent = yaml.stringify(file.data, {
-      sortMapEntries: true,
-      indentSeq: false,
-    });
+    const data =
+      typeof file.data === "string"
+        ? file.data
+        : yaml.stringify(file.data, {
+            sortMapEntries: true,
+            indentSeq: false,
+          });
     debug("Writing", filePath);
     const dir = path.dirname(filePath);
     if (!fs.existsSync(dir)) {
       fs.mkdirSync(dir, { recursive: true });
     }
-    fs.writeFileSync(filePath, yamlContent, { encoding: "utf-8" });
+    fs.writeFileSync(filePath, data, { encoding: "utf-8" });
   }
 };
 

--- a/provider-ci/providers/aws/config.yaml
+++ b/provider-ci/providers/aws/config.yaml
@@ -9,3 +9,4 @@ env:
   AWS_REGION: us-west-2
   PULUMI_MISSING_DOCS_ERROR: true
 upstream-provider-org: pulumi
+makeTemplate: bridged

--- a/provider-ci/providers/aws/repo/Makefile
+++ b/provider-ci/providers/aws/repo/Makefile
@@ -6,7 +6,7 @@ TF_NAME := aws
 PROVIDER_PATH := provider/v5
 SDK_PATH := sdk/v5
 VERSION_PATH := provider/v5/pkg/version.Version
-TF_GEN := pulumi-tfgen-aws
+TFGEN := pulumi-tfgen-aws
 PROVIDER := pulumi-resource-aws
 VERSION := $(shell pulumictl get version)
 TESTPARALLELISM := 10
@@ -19,12 +19,24 @@ build:: install_plugins provider build_sdks install_sdks
 only_build:: build
 
 tfgen:: install_plugins
+	(cd provider && go build -o $(WORKING_DIR)/bin/${TFGEN} -ldflags "-X ${PROJECT}/${VERSION_PATH}=${VERSION}" ${PROJECT}/${PROVIDER_PATH}/cmd/${TFGEN})
+	$(WORKING_DIR)/bin/pulumi-tfgen-aws schema --out provider/cmd/pulumi-resource-aws
+	(cd provider && VERSION=$(VERSION) go generate cmd/pulumi-resource-aws/main.go)
 
 provider:: tfgen install_plugins
+	(cd provider && go build -o $(WORKING_DIR)/bin/${PROVIDER} -ldflags "-X ${PROJECT}/${VERSION_PATH}=${VERSION} -X github.com/terraform-providers/terraform-provider-aws/version.ProviderVersion=${VERSION}" ${PROJECT}/${PROVIDER_PATH}/cmd/${PROVIDER})
 
 build_sdks:: build_nodejs build_python build_go build_dotnet
 
+build_nodejs:: VERSION := $(shell pulumictl get version --language javascript)
 build_nodejs:: 
+	$(WORKING_DIR)/bin/$(TFGEN) nodejs --overlays provider/overlays/nodejs --out sdk/nodejs/
+	cd sdk/nodejs/ && \
+		echo "module fake_nodejs_module // Exclude this directory from Go tools\n\ngo 1.16" > go.mod && \
+		yarn install && \
+		yarn run tsc && \
+		cp ../../README.md ../../LICENSE package.json yarn.lock ./bin/ && \
+		sed -i.bak -e "s/$${VERSION}/$(VERSION)/g" ./bin/package.json
 
 build_python:: 
 

--- a/provider-ci/providers/aws/repo/Makefile
+++ b/provider-ci/providers/aws/repo/Makefile
@@ -1,0 +1,60 @@
+PACK := aws
+ORG := pulumi
+PROJECT := github.com/pulumi/pulumi-aws
+NODE_MODULE_NAME := @pulumi/aws
+TF_NAME := aws
+PROVIDER_PATH := provider/v5
+SDK_PATH := sdk/v5
+VERSION_PATH := provider/v5/pkg/version.Version
+TF_GEN := pulumi-tfgen-aws
+PROVIDER := pulumi-resource-aws
+VERSION := $(shell pulumictl get version)
+TESTPARALLELISM := 10
+WORKING_DIR := $(shell pwd)
+
+development:: install_plugins
+
+build:: install_plugins provider build_sdks install_sdks
+
+only_build:: build
+
+tfgen:: install_plugins
+
+provider:: tfgen install_plugins
+
+build_sdks:: build_nodejs build_python build_go build_dotnet
+
+build_nodejs:: 
+
+build_python:: 
+
+build_go:: 
+
+build_dotnet:: 
+
+lint_provider:: provider
+
+cleanup:: 
+
+help:: 
+
+clean:: 
+
+install_plugins:: 
+	[ -x $(shell which pulumi) ] || curl -fsSL https://get.pulumi.com | sh
+	pulumi plugin install resource tls 4.1.0
+	pulumi plugin install resource github 4.10.0
+	pulumi plugin install resource kubernetes 3.17.0
+	pulumi plugin install resource random 4.4.1
+
+install_dotnet_sdk:: 
+
+install_python_sdk:: 
+
+install_go_sdk:: 
+
+install_nodejs_sdk:: 
+
+install_sdks:: install_dotnet_sdk install_python_sdk install_nodejs_sdk
+
+test:: 

--- a/provider-ci/providers/aws/repo/Makefile
+++ b/provider-ci/providers/aws/repo/Makefile
@@ -36,21 +36,44 @@ build_nodejs::
 		yarn install && \
 		yarn run tsc && \
 		cp ../../README.md ../../LICENSE package.json yarn.lock ./bin/ && \
-		sed -i.bak -e "s/$${VERSION}/$(VERSION)/g" ./bin/package.json
+		sed -i.bak -e "s/\$${VERSION}/$(VERSION)/g" ./bin/package.json
 
+build_python:: PYPI_VERSION := $(shell pulumictl get version --language python)
 build_python:: 
+	$(WORKING_DIR)/bin/$(TFGEN) python --overlays provider/overlays/python --out sdk/python/
+	cd sdk/python/ && \
+		echo "module fake_python_module // Exclude this directory from Go tools\n\ngo 1.16" > go.mod && \
+		cp ../../README.md . && \
+		python3 setup.py clean --all 2>/dev/null && \
+		rm -rf ./bin/ ../python.bin/ && cp -R . ../python.bin && mv ../python.bin ./bin && \
+		sed -i.bak -e 's/^VERSION = .*/VERSION = "$(PYPI_VERSION)"/g' -e 's/^PLUGIN_VERSION = .*/PLUGIN_VERSION = "$(VERSION)"/g' ./bin/setup.py && \
+		rm ./bin/setup.py.bak && rm ./bin/go.mod && \
+		cd ./bin && python3 setup.py build sdist
 
 build_go:: 
+	$(WORKING_DIR)/bin/$(TFGEN) go --overlays provider/overlays/go --out sdk/go/
 
+build_dotnet:: DOTNET_VERSION := $(shell pulumictl get version --language dotnet)
 build_dotnet:: 
+	pulumictl get version --language dotnet
+	$(WORKING_DIR)/bin/$(TFGEN) dotnet --overlays provider/overlays/dotnet --out sdk/dotnet/
+	cd sdk/dotnet/ && \
+		echo "module fake_dotnet_module // Exclude this directory from Go tools\n\ngo 1.16" > go.mod && \
+		echo "${DOTNET_VERSION}" >version.txt && \
+		dotnet build /p:Version=${DOTNET_VERSION}
 
 lint_provider:: provider
+	cd provider && golangci-lint run -c ../.golangci.yml
 
 cleanup:: 
+	rm -r $(WORKING_DIR)/bin
+	rm -f provider/cmd/pulumi-resource-aws/schema.go
 
 help:: 
+	@grep '^[^.#]\+:\s\+.*#' Makefile | sed "s/\(.\+\):\s*\(.*\) #\s*\(.*\)/`printf "\033[93m"`\1`printf "\033[0m"`	\3 [\2]/" | expand -t20
 
 clean:: 
+	rm -rf sdk/{dotnet,nodejs,go,python}
 
 install_plugins:: 
 	[ -x $(shell which pulumi) ] || curl -fsSL https://get.pulumi.com | sh
@@ -60,13 +83,19 @@ install_plugins::
 	pulumi plugin install resource random 4.4.1
 
 install_dotnet_sdk:: 
+	mkdir -p $(WORKING_DIR)/nuget
+	find . -name '*.nupkg' -print -exec cp -p {} ${WORKING_DIR}/nuget \;
 
 install_python_sdk:: 
 
 install_go_sdk:: 
 
 install_nodejs_sdk:: 
+	yarn link --cwd $(WORKING_DIR)/sdk/nodejs/bin
 
 install_sdks:: install_dotnet_sdk install_python_sdk install_nodejs_sdk
 
 test:: 
+	cd examples && go test -v -tags=all -parallel ${TESTPARALLELISM} -timeout 2h
+
+.PHONY:: development build tfgen provider build_sdks build_nodejs build_python build_go build_dotnet lint_provider cleanup help clean install_plugins install_dotnet_sdk install_python_sdk install_go_sdk install_nodejs_sdk install_sdks test

--- a/provider-ci/src/make-bridged-provider.ts
+++ b/provider-ci/src/make-bridged-provider.ts
@@ -1,0 +1,114 @@
+import { Makefile, Target } from "./make";
+import { goBuild, genSchema, yarnInstall, cwd } from "./make-targets";
+
+type BridgedProviderConfig = {
+  provider: string;
+  org: string;
+};
+
+export function bridgedProvider(config: BridgedProviderConfig): Makefile {
+  const PACK = config.provider;
+  const ORG = config.org;
+  const PROJECT = `github.com/${ORG}/pulumi-${PACK}`;
+  const NODE_MODULE_NAME = `@pulumi/${PACK}`;
+  const TF_NAME = PACK;
+  const PROVIDER_PATH = `provider/v5`;
+  const SDK_PATH = `sdk/v5`;
+  const VERSION_PATH = `${PROVIDER_PATH}/pkg/version.Version`;
+  const TF_GEN = `pulumi-tfgen-${PACK}`;
+  const PROVIDER = `pulumi-resource-${PACK}`;
+  const VERSION = "$(shell pulumictl get version)";
+  const TESTPARALLELISM = "10";
+  const WORKING_DIR = "$(shell pwd)";
+
+  const variables = {
+    PACK,
+    ORG,
+    PROJECT,
+    NODE_MODULE_NAME,
+    TF_NAME,
+    PROVIDER_PATH,
+    SDK_PATH,
+    VERSION_PATH,
+    TF_GEN,
+    PROVIDER,
+    VERSION,
+    TESTPARALLELISM,
+    WORKING_DIR,
+  } as const;
+
+  const install_plugins: Target = {
+    name: "install_plugins",
+    commands: [
+      "[ -x $(shell which pulumi) ] || curl -fsSL https://get.pulumi.com | sh",
+      "pulumi plugin install resource tls 4.1.0",
+      "pulumi plugin install resource github 4.10.0",
+      "pulumi plugin install resource kubernetes 3.17.0",
+      "pulumi plugin install resource random 4.4.1",
+    ],
+  };
+  const development: Target = {
+    name: "development",
+    dependencies: [install_plugins],
+  };
+  const tfgen: Target = { name: "tfgen", dependencies: [install_plugins] };
+  const provider: Target = {
+    name: "provider",
+    dependencies: [tfgen, install_plugins],
+  };
+  const build_nodejs: Target = { name: "build_nodejs" };
+  const build_python: Target = { name: "build_python" };
+  const build_go: Target = { name: "build_go" };
+  const build_dotnet: Target = { name: "build_dotnet" };
+  const build_sdks: Target = {
+    name: "build_sdks",
+    dependencies: [build_nodejs, build_python, build_go, build_dotnet],
+  };
+  const lint_provider: Target = {
+    name: "lint_provider",
+    dependencies: [provider],
+  };
+  const cleanup: Target = { name: "cleanup" };
+  const help: Target = { name: "help" };
+  const clean: Target = { name: "clean" };
+  const install_dotnet_sdk: Target = { name: "install_dotnet_sdk" };
+  const install_python_sdk: Target = { name: "install_python_sdk" };
+  const install_go_sdk: Target = { name: "install_go_sdk" };
+  const install_nodejs_sdk: Target = { name: "install_nodejs_sdk" };
+  const install_sdks: Target = {
+    name: "install_sdks",
+    dependencies: [install_dotnet_sdk, install_python_sdk, install_nodejs_sdk],
+  };
+  const build: Target = {
+    name: "build",
+    dependencies: [install_plugins, provider, build_sdks, install_sdks],
+  };
+  const only_build: Target = { name: "only_build", dependencies: [build] };
+  const test: Target = { name: "test" };
+  return {
+    variables,
+    targets: [
+      development,
+      build,
+      only_build,
+      tfgen,
+      provider,
+      build_sdks,
+      build_nodejs,
+      build_python,
+      build_go,
+      build_dotnet,
+      lint_provider,
+      cleanup,
+      help,
+      clean,
+      install_plugins,
+      install_dotnet_sdk,
+      install_python_sdk,
+      install_go_sdk,
+      install_nodejs_sdk,
+      install_sdks,
+      test,
+    ],
+  };
+}

--- a/provider-ci/src/make-targets.ts
+++ b/provider-ci/src/make-targets.ts
@@ -1,0 +1,53 @@
+import { Target } from "./make";
+
+/** Add `&&` between each */
+function shellChain(...commands: string[]): string {
+  return commands.join(" && ");
+}
+
+export function cwd(dir: string, ...commands: string[]): string {
+  return shellChain(`cd ${dir}`, ...commands);
+}
+
+export function goBuild({
+  binaryName,
+  goDir,
+}: {
+  binaryName: string;
+  goDir: string;
+}): Target {
+  return {
+    name: `bin/${binaryName}`,
+    dependencies: ["$(GO_SRC)"],
+    commands: [
+      shellChain(
+        `cd ${goDir}`,
+        `go build -o $(CWD)/bin/${binaryName} $(VERSION_FLAGS) $(CWD)/${goDir}/cmd/${binaryName}`
+      ),
+    ],
+  };
+}
+
+interface GenSchemaArgs {
+  schemaDir: string;
+  genBinaryName: string;
+}
+
+export function genSchema({ schemaDir, genBinaryName }: GenSchemaArgs): Target {
+  return {
+    name: `${schemaDir}/schema.json`,
+    dependencies: [`bin/${genBinaryName}`],
+    commands: [`bin/${genBinaryName} schema $(CWD)/${schemaDir}`],
+  };
+}
+
+export function yarnInstall({ dir }: { dir: string }): Target {
+  return {
+    name: `${dir}/node_modules`,
+    dependencies: [`${dir}/package.json`, `${dir}/yarn.lock`],
+    commands: [
+      `yarn install --cwd ${dir} --no-progress`,
+      `@touch ${dir}/node_modules`,
+    ],
+  };
+}

--- a/provider-ci/src/make.ts
+++ b/provider-ci/src/make.ts
@@ -1,0 +1,82 @@
+type AssignmentType = "simple" | "conditional" | "recursive";
+
+type Assignment =
+  | string
+  | {
+      value: string;
+      /** Assignment type:
+       * - simple `:=`
+       * - conditional `?=`
+       * - recursive `=`
+       * @default "simple" */
+      type?: AssignmentType;
+    };
+
+export type Target = {
+  name: string;
+  dependencies?: (string | Target)[];
+  commands?: string[];
+  phony?: boolean;
+};
+
+export type Makefile = {
+  variables?: Record<string, Assignment>;
+  targets?: Target[];
+};
+
+function getAssignmentToken(type: AssignmentType): string {
+  switch (type) {
+    case "simple":
+      return ":=";
+    case "conditional":
+      return "?=";
+    case "recursive":
+      return "=";
+  }
+}
+
+const indent = "\t";
+
+function renderTarget(target: Target): string {
+  const dependencies = target.dependencies ?? [];
+  const dependencyNames = dependencies.map((d) =>
+    typeof d === "string" ? d : d.name
+  );
+  const declaration = `${target.name}:: ${dependencyNames.join(" ")}`;
+  const commands = target.commands?.map((cmd) => indent + cmd) ?? [];
+  return [declaration, ...commands].join("\n");
+}
+
+function renderVariable([name, assignment]: [string, Assignment]): string {
+  if (typeof assignment === "string") {
+    return `${name} := ${assignment}`;
+  }
+  const assignmentToken = getAssignmentToken(assignment.type ?? "simple");
+  return `${name} ${assignmentToken} ${assignment.value}`;
+}
+
+function phonyTarget(targets: Target[]): Target | undefined {
+  const phonyTargets = targets.filter((t) => t.phony);
+  if (phonyTargets.length === 0) {
+    return undefined;
+  }
+  return {
+    name: ".PHONY",
+    dependencies: phonyTargets,
+  };
+}
+
+export function render(makefile: Makefile): string {
+  const variableLines = Object.entries(makefile.variables ?? {}).map(
+    renderVariable
+  );
+
+  const inputTargets = makefile.targets ?? [];
+  const phony = phonyTarget(inputTargets);
+  if (phony !== undefined) {
+    inputTargets.push(phony);
+  }
+  const targets = inputTargets.map(renderTarget);
+
+  return [variableLines.join("\n"), targets.join("\n\n")].join("\n\n");
+}

--- a/provider-ci/src/makefiles.ts
+++ b/provider-ci/src/makefiles.ts
@@ -1,0 +1,14 @@
+import { render } from "./make";
+import { bridgedProvider } from "./make-bridged-provider";
+
+export function buildMakefile(config: {
+  provider: string;
+  makeTemplate: string;
+}): string {
+  switch (config.makeTemplate) {
+    case "bridged":
+      return render(bridgedProvider({ ...config, org: "pulumi" }));
+    default:
+      throw new Error(`Unknown makefile template: ${config.makeTemplate}`);
+  }
+}


### PR DESCRIPTION
- Comments are removed, some line breaks and spacing changed, otherwise identical.
- Make generation opt-in via setting `makeTemplate: bridged` in the `config.yaml`.
- Adapt generation to handle non-yaml output.