### PR TITLE
Allow git lfs when interacting with tf based providers

### DIFF
--- a/provider-ci/providers/aiven/repo/.github/workflows/command-dispatch.yml
+++ b/provider-ci/providers/aiven/repo/.github/workflows/command-dispatch.yml
@@ -25,6 +25,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - uses: peter-evans/slash-command-dispatch@v2
       with:
         commands: run-acceptance-tests

--- a/provider-ci/providers/aiven/repo/.github/workflows/community-moderation.yml
+++ b/provider-ci/providers/aiven/repo/.github/workflows/community-moderation.yml
@@ -7,6 +7,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - id: schema_changed
       name: Check for diff in schema
       uses: dorny/paths-filter@v2

--- a/provider-ci/providers/aiven/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/aiven/repo/.github/workflows/main.yml
@@ -26,6 +26,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -127,6 +129,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Configure AWS Credentials
       uses: aws-actions/configure-aws-credentials@v1
       with:
@@ -179,6 +183,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -254,6 +260,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -310,6 +318,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -419,6 +429,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:

--- a/provider-ci/providers/aiven/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/aiven/repo/.github/workflows/master.yml
@@ -26,6 +26,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -127,6 +129,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Configure AWS Credentials
       uses: aws-actions/configure-aws-credentials@v1
       with:
@@ -179,6 +183,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -254,6 +260,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -310,6 +318,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -419,6 +429,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:

--- a/provider-ci/providers/aiven/repo/.github/workflows/nightly-test.yml
+++ b/provider-ci/providers/aiven/repo/.github/workflows/nightly-test.yml
@@ -26,6 +26,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -123,6 +125,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -198,6 +202,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:

--- a/provider-ci/providers/aiven/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/aiven/repo/.github/workflows/prerelease.yml
@@ -26,6 +26,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -123,6 +125,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -198,6 +202,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -254,6 +260,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -363,6 +371,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:

--- a/provider-ci/providers/aiven/repo/.github/workflows/pull-request.yml
+++ b/provider-ci/providers/aiven/repo/.github/workflows/pull-request.yml
@@ -26,6 +26,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Comment PR
       uses: thollander/actions-comment-pull-request@v1
       with:

--- a/provider-ci/providers/aiven/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/aiven/repo/.github/workflows/release.yml
@@ -26,6 +26,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -137,6 +139,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -212,6 +216,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -267,6 +273,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -376,6 +384,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Install pulumictl
       uses: jaxxstorm/action-install-gh-release@v1.5.0
       with:
@@ -390,6 +400,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:

--- a/provider-ci/providers/aiven/repo/.github/workflows/update-bridge.yml
+++ b/provider-ci/providers/aiven/repo/.github/workflows/update-bridge.yml
@@ -9,6 +9,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/provider-ci/providers/aiven/repo/.github/workflows/update-upstream-provider.yml
+++ b/provider-ci/providers/aiven/repo/.github/workflows/update-upstream-provider.yml
@@ -34,6 +34,8 @@ jobs:
         name=run-url::https://github.com/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/provider-ci/providers/akamai/repo/.github/workflows/command-dispatch.yml
+++ b/provider-ci/providers/akamai/repo/.github/workflows/command-dispatch.yml
@@ -27,6 +27,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - uses: peter-evans/slash-command-dispatch@v2
       with:
         commands: run-acceptance-tests

--- a/provider-ci/providers/akamai/repo/.github/workflows/community-moderation.yml
+++ b/provider-ci/providers/akamai/repo/.github/workflows/community-moderation.yml
@@ -7,6 +7,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - id: schema_changed
       name: Check for diff in schema
       uses: dorny/paths-filter@v2

--- a/provider-ci/providers/akamai/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/akamai/repo/.github/workflows/main.yml
@@ -28,6 +28,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -129,6 +131,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Configure AWS Credentials
       uses: aws-actions/configure-aws-credentials@v1
       with:
@@ -181,6 +185,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -256,6 +262,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -312,6 +320,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -421,6 +431,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:

--- a/provider-ci/providers/akamai/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/akamai/repo/.github/workflows/master.yml
@@ -28,6 +28,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -129,6 +131,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Configure AWS Credentials
       uses: aws-actions/configure-aws-credentials@v1
       with:
@@ -181,6 +185,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -256,6 +262,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -312,6 +320,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -421,6 +431,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:

--- a/provider-ci/providers/akamai/repo/.github/workflows/nightly-test.yml
+++ b/provider-ci/providers/akamai/repo/.github/workflows/nightly-test.yml
@@ -28,6 +28,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -125,6 +127,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -200,6 +204,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:

--- a/provider-ci/providers/akamai/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/akamai/repo/.github/workflows/prerelease.yml
@@ -28,6 +28,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -125,6 +127,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -200,6 +204,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -256,6 +262,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -365,6 +373,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:

--- a/provider-ci/providers/akamai/repo/.github/workflows/pull-request.yml
+++ b/provider-ci/providers/akamai/repo/.github/workflows/pull-request.yml
@@ -28,6 +28,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Comment PR
       uses: thollander/actions-comment-pull-request@v1
       with:

--- a/provider-ci/providers/akamai/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/akamai/repo/.github/workflows/release.yml
@@ -28,6 +28,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -139,6 +141,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -214,6 +218,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -269,6 +275,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -378,6 +386,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Install pulumictl
       uses: jaxxstorm/action-install-gh-release@v1.5.0
       with:
@@ -392,6 +402,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:

--- a/provider-ci/providers/akamai/repo/.github/workflows/update-bridge.yml
+++ b/provider-ci/providers/akamai/repo/.github/workflows/update-bridge.yml
@@ -9,6 +9,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/provider-ci/providers/akamai/repo/.github/workflows/update-upstream-provider.yml
+++ b/provider-ci/providers/akamai/repo/.github/workflows/update-upstream-provider.yml
@@ -36,6 +36,8 @@ jobs:
         name=run-url::https://github.com/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/provider-ci/providers/alicloud/repo/.github/workflows/command-dispatch.yml
+++ b/provider-ci/providers/alicloud/repo/.github/workflows/command-dispatch.yml
@@ -26,6 +26,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - uses: peter-evans/slash-command-dispatch@v2
       with:
         commands: run-acceptance-tests

--- a/provider-ci/providers/alicloud/repo/.github/workflows/community-moderation.yml
+++ b/provider-ci/providers/alicloud/repo/.github/workflows/community-moderation.yml
@@ -7,6 +7,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - id: schema_changed
       name: Check for diff in schema
       uses: dorny/paths-filter@v2

--- a/provider-ci/providers/alicloud/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/alicloud/repo/.github/workflows/main.yml
@@ -27,6 +27,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -128,6 +130,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Configure AWS Credentials
       uses: aws-actions/configure-aws-credentials@v1
       with:
@@ -180,6 +184,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -255,6 +261,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -311,6 +319,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -420,6 +430,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:

--- a/provider-ci/providers/alicloud/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/alicloud/repo/.github/workflows/master.yml
@@ -27,6 +27,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -128,6 +130,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Configure AWS Credentials
       uses: aws-actions/configure-aws-credentials@v1
       with:
@@ -180,6 +184,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -255,6 +261,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -311,6 +319,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -420,6 +430,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:

--- a/provider-ci/providers/alicloud/repo/.github/workflows/nightly-test.yml
+++ b/provider-ci/providers/alicloud/repo/.github/workflows/nightly-test.yml
@@ -27,6 +27,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -124,6 +126,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -199,6 +203,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:

--- a/provider-ci/providers/alicloud/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/alicloud/repo/.github/workflows/prerelease.yml
@@ -27,6 +27,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -124,6 +126,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -199,6 +203,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -255,6 +261,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -364,6 +372,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:

--- a/provider-ci/providers/alicloud/repo/.github/workflows/pull-request.yml
+++ b/provider-ci/providers/alicloud/repo/.github/workflows/pull-request.yml
@@ -27,6 +27,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Comment PR
       uses: thollander/actions-comment-pull-request@v1
       with:

--- a/provider-ci/providers/alicloud/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/alicloud/repo/.github/workflows/release.yml
@@ -27,6 +27,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -138,6 +140,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -213,6 +217,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -268,6 +274,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -377,6 +385,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Install pulumictl
       uses: jaxxstorm/action-install-gh-release@v1.5.0
       with:
@@ -391,6 +401,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:

--- a/provider-ci/providers/alicloud/repo/.github/workflows/update-bridge.yml
+++ b/provider-ci/providers/alicloud/repo/.github/workflows/update-bridge.yml
@@ -9,6 +9,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/provider-ci/providers/alicloud/repo/.github/workflows/update-upstream-provider.yml
+++ b/provider-ci/providers/alicloud/repo/.github/workflows/update-upstream-provider.yml
@@ -35,6 +35,8 @@ jobs:
         name=run-url::https://github.com/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/provider-ci/providers/artifactory/repo/.github/workflows/command-dispatch.yml
+++ b/provider-ci/providers/artifactory/repo/.github/workflows/command-dispatch.yml
@@ -26,6 +26,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - uses: peter-evans/slash-command-dispatch@v2
       with:
         commands: run-acceptance-tests

--- a/provider-ci/providers/artifactory/repo/.github/workflows/community-moderation.yml
+++ b/provider-ci/providers/artifactory/repo/.github/workflows/community-moderation.yml
@@ -7,6 +7,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - id: schema_changed
       name: Check for diff in schema
       uses: dorny/paths-filter@v2

--- a/provider-ci/providers/artifactory/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/artifactory/repo/.github/workflows/main.yml
@@ -27,6 +27,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -128,6 +130,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Configure AWS Credentials
       uses: aws-actions/configure-aws-credentials@v1
       with:
@@ -181,6 +185,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -219,6 +225,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -255,6 +263,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -330,6 +340,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -386,6 +398,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -495,6 +509,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:

--- a/provider-ci/providers/artifactory/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/artifactory/repo/.github/workflows/master.yml
@@ -27,6 +27,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -128,6 +130,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Configure AWS Credentials
       uses: aws-actions/configure-aws-credentials@v1
       with:
@@ -181,6 +185,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -219,6 +225,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -255,6 +263,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -330,6 +340,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -386,6 +398,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -495,6 +509,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:

--- a/provider-ci/providers/artifactory/repo/.github/workflows/nightly-test.yml
+++ b/provider-ci/providers/artifactory/repo/.github/workflows/nightly-test.yml
@@ -27,6 +27,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -124,6 +126,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -199,6 +203,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:

--- a/provider-ci/providers/artifactory/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/artifactory/repo/.github/workflows/prerelease.yml
@@ -27,6 +27,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -125,6 +127,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -163,6 +167,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -199,6 +205,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -274,6 +282,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -330,6 +340,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -439,6 +451,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:

--- a/provider-ci/providers/artifactory/repo/.github/workflows/pull-request.yml
+++ b/provider-ci/providers/artifactory/repo/.github/workflows/pull-request.yml
@@ -27,6 +27,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Comment PR
       uses: thollander/actions-comment-pull-request@v1
       with:

--- a/provider-ci/providers/artifactory/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/artifactory/repo/.github/workflows/release.yml
@@ -27,6 +27,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -139,6 +141,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -177,6 +181,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -213,6 +219,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -288,6 +296,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -343,6 +353,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -452,6 +464,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Install pulumictl
       uses: jaxxstorm/action-install-gh-release@v1.5.0
       with:
@@ -466,6 +480,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:

--- a/provider-ci/providers/artifactory/repo/.github/workflows/update-bridge.yml
+++ b/provider-ci/providers/artifactory/repo/.github/workflows/update-bridge.yml
@@ -9,6 +9,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/provider-ci/providers/artifactory/repo/.github/workflows/update-upstream-provider.yml
+++ b/provider-ci/providers/artifactory/repo/.github/workflows/update-upstream-provider.yml
@@ -35,6 +35,8 @@ jobs:
         name=run-url::https://github.com/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/provider-ci/providers/auth0/repo/.github/workflows/command-dispatch.yml
+++ b/provider-ci/providers/auth0/repo/.github/workflows/command-dispatch.yml
@@ -26,6 +26,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - uses: peter-evans/slash-command-dispatch@v2
       with:
         commands: run-acceptance-tests

--- a/provider-ci/providers/auth0/repo/.github/workflows/community-moderation.yml
+++ b/provider-ci/providers/auth0/repo/.github/workflows/community-moderation.yml
@@ -7,6 +7,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - id: schema_changed
       name: Check for diff in schema
       uses: dorny/paths-filter@v2

--- a/provider-ci/providers/auth0/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/auth0/repo/.github/workflows/main.yml
@@ -27,6 +27,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -128,6 +130,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Configure AWS Credentials
       uses: aws-actions/configure-aws-credentials@v1
       with:
@@ -181,6 +185,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -219,6 +225,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -255,6 +263,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -330,6 +340,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -386,6 +398,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -495,6 +509,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:

--- a/provider-ci/providers/auth0/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/auth0/repo/.github/workflows/master.yml
@@ -27,6 +27,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -128,6 +130,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Configure AWS Credentials
       uses: aws-actions/configure-aws-credentials@v1
       with:
@@ -181,6 +185,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -219,6 +225,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -255,6 +263,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -330,6 +340,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -386,6 +398,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -495,6 +509,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:

--- a/provider-ci/providers/auth0/repo/.github/workflows/nightly-test.yml
+++ b/provider-ci/providers/auth0/repo/.github/workflows/nightly-test.yml
@@ -27,6 +27,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -124,6 +126,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -199,6 +203,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:

--- a/provider-ci/providers/auth0/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/auth0/repo/.github/workflows/prerelease.yml
@@ -27,6 +27,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -125,6 +127,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -163,6 +167,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -199,6 +205,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -274,6 +282,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -330,6 +340,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -439,6 +451,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:

--- a/provider-ci/providers/auth0/repo/.github/workflows/pull-request.yml
+++ b/provider-ci/providers/auth0/repo/.github/workflows/pull-request.yml
@@ -27,6 +27,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Comment PR
       uses: thollander/actions-comment-pull-request@v1
       with:

--- a/provider-ci/providers/auth0/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/auth0/repo/.github/workflows/release.yml
@@ -27,6 +27,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -139,6 +141,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -177,6 +181,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -213,6 +219,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -288,6 +296,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -343,6 +353,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -452,6 +464,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Install pulumictl
       uses: jaxxstorm/action-install-gh-release@v1.5.0
       with:
@@ -466,6 +480,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:

--- a/provider-ci/providers/auth0/repo/.github/workflows/update-bridge.yml
+++ b/provider-ci/providers/auth0/repo/.github/workflows/update-bridge.yml
@@ -9,6 +9,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/provider-ci/providers/auth0/repo/.github/workflows/update-upstream-provider.yml
+++ b/provider-ci/providers/auth0/repo/.github/workflows/update-upstream-provider.yml
@@ -35,6 +35,8 @@ jobs:
         name=run-url::https://github.com/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/provider-ci/providers/aws/repo/.github/workflows/command-dispatch.yml
+++ b/provider-ci/providers/aws/repo/.github/workflows/command-dispatch.yml
@@ -25,6 +25,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - uses: peter-evans/slash-command-dispatch@v2
       with:
         commands: run-acceptance-tests

--- a/provider-ci/providers/aws/repo/.github/workflows/community-moderation.yml
+++ b/provider-ci/providers/aws/repo/.github/workflows/community-moderation.yml
@@ -7,6 +7,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - id: schema_changed
       name: Check for diff in schema
       uses: dorny/paths-filter@v2

--- a/provider-ci/providers/aws/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/aws/repo/.github/workflows/main.yml
@@ -26,6 +26,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -127,6 +129,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Configure AWS Credentials
       uses: aws-actions/configure-aws-credentials@v1
       with:
@@ -179,6 +183,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -254,6 +260,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -310,6 +318,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -419,6 +429,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:

--- a/provider-ci/providers/aws/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/aws/repo/.github/workflows/master.yml
@@ -26,6 +26,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -127,6 +129,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Configure AWS Credentials
       uses: aws-actions/configure-aws-credentials@v1
       with:
@@ -179,6 +183,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -254,6 +260,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -310,6 +318,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -419,6 +429,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:

--- a/provider-ci/providers/aws/repo/.github/workflows/nightly-test.yml
+++ b/provider-ci/providers/aws/repo/.github/workflows/nightly-test.yml
@@ -26,6 +26,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -123,6 +125,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -198,6 +202,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:

--- a/provider-ci/providers/aws/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/aws/repo/.github/workflows/prerelease.yml
@@ -26,6 +26,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -123,6 +125,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -198,6 +202,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -254,6 +260,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -363,6 +371,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:

--- a/provider-ci/providers/aws/repo/.github/workflows/pull-request.yml
+++ b/provider-ci/providers/aws/repo/.github/workflows/pull-request.yml
@@ -26,6 +26,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Comment PR
       uses: thollander/actions-comment-pull-request@v1
       with:

--- a/provider-ci/providers/aws/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/aws/repo/.github/workflows/release.yml
@@ -26,6 +26,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -137,6 +139,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -212,6 +216,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -267,6 +273,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -376,6 +384,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Install pulumictl
       uses: jaxxstorm/action-install-gh-release@v1.5.0
       with:
@@ -390,6 +400,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:

--- a/provider-ci/providers/aws/repo/.github/workflows/update-bridge.yml
+++ b/provider-ci/providers/aws/repo/.github/workflows/update-bridge.yml
@@ -9,6 +9,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/provider-ci/providers/aws/repo/.github/workflows/update-upstream-provider.yml
+++ b/provider-ci/providers/aws/repo/.github/workflows/update-upstream-provider.yml
@@ -34,6 +34,8 @@ jobs:
         name=run-url::https://github.com/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/provider-ci/providers/azure/repo/.github/workflows/command-dispatch.yml
+++ b/provider-ci/providers/azure/repo/.github/workflows/command-dispatch.yml
@@ -30,6 +30,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - uses: peter-evans/slash-command-dispatch@v2
       with:
         commands: run-acceptance-tests

--- a/provider-ci/providers/azure/repo/.github/workflows/community-moderation.yml
+++ b/provider-ci/providers/azure/repo/.github/workflows/community-moderation.yml
@@ -7,6 +7,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - id: schema_changed
       name: Check for diff in schema
       uses: dorny/paths-filter@v2

--- a/provider-ci/providers/azure/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/azure/repo/.github/workflows/main.yml
@@ -31,6 +31,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -132,6 +134,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Configure AWS Credentials
       uses: aws-actions/configure-aws-credentials@v1
       with:
@@ -184,6 +188,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -259,6 +265,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -315,6 +323,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -424,6 +434,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:

--- a/provider-ci/providers/azure/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/azure/repo/.github/workflows/master.yml
@@ -31,6 +31,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -132,6 +134,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Configure AWS Credentials
       uses: aws-actions/configure-aws-credentials@v1
       with:
@@ -184,6 +188,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -259,6 +265,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -315,6 +323,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -424,6 +434,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:

--- a/provider-ci/providers/azure/repo/.github/workflows/nightly-test.yml
+++ b/provider-ci/providers/azure/repo/.github/workflows/nightly-test.yml
@@ -31,6 +31,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -128,6 +130,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -203,6 +207,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:

--- a/provider-ci/providers/azure/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/azure/repo/.github/workflows/prerelease.yml
@@ -31,6 +31,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -128,6 +130,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -203,6 +207,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -259,6 +265,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -368,6 +376,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:

--- a/provider-ci/providers/azure/repo/.github/workflows/pull-request.yml
+++ b/provider-ci/providers/azure/repo/.github/workflows/pull-request.yml
@@ -31,6 +31,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Comment PR
       uses: thollander/actions-comment-pull-request@v1
       with:

--- a/provider-ci/providers/azure/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/azure/repo/.github/workflows/release.yml
@@ -31,6 +31,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -142,6 +144,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -217,6 +221,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -272,6 +278,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -381,6 +389,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Install pulumictl
       uses: jaxxstorm/action-install-gh-release@v1.5.0
       with:
@@ -395,6 +405,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:

--- a/provider-ci/providers/azure/repo/.github/workflows/update-bridge.yml
+++ b/provider-ci/providers/azure/repo/.github/workflows/update-bridge.yml
@@ -9,6 +9,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/provider-ci/providers/azure/repo/.github/workflows/update-upstream-provider.yml
+++ b/provider-ci/providers/azure/repo/.github/workflows/update-upstream-provider.yml
@@ -39,6 +39,8 @@ jobs:
         name=run-url::https://github.com/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/provider-ci/providers/azuread/repo/.github/workflows/command-dispatch.yml
+++ b/provider-ci/providers/azuread/repo/.github/workflows/command-dispatch.yml
@@ -28,6 +28,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - uses: peter-evans/slash-command-dispatch@v2
       with:
         commands: run-acceptance-tests

--- a/provider-ci/providers/azuread/repo/.github/workflows/community-moderation.yml
+++ b/provider-ci/providers/azuread/repo/.github/workflows/community-moderation.yml
@@ -7,6 +7,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - id: schema_changed
       name: Check for diff in schema
       uses: dorny/paths-filter@v2

--- a/provider-ci/providers/azuread/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/azuread/repo/.github/workflows/main.yml
@@ -29,6 +29,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -130,6 +132,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Configure AWS Credentials
       uses: aws-actions/configure-aws-credentials@v1
       with:
@@ -183,6 +187,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -221,6 +227,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -257,6 +265,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -332,6 +342,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -388,6 +400,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -497,6 +511,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:

--- a/provider-ci/providers/azuread/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/azuread/repo/.github/workflows/master.yml
@@ -29,6 +29,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -130,6 +132,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Configure AWS Credentials
       uses: aws-actions/configure-aws-credentials@v1
       with:
@@ -183,6 +187,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -221,6 +227,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -257,6 +265,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -332,6 +342,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -388,6 +400,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -497,6 +511,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:

--- a/provider-ci/providers/azuread/repo/.github/workflows/nightly-test.yml
+++ b/provider-ci/providers/azuread/repo/.github/workflows/nightly-test.yml
@@ -29,6 +29,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -126,6 +128,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -201,6 +205,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:

--- a/provider-ci/providers/azuread/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/azuread/repo/.github/workflows/prerelease.yml
@@ -29,6 +29,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -127,6 +129,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -165,6 +169,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -201,6 +207,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -276,6 +284,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -332,6 +342,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -441,6 +453,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:

--- a/provider-ci/providers/azuread/repo/.github/workflows/pull-request.yml
+++ b/provider-ci/providers/azuread/repo/.github/workflows/pull-request.yml
@@ -29,6 +29,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Comment PR
       uses: thollander/actions-comment-pull-request@v1
       with:

--- a/provider-ci/providers/azuread/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/azuread/repo/.github/workflows/release.yml
@@ -29,6 +29,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -141,6 +143,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -179,6 +183,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -215,6 +221,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -290,6 +298,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -345,6 +355,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -454,6 +466,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Install pulumictl
       uses: jaxxstorm/action-install-gh-release@v1.5.0
       with:
@@ -468,6 +482,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:

--- a/provider-ci/providers/azuread/repo/.github/workflows/update-bridge.yml
+++ b/provider-ci/providers/azuread/repo/.github/workflows/update-bridge.yml
@@ -9,6 +9,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/provider-ci/providers/azuread/repo/.github/workflows/update-upstream-provider.yml
+++ b/provider-ci/providers/azuread/repo/.github/workflows/update-upstream-provider.yml
@@ -37,6 +37,8 @@ jobs:
         name=run-url::https://github.com/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/provider-ci/providers/azuredevops/repo/.github/workflows/command-dispatch.yml
+++ b/provider-ci/providers/azuredevops/repo/.github/workflows/command-dispatch.yml
@@ -25,6 +25,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - uses: peter-evans/slash-command-dispatch@v2
       with:
         commands: run-acceptance-tests

--- a/provider-ci/providers/azuredevops/repo/.github/workflows/community-moderation.yml
+++ b/provider-ci/providers/azuredevops/repo/.github/workflows/community-moderation.yml
@@ -7,6 +7,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - id: schema_changed
       name: Check for diff in schema
       uses: dorny/paths-filter@v2

--- a/provider-ci/providers/azuredevops/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/azuredevops/repo/.github/workflows/main.yml
@@ -26,6 +26,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -127,6 +129,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Configure AWS Credentials
       uses: aws-actions/configure-aws-credentials@v1
       with:
@@ -179,6 +183,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -254,6 +260,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -310,6 +318,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -419,6 +429,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:

--- a/provider-ci/providers/azuredevops/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/azuredevops/repo/.github/workflows/master.yml
@@ -26,6 +26,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -127,6 +129,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Configure AWS Credentials
       uses: aws-actions/configure-aws-credentials@v1
       with:
@@ -179,6 +183,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -254,6 +260,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -310,6 +318,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -419,6 +429,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:

--- a/provider-ci/providers/azuredevops/repo/.github/workflows/nightly-test.yml
+++ b/provider-ci/providers/azuredevops/repo/.github/workflows/nightly-test.yml
@@ -26,6 +26,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -123,6 +125,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -198,6 +202,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:

--- a/provider-ci/providers/azuredevops/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/azuredevops/repo/.github/workflows/prerelease.yml
@@ -26,6 +26,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -123,6 +125,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -198,6 +202,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -254,6 +260,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -363,6 +371,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:

--- a/provider-ci/providers/azuredevops/repo/.github/workflows/pull-request.yml
+++ b/provider-ci/providers/azuredevops/repo/.github/workflows/pull-request.yml
@@ -26,6 +26,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Comment PR
       uses: thollander/actions-comment-pull-request@v1
       with:

--- a/provider-ci/providers/azuredevops/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/azuredevops/repo/.github/workflows/release.yml
@@ -26,6 +26,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -137,6 +139,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -212,6 +216,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -267,6 +273,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -376,6 +384,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Install pulumictl
       uses: jaxxstorm/action-install-gh-release@v1.5.0
       with:
@@ -390,6 +400,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:

--- a/provider-ci/providers/azuredevops/repo/.github/workflows/update-bridge.yml
+++ b/provider-ci/providers/azuredevops/repo/.github/workflows/update-bridge.yml
@@ -9,6 +9,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/provider-ci/providers/azuredevops/repo/.github/workflows/update-upstream-provider.yml
+++ b/provider-ci/providers/azuredevops/repo/.github/workflows/update-upstream-provider.yml
@@ -34,6 +34,8 @@ jobs:
         name=run-url::https://github.com/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/provider-ci/providers/civo/repo/.github/workflows/command-dispatch.yml
+++ b/provider-ci/providers/civo/repo/.github/workflows/command-dispatch.yml
@@ -24,6 +24,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - uses: peter-evans/slash-command-dispatch@v2
       with:
         commands: run-acceptance-tests

--- a/provider-ci/providers/civo/repo/.github/workflows/community-moderation.yml
+++ b/provider-ci/providers/civo/repo/.github/workflows/community-moderation.yml
@@ -7,6 +7,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - id: schema_changed
       name: Check for diff in schema
       uses: dorny/paths-filter@v2

--- a/provider-ci/providers/civo/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/civo/repo/.github/workflows/main.yml
@@ -25,6 +25,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -126,6 +128,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Configure AWS Credentials
       uses: aws-actions/configure-aws-credentials@v1
       with:
@@ -179,6 +183,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -217,6 +223,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -253,6 +261,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -328,6 +338,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -384,6 +396,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -493,6 +507,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:

--- a/provider-ci/providers/civo/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/civo/repo/.github/workflows/master.yml
@@ -25,6 +25,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -126,6 +128,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Configure AWS Credentials
       uses: aws-actions/configure-aws-credentials@v1
       with:
@@ -179,6 +183,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -217,6 +223,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -253,6 +261,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -328,6 +338,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -384,6 +396,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -493,6 +507,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:

--- a/provider-ci/providers/civo/repo/.github/workflows/nightly-test.yml
+++ b/provider-ci/providers/civo/repo/.github/workflows/nightly-test.yml
@@ -25,6 +25,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -122,6 +124,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -197,6 +201,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:

--- a/provider-ci/providers/civo/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/civo/repo/.github/workflows/prerelease.yml
@@ -25,6 +25,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -123,6 +125,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -161,6 +165,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -197,6 +203,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -272,6 +280,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -328,6 +338,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -437,6 +449,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:

--- a/provider-ci/providers/civo/repo/.github/workflows/pull-request.yml
+++ b/provider-ci/providers/civo/repo/.github/workflows/pull-request.yml
@@ -25,6 +25,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Comment PR
       uses: thollander/actions-comment-pull-request@v1
       with:

--- a/provider-ci/providers/civo/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/civo/repo/.github/workflows/release.yml
@@ -25,6 +25,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -137,6 +139,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -175,6 +179,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -211,6 +217,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -286,6 +294,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -341,6 +351,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -450,6 +462,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Install pulumictl
       uses: jaxxstorm/action-install-gh-release@v1.5.0
       with:
@@ -464,6 +478,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:

--- a/provider-ci/providers/civo/repo/.github/workflows/update-bridge.yml
+++ b/provider-ci/providers/civo/repo/.github/workflows/update-bridge.yml
@@ -9,6 +9,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/provider-ci/providers/civo/repo/.github/workflows/update-upstream-provider.yml
+++ b/provider-ci/providers/civo/repo/.github/workflows/update-upstream-provider.yml
@@ -33,6 +33,8 @@ jobs:
         name=run-url::https://github.com/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/provider-ci/providers/cloudamqp/repo/.github/workflows/command-dispatch.yml
+++ b/provider-ci/providers/cloudamqp/repo/.github/workflows/command-dispatch.yml
@@ -23,6 +23,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - uses: peter-evans/slash-command-dispatch@v2
       with:
         commands: run-acceptance-tests

--- a/provider-ci/providers/cloudamqp/repo/.github/workflows/community-moderation.yml
+++ b/provider-ci/providers/cloudamqp/repo/.github/workflows/community-moderation.yml
@@ -7,6 +7,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - id: schema_changed
       name: Check for diff in schema
       uses: dorny/paths-filter@v2

--- a/provider-ci/providers/cloudamqp/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/cloudamqp/repo/.github/workflows/main.yml
@@ -24,6 +24,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -125,6 +127,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Configure AWS Credentials
       uses: aws-actions/configure-aws-credentials@v1
       with:
@@ -178,6 +182,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -216,6 +222,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -252,6 +260,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -327,6 +337,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -383,6 +395,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -492,6 +506,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:

--- a/provider-ci/providers/cloudamqp/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/cloudamqp/repo/.github/workflows/master.yml
@@ -24,6 +24,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -125,6 +127,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Configure AWS Credentials
       uses: aws-actions/configure-aws-credentials@v1
       with:
@@ -178,6 +182,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -216,6 +222,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -252,6 +260,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -327,6 +337,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -383,6 +395,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -492,6 +506,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:

--- a/provider-ci/providers/cloudamqp/repo/.github/workflows/nightly-test.yml
+++ b/provider-ci/providers/cloudamqp/repo/.github/workflows/nightly-test.yml
@@ -24,6 +24,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -121,6 +123,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -196,6 +200,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:

--- a/provider-ci/providers/cloudamqp/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/cloudamqp/repo/.github/workflows/prerelease.yml
@@ -24,6 +24,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -122,6 +124,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -160,6 +164,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -196,6 +202,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -271,6 +279,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -327,6 +337,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -436,6 +448,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:

--- a/provider-ci/providers/cloudamqp/repo/.github/workflows/pull-request.yml
+++ b/provider-ci/providers/cloudamqp/repo/.github/workflows/pull-request.yml
@@ -24,6 +24,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Comment PR
       uses: thollander/actions-comment-pull-request@v1
       with:

--- a/provider-ci/providers/cloudamqp/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/cloudamqp/repo/.github/workflows/release.yml
@@ -24,6 +24,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -136,6 +138,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -174,6 +178,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -210,6 +216,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -285,6 +293,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -340,6 +350,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -449,6 +461,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Install pulumictl
       uses: jaxxstorm/action-install-gh-release@v1.5.0
       with:
@@ -463,6 +477,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:

--- a/provider-ci/providers/cloudamqp/repo/.github/workflows/update-bridge.yml
+++ b/provider-ci/providers/cloudamqp/repo/.github/workflows/update-bridge.yml
@@ -9,6 +9,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/provider-ci/providers/cloudamqp/repo/.github/workflows/update-upstream-provider.yml
+++ b/provider-ci/providers/cloudamqp/repo/.github/workflows/update-upstream-provider.yml
@@ -32,6 +32,8 @@ jobs:
         name=run-url::https://github.com/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/provider-ci/providers/cloudflare/repo/.github/workflows/command-dispatch.yml
+++ b/provider-ci/providers/cloudflare/repo/.github/workflows/command-dispatch.yml
@@ -23,6 +23,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - uses: peter-evans/slash-command-dispatch@v2
       with:
         commands: run-acceptance-tests

--- a/provider-ci/providers/cloudflare/repo/.github/workflows/community-moderation.yml
+++ b/provider-ci/providers/cloudflare/repo/.github/workflows/community-moderation.yml
@@ -7,6 +7,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - id: schema_changed
       name: Check for diff in schema
       uses: dorny/paths-filter@v2

--- a/provider-ci/providers/cloudflare/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/cloudflare/repo/.github/workflows/main.yml
@@ -24,6 +24,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -125,6 +127,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Configure AWS Credentials
       uses: aws-actions/configure-aws-credentials@v1
       with:
@@ -178,6 +182,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -216,6 +222,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -252,6 +260,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -327,6 +337,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -383,6 +395,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -492,6 +506,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:

--- a/provider-ci/providers/cloudflare/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/cloudflare/repo/.github/workflows/master.yml
@@ -24,6 +24,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -125,6 +127,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Configure AWS Credentials
       uses: aws-actions/configure-aws-credentials@v1
       with:
@@ -178,6 +182,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -216,6 +222,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -252,6 +260,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -327,6 +337,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -383,6 +395,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -492,6 +506,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:

--- a/provider-ci/providers/cloudflare/repo/.github/workflows/nightly-test.yml
+++ b/provider-ci/providers/cloudflare/repo/.github/workflows/nightly-test.yml
@@ -24,6 +24,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -121,6 +123,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -196,6 +200,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:

--- a/provider-ci/providers/cloudflare/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/cloudflare/repo/.github/workflows/prerelease.yml
@@ -24,6 +24,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -122,6 +124,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -160,6 +164,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -196,6 +202,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -271,6 +279,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -327,6 +337,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -436,6 +448,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:

--- a/provider-ci/providers/cloudflare/repo/.github/workflows/pull-request.yml
+++ b/provider-ci/providers/cloudflare/repo/.github/workflows/pull-request.yml
@@ -24,6 +24,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Comment PR
       uses: thollander/actions-comment-pull-request@v1
       with:

--- a/provider-ci/providers/cloudflare/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/cloudflare/repo/.github/workflows/release.yml
@@ -24,6 +24,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -136,6 +138,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -174,6 +178,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -210,6 +216,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -285,6 +293,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -340,6 +350,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -449,6 +461,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Install pulumictl
       uses: jaxxstorm/action-install-gh-release@v1.5.0
       with:
@@ -463,6 +477,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:

--- a/provider-ci/providers/cloudflare/repo/.github/workflows/update-bridge.yml
+++ b/provider-ci/providers/cloudflare/repo/.github/workflows/update-bridge.yml
@@ -9,6 +9,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/provider-ci/providers/cloudflare/repo/.github/workflows/update-upstream-provider.yml
+++ b/provider-ci/providers/cloudflare/repo/.github/workflows/update-upstream-provider.yml
@@ -32,6 +32,8 @@ jobs:
         name=run-url::https://github.com/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/provider-ci/providers/cloudinit/repo/.github/workflows/command-dispatch.yml
+++ b/provider-ci/providers/cloudinit/repo/.github/workflows/command-dispatch.yml
@@ -23,6 +23,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - uses: peter-evans/slash-command-dispatch@v2
       with:
         commands: run-acceptance-tests

--- a/provider-ci/providers/cloudinit/repo/.github/workflows/community-moderation.yml
+++ b/provider-ci/providers/cloudinit/repo/.github/workflows/community-moderation.yml
@@ -7,6 +7,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - id: schema_changed
       name: Check for diff in schema
       uses: dorny/paths-filter@v2

--- a/provider-ci/providers/cloudinit/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/cloudinit/repo/.github/workflows/main.yml
@@ -24,6 +24,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -125,6 +127,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Configure AWS Credentials
       uses: aws-actions/configure-aws-credentials@v1
       with:
@@ -177,6 +181,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -252,6 +258,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -308,6 +316,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -417,6 +427,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:

--- a/provider-ci/providers/cloudinit/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/cloudinit/repo/.github/workflows/master.yml
@@ -24,6 +24,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -125,6 +127,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Configure AWS Credentials
       uses: aws-actions/configure-aws-credentials@v1
       with:
@@ -177,6 +181,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -252,6 +258,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -308,6 +316,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -417,6 +427,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:

--- a/provider-ci/providers/cloudinit/repo/.github/workflows/nightly-test.yml
+++ b/provider-ci/providers/cloudinit/repo/.github/workflows/nightly-test.yml
@@ -24,6 +24,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -121,6 +123,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -196,6 +200,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:

--- a/provider-ci/providers/cloudinit/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/cloudinit/repo/.github/workflows/prerelease.yml
@@ -24,6 +24,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -121,6 +123,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -196,6 +200,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -252,6 +258,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -361,6 +369,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:

--- a/provider-ci/providers/cloudinit/repo/.github/workflows/pull-request.yml
+++ b/provider-ci/providers/cloudinit/repo/.github/workflows/pull-request.yml
@@ -24,6 +24,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Comment PR
       uses: thollander/actions-comment-pull-request@v1
       with:

--- a/provider-ci/providers/cloudinit/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/cloudinit/repo/.github/workflows/release.yml
@@ -24,6 +24,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -135,6 +137,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -210,6 +214,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -265,6 +271,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -374,6 +382,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Install pulumictl
       uses: jaxxstorm/action-install-gh-release@v1.5.0
       with:
@@ -388,6 +398,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:

--- a/provider-ci/providers/cloudinit/repo/.github/workflows/update-bridge.yml
+++ b/provider-ci/providers/cloudinit/repo/.github/workflows/update-bridge.yml
@@ -9,6 +9,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/provider-ci/providers/cloudinit/repo/.github/workflows/update-upstream-provider.yml
+++ b/provider-ci/providers/cloudinit/repo/.github/workflows/update-upstream-provider.yml
@@ -32,6 +32,8 @@ jobs:
         name=run-url::https://github.com/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/provider-ci/providers/confluent/repo/.github/workflows/command-dispatch.yml
+++ b/provider-ci/providers/confluent/repo/.github/workflows/command-dispatch.yml
@@ -25,6 +25,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - uses: peter-evans/slash-command-dispatch@v2
       with:
         commands: run-acceptance-tests

--- a/provider-ci/providers/confluent/repo/.github/workflows/community-moderation.yml
+++ b/provider-ci/providers/confluent/repo/.github/workflows/community-moderation.yml
@@ -7,6 +7,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - id: schema_changed
       name: Check for diff in schema
       uses: dorny/paths-filter@v2

--- a/provider-ci/providers/confluent/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/confluent/repo/.github/workflows/main.yml
@@ -26,6 +26,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -127,6 +129,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Configure AWS Credentials
       uses: aws-actions/configure-aws-credentials@v1
       with:
@@ -180,6 +184,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -218,6 +224,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -254,6 +262,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -329,6 +339,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -385,6 +397,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -494,6 +508,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:

--- a/provider-ci/providers/confluent/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/confluent/repo/.github/workflows/master.yml
@@ -26,6 +26,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -127,6 +129,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Configure AWS Credentials
       uses: aws-actions/configure-aws-credentials@v1
       with:
@@ -180,6 +184,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -218,6 +224,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -254,6 +262,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -329,6 +339,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -385,6 +397,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -494,6 +508,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:

--- a/provider-ci/providers/confluent/repo/.github/workflows/nightly-test.yml
+++ b/provider-ci/providers/confluent/repo/.github/workflows/nightly-test.yml
@@ -26,6 +26,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -123,6 +125,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -198,6 +202,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:

--- a/provider-ci/providers/confluent/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/confluent/repo/.github/workflows/prerelease.yml
@@ -26,6 +26,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -124,6 +126,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -162,6 +166,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -198,6 +204,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -273,6 +281,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -329,6 +339,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -438,6 +450,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:

--- a/provider-ci/providers/confluent/repo/.github/workflows/pull-request.yml
+++ b/provider-ci/providers/confluent/repo/.github/workflows/pull-request.yml
@@ -26,6 +26,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Comment PR
       uses: thollander/actions-comment-pull-request@v1
       with:

--- a/provider-ci/providers/confluent/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/confluent/repo/.github/workflows/release.yml
@@ -26,6 +26,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -138,6 +140,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -176,6 +180,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -212,6 +218,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -287,6 +295,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -342,6 +352,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -451,6 +463,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Install pulumictl
       uses: jaxxstorm/action-install-gh-release@v1.5.0
       with:
@@ -465,6 +479,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:

--- a/provider-ci/providers/confluent/repo/.github/workflows/update-bridge.yml
+++ b/provider-ci/providers/confluent/repo/.github/workflows/update-bridge.yml
@@ -9,6 +9,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/provider-ci/providers/confluent/repo/.github/workflows/update-upstream-provider.yml
+++ b/provider-ci/providers/confluent/repo/.github/workflows/update-upstream-provider.yml
@@ -34,6 +34,8 @@ jobs:
         name=run-url::https://github.com/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/provider-ci/providers/confluentcloud/repo/.github/workflows/command-dispatch.yml
+++ b/provider-ci/providers/confluentcloud/repo/.github/workflows/command-dispatch.yml
@@ -25,6 +25,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - uses: peter-evans/slash-command-dispatch@v2
       with:
         commands: run-acceptance-tests

--- a/provider-ci/providers/confluentcloud/repo/.github/workflows/community-moderation.yml
+++ b/provider-ci/providers/confluentcloud/repo/.github/workflows/community-moderation.yml
@@ -7,6 +7,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - id: schema_changed
       name: Check for diff in schema
       uses: dorny/paths-filter@v2

--- a/provider-ci/providers/confluentcloud/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/confluentcloud/repo/.github/workflows/main.yml
@@ -26,6 +26,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -127,6 +129,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Configure AWS Credentials
       uses: aws-actions/configure-aws-credentials@v1
       with:
@@ -179,6 +183,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -254,6 +260,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -310,6 +318,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -419,6 +429,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:

--- a/provider-ci/providers/confluentcloud/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/confluentcloud/repo/.github/workflows/master.yml
@@ -26,6 +26,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -127,6 +129,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Configure AWS Credentials
       uses: aws-actions/configure-aws-credentials@v1
       with:
@@ -179,6 +183,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -254,6 +260,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -310,6 +318,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -419,6 +429,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:

--- a/provider-ci/providers/confluentcloud/repo/.github/workflows/nightly-test.yml
+++ b/provider-ci/providers/confluentcloud/repo/.github/workflows/nightly-test.yml
@@ -26,6 +26,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -123,6 +125,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -198,6 +202,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:

--- a/provider-ci/providers/confluentcloud/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/confluentcloud/repo/.github/workflows/prerelease.yml
@@ -26,6 +26,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -123,6 +125,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -198,6 +202,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -254,6 +260,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -363,6 +371,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:

--- a/provider-ci/providers/confluentcloud/repo/.github/workflows/pull-request.yml
+++ b/provider-ci/providers/confluentcloud/repo/.github/workflows/pull-request.yml
@@ -26,6 +26,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Comment PR
       uses: thollander/actions-comment-pull-request@v1
       with:

--- a/provider-ci/providers/confluentcloud/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/confluentcloud/repo/.github/workflows/release.yml
@@ -26,6 +26,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -137,6 +139,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -212,6 +216,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -267,6 +273,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -376,6 +384,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Install pulumictl
       uses: jaxxstorm/action-install-gh-release@v1.5.0
       with:
@@ -390,6 +400,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:

--- a/provider-ci/providers/confluentcloud/repo/.github/workflows/update-bridge.yml
+++ b/provider-ci/providers/confluentcloud/repo/.github/workflows/update-bridge.yml
@@ -9,6 +9,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/provider-ci/providers/confluentcloud/repo/.github/workflows/update-upstream-provider.yml
+++ b/provider-ci/providers/confluentcloud/repo/.github/workflows/update-upstream-provider.yml
@@ -34,6 +34,8 @@ jobs:
         name=run-url::https://github.com/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/provider-ci/providers/consul/repo/.github/workflows/command-dispatch.yml
+++ b/provider-ci/providers/consul/repo/.github/workflows/command-dispatch.yml
@@ -23,6 +23,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - uses: peter-evans/slash-command-dispatch@v2
       with:
         commands: run-acceptance-tests

--- a/provider-ci/providers/consul/repo/.github/workflows/community-moderation.yml
+++ b/provider-ci/providers/consul/repo/.github/workflows/community-moderation.yml
@@ -7,6 +7,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - id: schema_changed
       name: Check for diff in schema
       uses: dorny/paths-filter@v2

--- a/provider-ci/providers/consul/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/consul/repo/.github/workflows/main.yml
@@ -24,6 +24,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -125,6 +127,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Configure AWS Credentials
       uses: aws-actions/configure-aws-credentials@v1
       with:
@@ -178,6 +182,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -216,6 +222,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -252,6 +260,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -327,6 +337,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -383,6 +395,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -492,6 +506,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:

--- a/provider-ci/providers/consul/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/consul/repo/.github/workflows/master.yml
@@ -24,6 +24,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -125,6 +127,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Configure AWS Credentials
       uses: aws-actions/configure-aws-credentials@v1
       with:
@@ -178,6 +182,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -216,6 +222,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -252,6 +260,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -327,6 +337,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -383,6 +395,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -492,6 +506,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:

--- a/provider-ci/providers/consul/repo/.github/workflows/nightly-test.yml
+++ b/provider-ci/providers/consul/repo/.github/workflows/nightly-test.yml
@@ -24,6 +24,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -121,6 +123,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -196,6 +200,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:

--- a/provider-ci/providers/consul/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/consul/repo/.github/workflows/prerelease.yml
@@ -24,6 +24,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -122,6 +124,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -160,6 +164,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -196,6 +202,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -271,6 +279,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -327,6 +337,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -436,6 +448,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:

--- a/provider-ci/providers/consul/repo/.github/workflows/pull-request.yml
+++ b/provider-ci/providers/consul/repo/.github/workflows/pull-request.yml
@@ -24,6 +24,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Comment PR
       uses: thollander/actions-comment-pull-request@v1
       with:

--- a/provider-ci/providers/consul/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/consul/repo/.github/workflows/release.yml
@@ -24,6 +24,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -136,6 +138,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -174,6 +178,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -210,6 +216,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -285,6 +293,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -340,6 +350,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -449,6 +461,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Install pulumictl
       uses: jaxxstorm/action-install-gh-release@v1.5.0
       with:
@@ -463,6 +477,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:

--- a/provider-ci/providers/consul/repo/.github/workflows/update-bridge.yml
+++ b/provider-ci/providers/consul/repo/.github/workflows/update-bridge.yml
@@ -9,6 +9,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/provider-ci/providers/consul/repo/.github/workflows/update-upstream-provider.yml
+++ b/provider-ci/providers/consul/repo/.github/workflows/update-upstream-provider.yml
@@ -32,6 +32,8 @@ jobs:
         name=run-url::https://github.com/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/provider-ci/providers/databricks/repo/.github/workflows/command-dispatch.yml
+++ b/provider-ci/providers/databricks/repo/.github/workflows/command-dispatch.yml
@@ -27,6 +27,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - uses: peter-evans/slash-command-dispatch@v2
       with:
         commands: run-acceptance-tests

--- a/provider-ci/providers/databricks/repo/.github/workflows/community-moderation.yml
+++ b/provider-ci/providers/databricks/repo/.github/workflows/community-moderation.yml
@@ -7,6 +7,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - id: schema_changed
       name: Check for diff in schema
       uses: dorny/paths-filter@v2

--- a/provider-ci/providers/databricks/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/databricks/repo/.github/workflows/main.yml
@@ -28,6 +28,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -129,6 +131,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Configure AWS Credentials
       uses: aws-actions/configure-aws-credentials@v1
       with:
@@ -182,6 +186,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -220,6 +226,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -256,6 +264,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -331,6 +341,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -387,6 +399,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -496,6 +510,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:

--- a/provider-ci/providers/databricks/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/databricks/repo/.github/workflows/master.yml
@@ -28,6 +28,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -129,6 +131,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Configure AWS Credentials
       uses: aws-actions/configure-aws-credentials@v1
       with:
@@ -182,6 +186,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -220,6 +226,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -256,6 +264,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -331,6 +341,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -387,6 +399,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -496,6 +510,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:

--- a/provider-ci/providers/databricks/repo/.github/workflows/nightly-test.yml
+++ b/provider-ci/providers/databricks/repo/.github/workflows/nightly-test.yml
@@ -28,6 +28,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -125,6 +127,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -200,6 +204,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:

--- a/provider-ci/providers/databricks/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/databricks/repo/.github/workflows/prerelease.yml
@@ -28,6 +28,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -126,6 +128,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -164,6 +168,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -200,6 +206,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -275,6 +283,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -331,6 +341,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -440,6 +452,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:

--- a/provider-ci/providers/databricks/repo/.github/workflows/pull-request.yml
+++ b/provider-ci/providers/databricks/repo/.github/workflows/pull-request.yml
@@ -28,6 +28,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Comment PR
       uses: thollander/actions-comment-pull-request@v1
       with:

--- a/provider-ci/providers/databricks/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/databricks/repo/.github/workflows/release.yml
@@ -28,6 +28,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -140,6 +142,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -178,6 +182,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -214,6 +220,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -289,6 +297,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -344,6 +354,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -453,6 +465,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Install pulumictl
       uses: jaxxstorm/action-install-gh-release@v1.5.0
       with:
@@ -467,6 +481,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:

--- a/provider-ci/providers/databricks/repo/.github/workflows/update-bridge.yml
+++ b/provider-ci/providers/databricks/repo/.github/workflows/update-bridge.yml
@@ -9,6 +9,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/provider-ci/providers/databricks/repo/.github/workflows/update-upstream-provider.yml
+++ b/provider-ci/providers/databricks/repo/.github/workflows/update-upstream-provider.yml
@@ -36,6 +36,8 @@ jobs:
         name=run-url::https://github.com/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/provider-ci/providers/datadog/repo/.github/workflows/command-dispatch.yml
+++ b/provider-ci/providers/datadog/repo/.github/workflows/command-dispatch.yml
@@ -23,6 +23,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - uses: peter-evans/slash-command-dispatch@v2
       with:
         commands: run-acceptance-tests

--- a/provider-ci/providers/datadog/repo/.github/workflows/community-moderation.yml
+++ b/provider-ci/providers/datadog/repo/.github/workflows/community-moderation.yml
@@ -7,6 +7,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - id: schema_changed
       name: Check for diff in schema
       uses: dorny/paths-filter@v2

--- a/provider-ci/providers/datadog/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/datadog/repo/.github/workflows/main.yml
@@ -24,6 +24,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -125,6 +127,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Configure AWS Credentials
       uses: aws-actions/configure-aws-credentials@v1
       with:
@@ -177,6 +181,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -252,6 +258,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -308,6 +316,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -417,6 +427,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:

--- a/provider-ci/providers/datadog/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/datadog/repo/.github/workflows/master.yml
@@ -24,6 +24,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -125,6 +127,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Configure AWS Credentials
       uses: aws-actions/configure-aws-credentials@v1
       with:
@@ -177,6 +181,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -252,6 +258,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -308,6 +316,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -417,6 +427,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:

--- a/provider-ci/providers/datadog/repo/.github/workflows/nightly-test.yml
+++ b/provider-ci/providers/datadog/repo/.github/workflows/nightly-test.yml
@@ -24,6 +24,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -121,6 +123,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -196,6 +200,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:

--- a/provider-ci/providers/datadog/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/datadog/repo/.github/workflows/prerelease.yml
@@ -24,6 +24,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -121,6 +123,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -196,6 +200,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -252,6 +258,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -361,6 +369,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:

--- a/provider-ci/providers/datadog/repo/.github/workflows/pull-request.yml
+++ b/provider-ci/providers/datadog/repo/.github/workflows/pull-request.yml
@@ -24,6 +24,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Comment PR
       uses: thollander/actions-comment-pull-request@v1
       with:

--- a/provider-ci/providers/datadog/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/datadog/repo/.github/workflows/release.yml
@@ -24,6 +24,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -135,6 +137,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -210,6 +214,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -265,6 +271,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -374,6 +382,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Install pulumictl
       uses: jaxxstorm/action-install-gh-release@v1.5.0
       with:
@@ -388,6 +398,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:

--- a/provider-ci/providers/datadog/repo/.github/workflows/update-bridge.yml
+++ b/provider-ci/providers/datadog/repo/.github/workflows/update-bridge.yml
@@ -9,6 +9,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/provider-ci/providers/datadog/repo/.github/workflows/update-upstream-provider.yml
+++ b/provider-ci/providers/datadog/repo/.github/workflows/update-upstream-provider.yml
@@ -32,6 +32,8 @@ jobs:
         name=run-url::https://github.com/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/provider-ci/providers/digitalocean/repo/.github/workflows/command-dispatch.yml
+++ b/provider-ci/providers/digitalocean/repo/.github/workflows/command-dispatch.yml
@@ -24,6 +24,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - uses: peter-evans/slash-command-dispatch@v2
       with:
         commands: run-acceptance-tests

--- a/provider-ci/providers/digitalocean/repo/.github/workflows/community-moderation.yml
+++ b/provider-ci/providers/digitalocean/repo/.github/workflows/community-moderation.yml
@@ -7,6 +7,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - id: schema_changed
       name: Check for diff in schema
       uses: dorny/paths-filter@v2

--- a/provider-ci/providers/digitalocean/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/digitalocean/repo/.github/workflows/main.yml
@@ -25,6 +25,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -126,6 +128,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Configure AWS Credentials
       uses: aws-actions/configure-aws-credentials@v1
       with:
@@ -179,6 +183,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -217,6 +223,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -253,6 +261,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -328,6 +338,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -384,6 +396,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -493,6 +507,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:

--- a/provider-ci/providers/digitalocean/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/digitalocean/repo/.github/workflows/master.yml
@@ -25,6 +25,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -126,6 +128,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Configure AWS Credentials
       uses: aws-actions/configure-aws-credentials@v1
       with:
@@ -179,6 +183,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -217,6 +223,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -253,6 +261,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -328,6 +338,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -384,6 +396,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -493,6 +507,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:

--- a/provider-ci/providers/digitalocean/repo/.github/workflows/nightly-test.yml
+++ b/provider-ci/providers/digitalocean/repo/.github/workflows/nightly-test.yml
@@ -25,6 +25,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -122,6 +124,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -197,6 +201,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:

--- a/provider-ci/providers/digitalocean/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/digitalocean/repo/.github/workflows/prerelease.yml
@@ -25,6 +25,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -123,6 +125,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -161,6 +165,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -197,6 +203,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -272,6 +280,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -328,6 +338,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -437,6 +449,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:

--- a/provider-ci/providers/digitalocean/repo/.github/workflows/pull-request.yml
+++ b/provider-ci/providers/digitalocean/repo/.github/workflows/pull-request.yml
@@ -25,6 +25,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Comment PR
       uses: thollander/actions-comment-pull-request@v1
       with:

--- a/provider-ci/providers/digitalocean/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/digitalocean/repo/.github/workflows/release.yml
@@ -25,6 +25,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -137,6 +139,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -175,6 +179,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -211,6 +217,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -286,6 +294,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -341,6 +351,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -450,6 +462,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Install pulumictl
       uses: jaxxstorm/action-install-gh-release@v1.5.0
       with:
@@ -464,6 +478,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:

--- a/provider-ci/providers/digitalocean/repo/.github/workflows/update-bridge.yml
+++ b/provider-ci/providers/digitalocean/repo/.github/workflows/update-bridge.yml
@@ -9,6 +9,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/provider-ci/providers/digitalocean/repo/.github/workflows/update-upstream-provider.yml
+++ b/provider-ci/providers/digitalocean/repo/.github/workflows/update-upstream-provider.yml
@@ -33,6 +33,8 @@ jobs:
         name=run-url::https://github.com/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/provider-ci/providers/dnsimple/repo/.github/workflows/command-dispatch.yml
+++ b/provider-ci/providers/dnsimple/repo/.github/workflows/command-dispatch.yml
@@ -25,6 +25,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - uses: peter-evans/slash-command-dispatch@v2
       with:
         commands: run-acceptance-tests

--- a/provider-ci/providers/dnsimple/repo/.github/workflows/community-moderation.yml
+++ b/provider-ci/providers/dnsimple/repo/.github/workflows/community-moderation.yml
@@ -7,6 +7,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - id: schema_changed
       name: Check for diff in schema
       uses: dorny/paths-filter@v2

--- a/provider-ci/providers/dnsimple/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/dnsimple/repo/.github/workflows/main.yml
@@ -26,6 +26,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -127,6 +129,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Configure AWS Credentials
       uses: aws-actions/configure-aws-credentials@v1
       with:
@@ -180,6 +184,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -218,6 +224,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -254,6 +262,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -329,6 +339,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -385,6 +397,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -494,6 +508,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:

--- a/provider-ci/providers/dnsimple/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/dnsimple/repo/.github/workflows/master.yml
@@ -26,6 +26,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -127,6 +129,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Configure AWS Credentials
       uses: aws-actions/configure-aws-credentials@v1
       with:
@@ -180,6 +184,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -218,6 +224,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -254,6 +262,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -329,6 +339,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -385,6 +397,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -494,6 +508,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:

--- a/provider-ci/providers/dnsimple/repo/.github/workflows/nightly-test.yml
+++ b/provider-ci/providers/dnsimple/repo/.github/workflows/nightly-test.yml
@@ -26,6 +26,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -123,6 +125,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -198,6 +202,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:

--- a/provider-ci/providers/dnsimple/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/dnsimple/repo/.github/workflows/prerelease.yml
@@ -26,6 +26,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -124,6 +126,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -162,6 +166,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -198,6 +204,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -273,6 +281,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -329,6 +339,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -438,6 +450,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:

--- a/provider-ci/providers/dnsimple/repo/.github/workflows/pull-request.yml
+++ b/provider-ci/providers/dnsimple/repo/.github/workflows/pull-request.yml
@@ -26,6 +26,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Comment PR
       uses: thollander/actions-comment-pull-request@v1
       with:

--- a/provider-ci/providers/dnsimple/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/dnsimple/repo/.github/workflows/release.yml
@@ -26,6 +26,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -138,6 +140,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -176,6 +180,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -212,6 +218,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -287,6 +295,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -342,6 +352,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -451,6 +463,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Install pulumictl
       uses: jaxxstorm/action-install-gh-release@v1.5.0
       with:
@@ -465,6 +479,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:

--- a/provider-ci/providers/dnsimple/repo/.github/workflows/update-bridge.yml
+++ b/provider-ci/providers/dnsimple/repo/.github/workflows/update-bridge.yml
@@ -9,6 +9,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/provider-ci/providers/dnsimple/repo/.github/workflows/update-upstream-provider.yml
+++ b/provider-ci/providers/dnsimple/repo/.github/workflows/update-upstream-provider.yml
@@ -34,6 +34,8 @@ jobs:
         name=run-url::https://github.com/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/provider-ci/providers/docker/repo/.github/workflows/command-dispatch.yml
+++ b/provider-ci/providers/docker/repo/.github/workflows/command-dispatch.yml
@@ -29,6 +29,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - uses: peter-evans/slash-command-dispatch@v2
       with:
         commands: run-acceptance-tests

--- a/provider-ci/providers/docker/repo/.github/workflows/community-moderation.yml
+++ b/provider-ci/providers/docker/repo/.github/workflows/community-moderation.yml
@@ -7,6 +7,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - id: schema_changed
       name: Check for diff in schema
       uses: dorny/paths-filter@v2

--- a/provider-ci/providers/docker/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/docker/repo/.github/workflows/main.yml
@@ -30,6 +30,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -131,6 +133,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Configure AWS Credentials
       uses: aws-actions/configure-aws-credentials@v1
       with:
@@ -184,6 +188,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -222,6 +228,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -258,6 +266,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -333,6 +343,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -389,6 +401,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -498,6 +512,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:

--- a/provider-ci/providers/docker/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/docker/repo/.github/workflows/master.yml
@@ -30,6 +30,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -131,6 +133,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Configure AWS Credentials
       uses: aws-actions/configure-aws-credentials@v1
       with:
@@ -184,6 +188,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -222,6 +228,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -258,6 +266,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -333,6 +343,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -389,6 +401,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -498,6 +512,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:

--- a/provider-ci/providers/docker/repo/.github/workflows/nightly-test.yml
+++ b/provider-ci/providers/docker/repo/.github/workflows/nightly-test.yml
@@ -30,6 +30,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -127,6 +129,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -202,6 +206,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:

--- a/provider-ci/providers/docker/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/docker/repo/.github/workflows/prerelease.yml
@@ -30,6 +30,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -128,6 +130,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -166,6 +170,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -202,6 +208,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -277,6 +285,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -333,6 +343,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -442,6 +454,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:

--- a/provider-ci/providers/docker/repo/.github/workflows/pull-request.yml
+++ b/provider-ci/providers/docker/repo/.github/workflows/pull-request.yml
@@ -30,6 +30,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Comment PR
       uses: thollander/actions-comment-pull-request@v1
       with:

--- a/provider-ci/providers/docker/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/docker/repo/.github/workflows/release.yml
@@ -30,6 +30,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -142,6 +144,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -180,6 +184,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -216,6 +222,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -291,6 +299,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -346,6 +356,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -455,6 +467,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Install pulumictl
       uses: jaxxstorm/action-install-gh-release@v1.5.0
       with:
@@ -469,6 +483,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:

--- a/provider-ci/providers/docker/repo/.github/workflows/update-bridge.yml
+++ b/provider-ci/providers/docker/repo/.github/workflows/update-bridge.yml
@@ -9,6 +9,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/provider-ci/providers/docker/repo/.github/workflows/update-upstream-provider.yml
+++ b/provider-ci/providers/docker/repo/.github/workflows/update-upstream-provider.yml
@@ -38,6 +38,8 @@ jobs:
         name=run-url::https://github.com/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/provider-ci/providers/ec/repo/.github/workflows/command-dispatch.yml
+++ b/provider-ci/providers/ec/repo/.github/workflows/command-dispatch.yml
@@ -24,6 +24,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - uses: peter-evans/slash-command-dispatch@v2
       with:
         commands: run-acceptance-tests

--- a/provider-ci/providers/ec/repo/.github/workflows/community-moderation.yml
+++ b/provider-ci/providers/ec/repo/.github/workflows/community-moderation.yml
@@ -7,6 +7,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - id: schema_changed
       name: Check for diff in schema
       uses: dorny/paths-filter@v2

--- a/provider-ci/providers/ec/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/ec/repo/.github/workflows/main.yml
@@ -25,6 +25,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -126,6 +128,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Configure AWS Credentials
       uses: aws-actions/configure-aws-credentials@v1
       with:
@@ -179,6 +183,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -217,6 +223,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -253,6 +261,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -328,6 +338,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -384,6 +396,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -493,6 +507,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:

--- a/provider-ci/providers/ec/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/ec/repo/.github/workflows/master.yml
@@ -25,6 +25,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -126,6 +128,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Configure AWS Credentials
       uses: aws-actions/configure-aws-credentials@v1
       with:
@@ -179,6 +183,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -217,6 +223,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -253,6 +261,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -328,6 +338,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -384,6 +396,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -493,6 +507,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:

--- a/provider-ci/providers/ec/repo/.github/workflows/nightly-test.yml
+++ b/provider-ci/providers/ec/repo/.github/workflows/nightly-test.yml
@@ -25,6 +25,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -122,6 +124,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -197,6 +201,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:

--- a/provider-ci/providers/ec/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/ec/repo/.github/workflows/prerelease.yml
@@ -25,6 +25,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -123,6 +125,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -161,6 +165,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -197,6 +203,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -272,6 +280,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -328,6 +338,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -437,6 +449,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:

--- a/provider-ci/providers/ec/repo/.github/workflows/pull-request.yml
+++ b/provider-ci/providers/ec/repo/.github/workflows/pull-request.yml
@@ -25,6 +25,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Comment PR
       uses: thollander/actions-comment-pull-request@v1
       with:

--- a/provider-ci/providers/ec/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/ec/repo/.github/workflows/release.yml
@@ -25,6 +25,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -137,6 +139,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -175,6 +179,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -211,6 +217,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -286,6 +294,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -341,6 +351,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -450,6 +462,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Install pulumictl
       uses: jaxxstorm/action-install-gh-release@v1.5.0
       with:
@@ -464,6 +478,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:

--- a/provider-ci/providers/ec/repo/.github/workflows/update-bridge.yml
+++ b/provider-ci/providers/ec/repo/.github/workflows/update-bridge.yml
@@ -9,6 +9,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/provider-ci/providers/ec/repo/.github/workflows/update-upstream-provider.yml
+++ b/provider-ci/providers/ec/repo/.github/workflows/update-upstream-provider.yml
@@ -33,6 +33,8 @@ jobs:
         name=run-url::https://github.com/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/provider-ci/providers/equinix-metal/repo/.github/workflows/command-dispatch.yml
+++ b/provider-ci/providers/equinix-metal/repo/.github/workflows/command-dispatch.yml
@@ -24,6 +24,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - uses: peter-evans/slash-command-dispatch@v2
       with:
         commands: run-acceptance-tests

--- a/provider-ci/providers/equinix-metal/repo/.github/workflows/community-moderation.yml
+++ b/provider-ci/providers/equinix-metal/repo/.github/workflows/community-moderation.yml
@@ -7,6 +7,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - id: schema_changed
       name: Check for diff in schema
       uses: dorny/paths-filter@v2

--- a/provider-ci/providers/equinix-metal/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/equinix-metal/repo/.github/workflows/main.yml
@@ -25,6 +25,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -126,6 +128,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Configure AWS Credentials
       uses: aws-actions/configure-aws-credentials@v1
       with:
@@ -178,6 +182,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -253,6 +259,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -309,6 +317,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -418,6 +428,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:

--- a/provider-ci/providers/equinix-metal/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/equinix-metal/repo/.github/workflows/master.yml
@@ -25,6 +25,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -126,6 +128,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Configure AWS Credentials
       uses: aws-actions/configure-aws-credentials@v1
       with:
@@ -178,6 +182,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -253,6 +259,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -309,6 +317,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -418,6 +428,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:

--- a/provider-ci/providers/equinix-metal/repo/.github/workflows/nightly-test.yml
+++ b/provider-ci/providers/equinix-metal/repo/.github/workflows/nightly-test.yml
@@ -25,6 +25,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -122,6 +124,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -197,6 +201,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:

--- a/provider-ci/providers/equinix-metal/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/equinix-metal/repo/.github/workflows/prerelease.yml
@@ -25,6 +25,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -122,6 +124,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -197,6 +201,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -253,6 +259,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -362,6 +370,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:

--- a/provider-ci/providers/equinix-metal/repo/.github/workflows/pull-request.yml
+++ b/provider-ci/providers/equinix-metal/repo/.github/workflows/pull-request.yml
@@ -25,6 +25,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Comment PR
       uses: thollander/actions-comment-pull-request@v1
       with:

--- a/provider-ci/providers/equinix-metal/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/equinix-metal/repo/.github/workflows/release.yml
@@ -25,6 +25,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -136,6 +138,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -211,6 +215,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -266,6 +272,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -375,6 +383,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Install pulumictl
       uses: jaxxstorm/action-install-gh-release@v1.5.0
       with:
@@ -389,6 +399,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:

--- a/provider-ci/providers/equinix-metal/repo/.github/workflows/update-bridge.yml
+++ b/provider-ci/providers/equinix-metal/repo/.github/workflows/update-bridge.yml
@@ -9,6 +9,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/provider-ci/providers/equinix-metal/repo/.github/workflows/update-upstream-provider.yml
+++ b/provider-ci/providers/equinix-metal/repo/.github/workflows/update-upstream-provider.yml
@@ -33,6 +33,8 @@ jobs:
         name=run-url::https://github.com/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/provider-ci/providers/f5bigip/repo/.github/workflows/command-dispatch.yml
+++ b/provider-ci/providers/f5bigip/repo/.github/workflows/command-dispatch.yml
@@ -27,6 +27,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - uses: peter-evans/slash-command-dispatch@v2
       with:
         commands: run-acceptance-tests

--- a/provider-ci/providers/f5bigip/repo/.github/workflows/community-moderation.yml
+++ b/provider-ci/providers/f5bigip/repo/.github/workflows/community-moderation.yml
@@ -7,6 +7,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - id: schema_changed
       name: Check for diff in schema
       uses: dorny/paths-filter@v2

--- a/provider-ci/providers/f5bigip/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/f5bigip/repo/.github/workflows/main.yml
@@ -28,6 +28,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -129,6 +131,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Configure AWS Credentials
       uses: aws-actions/configure-aws-credentials@v1
       with:
@@ -182,6 +186,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -220,6 +226,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -256,6 +264,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -331,6 +341,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -387,6 +399,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -496,6 +510,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:

--- a/provider-ci/providers/f5bigip/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/f5bigip/repo/.github/workflows/master.yml
@@ -28,6 +28,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -129,6 +131,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Configure AWS Credentials
       uses: aws-actions/configure-aws-credentials@v1
       with:
@@ -182,6 +186,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -220,6 +226,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -256,6 +264,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -331,6 +341,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -387,6 +399,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -496,6 +510,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:

--- a/provider-ci/providers/f5bigip/repo/.github/workflows/nightly-test.yml
+++ b/provider-ci/providers/f5bigip/repo/.github/workflows/nightly-test.yml
@@ -28,6 +28,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -125,6 +127,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -200,6 +204,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:

--- a/provider-ci/providers/f5bigip/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/f5bigip/repo/.github/workflows/prerelease.yml
@@ -28,6 +28,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -126,6 +128,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -164,6 +168,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -200,6 +206,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -275,6 +283,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -331,6 +341,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -440,6 +452,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:

--- a/provider-ci/providers/f5bigip/repo/.github/workflows/pull-request.yml
+++ b/provider-ci/providers/f5bigip/repo/.github/workflows/pull-request.yml
@@ -28,6 +28,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Comment PR
       uses: thollander/actions-comment-pull-request@v1
       with:

--- a/provider-ci/providers/f5bigip/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/f5bigip/repo/.github/workflows/release.yml
@@ -28,6 +28,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -140,6 +142,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -178,6 +182,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -214,6 +220,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -289,6 +297,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -344,6 +354,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -453,6 +465,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Install pulumictl
       uses: jaxxstorm/action-install-gh-release@v1.5.0
       with:
@@ -467,6 +481,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:

--- a/provider-ci/providers/f5bigip/repo/.github/workflows/update-bridge.yml
+++ b/provider-ci/providers/f5bigip/repo/.github/workflows/update-bridge.yml
@@ -9,6 +9,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/provider-ci/providers/f5bigip/repo/.github/workflows/update-upstream-provider.yml
+++ b/provider-ci/providers/f5bigip/repo/.github/workflows/update-upstream-provider.yml
@@ -36,6 +36,8 @@ jobs:
         name=run-url::https://github.com/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/provider-ci/providers/fastly/repo/.github/workflows/command-dispatch.yml
+++ b/provider-ci/providers/fastly/repo/.github/workflows/command-dispatch.yml
@@ -24,6 +24,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - uses: peter-evans/slash-command-dispatch@v2
       with:
         commands: run-acceptance-tests

--- a/provider-ci/providers/fastly/repo/.github/workflows/community-moderation.yml
+++ b/provider-ci/providers/fastly/repo/.github/workflows/community-moderation.yml
@@ -7,6 +7,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - id: schema_changed
       name: Check for diff in schema
       uses: dorny/paths-filter@v2

--- a/provider-ci/providers/fastly/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/fastly/repo/.github/workflows/main.yml
@@ -25,6 +25,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -126,6 +128,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Configure AWS Credentials
       uses: aws-actions/configure-aws-credentials@v1
       with:
@@ -179,6 +183,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -217,6 +223,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -253,6 +261,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -328,6 +338,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -384,6 +396,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -493,6 +507,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:

--- a/provider-ci/providers/fastly/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/fastly/repo/.github/workflows/master.yml
@@ -25,6 +25,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -126,6 +128,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Configure AWS Credentials
       uses: aws-actions/configure-aws-credentials@v1
       with:
@@ -179,6 +183,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -217,6 +223,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -253,6 +261,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -328,6 +338,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -384,6 +396,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -493,6 +507,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:

--- a/provider-ci/providers/fastly/repo/.github/workflows/nightly-test.yml
+++ b/provider-ci/providers/fastly/repo/.github/workflows/nightly-test.yml
@@ -25,6 +25,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -122,6 +124,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -197,6 +201,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:

--- a/provider-ci/providers/fastly/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/fastly/repo/.github/workflows/prerelease.yml
@@ -25,6 +25,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -123,6 +125,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -161,6 +165,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -197,6 +203,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -272,6 +280,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -328,6 +338,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -437,6 +449,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:

--- a/provider-ci/providers/fastly/repo/.github/workflows/pull-request.yml
+++ b/provider-ci/providers/fastly/repo/.github/workflows/pull-request.yml
@@ -25,6 +25,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Comment PR
       uses: thollander/actions-comment-pull-request@v1
       with:

--- a/provider-ci/providers/fastly/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/fastly/repo/.github/workflows/release.yml
@@ -25,6 +25,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -137,6 +139,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -175,6 +179,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -211,6 +217,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -286,6 +294,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -341,6 +351,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -450,6 +462,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Install pulumictl
       uses: jaxxstorm/action-install-gh-release@v1.5.0
       with:
@@ -464,6 +478,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:

--- a/provider-ci/providers/fastly/repo/.github/workflows/update-bridge.yml
+++ b/provider-ci/providers/fastly/repo/.github/workflows/update-bridge.yml
@@ -9,6 +9,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/provider-ci/providers/fastly/repo/.github/workflows/update-upstream-provider.yml
+++ b/provider-ci/providers/fastly/repo/.github/workflows/update-upstream-provider.yml
@@ -33,6 +33,8 @@ jobs:
         name=run-url::https://github.com/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/provider-ci/providers/gcp/repo/.github/workflows/command-dispatch.yml
+++ b/provider-ci/providers/gcp/repo/.github/workflows/command-dispatch.yml
@@ -27,6 +27,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - uses: peter-evans/slash-command-dispatch@v2
       with:
         commands: run-acceptance-tests

--- a/provider-ci/providers/gcp/repo/.github/workflows/community-moderation.yml
+++ b/provider-ci/providers/gcp/repo/.github/workflows/community-moderation.yml
@@ -7,6 +7,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - id: schema_changed
       name: Check for diff in schema
       uses: dorny/paths-filter@v2

--- a/provider-ci/providers/gcp/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/gcp/repo/.github/workflows/main.yml
@@ -28,6 +28,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -129,6 +131,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Configure AWS Credentials
       uses: aws-actions/configure-aws-credentials@v1
       with:
@@ -181,6 +185,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -256,6 +262,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -312,6 +320,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -421,6 +431,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:

--- a/provider-ci/providers/gcp/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/gcp/repo/.github/workflows/master.yml
@@ -28,6 +28,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -129,6 +131,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Configure AWS Credentials
       uses: aws-actions/configure-aws-credentials@v1
       with:
@@ -181,6 +185,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -256,6 +262,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -312,6 +320,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -421,6 +431,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:

--- a/provider-ci/providers/gcp/repo/.github/workflows/nightly-test.yml
+++ b/provider-ci/providers/gcp/repo/.github/workflows/nightly-test.yml
@@ -28,6 +28,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -125,6 +127,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -200,6 +204,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:

--- a/provider-ci/providers/gcp/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/gcp/repo/.github/workflows/prerelease.yml
@@ -28,6 +28,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -125,6 +127,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -200,6 +204,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -256,6 +262,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -365,6 +373,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:

--- a/provider-ci/providers/gcp/repo/.github/workflows/pull-request.yml
+++ b/provider-ci/providers/gcp/repo/.github/workflows/pull-request.yml
@@ -28,6 +28,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Comment PR
       uses: thollander/actions-comment-pull-request@v1
       with:

--- a/provider-ci/providers/gcp/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/gcp/repo/.github/workflows/release.yml
@@ -28,6 +28,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -139,6 +141,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -214,6 +218,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -269,6 +275,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -378,6 +386,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Install pulumictl
       uses: jaxxstorm/action-install-gh-release@v1.5.0
       with:
@@ -392,6 +402,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:

--- a/provider-ci/providers/gcp/repo/.github/workflows/update-bridge.yml
+++ b/provider-ci/providers/gcp/repo/.github/workflows/update-bridge.yml
@@ -9,6 +9,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/provider-ci/providers/gcp/repo/.github/workflows/update-upstream-provider.yml
+++ b/provider-ci/providers/gcp/repo/.github/workflows/update-upstream-provider.yml
@@ -36,6 +36,8 @@ jobs:
         name=run-url::https://github.com/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/provider-ci/providers/github/repo/.github/workflows/command-dispatch.yml
+++ b/provider-ci/providers/github/repo/.github/workflows/command-dispatch.yml
@@ -25,6 +25,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - uses: peter-evans/slash-command-dispatch@v2
       with:
         commands: run-acceptance-tests

--- a/provider-ci/providers/github/repo/.github/workflows/community-moderation.yml
+++ b/provider-ci/providers/github/repo/.github/workflows/community-moderation.yml
@@ -7,6 +7,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - id: schema_changed
       name: Check for diff in schema
       uses: dorny/paths-filter@v2

--- a/provider-ci/providers/github/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/github/repo/.github/workflows/main.yml
@@ -26,6 +26,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -127,6 +129,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Configure AWS Credentials
       uses: aws-actions/configure-aws-credentials@v1
       with:
@@ -180,6 +184,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -218,6 +224,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -254,6 +262,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -329,6 +339,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -385,6 +397,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -494,6 +508,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:

--- a/provider-ci/providers/github/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/github/repo/.github/workflows/master.yml
@@ -26,6 +26,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -127,6 +129,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Configure AWS Credentials
       uses: aws-actions/configure-aws-credentials@v1
       with:
@@ -180,6 +184,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -218,6 +224,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -254,6 +262,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -329,6 +339,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -385,6 +397,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -494,6 +508,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:

--- a/provider-ci/providers/github/repo/.github/workflows/nightly-test.yml
+++ b/provider-ci/providers/github/repo/.github/workflows/nightly-test.yml
@@ -26,6 +26,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -123,6 +125,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -198,6 +202,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:

--- a/provider-ci/providers/github/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/github/repo/.github/workflows/prerelease.yml
@@ -26,6 +26,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -124,6 +126,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -162,6 +166,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -198,6 +204,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -273,6 +281,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -329,6 +339,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -438,6 +450,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:

--- a/provider-ci/providers/github/repo/.github/workflows/pull-request.yml
+++ b/provider-ci/providers/github/repo/.github/workflows/pull-request.yml
@@ -26,6 +26,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Comment PR
       uses: thollander/actions-comment-pull-request@v1
       with:

--- a/provider-ci/providers/github/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/github/repo/.github/workflows/release.yml
@@ -26,6 +26,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -138,6 +140,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -176,6 +180,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -212,6 +218,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -287,6 +295,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -342,6 +352,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -451,6 +463,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Install pulumictl
       uses: jaxxstorm/action-install-gh-release@v1.5.0
       with:
@@ -465,6 +479,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:

--- a/provider-ci/providers/github/repo/.github/workflows/update-bridge.yml
+++ b/provider-ci/providers/github/repo/.github/workflows/update-bridge.yml
@@ -9,6 +9,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/provider-ci/providers/github/repo/.github/workflows/update-upstream-provider.yml
+++ b/provider-ci/providers/github/repo/.github/workflows/update-upstream-provider.yml
@@ -34,6 +34,8 @@ jobs:
         name=run-url::https://github.com/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/provider-ci/providers/gitlab/repo/.github/workflows/command-dispatch.yml
+++ b/provider-ci/providers/gitlab/repo/.github/workflows/command-dispatch.yml
@@ -24,6 +24,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - uses: peter-evans/slash-command-dispatch@v2
       with:
         commands: run-acceptance-tests

--- a/provider-ci/providers/gitlab/repo/.github/workflows/community-moderation.yml
+++ b/provider-ci/providers/gitlab/repo/.github/workflows/community-moderation.yml
@@ -7,6 +7,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - id: schema_changed
       name: Check for diff in schema
       uses: dorny/paths-filter@v2

--- a/provider-ci/providers/gitlab/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/gitlab/repo/.github/workflows/main.yml
@@ -25,6 +25,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -126,6 +128,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Configure AWS Credentials
       uses: aws-actions/configure-aws-credentials@v1
       with:
@@ -179,6 +183,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -217,6 +223,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -253,6 +261,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -328,6 +338,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -384,6 +396,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -493,6 +507,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:

--- a/provider-ci/providers/gitlab/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/gitlab/repo/.github/workflows/master.yml
@@ -25,6 +25,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -126,6 +128,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Configure AWS Credentials
       uses: aws-actions/configure-aws-credentials@v1
       with:
@@ -179,6 +183,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -217,6 +223,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -253,6 +261,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -328,6 +338,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -384,6 +396,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -493,6 +507,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:

--- a/provider-ci/providers/gitlab/repo/.github/workflows/nightly-test.yml
+++ b/provider-ci/providers/gitlab/repo/.github/workflows/nightly-test.yml
@@ -25,6 +25,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -122,6 +124,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -197,6 +201,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:

--- a/provider-ci/providers/gitlab/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/gitlab/repo/.github/workflows/prerelease.yml
@@ -25,6 +25,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -123,6 +125,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -161,6 +165,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -197,6 +203,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -272,6 +280,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -328,6 +338,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -437,6 +449,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:

--- a/provider-ci/providers/gitlab/repo/.github/workflows/pull-request.yml
+++ b/provider-ci/providers/gitlab/repo/.github/workflows/pull-request.yml
@@ -25,6 +25,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Comment PR
       uses: thollander/actions-comment-pull-request@v1
       with:

--- a/provider-ci/providers/gitlab/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/gitlab/repo/.github/workflows/release.yml
@@ -25,6 +25,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -137,6 +139,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -175,6 +179,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -211,6 +217,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -286,6 +294,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -341,6 +351,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -450,6 +462,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Install pulumictl
       uses: jaxxstorm/action-install-gh-release@v1.5.0
       with:
@@ -464,6 +478,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:

--- a/provider-ci/providers/gitlab/repo/.github/workflows/update-bridge.yml
+++ b/provider-ci/providers/gitlab/repo/.github/workflows/update-bridge.yml
@@ -9,6 +9,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/provider-ci/providers/gitlab/repo/.github/workflows/update-upstream-provider.yml
+++ b/provider-ci/providers/gitlab/repo/.github/workflows/update-upstream-provider.yml
@@ -33,6 +33,8 @@ jobs:
         name=run-url::https://github.com/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/provider-ci/providers/hcloud/repo/.github/workflows/command-dispatch.yml
+++ b/provider-ci/providers/hcloud/repo/.github/workflows/command-dispatch.yml
@@ -24,6 +24,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - uses: peter-evans/slash-command-dispatch@v2
       with:
         commands: run-acceptance-tests

--- a/provider-ci/providers/hcloud/repo/.github/workflows/community-moderation.yml
+++ b/provider-ci/providers/hcloud/repo/.github/workflows/community-moderation.yml
@@ -7,6 +7,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - id: schema_changed
       name: Check for diff in schema
       uses: dorny/paths-filter@v2

--- a/provider-ci/providers/hcloud/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/hcloud/repo/.github/workflows/main.yml
@@ -25,6 +25,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -126,6 +128,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Configure AWS Credentials
       uses: aws-actions/configure-aws-credentials@v1
       with:
@@ -179,6 +183,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -217,6 +223,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -253,6 +261,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -328,6 +338,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -384,6 +396,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -493,6 +507,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:

--- a/provider-ci/providers/hcloud/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/hcloud/repo/.github/workflows/master.yml
@@ -25,6 +25,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -126,6 +128,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Configure AWS Credentials
       uses: aws-actions/configure-aws-credentials@v1
       with:
@@ -179,6 +183,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -217,6 +223,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -253,6 +261,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -328,6 +338,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -384,6 +396,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -493,6 +507,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:

--- a/provider-ci/providers/hcloud/repo/.github/workflows/nightly-test.yml
+++ b/provider-ci/providers/hcloud/repo/.github/workflows/nightly-test.yml
@@ -25,6 +25,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -122,6 +124,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -197,6 +201,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:

--- a/provider-ci/providers/hcloud/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/hcloud/repo/.github/workflows/prerelease.yml
@@ -25,6 +25,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -123,6 +125,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -161,6 +165,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -197,6 +203,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -272,6 +280,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -328,6 +338,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -437,6 +449,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:

--- a/provider-ci/providers/hcloud/repo/.github/workflows/pull-request.yml
+++ b/provider-ci/providers/hcloud/repo/.github/workflows/pull-request.yml
@@ -25,6 +25,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Comment PR
       uses: thollander/actions-comment-pull-request@v1
       with:

--- a/provider-ci/providers/hcloud/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/hcloud/repo/.github/workflows/release.yml
@@ -25,6 +25,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -137,6 +139,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -175,6 +179,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -211,6 +217,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -286,6 +294,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -341,6 +351,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -450,6 +462,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Install pulumictl
       uses: jaxxstorm/action-install-gh-release@v1.5.0
       with:
@@ -464,6 +478,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:

--- a/provider-ci/providers/hcloud/repo/.github/workflows/update-bridge.yml
+++ b/provider-ci/providers/hcloud/repo/.github/workflows/update-bridge.yml
@@ -9,6 +9,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/provider-ci/providers/hcloud/repo/.github/workflows/update-upstream-provider.yml
+++ b/provider-ci/providers/hcloud/repo/.github/workflows/update-upstream-provider.yml
@@ -33,6 +33,8 @@ jobs:
         name=run-url::https://github.com/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/provider-ci/providers/kafka/repo/.github/workflows/command-dispatch.yml
+++ b/provider-ci/providers/kafka/repo/.github/workflows/command-dispatch.yml
@@ -23,6 +23,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - uses: peter-evans/slash-command-dispatch@v2
       with:
         commands: run-acceptance-tests

--- a/provider-ci/providers/kafka/repo/.github/workflows/community-moderation.yml
+++ b/provider-ci/providers/kafka/repo/.github/workflows/community-moderation.yml
@@ -7,6 +7,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - id: schema_changed
       name: Check for diff in schema
       uses: dorny/paths-filter@v2

--- a/provider-ci/providers/kafka/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/kafka/repo/.github/workflows/main.yml
@@ -24,6 +24,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -125,6 +127,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Configure AWS Credentials
       uses: aws-actions/configure-aws-credentials@v1
       with:
@@ -178,6 +182,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -216,6 +222,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -252,6 +260,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -327,6 +337,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -383,6 +395,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -492,6 +506,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:

--- a/provider-ci/providers/kafka/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/kafka/repo/.github/workflows/master.yml
@@ -24,6 +24,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -125,6 +127,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Configure AWS Credentials
       uses: aws-actions/configure-aws-credentials@v1
       with:
@@ -178,6 +182,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -216,6 +222,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -252,6 +260,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -327,6 +337,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -383,6 +395,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -492,6 +506,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:

--- a/provider-ci/providers/kafka/repo/.github/workflows/nightly-test.yml
+++ b/provider-ci/providers/kafka/repo/.github/workflows/nightly-test.yml
@@ -24,6 +24,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -121,6 +123,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -196,6 +200,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:

--- a/provider-ci/providers/kafka/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/kafka/repo/.github/workflows/prerelease.yml
@@ -24,6 +24,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -122,6 +124,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -160,6 +164,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -196,6 +202,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -271,6 +279,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -327,6 +337,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -436,6 +448,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:

--- a/provider-ci/providers/kafka/repo/.github/workflows/pull-request.yml
+++ b/provider-ci/providers/kafka/repo/.github/workflows/pull-request.yml
@@ -24,6 +24,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Comment PR
       uses: thollander/actions-comment-pull-request@v1
       with:

--- a/provider-ci/providers/kafka/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/kafka/repo/.github/workflows/release.yml
@@ -24,6 +24,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -136,6 +138,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -174,6 +178,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -210,6 +216,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -285,6 +293,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -340,6 +350,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -449,6 +461,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Install pulumictl
       uses: jaxxstorm/action-install-gh-release@v1.5.0
       with:
@@ -463,6 +477,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:

--- a/provider-ci/providers/kafka/repo/.github/workflows/update-bridge.yml
+++ b/provider-ci/providers/kafka/repo/.github/workflows/update-bridge.yml
@@ -9,6 +9,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/provider-ci/providers/kafka/repo/.github/workflows/update-upstream-provider.yml
+++ b/provider-ci/providers/kafka/repo/.github/workflows/update-upstream-provider.yml
@@ -32,6 +32,8 @@ jobs:
         name=run-url::https://github.com/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/provider-ci/providers/keycloak/repo/.github/workflows/command-dispatch.yml
+++ b/provider-ci/providers/keycloak/repo/.github/workflows/command-dispatch.yml
@@ -28,6 +28,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - uses: peter-evans/slash-command-dispatch@v2
       with:
         commands: run-acceptance-tests

--- a/provider-ci/providers/keycloak/repo/.github/workflows/community-moderation.yml
+++ b/provider-ci/providers/keycloak/repo/.github/workflows/community-moderation.yml
@@ -7,6 +7,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - id: schema_changed
       name: Check for diff in schema
       uses: dorny/paths-filter@v2

--- a/provider-ci/providers/keycloak/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/keycloak/repo/.github/workflows/main.yml
@@ -29,6 +29,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -130,6 +132,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Configure AWS Credentials
       uses: aws-actions/configure-aws-credentials@v1
       with:
@@ -183,6 +187,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -221,6 +227,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -257,6 +265,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -332,6 +342,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -388,6 +400,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -497,6 +511,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:

--- a/provider-ci/providers/keycloak/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/keycloak/repo/.github/workflows/master.yml
@@ -29,6 +29,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -130,6 +132,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Configure AWS Credentials
       uses: aws-actions/configure-aws-credentials@v1
       with:
@@ -183,6 +187,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -221,6 +227,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -257,6 +265,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -332,6 +342,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -388,6 +400,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -497,6 +511,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:

--- a/provider-ci/providers/keycloak/repo/.github/workflows/nightly-test.yml
+++ b/provider-ci/providers/keycloak/repo/.github/workflows/nightly-test.yml
@@ -29,6 +29,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -126,6 +128,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -201,6 +205,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:

--- a/provider-ci/providers/keycloak/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/keycloak/repo/.github/workflows/prerelease.yml
@@ -29,6 +29,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -127,6 +129,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -165,6 +169,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -201,6 +207,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -276,6 +284,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -332,6 +342,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -441,6 +453,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:

--- a/provider-ci/providers/keycloak/repo/.github/workflows/pull-request.yml
+++ b/provider-ci/providers/keycloak/repo/.github/workflows/pull-request.yml
@@ -29,6 +29,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Comment PR
       uses: thollander/actions-comment-pull-request@v1
       with:

--- a/provider-ci/providers/keycloak/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/keycloak/repo/.github/workflows/release.yml
@@ -29,6 +29,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -141,6 +143,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -179,6 +183,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -215,6 +221,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -290,6 +298,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -345,6 +355,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -454,6 +466,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Install pulumictl
       uses: jaxxstorm/action-install-gh-release@v1.5.0
       with:
@@ -468,6 +482,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:

--- a/provider-ci/providers/keycloak/repo/.github/workflows/update-bridge.yml
+++ b/provider-ci/providers/keycloak/repo/.github/workflows/update-bridge.yml
@@ -9,6 +9,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/provider-ci/providers/keycloak/repo/.github/workflows/update-upstream-provider.yml
+++ b/provider-ci/providers/keycloak/repo/.github/workflows/update-upstream-provider.yml
@@ -37,6 +37,8 @@ jobs:
         name=run-url::https://github.com/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/provider-ci/providers/kong/repo/.github/workflows/command-dispatch.yml
+++ b/provider-ci/providers/kong/repo/.github/workflows/command-dispatch.yml
@@ -23,6 +23,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - uses: peter-evans/slash-command-dispatch@v2
       with:
         commands: run-acceptance-tests

--- a/provider-ci/providers/kong/repo/.github/workflows/community-moderation.yml
+++ b/provider-ci/providers/kong/repo/.github/workflows/community-moderation.yml
@@ -7,6 +7,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - id: schema_changed
       name: Check for diff in schema
       uses: dorny/paths-filter@v2

--- a/provider-ci/providers/kong/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/kong/repo/.github/workflows/main.yml
@@ -24,6 +24,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -125,6 +127,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Configure AWS Credentials
       uses: aws-actions/configure-aws-credentials@v1
       with:
@@ -178,6 +182,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -216,6 +222,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -252,6 +260,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -327,6 +337,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -383,6 +395,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -492,6 +506,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:

--- a/provider-ci/providers/kong/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/kong/repo/.github/workflows/master.yml
@@ -24,6 +24,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -125,6 +127,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Configure AWS Credentials
       uses: aws-actions/configure-aws-credentials@v1
       with:
@@ -178,6 +182,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -216,6 +222,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -252,6 +260,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -327,6 +337,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -383,6 +395,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -492,6 +506,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:

--- a/provider-ci/providers/kong/repo/.github/workflows/nightly-test.yml
+++ b/provider-ci/providers/kong/repo/.github/workflows/nightly-test.yml
@@ -24,6 +24,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -121,6 +123,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -196,6 +200,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:

--- a/provider-ci/providers/kong/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/kong/repo/.github/workflows/prerelease.yml
@@ -24,6 +24,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -122,6 +124,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -160,6 +164,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -196,6 +202,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -271,6 +279,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -327,6 +337,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -436,6 +448,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:

--- a/provider-ci/providers/kong/repo/.github/workflows/pull-request.yml
+++ b/provider-ci/providers/kong/repo/.github/workflows/pull-request.yml
@@ -24,6 +24,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Comment PR
       uses: thollander/actions-comment-pull-request@v1
       with:

--- a/provider-ci/providers/kong/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/kong/repo/.github/workflows/release.yml
@@ -24,6 +24,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -136,6 +138,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -174,6 +178,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -210,6 +216,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -285,6 +293,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -340,6 +350,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -449,6 +461,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Install pulumictl
       uses: jaxxstorm/action-install-gh-release@v1.5.0
       with:
@@ -463,6 +477,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:

--- a/provider-ci/providers/kong/repo/.github/workflows/update-bridge.yml
+++ b/provider-ci/providers/kong/repo/.github/workflows/update-bridge.yml
@@ -9,6 +9,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/provider-ci/providers/kong/repo/.github/workflows/update-upstream-provider.yml
+++ b/provider-ci/providers/kong/repo/.github/workflows/update-upstream-provider.yml
@@ -32,6 +32,8 @@ jobs:
         name=run-url::https://github.com/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/provider-ci/providers/libvirt/repo/.github/workflows/command-dispatch.yml
+++ b/provider-ci/providers/libvirt/repo/.github/workflows/command-dispatch.yml
@@ -24,6 +24,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - uses: peter-evans/slash-command-dispatch@v2
       with:
         commands: run-acceptance-tests

--- a/provider-ci/providers/libvirt/repo/.github/workflows/community-moderation.yml
+++ b/provider-ci/providers/libvirt/repo/.github/workflows/community-moderation.yml
@@ -7,6 +7,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - id: schema_changed
       name: Check for diff in schema
       uses: dorny/paths-filter@v2

--- a/provider-ci/providers/libvirt/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/libvirt/repo/.github/workflows/main.yml
@@ -25,6 +25,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -126,6 +128,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Configure AWS Credentials
       uses: aws-actions/configure-aws-credentials@v1
       with:
@@ -179,6 +183,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -217,6 +223,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -253,6 +261,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -328,6 +338,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -384,6 +396,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -493,6 +507,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:

--- a/provider-ci/providers/libvirt/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/libvirt/repo/.github/workflows/master.yml
@@ -25,6 +25,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -126,6 +128,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Configure AWS Credentials
       uses: aws-actions/configure-aws-credentials@v1
       with:
@@ -179,6 +183,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -217,6 +223,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -253,6 +261,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -328,6 +338,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -384,6 +396,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -493,6 +507,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:

--- a/provider-ci/providers/libvirt/repo/.github/workflows/nightly-test.yml
+++ b/provider-ci/providers/libvirt/repo/.github/workflows/nightly-test.yml
@@ -25,6 +25,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -122,6 +124,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -197,6 +201,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:

--- a/provider-ci/providers/libvirt/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/libvirt/repo/.github/workflows/prerelease.yml
@@ -25,6 +25,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -123,6 +125,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -161,6 +165,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -197,6 +203,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -272,6 +280,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -328,6 +338,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -437,6 +449,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:

--- a/provider-ci/providers/libvirt/repo/.github/workflows/pull-request.yml
+++ b/provider-ci/providers/libvirt/repo/.github/workflows/pull-request.yml
@@ -25,6 +25,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Comment PR
       uses: thollander/actions-comment-pull-request@v1
       with:

--- a/provider-ci/providers/libvirt/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/libvirt/repo/.github/workflows/release.yml
@@ -25,6 +25,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -137,6 +139,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -175,6 +179,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -211,6 +217,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -286,6 +294,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -341,6 +351,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -450,6 +462,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Install pulumictl
       uses: jaxxstorm/action-install-gh-release@v1.5.0
       with:
@@ -464,6 +478,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:

--- a/provider-ci/providers/libvirt/repo/.github/workflows/update-bridge.yml
+++ b/provider-ci/providers/libvirt/repo/.github/workflows/update-bridge.yml
@@ -9,6 +9,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/provider-ci/providers/libvirt/repo/.github/workflows/update-upstream-provider.yml
+++ b/provider-ci/providers/libvirt/repo/.github/workflows/update-upstream-provider.yml
@@ -33,6 +33,8 @@ jobs:
         name=run-url::https://github.com/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/provider-ci/providers/linode/repo/.github/workflows/command-dispatch.yml
+++ b/provider-ci/providers/linode/repo/.github/workflows/command-dispatch.yml
@@ -24,6 +24,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - uses: peter-evans/slash-command-dispatch@v2
       with:
         commands: run-acceptance-tests

--- a/provider-ci/providers/linode/repo/.github/workflows/community-moderation.yml
+++ b/provider-ci/providers/linode/repo/.github/workflows/community-moderation.yml
@@ -7,6 +7,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - id: schema_changed
       name: Check for diff in schema
       uses: dorny/paths-filter@v2

--- a/provider-ci/providers/linode/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/linode/repo/.github/workflows/main.yml
@@ -25,6 +25,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -126,6 +128,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Configure AWS Credentials
       uses: aws-actions/configure-aws-credentials@v1
       with:
@@ -179,6 +183,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -217,6 +223,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -253,6 +261,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -328,6 +338,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -384,6 +396,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -493,6 +507,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:

--- a/provider-ci/providers/linode/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/linode/repo/.github/workflows/master.yml
@@ -25,6 +25,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -126,6 +128,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Configure AWS Credentials
       uses: aws-actions/configure-aws-credentials@v1
       with:
@@ -179,6 +183,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -217,6 +223,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -253,6 +261,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -328,6 +338,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -384,6 +396,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -493,6 +507,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:

--- a/provider-ci/providers/linode/repo/.github/workflows/nightly-test.yml
+++ b/provider-ci/providers/linode/repo/.github/workflows/nightly-test.yml
@@ -25,6 +25,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -122,6 +124,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -197,6 +201,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:

--- a/provider-ci/providers/linode/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/linode/repo/.github/workflows/prerelease.yml
@@ -25,6 +25,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -123,6 +125,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -161,6 +165,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -197,6 +203,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -272,6 +280,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -328,6 +338,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -437,6 +449,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:

--- a/provider-ci/providers/linode/repo/.github/workflows/pull-request.yml
+++ b/provider-ci/providers/linode/repo/.github/workflows/pull-request.yml
@@ -25,6 +25,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Comment PR
       uses: thollander/actions-comment-pull-request@v1
       with:

--- a/provider-ci/providers/linode/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/linode/repo/.github/workflows/release.yml
@@ -25,6 +25,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -137,6 +139,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -175,6 +179,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -211,6 +217,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -286,6 +294,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -341,6 +351,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -450,6 +462,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Install pulumictl
       uses: jaxxstorm/action-install-gh-release@v1.5.0
       with:
@@ -464,6 +478,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:

--- a/provider-ci/providers/linode/repo/.github/workflows/update-bridge.yml
+++ b/provider-ci/providers/linode/repo/.github/workflows/update-bridge.yml
@@ -9,6 +9,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/provider-ci/providers/linode/repo/.github/workflows/update-upstream-provider.yml
+++ b/provider-ci/providers/linode/repo/.github/workflows/update-upstream-provider.yml
@@ -33,6 +33,8 @@ jobs:
         name=run-url::https://github.com/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/provider-ci/providers/mailgun/repo/.github/workflows/command-dispatch.yml
+++ b/provider-ci/providers/mailgun/repo/.github/workflows/command-dispatch.yml
@@ -24,6 +24,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - uses: peter-evans/slash-command-dispatch@v2
       with:
         commands: run-acceptance-tests

--- a/provider-ci/providers/mailgun/repo/.github/workflows/community-moderation.yml
+++ b/provider-ci/providers/mailgun/repo/.github/workflows/community-moderation.yml
@@ -7,6 +7,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - id: schema_changed
       name: Check for diff in schema
       uses: dorny/paths-filter@v2

--- a/provider-ci/providers/mailgun/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/mailgun/repo/.github/workflows/main.yml
@@ -25,6 +25,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -126,6 +128,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Configure AWS Credentials
       uses: aws-actions/configure-aws-credentials@v1
       with:
@@ -179,6 +183,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -217,6 +223,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -253,6 +261,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -328,6 +338,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -384,6 +396,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -493,6 +507,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:

--- a/provider-ci/providers/mailgun/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/mailgun/repo/.github/workflows/master.yml
@@ -25,6 +25,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -126,6 +128,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Configure AWS Credentials
       uses: aws-actions/configure-aws-credentials@v1
       with:
@@ -179,6 +183,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -217,6 +223,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -253,6 +261,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -328,6 +338,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -384,6 +396,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -493,6 +507,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:

--- a/provider-ci/providers/mailgun/repo/.github/workflows/nightly-test.yml
+++ b/provider-ci/providers/mailgun/repo/.github/workflows/nightly-test.yml
@@ -25,6 +25,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -122,6 +124,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -197,6 +201,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:

--- a/provider-ci/providers/mailgun/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/mailgun/repo/.github/workflows/prerelease.yml
@@ -25,6 +25,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -123,6 +125,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -161,6 +165,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -197,6 +203,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -272,6 +280,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -328,6 +338,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -437,6 +449,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:

--- a/provider-ci/providers/mailgun/repo/.github/workflows/pull-request.yml
+++ b/provider-ci/providers/mailgun/repo/.github/workflows/pull-request.yml
@@ -25,6 +25,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Comment PR
       uses: thollander/actions-comment-pull-request@v1
       with:

--- a/provider-ci/providers/mailgun/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/mailgun/repo/.github/workflows/release.yml
@@ -25,6 +25,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -137,6 +139,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -175,6 +179,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -211,6 +217,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -286,6 +294,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -341,6 +351,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -450,6 +462,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Install pulumictl
       uses: jaxxstorm/action-install-gh-release@v1.5.0
       with:
@@ -464,6 +478,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:

--- a/provider-ci/providers/mailgun/repo/.github/workflows/update-bridge.yml
+++ b/provider-ci/providers/mailgun/repo/.github/workflows/update-bridge.yml
@@ -9,6 +9,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/provider-ci/providers/mailgun/repo/.github/workflows/update-upstream-provider.yml
+++ b/provider-ci/providers/mailgun/repo/.github/workflows/update-upstream-provider.yml
@@ -33,6 +33,8 @@ jobs:
         name=run-url::https://github.com/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/provider-ci/providers/minio/repo/.github/workflows/command-dispatch.yml
+++ b/provider-ci/providers/minio/repo/.github/workflows/command-dispatch.yml
@@ -27,6 +27,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - uses: peter-evans/slash-command-dispatch@v2
       with:
         commands: run-acceptance-tests

--- a/provider-ci/providers/minio/repo/.github/workflows/community-moderation.yml
+++ b/provider-ci/providers/minio/repo/.github/workflows/community-moderation.yml
@@ -7,6 +7,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - id: schema_changed
       name: Check for diff in schema
       uses: dorny/paths-filter@v2

--- a/provider-ci/providers/minio/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/minio/repo/.github/workflows/main.yml
@@ -28,6 +28,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -129,6 +131,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Configure AWS Credentials
       uses: aws-actions/configure-aws-credentials@v1
       with:
@@ -182,6 +186,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -220,6 +226,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -256,6 +264,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -331,6 +341,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -387,6 +399,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -496,6 +510,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:

--- a/provider-ci/providers/minio/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/minio/repo/.github/workflows/master.yml
@@ -28,6 +28,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -129,6 +131,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Configure AWS Credentials
       uses: aws-actions/configure-aws-credentials@v1
       with:
@@ -182,6 +186,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -220,6 +226,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -256,6 +264,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -331,6 +341,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -387,6 +399,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -496,6 +510,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:

--- a/provider-ci/providers/minio/repo/.github/workflows/nightly-test.yml
+++ b/provider-ci/providers/minio/repo/.github/workflows/nightly-test.yml
@@ -28,6 +28,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -125,6 +127,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -200,6 +204,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:

--- a/provider-ci/providers/minio/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/minio/repo/.github/workflows/prerelease.yml
@@ -28,6 +28,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -126,6 +128,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -164,6 +168,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -200,6 +206,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -275,6 +283,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -331,6 +341,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -440,6 +452,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:

--- a/provider-ci/providers/minio/repo/.github/workflows/pull-request.yml
+++ b/provider-ci/providers/minio/repo/.github/workflows/pull-request.yml
@@ -28,6 +28,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Comment PR
       uses: thollander/actions-comment-pull-request@v1
       with:

--- a/provider-ci/providers/minio/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/minio/repo/.github/workflows/release.yml
@@ -28,6 +28,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -140,6 +142,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -178,6 +182,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -214,6 +220,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -289,6 +297,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -344,6 +354,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -453,6 +465,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Install pulumictl
       uses: jaxxstorm/action-install-gh-release@v1.5.0
       with:
@@ -467,6 +481,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:

--- a/provider-ci/providers/minio/repo/.github/workflows/update-bridge.yml
+++ b/provider-ci/providers/minio/repo/.github/workflows/update-bridge.yml
@@ -9,6 +9,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/provider-ci/providers/minio/repo/.github/workflows/update-upstream-provider.yml
+++ b/provider-ci/providers/minio/repo/.github/workflows/update-upstream-provider.yml
@@ -36,6 +36,8 @@ jobs:
         name=run-url::https://github.com/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/provider-ci/providers/mongodbatlas/repo/.github/workflows/command-dispatch.yml
+++ b/provider-ci/providers/mongodbatlas/repo/.github/workflows/command-dispatch.yml
@@ -26,6 +26,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - uses: peter-evans/slash-command-dispatch@v2
       with:
         commands: run-acceptance-tests

--- a/provider-ci/providers/mongodbatlas/repo/.github/workflows/community-moderation.yml
+++ b/provider-ci/providers/mongodbatlas/repo/.github/workflows/community-moderation.yml
@@ -7,6 +7,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - id: schema_changed
       name: Check for diff in schema
       uses: dorny/paths-filter@v2

--- a/provider-ci/providers/mongodbatlas/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/mongodbatlas/repo/.github/workflows/main.yml
@@ -27,6 +27,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -128,6 +130,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Configure AWS Credentials
       uses: aws-actions/configure-aws-credentials@v1
       with:
@@ -181,6 +185,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -219,6 +225,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -255,6 +263,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -330,6 +340,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -386,6 +398,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -495,6 +509,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:

--- a/provider-ci/providers/mongodbatlas/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/mongodbatlas/repo/.github/workflows/master.yml
@@ -27,6 +27,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -128,6 +130,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Configure AWS Credentials
       uses: aws-actions/configure-aws-credentials@v1
       with:
@@ -181,6 +185,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -219,6 +225,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -255,6 +263,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -330,6 +340,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -386,6 +398,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -495,6 +509,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:

--- a/provider-ci/providers/mongodbatlas/repo/.github/workflows/nightly-test.yml
+++ b/provider-ci/providers/mongodbatlas/repo/.github/workflows/nightly-test.yml
@@ -27,6 +27,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -124,6 +126,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -199,6 +203,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:

--- a/provider-ci/providers/mongodbatlas/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/mongodbatlas/repo/.github/workflows/prerelease.yml
@@ -27,6 +27,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -125,6 +127,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -163,6 +167,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -199,6 +205,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -274,6 +282,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -330,6 +340,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -439,6 +451,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:

--- a/provider-ci/providers/mongodbatlas/repo/.github/workflows/pull-request.yml
+++ b/provider-ci/providers/mongodbatlas/repo/.github/workflows/pull-request.yml
@@ -27,6 +27,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Comment PR
       uses: thollander/actions-comment-pull-request@v1
       with:

--- a/provider-ci/providers/mongodbatlas/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/mongodbatlas/repo/.github/workflows/release.yml
@@ -27,6 +27,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -139,6 +141,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -177,6 +181,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -213,6 +219,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -288,6 +296,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -343,6 +353,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -452,6 +464,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Install pulumictl
       uses: jaxxstorm/action-install-gh-release@v1.5.0
       with:
@@ -466,6 +480,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:

--- a/provider-ci/providers/mongodbatlas/repo/.github/workflows/update-bridge.yml
+++ b/provider-ci/providers/mongodbatlas/repo/.github/workflows/update-bridge.yml
@@ -9,6 +9,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/provider-ci/providers/mongodbatlas/repo/.github/workflows/update-upstream-provider.yml
+++ b/provider-ci/providers/mongodbatlas/repo/.github/workflows/update-upstream-provider.yml
@@ -35,6 +35,8 @@ jobs:
         name=run-url::https://github.com/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/provider-ci/providers/mysql/repo/.github/workflows/command-dispatch.yml
+++ b/provider-ci/providers/mysql/repo/.github/workflows/command-dispatch.yml
@@ -23,6 +23,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - uses: peter-evans/slash-command-dispatch@v2
       with:
         commands: run-acceptance-tests

--- a/provider-ci/providers/mysql/repo/.github/workflows/community-moderation.yml
+++ b/provider-ci/providers/mysql/repo/.github/workflows/community-moderation.yml
@@ -7,6 +7,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - id: schema_changed
       name: Check for diff in schema
       uses: dorny/paths-filter@v2

--- a/provider-ci/providers/mysql/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/mysql/repo/.github/workflows/main.yml
@@ -24,6 +24,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -125,6 +127,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Configure AWS Credentials
       uses: aws-actions/configure-aws-credentials@v1
       with:
@@ -178,6 +182,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -216,6 +222,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -252,6 +260,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -327,6 +337,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -383,6 +395,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -492,6 +506,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:

--- a/provider-ci/providers/mysql/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/mysql/repo/.github/workflows/master.yml
@@ -24,6 +24,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -125,6 +127,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Configure AWS Credentials
       uses: aws-actions/configure-aws-credentials@v1
       with:
@@ -178,6 +182,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -216,6 +222,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -252,6 +260,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -327,6 +337,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -383,6 +395,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -492,6 +506,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:

--- a/provider-ci/providers/mysql/repo/.github/workflows/nightly-test.yml
+++ b/provider-ci/providers/mysql/repo/.github/workflows/nightly-test.yml
@@ -24,6 +24,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -121,6 +123,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -196,6 +200,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:

--- a/provider-ci/providers/mysql/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/mysql/repo/.github/workflows/prerelease.yml
@@ -24,6 +24,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -122,6 +124,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -160,6 +164,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -196,6 +202,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -271,6 +279,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -327,6 +337,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -436,6 +448,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:

--- a/provider-ci/providers/mysql/repo/.github/workflows/pull-request.yml
+++ b/provider-ci/providers/mysql/repo/.github/workflows/pull-request.yml
@@ -24,6 +24,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Comment PR
       uses: thollander/actions-comment-pull-request@v1
       with:

--- a/provider-ci/providers/mysql/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/mysql/repo/.github/workflows/release.yml
@@ -24,6 +24,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -136,6 +138,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -174,6 +178,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -210,6 +216,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -285,6 +293,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -340,6 +350,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -449,6 +461,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Install pulumictl
       uses: jaxxstorm/action-install-gh-release@v1.5.0
       with:
@@ -463,6 +477,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:

--- a/provider-ci/providers/mysql/repo/.github/workflows/update-bridge.yml
+++ b/provider-ci/providers/mysql/repo/.github/workflows/update-bridge.yml
@@ -9,6 +9,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/provider-ci/providers/mysql/repo/.github/workflows/update-upstream-provider.yml
+++ b/provider-ci/providers/mysql/repo/.github/workflows/update-upstream-provider.yml
@@ -32,6 +32,8 @@ jobs:
         name=run-url::https://github.com/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/provider-ci/providers/newrelic/repo/.github/workflows/command-dispatch.yml
+++ b/provider-ci/providers/newrelic/repo/.github/workflows/command-dispatch.yml
@@ -25,6 +25,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - uses: peter-evans/slash-command-dispatch@v2
       with:
         commands: run-acceptance-tests

--- a/provider-ci/providers/newrelic/repo/.github/workflows/community-moderation.yml
+++ b/provider-ci/providers/newrelic/repo/.github/workflows/community-moderation.yml
@@ -7,6 +7,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - id: schema_changed
       name: Check for diff in schema
       uses: dorny/paths-filter@v2

--- a/provider-ci/providers/newrelic/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/newrelic/repo/.github/workflows/main.yml
@@ -26,6 +26,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -127,6 +129,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Configure AWS Credentials
       uses: aws-actions/configure-aws-credentials@v1
       with:
@@ -180,6 +184,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -218,6 +224,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -254,6 +262,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -329,6 +339,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -385,6 +397,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -494,6 +508,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:

--- a/provider-ci/providers/newrelic/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/newrelic/repo/.github/workflows/master.yml
@@ -26,6 +26,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -127,6 +129,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Configure AWS Credentials
       uses: aws-actions/configure-aws-credentials@v1
       with:
@@ -180,6 +184,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -218,6 +224,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -254,6 +262,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -329,6 +339,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -385,6 +397,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -494,6 +508,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:

--- a/provider-ci/providers/newrelic/repo/.github/workflows/nightly-test.yml
+++ b/provider-ci/providers/newrelic/repo/.github/workflows/nightly-test.yml
@@ -26,6 +26,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -123,6 +125,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -198,6 +202,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:

--- a/provider-ci/providers/newrelic/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/newrelic/repo/.github/workflows/prerelease.yml
@@ -26,6 +26,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -124,6 +126,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -162,6 +166,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -198,6 +204,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -273,6 +281,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -329,6 +339,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -438,6 +450,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:

--- a/provider-ci/providers/newrelic/repo/.github/workflows/pull-request.yml
+++ b/provider-ci/providers/newrelic/repo/.github/workflows/pull-request.yml
@@ -26,6 +26,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Comment PR
       uses: thollander/actions-comment-pull-request@v1
       with:

--- a/provider-ci/providers/newrelic/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/newrelic/repo/.github/workflows/release.yml
@@ -26,6 +26,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -138,6 +140,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -176,6 +180,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -212,6 +218,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -287,6 +295,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -342,6 +352,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -451,6 +463,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Install pulumictl
       uses: jaxxstorm/action-install-gh-release@v1.5.0
       with:
@@ -465,6 +479,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:

--- a/provider-ci/providers/newrelic/repo/.github/workflows/update-bridge.yml
+++ b/provider-ci/providers/newrelic/repo/.github/workflows/update-bridge.yml
@@ -9,6 +9,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/provider-ci/providers/newrelic/repo/.github/workflows/update-upstream-provider.yml
+++ b/provider-ci/providers/newrelic/repo/.github/workflows/update-upstream-provider.yml
@@ -34,6 +34,8 @@ jobs:
         name=run-url::https://github.com/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/provider-ci/providers/nomad/repo/.github/workflows/command-dispatch.yml
+++ b/provider-ci/providers/nomad/repo/.github/workflows/command-dispatch.yml
@@ -24,6 +24,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - uses: peter-evans/slash-command-dispatch@v2
       with:
         commands: run-acceptance-tests

--- a/provider-ci/providers/nomad/repo/.github/workflows/community-moderation.yml
+++ b/provider-ci/providers/nomad/repo/.github/workflows/community-moderation.yml
@@ -7,6 +7,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - id: schema_changed
       name: Check for diff in schema
       uses: dorny/paths-filter@v2

--- a/provider-ci/providers/nomad/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/nomad/repo/.github/workflows/main.yml
@@ -25,6 +25,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -126,6 +128,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Configure AWS Credentials
       uses: aws-actions/configure-aws-credentials@v1
       with:
@@ -179,6 +183,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -217,6 +223,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -253,6 +261,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -328,6 +338,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -384,6 +396,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -493,6 +507,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:

--- a/provider-ci/providers/nomad/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/nomad/repo/.github/workflows/master.yml
@@ -25,6 +25,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -126,6 +128,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Configure AWS Credentials
       uses: aws-actions/configure-aws-credentials@v1
       with:
@@ -179,6 +183,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -217,6 +223,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -253,6 +261,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -328,6 +338,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -384,6 +396,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -493,6 +507,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:

--- a/provider-ci/providers/nomad/repo/.github/workflows/nightly-test.yml
+++ b/provider-ci/providers/nomad/repo/.github/workflows/nightly-test.yml
@@ -25,6 +25,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -122,6 +124,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -197,6 +201,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:

--- a/provider-ci/providers/nomad/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/nomad/repo/.github/workflows/prerelease.yml
@@ -25,6 +25,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -123,6 +125,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -161,6 +165,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -197,6 +203,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -272,6 +280,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -328,6 +338,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -437,6 +449,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:

--- a/provider-ci/providers/nomad/repo/.github/workflows/pull-request.yml
+++ b/provider-ci/providers/nomad/repo/.github/workflows/pull-request.yml
@@ -25,6 +25,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Comment PR
       uses: thollander/actions-comment-pull-request@v1
       with:

--- a/provider-ci/providers/nomad/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/nomad/repo/.github/workflows/release.yml
@@ -25,6 +25,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -137,6 +139,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -175,6 +179,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -211,6 +217,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -286,6 +294,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -341,6 +351,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -450,6 +462,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Install pulumictl
       uses: jaxxstorm/action-install-gh-release@v1.5.0
       with:
@@ -464,6 +478,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:

--- a/provider-ci/providers/nomad/repo/.github/workflows/update-bridge.yml
+++ b/provider-ci/providers/nomad/repo/.github/workflows/update-bridge.yml
@@ -9,6 +9,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/provider-ci/providers/nomad/repo/.github/workflows/update-upstream-provider.yml
+++ b/provider-ci/providers/nomad/repo/.github/workflows/update-upstream-provider.yml
@@ -33,6 +33,8 @@ jobs:
         name=run-url::https://github.com/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/provider-ci/providers/ns1/repo/.github/workflows/command-dispatch.yml
+++ b/provider-ci/providers/ns1/repo/.github/workflows/command-dispatch.yml
@@ -24,6 +24,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - uses: peter-evans/slash-command-dispatch@v2
       with:
         commands: run-acceptance-tests

--- a/provider-ci/providers/ns1/repo/.github/workflows/community-moderation.yml
+++ b/provider-ci/providers/ns1/repo/.github/workflows/community-moderation.yml
@@ -7,6 +7,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - id: schema_changed
       name: Check for diff in schema
       uses: dorny/paths-filter@v2

--- a/provider-ci/providers/ns1/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/ns1/repo/.github/workflows/main.yml
@@ -25,6 +25,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -126,6 +128,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Configure AWS Credentials
       uses: aws-actions/configure-aws-credentials@v1
       with:
@@ -179,6 +183,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -217,6 +223,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -253,6 +261,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -328,6 +338,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -384,6 +396,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -493,6 +507,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:

--- a/provider-ci/providers/ns1/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/ns1/repo/.github/workflows/master.yml
@@ -25,6 +25,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -126,6 +128,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Configure AWS Credentials
       uses: aws-actions/configure-aws-credentials@v1
       with:
@@ -179,6 +183,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -217,6 +223,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -253,6 +261,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -328,6 +338,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -384,6 +396,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -493,6 +507,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:

--- a/provider-ci/providers/ns1/repo/.github/workflows/nightly-test.yml
+++ b/provider-ci/providers/ns1/repo/.github/workflows/nightly-test.yml
@@ -25,6 +25,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -122,6 +124,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -197,6 +201,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:

--- a/provider-ci/providers/ns1/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/ns1/repo/.github/workflows/prerelease.yml
@@ -25,6 +25,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -123,6 +125,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -161,6 +165,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -197,6 +203,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -272,6 +280,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -328,6 +338,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -437,6 +449,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:

--- a/provider-ci/providers/ns1/repo/.github/workflows/pull-request.yml
+++ b/provider-ci/providers/ns1/repo/.github/workflows/pull-request.yml
@@ -25,6 +25,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Comment PR
       uses: thollander/actions-comment-pull-request@v1
       with:

--- a/provider-ci/providers/ns1/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/ns1/repo/.github/workflows/release.yml
@@ -25,6 +25,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -137,6 +139,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -175,6 +179,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -211,6 +217,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -286,6 +294,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -341,6 +351,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -450,6 +462,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Install pulumictl
       uses: jaxxstorm/action-install-gh-release@v1.5.0
       with:
@@ -464,6 +478,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:

--- a/provider-ci/providers/ns1/repo/.github/workflows/update-bridge.yml
+++ b/provider-ci/providers/ns1/repo/.github/workflows/update-bridge.yml
@@ -9,6 +9,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/provider-ci/providers/ns1/repo/.github/workflows/update-upstream-provider.yml
+++ b/provider-ci/providers/ns1/repo/.github/workflows/update-upstream-provider.yml
@@ -33,6 +33,8 @@ jobs:
         name=run-url::https://github.com/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/provider-ci/providers/oci/repo/.github/workflows/command-dispatch.yml
+++ b/provider-ci/providers/oci/repo/.github/workflows/command-dispatch.yml
@@ -27,6 +27,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - uses: peter-evans/slash-command-dispatch@v2
       with:
         commands: run-acceptance-tests

--- a/provider-ci/providers/oci/repo/.github/workflows/community-moderation.yml
+++ b/provider-ci/providers/oci/repo/.github/workflows/community-moderation.yml
@@ -7,6 +7,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - id: schema_changed
       name: Check for diff in schema
       uses: dorny/paths-filter@v2

--- a/provider-ci/providers/oci/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/oci/repo/.github/workflows/main.yml
@@ -28,6 +28,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -129,6 +131,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Configure AWS Credentials
       uses: aws-actions/configure-aws-credentials@v1
       with:
@@ -181,6 +185,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -256,6 +262,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -312,6 +320,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -421,6 +431,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:

--- a/provider-ci/providers/oci/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/oci/repo/.github/workflows/master.yml
@@ -28,6 +28,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -129,6 +131,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Configure AWS Credentials
       uses: aws-actions/configure-aws-credentials@v1
       with:
@@ -181,6 +185,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -256,6 +262,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -312,6 +320,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -421,6 +431,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:

--- a/provider-ci/providers/oci/repo/.github/workflows/nightly-test.yml
+++ b/provider-ci/providers/oci/repo/.github/workflows/nightly-test.yml
@@ -28,6 +28,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -125,6 +127,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -200,6 +204,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:

--- a/provider-ci/providers/oci/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/oci/repo/.github/workflows/prerelease.yml
@@ -28,6 +28,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -125,6 +127,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -200,6 +204,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -256,6 +262,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -365,6 +373,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:

--- a/provider-ci/providers/oci/repo/.github/workflows/pull-request.yml
+++ b/provider-ci/providers/oci/repo/.github/workflows/pull-request.yml
@@ -28,6 +28,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Comment PR
       uses: thollander/actions-comment-pull-request@v1
       with:

--- a/provider-ci/providers/oci/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/oci/repo/.github/workflows/release.yml
@@ -28,6 +28,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -139,6 +141,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -214,6 +218,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -269,6 +275,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -378,6 +386,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Install pulumictl
       uses: jaxxstorm/action-install-gh-release@v1.5.0
       with:
@@ -392,6 +402,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:

--- a/provider-ci/providers/oci/repo/.github/workflows/update-bridge.yml
+++ b/provider-ci/providers/oci/repo/.github/workflows/update-bridge.yml
@@ -9,6 +9,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/provider-ci/providers/oci/repo/.github/workflows/update-upstream-provider.yml
+++ b/provider-ci/providers/oci/repo/.github/workflows/update-upstream-provider.yml
@@ -36,6 +36,8 @@ jobs:
         name=run-url::https://github.com/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/provider-ci/providers/okta/repo/.github/workflows/command-dispatch.yml
+++ b/provider-ci/providers/okta/repo/.github/workflows/command-dispatch.yml
@@ -26,6 +26,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - uses: peter-evans/slash-command-dispatch@v2
       with:
         commands: run-acceptance-tests

--- a/provider-ci/providers/okta/repo/.github/workflows/community-moderation.yml
+++ b/provider-ci/providers/okta/repo/.github/workflows/community-moderation.yml
@@ -7,6 +7,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - id: schema_changed
       name: Check for diff in schema
       uses: dorny/paths-filter@v2

--- a/provider-ci/providers/okta/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/okta/repo/.github/workflows/main.yml
@@ -27,6 +27,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -128,6 +130,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Configure AWS Credentials
       uses: aws-actions/configure-aws-credentials@v1
       with:
@@ -181,6 +185,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -219,6 +225,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -255,6 +263,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -330,6 +340,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -386,6 +398,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -495,6 +509,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:

--- a/provider-ci/providers/okta/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/okta/repo/.github/workflows/master.yml
@@ -27,6 +27,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -128,6 +130,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Configure AWS Credentials
       uses: aws-actions/configure-aws-credentials@v1
       with:
@@ -181,6 +185,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -219,6 +225,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -255,6 +263,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -330,6 +340,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -386,6 +398,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -495,6 +509,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:

--- a/provider-ci/providers/okta/repo/.github/workflows/nightly-test.yml
+++ b/provider-ci/providers/okta/repo/.github/workflows/nightly-test.yml
@@ -27,6 +27,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -124,6 +126,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -199,6 +203,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:

--- a/provider-ci/providers/okta/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/okta/repo/.github/workflows/prerelease.yml
@@ -27,6 +27,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -125,6 +127,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -163,6 +167,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -199,6 +205,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -274,6 +282,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -330,6 +340,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -439,6 +451,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:

--- a/provider-ci/providers/okta/repo/.github/workflows/pull-request.yml
+++ b/provider-ci/providers/okta/repo/.github/workflows/pull-request.yml
@@ -27,6 +27,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Comment PR
       uses: thollander/actions-comment-pull-request@v1
       with:

--- a/provider-ci/providers/okta/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/okta/repo/.github/workflows/release.yml
@@ -27,6 +27,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -139,6 +141,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -177,6 +181,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -213,6 +219,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -288,6 +296,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -343,6 +353,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -452,6 +464,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Install pulumictl
       uses: jaxxstorm/action-install-gh-release@v1.5.0
       with:
@@ -466,6 +480,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:

--- a/provider-ci/providers/okta/repo/.github/workflows/update-bridge.yml
+++ b/provider-ci/providers/okta/repo/.github/workflows/update-bridge.yml
@@ -9,6 +9,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/provider-ci/providers/okta/repo/.github/workflows/update-upstream-provider.yml
+++ b/provider-ci/providers/okta/repo/.github/workflows/update-upstream-provider.yml
@@ -35,6 +35,8 @@ jobs:
         name=run-url::https://github.com/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/provider-ci/providers/onelogin/repo/.github/workflows/command-dispatch.yml
+++ b/provider-ci/providers/onelogin/repo/.github/workflows/command-dispatch.yml
@@ -23,6 +23,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - uses: peter-evans/slash-command-dispatch@v2
       with:
         commands: run-acceptance-tests

--- a/provider-ci/providers/onelogin/repo/.github/workflows/community-moderation.yml
+++ b/provider-ci/providers/onelogin/repo/.github/workflows/community-moderation.yml
@@ -7,6 +7,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - id: schema_changed
       name: Check for diff in schema
       uses: dorny/paths-filter@v2

--- a/provider-ci/providers/onelogin/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/onelogin/repo/.github/workflows/main.yml
@@ -24,6 +24,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -125,6 +127,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Configure AWS Credentials
       uses: aws-actions/configure-aws-credentials@v1
       with:
@@ -178,6 +182,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -216,6 +222,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -252,6 +260,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -327,6 +337,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -383,6 +395,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -492,6 +506,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:

--- a/provider-ci/providers/onelogin/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/onelogin/repo/.github/workflows/master.yml
@@ -24,6 +24,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -125,6 +127,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Configure AWS Credentials
       uses: aws-actions/configure-aws-credentials@v1
       with:
@@ -178,6 +182,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -216,6 +222,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -252,6 +260,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -327,6 +337,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -383,6 +395,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -492,6 +506,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:

--- a/provider-ci/providers/onelogin/repo/.github/workflows/nightly-test.yml
+++ b/provider-ci/providers/onelogin/repo/.github/workflows/nightly-test.yml
@@ -24,6 +24,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -121,6 +123,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -196,6 +200,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:

--- a/provider-ci/providers/onelogin/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/onelogin/repo/.github/workflows/prerelease.yml
@@ -24,6 +24,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -122,6 +124,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -160,6 +164,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -196,6 +202,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -271,6 +279,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -327,6 +337,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -436,6 +448,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:

--- a/provider-ci/providers/onelogin/repo/.github/workflows/pull-request.yml
+++ b/provider-ci/providers/onelogin/repo/.github/workflows/pull-request.yml
@@ -24,6 +24,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Comment PR
       uses: thollander/actions-comment-pull-request@v1
       with:

--- a/provider-ci/providers/onelogin/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/onelogin/repo/.github/workflows/release.yml
@@ -24,6 +24,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -136,6 +138,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -174,6 +178,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -210,6 +216,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -285,6 +293,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -340,6 +350,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -449,6 +461,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Install pulumictl
       uses: jaxxstorm/action-install-gh-release@v1.5.0
       with:
@@ -463,6 +477,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:

--- a/provider-ci/providers/onelogin/repo/.github/workflows/update-bridge.yml
+++ b/provider-ci/providers/onelogin/repo/.github/workflows/update-bridge.yml
@@ -9,6 +9,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/provider-ci/providers/onelogin/repo/.github/workflows/update-upstream-provider.yml
+++ b/provider-ci/providers/onelogin/repo/.github/workflows/update-upstream-provider.yml
@@ -32,6 +32,8 @@ jobs:
         name=run-url::https://github.com/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/provider-ci/providers/openstack/repo/.github/workflows/command-dispatch.yml
+++ b/provider-ci/providers/openstack/repo/.github/workflows/command-dispatch.yml
@@ -32,6 +32,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - uses: peter-evans/slash-command-dispatch@v2
       with:
         commands: run-acceptance-tests

--- a/provider-ci/providers/openstack/repo/.github/workflows/community-moderation.yml
+++ b/provider-ci/providers/openstack/repo/.github/workflows/community-moderation.yml
@@ -7,6 +7,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - id: schema_changed
       name: Check for diff in schema
       uses: dorny/paths-filter@v2

--- a/provider-ci/providers/openstack/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/openstack/repo/.github/workflows/main.yml
@@ -33,6 +33,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -134,6 +136,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Configure AWS Credentials
       uses: aws-actions/configure-aws-credentials@v1
       with:
@@ -187,6 +191,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -225,6 +231,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -261,6 +269,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -336,6 +346,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -392,6 +404,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -501,6 +515,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:

--- a/provider-ci/providers/openstack/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/openstack/repo/.github/workflows/master.yml
@@ -33,6 +33,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -134,6 +136,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Configure AWS Credentials
       uses: aws-actions/configure-aws-credentials@v1
       with:
@@ -187,6 +191,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -225,6 +231,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -261,6 +269,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -336,6 +346,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -392,6 +404,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -501,6 +515,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:

--- a/provider-ci/providers/openstack/repo/.github/workflows/nightly-test.yml
+++ b/provider-ci/providers/openstack/repo/.github/workflows/nightly-test.yml
@@ -33,6 +33,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -130,6 +132,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -205,6 +209,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:

--- a/provider-ci/providers/openstack/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/openstack/repo/.github/workflows/prerelease.yml
@@ -33,6 +33,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -131,6 +133,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -169,6 +173,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -205,6 +211,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -280,6 +288,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -336,6 +346,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -445,6 +457,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:

--- a/provider-ci/providers/openstack/repo/.github/workflows/pull-request.yml
+++ b/provider-ci/providers/openstack/repo/.github/workflows/pull-request.yml
@@ -33,6 +33,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Comment PR
       uses: thollander/actions-comment-pull-request@v1
       with:

--- a/provider-ci/providers/openstack/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/openstack/repo/.github/workflows/release.yml
@@ -33,6 +33,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -145,6 +147,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -183,6 +187,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -219,6 +225,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -294,6 +302,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -349,6 +359,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -458,6 +470,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Install pulumictl
       uses: jaxxstorm/action-install-gh-release@v1.5.0
       with:
@@ -472,6 +486,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:

--- a/provider-ci/providers/openstack/repo/.github/workflows/update-bridge.yml
+++ b/provider-ci/providers/openstack/repo/.github/workflows/update-bridge.yml
@@ -9,6 +9,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/provider-ci/providers/openstack/repo/.github/workflows/update-upstream-provider.yml
+++ b/provider-ci/providers/openstack/repo/.github/workflows/update-upstream-provider.yml
@@ -41,6 +41,8 @@ jobs:
         name=run-url::https://github.com/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/provider-ci/providers/opsgenie/repo/.github/workflows/command-dispatch.yml
+++ b/provider-ci/providers/opsgenie/repo/.github/workflows/command-dispatch.yml
@@ -24,6 +24,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - uses: peter-evans/slash-command-dispatch@v2
       with:
         commands: run-acceptance-tests

--- a/provider-ci/providers/opsgenie/repo/.github/workflows/community-moderation.yml
+++ b/provider-ci/providers/opsgenie/repo/.github/workflows/community-moderation.yml
@@ -7,6 +7,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - id: schema_changed
       name: Check for diff in schema
       uses: dorny/paths-filter@v2

--- a/provider-ci/providers/opsgenie/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/opsgenie/repo/.github/workflows/main.yml
@@ -25,6 +25,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -126,6 +128,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Configure AWS Credentials
       uses: aws-actions/configure-aws-credentials@v1
       with:
@@ -179,6 +183,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -217,6 +223,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -253,6 +261,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -328,6 +338,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -384,6 +396,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -493,6 +507,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:

--- a/provider-ci/providers/opsgenie/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/opsgenie/repo/.github/workflows/master.yml
@@ -25,6 +25,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -126,6 +128,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Configure AWS Credentials
       uses: aws-actions/configure-aws-credentials@v1
       with:
@@ -179,6 +183,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -217,6 +223,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -253,6 +261,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -328,6 +338,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -384,6 +396,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -493,6 +507,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:

--- a/provider-ci/providers/opsgenie/repo/.github/workflows/nightly-test.yml
+++ b/provider-ci/providers/opsgenie/repo/.github/workflows/nightly-test.yml
@@ -25,6 +25,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -122,6 +124,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -197,6 +201,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:

--- a/provider-ci/providers/opsgenie/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/opsgenie/repo/.github/workflows/prerelease.yml
@@ -25,6 +25,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -123,6 +125,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -161,6 +165,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -197,6 +203,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -272,6 +280,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -328,6 +338,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -437,6 +449,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:

--- a/provider-ci/providers/opsgenie/repo/.github/workflows/pull-request.yml
+++ b/provider-ci/providers/opsgenie/repo/.github/workflows/pull-request.yml
@@ -25,6 +25,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Comment PR
       uses: thollander/actions-comment-pull-request@v1
       with:

--- a/provider-ci/providers/opsgenie/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/opsgenie/repo/.github/workflows/release.yml
@@ -25,6 +25,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -137,6 +139,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -175,6 +179,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -211,6 +217,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -286,6 +294,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -341,6 +351,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -450,6 +462,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Install pulumictl
       uses: jaxxstorm/action-install-gh-release@v1.5.0
       with:
@@ -464,6 +478,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:

--- a/provider-ci/providers/opsgenie/repo/.github/workflows/update-bridge.yml
+++ b/provider-ci/providers/opsgenie/repo/.github/workflows/update-bridge.yml
@@ -9,6 +9,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/provider-ci/providers/opsgenie/repo/.github/workflows/update-upstream-provider.yml
+++ b/provider-ci/providers/opsgenie/repo/.github/workflows/update-upstream-provider.yml
@@ -33,6 +33,8 @@ jobs:
         name=run-url::https://github.com/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/provider-ci/providers/pagerduty/repo/.github/workflows/command-dispatch.yml
+++ b/provider-ci/providers/pagerduty/repo/.github/workflows/command-dispatch.yml
@@ -24,6 +24,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - uses: peter-evans/slash-command-dispatch@v2
       with:
         commands: run-acceptance-tests

--- a/provider-ci/providers/pagerduty/repo/.github/workflows/community-moderation.yml
+++ b/provider-ci/providers/pagerduty/repo/.github/workflows/community-moderation.yml
@@ -7,6 +7,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - id: schema_changed
       name: Check for diff in schema
       uses: dorny/paths-filter@v2

--- a/provider-ci/providers/pagerduty/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/pagerduty/repo/.github/workflows/main.yml
@@ -25,6 +25,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -126,6 +128,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Configure AWS Credentials
       uses: aws-actions/configure-aws-credentials@v1
       with:
@@ -179,6 +183,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -217,6 +223,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -253,6 +261,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -328,6 +338,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -384,6 +396,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -493,6 +507,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:

--- a/provider-ci/providers/pagerduty/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/pagerduty/repo/.github/workflows/master.yml
@@ -25,6 +25,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -126,6 +128,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Configure AWS Credentials
       uses: aws-actions/configure-aws-credentials@v1
       with:
@@ -179,6 +183,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -217,6 +223,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -253,6 +261,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -328,6 +338,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -384,6 +396,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -493,6 +507,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:

--- a/provider-ci/providers/pagerduty/repo/.github/workflows/nightly-test.yml
+++ b/provider-ci/providers/pagerduty/repo/.github/workflows/nightly-test.yml
@@ -25,6 +25,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -122,6 +124,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -197,6 +201,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:

--- a/provider-ci/providers/pagerduty/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/pagerduty/repo/.github/workflows/prerelease.yml
@@ -25,6 +25,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -123,6 +125,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -161,6 +165,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -197,6 +203,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -272,6 +280,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -328,6 +338,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -437,6 +449,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:

--- a/provider-ci/providers/pagerduty/repo/.github/workflows/pull-request.yml
+++ b/provider-ci/providers/pagerduty/repo/.github/workflows/pull-request.yml
@@ -25,6 +25,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Comment PR
       uses: thollander/actions-comment-pull-request@v1
       with:

--- a/provider-ci/providers/pagerduty/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/pagerduty/repo/.github/workflows/release.yml
@@ -25,6 +25,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -137,6 +139,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -175,6 +179,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -211,6 +217,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -286,6 +294,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -341,6 +351,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -450,6 +462,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Install pulumictl
       uses: jaxxstorm/action-install-gh-release@v1.5.0
       with:
@@ -464,6 +478,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:

--- a/provider-ci/providers/pagerduty/repo/.github/workflows/update-bridge.yml
+++ b/provider-ci/providers/pagerduty/repo/.github/workflows/update-bridge.yml
@@ -9,6 +9,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/provider-ci/providers/pagerduty/repo/.github/workflows/update-upstream-provider.yml
+++ b/provider-ci/providers/pagerduty/repo/.github/workflows/update-upstream-provider.yml
@@ -33,6 +33,8 @@ jobs:
         name=run-url::https://github.com/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/provider-ci/providers/postgresql/repo/.github/workflows/command-dispatch.yml
+++ b/provider-ci/providers/postgresql/repo/.github/workflows/command-dispatch.yml
@@ -23,6 +23,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - uses: peter-evans/slash-command-dispatch@v2
       with:
         commands: run-acceptance-tests

--- a/provider-ci/providers/postgresql/repo/.github/workflows/community-moderation.yml
+++ b/provider-ci/providers/postgresql/repo/.github/workflows/community-moderation.yml
@@ -7,6 +7,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - id: schema_changed
       name: Check for diff in schema
       uses: dorny/paths-filter@v2

--- a/provider-ci/providers/postgresql/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/postgresql/repo/.github/workflows/main.yml
@@ -24,6 +24,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -125,6 +127,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Configure AWS Credentials
       uses: aws-actions/configure-aws-credentials@v1
       with:
@@ -178,6 +182,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -216,6 +222,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -252,6 +260,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -327,6 +337,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -383,6 +395,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -492,6 +506,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:

--- a/provider-ci/providers/postgresql/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/postgresql/repo/.github/workflows/master.yml
@@ -24,6 +24,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -125,6 +127,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Configure AWS Credentials
       uses: aws-actions/configure-aws-credentials@v1
       with:
@@ -178,6 +182,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -216,6 +222,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -252,6 +260,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -327,6 +337,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -383,6 +395,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -492,6 +506,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:

--- a/provider-ci/providers/postgresql/repo/.github/workflows/nightly-test.yml
+++ b/provider-ci/providers/postgresql/repo/.github/workflows/nightly-test.yml
@@ -24,6 +24,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -121,6 +123,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -196,6 +200,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:

--- a/provider-ci/providers/postgresql/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/postgresql/repo/.github/workflows/prerelease.yml
@@ -24,6 +24,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -122,6 +124,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -160,6 +164,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -196,6 +202,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -271,6 +279,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -327,6 +337,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -436,6 +448,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:

--- a/provider-ci/providers/postgresql/repo/.github/workflows/pull-request.yml
+++ b/provider-ci/providers/postgresql/repo/.github/workflows/pull-request.yml
@@ -24,6 +24,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Comment PR
       uses: thollander/actions-comment-pull-request@v1
       with:

--- a/provider-ci/providers/postgresql/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/postgresql/repo/.github/workflows/release.yml
@@ -24,6 +24,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -136,6 +138,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -174,6 +178,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -210,6 +216,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -285,6 +293,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -340,6 +350,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -449,6 +461,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Install pulumictl
       uses: jaxxstorm/action-install-gh-release@v1.5.0
       with:
@@ -463,6 +477,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:

--- a/provider-ci/providers/postgresql/repo/.github/workflows/update-bridge.yml
+++ b/provider-ci/providers/postgresql/repo/.github/workflows/update-bridge.yml
@@ -9,6 +9,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/provider-ci/providers/postgresql/repo/.github/workflows/update-upstream-provider.yml
+++ b/provider-ci/providers/postgresql/repo/.github/workflows/update-upstream-provider.yml
@@ -32,6 +32,8 @@ jobs:
         name=run-url::https://github.com/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/provider-ci/providers/rabbitmq/repo/.github/workflows/command-dispatch.yml
+++ b/provider-ci/providers/rabbitmq/repo/.github/workflows/command-dispatch.yml
@@ -23,6 +23,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - uses: peter-evans/slash-command-dispatch@v2
       with:
         commands: run-acceptance-tests

--- a/provider-ci/providers/rabbitmq/repo/.github/workflows/community-moderation.yml
+++ b/provider-ci/providers/rabbitmq/repo/.github/workflows/community-moderation.yml
@@ -7,6 +7,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - id: schema_changed
       name: Check for diff in schema
       uses: dorny/paths-filter@v2

--- a/provider-ci/providers/rabbitmq/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/rabbitmq/repo/.github/workflows/main.yml
@@ -24,6 +24,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -125,6 +127,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Configure AWS Credentials
       uses: aws-actions/configure-aws-credentials@v1
       with:
@@ -178,6 +182,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -216,6 +222,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -252,6 +260,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -327,6 +337,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -383,6 +395,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -492,6 +506,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:

--- a/provider-ci/providers/rabbitmq/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/rabbitmq/repo/.github/workflows/master.yml
@@ -24,6 +24,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -125,6 +127,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Configure AWS Credentials
       uses: aws-actions/configure-aws-credentials@v1
       with:
@@ -178,6 +182,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -216,6 +222,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -252,6 +260,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -327,6 +337,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -383,6 +395,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -492,6 +506,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:

--- a/provider-ci/providers/rabbitmq/repo/.github/workflows/nightly-test.yml
+++ b/provider-ci/providers/rabbitmq/repo/.github/workflows/nightly-test.yml
@@ -24,6 +24,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -121,6 +123,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -196,6 +200,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:

--- a/provider-ci/providers/rabbitmq/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/rabbitmq/repo/.github/workflows/prerelease.yml
@@ -24,6 +24,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -122,6 +124,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -160,6 +164,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -196,6 +202,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -271,6 +279,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -327,6 +337,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -436,6 +448,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:

--- a/provider-ci/providers/rabbitmq/repo/.github/workflows/pull-request.yml
+++ b/provider-ci/providers/rabbitmq/repo/.github/workflows/pull-request.yml
@@ -24,6 +24,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Comment PR
       uses: thollander/actions-comment-pull-request@v1
       with:

--- a/provider-ci/providers/rabbitmq/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/rabbitmq/repo/.github/workflows/release.yml
@@ -24,6 +24,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -136,6 +138,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -174,6 +178,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -210,6 +216,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -285,6 +293,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -340,6 +350,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -449,6 +461,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Install pulumictl
       uses: jaxxstorm/action-install-gh-release@v1.5.0
       with:
@@ -463,6 +477,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:

--- a/provider-ci/providers/rabbitmq/repo/.github/workflows/update-bridge.yml
+++ b/provider-ci/providers/rabbitmq/repo/.github/workflows/update-bridge.yml
@@ -9,6 +9,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/provider-ci/providers/rabbitmq/repo/.github/workflows/update-upstream-provider.yml
+++ b/provider-ci/providers/rabbitmq/repo/.github/workflows/update-upstream-provider.yml
@@ -32,6 +32,8 @@ jobs:
         name=run-url::https://github.com/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/provider-ci/providers/rancher2/repo/.github/workflows/command-dispatch.yml
+++ b/provider-ci/providers/rancher2/repo/.github/workflows/command-dispatch.yml
@@ -25,6 +25,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - uses: peter-evans/slash-command-dispatch@v2
       with:
         commands: run-acceptance-tests

--- a/provider-ci/providers/rancher2/repo/.github/workflows/community-moderation.yml
+++ b/provider-ci/providers/rancher2/repo/.github/workflows/community-moderation.yml
@@ -7,6 +7,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - id: schema_changed
       name: Check for diff in schema
       uses: dorny/paths-filter@v2

--- a/provider-ci/providers/rancher2/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/rancher2/repo/.github/workflows/main.yml
@@ -26,6 +26,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -127,6 +129,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Configure AWS Credentials
       uses: aws-actions/configure-aws-credentials@v1
       with:
@@ -179,6 +183,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -254,6 +260,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -310,6 +318,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -419,6 +429,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:

--- a/provider-ci/providers/rancher2/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/rancher2/repo/.github/workflows/master.yml
@@ -26,6 +26,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -127,6 +129,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Configure AWS Credentials
       uses: aws-actions/configure-aws-credentials@v1
       with:
@@ -179,6 +183,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -254,6 +260,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -310,6 +318,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -419,6 +429,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:

--- a/provider-ci/providers/rancher2/repo/.github/workflows/nightly-test.yml
+++ b/provider-ci/providers/rancher2/repo/.github/workflows/nightly-test.yml
@@ -26,6 +26,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -123,6 +125,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -198,6 +202,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:

--- a/provider-ci/providers/rancher2/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/rancher2/repo/.github/workflows/prerelease.yml
@@ -26,6 +26,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -123,6 +125,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -198,6 +202,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -254,6 +260,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -363,6 +371,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:

--- a/provider-ci/providers/rancher2/repo/.github/workflows/pull-request.yml
+++ b/provider-ci/providers/rancher2/repo/.github/workflows/pull-request.yml
@@ -26,6 +26,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Comment PR
       uses: thollander/actions-comment-pull-request@v1
       with:

--- a/provider-ci/providers/rancher2/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/rancher2/repo/.github/workflows/release.yml
@@ -26,6 +26,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -137,6 +139,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -212,6 +216,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -267,6 +273,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -376,6 +384,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Install pulumictl
       uses: jaxxstorm/action-install-gh-release@v1.5.0
       with:
@@ -390,6 +400,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:

--- a/provider-ci/providers/rancher2/repo/.github/workflows/update-bridge.yml
+++ b/provider-ci/providers/rancher2/repo/.github/workflows/update-bridge.yml
@@ -9,6 +9,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/provider-ci/providers/rancher2/repo/.github/workflows/update-upstream-provider.yml
+++ b/provider-ci/providers/rancher2/repo/.github/workflows/update-upstream-provider.yml
@@ -34,6 +34,8 @@ jobs:
         name=run-url::https://github.com/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/provider-ci/providers/random/repo/.github/workflows/command-dispatch.yml
+++ b/provider-ci/providers/random/repo/.github/workflows/command-dispatch.yml
@@ -23,6 +23,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - uses: peter-evans/slash-command-dispatch@v2
       with:
         commands: run-acceptance-tests

--- a/provider-ci/providers/random/repo/.github/workflows/community-moderation.yml
+++ b/provider-ci/providers/random/repo/.github/workflows/community-moderation.yml
@@ -7,6 +7,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - id: schema_changed
       name: Check for diff in schema
       uses: dorny/paths-filter@v2

--- a/provider-ci/providers/random/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/random/repo/.github/workflows/main.yml
@@ -24,6 +24,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -125,6 +127,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Configure AWS Credentials
       uses: aws-actions/configure-aws-credentials@v1
       with:
@@ -178,6 +182,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -216,6 +222,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -252,6 +260,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -327,6 +337,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -383,6 +395,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -492,6 +506,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:

--- a/provider-ci/providers/random/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/random/repo/.github/workflows/master.yml
@@ -24,6 +24,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -125,6 +127,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Configure AWS Credentials
       uses: aws-actions/configure-aws-credentials@v1
       with:
@@ -178,6 +182,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -216,6 +222,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -252,6 +260,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -327,6 +337,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -383,6 +395,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -492,6 +506,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:

--- a/provider-ci/providers/random/repo/.github/workflows/nightly-test.yml
+++ b/provider-ci/providers/random/repo/.github/workflows/nightly-test.yml
@@ -24,6 +24,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -121,6 +123,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -196,6 +200,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:

--- a/provider-ci/providers/random/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/random/repo/.github/workflows/prerelease.yml
@@ -24,6 +24,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -122,6 +124,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -160,6 +164,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -196,6 +202,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -271,6 +279,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -327,6 +337,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -436,6 +448,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:

--- a/provider-ci/providers/random/repo/.github/workflows/pull-request.yml
+++ b/provider-ci/providers/random/repo/.github/workflows/pull-request.yml
@@ -24,6 +24,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Comment PR
       uses: thollander/actions-comment-pull-request@v1
       with:

--- a/provider-ci/providers/random/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/random/repo/.github/workflows/release.yml
@@ -24,6 +24,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -136,6 +138,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -174,6 +178,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -210,6 +216,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -285,6 +293,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -340,6 +350,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -449,6 +461,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Install pulumictl
       uses: jaxxstorm/action-install-gh-release@v1.5.0
       with:
@@ -463,6 +477,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:

--- a/provider-ci/providers/random/repo/.github/workflows/update-bridge.yml
+++ b/provider-ci/providers/random/repo/.github/workflows/update-bridge.yml
@@ -9,6 +9,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/provider-ci/providers/random/repo/.github/workflows/update-upstream-provider.yml
+++ b/provider-ci/providers/random/repo/.github/workflows/update-upstream-provider.yml
@@ -32,6 +32,8 @@ jobs:
         name=run-url::https://github.com/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/provider-ci/providers/rke/repo/.github/workflows/command-dispatch.yml
+++ b/provider-ci/providers/rke/repo/.github/workflows/command-dispatch.yml
@@ -24,6 +24,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - uses: peter-evans/slash-command-dispatch@v2
       with:
         commands: run-acceptance-tests

--- a/provider-ci/providers/rke/repo/.github/workflows/community-moderation.yml
+++ b/provider-ci/providers/rke/repo/.github/workflows/community-moderation.yml
@@ -7,6 +7,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - id: schema_changed
       name: Check for diff in schema
       uses: dorny/paths-filter@v2

--- a/provider-ci/providers/rke/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/rke/repo/.github/workflows/main.yml
@@ -25,6 +25,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -126,6 +128,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Configure AWS Credentials
       uses: aws-actions/configure-aws-credentials@v1
       with:
@@ -179,6 +183,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -217,6 +223,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -253,6 +261,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -328,6 +338,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -384,6 +396,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -493,6 +507,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:

--- a/provider-ci/providers/rke/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/rke/repo/.github/workflows/master.yml
@@ -25,6 +25,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -126,6 +128,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Configure AWS Credentials
       uses: aws-actions/configure-aws-credentials@v1
       with:
@@ -179,6 +183,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -217,6 +223,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -253,6 +261,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -328,6 +338,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -384,6 +396,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -493,6 +507,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:

--- a/provider-ci/providers/rke/repo/.github/workflows/nightly-test.yml
+++ b/provider-ci/providers/rke/repo/.github/workflows/nightly-test.yml
@@ -25,6 +25,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -122,6 +124,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -197,6 +201,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:

--- a/provider-ci/providers/rke/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/rke/repo/.github/workflows/prerelease.yml
@@ -25,6 +25,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -123,6 +125,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -161,6 +165,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -197,6 +203,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -272,6 +280,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -328,6 +338,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -437,6 +449,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:

--- a/provider-ci/providers/rke/repo/.github/workflows/pull-request.yml
+++ b/provider-ci/providers/rke/repo/.github/workflows/pull-request.yml
@@ -25,6 +25,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Comment PR
       uses: thollander/actions-comment-pull-request@v1
       with:

--- a/provider-ci/providers/rke/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/rke/repo/.github/workflows/release.yml
@@ -25,6 +25,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -137,6 +139,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -175,6 +179,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -211,6 +217,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -286,6 +294,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -341,6 +351,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -450,6 +462,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Install pulumictl
       uses: jaxxstorm/action-install-gh-release@v1.5.0
       with:
@@ -464,6 +478,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:

--- a/provider-ci/providers/rke/repo/.github/workflows/update-bridge.yml
+++ b/provider-ci/providers/rke/repo/.github/workflows/update-bridge.yml
@@ -9,6 +9,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/provider-ci/providers/rke/repo/.github/workflows/update-upstream-provider.yml
+++ b/provider-ci/providers/rke/repo/.github/workflows/update-upstream-provider.yml
@@ -33,6 +33,8 @@ jobs:
         name=run-url::https://github.com/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/provider-ci/providers/signalfx/repo/.github/workflows/command-dispatch.yml
+++ b/provider-ci/providers/signalfx/repo/.github/workflows/command-dispatch.yml
@@ -23,6 +23,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - uses: peter-evans/slash-command-dispatch@v2
       with:
         commands: run-acceptance-tests

--- a/provider-ci/providers/signalfx/repo/.github/workflows/community-moderation.yml
+++ b/provider-ci/providers/signalfx/repo/.github/workflows/community-moderation.yml
@@ -7,6 +7,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - id: schema_changed
       name: Check for diff in schema
       uses: dorny/paths-filter@v2

--- a/provider-ci/providers/signalfx/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/signalfx/repo/.github/workflows/main.yml
@@ -24,6 +24,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -125,6 +127,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Configure AWS Credentials
       uses: aws-actions/configure-aws-credentials@v1
       with:
@@ -178,6 +182,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -216,6 +222,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -252,6 +260,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -327,6 +337,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -383,6 +395,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -492,6 +506,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:

--- a/provider-ci/providers/signalfx/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/signalfx/repo/.github/workflows/master.yml
@@ -24,6 +24,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -125,6 +127,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Configure AWS Credentials
       uses: aws-actions/configure-aws-credentials@v1
       with:
@@ -178,6 +182,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -216,6 +222,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -252,6 +260,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -327,6 +337,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -383,6 +395,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -492,6 +506,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:

--- a/provider-ci/providers/signalfx/repo/.github/workflows/nightly-test.yml
+++ b/provider-ci/providers/signalfx/repo/.github/workflows/nightly-test.yml
@@ -24,6 +24,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -121,6 +123,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -196,6 +200,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:

--- a/provider-ci/providers/signalfx/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/signalfx/repo/.github/workflows/prerelease.yml
@@ -24,6 +24,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -122,6 +124,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -160,6 +164,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -196,6 +202,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -271,6 +279,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -327,6 +337,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -436,6 +448,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:

--- a/provider-ci/providers/signalfx/repo/.github/workflows/pull-request.yml
+++ b/provider-ci/providers/signalfx/repo/.github/workflows/pull-request.yml
@@ -24,6 +24,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Comment PR
       uses: thollander/actions-comment-pull-request@v1
       with:

--- a/provider-ci/providers/signalfx/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/signalfx/repo/.github/workflows/release.yml
@@ -24,6 +24,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -136,6 +138,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -174,6 +178,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -210,6 +216,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -285,6 +293,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -340,6 +350,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -449,6 +461,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Install pulumictl
       uses: jaxxstorm/action-install-gh-release@v1.5.0
       with:
@@ -463,6 +477,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:

--- a/provider-ci/providers/signalfx/repo/.github/workflows/update-bridge.yml
+++ b/provider-ci/providers/signalfx/repo/.github/workflows/update-bridge.yml
@@ -9,6 +9,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/provider-ci/providers/signalfx/repo/.github/workflows/update-upstream-provider.yml
+++ b/provider-ci/providers/signalfx/repo/.github/workflows/update-upstream-provider.yml
@@ -32,6 +32,8 @@ jobs:
         name=run-url::https://github.com/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/provider-ci/providers/slack/repo/.github/workflows/command-dispatch.yml
+++ b/provider-ci/providers/slack/repo/.github/workflows/command-dispatch.yml
@@ -24,6 +24,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - uses: peter-evans/slash-command-dispatch@v2
       with:
         commands: run-acceptance-tests

--- a/provider-ci/providers/slack/repo/.github/workflows/community-moderation.yml
+++ b/provider-ci/providers/slack/repo/.github/workflows/community-moderation.yml
@@ -7,6 +7,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - id: schema_changed
       name: Check for diff in schema
       uses: dorny/paths-filter@v2

--- a/provider-ci/providers/slack/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/slack/repo/.github/workflows/main.yml
@@ -25,6 +25,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -126,6 +128,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Configure AWS Credentials
       uses: aws-actions/configure-aws-credentials@v1
       with:
@@ -179,6 +183,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -217,6 +223,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -253,6 +261,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -328,6 +338,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -384,6 +396,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -493,6 +507,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:

--- a/provider-ci/providers/slack/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/slack/repo/.github/workflows/master.yml
@@ -25,6 +25,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -126,6 +128,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Configure AWS Credentials
       uses: aws-actions/configure-aws-credentials@v1
       with:
@@ -179,6 +183,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -217,6 +223,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -253,6 +261,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -328,6 +338,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -384,6 +396,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -493,6 +507,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:

--- a/provider-ci/providers/slack/repo/.github/workflows/nightly-test.yml
+++ b/provider-ci/providers/slack/repo/.github/workflows/nightly-test.yml
@@ -25,6 +25,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -122,6 +124,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -197,6 +201,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:

--- a/provider-ci/providers/slack/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/slack/repo/.github/workflows/prerelease.yml
@@ -25,6 +25,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -123,6 +125,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -161,6 +165,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -197,6 +203,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -272,6 +280,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -328,6 +338,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -437,6 +449,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:

--- a/provider-ci/providers/slack/repo/.github/workflows/pull-request.yml
+++ b/provider-ci/providers/slack/repo/.github/workflows/pull-request.yml
@@ -25,6 +25,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Comment PR
       uses: thollander/actions-comment-pull-request@v1
       with:

--- a/provider-ci/providers/slack/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/slack/repo/.github/workflows/release.yml
@@ -25,6 +25,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -137,6 +139,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -175,6 +179,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -211,6 +217,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -286,6 +294,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -341,6 +351,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -450,6 +462,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Install pulumictl
       uses: jaxxstorm/action-install-gh-release@v1.5.0
       with:
@@ -464,6 +478,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:

--- a/provider-ci/providers/slack/repo/.github/workflows/update-bridge.yml
+++ b/provider-ci/providers/slack/repo/.github/workflows/update-bridge.yml
@@ -9,6 +9,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/provider-ci/providers/slack/repo/.github/workflows/update-upstream-provider.yml
+++ b/provider-ci/providers/slack/repo/.github/workflows/update-upstream-provider.yml
@@ -33,6 +33,8 @@ jobs:
         name=run-url::https://github.com/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/provider-ci/providers/snowflake/repo/.github/workflows/command-dispatch.yml
+++ b/provider-ci/providers/snowflake/repo/.github/workflows/command-dispatch.yml
@@ -28,6 +28,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - uses: peter-evans/slash-command-dispatch@v2
       with:
         commands: run-acceptance-tests

--- a/provider-ci/providers/snowflake/repo/.github/workflows/community-moderation.yml
+++ b/provider-ci/providers/snowflake/repo/.github/workflows/community-moderation.yml
@@ -7,6 +7,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - id: schema_changed
       name: Check for diff in schema
       uses: dorny/paths-filter@v2

--- a/provider-ci/providers/snowflake/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/snowflake/repo/.github/workflows/main.yml
@@ -29,6 +29,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -130,6 +132,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Configure AWS Credentials
       uses: aws-actions/configure-aws-credentials@v1
       with:
@@ -183,6 +187,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -221,6 +227,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -257,6 +265,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -332,6 +342,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -388,6 +400,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -497,6 +511,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:

--- a/provider-ci/providers/snowflake/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/snowflake/repo/.github/workflows/master.yml
@@ -29,6 +29,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -130,6 +132,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Configure AWS Credentials
       uses: aws-actions/configure-aws-credentials@v1
       with:
@@ -183,6 +187,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -221,6 +227,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -257,6 +265,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -332,6 +342,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -388,6 +400,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -497,6 +511,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:

--- a/provider-ci/providers/snowflake/repo/.github/workflows/nightly-test.yml
+++ b/provider-ci/providers/snowflake/repo/.github/workflows/nightly-test.yml
@@ -29,6 +29,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -126,6 +128,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -201,6 +205,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:

--- a/provider-ci/providers/snowflake/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/snowflake/repo/.github/workflows/prerelease.yml
@@ -29,6 +29,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -127,6 +129,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -165,6 +169,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -201,6 +207,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -276,6 +284,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -332,6 +342,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -441,6 +453,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:

--- a/provider-ci/providers/snowflake/repo/.github/workflows/pull-request.yml
+++ b/provider-ci/providers/snowflake/repo/.github/workflows/pull-request.yml
@@ -29,6 +29,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Comment PR
       uses: thollander/actions-comment-pull-request@v1
       with:

--- a/provider-ci/providers/snowflake/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/snowflake/repo/.github/workflows/release.yml
@@ -29,6 +29,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -141,6 +143,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -179,6 +183,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -215,6 +221,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -290,6 +298,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -345,6 +355,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -454,6 +466,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Install pulumictl
       uses: jaxxstorm/action-install-gh-release@v1.5.0
       with:
@@ -468,6 +482,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:

--- a/provider-ci/providers/snowflake/repo/.github/workflows/update-bridge.yml
+++ b/provider-ci/providers/snowflake/repo/.github/workflows/update-bridge.yml
@@ -9,6 +9,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/provider-ci/providers/snowflake/repo/.github/workflows/update-upstream-provider.yml
+++ b/provider-ci/providers/snowflake/repo/.github/workflows/update-upstream-provider.yml
@@ -37,6 +37,8 @@ jobs:
         name=run-url::https://github.com/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/provider-ci/providers/splunk/repo/.github/workflows/command-dispatch.yml
+++ b/provider-ci/providers/splunk/repo/.github/workflows/command-dispatch.yml
@@ -26,6 +26,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - uses: peter-evans/slash-command-dispatch@v2
       with:
         commands: run-acceptance-tests

--- a/provider-ci/providers/splunk/repo/.github/workflows/community-moderation.yml
+++ b/provider-ci/providers/splunk/repo/.github/workflows/community-moderation.yml
@@ -7,6 +7,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - id: schema_changed
       name: Check for diff in schema
       uses: dorny/paths-filter@v2

--- a/provider-ci/providers/splunk/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/splunk/repo/.github/workflows/main.yml
@@ -27,6 +27,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -128,6 +130,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Configure AWS Credentials
       uses: aws-actions/configure-aws-credentials@v1
       with:
@@ -181,6 +185,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -219,6 +225,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -255,6 +263,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -330,6 +340,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -386,6 +398,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -495,6 +509,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:

--- a/provider-ci/providers/splunk/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/splunk/repo/.github/workflows/master.yml
@@ -27,6 +27,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -128,6 +130,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Configure AWS Credentials
       uses: aws-actions/configure-aws-credentials@v1
       with:
@@ -181,6 +185,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -219,6 +225,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -255,6 +263,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -330,6 +340,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -386,6 +398,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -495,6 +509,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:

--- a/provider-ci/providers/splunk/repo/.github/workflows/nightly-test.yml
+++ b/provider-ci/providers/splunk/repo/.github/workflows/nightly-test.yml
@@ -27,6 +27,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -124,6 +126,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -199,6 +203,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:

--- a/provider-ci/providers/splunk/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/splunk/repo/.github/workflows/prerelease.yml
@@ -27,6 +27,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -125,6 +127,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -163,6 +167,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -199,6 +205,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -274,6 +282,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -330,6 +340,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -439,6 +451,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:

--- a/provider-ci/providers/splunk/repo/.github/workflows/pull-request.yml
+++ b/provider-ci/providers/splunk/repo/.github/workflows/pull-request.yml
@@ -27,6 +27,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Comment PR
       uses: thollander/actions-comment-pull-request@v1
       with:

--- a/provider-ci/providers/splunk/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/splunk/repo/.github/workflows/release.yml
@@ -27,6 +27,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -139,6 +141,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -177,6 +181,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -213,6 +219,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -288,6 +296,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -343,6 +353,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -452,6 +464,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Install pulumictl
       uses: jaxxstorm/action-install-gh-release@v1.5.0
       with:
@@ -466,6 +480,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:

--- a/provider-ci/providers/splunk/repo/.github/workflows/update-bridge.yml
+++ b/provider-ci/providers/splunk/repo/.github/workflows/update-bridge.yml
@@ -9,6 +9,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/provider-ci/providers/splunk/repo/.github/workflows/update-upstream-provider.yml
+++ b/provider-ci/providers/splunk/repo/.github/workflows/update-upstream-provider.yml
@@ -35,6 +35,8 @@ jobs:
         name=run-url::https://github.com/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/provider-ci/providers/spotinst/repo/.github/workflows/command-dispatch.yml
+++ b/provider-ci/providers/spotinst/repo/.github/workflows/command-dispatch.yml
@@ -26,6 +26,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - uses: peter-evans/slash-command-dispatch@v2
       with:
         commands: run-acceptance-tests

--- a/provider-ci/providers/spotinst/repo/.github/workflows/community-moderation.yml
+++ b/provider-ci/providers/spotinst/repo/.github/workflows/community-moderation.yml
@@ -7,6 +7,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - id: schema_changed
       name: Check for diff in schema
       uses: dorny/paths-filter@v2

--- a/provider-ci/providers/spotinst/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/spotinst/repo/.github/workflows/main.yml
@@ -27,6 +27,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -128,6 +130,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Configure AWS Credentials
       uses: aws-actions/configure-aws-credentials@v1
       with:
@@ -181,6 +185,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -219,6 +225,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -255,6 +263,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -330,6 +340,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -386,6 +398,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -495,6 +509,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:

--- a/provider-ci/providers/spotinst/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/spotinst/repo/.github/workflows/master.yml
@@ -27,6 +27,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -128,6 +130,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Configure AWS Credentials
       uses: aws-actions/configure-aws-credentials@v1
       with:
@@ -181,6 +185,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -219,6 +225,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -255,6 +263,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -330,6 +340,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -386,6 +398,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -495,6 +509,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:

--- a/provider-ci/providers/spotinst/repo/.github/workflows/nightly-test.yml
+++ b/provider-ci/providers/spotinst/repo/.github/workflows/nightly-test.yml
@@ -27,6 +27,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -124,6 +126,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -199,6 +203,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:

--- a/provider-ci/providers/spotinst/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/spotinst/repo/.github/workflows/prerelease.yml
@@ -27,6 +27,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -125,6 +127,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -163,6 +167,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -199,6 +205,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -274,6 +282,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -330,6 +340,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -439,6 +451,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:

--- a/provider-ci/providers/spotinst/repo/.github/workflows/pull-request.yml
+++ b/provider-ci/providers/spotinst/repo/.github/workflows/pull-request.yml
@@ -27,6 +27,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Comment PR
       uses: thollander/actions-comment-pull-request@v1
       with:

--- a/provider-ci/providers/spotinst/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/spotinst/repo/.github/workflows/release.yml
@@ -27,6 +27,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -139,6 +141,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -177,6 +181,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -213,6 +219,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -288,6 +296,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -343,6 +353,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -452,6 +464,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Install pulumictl
       uses: jaxxstorm/action-install-gh-release@v1.5.0
       with:
@@ -466,6 +480,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:

--- a/provider-ci/providers/spotinst/repo/.github/workflows/update-bridge.yml
+++ b/provider-ci/providers/spotinst/repo/.github/workflows/update-bridge.yml
@@ -9,6 +9,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/provider-ci/providers/spotinst/repo/.github/workflows/update-upstream-provider.yml
+++ b/provider-ci/providers/spotinst/repo/.github/workflows/update-upstream-provider.yml
@@ -35,6 +35,8 @@ jobs:
         name=run-url::https://github.com/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/provider-ci/providers/sumologic/repo/.github/workflows/command-dispatch.yml
+++ b/provider-ci/providers/sumologic/repo/.github/workflows/command-dispatch.yml
@@ -26,6 +26,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - uses: peter-evans/slash-command-dispatch@v2
       with:
         commands: run-acceptance-tests

--- a/provider-ci/providers/sumologic/repo/.github/workflows/community-moderation.yml
+++ b/provider-ci/providers/sumologic/repo/.github/workflows/community-moderation.yml
@@ -7,6 +7,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - id: schema_changed
       name: Check for diff in schema
       uses: dorny/paths-filter@v2

--- a/provider-ci/providers/sumologic/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/sumologic/repo/.github/workflows/main.yml
@@ -27,6 +27,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -128,6 +130,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Configure AWS Credentials
       uses: aws-actions/configure-aws-credentials@v1
       with:
@@ -181,6 +185,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -219,6 +225,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -255,6 +263,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -330,6 +340,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -386,6 +398,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -495,6 +509,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:

--- a/provider-ci/providers/sumologic/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/sumologic/repo/.github/workflows/master.yml
@@ -27,6 +27,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -128,6 +130,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Configure AWS Credentials
       uses: aws-actions/configure-aws-credentials@v1
       with:
@@ -181,6 +185,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -219,6 +225,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -255,6 +263,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -330,6 +340,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -386,6 +398,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -495,6 +509,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:

--- a/provider-ci/providers/sumologic/repo/.github/workflows/nightly-test.yml
+++ b/provider-ci/providers/sumologic/repo/.github/workflows/nightly-test.yml
@@ -27,6 +27,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -124,6 +126,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -199,6 +203,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:

--- a/provider-ci/providers/sumologic/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/sumologic/repo/.github/workflows/prerelease.yml
@@ -27,6 +27,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -125,6 +127,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -163,6 +167,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -199,6 +205,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -274,6 +282,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -330,6 +340,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -439,6 +451,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:

--- a/provider-ci/providers/sumologic/repo/.github/workflows/pull-request.yml
+++ b/provider-ci/providers/sumologic/repo/.github/workflows/pull-request.yml
@@ -27,6 +27,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Comment PR
       uses: thollander/actions-comment-pull-request@v1
       with:

--- a/provider-ci/providers/sumologic/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/sumologic/repo/.github/workflows/release.yml
@@ -27,6 +27,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -139,6 +141,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -177,6 +181,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -213,6 +219,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -288,6 +296,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -343,6 +353,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -452,6 +464,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Install pulumictl
       uses: jaxxstorm/action-install-gh-release@v1.5.0
       with:
@@ -466,6 +480,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:

--- a/provider-ci/providers/sumologic/repo/.github/workflows/update-bridge.yml
+++ b/provider-ci/providers/sumologic/repo/.github/workflows/update-bridge.yml
@@ -9,6 +9,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/provider-ci/providers/sumologic/repo/.github/workflows/update-upstream-provider.yml
+++ b/provider-ci/providers/sumologic/repo/.github/workflows/update-upstream-provider.yml
@@ -35,6 +35,8 @@ jobs:
         name=run-url::https://github.com/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/provider-ci/providers/tailscale/repo/.github/workflows/command-dispatch.yml
+++ b/provider-ci/providers/tailscale/repo/.github/workflows/command-dispatch.yml
@@ -25,6 +25,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - uses: peter-evans/slash-command-dispatch@v2
       with:
         commands: run-acceptance-tests

--- a/provider-ci/providers/tailscale/repo/.github/workflows/community-moderation.yml
+++ b/provider-ci/providers/tailscale/repo/.github/workflows/community-moderation.yml
@@ -7,6 +7,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - id: schema_changed
       name: Check for diff in schema
       uses: dorny/paths-filter@v2

--- a/provider-ci/providers/tailscale/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/tailscale/repo/.github/workflows/main.yml
@@ -26,6 +26,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -127,6 +129,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Configure AWS Credentials
       uses: aws-actions/configure-aws-credentials@v1
       with:
@@ -180,6 +184,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -218,6 +224,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -254,6 +262,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -329,6 +339,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -385,6 +397,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -494,6 +508,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:

--- a/provider-ci/providers/tailscale/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/tailscale/repo/.github/workflows/master.yml
@@ -26,6 +26,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -127,6 +129,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Configure AWS Credentials
       uses: aws-actions/configure-aws-credentials@v1
       with:
@@ -180,6 +184,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -218,6 +224,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -254,6 +262,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -329,6 +339,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -385,6 +397,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -494,6 +508,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:

--- a/provider-ci/providers/tailscale/repo/.github/workflows/nightly-test.yml
+++ b/provider-ci/providers/tailscale/repo/.github/workflows/nightly-test.yml
@@ -26,6 +26,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -123,6 +125,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -198,6 +202,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:

--- a/provider-ci/providers/tailscale/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/tailscale/repo/.github/workflows/prerelease.yml
@@ -26,6 +26,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -124,6 +126,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -162,6 +166,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -198,6 +204,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -273,6 +281,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -329,6 +339,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -438,6 +450,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:

--- a/provider-ci/providers/tailscale/repo/.github/workflows/pull-request.yml
+++ b/provider-ci/providers/tailscale/repo/.github/workflows/pull-request.yml
@@ -26,6 +26,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Comment PR
       uses: thollander/actions-comment-pull-request@v1
       with:

--- a/provider-ci/providers/tailscale/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/tailscale/repo/.github/workflows/release.yml
@@ -26,6 +26,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -138,6 +140,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -176,6 +180,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -212,6 +218,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -287,6 +295,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -342,6 +352,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -451,6 +463,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Install pulumictl
       uses: jaxxstorm/action-install-gh-release@v1.5.0
       with:
@@ -465,6 +479,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:

--- a/provider-ci/providers/tailscale/repo/.github/workflows/update-bridge.yml
+++ b/provider-ci/providers/tailscale/repo/.github/workflows/update-bridge.yml
@@ -9,6 +9,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/provider-ci/providers/tailscale/repo/.github/workflows/update-upstream-provider.yml
+++ b/provider-ci/providers/tailscale/repo/.github/workflows/update-upstream-provider.yml
@@ -34,6 +34,8 @@ jobs:
         name=run-url::https://github.com/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/provider-ci/providers/tls/repo/.github/workflows/command-dispatch.yml
+++ b/provider-ci/providers/tls/repo/.github/workflows/command-dispatch.yml
@@ -23,6 +23,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - uses: peter-evans/slash-command-dispatch@v2
       with:
         commands: run-acceptance-tests

--- a/provider-ci/providers/tls/repo/.github/workflows/community-moderation.yml
+++ b/provider-ci/providers/tls/repo/.github/workflows/community-moderation.yml
@@ -7,6 +7,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - id: schema_changed
       name: Check for diff in schema
       uses: dorny/paths-filter@v2

--- a/provider-ci/providers/tls/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/tls/repo/.github/workflows/main.yml
@@ -24,6 +24,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -125,6 +127,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Configure AWS Credentials
       uses: aws-actions/configure-aws-credentials@v1
       with:
@@ -178,6 +182,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -216,6 +222,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -252,6 +260,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -327,6 +337,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -383,6 +395,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -492,6 +506,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:

--- a/provider-ci/providers/tls/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/tls/repo/.github/workflows/master.yml
@@ -24,6 +24,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -125,6 +127,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Configure AWS Credentials
       uses: aws-actions/configure-aws-credentials@v1
       with:
@@ -178,6 +182,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -216,6 +222,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -252,6 +260,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -327,6 +337,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -383,6 +395,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -492,6 +506,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:

--- a/provider-ci/providers/tls/repo/.github/workflows/nightly-test.yml
+++ b/provider-ci/providers/tls/repo/.github/workflows/nightly-test.yml
@@ -24,6 +24,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -121,6 +123,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -196,6 +200,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:

--- a/provider-ci/providers/tls/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/tls/repo/.github/workflows/prerelease.yml
@@ -24,6 +24,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -122,6 +124,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -160,6 +164,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -196,6 +202,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -271,6 +279,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -327,6 +337,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -436,6 +448,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:

--- a/provider-ci/providers/tls/repo/.github/workflows/pull-request.yml
+++ b/provider-ci/providers/tls/repo/.github/workflows/pull-request.yml
@@ -24,6 +24,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Comment PR
       uses: thollander/actions-comment-pull-request@v1
       with:

--- a/provider-ci/providers/tls/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/tls/repo/.github/workflows/release.yml
@@ -24,6 +24,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -136,6 +138,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -174,6 +178,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -210,6 +216,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -285,6 +293,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -340,6 +350,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -449,6 +461,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Install pulumictl
       uses: jaxxstorm/action-install-gh-release@v1.5.0
       with:
@@ -463,6 +477,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:

--- a/provider-ci/providers/tls/repo/.github/workflows/update-bridge.yml
+++ b/provider-ci/providers/tls/repo/.github/workflows/update-bridge.yml
@@ -9,6 +9,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/provider-ci/providers/tls/repo/.github/workflows/update-upstream-provider.yml
+++ b/provider-ci/providers/tls/repo/.github/workflows/update-upstream-provider.yml
@@ -32,6 +32,8 @@ jobs:
         name=run-url::https://github.com/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/provider-ci/providers/vault/repo/.github/workflows/command-dispatch.yml
+++ b/provider-ci/providers/vault/repo/.github/workflows/command-dispatch.yml
@@ -23,6 +23,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - uses: peter-evans/slash-command-dispatch@v2
       with:
         commands: run-acceptance-tests

--- a/provider-ci/providers/vault/repo/.github/workflows/community-moderation.yml
+++ b/provider-ci/providers/vault/repo/.github/workflows/community-moderation.yml
@@ -7,6 +7,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - id: schema_changed
       name: Check for diff in schema
       uses: dorny/paths-filter@v2

--- a/provider-ci/providers/vault/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/vault/repo/.github/workflows/main.yml
@@ -24,6 +24,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -125,6 +127,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Configure AWS Credentials
       uses: aws-actions/configure-aws-credentials@v1
       with:
@@ -178,6 +182,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -216,6 +222,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -252,6 +260,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -327,6 +337,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -383,6 +395,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -492,6 +506,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:

--- a/provider-ci/providers/vault/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/vault/repo/.github/workflows/master.yml
@@ -24,6 +24,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -125,6 +127,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Configure AWS Credentials
       uses: aws-actions/configure-aws-credentials@v1
       with:
@@ -178,6 +182,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -216,6 +222,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -252,6 +260,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -327,6 +337,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -383,6 +395,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -492,6 +506,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:

--- a/provider-ci/providers/vault/repo/.github/workflows/nightly-test.yml
+++ b/provider-ci/providers/vault/repo/.github/workflows/nightly-test.yml
@@ -24,6 +24,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -121,6 +123,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -196,6 +200,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:

--- a/provider-ci/providers/vault/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/vault/repo/.github/workflows/prerelease.yml
@@ -24,6 +24,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -122,6 +124,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -160,6 +164,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -196,6 +202,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -271,6 +279,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -327,6 +337,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -436,6 +448,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:

--- a/provider-ci/providers/vault/repo/.github/workflows/pull-request.yml
+++ b/provider-ci/providers/vault/repo/.github/workflows/pull-request.yml
@@ -24,6 +24,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Comment PR
       uses: thollander/actions-comment-pull-request@v1
       with:

--- a/provider-ci/providers/vault/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/vault/repo/.github/workflows/release.yml
@@ -24,6 +24,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -136,6 +138,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -174,6 +178,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -210,6 +216,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -285,6 +293,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -340,6 +350,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -449,6 +461,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Install pulumictl
       uses: jaxxstorm/action-install-gh-release@v1.5.0
       with:
@@ -463,6 +477,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:

--- a/provider-ci/providers/vault/repo/.github/workflows/update-bridge.yml
+++ b/provider-ci/providers/vault/repo/.github/workflows/update-bridge.yml
@@ -9,6 +9,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/provider-ci/providers/vault/repo/.github/workflows/update-upstream-provider.yml
+++ b/provider-ci/providers/vault/repo/.github/workflows/update-upstream-provider.yml
@@ -32,6 +32,8 @@ jobs:
         name=run-url::https://github.com/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/provider-ci/providers/venafi/repo/.github/workflows/command-dispatch.yml
+++ b/provider-ci/providers/venafi/repo/.github/workflows/command-dispatch.yml
@@ -26,6 +26,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - uses: peter-evans/slash-command-dispatch@v2
       with:
         commands: run-acceptance-tests

--- a/provider-ci/providers/venafi/repo/.github/workflows/community-moderation.yml
+++ b/provider-ci/providers/venafi/repo/.github/workflows/community-moderation.yml
@@ -7,6 +7,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - id: schema_changed
       name: Check for diff in schema
       uses: dorny/paths-filter@v2

--- a/provider-ci/providers/venafi/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/venafi/repo/.github/workflows/main.yml
@@ -27,6 +27,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -128,6 +130,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Configure AWS Credentials
       uses: aws-actions/configure-aws-credentials@v1
       with:
@@ -181,6 +185,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -219,6 +225,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -255,6 +263,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -330,6 +340,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -386,6 +398,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -495,6 +509,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:

--- a/provider-ci/providers/venafi/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/venafi/repo/.github/workflows/master.yml
@@ -27,6 +27,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -128,6 +130,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Configure AWS Credentials
       uses: aws-actions/configure-aws-credentials@v1
       with:
@@ -181,6 +185,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -219,6 +225,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -255,6 +263,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -330,6 +340,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -386,6 +398,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -495,6 +509,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:

--- a/provider-ci/providers/venafi/repo/.github/workflows/nightly-test.yml
+++ b/provider-ci/providers/venafi/repo/.github/workflows/nightly-test.yml
@@ -27,6 +27,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -124,6 +126,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -199,6 +203,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:

--- a/provider-ci/providers/venafi/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/venafi/repo/.github/workflows/prerelease.yml
@@ -27,6 +27,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -125,6 +127,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -163,6 +167,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -199,6 +205,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -274,6 +282,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -330,6 +340,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -439,6 +451,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:

--- a/provider-ci/providers/venafi/repo/.github/workflows/pull-request.yml
+++ b/provider-ci/providers/venafi/repo/.github/workflows/pull-request.yml
@@ -27,6 +27,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Comment PR
       uses: thollander/actions-comment-pull-request@v1
       with:

--- a/provider-ci/providers/venafi/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/venafi/repo/.github/workflows/release.yml
@@ -27,6 +27,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -139,6 +141,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -177,6 +181,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -213,6 +219,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -288,6 +296,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -343,6 +353,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -452,6 +464,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Install pulumictl
       uses: jaxxstorm/action-install-gh-release@v1.5.0
       with:
@@ -466,6 +480,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:

--- a/provider-ci/providers/venafi/repo/.github/workflows/update-bridge.yml
+++ b/provider-ci/providers/venafi/repo/.github/workflows/update-bridge.yml
@@ -9,6 +9,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/provider-ci/providers/venafi/repo/.github/workflows/update-upstream-provider.yml
+++ b/provider-ci/providers/venafi/repo/.github/workflows/update-upstream-provider.yml
@@ -35,6 +35,8 @@ jobs:
         name=run-url::https://github.com/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/provider-ci/providers/vsphere/repo/.github/workflows/command-dispatch.yml
+++ b/provider-ci/providers/vsphere/repo/.github/workflows/command-dispatch.yml
@@ -23,6 +23,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - uses: peter-evans/slash-command-dispatch@v2
       with:
         commands: run-acceptance-tests

--- a/provider-ci/providers/vsphere/repo/.github/workflows/community-moderation.yml
+++ b/provider-ci/providers/vsphere/repo/.github/workflows/community-moderation.yml
@@ -7,6 +7,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - id: schema_changed
       name: Check for diff in schema
       uses: dorny/paths-filter@v2

--- a/provider-ci/providers/vsphere/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/vsphere/repo/.github/workflows/main.yml
@@ -24,6 +24,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -125,6 +127,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Configure AWS Credentials
       uses: aws-actions/configure-aws-credentials@v1
       with:
@@ -178,6 +182,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -216,6 +222,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -252,6 +260,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -327,6 +337,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -383,6 +395,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -492,6 +506,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:

--- a/provider-ci/providers/vsphere/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/vsphere/repo/.github/workflows/master.yml
@@ -24,6 +24,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -125,6 +127,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Configure AWS Credentials
       uses: aws-actions/configure-aws-credentials@v1
       with:
@@ -178,6 +182,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -216,6 +222,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -252,6 +260,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -327,6 +337,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -383,6 +395,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -492,6 +506,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:

--- a/provider-ci/providers/vsphere/repo/.github/workflows/nightly-test.yml
+++ b/provider-ci/providers/vsphere/repo/.github/workflows/nightly-test.yml
@@ -24,6 +24,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -121,6 +123,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -196,6 +200,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:

--- a/provider-ci/providers/vsphere/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/vsphere/repo/.github/workflows/prerelease.yml
@@ -24,6 +24,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -122,6 +124,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -160,6 +164,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -196,6 +202,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -271,6 +279,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -327,6 +337,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -436,6 +448,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:

--- a/provider-ci/providers/vsphere/repo/.github/workflows/pull-request.yml
+++ b/provider-ci/providers/vsphere/repo/.github/workflows/pull-request.yml
@@ -24,6 +24,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Comment PR
       uses: thollander/actions-comment-pull-request@v1
       with:

--- a/provider-ci/providers/vsphere/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/vsphere/repo/.github/workflows/release.yml
@@ -24,6 +24,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -136,6 +138,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -174,6 +178,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -210,6 +216,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -285,6 +293,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -340,6 +350,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -449,6 +461,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Install pulumictl
       uses: jaxxstorm/action-install-gh-release@v1.5.0
       with:
@@ -463,6 +477,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:

--- a/provider-ci/providers/vsphere/repo/.github/workflows/update-bridge.yml
+++ b/provider-ci/providers/vsphere/repo/.github/workflows/update-bridge.yml
@@ -9,6 +9,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/provider-ci/providers/vsphere/repo/.github/workflows/update-upstream-provider.yml
+++ b/provider-ci/providers/vsphere/repo/.github/workflows/update-upstream-provider.yml
@@ -32,6 +32,8 @@ jobs:
         name=run-url::https://github.com/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/provider-ci/providers/wavefront/repo/.github/workflows/command-dispatch.yml
+++ b/provider-ci/providers/wavefront/repo/.github/workflows/command-dispatch.yml
@@ -25,6 +25,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - uses: peter-evans/slash-command-dispatch@v2
       with:
         commands: run-acceptance-tests

--- a/provider-ci/providers/wavefront/repo/.github/workflows/community-moderation.yml
+++ b/provider-ci/providers/wavefront/repo/.github/workflows/community-moderation.yml
@@ -7,6 +7,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - id: schema_changed
       name: Check for diff in schema
       uses: dorny/paths-filter@v2

--- a/provider-ci/providers/wavefront/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/wavefront/repo/.github/workflows/main.yml
@@ -26,6 +26,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -127,6 +129,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Configure AWS Credentials
       uses: aws-actions/configure-aws-credentials@v1
       with:
@@ -180,6 +184,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -218,6 +224,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -254,6 +262,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -329,6 +339,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -385,6 +397,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -494,6 +508,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:

--- a/provider-ci/providers/wavefront/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/wavefront/repo/.github/workflows/master.yml
@@ -26,6 +26,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -127,6 +129,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Configure AWS Credentials
       uses: aws-actions/configure-aws-credentials@v1
       with:
@@ -180,6 +184,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -218,6 +224,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -254,6 +262,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -329,6 +339,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -385,6 +397,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -494,6 +508,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:

--- a/provider-ci/providers/wavefront/repo/.github/workflows/nightly-test.yml
+++ b/provider-ci/providers/wavefront/repo/.github/workflows/nightly-test.yml
@@ -26,6 +26,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -123,6 +125,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -198,6 +202,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:

--- a/provider-ci/providers/wavefront/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/wavefront/repo/.github/workflows/prerelease.yml
@@ -26,6 +26,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -124,6 +126,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -162,6 +166,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -198,6 +204,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -273,6 +281,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -329,6 +339,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -438,6 +450,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:

--- a/provider-ci/providers/wavefront/repo/.github/workflows/pull-request.yml
+++ b/provider-ci/providers/wavefront/repo/.github/workflows/pull-request.yml
@@ -26,6 +26,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Comment PR
       uses: thollander/actions-comment-pull-request@v1
       with:

--- a/provider-ci/providers/wavefront/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/wavefront/repo/.github/workflows/release.yml
@@ -26,6 +26,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -138,6 +140,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -176,6 +180,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -212,6 +218,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -287,6 +295,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -342,6 +352,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:
@@ -451,6 +463,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Install pulumictl
       uses: jaxxstorm/action-install-gh-release@v1.5.0
       with:
@@ -465,6 +479,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Checkout Scripts Repo
       uses: actions/checkout@v2
       with:

--- a/provider-ci/providers/wavefront/repo/.github/workflows/update-bridge.yml
+++ b/provider-ci/providers/wavefront/repo/.github/workflows/update-bridge.yml
@@ -9,6 +9,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/provider-ci/providers/wavefront/repo/.github/workflows/update-upstream-provider.yml
+++ b/provider-ci/providers/wavefront/repo/.github/workflows/update-upstream-provider.yml
@@ -34,6 +34,8 @@ jobs:
         name=run-url::https://github.com/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        lfs: true
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/provider-ci/src/steps.ts
+++ b/provider-ci/src/steps.ts
@@ -7,6 +7,9 @@ export function CheckoutRepoStep(): Step {
   return {
     name: "Checkout Repo",
     uses: action.checkout,
+    with: {
+      lfs: true,
+    },
   };
 }
 


### PR DESCRIPTION
The pulumi-aws provider has exceeded the size of a git supported file
it is now great than 100MB.... this PR enables git lfs as part of check
out rules so that we can interact with files this big
