### PR TITLE
update release.yml and restore notify for build_sdk and test steps

### DIFF
--- a/native-provider-ci/providers/aws-native/repo/.github/workflows/build.yml
+++ b/native-provider-ci/providers/aws-native/repo/.github/workflows/build.yml
@@ -204,6 +204,13 @@ jobs:
       with:
         name: ${{ matrix.language  }}-sdk.tar.gz
         path: ${{ github.workspace}}/sdk/${{ matrix.language }}.tar.gz
+    - if: failure() && github.event_name == 'push'
+      name: Notify Slack
+      uses: 8398a7/action-slack@v3
+      with:
+        author_name: Failure while building SDKs
+        fields: repo,commit,author,action
+        status: ${{ job.status }}
   test:
     runs-on: ubuntu-latest
     needs:
@@ -308,6 +315,13 @@ jobs:
         set -euo pipefail
 
         cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt
+    - if: failure() && github.event_name == 'push'
+      name: Notify Slack
+      uses: 8398a7/action-slack@v3
+      with:
+        author_name: Failure in SDK tests
+        fields: repo,commit,author,action
+        status: ${{ job.status }}
   publish:
     runs-on: macos-latest
     needs: test

--- a/native-provider-ci/providers/aws-native/repo/.github/workflows/prerelease.yml
+++ b/native-provider-ci/providers/aws-native/repo/.github/workflows/prerelease.yml
@@ -113,7 +113,7 @@ jobs:
         author_name: Failure in building provider prerequisites
         fields: repo,commit,author,action
         status: ${{ job.status }}
-  build_sdk:
+  build_sdks:
     needs: prerequisites
     runs-on: ubuntu-latest
     strategy:
@@ -132,7 +132,7 @@ jobs:
         - python
         - dotnet
         - go
-    name: build_sdk
+    name: build_sdks
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
@@ -195,6 +195,13 @@ jobs:
       with:
         name: ${{ matrix.language  }}-sdk.tar.gz
         path: ${{ github.workspace}}/sdk/${{ matrix.language }}.tar.gz
+    - if: failure() && github.event_name == 'push'
+      name: Notify Slack
+      uses: 8398a7/action-slack@v3
+      with:
+        author_name: Failure while building SDKs
+        fields: repo,commit,author,action
+        status: ${{ job.status }}
   test:
     runs-on: ubuntu-latest
     needs:
@@ -299,6 +306,13 @@ jobs:
         set -euo pipefail
 
         cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt
+    - if: failure() && github.event_name == 'push'
+      name: Notify Slack
+      uses: 8398a7/action-slack@v3
+      with:
+        author_name: Failure in SDK tests
+        fields: repo,commit,author,action
+        status: ${{ job.status }}
   publish:
     runs-on: macos-latest
     needs: test

--- a/native-provider-ci/providers/aws-native/repo/.github/workflows/release.yml
+++ b/native-provider-ci/providers/aws-native/repo/.github/workflows/release.yml
@@ -114,7 +114,7 @@ jobs:
         author_name: Failure in building provider prerequisites
         fields: repo,commit,author,action
         status: ${{ job.status }}
-  build_sdk:
+  build_sdks:
     needs: prerequisites
     runs-on: ubuntu-latest
     strategy:
@@ -133,7 +133,7 @@ jobs:
         - python
         - dotnet
         - go
-    name: build_sdk
+    name: build_sdks
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
@@ -196,6 +196,13 @@ jobs:
       with:
         name: ${{ matrix.language  }}-sdk.tar.gz
         path: ${{ github.workspace}}/sdk/${{ matrix.language }}.tar.gz
+    - if: failure() && github.event_name == 'push'
+      name: Notify Slack
+      uses: 8398a7/action-slack@v3
+      with:
+        author_name: Failure while building SDKs
+        fields: repo,commit,author,action
+        status: ${{ job.status }}
   test:
     runs-on: ubuntu-latest
     needs:
@@ -300,13 +307,27 @@ jobs:
         set -euo pipefail
 
         cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt
+    - if: failure() && github.event_name == 'push'
+      name: Notify Slack
+      uses: 8398a7/action-slack@v3
+      with:
+        author_name: Failure in SDK tests
+        fields: repo,commit,author,action
+        status: ${{ job.status }}
   publish:
     runs-on: macos-latest
     needs: test
     strategy:
+      fail-fast: true
       matrix:
         goversion:
         - 1.18.x
+        dotnetversion:
+        - 3.1.301
+        pythonversion:
+        - "3.7"
+        nodeversion:
+        - 14.x
     name: publish
     steps:
     - name: Checkout Repo
@@ -341,8 +362,7 @@ jobs:
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:
-        args: -p 3 -f .goreleaser.prerelease.yml --rm-dist --skip-validate --timeout
-          60m0s
+        args: -p 3 release --rm-dist --timeout 60m0s
         version: latest
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
@@ -365,7 +385,7 @@ jobs:
         - "3.7"
         nodeversion:
         - 14.x
-    name: publish_sdk
+    name: publish_sdks
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2

--- a/native-provider-ci/providers/aws-native/repo/.github/workflows/run-acceptance-tests.yml
+++ b/native-provider-ci/providers/aws-native/repo/.github/workflows/run-acceptance-tests.yml
@@ -223,6 +223,13 @@ jobs:
       with:
         name: ${{ matrix.language  }}-sdk.tar.gz
         path: ${{ github.workspace}}/sdk/${{ matrix.language }}.tar.gz
+    - if: failure() && github.event_name == 'push'
+      name: Notify Slack
+      uses: 8398a7/action-slack@v3
+      with:
+        author_name: Failure while building SDKs
+        fields: repo,commit,author,action
+        status: ${{ job.status }}
     if: github.event_name == 'repository_dispatch' ||
       github.event.pull_request.head.repo.full_name == github.repository
   test:
@@ -330,5 +337,12 @@ jobs:
         set -euo pipefail
 
         cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt
+    - if: failure() && github.event_name == 'push'
+      name: Notify Slack
+      uses: 8398a7/action-slack@v3
+      with:
+        author_name: Failure in SDK tests
+        fields: repo,commit,author,action
+        status: ${{ job.status }}
     if: github.event_name == 'repository_dispatch' ||
       github.event.pull_request.head.repo.full_name == github.repository

--- a/native-provider-ci/providers/azure-native/repo/.github/workflows/build.yml
+++ b/native-provider-ci/providers/azure-native/repo/.github/workflows/build.yml
@@ -216,6 +216,13 @@ jobs:
       with:
         name: ${{ matrix.language  }}-sdk.tar.gz
         path: ${{ github.workspace}}/sdk/${{ matrix.language }}.tar.gz
+    - if: failure() && github.event_name == 'push'
+      name: Notify Slack
+      uses: 8398a7/action-slack@v3
+      with:
+        author_name: Failure while building SDKs
+        fields: repo,commit,author,action
+        status: ${{ job.status }}
   test:
     runs-on: ubuntu-latest
     needs:
@@ -311,6 +318,13 @@ jobs:
         set -euo pipefail
 
         cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt
+    - if: failure() && github.event_name == 'push'
+      name: Notify Slack
+      uses: 8398a7/action-slack@v3
+      with:
+        author_name: Failure in SDK tests
+        fields: repo,commit,author,action
+        status: ${{ job.status }}
   publish:
     runs-on: macos-latest
     needs: test

--- a/native-provider-ci/providers/azure-native/repo/.github/workflows/prerelease.yml
+++ b/native-provider-ci/providers/azure-native/repo/.github/workflows/prerelease.yml
@@ -119,9 +119,9 @@ jobs:
         author_name: Failure in building provider prerequisites
         fields: repo,commit,author,action
         status: ${{ job.status }}
-  build_sdk:
+  build_sdks:
     needs: prerequisites
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.language }} == 'dotnet' && 'macos-latest' || 'ubuntu-latest'
     strategy:
       fail-fast: true
       matrix:
@@ -138,7 +138,7 @@ jobs:
         - python
         - dotnet
         - go
-    name: build_sdk
+    name: build_sdks
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
@@ -175,14 +175,17 @@ jobs:
       with:
         python-version: ${{matrix.pythonversion}}
     - name: Download provider + tfgen binaries
+      if: ${{ matrix.language != 'dotnet' }}
       uses: actions/download-artifact@v2
       with:
         name: pulumi-${{ env.PROVIDER }}-provider.tar.gz
         path: ${{ github.workspace }}/bin
     - name: UnTar provider binaries
+      if: ${{ matrix.language != 'dotnet' }}
       run: tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{
         github.workspace}}/bin
     - name: Restore Binary Permissions
+      if: ${{ matrix.language != 'dotnet' }}
       run: find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print
         -exec chmod +x {} \;
     - name: Build Codegen
@@ -204,6 +207,13 @@ jobs:
       with:
         name: ${{ matrix.language  }}-sdk.tar.gz
         path: ${{ github.workspace}}/sdk/${{ matrix.language }}.tar.gz
+    - if: failure() && github.event_name == 'push'
+      name: Notify Slack
+      uses: 8398a7/action-slack@v3
+      with:
+        author_name: Failure while building SDKs
+        fields: repo,commit,author,action
+        status: ${{ job.status }}
   test:
     runs-on: ubuntu-latest
     needs:
@@ -299,6 +309,13 @@ jobs:
         set -euo pipefail
 
         cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt
+    - if: failure() && github.event_name == 'push'
+      name: Notify Slack
+      uses: 8398a7/action-slack@v3
+      with:
+        author_name: Failure in SDK tests
+        fields: repo,commit,author,action
+        status: ${{ job.status }}
   publish:
     runs-on: macos-latest
     needs: test

--- a/native-provider-ci/providers/azure-native/repo/.github/workflows/release.yml
+++ b/native-provider-ci/providers/azure-native/repo/.github/workflows/release.yml
@@ -120,9 +120,9 @@ jobs:
         author_name: Failure in building provider prerequisites
         fields: repo,commit,author,action
         status: ${{ job.status }}
-  build_sdk:
+  build_sdks:
     needs: prerequisites
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.language }} == 'dotnet' && 'macos-latest' || 'ubuntu-latest'
     strategy:
       fail-fast: true
       matrix:
@@ -139,7 +139,7 @@ jobs:
         - python
         - dotnet
         - go
-    name: build_sdk
+    name: build_sdks
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
@@ -176,14 +176,17 @@ jobs:
       with:
         python-version: ${{matrix.pythonversion}}
     - name: Download provider + tfgen binaries
+      if: ${{ matrix.language != 'dotnet' }}
       uses: actions/download-artifact@v2
       with:
         name: pulumi-${{ env.PROVIDER }}-provider.tar.gz
         path: ${{ github.workspace }}/bin
     - name: UnTar provider binaries
+      if: ${{ matrix.language != 'dotnet' }}
       run: tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{
         github.workspace}}/bin
     - name: Restore Binary Permissions
+      if: ${{ matrix.language != 'dotnet' }}
       run: find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print
         -exec chmod +x {} \;
     - name: Build Codegen
@@ -205,6 +208,13 @@ jobs:
       with:
         name: ${{ matrix.language  }}-sdk.tar.gz
         path: ${{ github.workspace}}/sdk/${{ matrix.language }}.tar.gz
+    - if: failure() && github.event_name == 'push'
+      name: Notify Slack
+      uses: 8398a7/action-slack@v3
+      with:
+        author_name: Failure while building SDKs
+        fields: repo,commit,author,action
+        status: ${{ job.status }}
   test:
     runs-on: ubuntu-latest
     needs:
@@ -300,13 +310,27 @@ jobs:
         set -euo pipefail
 
         cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt
+    - if: failure() && github.event_name == 'push'
+      name: Notify Slack
+      uses: 8398a7/action-slack@v3
+      with:
+        author_name: Failure in SDK tests
+        fields: repo,commit,author,action
+        status: ${{ job.status }}
   publish:
     runs-on: macos-latest
     needs: test
     strategy:
+      fail-fast: true
       matrix:
         goversion:
         - 1.18.x
+        dotnetversion:
+        - 3.1.301
+        pythonversion:
+        - "3.7"
+        nodeversion:
+        - 14.x
     name: publish
     steps:
     - name: Checkout Repo
@@ -341,8 +365,7 @@ jobs:
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:
-        args: -p 3 -f .goreleaser.prerelease.yml --rm-dist --skip-validate --timeout
-          60m0s
+        args: -p 3 release --rm-dist --timeout 60m0s
         version: latest
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
@@ -365,7 +388,7 @@ jobs:
         - "3.7"
         nodeversion:
         - 14.x
-    name: publish_sdk
+    name: publish_sdks
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2

--- a/native-provider-ci/providers/azure-native/repo/.github/workflows/run-acceptance-tests.yml
+++ b/native-provider-ci/providers/azure-native/repo/.github/workflows/run-acceptance-tests.yml
@@ -235,6 +235,13 @@ jobs:
       with:
         name: ${{ matrix.language  }}-sdk.tar.gz
         path: ${{ github.workspace}}/sdk/${{ matrix.language }}.tar.gz
+    - if: failure() && github.event_name == 'push'
+      name: Notify Slack
+      uses: 8398a7/action-slack@v3
+      with:
+        author_name: Failure while building SDKs
+        fields: repo,commit,author,action
+        status: ${{ job.status }}
     if: github.event_name == 'repository_dispatch' ||
       github.event.pull_request.head.repo.full_name == github.repository
   test:
@@ -333,5 +340,12 @@ jobs:
         set -euo pipefail
 
         cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt
+    - if: failure() && github.event_name == 'push'
+      name: Notify Slack
+      uses: 8398a7/action-slack@v3
+      with:
+        author_name: Failure in SDK tests
+        fields: repo,commit,author,action
+        status: ${{ job.status }}
     if: github.event_name == 'repository_dispatch' ||
       github.event.pull_request.head.repo.full_name == github.repository

--- a/native-provider-ci/providers/command/repo/.github/workflows/build.yml
+++ b/native-provider-ci/providers/command/repo/.github/workflows/build.yml
@@ -166,6 +166,13 @@ jobs:
       with:
         name: ${{ matrix.language  }}-sdk.tar.gz
         path: ${{ github.workspace}}/sdk/${{ matrix.language }}.tar.gz
+    - if: failure() && github.event_name == 'push'
+      name: Notify Slack
+      uses: 8398a7/action-slack@v3
+      with:
+        author_name: Failure while building SDKs
+        fields: repo,commit,author,action
+        status: ${{ job.status }}
   test:
     runs-on: ubuntu-latest
     needs:
@@ -270,6 +277,13 @@ jobs:
         set -euo pipefail
 
         cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt
+    - if: failure() && github.event_name == 'push'
+      name: Notify Slack
+      uses: 8398a7/action-slack@v3
+      with:
+        author_name: Failure in SDK tests
+        fields: repo,commit,author,action
+        status: ${{ job.status }}
   publish:
     runs-on: ubuntu-latest
     needs: test

--- a/native-provider-ci/providers/command/repo/.github/workflows/prerelease.yml
+++ b/native-provider-ci/providers/command/repo/.github/workflows/prerelease.yml
@@ -79,7 +79,7 @@ jobs:
         author_name: Failure in building provider prerequisites
         fields: repo,commit,author,action
         status: ${{ job.status }}
-  build_sdk:
+  build_sdks:
     needs: prerequisites
     runs-on: ubuntu-latest
     strategy:
@@ -98,7 +98,7 @@ jobs:
         - python
         - dotnet
         - go
-    name: build_sdk
+    name: build_sdks
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
@@ -157,6 +157,13 @@ jobs:
       with:
         name: ${{ matrix.language  }}-sdk.tar.gz
         path: ${{ github.workspace}}/sdk/${{ matrix.language }}.tar.gz
+    - if: failure() && github.event_name == 'push'
+      name: Notify Slack
+      uses: 8398a7/action-slack@v3
+      with:
+        author_name: Failure while building SDKs
+        fields: repo,commit,author,action
+        status: ${{ job.status }}
   test:
     runs-on: ubuntu-latest
     needs:
@@ -261,6 +268,13 @@ jobs:
         set -euo pipefail
 
         cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt
+    - if: failure() && github.event_name == 'push'
+      name: Notify Slack
+      uses: 8398a7/action-slack@v3
+      with:
+        author_name: Failure in SDK tests
+        fields: repo,commit,author,action
+        status: ${{ job.status }}
   publish:
     runs-on: ubuntu-latest
     needs: test

--- a/native-provider-ci/providers/command/repo/.github/workflows/release.yml
+++ b/native-provider-ci/providers/command/repo/.github/workflows/release.yml
@@ -80,7 +80,7 @@ jobs:
         author_name: Failure in building provider prerequisites
         fields: repo,commit,author,action
         status: ${{ job.status }}
-  build_sdk:
+  build_sdks:
     needs: prerequisites
     runs-on: ubuntu-latest
     strategy:
@@ -99,7 +99,7 @@ jobs:
         - python
         - dotnet
         - go
-    name: build_sdk
+    name: build_sdks
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
@@ -158,6 +158,13 @@ jobs:
       with:
         name: ${{ matrix.language  }}-sdk.tar.gz
         path: ${{ github.workspace}}/sdk/${{ matrix.language }}.tar.gz
+    - if: failure() && github.event_name == 'push'
+      name: Notify Slack
+      uses: 8398a7/action-slack@v3
+      with:
+        author_name: Failure while building SDKs
+        fields: repo,commit,author,action
+        status: ${{ job.status }}
   test:
     runs-on: ubuntu-latest
     needs:
@@ -262,13 +269,27 @@ jobs:
         set -euo pipefail
 
         cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt
+    - if: failure() && github.event_name == 'push'
+      name: Notify Slack
+      uses: 8398a7/action-slack@v3
+      with:
+        author_name: Failure in SDK tests
+        fields: repo,commit,author,action
+        status: ${{ job.status }}
   publish:
     runs-on: ubuntu-latest
     needs: test
     strategy:
+      fail-fast: true
       matrix:
         goversion:
         - 1.18.x
+        dotnetversion:
+        - 3.1.301
+        pythonversion:
+        - "3.7"
+        nodeversion:
+        - 14.x
     name: publish
     steps:
     - name: Checkout Repo
@@ -303,8 +324,7 @@ jobs:
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:
-        args: -p 3 -f .goreleaser.prerelease.yml --rm-dist --skip-validate --timeout
-          60m0s
+        args: -p 3 release --rm-dist --timeout 60m0s
         version: latest
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
@@ -327,7 +347,7 @@ jobs:
         - "3.7"
         nodeversion:
         - 14.x
-    name: publish_sdk
+    name: publish_sdks
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2

--- a/native-provider-ci/providers/command/repo/.github/workflows/run-acceptance-tests.yml
+++ b/native-provider-ci/providers/command/repo/.github/workflows/run-acceptance-tests.yml
@@ -185,6 +185,13 @@ jobs:
       with:
         name: ${{ matrix.language  }}-sdk.tar.gz
         path: ${{ github.workspace}}/sdk/${{ matrix.language }}.tar.gz
+    - if: failure() && github.event_name == 'push'
+      name: Notify Slack
+      uses: 8398a7/action-slack@v3
+      with:
+        author_name: Failure while building SDKs
+        fields: repo,commit,author,action
+        status: ${{ job.status }}
     if: github.event_name == 'repository_dispatch' ||
       github.event.pull_request.head.repo.full_name == github.repository
   test:
@@ -292,5 +299,12 @@ jobs:
         set -euo pipefail
 
         cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt
+    - if: failure() && github.event_name == 'push'
+      name: Notify Slack
+      uses: 8398a7/action-slack@v3
+      with:
+        author_name: Failure in SDK tests
+        fields: repo,commit,author,action
+        status: ${{ job.status }}
     if: github.event_name == 'repository_dispatch' ||
       github.event.pull_request.head.repo.full_name == github.repository

--- a/native-provider-ci/providers/google-native/repo/.github/workflows/build.yml
+++ b/native-provider-ci/providers/google-native/repo/.github/workflows/build.yml
@@ -206,6 +206,13 @@ jobs:
       with:
         name: ${{ matrix.language  }}-sdk.tar.gz
         path: ${{ github.workspace}}/sdk/${{ matrix.language }}.tar.gz
+    - if: failure() && github.event_name == 'push'
+      name: Notify Slack
+      uses: 8398a7/action-slack@v3
+      with:
+        author_name: Failure while building SDKs
+        fields: repo,commit,author,action
+        status: ${{ job.status }}
   test:
     runs-on: ubuntu-latest
     needs:
@@ -308,6 +315,13 @@ jobs:
         set -euo pipefail
 
         cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt
+    - if: failure() && github.event_name == 'push'
+      name: Notify Slack
+      uses: 8398a7/action-slack@v3
+      with:
+        author_name: Failure in SDK tests
+        fields: repo,commit,author,action
+        status: ${{ job.status }}
   publish:
     runs-on: ubuntu-latest
     needs: test

--- a/native-provider-ci/providers/google-native/repo/.github/workflows/prerelease.yml
+++ b/native-provider-ci/providers/google-native/repo/.github/workflows/prerelease.yml
@@ -115,7 +115,7 @@ jobs:
         author_name: Failure in building provider prerequisites
         fields: repo,commit,author,action
         status: ${{ job.status }}
-  build_sdk:
+  build_sdks:
     needs: prerequisites
     runs-on: ubuntu-latest
     strategy:
@@ -134,7 +134,7 @@ jobs:
         - python
         - dotnet
         - go
-    name: build_sdk
+    name: build_sdks
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
@@ -197,6 +197,13 @@ jobs:
       with:
         name: ${{ matrix.language  }}-sdk.tar.gz
         path: ${{ github.workspace}}/sdk/${{ matrix.language }}.tar.gz
+    - if: failure() && github.event_name == 'push'
+      name: Notify Slack
+      uses: 8398a7/action-slack@v3
+      with:
+        author_name: Failure while building SDKs
+        fields: repo,commit,author,action
+        status: ${{ job.status }}
   test:
     runs-on: ubuntu-latest
     needs:
@@ -299,6 +306,13 @@ jobs:
         set -euo pipefail
 
         cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt
+    - if: failure() && github.event_name == 'push'
+      name: Notify Slack
+      uses: 8398a7/action-slack@v3
+      with:
+        author_name: Failure in SDK tests
+        fields: repo,commit,author,action
+        status: ${{ job.status }}
   publish:
     runs-on: ubuntu-latest
     needs: test

--- a/native-provider-ci/providers/google-native/repo/.github/workflows/release.yml
+++ b/native-provider-ci/providers/google-native/repo/.github/workflows/release.yml
@@ -116,7 +116,7 @@ jobs:
         author_name: Failure in building provider prerequisites
         fields: repo,commit,author,action
         status: ${{ job.status }}
-  build_sdk:
+  build_sdks:
     needs: prerequisites
     runs-on: ubuntu-latest
     strategy:
@@ -135,7 +135,7 @@ jobs:
         - python
         - dotnet
         - go
-    name: build_sdk
+    name: build_sdks
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
@@ -198,6 +198,13 @@ jobs:
       with:
         name: ${{ matrix.language  }}-sdk.tar.gz
         path: ${{ github.workspace}}/sdk/${{ matrix.language }}.tar.gz
+    - if: failure() && github.event_name == 'push'
+      name: Notify Slack
+      uses: 8398a7/action-slack@v3
+      with:
+        author_name: Failure while building SDKs
+        fields: repo,commit,author,action
+        status: ${{ job.status }}
   test:
     runs-on: ubuntu-latest
     needs:
@@ -300,13 +307,27 @@ jobs:
         set -euo pipefail
 
         cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt
+    - if: failure() && github.event_name == 'push'
+      name: Notify Slack
+      uses: 8398a7/action-slack@v3
+      with:
+        author_name: Failure in SDK tests
+        fields: repo,commit,author,action
+        status: ${{ job.status }}
   publish:
     runs-on: ubuntu-latest
     needs: test
     strategy:
+      fail-fast: true
       matrix:
         goversion:
         - 1.18.x
+        dotnetversion:
+        - 3.1.301
+        pythonversion:
+        - "3.7"
+        nodeversion:
+        - 14.x
     name: publish
     steps:
     - name: Checkout Repo
@@ -341,8 +362,7 @@ jobs:
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:
-        args: -p 3 -f .goreleaser.prerelease.yml --rm-dist --skip-validate --timeout
-          60m0s
+        args: -p 3 release --rm-dist --timeout 60m0s
         version: latest
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
@@ -365,7 +385,7 @@ jobs:
         - "3.7"
         nodeversion:
         - 14.x
-    name: publish_sdk
+    name: publish_sdks
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2

--- a/native-provider-ci/providers/google-native/repo/.github/workflows/run-acceptance-tests.yml
+++ b/native-provider-ci/providers/google-native/repo/.github/workflows/run-acceptance-tests.yml
@@ -225,6 +225,13 @@ jobs:
       with:
         name: ${{ matrix.language  }}-sdk.tar.gz
         path: ${{ github.workspace}}/sdk/${{ matrix.language }}.tar.gz
+    - if: failure() && github.event_name == 'push'
+      name: Notify Slack
+      uses: 8398a7/action-slack@v3
+      with:
+        author_name: Failure while building SDKs
+        fields: repo,commit,author,action
+        status: ${{ job.status }}
     if: github.event_name == 'repository_dispatch' ||
       github.event.pull_request.head.repo.full_name == github.repository
   test:
@@ -330,5 +337,12 @@ jobs:
         set -euo pipefail
 
         cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt
+    - if: failure() && github.event_name == 'push'
+      name: Notify Slack
+      uses: 8398a7/action-slack@v3
+      with:
+        author_name: Failure in SDK tests
+        fields: repo,commit,author,action
+        status: ${{ job.status }}
     if: github.event_name == 'repository_dispatch' ||
       github.event.pull_request.head.repo.full_name == github.repository

--- a/native-provider-ci/providers/kubernetes/repo/.github/workflows/build.yml
+++ b/native-provider-ci/providers/kubernetes/repo/.github/workflows/build.yml
@@ -202,6 +202,13 @@ jobs:
       with:
         name: ${{ matrix.language  }}-sdk.tar.gz
         path: ${{ github.workspace}}/sdk/${{ matrix.language }}.tar.gz
+    - if: failure() && github.event_name == 'push'
+      name: Notify Slack
+      uses: 8398a7/action-slack@v3
+      with:
+        author_name: Failure while building SDKs
+        fields: repo,commit,author,action
+        status: ${{ job.status }}
   test:
     runs-on: ubuntu-latest
     needs:
@@ -337,6 +344,13 @@ jobs:
         set -euo pipefail
 
         cd tests/sdk/${{ matrix.language }} && go test -v -json -count=1 -cover -timeout 2h -parallel 4 ./... 2>&1 | tee /tmp/gotest.log | gotestfmt
+    - if: failure() && github.event_name == 'push'
+      name: Notify Slack
+      uses: 8398a7/action-slack@v3
+      with:
+        author_name: Failure in SDK tests
+        fields: repo,commit,author,action
+        status: ${{ job.status }}
   publish:
     runs-on: ubuntu-latest
     needs: test

--- a/native-provider-ci/providers/kubernetes/repo/.github/workflows/prerelease.yml
+++ b/native-provider-ci/providers/kubernetes/repo/.github/workflows/prerelease.yml
@@ -115,7 +115,7 @@ jobs:
         author_name: Failure in building provider prerequisites
         fields: repo,commit,author,action
         status: ${{ job.status }}
-  build_sdk:
+  build_sdks:
     needs: prerequisites
     runs-on: ubuntu-latest
     strategy:
@@ -134,7 +134,7 @@ jobs:
         - python
         - dotnet
         - go
-    name: build_sdk
+    name: build_sdks
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
@@ -193,6 +193,13 @@ jobs:
       with:
         name: ${{ matrix.language  }}-sdk.tar.gz
         path: ${{ github.workspace}}/sdk/${{ matrix.language }}.tar.gz
+    - if: failure() && github.event_name == 'push'
+      name: Notify Slack
+      uses: 8398a7/action-slack@v3
+      with:
+        author_name: Failure while building SDKs
+        fields: repo,commit,author,action
+        status: ${{ job.status }}
   test:
     runs-on: ubuntu-latest
     needs:
@@ -328,6 +335,13 @@ jobs:
         set -euo pipefail
 
         cd tests/sdk/${{ matrix.language }} && go test -v -json -count=1 -cover -timeout 2h -parallel 4 ./... 2>&1 | tee /tmp/gotest.log | gotestfmt
+    - if: failure() && github.event_name == 'push'
+      name: Notify Slack
+      uses: 8398a7/action-slack@v3
+      with:
+        author_name: Failure in SDK tests
+        fields: repo,commit,author,action
+        status: ${{ job.status }}
   publish:
     runs-on: ubuntu-latest
     needs: test

--- a/native-provider-ci/providers/kubernetes/repo/.github/workflows/release.yml
+++ b/native-provider-ci/providers/kubernetes/repo/.github/workflows/release.yml
@@ -116,7 +116,7 @@ jobs:
         author_name: Failure in building provider prerequisites
         fields: repo,commit,author,action
         status: ${{ job.status }}
-  build_sdk:
+  build_sdks:
     needs: prerequisites
     runs-on: ubuntu-latest
     strategy:
@@ -135,7 +135,7 @@ jobs:
         - python
         - dotnet
         - go
-    name: build_sdk
+    name: build_sdks
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
@@ -194,6 +194,13 @@ jobs:
       with:
         name: ${{ matrix.language  }}-sdk.tar.gz
         path: ${{ github.workspace}}/sdk/${{ matrix.language }}.tar.gz
+    - if: failure() && github.event_name == 'push'
+      name: Notify Slack
+      uses: 8398a7/action-slack@v3
+      with:
+        author_name: Failure while building SDKs
+        fields: repo,commit,author,action
+        status: ${{ job.status }}
   test:
     runs-on: ubuntu-latest
     needs:
@@ -329,13 +336,27 @@ jobs:
         set -euo pipefail
 
         cd tests/sdk/${{ matrix.language }} && go test -v -json -count=1 -cover -timeout 2h -parallel 4 ./... 2>&1 | tee /tmp/gotest.log | gotestfmt
+    - if: failure() && github.event_name == 'push'
+      name: Notify Slack
+      uses: 8398a7/action-slack@v3
+      with:
+        author_name: Failure in SDK tests
+        fields: repo,commit,author,action
+        status: ${{ job.status }}
   publish:
     runs-on: ubuntu-latest
     needs: test
     strategy:
+      fail-fast: true
       matrix:
         goversion:
         - 1.18.x
+        dotnetversion:
+        - 3.1.301
+        pythonversion:
+        - "3.7"
+        nodeversion:
+        - 14.x
     name: publish
     steps:
     - name: Checkout Repo
@@ -370,8 +391,7 @@ jobs:
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:
-        args: -p 3 -f .goreleaser.prerelease.yml --rm-dist --skip-validate --timeout
-          60m0s
+        args: -p 3 release --rm-dist --timeout 60m0s
         version: latest
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
@@ -394,7 +414,7 @@ jobs:
         - "3.7"
         nodeversion:
         - 14.x
-    name: publish_sdk
+    name: publish_sdks
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2

--- a/native-provider-ci/providers/kubernetes/repo/.github/workflows/run-acceptance-tests.yml
+++ b/native-provider-ci/providers/kubernetes/repo/.github/workflows/run-acceptance-tests.yml
@@ -221,6 +221,13 @@ jobs:
       with:
         name: ${{ matrix.language  }}-sdk.tar.gz
         path: ${{ github.workspace}}/sdk/${{ matrix.language }}.tar.gz
+    - if: failure() && github.event_name == 'push'
+      name: Notify Slack
+      uses: 8398a7/action-slack@v3
+      with:
+        author_name: Failure while building SDKs
+        fields: repo,commit,author,action
+        status: ${{ job.status }}
     if: github.event_name == 'repository_dispatch' ||
       github.event.pull_request.head.repo.full_name == github.repository
   test:
@@ -359,6 +366,13 @@ jobs:
         set -euo pipefail
 
         cd tests/sdk/${{ matrix.language }} && go test -v -json -count=1 -cover -timeout 2h -parallel 4 ./... 2>&1 | tee /tmp/gotest.log | gotestfmt
+    - if: failure() && github.event_name == 'push'
+      name: Notify Slack
+      uses: 8398a7/action-slack@v3
+      with:
+        author_name: Failure in SDK tests
+        fields: repo,commit,author,action
+        status: ${{ job.status }}
     if: github.event_name == 'repository_dispatch' ||
       github.event.pull_request.head.repo.full_name == github.repository
   build-test-cluster:


### PR DESCRIPTION
part of https://github.com/pulumi/home/issues/2055  

Notes:

fix important issue in release.yml so that release doesn't call the prerelease command

add notify functionality for build_sdks and test steps (formerly not present consistently in native providers)

use macos runner for azure-native dotnet sdk builds

