### PR TITLE
Splitting the publishing of the Java SDK

### DIFF
--- a/native-provider-ci/providers/aws-native/repo/.github/workflows/build.yml
+++ b/native-provider-ci/providers/aws-native/repo/.github/workflows/build.yml
@@ -413,8 +413,6 @@ jobs:
         - "3.7"
         nodeversion:
         - 14.x
-        javaversion:
-        - "11"
     name: publish_sdk
     steps:
     - name: Checkout Repo
@@ -451,12 +449,6 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{matrix.pythonversion}}
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        java-version: ${{matrix.javaversion}}
-        distribution: temurin
-        cache: gradle
     - name: Download python SDK
       uses: actions/download-artifact@v2
       with:
@@ -481,6 +473,59 @@ jobs:
     - name: Uncompress nodejs SDK
       run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
         ${{github.workspace}}/sdk/nodejs
+    - name: Install Twine
+      run: python -m pip install pip twine
+    - name: Publish SDKs
+      run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
+      env:
+        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+    - if: failure() && github.event_name == 'push'
+      name: Notify Slack
+      uses: 8398a7/action-slack@v3
+      with:
+        author_name: Failure in publishing SDK
+        fields: repo,commit,author,action
+        status: ${{ job.status }}
+  publish_java_sdk:
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    needs: publish
+    strategy:
+      fail-fast: true
+      matrix:
+        goversion:
+        - 1.19.x
+        javaversion:
+        - "11"
+    name: publish_java_sdk
+    steps:
+    - name: Checkout Repo
+      uses: actions/checkout@v3
+      with:
+        lfs: true
+    - name: Checkout Scripts Repo
+      uses: actions/checkout@v3
+      with:
+        path: ci-scripts
+        repository: pulumi/scripts
+    - name: Unshallow clone for tags
+      run: git fetch --prune --unshallow --tags
+    - name: Install Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: ${{matrix.goversion}}
+    - name: Install pulumictl
+      uses: jaxxstorm/action-install-gh-release@v1.5.0
+      with:
+        repo: pulumi/pulumictl
+    - name: Install Pulumi CLI
+      uses: pulumi/action-install-pulumi-cli@v2
+    - name: Setup Java
+      uses: actions/setup-java@v3
+      with:
+        java-version: ${{matrix.javaversion}}
+        distribution: temurin
+        cache: gradle
     - name: Download java SDK
       uses: actions/download-artifact@v2
       with:
@@ -504,10 +549,3 @@ jobs:
         arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
         build-root-directory: ./sdk/java
         gradle-version: 7.4.1
-    - if: failure() && github.event_name == 'push'
-      name: Notify Slack
-      uses: 8398a7/action-slack@v3
-      with:
-        author_name: Failure in publishing SDK
-        fields: repo,commit,author,action
-        status: ${{ job.status }}

--- a/native-provider-ci/providers/aws-native/repo/.github/workflows/prerelease.yml
+++ b/native-provider-ci/providers/aws-native/repo/.github/workflows/prerelease.yml
@@ -404,8 +404,6 @@ jobs:
         - "3.7"
         nodeversion:
         - 14.x
-        javaversion:
-        - "11"
     name: publish_sdk
     steps:
     - name: Checkout Repo
@@ -442,12 +440,6 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{matrix.pythonversion}}
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        java-version: ${{matrix.javaversion}}
-        distribution: temurin
-        cache: gradle
     - name: Download python SDK
       uses: actions/download-artifact@v2
       with:
@@ -472,6 +464,59 @@ jobs:
     - name: Uncompress nodejs SDK
       run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
         ${{github.workspace}}/sdk/nodejs
+    - name: Install Twine
+      run: python -m pip install pip twine
+    - name: Publish SDKs
+      run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
+      env:
+        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+    - if: failure() && github.event_name == 'push'
+      name: Notify Slack
+      uses: 8398a7/action-slack@v3
+      with:
+        author_name: Failure in publishing SDK
+        fields: repo,commit,author,action
+        status: ${{ job.status }}
+  publish_java_sdk:
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    needs: publish
+    strategy:
+      fail-fast: true
+      matrix:
+        goversion:
+        - 1.19.x
+        javaversion:
+        - "11"
+    name: publish_java_sdk
+    steps:
+    - name: Checkout Repo
+      uses: actions/checkout@v3
+      with:
+        lfs: true
+    - name: Checkout Scripts Repo
+      uses: actions/checkout@v3
+      with:
+        path: ci-scripts
+        repository: pulumi/scripts
+    - name: Unshallow clone for tags
+      run: git fetch --prune --unshallow --tags
+    - name: Install Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: ${{matrix.goversion}}
+    - name: Install pulumictl
+      uses: jaxxstorm/action-install-gh-release@v1.5.0
+      with:
+        repo: pulumi/pulumictl
+    - name: Install Pulumi CLI
+      uses: pulumi/action-install-pulumi-cli@v2
+    - name: Setup Java
+      uses: actions/setup-java@v3
+      with:
+        java-version: ${{matrix.javaversion}}
+        distribution: temurin
+        cache: gradle
     - name: Download java SDK
       uses: actions/download-artifact@v2
       with:
@@ -495,10 +540,3 @@ jobs:
         arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
         build-root-directory: ./sdk/java
         gradle-version: 7.4.1
-    - if: failure() && github.event_name == 'push'
-      name: Notify Slack
-      uses: 8398a7/action-slack@v3
-      with:
-        author_name: Failure in publishing SDK
-        fields: repo,commit,author,action
-        status: ${{ job.status }}

--- a/native-provider-ci/providers/aws-native/repo/.github/workflows/release.yml
+++ b/native-provider-ci/providers/aws-native/repo/.github/workflows/release.yml
@@ -411,8 +411,6 @@ jobs:
         - "3.7"
         nodeversion:
         - 14.x
-        javaversion:
-        - "11"
     name: publish_sdks
     steps:
     - name: Checkout Repo
@@ -449,12 +447,6 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{matrix.pythonversion}}
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        java-version: ${{matrix.javaversion}}
-        distribution: temurin
-        cache: gradle
     - name: Download python SDK
       uses: actions/download-artifact@v2
       with:
@@ -479,6 +471,59 @@ jobs:
     - name: Uncompress nodejs SDK
       run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
         ${{github.workspace}}/sdk/nodejs
+    - name: Install Twine
+      run: python -m pip install pip twine
+    - name: Publish SDKs
+      run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
+      env:
+        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+    - if: failure() && github.event_name == 'push'
+      name: Notify Slack
+      uses: 8398a7/action-slack@v3
+      with:
+        author_name: Failure in publishing SDK
+        fields: repo,commit,author,action
+        status: ${{ job.status }}
+  publish_java_sdk:
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    needs: publish
+    strategy:
+      fail-fast: true
+      matrix:
+        goversion:
+        - 1.19.x
+        javaversion:
+        - "11"
+    name: publish_java_sdk
+    steps:
+    - name: Checkout Repo
+      uses: actions/checkout@v3
+      with:
+        lfs: true
+    - name: Checkout Scripts Repo
+      uses: actions/checkout@v3
+      with:
+        path: ci-scripts
+        repository: pulumi/scripts
+    - name: Unshallow clone for tags
+      run: git fetch --prune --unshallow --tags
+    - name: Install Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: ${{matrix.goversion}}
+    - name: Install pulumictl
+      uses: jaxxstorm/action-install-gh-release@v1.5.0
+      with:
+        repo: pulumi/pulumictl
+    - name: Install Pulumi CLI
+      uses: pulumi/action-install-pulumi-cli@v2
+    - name: Setup Java
+      uses: actions/setup-java@v3
+      with:
+        java-version: ${{matrix.javaversion}}
+        distribution: temurin
+        cache: gradle
     - name: Download java SDK
       uses: actions/download-artifact@v2
       with:
@@ -502,13 +547,6 @@ jobs:
         arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
         build-root-directory: ./sdk/java
         gradle-version: 7.4.1
-    - if: failure() && github.event_name == 'push'
-      name: Notify Slack
-      uses: 8398a7/action-slack@v3
-      with:
-        author_name: Failure in publishing SDK
-        fields: repo,commit,author,action
-        status: ${{ job.status }}
   tag_sdk:
     runs-on: ubuntu-latest
     needs: publish_sdk

--- a/native-provider-ci/providers/azure-native/repo/.github/workflows/build.yml
+++ b/native-provider-ci/providers/azure-native/repo/.github/workflows/build.yml
@@ -416,8 +416,6 @@ jobs:
         - "3.7"
         nodeversion:
         - 14.x
-        javaversion:
-        - "11"
     name: publish_sdk
     steps:
     - name: Checkout Repo
@@ -454,12 +452,6 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{matrix.pythonversion}}
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        java-version: ${{matrix.javaversion}}
-        distribution: temurin
-        cache: gradle
     - name: Download python SDK
       uses: actions/download-artifact@v2
       with:
@@ -484,6 +476,59 @@ jobs:
     - name: Uncompress nodejs SDK
       run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
         ${{github.workspace}}/sdk/nodejs
+    - name: Install Twine
+      run: python -m pip install pip twine
+    - name: Publish SDKs
+      run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
+      env:
+        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+    - if: failure() && github.event_name == 'push'
+      name: Notify Slack
+      uses: 8398a7/action-slack@v3
+      with:
+        author_name: Failure in publishing SDK
+        fields: repo,commit,author,action
+        status: ${{ job.status }}
+  publish_java_sdk:
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    needs: publish
+    strategy:
+      fail-fast: true
+      matrix:
+        goversion:
+        - 1.19.x
+        javaversion:
+        - "11"
+    name: publish_java_sdk
+    steps:
+    - name: Checkout Repo
+      uses: actions/checkout@v3
+      with:
+        lfs: true
+    - name: Checkout Scripts Repo
+      uses: actions/checkout@v3
+      with:
+        path: ci-scripts
+        repository: pulumi/scripts
+    - name: Unshallow clone for tags
+      run: git fetch --prune --unshallow --tags
+    - name: Install Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: ${{matrix.goversion}}
+    - name: Install pulumictl
+      uses: jaxxstorm/action-install-gh-release@v1.5.0
+      with:
+        repo: pulumi/pulumictl
+    - name: Install Pulumi CLI
+      uses: pulumi/action-install-pulumi-cli@v2
+    - name: Setup Java
+      uses: actions/setup-java@v3
+      with:
+        java-version: ${{matrix.javaversion}}
+        distribution: temurin
+        cache: gradle
     - name: Download java SDK
       uses: actions/download-artifact@v2
       with:
@@ -507,10 +552,3 @@ jobs:
         arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
         build-root-directory: ./sdk/java
         gradle-version: 7.4.1
-    - if: failure() && github.event_name == 'push'
-      name: Notify Slack
-      uses: 8398a7/action-slack@v3
-      with:
-        author_name: Failure in publishing SDK
-        fields: repo,commit,author,action
-        status: ${{ job.status }}

--- a/native-provider-ci/providers/azure-native/repo/.github/workflows/prerelease.yml
+++ b/native-provider-ci/providers/azure-native/repo/.github/workflows/prerelease.yml
@@ -407,8 +407,6 @@ jobs:
         - "3.7"
         nodeversion:
         - 14.x
-        javaversion:
-        - "11"
     name: publish_sdk
     steps:
     - name: Checkout Repo
@@ -445,12 +443,6 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{matrix.pythonversion}}
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        java-version: ${{matrix.javaversion}}
-        distribution: temurin
-        cache: gradle
     - name: Download python SDK
       uses: actions/download-artifact@v2
       with:
@@ -475,6 +467,59 @@ jobs:
     - name: Uncompress nodejs SDK
       run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
         ${{github.workspace}}/sdk/nodejs
+    - name: Install Twine
+      run: python -m pip install pip twine
+    - name: Publish SDKs
+      run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
+      env:
+        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+    - if: failure() && github.event_name == 'push'
+      name: Notify Slack
+      uses: 8398a7/action-slack@v3
+      with:
+        author_name: Failure in publishing SDK
+        fields: repo,commit,author,action
+        status: ${{ job.status }}
+  publish_java_sdk:
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    needs: publish
+    strategy:
+      fail-fast: true
+      matrix:
+        goversion:
+        - 1.19.x
+        javaversion:
+        - "11"
+    name: publish_java_sdk
+    steps:
+    - name: Checkout Repo
+      uses: actions/checkout@v3
+      with:
+        lfs: true
+    - name: Checkout Scripts Repo
+      uses: actions/checkout@v3
+      with:
+        path: ci-scripts
+        repository: pulumi/scripts
+    - name: Unshallow clone for tags
+      run: git fetch --prune --unshallow --tags
+    - name: Install Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: ${{matrix.goversion}}
+    - name: Install pulumictl
+      uses: jaxxstorm/action-install-gh-release@v1.5.0
+      with:
+        repo: pulumi/pulumictl
+    - name: Install Pulumi CLI
+      uses: pulumi/action-install-pulumi-cli@v2
+    - name: Setup Java
+      uses: actions/setup-java@v3
+      with:
+        java-version: ${{matrix.javaversion}}
+        distribution: temurin
+        cache: gradle
     - name: Download java SDK
       uses: actions/download-artifact@v2
       with:
@@ -498,10 +543,3 @@ jobs:
         arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
         build-root-directory: ./sdk/java
         gradle-version: 7.4.1
-    - if: failure() && github.event_name == 'push'
-      name: Notify Slack
-      uses: 8398a7/action-slack@v3
-      with:
-        author_name: Failure in publishing SDK
-        fields: repo,commit,author,action
-        status: ${{ job.status }}

--- a/native-provider-ci/providers/azure-native/repo/.github/workflows/release.yml
+++ b/native-provider-ci/providers/azure-native/repo/.github/workflows/release.yml
@@ -414,8 +414,6 @@ jobs:
         - "3.7"
         nodeversion:
         - 14.x
-        javaversion:
-        - "11"
     name: publish_sdks
     steps:
     - name: Checkout Repo
@@ -452,12 +450,6 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{matrix.pythonversion}}
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        java-version: ${{matrix.javaversion}}
-        distribution: temurin
-        cache: gradle
     - name: Download python SDK
       uses: actions/download-artifact@v2
       with:
@@ -482,6 +474,59 @@ jobs:
     - name: Uncompress nodejs SDK
       run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
         ${{github.workspace}}/sdk/nodejs
+    - name: Install Twine
+      run: python -m pip install pip twine
+    - name: Publish SDKs
+      run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
+      env:
+        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+    - if: failure() && github.event_name == 'push'
+      name: Notify Slack
+      uses: 8398a7/action-slack@v3
+      with:
+        author_name: Failure in publishing SDK
+        fields: repo,commit,author,action
+        status: ${{ job.status }}
+  publish_java_sdk:
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    needs: publish
+    strategy:
+      fail-fast: true
+      matrix:
+        goversion:
+        - 1.19.x
+        javaversion:
+        - "11"
+    name: publish_java_sdk
+    steps:
+    - name: Checkout Repo
+      uses: actions/checkout@v3
+      with:
+        lfs: true
+    - name: Checkout Scripts Repo
+      uses: actions/checkout@v3
+      with:
+        path: ci-scripts
+        repository: pulumi/scripts
+    - name: Unshallow clone for tags
+      run: git fetch --prune --unshallow --tags
+    - name: Install Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: ${{matrix.goversion}}
+    - name: Install pulumictl
+      uses: jaxxstorm/action-install-gh-release@v1.5.0
+      with:
+        repo: pulumi/pulumictl
+    - name: Install Pulumi CLI
+      uses: pulumi/action-install-pulumi-cli@v2
+    - name: Setup Java
+      uses: actions/setup-java@v3
+      with:
+        java-version: ${{matrix.javaversion}}
+        distribution: temurin
+        cache: gradle
     - name: Download java SDK
       uses: actions/download-artifact@v2
       with:
@@ -505,13 +550,6 @@ jobs:
         arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
         build-root-directory: ./sdk/java
         gradle-version: 7.4.1
-    - if: failure() && github.event_name == 'push'
-      name: Notify Slack
-      uses: 8398a7/action-slack@v3
-      with:
-        author_name: Failure in publishing SDK
-        fields: repo,commit,author,action
-        status: ${{ job.status }}
   tag_sdk:
     runs-on: ubuntu-latest
     needs: publish_sdk

--- a/native-provider-ci/providers/command/repo/.github/workflows/build.yml
+++ b/native-provider-ci/providers/command/repo/.github/workflows/build.yml
@@ -375,8 +375,6 @@ jobs:
         - "3.7"
         nodeversion:
         - 14.x
-        javaversion:
-        - "11"
     name: publish_sdk
     steps:
     - name: Checkout Repo
@@ -413,12 +411,6 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{matrix.pythonversion}}
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        java-version: ${{matrix.javaversion}}
-        distribution: temurin
-        cache: gradle
     - name: Download python SDK
       uses: actions/download-artifact@v2
       with:
@@ -443,6 +435,59 @@ jobs:
     - name: Uncompress nodejs SDK
       run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
         ${{github.workspace}}/sdk/nodejs
+    - name: Install Twine
+      run: python -m pip install pip twine
+    - name: Publish SDKs
+      run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
+      env:
+        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+    - if: failure() && github.event_name == 'push'
+      name: Notify Slack
+      uses: 8398a7/action-slack@v3
+      with:
+        author_name: Failure in publishing SDK
+        fields: repo,commit,author,action
+        status: ${{ job.status }}
+  publish_java_sdk:
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    needs: publish
+    strategy:
+      fail-fast: true
+      matrix:
+        goversion:
+        - 1.19.x
+        javaversion:
+        - "11"
+    name: publish_java_sdk
+    steps:
+    - name: Checkout Repo
+      uses: actions/checkout@v3
+      with:
+        lfs: true
+    - name: Checkout Scripts Repo
+      uses: actions/checkout@v3
+      with:
+        path: ci-scripts
+        repository: pulumi/scripts
+    - name: Unshallow clone for tags
+      run: git fetch --prune --unshallow --tags
+    - name: Install Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: ${{matrix.goversion}}
+    - name: Install pulumictl
+      uses: jaxxstorm/action-install-gh-release@v1.5.0
+      with:
+        repo: pulumi/pulumictl
+    - name: Install Pulumi CLI
+      uses: pulumi/action-install-pulumi-cli@v2
+    - name: Setup Java
+      uses: actions/setup-java@v3
+      with:
+        java-version: ${{matrix.javaversion}}
+        distribution: temurin
+        cache: gradle
     - name: Download java SDK
       uses: actions/download-artifact@v2
       with:
@@ -466,10 +511,3 @@ jobs:
         arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
         build-root-directory: ./sdk/java
         gradle-version: 7.4.1
-    - if: failure() && github.event_name == 'push'
-      name: Notify Slack
-      uses: 8398a7/action-slack@v3
-      with:
-        author_name: Failure in publishing SDK
-        fields: repo,commit,author,action
-        status: ${{ job.status }}

--- a/native-provider-ci/providers/command/repo/.github/workflows/prerelease.yml
+++ b/native-provider-ci/providers/command/repo/.github/workflows/prerelease.yml
@@ -366,8 +366,6 @@ jobs:
         - "3.7"
         nodeversion:
         - 14.x
-        javaversion:
-        - "11"
     name: publish_sdk
     steps:
     - name: Checkout Repo
@@ -404,12 +402,6 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{matrix.pythonversion}}
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        java-version: ${{matrix.javaversion}}
-        distribution: temurin
-        cache: gradle
     - name: Download python SDK
       uses: actions/download-artifact@v2
       with:
@@ -434,6 +426,59 @@ jobs:
     - name: Uncompress nodejs SDK
       run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
         ${{github.workspace}}/sdk/nodejs
+    - name: Install Twine
+      run: python -m pip install pip twine
+    - name: Publish SDKs
+      run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
+      env:
+        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+    - if: failure() && github.event_name == 'push'
+      name: Notify Slack
+      uses: 8398a7/action-slack@v3
+      with:
+        author_name: Failure in publishing SDK
+        fields: repo,commit,author,action
+        status: ${{ job.status }}
+  publish_java_sdk:
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    needs: publish
+    strategy:
+      fail-fast: true
+      matrix:
+        goversion:
+        - 1.19.x
+        javaversion:
+        - "11"
+    name: publish_java_sdk
+    steps:
+    - name: Checkout Repo
+      uses: actions/checkout@v3
+      with:
+        lfs: true
+    - name: Checkout Scripts Repo
+      uses: actions/checkout@v3
+      with:
+        path: ci-scripts
+        repository: pulumi/scripts
+    - name: Unshallow clone for tags
+      run: git fetch --prune --unshallow --tags
+    - name: Install Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: ${{matrix.goversion}}
+    - name: Install pulumictl
+      uses: jaxxstorm/action-install-gh-release@v1.5.0
+      with:
+        repo: pulumi/pulumictl
+    - name: Install Pulumi CLI
+      uses: pulumi/action-install-pulumi-cli@v2
+    - name: Setup Java
+      uses: actions/setup-java@v3
+      with:
+        java-version: ${{matrix.javaversion}}
+        distribution: temurin
+        cache: gradle
     - name: Download java SDK
       uses: actions/download-artifact@v2
       with:
@@ -457,10 +502,3 @@ jobs:
         arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
         build-root-directory: ./sdk/java
         gradle-version: 7.4.1
-    - if: failure() && github.event_name == 'push'
-      name: Notify Slack
-      uses: 8398a7/action-slack@v3
-      with:
-        author_name: Failure in publishing SDK
-        fields: repo,commit,author,action
-        status: ${{ job.status }}

--- a/native-provider-ci/providers/command/repo/.github/workflows/release.yml
+++ b/native-provider-ci/providers/command/repo/.github/workflows/release.yml
@@ -373,8 +373,6 @@ jobs:
         - "3.7"
         nodeversion:
         - 14.x
-        javaversion:
-        - "11"
     name: publish_sdks
     steps:
     - name: Checkout Repo
@@ -411,12 +409,6 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{matrix.pythonversion}}
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        java-version: ${{matrix.javaversion}}
-        distribution: temurin
-        cache: gradle
     - name: Download python SDK
       uses: actions/download-artifact@v2
       with:
@@ -441,6 +433,59 @@ jobs:
     - name: Uncompress nodejs SDK
       run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
         ${{github.workspace}}/sdk/nodejs
+    - name: Install Twine
+      run: python -m pip install pip twine
+    - name: Publish SDKs
+      run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
+      env:
+        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+    - if: failure() && github.event_name == 'push'
+      name: Notify Slack
+      uses: 8398a7/action-slack@v3
+      with:
+        author_name: Failure in publishing SDK
+        fields: repo,commit,author,action
+        status: ${{ job.status }}
+  publish_java_sdk:
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    needs: publish
+    strategy:
+      fail-fast: true
+      matrix:
+        goversion:
+        - 1.19.x
+        javaversion:
+        - "11"
+    name: publish_java_sdk
+    steps:
+    - name: Checkout Repo
+      uses: actions/checkout@v3
+      with:
+        lfs: true
+    - name: Checkout Scripts Repo
+      uses: actions/checkout@v3
+      with:
+        path: ci-scripts
+        repository: pulumi/scripts
+    - name: Unshallow clone for tags
+      run: git fetch --prune --unshallow --tags
+    - name: Install Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: ${{matrix.goversion}}
+    - name: Install pulumictl
+      uses: jaxxstorm/action-install-gh-release@v1.5.0
+      with:
+        repo: pulumi/pulumictl
+    - name: Install Pulumi CLI
+      uses: pulumi/action-install-pulumi-cli@v2
+    - name: Setup Java
+      uses: actions/setup-java@v3
+      with:
+        java-version: ${{matrix.javaversion}}
+        distribution: temurin
+        cache: gradle
     - name: Download java SDK
       uses: actions/download-artifact@v2
       with:
@@ -464,13 +509,6 @@ jobs:
         arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
         build-root-directory: ./sdk/java
         gradle-version: 7.4.1
-    - if: failure() && github.event_name == 'push'
-      name: Notify Slack
-      uses: 8398a7/action-slack@v3
-      with:
-        author_name: Failure in publishing SDK
-        fields: repo,commit,author,action
-        status: ${{ job.status }}
   tag_sdk:
     runs-on: ubuntu-latest
     needs: publish_sdk

--- a/native-provider-ci/providers/google-native/repo/.github/workflows/build.yml
+++ b/native-provider-ci/providers/google-native/repo/.github/workflows/build.yml
@@ -422,8 +422,6 @@ jobs:
         - "3.7"
         nodeversion:
         - 14.x
-        javaversion:
-        - "11"
     name: publish_sdk
     steps:
     - name: Checkout Repo
@@ -460,12 +458,6 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{matrix.pythonversion}}
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        java-version: ${{matrix.javaversion}}
-        distribution: temurin
-        cache: gradle
     - name: Download python SDK
       uses: actions/download-artifact@v2
       with:
@@ -490,6 +482,59 @@ jobs:
     - name: Uncompress nodejs SDK
       run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
         ${{github.workspace}}/sdk/nodejs
+    - name: Install Twine
+      run: python -m pip install pip twine
+    - name: Publish SDKs
+      run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
+      env:
+        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+    - if: failure() && github.event_name == 'push'
+      name: Notify Slack
+      uses: 8398a7/action-slack@v3
+      with:
+        author_name: Failure in publishing SDK
+        fields: repo,commit,author,action
+        status: ${{ job.status }}
+  publish_java_sdk:
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    needs: publish
+    strategy:
+      fail-fast: true
+      matrix:
+        goversion:
+        - 1.19.x
+        javaversion:
+        - "11"
+    name: publish_java_sdk
+    steps:
+    - name: Checkout Repo
+      uses: actions/checkout@v3
+      with:
+        lfs: true
+    - name: Checkout Scripts Repo
+      uses: actions/checkout@v3
+      with:
+        path: ci-scripts
+        repository: pulumi/scripts
+    - name: Unshallow clone for tags
+      run: git fetch --prune --unshallow --tags
+    - name: Install Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: ${{matrix.goversion}}
+    - name: Install pulumictl
+      uses: jaxxstorm/action-install-gh-release@v1.5.0
+      with:
+        repo: pulumi/pulumictl
+    - name: Install Pulumi CLI
+      uses: pulumi/action-install-pulumi-cli@v2
+    - name: Setup Java
+      uses: actions/setup-java@v3
+      with:
+        java-version: ${{matrix.javaversion}}
+        distribution: temurin
+        cache: gradle
     - name: Download java SDK
       uses: actions/download-artifact@v2
       with:
@@ -513,10 +558,3 @@ jobs:
         arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
         build-root-directory: ./sdk/java
         gradle-version: 7.4.1
-    - if: failure() && github.event_name == 'push'
-      name: Notify Slack
-      uses: 8398a7/action-slack@v3
-      with:
-        author_name: Failure in publishing SDK
-        fields: repo,commit,author,action
-        status: ${{ job.status }}

--- a/native-provider-ci/providers/google-native/repo/.github/workflows/prerelease.yml
+++ b/native-provider-ci/providers/google-native/repo/.github/workflows/prerelease.yml
@@ -413,8 +413,6 @@ jobs:
         - "3.7"
         nodeversion:
         - 14.x
-        javaversion:
-        - "11"
     name: publish_sdk
     steps:
     - name: Checkout Repo
@@ -451,12 +449,6 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{matrix.pythonversion}}
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        java-version: ${{matrix.javaversion}}
-        distribution: temurin
-        cache: gradle
     - name: Download python SDK
       uses: actions/download-artifact@v2
       with:
@@ -481,6 +473,59 @@ jobs:
     - name: Uncompress nodejs SDK
       run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
         ${{github.workspace}}/sdk/nodejs
+    - name: Install Twine
+      run: python -m pip install pip twine
+    - name: Publish SDKs
+      run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
+      env:
+        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+    - if: failure() && github.event_name == 'push'
+      name: Notify Slack
+      uses: 8398a7/action-slack@v3
+      with:
+        author_name: Failure in publishing SDK
+        fields: repo,commit,author,action
+        status: ${{ job.status }}
+  publish_java_sdk:
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    needs: publish
+    strategy:
+      fail-fast: true
+      matrix:
+        goversion:
+        - 1.19.x
+        javaversion:
+        - "11"
+    name: publish_java_sdk
+    steps:
+    - name: Checkout Repo
+      uses: actions/checkout@v3
+      with:
+        lfs: true
+    - name: Checkout Scripts Repo
+      uses: actions/checkout@v3
+      with:
+        path: ci-scripts
+        repository: pulumi/scripts
+    - name: Unshallow clone for tags
+      run: git fetch --prune --unshallow --tags
+    - name: Install Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: ${{matrix.goversion}}
+    - name: Install pulumictl
+      uses: jaxxstorm/action-install-gh-release@v1.5.0
+      with:
+        repo: pulumi/pulumictl
+    - name: Install Pulumi CLI
+      uses: pulumi/action-install-pulumi-cli@v2
+    - name: Setup Java
+      uses: actions/setup-java@v3
+      with:
+        java-version: ${{matrix.javaversion}}
+        distribution: temurin
+        cache: gradle
     - name: Download java SDK
       uses: actions/download-artifact@v2
       with:
@@ -504,10 +549,3 @@ jobs:
         arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
         build-root-directory: ./sdk/java
         gradle-version: 7.4.1
-    - if: failure() && github.event_name == 'push'
-      name: Notify Slack
-      uses: 8398a7/action-slack@v3
-      with:
-        author_name: Failure in publishing SDK
-        fields: repo,commit,author,action
-        status: ${{ job.status }}

--- a/native-provider-ci/providers/google-native/repo/.github/workflows/release.yml
+++ b/native-provider-ci/providers/google-native/repo/.github/workflows/release.yml
@@ -420,8 +420,6 @@ jobs:
         - "3.7"
         nodeversion:
         - 14.x
-        javaversion:
-        - "11"
     name: publish_sdks
     steps:
     - name: Checkout Repo
@@ -458,12 +456,6 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{matrix.pythonversion}}
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        java-version: ${{matrix.javaversion}}
-        distribution: temurin
-        cache: gradle
     - name: Download python SDK
       uses: actions/download-artifact@v2
       with:
@@ -488,6 +480,59 @@ jobs:
     - name: Uncompress nodejs SDK
       run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
         ${{github.workspace}}/sdk/nodejs
+    - name: Install Twine
+      run: python -m pip install pip twine
+    - name: Publish SDKs
+      run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
+      env:
+        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+    - if: failure() && github.event_name == 'push'
+      name: Notify Slack
+      uses: 8398a7/action-slack@v3
+      with:
+        author_name: Failure in publishing SDK
+        fields: repo,commit,author,action
+        status: ${{ job.status }}
+  publish_java_sdk:
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    needs: publish
+    strategy:
+      fail-fast: true
+      matrix:
+        goversion:
+        - 1.19.x
+        javaversion:
+        - "11"
+    name: publish_java_sdk
+    steps:
+    - name: Checkout Repo
+      uses: actions/checkout@v3
+      with:
+        lfs: true
+    - name: Checkout Scripts Repo
+      uses: actions/checkout@v3
+      with:
+        path: ci-scripts
+        repository: pulumi/scripts
+    - name: Unshallow clone for tags
+      run: git fetch --prune --unshallow --tags
+    - name: Install Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: ${{matrix.goversion}}
+    - name: Install pulumictl
+      uses: jaxxstorm/action-install-gh-release@v1.5.0
+      with:
+        repo: pulumi/pulumictl
+    - name: Install Pulumi CLI
+      uses: pulumi/action-install-pulumi-cli@v2
+    - name: Setup Java
+      uses: actions/setup-java@v3
+      with:
+        java-version: ${{matrix.javaversion}}
+        distribution: temurin
+        cache: gradle
     - name: Download java SDK
       uses: actions/download-artifact@v2
       with:
@@ -511,13 +556,6 @@ jobs:
         arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
         build-root-directory: ./sdk/java
         gradle-version: 7.4.1
-    - if: failure() && github.event_name == 'push'
-      name: Notify Slack
-      uses: 8398a7/action-slack@v3
-      with:
-        author_name: Failure in publishing SDK
-        fields: repo,commit,author,action
-        status: ${{ job.status }}
   tag_sdk:
     runs-on: ubuntu-latest
     needs: publish_sdk

--- a/native-provider-ci/providers/kubernetes/repo/.github/workflows/build.yml
+++ b/native-provider-ci/providers/kubernetes/repo/.github/workflows/build.yml
@@ -451,8 +451,6 @@ jobs:
         - "3.7"
         nodeversion:
         - 14.x
-        javaversion:
-        - "11"
     name: publish_sdk
     steps:
     - name: Checkout Repo
@@ -489,12 +487,6 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{matrix.pythonversion}}
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        java-version: ${{matrix.javaversion}}
-        distribution: temurin
-        cache: gradle
     - name: Download python SDK
       uses: actions/download-artifact@v2
       with:
@@ -519,6 +511,59 @@ jobs:
     - name: Uncompress nodejs SDK
       run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
         ${{github.workspace}}/sdk/nodejs
+    - name: Install Twine
+      run: python -m pip install pip twine
+    - name: Publish SDKs
+      run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
+      env:
+        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+    - if: failure() && github.event_name == 'push'
+      name: Notify Slack
+      uses: 8398a7/action-slack@v3
+      with:
+        author_name: Failure in publishing SDK
+        fields: repo,commit,author,action
+        status: ${{ job.status }}
+  publish_java_sdk:
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    needs: publish
+    strategy:
+      fail-fast: true
+      matrix:
+        goversion:
+        - 1.19.x
+        javaversion:
+        - "11"
+    name: publish_java_sdk
+    steps:
+    - name: Checkout Repo
+      uses: actions/checkout@v3
+      with:
+        lfs: true
+    - name: Checkout Scripts Repo
+      uses: actions/checkout@v3
+      with:
+        path: ci-scripts
+        repository: pulumi/scripts
+    - name: Unshallow clone for tags
+      run: git fetch --prune --unshallow --tags
+    - name: Install Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: ${{matrix.goversion}}
+    - name: Install pulumictl
+      uses: jaxxstorm/action-install-gh-release@v1.5.0
+      with:
+        repo: pulumi/pulumictl
+    - name: Install Pulumi CLI
+      uses: pulumi/action-install-pulumi-cli@v2
+    - name: Setup Java
+      uses: actions/setup-java@v3
+      with:
+        java-version: ${{matrix.javaversion}}
+        distribution: temurin
+        cache: gradle
     - name: Download java SDK
       uses: actions/download-artifact@v2
       with:
@@ -542,13 +587,6 @@ jobs:
         arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
         build-root-directory: ./sdk/java
         gradle-version: 7.4.1
-    - if: failure() && github.event_name == 'push'
-      name: Notify Slack
-      uses: 8398a7/action-slack@v3
-      with:
-        author_name: Failure in publishing SDK
-        fields: repo,commit,author,action
-        status: ${{ job.status }}
   build-test-cluster:
     runs-on: ubuntu-latest
     strategy:

--- a/native-provider-ci/providers/kubernetes/repo/.github/workflows/prerelease.yml
+++ b/native-provider-ci/providers/kubernetes/repo/.github/workflows/prerelease.yml
@@ -442,8 +442,6 @@ jobs:
         - "3.7"
         nodeversion:
         - 14.x
-        javaversion:
-        - "11"
     name: publish_sdk
     steps:
     - name: Checkout Repo
@@ -480,12 +478,6 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{matrix.pythonversion}}
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        java-version: ${{matrix.javaversion}}
-        distribution: temurin
-        cache: gradle
     - name: Download python SDK
       uses: actions/download-artifact@v2
       with:
@@ -510,6 +502,59 @@ jobs:
     - name: Uncompress nodejs SDK
       run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
         ${{github.workspace}}/sdk/nodejs
+    - name: Install Twine
+      run: python -m pip install pip twine
+    - name: Publish SDKs
+      run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
+      env:
+        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+    - if: failure() && github.event_name == 'push'
+      name: Notify Slack
+      uses: 8398a7/action-slack@v3
+      with:
+        author_name: Failure in publishing SDK
+        fields: repo,commit,author,action
+        status: ${{ job.status }}
+  publish_java_sdk:
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    needs: publish
+    strategy:
+      fail-fast: true
+      matrix:
+        goversion:
+        - 1.19.x
+        javaversion:
+        - "11"
+    name: publish_java_sdk
+    steps:
+    - name: Checkout Repo
+      uses: actions/checkout@v3
+      with:
+        lfs: true
+    - name: Checkout Scripts Repo
+      uses: actions/checkout@v3
+      with:
+        path: ci-scripts
+        repository: pulumi/scripts
+    - name: Unshallow clone for tags
+      run: git fetch --prune --unshallow --tags
+    - name: Install Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: ${{matrix.goversion}}
+    - name: Install pulumictl
+      uses: jaxxstorm/action-install-gh-release@v1.5.0
+      with:
+        repo: pulumi/pulumictl
+    - name: Install Pulumi CLI
+      uses: pulumi/action-install-pulumi-cli@v2
+    - name: Setup Java
+      uses: actions/setup-java@v3
+      with:
+        java-version: ${{matrix.javaversion}}
+        distribution: temurin
+        cache: gradle
     - name: Download java SDK
       uses: actions/download-artifact@v2
       with:
@@ -533,13 +578,6 @@ jobs:
         arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
         build-root-directory: ./sdk/java
         gradle-version: 7.4.1
-    - if: failure() && github.event_name == 'push'
-      name: Notify Slack
-      uses: 8398a7/action-slack@v3
-      with:
-        author_name: Failure in publishing SDK
-        fields: repo,commit,author,action
-        status: ${{ job.status }}
   build-test-cluster:
     runs-on: ubuntu-latest
     strategy:

--- a/native-provider-ci/providers/kubernetes/repo/.github/workflows/release.yml
+++ b/native-provider-ci/providers/kubernetes/repo/.github/workflows/release.yml
@@ -449,8 +449,6 @@ jobs:
         - "3.7"
         nodeversion:
         - 14.x
-        javaversion:
-        - "11"
     name: publish_sdks
     steps:
     - name: Checkout Repo
@@ -487,12 +485,6 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{matrix.pythonversion}}
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        java-version: ${{matrix.javaversion}}
-        distribution: temurin
-        cache: gradle
     - name: Download python SDK
       uses: actions/download-artifact@v2
       with:
@@ -517,6 +509,59 @@ jobs:
     - name: Uncompress nodejs SDK
       run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
         ${{github.workspace}}/sdk/nodejs
+    - name: Install Twine
+      run: python -m pip install pip twine
+    - name: Publish SDKs
+      run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
+      env:
+        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+    - if: failure() && github.event_name == 'push'
+      name: Notify Slack
+      uses: 8398a7/action-slack@v3
+      with:
+        author_name: Failure in publishing SDK
+        fields: repo,commit,author,action
+        status: ${{ job.status }}
+  publish_java_sdk:
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    needs: publish
+    strategy:
+      fail-fast: true
+      matrix:
+        goversion:
+        - 1.19.x
+        javaversion:
+        - "11"
+    name: publish_java_sdk
+    steps:
+    - name: Checkout Repo
+      uses: actions/checkout@v3
+      with:
+        lfs: true
+    - name: Checkout Scripts Repo
+      uses: actions/checkout@v3
+      with:
+        path: ci-scripts
+        repository: pulumi/scripts
+    - name: Unshallow clone for tags
+      run: git fetch --prune --unshallow --tags
+    - name: Install Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: ${{matrix.goversion}}
+    - name: Install pulumictl
+      uses: jaxxstorm/action-install-gh-release@v1.5.0
+      with:
+        repo: pulumi/pulumictl
+    - name: Install Pulumi CLI
+      uses: pulumi/action-install-pulumi-cli@v2
+    - name: Setup Java
+      uses: actions/setup-java@v3
+      with:
+        java-version: ${{matrix.javaversion}}
+        distribution: temurin
+        cache: gradle
     - name: Download java SDK
       uses: actions/download-artifact@v2
       with:
@@ -540,13 +585,6 @@ jobs:
         arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
         build-root-directory: ./sdk/java
         gradle-version: 7.4.1
-    - if: failure() && github.event_name == 'push'
-      name: Notify Slack
-      uses: 8398a7/action-slack@v3
-      with:
-        author_name: Failure in publishing SDK
-        fields: repo,commit,author,action
-        status: ${{ job.status }}
   tag_sdk:
     runs-on: ubuntu-latest
     needs: publish_sdk

--- a/provider-ci/providers/aiven/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/aiven/repo/.github/workflows/main.yml
@@ -303,6 +303,61 @@ jobs:
         - 16.x
         pythonversion:
         - "3.9"
+  publish_java_sdk:
+    continue-on-error: true
+    name: publish_java_sdk
+    needs: publish
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout Repo
+      uses: actions/checkout@v3
+    - name: Checkout Scripts Repo
+      uses: actions/checkout@v3
+      with:
+        path: ci-scripts
+        repository: pulumi/scripts
+    - name: Unshallow clone for tags
+      run: git fetch --prune --unshallow --tags
+    - name: Install Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: ${{matrix.goversion}}
+    - name: Install pulumictl
+      uses: jaxxstorm/action-install-gh-release@v1.5.0
+      with:
+        repo: pulumi/pulumictl
+    - name: Install Pulumi CLI
+      uses: pulumi/action-install-pulumi-cli@v2
+    - name: Setup Java
+      uses: actions/setup-java@v3
+      with:
+        cache: gradle
+        distribution: temurin
+        java-version: ${{matrix.javaversion}}
+    - name: Download java SDK
+      uses: actions/download-artifact@v2
+      with:
+        name: java-sdk.tar.gz
+        path: ${{ github.workspace}}/sdk/
+    - name: Uncompress java SDK
+      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
+        ${{github.workspace}}/sdk/java
+    - name: Set PACKAGE_VERSION to Env
+      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
+        $GITHUB_ENV
+    - name: Publish Java SDK
+      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
+      with:
+        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
+        build-root-directory: ./sdk/java
+        gradle-version: 7.4.1
+    strategy:
+      fail-fast: true
+      matrix:
+        goversion:
+        - 1.19.x
+        javaversion:
+        - "11"
   publish_sdk:
     name: publish_sdk
     needs: publish
@@ -340,12 +395,6 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{matrix.pythonversion}}
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{matrix.javaversion}}
     - name: Download python SDK
       uses: actions/download-artifact@v2
       with:
@@ -370,28 +419,11 @@ jobs:
     - name: Uncompress nodejs SDK
       run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
         ${{github.workspace}}/sdk/nodejs
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
     - run: python -m pip install pip twine
     - env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       name: Publish SDKs
       run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3
@@ -406,8 +438,6 @@ jobs:
         - 3.1.301
         goversion:
         - 1.19.x
-        javaversion:
-        - "11"
         nodeversion:
         - 16.x
         pythonversion:

--- a/provider-ci/providers/aiven/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/aiven/repo/.github/workflows/master.yml
@@ -303,6 +303,61 @@ jobs:
         - 16.x
         pythonversion:
         - "3.9"
+  publish_java_sdk:
+    continue-on-error: true
+    name: publish_java_sdk
+    needs: publish
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout Repo
+      uses: actions/checkout@v3
+    - name: Checkout Scripts Repo
+      uses: actions/checkout@v3
+      with:
+        path: ci-scripts
+        repository: pulumi/scripts
+    - name: Unshallow clone for tags
+      run: git fetch --prune --unshallow --tags
+    - name: Install Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: ${{matrix.goversion}}
+    - name: Install pulumictl
+      uses: jaxxstorm/action-install-gh-release@v1.5.0
+      with:
+        repo: pulumi/pulumictl
+    - name: Install Pulumi CLI
+      uses: pulumi/action-install-pulumi-cli@v2
+    - name: Setup Java
+      uses: actions/setup-java@v3
+      with:
+        cache: gradle
+        distribution: temurin
+        java-version: ${{matrix.javaversion}}
+    - name: Download java SDK
+      uses: actions/download-artifact@v2
+      with:
+        name: java-sdk.tar.gz
+        path: ${{ github.workspace}}/sdk/
+    - name: Uncompress java SDK
+      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
+        ${{github.workspace}}/sdk/java
+    - name: Set PACKAGE_VERSION to Env
+      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
+        $GITHUB_ENV
+    - name: Publish Java SDK
+      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
+      with:
+        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
+        build-root-directory: ./sdk/java
+        gradle-version: 7.4.1
+    strategy:
+      fail-fast: true
+      matrix:
+        goversion:
+        - 1.19.x
+        javaversion:
+        - "11"
   publish_sdk:
     name: publish_sdk
     needs: publish
@@ -340,12 +395,6 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{matrix.pythonversion}}
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{matrix.javaversion}}
     - name: Download python SDK
       uses: actions/download-artifact@v2
       with:
@@ -370,28 +419,11 @@ jobs:
     - name: Uncompress nodejs SDK
       run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
         ${{github.workspace}}/sdk/nodejs
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
     - run: python -m pip install pip twine
     - env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       name: Publish SDKs
       run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3
@@ -406,8 +438,6 @@ jobs:
         - 3.1.301
         goversion:
         - 1.19.x
-        javaversion:
-        - "11"
         nodeversion:
         - 16.x
         pythonversion:

--- a/provider-ci/providers/aiven/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/aiven/repo/.github/workflows/prerelease.yml
@@ -247,6 +247,61 @@ jobs:
         - 16.x
         pythonversion:
         - "3.9"
+  publish_java_sdk:
+    continue-on-error: true
+    name: publish_java_sdk
+    needs: publish
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout Repo
+      uses: actions/checkout@v3
+    - name: Checkout Scripts Repo
+      uses: actions/checkout@v3
+      with:
+        path: ci-scripts
+        repository: pulumi/scripts
+    - name: Unshallow clone for tags
+      run: git fetch --prune --unshallow --tags
+    - name: Install Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: ${{matrix.goversion}}
+    - name: Install pulumictl
+      uses: jaxxstorm/action-install-gh-release@v1.5.0
+      with:
+        repo: pulumi/pulumictl
+    - name: Install Pulumi CLI
+      uses: pulumi/action-install-pulumi-cli@v2
+    - name: Setup Java
+      uses: actions/setup-java@v3
+      with:
+        cache: gradle
+        distribution: temurin
+        java-version: ${{matrix.javaversion}}
+    - name: Download java SDK
+      uses: actions/download-artifact@v2
+      with:
+        name: java-sdk.tar.gz
+        path: ${{ github.workspace}}/sdk/
+    - name: Uncompress java SDK
+      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
+        ${{github.workspace}}/sdk/java
+    - name: Set PACKAGE_VERSION to Env
+      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
+        $GITHUB_ENV
+    - name: Publish Java SDK
+      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
+      with:
+        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
+        build-root-directory: ./sdk/java
+        gradle-version: 7.4.1
+    strategy:
+      fail-fast: true
+      matrix:
+        goversion:
+        - 1.19.x
+        javaversion:
+        - "11"
   publish_sdk:
     name: publish_sdk
     needs: publish
@@ -284,12 +339,6 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{matrix.pythonversion}}
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{matrix.javaversion}}
     - name: Download python SDK
       uses: actions/download-artifact@v2
       with:
@@ -314,28 +363,11 @@ jobs:
     - name: Uncompress nodejs SDK
       run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
         ${{github.workspace}}/sdk/nodejs
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
     - run: python -m pip install pip twine
     - env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       name: Publish SDKs
       run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3
@@ -350,8 +382,6 @@ jobs:
         - 3.1.301
         goversion:
         - 1.19.x
-        javaversion:
-        - "11"
         nodeversion:
         - 16.x
         pythonversion:

--- a/provider-ci/providers/aiven/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/aiven/repo/.github/workflows/release.yml
@@ -260,6 +260,61 @@ jobs:
         - 16.x
         pythonversion:
         - "3.9"
+  publish_java_sdk:
+    continue-on-error: true
+    name: publish_java_sdk
+    needs: publish
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout Repo
+      uses: actions/checkout@v3
+    - name: Checkout Scripts Repo
+      uses: actions/checkout@v3
+      with:
+        path: ci-scripts
+        repository: pulumi/scripts
+    - name: Unshallow clone for tags
+      run: git fetch --prune --unshallow --tags
+    - name: Install Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: ${{matrix.goversion}}
+    - name: Install pulumictl
+      uses: jaxxstorm/action-install-gh-release@v1.5.0
+      with:
+        repo: pulumi/pulumictl
+    - name: Install Pulumi CLI
+      uses: pulumi/action-install-pulumi-cli@v2
+    - name: Setup Java
+      uses: actions/setup-java@v3
+      with:
+        cache: gradle
+        distribution: temurin
+        java-version: ${{matrix.javaversion}}
+    - name: Download java SDK
+      uses: actions/download-artifact@v2
+      with:
+        name: java-sdk.tar.gz
+        path: ${{ github.workspace}}/sdk/
+    - name: Uncompress java SDK
+      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
+        ${{github.workspace}}/sdk/java
+    - name: Set PACKAGE_VERSION to Env
+      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
+        $GITHUB_ENV
+    - name: Publish Java SDK
+      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
+      with:
+        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
+        build-root-directory: ./sdk/java
+        gradle-version: 7.4.1
+    strategy:
+      fail-fast: true
+      matrix:
+        goversion:
+        - 1.19.x
+        javaversion:
+        - "11"
   publish_sdk:
     name: publish_sdk
     needs: publish
@@ -297,12 +352,6 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{matrix.pythonversion}}
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{matrix.javaversion}}
     - name: Download python SDK
       uses: actions/download-artifact@v2
       with:
@@ -327,28 +376,11 @@ jobs:
     - name: Uncompress nodejs SDK
       run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
         ${{github.workspace}}/sdk/nodejs
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
     - run: python -m pip install pip twine
     - env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       name: Publish SDKs
       run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3
@@ -363,8 +395,6 @@ jobs:
         - 3.1.301
         goversion:
         - 1.19.x
-        javaversion:
-        - "11"
         nodeversion:
         - 16.x
         pythonversion:

--- a/provider-ci/providers/akamai/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/akamai/repo/.github/workflows/main.yml
@@ -305,6 +305,61 @@ jobs:
         - 16.x
         pythonversion:
         - "3.9"
+  publish_java_sdk:
+    continue-on-error: true
+    name: publish_java_sdk
+    needs: publish
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout Repo
+      uses: actions/checkout@v3
+    - name: Checkout Scripts Repo
+      uses: actions/checkout@v3
+      with:
+        path: ci-scripts
+        repository: pulumi/scripts
+    - name: Unshallow clone for tags
+      run: git fetch --prune --unshallow --tags
+    - name: Install Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: ${{matrix.goversion}}
+    - name: Install pulumictl
+      uses: jaxxstorm/action-install-gh-release@v1.5.0
+      with:
+        repo: pulumi/pulumictl
+    - name: Install Pulumi CLI
+      uses: pulumi/action-install-pulumi-cli@v2
+    - name: Setup Java
+      uses: actions/setup-java@v3
+      with:
+        cache: gradle
+        distribution: temurin
+        java-version: ${{matrix.javaversion}}
+    - name: Download java SDK
+      uses: actions/download-artifact@v2
+      with:
+        name: java-sdk.tar.gz
+        path: ${{ github.workspace}}/sdk/
+    - name: Uncompress java SDK
+      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
+        ${{github.workspace}}/sdk/java
+    - name: Set PACKAGE_VERSION to Env
+      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
+        $GITHUB_ENV
+    - name: Publish Java SDK
+      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
+      with:
+        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
+        build-root-directory: ./sdk/java
+        gradle-version: 7.4.1
+    strategy:
+      fail-fast: true
+      matrix:
+        goversion:
+        - 1.19.x
+        javaversion:
+        - "11"
   publish_sdk:
     name: publish_sdk
     needs: publish
@@ -342,12 +397,6 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{matrix.pythonversion}}
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{matrix.javaversion}}
     - name: Download python SDK
       uses: actions/download-artifact@v2
       with:
@@ -372,28 +421,11 @@ jobs:
     - name: Uncompress nodejs SDK
       run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
         ${{github.workspace}}/sdk/nodejs
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
     - run: python -m pip install pip twine
     - env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       name: Publish SDKs
       run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3
@@ -408,8 +440,6 @@ jobs:
         - 3.1.301
         goversion:
         - 1.19.x
-        javaversion:
-        - "11"
         nodeversion:
         - 16.x
         pythonversion:

--- a/provider-ci/providers/akamai/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/akamai/repo/.github/workflows/master.yml
@@ -305,6 +305,61 @@ jobs:
         - 16.x
         pythonversion:
         - "3.9"
+  publish_java_sdk:
+    continue-on-error: true
+    name: publish_java_sdk
+    needs: publish
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout Repo
+      uses: actions/checkout@v3
+    - name: Checkout Scripts Repo
+      uses: actions/checkout@v3
+      with:
+        path: ci-scripts
+        repository: pulumi/scripts
+    - name: Unshallow clone for tags
+      run: git fetch --prune --unshallow --tags
+    - name: Install Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: ${{matrix.goversion}}
+    - name: Install pulumictl
+      uses: jaxxstorm/action-install-gh-release@v1.5.0
+      with:
+        repo: pulumi/pulumictl
+    - name: Install Pulumi CLI
+      uses: pulumi/action-install-pulumi-cli@v2
+    - name: Setup Java
+      uses: actions/setup-java@v3
+      with:
+        cache: gradle
+        distribution: temurin
+        java-version: ${{matrix.javaversion}}
+    - name: Download java SDK
+      uses: actions/download-artifact@v2
+      with:
+        name: java-sdk.tar.gz
+        path: ${{ github.workspace}}/sdk/
+    - name: Uncompress java SDK
+      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
+        ${{github.workspace}}/sdk/java
+    - name: Set PACKAGE_VERSION to Env
+      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
+        $GITHUB_ENV
+    - name: Publish Java SDK
+      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
+      with:
+        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
+        build-root-directory: ./sdk/java
+        gradle-version: 7.4.1
+    strategy:
+      fail-fast: true
+      matrix:
+        goversion:
+        - 1.19.x
+        javaversion:
+        - "11"
   publish_sdk:
     name: publish_sdk
     needs: publish
@@ -342,12 +397,6 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{matrix.pythonversion}}
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{matrix.javaversion}}
     - name: Download python SDK
       uses: actions/download-artifact@v2
       with:
@@ -372,28 +421,11 @@ jobs:
     - name: Uncompress nodejs SDK
       run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
         ${{github.workspace}}/sdk/nodejs
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
     - run: python -m pip install pip twine
     - env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       name: Publish SDKs
       run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3
@@ -408,8 +440,6 @@ jobs:
         - 3.1.301
         goversion:
         - 1.19.x
-        javaversion:
-        - "11"
         nodeversion:
         - 16.x
         pythonversion:

--- a/provider-ci/providers/akamai/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/akamai/repo/.github/workflows/prerelease.yml
@@ -249,6 +249,61 @@ jobs:
         - 16.x
         pythonversion:
         - "3.9"
+  publish_java_sdk:
+    continue-on-error: true
+    name: publish_java_sdk
+    needs: publish
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout Repo
+      uses: actions/checkout@v3
+    - name: Checkout Scripts Repo
+      uses: actions/checkout@v3
+      with:
+        path: ci-scripts
+        repository: pulumi/scripts
+    - name: Unshallow clone for tags
+      run: git fetch --prune --unshallow --tags
+    - name: Install Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: ${{matrix.goversion}}
+    - name: Install pulumictl
+      uses: jaxxstorm/action-install-gh-release@v1.5.0
+      with:
+        repo: pulumi/pulumictl
+    - name: Install Pulumi CLI
+      uses: pulumi/action-install-pulumi-cli@v2
+    - name: Setup Java
+      uses: actions/setup-java@v3
+      with:
+        cache: gradle
+        distribution: temurin
+        java-version: ${{matrix.javaversion}}
+    - name: Download java SDK
+      uses: actions/download-artifact@v2
+      with:
+        name: java-sdk.tar.gz
+        path: ${{ github.workspace}}/sdk/
+    - name: Uncompress java SDK
+      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
+        ${{github.workspace}}/sdk/java
+    - name: Set PACKAGE_VERSION to Env
+      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
+        $GITHUB_ENV
+    - name: Publish Java SDK
+      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
+      with:
+        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
+        build-root-directory: ./sdk/java
+        gradle-version: 7.4.1
+    strategy:
+      fail-fast: true
+      matrix:
+        goversion:
+        - 1.19.x
+        javaversion:
+        - "11"
   publish_sdk:
     name: publish_sdk
     needs: publish
@@ -286,12 +341,6 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{matrix.pythonversion}}
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{matrix.javaversion}}
     - name: Download python SDK
       uses: actions/download-artifact@v2
       with:
@@ -316,28 +365,11 @@ jobs:
     - name: Uncompress nodejs SDK
       run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
         ${{github.workspace}}/sdk/nodejs
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
     - run: python -m pip install pip twine
     - env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       name: Publish SDKs
       run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3
@@ -352,8 +384,6 @@ jobs:
         - 3.1.301
         goversion:
         - 1.19.x
-        javaversion:
-        - "11"
         nodeversion:
         - 16.x
         pythonversion:

--- a/provider-ci/providers/akamai/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/akamai/repo/.github/workflows/release.yml
@@ -262,6 +262,61 @@ jobs:
         - 16.x
         pythonversion:
         - "3.9"
+  publish_java_sdk:
+    continue-on-error: true
+    name: publish_java_sdk
+    needs: publish
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout Repo
+      uses: actions/checkout@v3
+    - name: Checkout Scripts Repo
+      uses: actions/checkout@v3
+      with:
+        path: ci-scripts
+        repository: pulumi/scripts
+    - name: Unshallow clone for tags
+      run: git fetch --prune --unshallow --tags
+    - name: Install Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: ${{matrix.goversion}}
+    - name: Install pulumictl
+      uses: jaxxstorm/action-install-gh-release@v1.5.0
+      with:
+        repo: pulumi/pulumictl
+    - name: Install Pulumi CLI
+      uses: pulumi/action-install-pulumi-cli@v2
+    - name: Setup Java
+      uses: actions/setup-java@v3
+      with:
+        cache: gradle
+        distribution: temurin
+        java-version: ${{matrix.javaversion}}
+    - name: Download java SDK
+      uses: actions/download-artifact@v2
+      with:
+        name: java-sdk.tar.gz
+        path: ${{ github.workspace}}/sdk/
+    - name: Uncompress java SDK
+      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
+        ${{github.workspace}}/sdk/java
+    - name: Set PACKAGE_VERSION to Env
+      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
+        $GITHUB_ENV
+    - name: Publish Java SDK
+      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
+      with:
+        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
+        build-root-directory: ./sdk/java
+        gradle-version: 7.4.1
+    strategy:
+      fail-fast: true
+      matrix:
+        goversion:
+        - 1.19.x
+        javaversion:
+        - "11"
   publish_sdk:
     name: publish_sdk
     needs: publish
@@ -299,12 +354,6 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{matrix.pythonversion}}
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{matrix.javaversion}}
     - name: Download python SDK
       uses: actions/download-artifact@v2
       with:
@@ -329,28 +378,11 @@ jobs:
     - name: Uncompress nodejs SDK
       run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
         ${{github.workspace}}/sdk/nodejs
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
     - run: python -m pip install pip twine
     - env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       name: Publish SDKs
       run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3
@@ -365,8 +397,6 @@ jobs:
         - 3.1.301
         goversion:
         - 1.19.x
-        javaversion:
-        - "11"
         nodeversion:
         - 16.x
         pythonversion:

--- a/provider-ci/providers/alicloud/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/alicloud/repo/.github/workflows/main.yml
@@ -304,6 +304,61 @@ jobs:
         - 16.x
         pythonversion:
         - "3.9"
+  publish_java_sdk:
+    continue-on-error: true
+    name: publish_java_sdk
+    needs: publish
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout Repo
+      uses: actions/checkout@v3
+    - name: Checkout Scripts Repo
+      uses: actions/checkout@v3
+      with:
+        path: ci-scripts
+        repository: pulumi/scripts
+    - name: Unshallow clone for tags
+      run: git fetch --prune --unshallow --tags
+    - name: Install Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: ${{matrix.goversion}}
+    - name: Install pulumictl
+      uses: jaxxstorm/action-install-gh-release@v1.5.0
+      with:
+        repo: pulumi/pulumictl
+    - name: Install Pulumi CLI
+      uses: pulumi/action-install-pulumi-cli@v2
+    - name: Setup Java
+      uses: actions/setup-java@v3
+      with:
+        cache: gradle
+        distribution: temurin
+        java-version: ${{matrix.javaversion}}
+    - name: Download java SDK
+      uses: actions/download-artifact@v2
+      with:
+        name: java-sdk.tar.gz
+        path: ${{ github.workspace}}/sdk/
+    - name: Uncompress java SDK
+      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
+        ${{github.workspace}}/sdk/java
+    - name: Set PACKAGE_VERSION to Env
+      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
+        $GITHUB_ENV
+    - name: Publish Java SDK
+      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
+      with:
+        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
+        build-root-directory: ./sdk/java
+        gradle-version: 7.4.1
+    strategy:
+      fail-fast: true
+      matrix:
+        goversion:
+        - 1.19.x
+        javaversion:
+        - "11"
   publish_sdk:
     name: publish_sdk
     needs: publish
@@ -341,12 +396,6 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{matrix.pythonversion}}
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{matrix.javaversion}}
     - name: Download python SDK
       uses: actions/download-artifact@v2
       with:
@@ -371,28 +420,11 @@ jobs:
     - name: Uncompress nodejs SDK
       run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
         ${{github.workspace}}/sdk/nodejs
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
     - run: python -m pip install pip twine
     - env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       name: Publish SDKs
       run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3
@@ -407,8 +439,6 @@ jobs:
         - 3.1.301
         goversion:
         - 1.19.x
-        javaversion:
-        - "11"
         nodeversion:
         - 16.x
         pythonversion:

--- a/provider-ci/providers/alicloud/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/alicloud/repo/.github/workflows/master.yml
@@ -304,6 +304,61 @@ jobs:
         - 16.x
         pythonversion:
         - "3.9"
+  publish_java_sdk:
+    continue-on-error: true
+    name: publish_java_sdk
+    needs: publish
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout Repo
+      uses: actions/checkout@v3
+    - name: Checkout Scripts Repo
+      uses: actions/checkout@v3
+      with:
+        path: ci-scripts
+        repository: pulumi/scripts
+    - name: Unshallow clone for tags
+      run: git fetch --prune --unshallow --tags
+    - name: Install Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: ${{matrix.goversion}}
+    - name: Install pulumictl
+      uses: jaxxstorm/action-install-gh-release@v1.5.0
+      with:
+        repo: pulumi/pulumictl
+    - name: Install Pulumi CLI
+      uses: pulumi/action-install-pulumi-cli@v2
+    - name: Setup Java
+      uses: actions/setup-java@v3
+      with:
+        cache: gradle
+        distribution: temurin
+        java-version: ${{matrix.javaversion}}
+    - name: Download java SDK
+      uses: actions/download-artifact@v2
+      with:
+        name: java-sdk.tar.gz
+        path: ${{ github.workspace}}/sdk/
+    - name: Uncompress java SDK
+      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
+        ${{github.workspace}}/sdk/java
+    - name: Set PACKAGE_VERSION to Env
+      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
+        $GITHUB_ENV
+    - name: Publish Java SDK
+      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
+      with:
+        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
+        build-root-directory: ./sdk/java
+        gradle-version: 7.4.1
+    strategy:
+      fail-fast: true
+      matrix:
+        goversion:
+        - 1.19.x
+        javaversion:
+        - "11"
   publish_sdk:
     name: publish_sdk
     needs: publish
@@ -341,12 +396,6 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{matrix.pythonversion}}
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{matrix.javaversion}}
     - name: Download python SDK
       uses: actions/download-artifact@v2
       with:
@@ -371,28 +420,11 @@ jobs:
     - name: Uncompress nodejs SDK
       run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
         ${{github.workspace}}/sdk/nodejs
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
     - run: python -m pip install pip twine
     - env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       name: Publish SDKs
       run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3
@@ -407,8 +439,6 @@ jobs:
         - 3.1.301
         goversion:
         - 1.19.x
-        javaversion:
-        - "11"
         nodeversion:
         - 16.x
         pythonversion:

--- a/provider-ci/providers/alicloud/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/alicloud/repo/.github/workflows/prerelease.yml
@@ -248,6 +248,61 @@ jobs:
         - 16.x
         pythonversion:
         - "3.9"
+  publish_java_sdk:
+    continue-on-error: true
+    name: publish_java_sdk
+    needs: publish
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout Repo
+      uses: actions/checkout@v3
+    - name: Checkout Scripts Repo
+      uses: actions/checkout@v3
+      with:
+        path: ci-scripts
+        repository: pulumi/scripts
+    - name: Unshallow clone for tags
+      run: git fetch --prune --unshallow --tags
+    - name: Install Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: ${{matrix.goversion}}
+    - name: Install pulumictl
+      uses: jaxxstorm/action-install-gh-release@v1.5.0
+      with:
+        repo: pulumi/pulumictl
+    - name: Install Pulumi CLI
+      uses: pulumi/action-install-pulumi-cli@v2
+    - name: Setup Java
+      uses: actions/setup-java@v3
+      with:
+        cache: gradle
+        distribution: temurin
+        java-version: ${{matrix.javaversion}}
+    - name: Download java SDK
+      uses: actions/download-artifact@v2
+      with:
+        name: java-sdk.tar.gz
+        path: ${{ github.workspace}}/sdk/
+    - name: Uncompress java SDK
+      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
+        ${{github.workspace}}/sdk/java
+    - name: Set PACKAGE_VERSION to Env
+      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
+        $GITHUB_ENV
+    - name: Publish Java SDK
+      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
+      with:
+        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
+        build-root-directory: ./sdk/java
+        gradle-version: 7.4.1
+    strategy:
+      fail-fast: true
+      matrix:
+        goversion:
+        - 1.19.x
+        javaversion:
+        - "11"
   publish_sdk:
     name: publish_sdk
     needs: publish
@@ -285,12 +340,6 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{matrix.pythonversion}}
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{matrix.javaversion}}
     - name: Download python SDK
       uses: actions/download-artifact@v2
       with:
@@ -315,28 +364,11 @@ jobs:
     - name: Uncompress nodejs SDK
       run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
         ${{github.workspace}}/sdk/nodejs
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
     - run: python -m pip install pip twine
     - env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       name: Publish SDKs
       run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3
@@ -351,8 +383,6 @@ jobs:
         - 3.1.301
         goversion:
         - 1.19.x
-        javaversion:
-        - "11"
         nodeversion:
         - 16.x
         pythonversion:

--- a/provider-ci/providers/alicloud/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/alicloud/repo/.github/workflows/release.yml
@@ -261,6 +261,61 @@ jobs:
         - 16.x
         pythonversion:
         - "3.9"
+  publish_java_sdk:
+    continue-on-error: true
+    name: publish_java_sdk
+    needs: publish
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout Repo
+      uses: actions/checkout@v3
+    - name: Checkout Scripts Repo
+      uses: actions/checkout@v3
+      with:
+        path: ci-scripts
+        repository: pulumi/scripts
+    - name: Unshallow clone for tags
+      run: git fetch --prune --unshallow --tags
+    - name: Install Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: ${{matrix.goversion}}
+    - name: Install pulumictl
+      uses: jaxxstorm/action-install-gh-release@v1.5.0
+      with:
+        repo: pulumi/pulumictl
+    - name: Install Pulumi CLI
+      uses: pulumi/action-install-pulumi-cli@v2
+    - name: Setup Java
+      uses: actions/setup-java@v3
+      with:
+        cache: gradle
+        distribution: temurin
+        java-version: ${{matrix.javaversion}}
+    - name: Download java SDK
+      uses: actions/download-artifact@v2
+      with:
+        name: java-sdk.tar.gz
+        path: ${{ github.workspace}}/sdk/
+    - name: Uncompress java SDK
+      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
+        ${{github.workspace}}/sdk/java
+    - name: Set PACKAGE_VERSION to Env
+      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
+        $GITHUB_ENV
+    - name: Publish Java SDK
+      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
+      with:
+        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
+        build-root-directory: ./sdk/java
+        gradle-version: 7.4.1
+    strategy:
+      fail-fast: true
+      matrix:
+        goversion:
+        - 1.19.x
+        javaversion:
+        - "11"
   publish_sdk:
     name: publish_sdk
     needs: publish
@@ -298,12 +353,6 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{matrix.pythonversion}}
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{matrix.javaversion}}
     - name: Download python SDK
       uses: actions/download-artifact@v2
       with:
@@ -328,28 +377,11 @@ jobs:
     - name: Uncompress nodejs SDK
       run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
         ${{github.workspace}}/sdk/nodejs
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
     - run: python -m pip install pip twine
     - env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       name: Publish SDKs
       run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3
@@ -364,8 +396,6 @@ jobs:
         - 3.1.301
         goversion:
         - 1.19.x
-        javaversion:
-        - "11"
         nodeversion:
         - 16.x
         pythonversion:

--- a/provider-ci/providers/artifactory/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/artifactory/repo/.github/workflows/main.yml
@@ -379,6 +379,61 @@ jobs:
         - 16.x
         pythonversion:
         - "3.9"
+  publish_java_sdk:
+    continue-on-error: true
+    name: publish_java_sdk
+    needs: publish
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout Repo
+      uses: actions/checkout@v3
+    - name: Checkout Scripts Repo
+      uses: actions/checkout@v3
+      with:
+        path: ci-scripts
+        repository: pulumi/scripts
+    - name: Unshallow clone for tags
+      run: git fetch --prune --unshallow --tags
+    - name: Install Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: ${{matrix.goversion}}
+    - name: Install pulumictl
+      uses: jaxxstorm/action-install-gh-release@v1.5.0
+      with:
+        repo: pulumi/pulumictl
+    - name: Install Pulumi CLI
+      uses: pulumi/action-install-pulumi-cli@v2
+    - name: Setup Java
+      uses: actions/setup-java@v3
+      with:
+        cache: gradle
+        distribution: temurin
+        java-version: ${{matrix.javaversion}}
+    - name: Download java SDK
+      uses: actions/download-artifact@v2
+      with:
+        name: java-sdk.tar.gz
+        path: ${{ github.workspace}}/sdk/
+    - name: Uncompress java SDK
+      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
+        ${{github.workspace}}/sdk/java
+    - name: Set PACKAGE_VERSION to Env
+      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
+        $GITHUB_ENV
+    - name: Publish Java SDK
+      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
+      with:
+        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
+        build-root-directory: ./sdk/java
+        gradle-version: 7.4.1
+    strategy:
+      fail-fast: true
+      matrix:
+        goversion:
+        - 1.19.x
+        javaversion:
+        - "11"
   publish_sdk:
     name: publish_sdk
     needs: publish
@@ -416,12 +471,6 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{matrix.pythonversion}}
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{matrix.javaversion}}
     - name: Download python SDK
       uses: actions/download-artifact@v2
       with:
@@ -446,28 +495,11 @@ jobs:
     - name: Uncompress nodejs SDK
       run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
         ${{github.workspace}}/sdk/nodejs
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
     - run: python -m pip install pip twine
     - env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       name: Publish SDKs
       run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3
@@ -482,8 +514,6 @@ jobs:
         - 3.1.301
         goversion:
         - 1.19.x
-        javaversion:
-        - "11"
         nodeversion:
         - 16.x
         pythonversion:

--- a/provider-ci/providers/artifactory/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/artifactory/repo/.github/workflows/master.yml
@@ -379,6 +379,61 @@ jobs:
         - 16.x
         pythonversion:
         - "3.9"
+  publish_java_sdk:
+    continue-on-error: true
+    name: publish_java_sdk
+    needs: publish
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout Repo
+      uses: actions/checkout@v3
+    - name: Checkout Scripts Repo
+      uses: actions/checkout@v3
+      with:
+        path: ci-scripts
+        repository: pulumi/scripts
+    - name: Unshallow clone for tags
+      run: git fetch --prune --unshallow --tags
+    - name: Install Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: ${{matrix.goversion}}
+    - name: Install pulumictl
+      uses: jaxxstorm/action-install-gh-release@v1.5.0
+      with:
+        repo: pulumi/pulumictl
+    - name: Install Pulumi CLI
+      uses: pulumi/action-install-pulumi-cli@v2
+    - name: Setup Java
+      uses: actions/setup-java@v3
+      with:
+        cache: gradle
+        distribution: temurin
+        java-version: ${{matrix.javaversion}}
+    - name: Download java SDK
+      uses: actions/download-artifact@v2
+      with:
+        name: java-sdk.tar.gz
+        path: ${{ github.workspace}}/sdk/
+    - name: Uncompress java SDK
+      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
+        ${{github.workspace}}/sdk/java
+    - name: Set PACKAGE_VERSION to Env
+      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
+        $GITHUB_ENV
+    - name: Publish Java SDK
+      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
+      with:
+        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
+        build-root-directory: ./sdk/java
+        gradle-version: 7.4.1
+    strategy:
+      fail-fast: true
+      matrix:
+        goversion:
+        - 1.19.x
+        javaversion:
+        - "11"
   publish_sdk:
     name: publish_sdk
     needs: publish
@@ -416,12 +471,6 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{matrix.pythonversion}}
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{matrix.javaversion}}
     - name: Download python SDK
       uses: actions/download-artifact@v2
       with:
@@ -446,28 +495,11 @@ jobs:
     - name: Uncompress nodejs SDK
       run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
         ${{github.workspace}}/sdk/nodejs
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
     - run: python -m pip install pip twine
     - env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       name: Publish SDKs
       run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3
@@ -482,8 +514,6 @@ jobs:
         - 3.1.301
         goversion:
         - 1.19.x
-        javaversion:
-        - "11"
         nodeversion:
         - 16.x
         pythonversion:

--- a/provider-ci/providers/artifactory/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/artifactory/repo/.github/workflows/prerelease.yml
@@ -323,6 +323,61 @@ jobs:
         - 16.x
         pythonversion:
         - "3.9"
+  publish_java_sdk:
+    continue-on-error: true
+    name: publish_java_sdk
+    needs: publish
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout Repo
+      uses: actions/checkout@v3
+    - name: Checkout Scripts Repo
+      uses: actions/checkout@v3
+      with:
+        path: ci-scripts
+        repository: pulumi/scripts
+    - name: Unshallow clone for tags
+      run: git fetch --prune --unshallow --tags
+    - name: Install Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: ${{matrix.goversion}}
+    - name: Install pulumictl
+      uses: jaxxstorm/action-install-gh-release@v1.5.0
+      with:
+        repo: pulumi/pulumictl
+    - name: Install Pulumi CLI
+      uses: pulumi/action-install-pulumi-cli@v2
+    - name: Setup Java
+      uses: actions/setup-java@v3
+      with:
+        cache: gradle
+        distribution: temurin
+        java-version: ${{matrix.javaversion}}
+    - name: Download java SDK
+      uses: actions/download-artifact@v2
+      with:
+        name: java-sdk.tar.gz
+        path: ${{ github.workspace}}/sdk/
+    - name: Uncompress java SDK
+      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
+        ${{github.workspace}}/sdk/java
+    - name: Set PACKAGE_VERSION to Env
+      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
+        $GITHUB_ENV
+    - name: Publish Java SDK
+      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
+      with:
+        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
+        build-root-directory: ./sdk/java
+        gradle-version: 7.4.1
+    strategy:
+      fail-fast: true
+      matrix:
+        goversion:
+        - 1.19.x
+        javaversion:
+        - "11"
   publish_sdk:
     name: publish_sdk
     needs: publish
@@ -360,12 +415,6 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{matrix.pythonversion}}
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{matrix.javaversion}}
     - name: Download python SDK
       uses: actions/download-artifact@v2
       with:
@@ -390,28 +439,11 @@ jobs:
     - name: Uncompress nodejs SDK
       run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
         ${{github.workspace}}/sdk/nodejs
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
     - run: python -m pip install pip twine
     - env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       name: Publish SDKs
       run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3
@@ -426,8 +458,6 @@ jobs:
         - 3.1.301
         goversion:
         - 1.19.x
-        javaversion:
-        - "11"
         nodeversion:
         - 16.x
         pythonversion:

--- a/provider-ci/providers/artifactory/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/artifactory/repo/.github/workflows/release.yml
@@ -336,6 +336,61 @@ jobs:
         - 16.x
         pythonversion:
         - "3.9"
+  publish_java_sdk:
+    continue-on-error: true
+    name: publish_java_sdk
+    needs: publish
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout Repo
+      uses: actions/checkout@v3
+    - name: Checkout Scripts Repo
+      uses: actions/checkout@v3
+      with:
+        path: ci-scripts
+        repository: pulumi/scripts
+    - name: Unshallow clone for tags
+      run: git fetch --prune --unshallow --tags
+    - name: Install Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: ${{matrix.goversion}}
+    - name: Install pulumictl
+      uses: jaxxstorm/action-install-gh-release@v1.5.0
+      with:
+        repo: pulumi/pulumictl
+    - name: Install Pulumi CLI
+      uses: pulumi/action-install-pulumi-cli@v2
+    - name: Setup Java
+      uses: actions/setup-java@v3
+      with:
+        cache: gradle
+        distribution: temurin
+        java-version: ${{matrix.javaversion}}
+    - name: Download java SDK
+      uses: actions/download-artifact@v2
+      with:
+        name: java-sdk.tar.gz
+        path: ${{ github.workspace}}/sdk/
+    - name: Uncompress java SDK
+      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
+        ${{github.workspace}}/sdk/java
+    - name: Set PACKAGE_VERSION to Env
+      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
+        $GITHUB_ENV
+    - name: Publish Java SDK
+      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
+      with:
+        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
+        build-root-directory: ./sdk/java
+        gradle-version: 7.4.1
+    strategy:
+      fail-fast: true
+      matrix:
+        goversion:
+        - 1.19.x
+        javaversion:
+        - "11"
   publish_sdk:
     name: publish_sdk
     needs: publish
@@ -373,12 +428,6 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{matrix.pythonversion}}
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{matrix.javaversion}}
     - name: Download python SDK
       uses: actions/download-artifact@v2
       with:
@@ -403,28 +452,11 @@ jobs:
     - name: Uncompress nodejs SDK
       run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
         ${{github.workspace}}/sdk/nodejs
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
     - run: python -m pip install pip twine
     - env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       name: Publish SDKs
       run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3
@@ -439,8 +471,6 @@ jobs:
         - 3.1.301
         goversion:
         - 1.19.x
-        javaversion:
-        - "11"
         nodeversion:
         - 16.x
         pythonversion:

--- a/provider-ci/providers/auth0/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/auth0/repo/.github/workflows/main.yml
@@ -379,6 +379,61 @@ jobs:
         - 16.x
         pythonversion:
         - "3.9"
+  publish_java_sdk:
+    continue-on-error: true
+    name: publish_java_sdk
+    needs: publish
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout Repo
+      uses: actions/checkout@v3
+    - name: Checkout Scripts Repo
+      uses: actions/checkout@v3
+      with:
+        path: ci-scripts
+        repository: pulumi/scripts
+    - name: Unshallow clone for tags
+      run: git fetch --prune --unshallow --tags
+    - name: Install Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: ${{matrix.goversion}}
+    - name: Install pulumictl
+      uses: jaxxstorm/action-install-gh-release@v1.5.0
+      with:
+        repo: pulumi/pulumictl
+    - name: Install Pulumi CLI
+      uses: pulumi/action-install-pulumi-cli@v2
+    - name: Setup Java
+      uses: actions/setup-java@v3
+      with:
+        cache: gradle
+        distribution: temurin
+        java-version: ${{matrix.javaversion}}
+    - name: Download java SDK
+      uses: actions/download-artifact@v2
+      with:
+        name: java-sdk.tar.gz
+        path: ${{ github.workspace}}/sdk/
+    - name: Uncompress java SDK
+      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
+        ${{github.workspace}}/sdk/java
+    - name: Set PACKAGE_VERSION to Env
+      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
+        $GITHUB_ENV
+    - name: Publish Java SDK
+      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
+      with:
+        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
+        build-root-directory: ./sdk/java
+        gradle-version: 7.4.1
+    strategy:
+      fail-fast: true
+      matrix:
+        goversion:
+        - 1.19.x
+        javaversion:
+        - "11"
   publish_sdk:
     name: publish_sdk
     needs: publish
@@ -416,12 +471,6 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{matrix.pythonversion}}
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{matrix.javaversion}}
     - name: Download python SDK
       uses: actions/download-artifact@v2
       with:
@@ -446,28 +495,11 @@ jobs:
     - name: Uncompress nodejs SDK
       run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
         ${{github.workspace}}/sdk/nodejs
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
     - run: python -m pip install pip twine
     - env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       name: Publish SDKs
       run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3
@@ -482,8 +514,6 @@ jobs:
         - 3.1.301
         goversion:
         - 1.19.x
-        javaversion:
-        - "11"
         nodeversion:
         - 16.x
         pythonversion:

--- a/provider-ci/providers/auth0/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/auth0/repo/.github/workflows/master.yml
@@ -379,6 +379,61 @@ jobs:
         - 16.x
         pythonversion:
         - "3.9"
+  publish_java_sdk:
+    continue-on-error: true
+    name: publish_java_sdk
+    needs: publish
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout Repo
+      uses: actions/checkout@v3
+    - name: Checkout Scripts Repo
+      uses: actions/checkout@v3
+      with:
+        path: ci-scripts
+        repository: pulumi/scripts
+    - name: Unshallow clone for tags
+      run: git fetch --prune --unshallow --tags
+    - name: Install Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: ${{matrix.goversion}}
+    - name: Install pulumictl
+      uses: jaxxstorm/action-install-gh-release@v1.5.0
+      with:
+        repo: pulumi/pulumictl
+    - name: Install Pulumi CLI
+      uses: pulumi/action-install-pulumi-cli@v2
+    - name: Setup Java
+      uses: actions/setup-java@v3
+      with:
+        cache: gradle
+        distribution: temurin
+        java-version: ${{matrix.javaversion}}
+    - name: Download java SDK
+      uses: actions/download-artifact@v2
+      with:
+        name: java-sdk.tar.gz
+        path: ${{ github.workspace}}/sdk/
+    - name: Uncompress java SDK
+      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
+        ${{github.workspace}}/sdk/java
+    - name: Set PACKAGE_VERSION to Env
+      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
+        $GITHUB_ENV
+    - name: Publish Java SDK
+      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
+      with:
+        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
+        build-root-directory: ./sdk/java
+        gradle-version: 7.4.1
+    strategy:
+      fail-fast: true
+      matrix:
+        goversion:
+        - 1.19.x
+        javaversion:
+        - "11"
   publish_sdk:
     name: publish_sdk
     needs: publish
@@ -416,12 +471,6 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{matrix.pythonversion}}
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{matrix.javaversion}}
     - name: Download python SDK
       uses: actions/download-artifact@v2
       with:
@@ -446,28 +495,11 @@ jobs:
     - name: Uncompress nodejs SDK
       run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
         ${{github.workspace}}/sdk/nodejs
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
     - run: python -m pip install pip twine
     - env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       name: Publish SDKs
       run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3
@@ -482,8 +514,6 @@ jobs:
         - 3.1.301
         goversion:
         - 1.19.x
-        javaversion:
-        - "11"
         nodeversion:
         - 16.x
         pythonversion:

--- a/provider-ci/providers/auth0/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/auth0/repo/.github/workflows/prerelease.yml
@@ -323,6 +323,61 @@ jobs:
         - 16.x
         pythonversion:
         - "3.9"
+  publish_java_sdk:
+    continue-on-error: true
+    name: publish_java_sdk
+    needs: publish
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout Repo
+      uses: actions/checkout@v3
+    - name: Checkout Scripts Repo
+      uses: actions/checkout@v3
+      with:
+        path: ci-scripts
+        repository: pulumi/scripts
+    - name: Unshallow clone for tags
+      run: git fetch --prune --unshallow --tags
+    - name: Install Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: ${{matrix.goversion}}
+    - name: Install pulumictl
+      uses: jaxxstorm/action-install-gh-release@v1.5.0
+      with:
+        repo: pulumi/pulumictl
+    - name: Install Pulumi CLI
+      uses: pulumi/action-install-pulumi-cli@v2
+    - name: Setup Java
+      uses: actions/setup-java@v3
+      with:
+        cache: gradle
+        distribution: temurin
+        java-version: ${{matrix.javaversion}}
+    - name: Download java SDK
+      uses: actions/download-artifact@v2
+      with:
+        name: java-sdk.tar.gz
+        path: ${{ github.workspace}}/sdk/
+    - name: Uncompress java SDK
+      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
+        ${{github.workspace}}/sdk/java
+    - name: Set PACKAGE_VERSION to Env
+      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
+        $GITHUB_ENV
+    - name: Publish Java SDK
+      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
+      with:
+        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
+        build-root-directory: ./sdk/java
+        gradle-version: 7.4.1
+    strategy:
+      fail-fast: true
+      matrix:
+        goversion:
+        - 1.19.x
+        javaversion:
+        - "11"
   publish_sdk:
     name: publish_sdk
     needs: publish
@@ -360,12 +415,6 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{matrix.pythonversion}}
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{matrix.javaversion}}
     - name: Download python SDK
       uses: actions/download-artifact@v2
       with:
@@ -390,28 +439,11 @@ jobs:
     - name: Uncompress nodejs SDK
       run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
         ${{github.workspace}}/sdk/nodejs
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
     - run: python -m pip install pip twine
     - env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       name: Publish SDKs
       run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3
@@ -426,8 +458,6 @@ jobs:
         - 3.1.301
         goversion:
         - 1.19.x
-        javaversion:
-        - "11"
         nodeversion:
         - 16.x
         pythonversion:

--- a/provider-ci/providers/auth0/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/auth0/repo/.github/workflows/release.yml
@@ -336,6 +336,61 @@ jobs:
         - 16.x
         pythonversion:
         - "3.9"
+  publish_java_sdk:
+    continue-on-error: true
+    name: publish_java_sdk
+    needs: publish
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout Repo
+      uses: actions/checkout@v3
+    - name: Checkout Scripts Repo
+      uses: actions/checkout@v3
+      with:
+        path: ci-scripts
+        repository: pulumi/scripts
+    - name: Unshallow clone for tags
+      run: git fetch --prune --unshallow --tags
+    - name: Install Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: ${{matrix.goversion}}
+    - name: Install pulumictl
+      uses: jaxxstorm/action-install-gh-release@v1.5.0
+      with:
+        repo: pulumi/pulumictl
+    - name: Install Pulumi CLI
+      uses: pulumi/action-install-pulumi-cli@v2
+    - name: Setup Java
+      uses: actions/setup-java@v3
+      with:
+        cache: gradle
+        distribution: temurin
+        java-version: ${{matrix.javaversion}}
+    - name: Download java SDK
+      uses: actions/download-artifact@v2
+      with:
+        name: java-sdk.tar.gz
+        path: ${{ github.workspace}}/sdk/
+    - name: Uncompress java SDK
+      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
+        ${{github.workspace}}/sdk/java
+    - name: Set PACKAGE_VERSION to Env
+      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
+        $GITHUB_ENV
+    - name: Publish Java SDK
+      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
+      with:
+        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
+        build-root-directory: ./sdk/java
+        gradle-version: 7.4.1
+    strategy:
+      fail-fast: true
+      matrix:
+        goversion:
+        - 1.19.x
+        javaversion:
+        - "11"
   publish_sdk:
     name: publish_sdk
     needs: publish
@@ -373,12 +428,6 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{matrix.pythonversion}}
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{matrix.javaversion}}
     - name: Download python SDK
       uses: actions/download-artifact@v2
       with:
@@ -403,28 +452,11 @@ jobs:
     - name: Uncompress nodejs SDK
       run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
         ${{github.workspace}}/sdk/nodejs
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
     - run: python -m pip install pip twine
     - env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       name: Publish SDKs
       run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3
@@ -439,8 +471,6 @@ jobs:
         - 3.1.301
         goversion:
         - 1.19.x
-        javaversion:
-        - "11"
         nodeversion:
         - 16.x
         pythonversion:

--- a/provider-ci/providers/aws/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/aws/repo/.github/workflows/main.yml
@@ -303,6 +303,61 @@ jobs:
         - 16.x
         pythonversion:
         - "3.9"
+  publish_java_sdk:
+    continue-on-error: true
+    name: publish_java_sdk
+    needs: publish
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout Repo
+      uses: actions/checkout@v3
+    - name: Checkout Scripts Repo
+      uses: actions/checkout@v3
+      with:
+        path: ci-scripts
+        repository: pulumi/scripts
+    - name: Unshallow clone for tags
+      run: git fetch --prune --unshallow --tags
+    - name: Install Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: ${{matrix.goversion}}
+    - name: Install pulumictl
+      uses: jaxxstorm/action-install-gh-release@v1.5.0
+      with:
+        repo: pulumi/pulumictl
+    - name: Install Pulumi CLI
+      uses: pulumi/action-install-pulumi-cli@v2
+    - name: Setup Java
+      uses: actions/setup-java@v3
+      with:
+        cache: gradle
+        distribution: temurin
+        java-version: ${{matrix.javaversion}}
+    - name: Download java SDK
+      uses: actions/download-artifact@v2
+      with:
+        name: java-sdk.tar.gz
+        path: ${{ github.workspace}}/sdk/
+    - name: Uncompress java SDK
+      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
+        ${{github.workspace}}/sdk/java
+    - name: Set PACKAGE_VERSION to Env
+      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
+        $GITHUB_ENV
+    - name: Publish Java SDK
+      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
+      with:
+        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
+        build-root-directory: ./sdk/java
+        gradle-version: 7.4.1
+    strategy:
+      fail-fast: true
+      matrix:
+        goversion:
+        - 1.19.x
+        javaversion:
+        - "11"
   publish_sdk:
     name: publish_sdk
     needs: publish
@@ -340,12 +395,6 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{matrix.pythonversion}}
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{matrix.javaversion}}
     - name: Download python SDK
       uses: actions/download-artifact@v2
       with:
@@ -370,28 +419,11 @@ jobs:
     - name: Uncompress nodejs SDK
       run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
         ${{github.workspace}}/sdk/nodejs
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
     - run: python -m pip install pip twine
     - env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       name: Publish SDKs
       run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3
@@ -406,8 +438,6 @@ jobs:
         - 3.1.301
         goversion:
         - 1.19.x
-        javaversion:
-        - "11"
         nodeversion:
         - 16.x
         pythonversion:

--- a/provider-ci/providers/aws/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/aws/repo/.github/workflows/master.yml
@@ -303,6 +303,61 @@ jobs:
         - 16.x
         pythonversion:
         - "3.9"
+  publish_java_sdk:
+    continue-on-error: true
+    name: publish_java_sdk
+    needs: publish
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout Repo
+      uses: actions/checkout@v3
+    - name: Checkout Scripts Repo
+      uses: actions/checkout@v3
+      with:
+        path: ci-scripts
+        repository: pulumi/scripts
+    - name: Unshallow clone for tags
+      run: git fetch --prune --unshallow --tags
+    - name: Install Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: ${{matrix.goversion}}
+    - name: Install pulumictl
+      uses: jaxxstorm/action-install-gh-release@v1.5.0
+      with:
+        repo: pulumi/pulumictl
+    - name: Install Pulumi CLI
+      uses: pulumi/action-install-pulumi-cli@v2
+    - name: Setup Java
+      uses: actions/setup-java@v3
+      with:
+        cache: gradle
+        distribution: temurin
+        java-version: ${{matrix.javaversion}}
+    - name: Download java SDK
+      uses: actions/download-artifact@v2
+      with:
+        name: java-sdk.tar.gz
+        path: ${{ github.workspace}}/sdk/
+    - name: Uncompress java SDK
+      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
+        ${{github.workspace}}/sdk/java
+    - name: Set PACKAGE_VERSION to Env
+      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
+        $GITHUB_ENV
+    - name: Publish Java SDK
+      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
+      with:
+        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
+        build-root-directory: ./sdk/java
+        gradle-version: 7.4.1
+    strategy:
+      fail-fast: true
+      matrix:
+        goversion:
+        - 1.19.x
+        javaversion:
+        - "11"
   publish_sdk:
     name: publish_sdk
     needs: publish
@@ -340,12 +395,6 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{matrix.pythonversion}}
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{matrix.javaversion}}
     - name: Download python SDK
       uses: actions/download-artifact@v2
       with:
@@ -370,28 +419,11 @@ jobs:
     - name: Uncompress nodejs SDK
       run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
         ${{github.workspace}}/sdk/nodejs
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
     - run: python -m pip install pip twine
     - env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       name: Publish SDKs
       run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3
@@ -406,8 +438,6 @@ jobs:
         - 3.1.301
         goversion:
         - 1.19.x
-        javaversion:
-        - "11"
         nodeversion:
         - 16.x
         pythonversion:

--- a/provider-ci/providers/aws/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/aws/repo/.github/workflows/prerelease.yml
@@ -247,6 +247,61 @@ jobs:
         - 16.x
         pythonversion:
         - "3.9"
+  publish_java_sdk:
+    continue-on-error: true
+    name: publish_java_sdk
+    needs: publish
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout Repo
+      uses: actions/checkout@v3
+    - name: Checkout Scripts Repo
+      uses: actions/checkout@v3
+      with:
+        path: ci-scripts
+        repository: pulumi/scripts
+    - name: Unshallow clone for tags
+      run: git fetch --prune --unshallow --tags
+    - name: Install Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: ${{matrix.goversion}}
+    - name: Install pulumictl
+      uses: jaxxstorm/action-install-gh-release@v1.5.0
+      with:
+        repo: pulumi/pulumictl
+    - name: Install Pulumi CLI
+      uses: pulumi/action-install-pulumi-cli@v2
+    - name: Setup Java
+      uses: actions/setup-java@v3
+      with:
+        cache: gradle
+        distribution: temurin
+        java-version: ${{matrix.javaversion}}
+    - name: Download java SDK
+      uses: actions/download-artifact@v2
+      with:
+        name: java-sdk.tar.gz
+        path: ${{ github.workspace}}/sdk/
+    - name: Uncompress java SDK
+      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
+        ${{github.workspace}}/sdk/java
+    - name: Set PACKAGE_VERSION to Env
+      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
+        $GITHUB_ENV
+    - name: Publish Java SDK
+      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
+      with:
+        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
+        build-root-directory: ./sdk/java
+        gradle-version: 7.4.1
+    strategy:
+      fail-fast: true
+      matrix:
+        goversion:
+        - 1.19.x
+        javaversion:
+        - "11"
   publish_sdk:
     name: publish_sdk
     needs: publish
@@ -284,12 +339,6 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{matrix.pythonversion}}
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{matrix.javaversion}}
     - name: Download python SDK
       uses: actions/download-artifact@v2
       with:
@@ -314,28 +363,11 @@ jobs:
     - name: Uncompress nodejs SDK
       run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
         ${{github.workspace}}/sdk/nodejs
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
     - run: python -m pip install pip twine
     - env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       name: Publish SDKs
       run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3
@@ -350,8 +382,6 @@ jobs:
         - 3.1.301
         goversion:
         - 1.19.x
-        javaversion:
-        - "11"
         nodeversion:
         - 16.x
         pythonversion:

--- a/provider-ci/providers/aws/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/aws/repo/.github/workflows/release.yml
@@ -260,6 +260,61 @@ jobs:
         - 16.x
         pythonversion:
         - "3.9"
+  publish_java_sdk:
+    continue-on-error: true
+    name: publish_java_sdk
+    needs: publish
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout Repo
+      uses: actions/checkout@v3
+    - name: Checkout Scripts Repo
+      uses: actions/checkout@v3
+      with:
+        path: ci-scripts
+        repository: pulumi/scripts
+    - name: Unshallow clone for tags
+      run: git fetch --prune --unshallow --tags
+    - name: Install Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: ${{matrix.goversion}}
+    - name: Install pulumictl
+      uses: jaxxstorm/action-install-gh-release@v1.5.0
+      with:
+        repo: pulumi/pulumictl
+    - name: Install Pulumi CLI
+      uses: pulumi/action-install-pulumi-cli@v2
+    - name: Setup Java
+      uses: actions/setup-java@v3
+      with:
+        cache: gradle
+        distribution: temurin
+        java-version: ${{matrix.javaversion}}
+    - name: Download java SDK
+      uses: actions/download-artifact@v2
+      with:
+        name: java-sdk.tar.gz
+        path: ${{ github.workspace}}/sdk/
+    - name: Uncompress java SDK
+      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
+        ${{github.workspace}}/sdk/java
+    - name: Set PACKAGE_VERSION to Env
+      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
+        $GITHUB_ENV
+    - name: Publish Java SDK
+      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
+      with:
+        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
+        build-root-directory: ./sdk/java
+        gradle-version: 7.4.1
+    strategy:
+      fail-fast: true
+      matrix:
+        goversion:
+        - 1.19.x
+        javaversion:
+        - "11"
   publish_sdk:
     name: publish_sdk
     needs: publish
@@ -297,12 +352,6 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{matrix.pythonversion}}
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{matrix.javaversion}}
     - name: Download python SDK
       uses: actions/download-artifact@v2
       with:
@@ -327,28 +376,11 @@ jobs:
     - name: Uncompress nodejs SDK
       run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
         ${{github.workspace}}/sdk/nodejs
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
     - run: python -m pip install pip twine
     - env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       name: Publish SDKs
       run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3
@@ -363,8 +395,6 @@ jobs:
         - 3.1.301
         goversion:
         - 1.19.x
-        javaversion:
-        - "11"
         nodeversion:
         - 16.x
         pythonversion:

--- a/provider-ci/providers/azure/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/azure/repo/.github/workflows/main.yml
@@ -308,6 +308,61 @@ jobs:
         - 16.x
         pythonversion:
         - "3.9"
+  publish_java_sdk:
+    continue-on-error: true
+    name: publish_java_sdk
+    needs: publish
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout Repo
+      uses: actions/checkout@v3
+    - name: Checkout Scripts Repo
+      uses: actions/checkout@v3
+      with:
+        path: ci-scripts
+        repository: pulumi/scripts
+    - name: Unshallow clone for tags
+      run: git fetch --prune --unshallow --tags
+    - name: Install Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: ${{matrix.goversion}}
+    - name: Install pulumictl
+      uses: jaxxstorm/action-install-gh-release@v1.5.0
+      with:
+        repo: pulumi/pulumictl
+    - name: Install Pulumi CLI
+      uses: pulumi/action-install-pulumi-cli@v2
+    - name: Setup Java
+      uses: actions/setup-java@v3
+      with:
+        cache: gradle
+        distribution: temurin
+        java-version: ${{matrix.javaversion}}
+    - name: Download java SDK
+      uses: actions/download-artifact@v2
+      with:
+        name: java-sdk.tar.gz
+        path: ${{ github.workspace}}/sdk/
+    - name: Uncompress java SDK
+      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
+        ${{github.workspace}}/sdk/java
+    - name: Set PACKAGE_VERSION to Env
+      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
+        $GITHUB_ENV
+    - name: Publish Java SDK
+      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
+      with:
+        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
+        build-root-directory: ./sdk/java
+        gradle-version: 7.4.1
+    strategy:
+      fail-fast: true
+      matrix:
+        goversion:
+        - 1.19.x
+        javaversion:
+        - "11"
   publish_sdk:
     name: publish_sdk
     needs: publish
@@ -345,12 +400,6 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{matrix.pythonversion}}
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{matrix.javaversion}}
     - name: Download python SDK
       uses: actions/download-artifact@v2
       with:
@@ -375,28 +424,11 @@ jobs:
     - name: Uncompress nodejs SDK
       run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
         ${{github.workspace}}/sdk/nodejs
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
     - run: python -m pip install pip twine
     - env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       name: Publish SDKs
       run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3
@@ -411,8 +443,6 @@ jobs:
         - 3.1.301
         goversion:
         - 1.19.x
-        javaversion:
-        - "11"
         nodeversion:
         - 16.x
         pythonversion:

--- a/provider-ci/providers/azure/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/azure/repo/.github/workflows/master.yml
@@ -308,6 +308,61 @@ jobs:
         - 16.x
         pythonversion:
         - "3.9"
+  publish_java_sdk:
+    continue-on-error: true
+    name: publish_java_sdk
+    needs: publish
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout Repo
+      uses: actions/checkout@v3
+    - name: Checkout Scripts Repo
+      uses: actions/checkout@v3
+      with:
+        path: ci-scripts
+        repository: pulumi/scripts
+    - name: Unshallow clone for tags
+      run: git fetch --prune --unshallow --tags
+    - name: Install Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: ${{matrix.goversion}}
+    - name: Install pulumictl
+      uses: jaxxstorm/action-install-gh-release@v1.5.0
+      with:
+        repo: pulumi/pulumictl
+    - name: Install Pulumi CLI
+      uses: pulumi/action-install-pulumi-cli@v2
+    - name: Setup Java
+      uses: actions/setup-java@v3
+      with:
+        cache: gradle
+        distribution: temurin
+        java-version: ${{matrix.javaversion}}
+    - name: Download java SDK
+      uses: actions/download-artifact@v2
+      with:
+        name: java-sdk.tar.gz
+        path: ${{ github.workspace}}/sdk/
+    - name: Uncompress java SDK
+      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
+        ${{github.workspace}}/sdk/java
+    - name: Set PACKAGE_VERSION to Env
+      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
+        $GITHUB_ENV
+    - name: Publish Java SDK
+      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
+      with:
+        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
+        build-root-directory: ./sdk/java
+        gradle-version: 7.4.1
+    strategy:
+      fail-fast: true
+      matrix:
+        goversion:
+        - 1.19.x
+        javaversion:
+        - "11"
   publish_sdk:
     name: publish_sdk
     needs: publish
@@ -345,12 +400,6 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{matrix.pythonversion}}
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{matrix.javaversion}}
     - name: Download python SDK
       uses: actions/download-artifact@v2
       with:
@@ -375,28 +424,11 @@ jobs:
     - name: Uncompress nodejs SDK
       run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
         ${{github.workspace}}/sdk/nodejs
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
     - run: python -m pip install pip twine
     - env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       name: Publish SDKs
       run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3
@@ -411,8 +443,6 @@ jobs:
         - 3.1.301
         goversion:
         - 1.19.x
-        javaversion:
-        - "11"
         nodeversion:
         - 16.x
         pythonversion:

--- a/provider-ci/providers/azure/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/azure/repo/.github/workflows/prerelease.yml
@@ -252,6 +252,61 @@ jobs:
         - 16.x
         pythonversion:
         - "3.9"
+  publish_java_sdk:
+    continue-on-error: true
+    name: publish_java_sdk
+    needs: publish
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout Repo
+      uses: actions/checkout@v3
+    - name: Checkout Scripts Repo
+      uses: actions/checkout@v3
+      with:
+        path: ci-scripts
+        repository: pulumi/scripts
+    - name: Unshallow clone for tags
+      run: git fetch --prune --unshallow --tags
+    - name: Install Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: ${{matrix.goversion}}
+    - name: Install pulumictl
+      uses: jaxxstorm/action-install-gh-release@v1.5.0
+      with:
+        repo: pulumi/pulumictl
+    - name: Install Pulumi CLI
+      uses: pulumi/action-install-pulumi-cli@v2
+    - name: Setup Java
+      uses: actions/setup-java@v3
+      with:
+        cache: gradle
+        distribution: temurin
+        java-version: ${{matrix.javaversion}}
+    - name: Download java SDK
+      uses: actions/download-artifact@v2
+      with:
+        name: java-sdk.tar.gz
+        path: ${{ github.workspace}}/sdk/
+    - name: Uncompress java SDK
+      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
+        ${{github.workspace}}/sdk/java
+    - name: Set PACKAGE_VERSION to Env
+      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
+        $GITHUB_ENV
+    - name: Publish Java SDK
+      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
+      with:
+        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
+        build-root-directory: ./sdk/java
+        gradle-version: 7.4.1
+    strategy:
+      fail-fast: true
+      matrix:
+        goversion:
+        - 1.19.x
+        javaversion:
+        - "11"
   publish_sdk:
     name: publish_sdk
     needs: publish
@@ -289,12 +344,6 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{matrix.pythonversion}}
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{matrix.javaversion}}
     - name: Download python SDK
       uses: actions/download-artifact@v2
       with:
@@ -319,28 +368,11 @@ jobs:
     - name: Uncompress nodejs SDK
       run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
         ${{github.workspace}}/sdk/nodejs
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
     - run: python -m pip install pip twine
     - env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       name: Publish SDKs
       run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3
@@ -355,8 +387,6 @@ jobs:
         - 3.1.301
         goversion:
         - 1.19.x
-        javaversion:
-        - "11"
         nodeversion:
         - 16.x
         pythonversion:

--- a/provider-ci/providers/azure/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/azure/repo/.github/workflows/release.yml
@@ -265,6 +265,61 @@ jobs:
         - 16.x
         pythonversion:
         - "3.9"
+  publish_java_sdk:
+    continue-on-error: true
+    name: publish_java_sdk
+    needs: publish
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout Repo
+      uses: actions/checkout@v3
+    - name: Checkout Scripts Repo
+      uses: actions/checkout@v3
+      with:
+        path: ci-scripts
+        repository: pulumi/scripts
+    - name: Unshallow clone for tags
+      run: git fetch --prune --unshallow --tags
+    - name: Install Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: ${{matrix.goversion}}
+    - name: Install pulumictl
+      uses: jaxxstorm/action-install-gh-release@v1.5.0
+      with:
+        repo: pulumi/pulumictl
+    - name: Install Pulumi CLI
+      uses: pulumi/action-install-pulumi-cli@v2
+    - name: Setup Java
+      uses: actions/setup-java@v3
+      with:
+        cache: gradle
+        distribution: temurin
+        java-version: ${{matrix.javaversion}}
+    - name: Download java SDK
+      uses: actions/download-artifact@v2
+      with:
+        name: java-sdk.tar.gz
+        path: ${{ github.workspace}}/sdk/
+    - name: Uncompress java SDK
+      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
+        ${{github.workspace}}/sdk/java
+    - name: Set PACKAGE_VERSION to Env
+      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
+        $GITHUB_ENV
+    - name: Publish Java SDK
+      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
+      with:
+        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
+        build-root-directory: ./sdk/java
+        gradle-version: 7.4.1
+    strategy:
+      fail-fast: true
+      matrix:
+        goversion:
+        - 1.19.x
+        javaversion:
+        - "11"
   publish_sdk:
     name: publish_sdk
     needs: publish
@@ -302,12 +357,6 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{matrix.pythonversion}}
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{matrix.javaversion}}
     - name: Download python SDK
       uses: actions/download-artifact@v2
       with:
@@ -332,28 +381,11 @@ jobs:
     - name: Uncompress nodejs SDK
       run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
         ${{github.workspace}}/sdk/nodejs
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
     - run: python -m pip install pip twine
     - env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       name: Publish SDKs
       run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3
@@ -368,8 +400,6 @@ jobs:
         - 3.1.301
         goversion:
         - 1.19.x
-        javaversion:
-        - "11"
         nodeversion:
         - 16.x
         pythonversion:

--- a/provider-ci/providers/azuread/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/azuread/repo/.github/workflows/main.yml
@@ -381,6 +381,61 @@ jobs:
         - 16.x
         pythonversion:
         - "3.9"
+  publish_java_sdk:
+    continue-on-error: true
+    name: publish_java_sdk
+    needs: publish
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout Repo
+      uses: actions/checkout@v3
+    - name: Checkout Scripts Repo
+      uses: actions/checkout@v3
+      with:
+        path: ci-scripts
+        repository: pulumi/scripts
+    - name: Unshallow clone for tags
+      run: git fetch --prune --unshallow --tags
+    - name: Install Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: ${{matrix.goversion}}
+    - name: Install pulumictl
+      uses: jaxxstorm/action-install-gh-release@v1.5.0
+      with:
+        repo: pulumi/pulumictl
+    - name: Install Pulumi CLI
+      uses: pulumi/action-install-pulumi-cli@v2
+    - name: Setup Java
+      uses: actions/setup-java@v3
+      with:
+        cache: gradle
+        distribution: temurin
+        java-version: ${{matrix.javaversion}}
+    - name: Download java SDK
+      uses: actions/download-artifact@v2
+      with:
+        name: java-sdk.tar.gz
+        path: ${{ github.workspace}}/sdk/
+    - name: Uncompress java SDK
+      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
+        ${{github.workspace}}/sdk/java
+    - name: Set PACKAGE_VERSION to Env
+      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
+        $GITHUB_ENV
+    - name: Publish Java SDK
+      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
+      with:
+        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
+        build-root-directory: ./sdk/java
+        gradle-version: 7.4.1
+    strategy:
+      fail-fast: true
+      matrix:
+        goversion:
+        - 1.19.x
+        javaversion:
+        - "11"
   publish_sdk:
     name: publish_sdk
     needs: publish
@@ -418,12 +473,6 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{matrix.pythonversion}}
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{matrix.javaversion}}
     - name: Download python SDK
       uses: actions/download-artifact@v2
       with:
@@ -448,28 +497,11 @@ jobs:
     - name: Uncompress nodejs SDK
       run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
         ${{github.workspace}}/sdk/nodejs
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
     - run: python -m pip install pip twine
     - env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       name: Publish SDKs
       run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3
@@ -484,8 +516,6 @@ jobs:
         - 3.1.301
         goversion:
         - 1.19.x
-        javaversion:
-        - "11"
         nodeversion:
         - 16.x
         pythonversion:

--- a/provider-ci/providers/azuread/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/azuread/repo/.github/workflows/master.yml
@@ -381,6 +381,61 @@ jobs:
         - 16.x
         pythonversion:
         - "3.9"
+  publish_java_sdk:
+    continue-on-error: true
+    name: publish_java_sdk
+    needs: publish
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout Repo
+      uses: actions/checkout@v3
+    - name: Checkout Scripts Repo
+      uses: actions/checkout@v3
+      with:
+        path: ci-scripts
+        repository: pulumi/scripts
+    - name: Unshallow clone for tags
+      run: git fetch --prune --unshallow --tags
+    - name: Install Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: ${{matrix.goversion}}
+    - name: Install pulumictl
+      uses: jaxxstorm/action-install-gh-release@v1.5.0
+      with:
+        repo: pulumi/pulumictl
+    - name: Install Pulumi CLI
+      uses: pulumi/action-install-pulumi-cli@v2
+    - name: Setup Java
+      uses: actions/setup-java@v3
+      with:
+        cache: gradle
+        distribution: temurin
+        java-version: ${{matrix.javaversion}}
+    - name: Download java SDK
+      uses: actions/download-artifact@v2
+      with:
+        name: java-sdk.tar.gz
+        path: ${{ github.workspace}}/sdk/
+    - name: Uncompress java SDK
+      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
+        ${{github.workspace}}/sdk/java
+    - name: Set PACKAGE_VERSION to Env
+      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
+        $GITHUB_ENV
+    - name: Publish Java SDK
+      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
+      with:
+        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
+        build-root-directory: ./sdk/java
+        gradle-version: 7.4.1
+    strategy:
+      fail-fast: true
+      matrix:
+        goversion:
+        - 1.19.x
+        javaversion:
+        - "11"
   publish_sdk:
     name: publish_sdk
     needs: publish
@@ -418,12 +473,6 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{matrix.pythonversion}}
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{matrix.javaversion}}
     - name: Download python SDK
       uses: actions/download-artifact@v2
       with:
@@ -448,28 +497,11 @@ jobs:
     - name: Uncompress nodejs SDK
       run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
         ${{github.workspace}}/sdk/nodejs
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
     - run: python -m pip install pip twine
     - env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       name: Publish SDKs
       run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3
@@ -484,8 +516,6 @@ jobs:
         - 3.1.301
         goversion:
         - 1.19.x
-        javaversion:
-        - "11"
         nodeversion:
         - 16.x
         pythonversion:

--- a/provider-ci/providers/azuread/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/azuread/repo/.github/workflows/prerelease.yml
@@ -325,6 +325,61 @@ jobs:
         - 16.x
         pythonversion:
         - "3.9"
+  publish_java_sdk:
+    continue-on-error: true
+    name: publish_java_sdk
+    needs: publish
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout Repo
+      uses: actions/checkout@v3
+    - name: Checkout Scripts Repo
+      uses: actions/checkout@v3
+      with:
+        path: ci-scripts
+        repository: pulumi/scripts
+    - name: Unshallow clone for tags
+      run: git fetch --prune --unshallow --tags
+    - name: Install Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: ${{matrix.goversion}}
+    - name: Install pulumictl
+      uses: jaxxstorm/action-install-gh-release@v1.5.0
+      with:
+        repo: pulumi/pulumictl
+    - name: Install Pulumi CLI
+      uses: pulumi/action-install-pulumi-cli@v2
+    - name: Setup Java
+      uses: actions/setup-java@v3
+      with:
+        cache: gradle
+        distribution: temurin
+        java-version: ${{matrix.javaversion}}
+    - name: Download java SDK
+      uses: actions/download-artifact@v2
+      with:
+        name: java-sdk.tar.gz
+        path: ${{ github.workspace}}/sdk/
+    - name: Uncompress java SDK
+      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
+        ${{github.workspace}}/sdk/java
+    - name: Set PACKAGE_VERSION to Env
+      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
+        $GITHUB_ENV
+    - name: Publish Java SDK
+      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
+      with:
+        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
+        build-root-directory: ./sdk/java
+        gradle-version: 7.4.1
+    strategy:
+      fail-fast: true
+      matrix:
+        goversion:
+        - 1.19.x
+        javaversion:
+        - "11"
   publish_sdk:
     name: publish_sdk
     needs: publish
@@ -362,12 +417,6 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{matrix.pythonversion}}
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{matrix.javaversion}}
     - name: Download python SDK
       uses: actions/download-artifact@v2
       with:
@@ -392,28 +441,11 @@ jobs:
     - name: Uncompress nodejs SDK
       run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
         ${{github.workspace}}/sdk/nodejs
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
     - run: python -m pip install pip twine
     - env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       name: Publish SDKs
       run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3
@@ -428,8 +460,6 @@ jobs:
         - 3.1.301
         goversion:
         - 1.19.x
-        javaversion:
-        - "11"
         nodeversion:
         - 16.x
         pythonversion:

--- a/provider-ci/providers/azuread/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/azuread/repo/.github/workflows/release.yml
@@ -338,6 +338,61 @@ jobs:
         - 16.x
         pythonversion:
         - "3.9"
+  publish_java_sdk:
+    continue-on-error: true
+    name: publish_java_sdk
+    needs: publish
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout Repo
+      uses: actions/checkout@v3
+    - name: Checkout Scripts Repo
+      uses: actions/checkout@v3
+      with:
+        path: ci-scripts
+        repository: pulumi/scripts
+    - name: Unshallow clone for tags
+      run: git fetch --prune --unshallow --tags
+    - name: Install Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: ${{matrix.goversion}}
+    - name: Install pulumictl
+      uses: jaxxstorm/action-install-gh-release@v1.5.0
+      with:
+        repo: pulumi/pulumictl
+    - name: Install Pulumi CLI
+      uses: pulumi/action-install-pulumi-cli@v2
+    - name: Setup Java
+      uses: actions/setup-java@v3
+      with:
+        cache: gradle
+        distribution: temurin
+        java-version: ${{matrix.javaversion}}
+    - name: Download java SDK
+      uses: actions/download-artifact@v2
+      with:
+        name: java-sdk.tar.gz
+        path: ${{ github.workspace}}/sdk/
+    - name: Uncompress java SDK
+      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
+        ${{github.workspace}}/sdk/java
+    - name: Set PACKAGE_VERSION to Env
+      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
+        $GITHUB_ENV
+    - name: Publish Java SDK
+      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
+      with:
+        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
+        build-root-directory: ./sdk/java
+        gradle-version: 7.4.1
+    strategy:
+      fail-fast: true
+      matrix:
+        goversion:
+        - 1.19.x
+        javaversion:
+        - "11"
   publish_sdk:
     name: publish_sdk
     needs: publish
@@ -375,12 +430,6 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{matrix.pythonversion}}
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{matrix.javaversion}}
     - name: Download python SDK
       uses: actions/download-artifact@v2
       with:
@@ -405,28 +454,11 @@ jobs:
     - name: Uncompress nodejs SDK
       run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
         ${{github.workspace}}/sdk/nodejs
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
     - run: python -m pip install pip twine
     - env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       name: Publish SDKs
       run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3
@@ -441,8 +473,6 @@ jobs:
         - 3.1.301
         goversion:
         - 1.19.x
-        javaversion:
-        - "11"
         nodeversion:
         - 16.x
         pythonversion:

--- a/provider-ci/providers/azuredevops/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/azuredevops/repo/.github/workflows/main.yml
@@ -303,6 +303,61 @@ jobs:
         - 16.x
         pythonversion:
         - "3.9"
+  publish_java_sdk:
+    continue-on-error: true
+    name: publish_java_sdk
+    needs: publish
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout Repo
+      uses: actions/checkout@v3
+    - name: Checkout Scripts Repo
+      uses: actions/checkout@v3
+      with:
+        path: ci-scripts
+        repository: pulumi/scripts
+    - name: Unshallow clone for tags
+      run: git fetch --prune --unshallow --tags
+    - name: Install Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: ${{matrix.goversion}}
+    - name: Install pulumictl
+      uses: jaxxstorm/action-install-gh-release@v1.5.0
+      with:
+        repo: pulumi/pulumictl
+    - name: Install Pulumi CLI
+      uses: pulumi/action-install-pulumi-cli@v2
+    - name: Setup Java
+      uses: actions/setup-java@v3
+      with:
+        cache: gradle
+        distribution: temurin
+        java-version: ${{matrix.javaversion}}
+    - name: Download java SDK
+      uses: actions/download-artifact@v2
+      with:
+        name: java-sdk.tar.gz
+        path: ${{ github.workspace}}/sdk/
+    - name: Uncompress java SDK
+      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
+        ${{github.workspace}}/sdk/java
+    - name: Set PACKAGE_VERSION to Env
+      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
+        $GITHUB_ENV
+    - name: Publish Java SDK
+      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
+      with:
+        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
+        build-root-directory: ./sdk/java
+        gradle-version: 7.4.1
+    strategy:
+      fail-fast: true
+      matrix:
+        goversion:
+        - 1.19.x
+        javaversion:
+        - "11"
   publish_sdk:
     name: publish_sdk
     needs: publish
@@ -340,12 +395,6 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{matrix.pythonversion}}
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{matrix.javaversion}}
     - name: Download python SDK
       uses: actions/download-artifact@v2
       with:
@@ -370,28 +419,11 @@ jobs:
     - name: Uncompress nodejs SDK
       run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
         ${{github.workspace}}/sdk/nodejs
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
     - run: python -m pip install pip twine
     - env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       name: Publish SDKs
       run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3
@@ -406,8 +438,6 @@ jobs:
         - 3.1.301
         goversion:
         - 1.19.x
-        javaversion:
-        - "11"
         nodeversion:
         - 16.x
         pythonversion:

--- a/provider-ci/providers/azuredevops/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/azuredevops/repo/.github/workflows/master.yml
@@ -303,6 +303,61 @@ jobs:
         - 16.x
         pythonversion:
         - "3.9"
+  publish_java_sdk:
+    continue-on-error: true
+    name: publish_java_sdk
+    needs: publish
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout Repo
+      uses: actions/checkout@v3
+    - name: Checkout Scripts Repo
+      uses: actions/checkout@v3
+      with:
+        path: ci-scripts
+        repository: pulumi/scripts
+    - name: Unshallow clone for tags
+      run: git fetch --prune --unshallow --tags
+    - name: Install Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: ${{matrix.goversion}}
+    - name: Install pulumictl
+      uses: jaxxstorm/action-install-gh-release@v1.5.0
+      with:
+        repo: pulumi/pulumictl
+    - name: Install Pulumi CLI
+      uses: pulumi/action-install-pulumi-cli@v2
+    - name: Setup Java
+      uses: actions/setup-java@v3
+      with:
+        cache: gradle
+        distribution: temurin
+        java-version: ${{matrix.javaversion}}
+    - name: Download java SDK
+      uses: actions/download-artifact@v2
+      with:
+        name: java-sdk.tar.gz
+        path: ${{ github.workspace}}/sdk/
+    - name: Uncompress java SDK
+      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
+        ${{github.workspace}}/sdk/java
+    - name: Set PACKAGE_VERSION to Env
+      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
+        $GITHUB_ENV
+    - name: Publish Java SDK
+      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
+      with:
+        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
+        build-root-directory: ./sdk/java
+        gradle-version: 7.4.1
+    strategy:
+      fail-fast: true
+      matrix:
+        goversion:
+        - 1.19.x
+        javaversion:
+        - "11"
   publish_sdk:
     name: publish_sdk
     needs: publish
@@ -340,12 +395,6 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{matrix.pythonversion}}
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{matrix.javaversion}}
     - name: Download python SDK
       uses: actions/download-artifact@v2
       with:
@@ -370,28 +419,11 @@ jobs:
     - name: Uncompress nodejs SDK
       run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
         ${{github.workspace}}/sdk/nodejs
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
     - run: python -m pip install pip twine
     - env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       name: Publish SDKs
       run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3
@@ -406,8 +438,6 @@ jobs:
         - 3.1.301
         goversion:
         - 1.19.x
-        javaversion:
-        - "11"
         nodeversion:
         - 16.x
         pythonversion:

--- a/provider-ci/providers/azuredevops/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/azuredevops/repo/.github/workflows/prerelease.yml
@@ -247,6 +247,61 @@ jobs:
         - 16.x
         pythonversion:
         - "3.9"
+  publish_java_sdk:
+    continue-on-error: true
+    name: publish_java_sdk
+    needs: publish
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout Repo
+      uses: actions/checkout@v3
+    - name: Checkout Scripts Repo
+      uses: actions/checkout@v3
+      with:
+        path: ci-scripts
+        repository: pulumi/scripts
+    - name: Unshallow clone for tags
+      run: git fetch --prune --unshallow --tags
+    - name: Install Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: ${{matrix.goversion}}
+    - name: Install pulumictl
+      uses: jaxxstorm/action-install-gh-release@v1.5.0
+      with:
+        repo: pulumi/pulumictl
+    - name: Install Pulumi CLI
+      uses: pulumi/action-install-pulumi-cli@v2
+    - name: Setup Java
+      uses: actions/setup-java@v3
+      with:
+        cache: gradle
+        distribution: temurin
+        java-version: ${{matrix.javaversion}}
+    - name: Download java SDK
+      uses: actions/download-artifact@v2
+      with:
+        name: java-sdk.tar.gz
+        path: ${{ github.workspace}}/sdk/
+    - name: Uncompress java SDK
+      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
+        ${{github.workspace}}/sdk/java
+    - name: Set PACKAGE_VERSION to Env
+      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
+        $GITHUB_ENV
+    - name: Publish Java SDK
+      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
+      with:
+        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
+        build-root-directory: ./sdk/java
+        gradle-version: 7.4.1
+    strategy:
+      fail-fast: true
+      matrix:
+        goversion:
+        - 1.19.x
+        javaversion:
+        - "11"
   publish_sdk:
     name: publish_sdk
     needs: publish
@@ -284,12 +339,6 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{matrix.pythonversion}}
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{matrix.javaversion}}
     - name: Download python SDK
       uses: actions/download-artifact@v2
       with:
@@ -314,28 +363,11 @@ jobs:
     - name: Uncompress nodejs SDK
       run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
         ${{github.workspace}}/sdk/nodejs
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
     - run: python -m pip install pip twine
     - env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       name: Publish SDKs
       run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3
@@ -350,8 +382,6 @@ jobs:
         - 3.1.301
         goversion:
         - 1.19.x
-        javaversion:
-        - "11"
         nodeversion:
         - 16.x
         pythonversion:

--- a/provider-ci/providers/azuredevops/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/azuredevops/repo/.github/workflows/release.yml
@@ -260,6 +260,61 @@ jobs:
         - 16.x
         pythonversion:
         - "3.9"
+  publish_java_sdk:
+    continue-on-error: true
+    name: publish_java_sdk
+    needs: publish
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout Repo
+      uses: actions/checkout@v3
+    - name: Checkout Scripts Repo
+      uses: actions/checkout@v3
+      with:
+        path: ci-scripts
+        repository: pulumi/scripts
+    - name: Unshallow clone for tags
+      run: git fetch --prune --unshallow --tags
+    - name: Install Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: ${{matrix.goversion}}
+    - name: Install pulumictl
+      uses: jaxxstorm/action-install-gh-release@v1.5.0
+      with:
+        repo: pulumi/pulumictl
+    - name: Install Pulumi CLI
+      uses: pulumi/action-install-pulumi-cli@v2
+    - name: Setup Java
+      uses: actions/setup-java@v3
+      with:
+        cache: gradle
+        distribution: temurin
+        java-version: ${{matrix.javaversion}}
+    - name: Download java SDK
+      uses: actions/download-artifact@v2
+      with:
+        name: java-sdk.tar.gz
+        path: ${{ github.workspace}}/sdk/
+    - name: Uncompress java SDK
+      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
+        ${{github.workspace}}/sdk/java
+    - name: Set PACKAGE_VERSION to Env
+      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
+        $GITHUB_ENV
+    - name: Publish Java SDK
+      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
+      with:
+        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
+        build-root-directory: ./sdk/java
+        gradle-version: 7.4.1
+    strategy:
+      fail-fast: true
+      matrix:
+        goversion:
+        - 1.19.x
+        javaversion:
+        - "11"
   publish_sdk:
     name: publish_sdk
     needs: publish
@@ -297,12 +352,6 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{matrix.pythonversion}}
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{matrix.javaversion}}
     - name: Download python SDK
       uses: actions/download-artifact@v2
       with:
@@ -327,28 +376,11 @@ jobs:
     - name: Uncompress nodejs SDK
       run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
         ${{github.workspace}}/sdk/nodejs
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
     - run: python -m pip install pip twine
     - env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       name: Publish SDKs
       run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3
@@ -363,8 +395,6 @@ jobs:
         - 3.1.301
         goversion:
         - 1.19.x
-        javaversion:
-        - "11"
         nodeversion:
         - 16.x
         pythonversion:

--- a/provider-ci/providers/civo/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/civo/repo/.github/workflows/main.yml
@@ -377,6 +377,61 @@ jobs:
         - 16.x
         pythonversion:
         - "3.9"
+  publish_java_sdk:
+    continue-on-error: true
+    name: publish_java_sdk
+    needs: publish
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout Repo
+      uses: actions/checkout@v3
+    - name: Checkout Scripts Repo
+      uses: actions/checkout@v3
+      with:
+        path: ci-scripts
+        repository: pulumi/scripts
+    - name: Unshallow clone for tags
+      run: git fetch --prune --unshallow --tags
+    - name: Install Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: ${{matrix.goversion}}
+    - name: Install pulumictl
+      uses: jaxxstorm/action-install-gh-release@v1.5.0
+      with:
+        repo: pulumi/pulumictl
+    - name: Install Pulumi CLI
+      uses: pulumi/action-install-pulumi-cli@v2
+    - name: Setup Java
+      uses: actions/setup-java@v3
+      with:
+        cache: gradle
+        distribution: temurin
+        java-version: ${{matrix.javaversion}}
+    - name: Download java SDK
+      uses: actions/download-artifact@v2
+      with:
+        name: java-sdk.tar.gz
+        path: ${{ github.workspace}}/sdk/
+    - name: Uncompress java SDK
+      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
+        ${{github.workspace}}/sdk/java
+    - name: Set PACKAGE_VERSION to Env
+      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
+        $GITHUB_ENV
+    - name: Publish Java SDK
+      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
+      with:
+        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
+        build-root-directory: ./sdk/java
+        gradle-version: 7.4.1
+    strategy:
+      fail-fast: true
+      matrix:
+        goversion:
+        - 1.19.x
+        javaversion:
+        - "11"
   publish_sdk:
     name: publish_sdk
     needs: publish
@@ -414,12 +469,6 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{matrix.pythonversion}}
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{matrix.javaversion}}
     - name: Download python SDK
       uses: actions/download-artifact@v2
       with:
@@ -444,28 +493,11 @@ jobs:
     - name: Uncompress nodejs SDK
       run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
         ${{github.workspace}}/sdk/nodejs
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
     - run: python -m pip install pip twine
     - env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       name: Publish SDKs
       run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3
@@ -480,8 +512,6 @@ jobs:
         - 3.1.301
         goversion:
         - 1.19.x
-        javaversion:
-        - "11"
         nodeversion:
         - 16.x
         pythonversion:

--- a/provider-ci/providers/civo/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/civo/repo/.github/workflows/master.yml
@@ -377,6 +377,61 @@ jobs:
         - 16.x
         pythonversion:
         - "3.9"
+  publish_java_sdk:
+    continue-on-error: true
+    name: publish_java_sdk
+    needs: publish
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout Repo
+      uses: actions/checkout@v3
+    - name: Checkout Scripts Repo
+      uses: actions/checkout@v3
+      with:
+        path: ci-scripts
+        repository: pulumi/scripts
+    - name: Unshallow clone for tags
+      run: git fetch --prune --unshallow --tags
+    - name: Install Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: ${{matrix.goversion}}
+    - name: Install pulumictl
+      uses: jaxxstorm/action-install-gh-release@v1.5.0
+      with:
+        repo: pulumi/pulumictl
+    - name: Install Pulumi CLI
+      uses: pulumi/action-install-pulumi-cli@v2
+    - name: Setup Java
+      uses: actions/setup-java@v3
+      with:
+        cache: gradle
+        distribution: temurin
+        java-version: ${{matrix.javaversion}}
+    - name: Download java SDK
+      uses: actions/download-artifact@v2
+      with:
+        name: java-sdk.tar.gz
+        path: ${{ github.workspace}}/sdk/
+    - name: Uncompress java SDK
+      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
+        ${{github.workspace}}/sdk/java
+    - name: Set PACKAGE_VERSION to Env
+      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
+        $GITHUB_ENV
+    - name: Publish Java SDK
+      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
+      with:
+        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
+        build-root-directory: ./sdk/java
+        gradle-version: 7.4.1
+    strategy:
+      fail-fast: true
+      matrix:
+        goversion:
+        - 1.19.x
+        javaversion:
+        - "11"
   publish_sdk:
     name: publish_sdk
     needs: publish
@@ -414,12 +469,6 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{matrix.pythonversion}}
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{matrix.javaversion}}
     - name: Download python SDK
       uses: actions/download-artifact@v2
       with:
@@ -444,28 +493,11 @@ jobs:
     - name: Uncompress nodejs SDK
       run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
         ${{github.workspace}}/sdk/nodejs
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
     - run: python -m pip install pip twine
     - env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       name: Publish SDKs
       run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3
@@ -480,8 +512,6 @@ jobs:
         - 3.1.301
         goversion:
         - 1.19.x
-        javaversion:
-        - "11"
         nodeversion:
         - 16.x
         pythonversion:

--- a/provider-ci/providers/civo/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/civo/repo/.github/workflows/prerelease.yml
@@ -321,6 +321,61 @@ jobs:
         - 16.x
         pythonversion:
         - "3.9"
+  publish_java_sdk:
+    continue-on-error: true
+    name: publish_java_sdk
+    needs: publish
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout Repo
+      uses: actions/checkout@v3
+    - name: Checkout Scripts Repo
+      uses: actions/checkout@v3
+      with:
+        path: ci-scripts
+        repository: pulumi/scripts
+    - name: Unshallow clone for tags
+      run: git fetch --prune --unshallow --tags
+    - name: Install Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: ${{matrix.goversion}}
+    - name: Install pulumictl
+      uses: jaxxstorm/action-install-gh-release@v1.5.0
+      with:
+        repo: pulumi/pulumictl
+    - name: Install Pulumi CLI
+      uses: pulumi/action-install-pulumi-cli@v2
+    - name: Setup Java
+      uses: actions/setup-java@v3
+      with:
+        cache: gradle
+        distribution: temurin
+        java-version: ${{matrix.javaversion}}
+    - name: Download java SDK
+      uses: actions/download-artifact@v2
+      with:
+        name: java-sdk.tar.gz
+        path: ${{ github.workspace}}/sdk/
+    - name: Uncompress java SDK
+      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
+        ${{github.workspace}}/sdk/java
+    - name: Set PACKAGE_VERSION to Env
+      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
+        $GITHUB_ENV
+    - name: Publish Java SDK
+      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
+      with:
+        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
+        build-root-directory: ./sdk/java
+        gradle-version: 7.4.1
+    strategy:
+      fail-fast: true
+      matrix:
+        goversion:
+        - 1.19.x
+        javaversion:
+        - "11"
   publish_sdk:
     name: publish_sdk
     needs: publish
@@ -358,12 +413,6 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{matrix.pythonversion}}
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{matrix.javaversion}}
     - name: Download python SDK
       uses: actions/download-artifact@v2
       with:
@@ -388,28 +437,11 @@ jobs:
     - name: Uncompress nodejs SDK
       run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
         ${{github.workspace}}/sdk/nodejs
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
     - run: python -m pip install pip twine
     - env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       name: Publish SDKs
       run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3
@@ -424,8 +456,6 @@ jobs:
         - 3.1.301
         goversion:
         - 1.19.x
-        javaversion:
-        - "11"
         nodeversion:
         - 16.x
         pythonversion:

--- a/provider-ci/providers/civo/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/civo/repo/.github/workflows/release.yml
@@ -334,6 +334,61 @@ jobs:
         - 16.x
         pythonversion:
         - "3.9"
+  publish_java_sdk:
+    continue-on-error: true
+    name: publish_java_sdk
+    needs: publish
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout Repo
+      uses: actions/checkout@v3
+    - name: Checkout Scripts Repo
+      uses: actions/checkout@v3
+      with:
+        path: ci-scripts
+        repository: pulumi/scripts
+    - name: Unshallow clone for tags
+      run: git fetch --prune --unshallow --tags
+    - name: Install Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: ${{matrix.goversion}}
+    - name: Install pulumictl
+      uses: jaxxstorm/action-install-gh-release@v1.5.0
+      with:
+        repo: pulumi/pulumictl
+    - name: Install Pulumi CLI
+      uses: pulumi/action-install-pulumi-cli@v2
+    - name: Setup Java
+      uses: actions/setup-java@v3
+      with:
+        cache: gradle
+        distribution: temurin
+        java-version: ${{matrix.javaversion}}
+    - name: Download java SDK
+      uses: actions/download-artifact@v2
+      with:
+        name: java-sdk.tar.gz
+        path: ${{ github.workspace}}/sdk/
+    - name: Uncompress java SDK
+      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
+        ${{github.workspace}}/sdk/java
+    - name: Set PACKAGE_VERSION to Env
+      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
+        $GITHUB_ENV
+    - name: Publish Java SDK
+      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
+      with:
+        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
+        build-root-directory: ./sdk/java
+        gradle-version: 7.4.1
+    strategy:
+      fail-fast: true
+      matrix:
+        goversion:
+        - 1.19.x
+        javaversion:
+        - "11"
   publish_sdk:
     name: publish_sdk
     needs: publish
@@ -371,12 +426,6 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{matrix.pythonversion}}
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{matrix.javaversion}}
     - name: Download python SDK
       uses: actions/download-artifact@v2
       with:
@@ -401,28 +450,11 @@ jobs:
     - name: Uncompress nodejs SDK
       run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
         ${{github.workspace}}/sdk/nodejs
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
     - run: python -m pip install pip twine
     - env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       name: Publish SDKs
       run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3
@@ -437,8 +469,6 @@ jobs:
         - 3.1.301
         goversion:
         - 1.19.x
-        javaversion:
-        - "11"
         nodeversion:
         - 16.x
         pythonversion:

--- a/provider-ci/providers/cloudamqp/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/cloudamqp/repo/.github/workflows/main.yml
@@ -376,6 +376,61 @@ jobs:
         - 16.x
         pythonversion:
         - "3.9"
+  publish_java_sdk:
+    continue-on-error: true
+    name: publish_java_sdk
+    needs: publish
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout Repo
+      uses: actions/checkout@v3
+    - name: Checkout Scripts Repo
+      uses: actions/checkout@v3
+      with:
+        path: ci-scripts
+        repository: pulumi/scripts
+    - name: Unshallow clone for tags
+      run: git fetch --prune --unshallow --tags
+    - name: Install Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: ${{matrix.goversion}}
+    - name: Install pulumictl
+      uses: jaxxstorm/action-install-gh-release@v1.5.0
+      with:
+        repo: pulumi/pulumictl
+    - name: Install Pulumi CLI
+      uses: pulumi/action-install-pulumi-cli@v2
+    - name: Setup Java
+      uses: actions/setup-java@v3
+      with:
+        cache: gradle
+        distribution: temurin
+        java-version: ${{matrix.javaversion}}
+    - name: Download java SDK
+      uses: actions/download-artifact@v2
+      with:
+        name: java-sdk.tar.gz
+        path: ${{ github.workspace}}/sdk/
+    - name: Uncompress java SDK
+      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
+        ${{github.workspace}}/sdk/java
+    - name: Set PACKAGE_VERSION to Env
+      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
+        $GITHUB_ENV
+    - name: Publish Java SDK
+      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
+      with:
+        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
+        build-root-directory: ./sdk/java
+        gradle-version: 7.4.1
+    strategy:
+      fail-fast: true
+      matrix:
+        goversion:
+        - 1.19.x
+        javaversion:
+        - "11"
   publish_sdk:
     name: publish_sdk
     needs: publish
@@ -413,12 +468,6 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{matrix.pythonversion}}
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{matrix.javaversion}}
     - name: Download python SDK
       uses: actions/download-artifact@v2
       with:
@@ -443,28 +492,11 @@ jobs:
     - name: Uncompress nodejs SDK
       run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
         ${{github.workspace}}/sdk/nodejs
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
     - run: python -m pip install pip twine
     - env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       name: Publish SDKs
       run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3
@@ -479,8 +511,6 @@ jobs:
         - 3.1.301
         goversion:
         - 1.19.x
-        javaversion:
-        - "11"
         nodeversion:
         - 16.x
         pythonversion:

--- a/provider-ci/providers/cloudamqp/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/cloudamqp/repo/.github/workflows/master.yml
@@ -376,6 +376,61 @@ jobs:
         - 16.x
         pythonversion:
         - "3.9"
+  publish_java_sdk:
+    continue-on-error: true
+    name: publish_java_sdk
+    needs: publish
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout Repo
+      uses: actions/checkout@v3
+    - name: Checkout Scripts Repo
+      uses: actions/checkout@v3
+      with:
+        path: ci-scripts
+        repository: pulumi/scripts
+    - name: Unshallow clone for tags
+      run: git fetch --prune --unshallow --tags
+    - name: Install Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: ${{matrix.goversion}}
+    - name: Install pulumictl
+      uses: jaxxstorm/action-install-gh-release@v1.5.0
+      with:
+        repo: pulumi/pulumictl
+    - name: Install Pulumi CLI
+      uses: pulumi/action-install-pulumi-cli@v2
+    - name: Setup Java
+      uses: actions/setup-java@v3
+      with:
+        cache: gradle
+        distribution: temurin
+        java-version: ${{matrix.javaversion}}
+    - name: Download java SDK
+      uses: actions/download-artifact@v2
+      with:
+        name: java-sdk.tar.gz
+        path: ${{ github.workspace}}/sdk/
+    - name: Uncompress java SDK
+      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
+        ${{github.workspace}}/sdk/java
+    - name: Set PACKAGE_VERSION to Env
+      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
+        $GITHUB_ENV
+    - name: Publish Java SDK
+      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
+      with:
+        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
+        build-root-directory: ./sdk/java
+        gradle-version: 7.4.1
+    strategy:
+      fail-fast: true
+      matrix:
+        goversion:
+        - 1.19.x
+        javaversion:
+        - "11"
   publish_sdk:
     name: publish_sdk
     needs: publish
@@ -413,12 +468,6 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{matrix.pythonversion}}
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{matrix.javaversion}}
     - name: Download python SDK
       uses: actions/download-artifact@v2
       with:
@@ -443,28 +492,11 @@ jobs:
     - name: Uncompress nodejs SDK
       run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
         ${{github.workspace}}/sdk/nodejs
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
     - run: python -m pip install pip twine
     - env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       name: Publish SDKs
       run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3
@@ -479,8 +511,6 @@ jobs:
         - 3.1.301
         goversion:
         - 1.19.x
-        javaversion:
-        - "11"
         nodeversion:
         - 16.x
         pythonversion:

--- a/provider-ci/providers/cloudamqp/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/cloudamqp/repo/.github/workflows/prerelease.yml
@@ -320,6 +320,61 @@ jobs:
         - 16.x
         pythonversion:
         - "3.9"
+  publish_java_sdk:
+    continue-on-error: true
+    name: publish_java_sdk
+    needs: publish
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout Repo
+      uses: actions/checkout@v3
+    - name: Checkout Scripts Repo
+      uses: actions/checkout@v3
+      with:
+        path: ci-scripts
+        repository: pulumi/scripts
+    - name: Unshallow clone for tags
+      run: git fetch --prune --unshallow --tags
+    - name: Install Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: ${{matrix.goversion}}
+    - name: Install pulumictl
+      uses: jaxxstorm/action-install-gh-release@v1.5.0
+      with:
+        repo: pulumi/pulumictl
+    - name: Install Pulumi CLI
+      uses: pulumi/action-install-pulumi-cli@v2
+    - name: Setup Java
+      uses: actions/setup-java@v3
+      with:
+        cache: gradle
+        distribution: temurin
+        java-version: ${{matrix.javaversion}}
+    - name: Download java SDK
+      uses: actions/download-artifact@v2
+      with:
+        name: java-sdk.tar.gz
+        path: ${{ github.workspace}}/sdk/
+    - name: Uncompress java SDK
+      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
+        ${{github.workspace}}/sdk/java
+    - name: Set PACKAGE_VERSION to Env
+      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
+        $GITHUB_ENV
+    - name: Publish Java SDK
+      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
+      with:
+        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
+        build-root-directory: ./sdk/java
+        gradle-version: 7.4.1
+    strategy:
+      fail-fast: true
+      matrix:
+        goversion:
+        - 1.19.x
+        javaversion:
+        - "11"
   publish_sdk:
     name: publish_sdk
     needs: publish
@@ -357,12 +412,6 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{matrix.pythonversion}}
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{matrix.javaversion}}
     - name: Download python SDK
       uses: actions/download-artifact@v2
       with:
@@ -387,28 +436,11 @@ jobs:
     - name: Uncompress nodejs SDK
       run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
         ${{github.workspace}}/sdk/nodejs
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
     - run: python -m pip install pip twine
     - env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       name: Publish SDKs
       run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3
@@ -423,8 +455,6 @@ jobs:
         - 3.1.301
         goversion:
         - 1.19.x
-        javaversion:
-        - "11"
         nodeversion:
         - 16.x
         pythonversion:

--- a/provider-ci/providers/cloudamqp/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/cloudamqp/repo/.github/workflows/release.yml
@@ -333,6 +333,61 @@ jobs:
         - 16.x
         pythonversion:
         - "3.9"
+  publish_java_sdk:
+    continue-on-error: true
+    name: publish_java_sdk
+    needs: publish
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout Repo
+      uses: actions/checkout@v3
+    - name: Checkout Scripts Repo
+      uses: actions/checkout@v3
+      with:
+        path: ci-scripts
+        repository: pulumi/scripts
+    - name: Unshallow clone for tags
+      run: git fetch --prune --unshallow --tags
+    - name: Install Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: ${{matrix.goversion}}
+    - name: Install pulumictl
+      uses: jaxxstorm/action-install-gh-release@v1.5.0
+      with:
+        repo: pulumi/pulumictl
+    - name: Install Pulumi CLI
+      uses: pulumi/action-install-pulumi-cli@v2
+    - name: Setup Java
+      uses: actions/setup-java@v3
+      with:
+        cache: gradle
+        distribution: temurin
+        java-version: ${{matrix.javaversion}}
+    - name: Download java SDK
+      uses: actions/download-artifact@v2
+      with:
+        name: java-sdk.tar.gz
+        path: ${{ github.workspace}}/sdk/
+    - name: Uncompress java SDK
+      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
+        ${{github.workspace}}/sdk/java
+    - name: Set PACKAGE_VERSION to Env
+      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
+        $GITHUB_ENV
+    - name: Publish Java SDK
+      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
+      with:
+        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
+        build-root-directory: ./sdk/java
+        gradle-version: 7.4.1
+    strategy:
+      fail-fast: true
+      matrix:
+        goversion:
+        - 1.19.x
+        javaversion:
+        - "11"
   publish_sdk:
     name: publish_sdk
     needs: publish
@@ -370,12 +425,6 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{matrix.pythonversion}}
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{matrix.javaversion}}
     - name: Download python SDK
       uses: actions/download-artifact@v2
       with:
@@ -400,28 +449,11 @@ jobs:
     - name: Uncompress nodejs SDK
       run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
         ${{github.workspace}}/sdk/nodejs
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
     - run: python -m pip install pip twine
     - env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       name: Publish SDKs
       run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3
@@ -436,8 +468,6 @@ jobs:
         - 3.1.301
         goversion:
         - 1.19.x
-        javaversion:
-        - "11"
         nodeversion:
         - 16.x
         pythonversion:

--- a/provider-ci/providers/cloudflare/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/cloudflare/repo/.github/workflows/main.yml
@@ -376,6 +376,61 @@ jobs:
         - 16.x
         pythonversion:
         - "3.9"
+  publish_java_sdk:
+    continue-on-error: true
+    name: publish_java_sdk
+    needs: publish
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout Repo
+      uses: actions/checkout@v3
+    - name: Checkout Scripts Repo
+      uses: actions/checkout@v3
+      with:
+        path: ci-scripts
+        repository: pulumi/scripts
+    - name: Unshallow clone for tags
+      run: git fetch --prune --unshallow --tags
+    - name: Install Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: ${{matrix.goversion}}
+    - name: Install pulumictl
+      uses: jaxxstorm/action-install-gh-release@v1.5.0
+      with:
+        repo: pulumi/pulumictl
+    - name: Install Pulumi CLI
+      uses: pulumi/action-install-pulumi-cli@v2
+    - name: Setup Java
+      uses: actions/setup-java@v3
+      with:
+        cache: gradle
+        distribution: temurin
+        java-version: ${{matrix.javaversion}}
+    - name: Download java SDK
+      uses: actions/download-artifact@v2
+      with:
+        name: java-sdk.tar.gz
+        path: ${{ github.workspace}}/sdk/
+    - name: Uncompress java SDK
+      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
+        ${{github.workspace}}/sdk/java
+    - name: Set PACKAGE_VERSION to Env
+      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
+        $GITHUB_ENV
+    - name: Publish Java SDK
+      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
+      with:
+        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
+        build-root-directory: ./sdk/java
+        gradle-version: 7.4.1
+    strategy:
+      fail-fast: true
+      matrix:
+        goversion:
+        - 1.19.x
+        javaversion:
+        - "11"
   publish_sdk:
     name: publish_sdk
     needs: publish
@@ -413,12 +468,6 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{matrix.pythonversion}}
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{matrix.javaversion}}
     - name: Download python SDK
       uses: actions/download-artifact@v2
       with:
@@ -443,28 +492,11 @@ jobs:
     - name: Uncompress nodejs SDK
       run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
         ${{github.workspace}}/sdk/nodejs
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
     - run: python -m pip install pip twine
     - env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       name: Publish SDKs
       run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3
@@ -479,8 +511,6 @@ jobs:
         - 3.1.301
         goversion:
         - 1.19.x
-        javaversion:
-        - "11"
         nodeversion:
         - 16.x
         pythonversion:

--- a/provider-ci/providers/cloudflare/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/cloudflare/repo/.github/workflows/master.yml
@@ -376,6 +376,61 @@ jobs:
         - 16.x
         pythonversion:
         - "3.9"
+  publish_java_sdk:
+    continue-on-error: true
+    name: publish_java_sdk
+    needs: publish
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout Repo
+      uses: actions/checkout@v3
+    - name: Checkout Scripts Repo
+      uses: actions/checkout@v3
+      with:
+        path: ci-scripts
+        repository: pulumi/scripts
+    - name: Unshallow clone for tags
+      run: git fetch --prune --unshallow --tags
+    - name: Install Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: ${{matrix.goversion}}
+    - name: Install pulumictl
+      uses: jaxxstorm/action-install-gh-release@v1.5.0
+      with:
+        repo: pulumi/pulumictl
+    - name: Install Pulumi CLI
+      uses: pulumi/action-install-pulumi-cli@v2
+    - name: Setup Java
+      uses: actions/setup-java@v3
+      with:
+        cache: gradle
+        distribution: temurin
+        java-version: ${{matrix.javaversion}}
+    - name: Download java SDK
+      uses: actions/download-artifact@v2
+      with:
+        name: java-sdk.tar.gz
+        path: ${{ github.workspace}}/sdk/
+    - name: Uncompress java SDK
+      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
+        ${{github.workspace}}/sdk/java
+    - name: Set PACKAGE_VERSION to Env
+      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
+        $GITHUB_ENV
+    - name: Publish Java SDK
+      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
+      with:
+        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
+        build-root-directory: ./sdk/java
+        gradle-version: 7.4.1
+    strategy:
+      fail-fast: true
+      matrix:
+        goversion:
+        - 1.19.x
+        javaversion:
+        - "11"
   publish_sdk:
     name: publish_sdk
     needs: publish
@@ -413,12 +468,6 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{matrix.pythonversion}}
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{matrix.javaversion}}
     - name: Download python SDK
       uses: actions/download-artifact@v2
       with:
@@ -443,28 +492,11 @@ jobs:
     - name: Uncompress nodejs SDK
       run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
         ${{github.workspace}}/sdk/nodejs
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
     - run: python -m pip install pip twine
     - env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       name: Publish SDKs
       run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3
@@ -479,8 +511,6 @@ jobs:
         - 3.1.301
         goversion:
         - 1.19.x
-        javaversion:
-        - "11"
         nodeversion:
         - 16.x
         pythonversion:

--- a/provider-ci/providers/cloudflare/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/cloudflare/repo/.github/workflows/prerelease.yml
@@ -320,6 +320,61 @@ jobs:
         - 16.x
         pythonversion:
         - "3.9"
+  publish_java_sdk:
+    continue-on-error: true
+    name: publish_java_sdk
+    needs: publish
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout Repo
+      uses: actions/checkout@v3
+    - name: Checkout Scripts Repo
+      uses: actions/checkout@v3
+      with:
+        path: ci-scripts
+        repository: pulumi/scripts
+    - name: Unshallow clone for tags
+      run: git fetch --prune --unshallow --tags
+    - name: Install Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: ${{matrix.goversion}}
+    - name: Install pulumictl
+      uses: jaxxstorm/action-install-gh-release@v1.5.0
+      with:
+        repo: pulumi/pulumictl
+    - name: Install Pulumi CLI
+      uses: pulumi/action-install-pulumi-cli@v2
+    - name: Setup Java
+      uses: actions/setup-java@v3
+      with:
+        cache: gradle
+        distribution: temurin
+        java-version: ${{matrix.javaversion}}
+    - name: Download java SDK
+      uses: actions/download-artifact@v2
+      with:
+        name: java-sdk.tar.gz
+        path: ${{ github.workspace}}/sdk/
+    - name: Uncompress java SDK
+      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
+        ${{github.workspace}}/sdk/java
+    - name: Set PACKAGE_VERSION to Env
+      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
+        $GITHUB_ENV
+    - name: Publish Java SDK
+      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
+      with:
+        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
+        build-root-directory: ./sdk/java
+        gradle-version: 7.4.1
+    strategy:
+      fail-fast: true
+      matrix:
+        goversion:
+        - 1.19.x
+        javaversion:
+        - "11"
   publish_sdk:
     name: publish_sdk
     needs: publish
@@ -357,12 +412,6 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{matrix.pythonversion}}
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{matrix.javaversion}}
     - name: Download python SDK
       uses: actions/download-artifact@v2
       with:
@@ -387,28 +436,11 @@ jobs:
     - name: Uncompress nodejs SDK
       run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
         ${{github.workspace}}/sdk/nodejs
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
     - run: python -m pip install pip twine
     - env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       name: Publish SDKs
       run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3
@@ -423,8 +455,6 @@ jobs:
         - 3.1.301
         goversion:
         - 1.19.x
-        javaversion:
-        - "11"
         nodeversion:
         - 16.x
         pythonversion:

--- a/provider-ci/providers/cloudflare/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/cloudflare/repo/.github/workflows/release.yml
@@ -333,6 +333,61 @@ jobs:
         - 16.x
         pythonversion:
         - "3.9"
+  publish_java_sdk:
+    continue-on-error: true
+    name: publish_java_sdk
+    needs: publish
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout Repo
+      uses: actions/checkout@v3
+    - name: Checkout Scripts Repo
+      uses: actions/checkout@v3
+      with:
+        path: ci-scripts
+        repository: pulumi/scripts
+    - name: Unshallow clone for tags
+      run: git fetch --prune --unshallow --tags
+    - name: Install Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: ${{matrix.goversion}}
+    - name: Install pulumictl
+      uses: jaxxstorm/action-install-gh-release@v1.5.0
+      with:
+        repo: pulumi/pulumictl
+    - name: Install Pulumi CLI
+      uses: pulumi/action-install-pulumi-cli@v2
+    - name: Setup Java
+      uses: actions/setup-java@v3
+      with:
+        cache: gradle
+        distribution: temurin
+        java-version: ${{matrix.javaversion}}
+    - name: Download java SDK
+      uses: actions/download-artifact@v2
+      with:
+        name: java-sdk.tar.gz
+        path: ${{ github.workspace}}/sdk/
+    - name: Uncompress java SDK
+      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
+        ${{github.workspace}}/sdk/java
+    - name: Set PACKAGE_VERSION to Env
+      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
+        $GITHUB_ENV
+    - name: Publish Java SDK
+      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
+      with:
+        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
+        build-root-directory: ./sdk/java
+        gradle-version: 7.4.1
+    strategy:
+      fail-fast: true
+      matrix:
+        goversion:
+        - 1.19.x
+        javaversion:
+        - "11"
   publish_sdk:
     name: publish_sdk
     needs: publish
@@ -370,12 +425,6 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{matrix.pythonversion}}
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{matrix.javaversion}}
     - name: Download python SDK
       uses: actions/download-artifact@v2
       with:
@@ -400,28 +449,11 @@ jobs:
     - name: Uncompress nodejs SDK
       run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
         ${{github.workspace}}/sdk/nodejs
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
     - run: python -m pip install pip twine
     - env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       name: Publish SDKs
       run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3
@@ -436,8 +468,6 @@ jobs:
         - 3.1.301
         goversion:
         - 1.19.x
-        javaversion:
-        - "11"
         nodeversion:
         - 16.x
         pythonversion:

--- a/provider-ci/providers/cloudinit/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/cloudinit/repo/.github/workflows/main.yml
@@ -301,6 +301,61 @@ jobs:
         - 16.x
         pythonversion:
         - "3.9"
+  publish_java_sdk:
+    continue-on-error: true
+    name: publish_java_sdk
+    needs: publish
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout Repo
+      uses: actions/checkout@v3
+    - name: Checkout Scripts Repo
+      uses: actions/checkout@v3
+      with:
+        path: ci-scripts
+        repository: pulumi/scripts
+    - name: Unshallow clone for tags
+      run: git fetch --prune --unshallow --tags
+    - name: Install Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: ${{matrix.goversion}}
+    - name: Install pulumictl
+      uses: jaxxstorm/action-install-gh-release@v1.5.0
+      with:
+        repo: pulumi/pulumictl
+    - name: Install Pulumi CLI
+      uses: pulumi/action-install-pulumi-cli@v2
+    - name: Setup Java
+      uses: actions/setup-java@v3
+      with:
+        cache: gradle
+        distribution: temurin
+        java-version: ${{matrix.javaversion}}
+    - name: Download java SDK
+      uses: actions/download-artifact@v2
+      with:
+        name: java-sdk.tar.gz
+        path: ${{ github.workspace}}/sdk/
+    - name: Uncompress java SDK
+      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
+        ${{github.workspace}}/sdk/java
+    - name: Set PACKAGE_VERSION to Env
+      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
+        $GITHUB_ENV
+    - name: Publish Java SDK
+      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
+      with:
+        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
+        build-root-directory: ./sdk/java
+        gradle-version: 7.4.1
+    strategy:
+      fail-fast: true
+      matrix:
+        goversion:
+        - 1.19.x
+        javaversion:
+        - "11"
   publish_sdk:
     name: publish_sdk
     needs: publish
@@ -338,12 +393,6 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{matrix.pythonversion}}
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{matrix.javaversion}}
     - name: Download python SDK
       uses: actions/download-artifact@v2
       with:
@@ -368,28 +417,11 @@ jobs:
     - name: Uncompress nodejs SDK
       run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
         ${{github.workspace}}/sdk/nodejs
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
     - run: python -m pip install pip twine
     - env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       name: Publish SDKs
       run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3
@@ -404,8 +436,6 @@ jobs:
         - 3.1.301
         goversion:
         - 1.19.x
-        javaversion:
-        - "11"
         nodeversion:
         - 16.x
         pythonversion:

--- a/provider-ci/providers/cloudinit/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/cloudinit/repo/.github/workflows/master.yml
@@ -301,6 +301,61 @@ jobs:
         - 16.x
         pythonversion:
         - "3.9"
+  publish_java_sdk:
+    continue-on-error: true
+    name: publish_java_sdk
+    needs: publish
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout Repo
+      uses: actions/checkout@v3
+    - name: Checkout Scripts Repo
+      uses: actions/checkout@v3
+      with:
+        path: ci-scripts
+        repository: pulumi/scripts
+    - name: Unshallow clone for tags
+      run: git fetch --prune --unshallow --tags
+    - name: Install Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: ${{matrix.goversion}}
+    - name: Install pulumictl
+      uses: jaxxstorm/action-install-gh-release@v1.5.0
+      with:
+        repo: pulumi/pulumictl
+    - name: Install Pulumi CLI
+      uses: pulumi/action-install-pulumi-cli@v2
+    - name: Setup Java
+      uses: actions/setup-java@v3
+      with:
+        cache: gradle
+        distribution: temurin
+        java-version: ${{matrix.javaversion}}
+    - name: Download java SDK
+      uses: actions/download-artifact@v2
+      with:
+        name: java-sdk.tar.gz
+        path: ${{ github.workspace}}/sdk/
+    - name: Uncompress java SDK
+      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
+        ${{github.workspace}}/sdk/java
+    - name: Set PACKAGE_VERSION to Env
+      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
+        $GITHUB_ENV
+    - name: Publish Java SDK
+      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
+      with:
+        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
+        build-root-directory: ./sdk/java
+        gradle-version: 7.4.1
+    strategy:
+      fail-fast: true
+      matrix:
+        goversion:
+        - 1.19.x
+        javaversion:
+        - "11"
   publish_sdk:
     name: publish_sdk
     needs: publish
@@ -338,12 +393,6 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{matrix.pythonversion}}
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{matrix.javaversion}}
     - name: Download python SDK
       uses: actions/download-artifact@v2
       with:
@@ -368,28 +417,11 @@ jobs:
     - name: Uncompress nodejs SDK
       run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
         ${{github.workspace}}/sdk/nodejs
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
     - run: python -m pip install pip twine
     - env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       name: Publish SDKs
       run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3
@@ -404,8 +436,6 @@ jobs:
         - 3.1.301
         goversion:
         - 1.19.x
-        javaversion:
-        - "11"
         nodeversion:
         - 16.x
         pythonversion:

--- a/provider-ci/providers/cloudinit/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/cloudinit/repo/.github/workflows/prerelease.yml
@@ -245,6 +245,61 @@ jobs:
         - 16.x
         pythonversion:
         - "3.9"
+  publish_java_sdk:
+    continue-on-error: true
+    name: publish_java_sdk
+    needs: publish
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout Repo
+      uses: actions/checkout@v3
+    - name: Checkout Scripts Repo
+      uses: actions/checkout@v3
+      with:
+        path: ci-scripts
+        repository: pulumi/scripts
+    - name: Unshallow clone for tags
+      run: git fetch --prune --unshallow --tags
+    - name: Install Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: ${{matrix.goversion}}
+    - name: Install pulumictl
+      uses: jaxxstorm/action-install-gh-release@v1.5.0
+      with:
+        repo: pulumi/pulumictl
+    - name: Install Pulumi CLI
+      uses: pulumi/action-install-pulumi-cli@v2
+    - name: Setup Java
+      uses: actions/setup-java@v3
+      with:
+        cache: gradle
+        distribution: temurin
+        java-version: ${{matrix.javaversion}}
+    - name: Download java SDK
+      uses: actions/download-artifact@v2
+      with:
+        name: java-sdk.tar.gz
+        path: ${{ github.workspace}}/sdk/
+    - name: Uncompress java SDK
+      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
+        ${{github.workspace}}/sdk/java
+    - name: Set PACKAGE_VERSION to Env
+      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
+        $GITHUB_ENV
+    - name: Publish Java SDK
+      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
+      with:
+        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
+        build-root-directory: ./sdk/java
+        gradle-version: 7.4.1
+    strategy:
+      fail-fast: true
+      matrix:
+        goversion:
+        - 1.19.x
+        javaversion:
+        - "11"
   publish_sdk:
     name: publish_sdk
     needs: publish
@@ -282,12 +337,6 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{matrix.pythonversion}}
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{matrix.javaversion}}
     - name: Download python SDK
       uses: actions/download-artifact@v2
       with:
@@ -312,28 +361,11 @@ jobs:
     - name: Uncompress nodejs SDK
       run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
         ${{github.workspace}}/sdk/nodejs
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
     - run: python -m pip install pip twine
     - env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       name: Publish SDKs
       run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3
@@ -348,8 +380,6 @@ jobs:
         - 3.1.301
         goversion:
         - 1.19.x
-        javaversion:
-        - "11"
         nodeversion:
         - 16.x
         pythonversion:

--- a/provider-ci/providers/cloudinit/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/cloudinit/repo/.github/workflows/release.yml
@@ -258,6 +258,61 @@ jobs:
         - 16.x
         pythonversion:
         - "3.9"
+  publish_java_sdk:
+    continue-on-error: true
+    name: publish_java_sdk
+    needs: publish
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout Repo
+      uses: actions/checkout@v3
+    - name: Checkout Scripts Repo
+      uses: actions/checkout@v3
+      with:
+        path: ci-scripts
+        repository: pulumi/scripts
+    - name: Unshallow clone for tags
+      run: git fetch --prune --unshallow --tags
+    - name: Install Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: ${{matrix.goversion}}
+    - name: Install pulumictl
+      uses: jaxxstorm/action-install-gh-release@v1.5.0
+      with:
+        repo: pulumi/pulumictl
+    - name: Install Pulumi CLI
+      uses: pulumi/action-install-pulumi-cli@v2
+    - name: Setup Java
+      uses: actions/setup-java@v3
+      with:
+        cache: gradle
+        distribution: temurin
+        java-version: ${{matrix.javaversion}}
+    - name: Download java SDK
+      uses: actions/download-artifact@v2
+      with:
+        name: java-sdk.tar.gz
+        path: ${{ github.workspace}}/sdk/
+    - name: Uncompress java SDK
+      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
+        ${{github.workspace}}/sdk/java
+    - name: Set PACKAGE_VERSION to Env
+      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
+        $GITHUB_ENV
+    - name: Publish Java SDK
+      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
+      with:
+        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
+        build-root-directory: ./sdk/java
+        gradle-version: 7.4.1
+    strategy:
+      fail-fast: true
+      matrix:
+        goversion:
+        - 1.19.x
+        javaversion:
+        - "11"
   publish_sdk:
     name: publish_sdk
     needs: publish
@@ -295,12 +350,6 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{matrix.pythonversion}}
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{matrix.javaversion}}
     - name: Download python SDK
       uses: actions/download-artifact@v2
       with:
@@ -325,28 +374,11 @@ jobs:
     - name: Uncompress nodejs SDK
       run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
         ${{github.workspace}}/sdk/nodejs
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
     - run: python -m pip install pip twine
     - env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       name: Publish SDKs
       run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3
@@ -361,8 +393,6 @@ jobs:
         - 3.1.301
         goversion:
         - 1.19.x
-        javaversion:
-        - "11"
         nodeversion:
         - 16.x
         pythonversion:

--- a/provider-ci/providers/confluent/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/confluent/repo/.github/workflows/main.yml
@@ -378,6 +378,61 @@ jobs:
         - 16.x
         pythonversion:
         - "3.9"
+  publish_java_sdk:
+    continue-on-error: true
+    name: publish_java_sdk
+    needs: publish
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout Repo
+      uses: actions/checkout@v3
+    - name: Checkout Scripts Repo
+      uses: actions/checkout@v3
+      with:
+        path: ci-scripts
+        repository: pulumi/scripts
+    - name: Unshallow clone for tags
+      run: git fetch --prune --unshallow --tags
+    - name: Install Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: ${{matrix.goversion}}
+    - name: Install pulumictl
+      uses: jaxxstorm/action-install-gh-release@v1.5.0
+      with:
+        repo: pulumi/pulumictl
+    - name: Install Pulumi CLI
+      uses: pulumi/action-install-pulumi-cli@v2
+    - name: Setup Java
+      uses: actions/setup-java@v3
+      with:
+        cache: gradle
+        distribution: temurin
+        java-version: ${{matrix.javaversion}}
+    - name: Download java SDK
+      uses: actions/download-artifact@v2
+      with:
+        name: java-sdk.tar.gz
+        path: ${{ github.workspace}}/sdk/
+    - name: Uncompress java SDK
+      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
+        ${{github.workspace}}/sdk/java
+    - name: Set PACKAGE_VERSION to Env
+      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
+        $GITHUB_ENV
+    - name: Publish Java SDK
+      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
+      with:
+        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
+        build-root-directory: ./sdk/java
+        gradle-version: 7.4.1
+    strategy:
+      fail-fast: true
+      matrix:
+        goversion:
+        - 1.19.x
+        javaversion:
+        - "11"
   publish_sdk:
     name: publish_sdk
     needs: publish
@@ -415,12 +470,6 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{matrix.pythonversion}}
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{matrix.javaversion}}
     - name: Download python SDK
       uses: actions/download-artifact@v2
       with:
@@ -445,28 +494,11 @@ jobs:
     - name: Uncompress nodejs SDK
       run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
         ${{github.workspace}}/sdk/nodejs
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
     - run: python -m pip install pip twine
     - env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       name: Publish SDKs
       run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3
@@ -481,8 +513,6 @@ jobs:
         - 3.1.301
         goversion:
         - 1.19.x
-        javaversion:
-        - "11"
         nodeversion:
         - 16.x
         pythonversion:

--- a/provider-ci/providers/confluent/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/confluent/repo/.github/workflows/master.yml
@@ -378,6 +378,61 @@ jobs:
         - 16.x
         pythonversion:
         - "3.9"
+  publish_java_sdk:
+    continue-on-error: true
+    name: publish_java_sdk
+    needs: publish
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout Repo
+      uses: actions/checkout@v3
+    - name: Checkout Scripts Repo
+      uses: actions/checkout@v3
+      with:
+        path: ci-scripts
+        repository: pulumi/scripts
+    - name: Unshallow clone for tags
+      run: git fetch --prune --unshallow --tags
+    - name: Install Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: ${{matrix.goversion}}
+    - name: Install pulumictl
+      uses: jaxxstorm/action-install-gh-release@v1.5.0
+      with:
+        repo: pulumi/pulumictl
+    - name: Install Pulumi CLI
+      uses: pulumi/action-install-pulumi-cli@v2
+    - name: Setup Java
+      uses: actions/setup-java@v3
+      with:
+        cache: gradle
+        distribution: temurin
+        java-version: ${{matrix.javaversion}}
+    - name: Download java SDK
+      uses: actions/download-artifact@v2
+      with:
+        name: java-sdk.tar.gz
+        path: ${{ github.workspace}}/sdk/
+    - name: Uncompress java SDK
+      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
+        ${{github.workspace}}/sdk/java
+    - name: Set PACKAGE_VERSION to Env
+      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
+        $GITHUB_ENV
+    - name: Publish Java SDK
+      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
+      with:
+        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
+        build-root-directory: ./sdk/java
+        gradle-version: 7.4.1
+    strategy:
+      fail-fast: true
+      matrix:
+        goversion:
+        - 1.19.x
+        javaversion:
+        - "11"
   publish_sdk:
     name: publish_sdk
     needs: publish
@@ -415,12 +470,6 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{matrix.pythonversion}}
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{matrix.javaversion}}
     - name: Download python SDK
       uses: actions/download-artifact@v2
       with:
@@ -445,28 +494,11 @@ jobs:
     - name: Uncompress nodejs SDK
       run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
         ${{github.workspace}}/sdk/nodejs
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
     - run: python -m pip install pip twine
     - env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       name: Publish SDKs
       run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3
@@ -481,8 +513,6 @@ jobs:
         - 3.1.301
         goversion:
         - 1.19.x
-        javaversion:
-        - "11"
         nodeversion:
         - 16.x
         pythonversion:

--- a/provider-ci/providers/confluent/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/confluent/repo/.github/workflows/prerelease.yml
@@ -322,6 +322,61 @@ jobs:
         - 16.x
         pythonversion:
         - "3.9"
+  publish_java_sdk:
+    continue-on-error: true
+    name: publish_java_sdk
+    needs: publish
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout Repo
+      uses: actions/checkout@v3
+    - name: Checkout Scripts Repo
+      uses: actions/checkout@v3
+      with:
+        path: ci-scripts
+        repository: pulumi/scripts
+    - name: Unshallow clone for tags
+      run: git fetch --prune --unshallow --tags
+    - name: Install Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: ${{matrix.goversion}}
+    - name: Install pulumictl
+      uses: jaxxstorm/action-install-gh-release@v1.5.0
+      with:
+        repo: pulumi/pulumictl
+    - name: Install Pulumi CLI
+      uses: pulumi/action-install-pulumi-cli@v2
+    - name: Setup Java
+      uses: actions/setup-java@v3
+      with:
+        cache: gradle
+        distribution: temurin
+        java-version: ${{matrix.javaversion}}
+    - name: Download java SDK
+      uses: actions/download-artifact@v2
+      with:
+        name: java-sdk.tar.gz
+        path: ${{ github.workspace}}/sdk/
+    - name: Uncompress java SDK
+      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
+        ${{github.workspace}}/sdk/java
+    - name: Set PACKAGE_VERSION to Env
+      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
+        $GITHUB_ENV
+    - name: Publish Java SDK
+      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
+      with:
+        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
+        build-root-directory: ./sdk/java
+        gradle-version: 7.4.1
+    strategy:
+      fail-fast: true
+      matrix:
+        goversion:
+        - 1.19.x
+        javaversion:
+        - "11"
   publish_sdk:
     name: publish_sdk
     needs: publish
@@ -359,12 +414,6 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{matrix.pythonversion}}
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{matrix.javaversion}}
     - name: Download python SDK
       uses: actions/download-artifact@v2
       with:
@@ -389,28 +438,11 @@ jobs:
     - name: Uncompress nodejs SDK
       run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
         ${{github.workspace}}/sdk/nodejs
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
     - run: python -m pip install pip twine
     - env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       name: Publish SDKs
       run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3
@@ -425,8 +457,6 @@ jobs:
         - 3.1.301
         goversion:
         - 1.19.x
-        javaversion:
-        - "11"
         nodeversion:
         - 16.x
         pythonversion:

--- a/provider-ci/providers/confluent/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/confluent/repo/.github/workflows/release.yml
@@ -335,6 +335,61 @@ jobs:
         - 16.x
         pythonversion:
         - "3.9"
+  publish_java_sdk:
+    continue-on-error: true
+    name: publish_java_sdk
+    needs: publish
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout Repo
+      uses: actions/checkout@v3
+    - name: Checkout Scripts Repo
+      uses: actions/checkout@v3
+      with:
+        path: ci-scripts
+        repository: pulumi/scripts
+    - name: Unshallow clone for tags
+      run: git fetch --prune --unshallow --tags
+    - name: Install Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: ${{matrix.goversion}}
+    - name: Install pulumictl
+      uses: jaxxstorm/action-install-gh-release@v1.5.0
+      with:
+        repo: pulumi/pulumictl
+    - name: Install Pulumi CLI
+      uses: pulumi/action-install-pulumi-cli@v2
+    - name: Setup Java
+      uses: actions/setup-java@v3
+      with:
+        cache: gradle
+        distribution: temurin
+        java-version: ${{matrix.javaversion}}
+    - name: Download java SDK
+      uses: actions/download-artifact@v2
+      with:
+        name: java-sdk.tar.gz
+        path: ${{ github.workspace}}/sdk/
+    - name: Uncompress java SDK
+      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
+        ${{github.workspace}}/sdk/java
+    - name: Set PACKAGE_VERSION to Env
+      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
+        $GITHUB_ENV
+    - name: Publish Java SDK
+      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
+      with:
+        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
+        build-root-directory: ./sdk/java
+        gradle-version: 7.4.1
+    strategy:
+      fail-fast: true
+      matrix:
+        goversion:
+        - 1.19.x
+        javaversion:
+        - "11"
   publish_sdk:
     name: publish_sdk
     needs: publish
@@ -372,12 +427,6 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{matrix.pythonversion}}
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{matrix.javaversion}}
     - name: Download python SDK
       uses: actions/download-artifact@v2
       with:
@@ -402,28 +451,11 @@ jobs:
     - name: Uncompress nodejs SDK
       run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
         ${{github.workspace}}/sdk/nodejs
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
     - run: python -m pip install pip twine
     - env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       name: Publish SDKs
       run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3
@@ -438,8 +470,6 @@ jobs:
         - 3.1.301
         goversion:
         - 1.19.x
-        javaversion:
-        - "11"
         nodeversion:
         - 16.x
         pythonversion:

--- a/provider-ci/providers/confluentcloud/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/confluentcloud/repo/.github/workflows/main.yml
@@ -303,6 +303,61 @@ jobs:
         - 16.x
         pythonversion:
         - "3.9"
+  publish_java_sdk:
+    continue-on-error: true
+    name: publish_java_sdk
+    needs: publish
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout Repo
+      uses: actions/checkout@v3
+    - name: Checkout Scripts Repo
+      uses: actions/checkout@v3
+      with:
+        path: ci-scripts
+        repository: pulumi/scripts
+    - name: Unshallow clone for tags
+      run: git fetch --prune --unshallow --tags
+    - name: Install Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: ${{matrix.goversion}}
+    - name: Install pulumictl
+      uses: jaxxstorm/action-install-gh-release@v1.5.0
+      with:
+        repo: pulumi/pulumictl
+    - name: Install Pulumi CLI
+      uses: pulumi/action-install-pulumi-cli@v2
+    - name: Setup Java
+      uses: actions/setup-java@v3
+      with:
+        cache: gradle
+        distribution: temurin
+        java-version: ${{matrix.javaversion}}
+    - name: Download java SDK
+      uses: actions/download-artifact@v2
+      with:
+        name: java-sdk.tar.gz
+        path: ${{ github.workspace}}/sdk/
+    - name: Uncompress java SDK
+      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
+        ${{github.workspace}}/sdk/java
+    - name: Set PACKAGE_VERSION to Env
+      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
+        $GITHUB_ENV
+    - name: Publish Java SDK
+      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
+      with:
+        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
+        build-root-directory: ./sdk/java
+        gradle-version: 7.4.1
+    strategy:
+      fail-fast: true
+      matrix:
+        goversion:
+        - 1.19.x
+        javaversion:
+        - "11"
   publish_sdk:
     name: publish_sdk
     needs: publish
@@ -340,12 +395,6 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{matrix.pythonversion}}
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{matrix.javaversion}}
     - name: Download python SDK
       uses: actions/download-artifact@v2
       with:
@@ -370,28 +419,11 @@ jobs:
     - name: Uncompress nodejs SDK
       run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
         ${{github.workspace}}/sdk/nodejs
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
     - run: python -m pip install pip twine
     - env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       name: Publish SDKs
       run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3
@@ -406,8 +438,6 @@ jobs:
         - 3.1.301
         goversion:
         - 1.19.x
-        javaversion:
-        - "11"
         nodeversion:
         - 16.x
         pythonversion:

--- a/provider-ci/providers/confluentcloud/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/confluentcloud/repo/.github/workflows/master.yml
@@ -303,6 +303,61 @@ jobs:
         - 16.x
         pythonversion:
         - "3.9"
+  publish_java_sdk:
+    continue-on-error: true
+    name: publish_java_sdk
+    needs: publish
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout Repo
+      uses: actions/checkout@v3
+    - name: Checkout Scripts Repo
+      uses: actions/checkout@v3
+      with:
+        path: ci-scripts
+        repository: pulumi/scripts
+    - name: Unshallow clone for tags
+      run: git fetch --prune --unshallow --tags
+    - name: Install Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: ${{matrix.goversion}}
+    - name: Install pulumictl
+      uses: jaxxstorm/action-install-gh-release@v1.5.0
+      with:
+        repo: pulumi/pulumictl
+    - name: Install Pulumi CLI
+      uses: pulumi/action-install-pulumi-cli@v2
+    - name: Setup Java
+      uses: actions/setup-java@v3
+      with:
+        cache: gradle
+        distribution: temurin
+        java-version: ${{matrix.javaversion}}
+    - name: Download java SDK
+      uses: actions/download-artifact@v2
+      with:
+        name: java-sdk.tar.gz
+        path: ${{ github.workspace}}/sdk/
+    - name: Uncompress java SDK
+      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
+        ${{github.workspace}}/sdk/java
+    - name: Set PACKAGE_VERSION to Env
+      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
+        $GITHUB_ENV
+    - name: Publish Java SDK
+      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
+      with:
+        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
+        build-root-directory: ./sdk/java
+        gradle-version: 7.4.1
+    strategy:
+      fail-fast: true
+      matrix:
+        goversion:
+        - 1.19.x
+        javaversion:
+        - "11"
   publish_sdk:
     name: publish_sdk
     needs: publish
@@ -340,12 +395,6 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{matrix.pythonversion}}
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{matrix.javaversion}}
     - name: Download python SDK
       uses: actions/download-artifact@v2
       with:
@@ -370,28 +419,11 @@ jobs:
     - name: Uncompress nodejs SDK
       run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
         ${{github.workspace}}/sdk/nodejs
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
     - run: python -m pip install pip twine
     - env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       name: Publish SDKs
       run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3
@@ -406,8 +438,6 @@ jobs:
         - 3.1.301
         goversion:
         - 1.19.x
-        javaversion:
-        - "11"
         nodeversion:
         - 16.x
         pythonversion:

--- a/provider-ci/providers/confluentcloud/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/confluentcloud/repo/.github/workflows/prerelease.yml
@@ -247,6 +247,61 @@ jobs:
         - 16.x
         pythonversion:
         - "3.9"
+  publish_java_sdk:
+    continue-on-error: true
+    name: publish_java_sdk
+    needs: publish
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout Repo
+      uses: actions/checkout@v3
+    - name: Checkout Scripts Repo
+      uses: actions/checkout@v3
+      with:
+        path: ci-scripts
+        repository: pulumi/scripts
+    - name: Unshallow clone for tags
+      run: git fetch --prune --unshallow --tags
+    - name: Install Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: ${{matrix.goversion}}
+    - name: Install pulumictl
+      uses: jaxxstorm/action-install-gh-release@v1.5.0
+      with:
+        repo: pulumi/pulumictl
+    - name: Install Pulumi CLI
+      uses: pulumi/action-install-pulumi-cli@v2
+    - name: Setup Java
+      uses: actions/setup-java@v3
+      with:
+        cache: gradle
+        distribution: temurin
+        java-version: ${{matrix.javaversion}}
+    - name: Download java SDK
+      uses: actions/download-artifact@v2
+      with:
+        name: java-sdk.tar.gz
+        path: ${{ github.workspace}}/sdk/
+    - name: Uncompress java SDK
+      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
+        ${{github.workspace}}/sdk/java
+    - name: Set PACKAGE_VERSION to Env
+      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
+        $GITHUB_ENV
+    - name: Publish Java SDK
+      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
+      with:
+        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
+        build-root-directory: ./sdk/java
+        gradle-version: 7.4.1
+    strategy:
+      fail-fast: true
+      matrix:
+        goversion:
+        - 1.19.x
+        javaversion:
+        - "11"
   publish_sdk:
     name: publish_sdk
     needs: publish
@@ -284,12 +339,6 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{matrix.pythonversion}}
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{matrix.javaversion}}
     - name: Download python SDK
       uses: actions/download-artifact@v2
       with:
@@ -314,28 +363,11 @@ jobs:
     - name: Uncompress nodejs SDK
       run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
         ${{github.workspace}}/sdk/nodejs
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
     - run: python -m pip install pip twine
     - env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       name: Publish SDKs
       run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3
@@ -350,8 +382,6 @@ jobs:
         - 3.1.301
         goversion:
         - 1.19.x
-        javaversion:
-        - "11"
         nodeversion:
         - 16.x
         pythonversion:

--- a/provider-ci/providers/confluentcloud/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/confluentcloud/repo/.github/workflows/release.yml
@@ -260,6 +260,61 @@ jobs:
         - 16.x
         pythonversion:
         - "3.9"
+  publish_java_sdk:
+    continue-on-error: true
+    name: publish_java_sdk
+    needs: publish
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout Repo
+      uses: actions/checkout@v3
+    - name: Checkout Scripts Repo
+      uses: actions/checkout@v3
+      with:
+        path: ci-scripts
+        repository: pulumi/scripts
+    - name: Unshallow clone for tags
+      run: git fetch --prune --unshallow --tags
+    - name: Install Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: ${{matrix.goversion}}
+    - name: Install pulumictl
+      uses: jaxxstorm/action-install-gh-release@v1.5.0
+      with:
+        repo: pulumi/pulumictl
+    - name: Install Pulumi CLI
+      uses: pulumi/action-install-pulumi-cli@v2
+    - name: Setup Java
+      uses: actions/setup-java@v3
+      with:
+        cache: gradle
+        distribution: temurin
+        java-version: ${{matrix.javaversion}}
+    - name: Download java SDK
+      uses: actions/download-artifact@v2
+      with:
+        name: java-sdk.tar.gz
+        path: ${{ github.workspace}}/sdk/
+    - name: Uncompress java SDK
+      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
+        ${{github.workspace}}/sdk/java
+    - name: Set PACKAGE_VERSION to Env
+      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
+        $GITHUB_ENV
+    - name: Publish Java SDK
+      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
+      with:
+        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
+        build-root-directory: ./sdk/java
+        gradle-version: 7.4.1
+    strategy:
+      fail-fast: true
+      matrix:
+        goversion:
+        - 1.19.x
+        javaversion:
+        - "11"
   publish_sdk:
     name: publish_sdk
     needs: publish
@@ -297,12 +352,6 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{matrix.pythonversion}}
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{matrix.javaversion}}
     - name: Download python SDK
       uses: actions/download-artifact@v2
       with:
@@ -327,28 +376,11 @@ jobs:
     - name: Uncompress nodejs SDK
       run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
         ${{github.workspace}}/sdk/nodejs
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
     - run: python -m pip install pip twine
     - env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       name: Publish SDKs
       run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3
@@ -363,8 +395,6 @@ jobs:
         - 3.1.301
         goversion:
         - 1.19.x
-        javaversion:
-        - "11"
         nodeversion:
         - 16.x
         pythonversion:

--- a/provider-ci/providers/consul/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/consul/repo/.github/workflows/main.yml
@@ -376,6 +376,61 @@ jobs:
         - 16.x
         pythonversion:
         - "3.9"
+  publish_java_sdk:
+    continue-on-error: true
+    name: publish_java_sdk
+    needs: publish
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout Repo
+      uses: actions/checkout@v3
+    - name: Checkout Scripts Repo
+      uses: actions/checkout@v3
+      with:
+        path: ci-scripts
+        repository: pulumi/scripts
+    - name: Unshallow clone for tags
+      run: git fetch --prune --unshallow --tags
+    - name: Install Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: ${{matrix.goversion}}
+    - name: Install pulumictl
+      uses: jaxxstorm/action-install-gh-release@v1.5.0
+      with:
+        repo: pulumi/pulumictl
+    - name: Install Pulumi CLI
+      uses: pulumi/action-install-pulumi-cli@v2
+    - name: Setup Java
+      uses: actions/setup-java@v3
+      with:
+        cache: gradle
+        distribution: temurin
+        java-version: ${{matrix.javaversion}}
+    - name: Download java SDK
+      uses: actions/download-artifact@v2
+      with:
+        name: java-sdk.tar.gz
+        path: ${{ github.workspace}}/sdk/
+    - name: Uncompress java SDK
+      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
+        ${{github.workspace}}/sdk/java
+    - name: Set PACKAGE_VERSION to Env
+      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
+        $GITHUB_ENV
+    - name: Publish Java SDK
+      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
+      with:
+        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
+        build-root-directory: ./sdk/java
+        gradle-version: 7.4.1
+    strategy:
+      fail-fast: true
+      matrix:
+        goversion:
+        - 1.19.x
+        javaversion:
+        - "11"
   publish_sdk:
     name: publish_sdk
     needs: publish
@@ -413,12 +468,6 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{matrix.pythonversion}}
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{matrix.javaversion}}
     - name: Download python SDK
       uses: actions/download-artifact@v2
       with:
@@ -443,28 +492,11 @@ jobs:
     - name: Uncompress nodejs SDK
       run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
         ${{github.workspace}}/sdk/nodejs
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
     - run: python -m pip install pip twine
     - env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       name: Publish SDKs
       run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3
@@ -479,8 +511,6 @@ jobs:
         - 3.1.301
         goversion:
         - 1.19.x
-        javaversion:
-        - "11"
         nodeversion:
         - 16.x
         pythonversion:

--- a/provider-ci/providers/consul/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/consul/repo/.github/workflows/master.yml
@@ -376,6 +376,61 @@ jobs:
         - 16.x
         pythonversion:
         - "3.9"
+  publish_java_sdk:
+    continue-on-error: true
+    name: publish_java_sdk
+    needs: publish
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout Repo
+      uses: actions/checkout@v3
+    - name: Checkout Scripts Repo
+      uses: actions/checkout@v3
+      with:
+        path: ci-scripts
+        repository: pulumi/scripts
+    - name: Unshallow clone for tags
+      run: git fetch --prune --unshallow --tags
+    - name: Install Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: ${{matrix.goversion}}
+    - name: Install pulumictl
+      uses: jaxxstorm/action-install-gh-release@v1.5.0
+      with:
+        repo: pulumi/pulumictl
+    - name: Install Pulumi CLI
+      uses: pulumi/action-install-pulumi-cli@v2
+    - name: Setup Java
+      uses: actions/setup-java@v3
+      with:
+        cache: gradle
+        distribution: temurin
+        java-version: ${{matrix.javaversion}}
+    - name: Download java SDK
+      uses: actions/download-artifact@v2
+      with:
+        name: java-sdk.tar.gz
+        path: ${{ github.workspace}}/sdk/
+    - name: Uncompress java SDK
+      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
+        ${{github.workspace}}/sdk/java
+    - name: Set PACKAGE_VERSION to Env
+      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
+        $GITHUB_ENV
+    - name: Publish Java SDK
+      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
+      with:
+        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
+        build-root-directory: ./sdk/java
+        gradle-version: 7.4.1
+    strategy:
+      fail-fast: true
+      matrix:
+        goversion:
+        - 1.19.x
+        javaversion:
+        - "11"
   publish_sdk:
     name: publish_sdk
     needs: publish
@@ -413,12 +468,6 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{matrix.pythonversion}}
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{matrix.javaversion}}
     - name: Download python SDK
       uses: actions/download-artifact@v2
       with:
@@ -443,28 +492,11 @@ jobs:
     - name: Uncompress nodejs SDK
       run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
         ${{github.workspace}}/sdk/nodejs
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
     - run: python -m pip install pip twine
     - env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       name: Publish SDKs
       run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3
@@ -479,8 +511,6 @@ jobs:
         - 3.1.301
         goversion:
         - 1.19.x
-        javaversion:
-        - "11"
         nodeversion:
         - 16.x
         pythonversion:

--- a/provider-ci/providers/consul/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/consul/repo/.github/workflows/prerelease.yml
@@ -320,6 +320,61 @@ jobs:
         - 16.x
         pythonversion:
         - "3.9"
+  publish_java_sdk:
+    continue-on-error: true
+    name: publish_java_sdk
+    needs: publish
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout Repo
+      uses: actions/checkout@v3
+    - name: Checkout Scripts Repo
+      uses: actions/checkout@v3
+      with:
+        path: ci-scripts
+        repository: pulumi/scripts
+    - name: Unshallow clone for tags
+      run: git fetch --prune --unshallow --tags
+    - name: Install Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: ${{matrix.goversion}}
+    - name: Install pulumictl
+      uses: jaxxstorm/action-install-gh-release@v1.5.0
+      with:
+        repo: pulumi/pulumictl
+    - name: Install Pulumi CLI
+      uses: pulumi/action-install-pulumi-cli@v2
+    - name: Setup Java
+      uses: actions/setup-java@v3
+      with:
+        cache: gradle
+        distribution: temurin
+        java-version: ${{matrix.javaversion}}
+    - name: Download java SDK
+      uses: actions/download-artifact@v2
+      with:
+        name: java-sdk.tar.gz
+        path: ${{ github.workspace}}/sdk/
+    - name: Uncompress java SDK
+      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
+        ${{github.workspace}}/sdk/java
+    - name: Set PACKAGE_VERSION to Env
+      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
+        $GITHUB_ENV
+    - name: Publish Java SDK
+      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
+      with:
+        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
+        build-root-directory: ./sdk/java
+        gradle-version: 7.4.1
+    strategy:
+      fail-fast: true
+      matrix:
+        goversion:
+        - 1.19.x
+        javaversion:
+        - "11"
   publish_sdk:
     name: publish_sdk
     needs: publish
@@ -357,12 +412,6 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{matrix.pythonversion}}
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{matrix.javaversion}}
     - name: Download python SDK
       uses: actions/download-artifact@v2
       with:
@@ -387,28 +436,11 @@ jobs:
     - name: Uncompress nodejs SDK
       run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
         ${{github.workspace}}/sdk/nodejs
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
     - run: python -m pip install pip twine
     - env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       name: Publish SDKs
       run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3
@@ -423,8 +455,6 @@ jobs:
         - 3.1.301
         goversion:
         - 1.19.x
-        javaversion:
-        - "11"
         nodeversion:
         - 16.x
         pythonversion:

--- a/provider-ci/providers/consul/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/consul/repo/.github/workflows/release.yml
@@ -333,6 +333,61 @@ jobs:
         - 16.x
         pythonversion:
         - "3.9"
+  publish_java_sdk:
+    continue-on-error: true
+    name: publish_java_sdk
+    needs: publish
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout Repo
+      uses: actions/checkout@v3
+    - name: Checkout Scripts Repo
+      uses: actions/checkout@v3
+      with:
+        path: ci-scripts
+        repository: pulumi/scripts
+    - name: Unshallow clone for tags
+      run: git fetch --prune --unshallow --tags
+    - name: Install Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: ${{matrix.goversion}}
+    - name: Install pulumictl
+      uses: jaxxstorm/action-install-gh-release@v1.5.0
+      with:
+        repo: pulumi/pulumictl
+    - name: Install Pulumi CLI
+      uses: pulumi/action-install-pulumi-cli@v2
+    - name: Setup Java
+      uses: actions/setup-java@v3
+      with:
+        cache: gradle
+        distribution: temurin
+        java-version: ${{matrix.javaversion}}
+    - name: Download java SDK
+      uses: actions/download-artifact@v2
+      with:
+        name: java-sdk.tar.gz
+        path: ${{ github.workspace}}/sdk/
+    - name: Uncompress java SDK
+      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
+        ${{github.workspace}}/sdk/java
+    - name: Set PACKAGE_VERSION to Env
+      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
+        $GITHUB_ENV
+    - name: Publish Java SDK
+      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
+      with:
+        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
+        build-root-directory: ./sdk/java
+        gradle-version: 7.4.1
+    strategy:
+      fail-fast: true
+      matrix:
+        goversion:
+        - 1.19.x
+        javaversion:
+        - "11"
   publish_sdk:
     name: publish_sdk
     needs: publish
@@ -370,12 +425,6 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{matrix.pythonversion}}
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{matrix.javaversion}}
     - name: Download python SDK
       uses: actions/download-artifact@v2
       with:
@@ -400,28 +449,11 @@ jobs:
     - name: Uncompress nodejs SDK
       run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
         ${{github.workspace}}/sdk/nodejs
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
     - run: python -m pip install pip twine
     - env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       name: Publish SDKs
       run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3
@@ -436,8 +468,6 @@ jobs:
         - 3.1.301
         goversion:
         - 1.19.x
-        javaversion:
-        - "11"
         nodeversion:
         - 16.x
         pythonversion:

--- a/provider-ci/providers/databricks/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/databricks/repo/.github/workflows/main.yml
@@ -380,6 +380,61 @@ jobs:
         - 16.x
         pythonversion:
         - "3.9"
+  publish_java_sdk:
+    continue-on-error: true
+    name: publish_java_sdk
+    needs: publish
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout Repo
+      uses: actions/checkout@v3
+    - name: Checkout Scripts Repo
+      uses: actions/checkout@v3
+      with:
+        path: ci-scripts
+        repository: pulumi/scripts
+    - name: Unshallow clone for tags
+      run: git fetch --prune --unshallow --tags
+    - name: Install Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: ${{matrix.goversion}}
+    - name: Install pulumictl
+      uses: jaxxstorm/action-install-gh-release@v1.5.0
+      with:
+        repo: pulumi/pulumictl
+    - name: Install Pulumi CLI
+      uses: pulumi/action-install-pulumi-cli@v2
+    - name: Setup Java
+      uses: actions/setup-java@v3
+      with:
+        cache: gradle
+        distribution: temurin
+        java-version: ${{matrix.javaversion}}
+    - name: Download java SDK
+      uses: actions/download-artifact@v2
+      with:
+        name: java-sdk.tar.gz
+        path: ${{ github.workspace}}/sdk/
+    - name: Uncompress java SDK
+      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
+        ${{github.workspace}}/sdk/java
+    - name: Set PACKAGE_VERSION to Env
+      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
+        $GITHUB_ENV
+    - name: Publish Java SDK
+      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
+      with:
+        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
+        build-root-directory: ./sdk/java
+        gradle-version: 7.4.1
+    strategy:
+      fail-fast: true
+      matrix:
+        goversion:
+        - 1.19.x
+        javaversion:
+        - "11"
   publish_sdk:
     name: publish_sdk
     needs: publish
@@ -417,12 +472,6 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{matrix.pythonversion}}
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{matrix.javaversion}}
     - name: Download python SDK
       uses: actions/download-artifact@v2
       with:
@@ -447,28 +496,11 @@ jobs:
     - name: Uncompress nodejs SDK
       run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
         ${{github.workspace}}/sdk/nodejs
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
     - run: python -m pip install pip twine
     - env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       name: Publish SDKs
       run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3
@@ -483,8 +515,6 @@ jobs:
         - 3.1.301
         goversion:
         - 1.19.x
-        javaversion:
-        - "11"
         nodeversion:
         - 16.x
         pythonversion:

--- a/provider-ci/providers/databricks/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/databricks/repo/.github/workflows/master.yml
@@ -380,6 +380,61 @@ jobs:
         - 16.x
         pythonversion:
         - "3.9"
+  publish_java_sdk:
+    continue-on-error: true
+    name: publish_java_sdk
+    needs: publish
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout Repo
+      uses: actions/checkout@v3
+    - name: Checkout Scripts Repo
+      uses: actions/checkout@v3
+      with:
+        path: ci-scripts
+        repository: pulumi/scripts
+    - name: Unshallow clone for tags
+      run: git fetch --prune --unshallow --tags
+    - name: Install Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: ${{matrix.goversion}}
+    - name: Install pulumictl
+      uses: jaxxstorm/action-install-gh-release@v1.5.0
+      with:
+        repo: pulumi/pulumictl
+    - name: Install Pulumi CLI
+      uses: pulumi/action-install-pulumi-cli@v2
+    - name: Setup Java
+      uses: actions/setup-java@v3
+      with:
+        cache: gradle
+        distribution: temurin
+        java-version: ${{matrix.javaversion}}
+    - name: Download java SDK
+      uses: actions/download-artifact@v2
+      with:
+        name: java-sdk.tar.gz
+        path: ${{ github.workspace}}/sdk/
+    - name: Uncompress java SDK
+      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
+        ${{github.workspace}}/sdk/java
+    - name: Set PACKAGE_VERSION to Env
+      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
+        $GITHUB_ENV
+    - name: Publish Java SDK
+      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
+      with:
+        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
+        build-root-directory: ./sdk/java
+        gradle-version: 7.4.1
+    strategy:
+      fail-fast: true
+      matrix:
+        goversion:
+        - 1.19.x
+        javaversion:
+        - "11"
   publish_sdk:
     name: publish_sdk
     needs: publish
@@ -417,12 +472,6 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{matrix.pythonversion}}
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{matrix.javaversion}}
     - name: Download python SDK
       uses: actions/download-artifact@v2
       with:
@@ -447,28 +496,11 @@ jobs:
     - name: Uncompress nodejs SDK
       run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
         ${{github.workspace}}/sdk/nodejs
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
     - run: python -m pip install pip twine
     - env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       name: Publish SDKs
       run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3
@@ -483,8 +515,6 @@ jobs:
         - 3.1.301
         goversion:
         - 1.19.x
-        javaversion:
-        - "11"
         nodeversion:
         - 16.x
         pythonversion:

--- a/provider-ci/providers/databricks/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/databricks/repo/.github/workflows/prerelease.yml
@@ -324,6 +324,61 @@ jobs:
         - 16.x
         pythonversion:
         - "3.9"
+  publish_java_sdk:
+    continue-on-error: true
+    name: publish_java_sdk
+    needs: publish
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout Repo
+      uses: actions/checkout@v3
+    - name: Checkout Scripts Repo
+      uses: actions/checkout@v3
+      with:
+        path: ci-scripts
+        repository: pulumi/scripts
+    - name: Unshallow clone for tags
+      run: git fetch --prune --unshallow --tags
+    - name: Install Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: ${{matrix.goversion}}
+    - name: Install pulumictl
+      uses: jaxxstorm/action-install-gh-release@v1.5.0
+      with:
+        repo: pulumi/pulumictl
+    - name: Install Pulumi CLI
+      uses: pulumi/action-install-pulumi-cli@v2
+    - name: Setup Java
+      uses: actions/setup-java@v3
+      with:
+        cache: gradle
+        distribution: temurin
+        java-version: ${{matrix.javaversion}}
+    - name: Download java SDK
+      uses: actions/download-artifact@v2
+      with:
+        name: java-sdk.tar.gz
+        path: ${{ github.workspace}}/sdk/
+    - name: Uncompress java SDK
+      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
+        ${{github.workspace}}/sdk/java
+    - name: Set PACKAGE_VERSION to Env
+      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
+        $GITHUB_ENV
+    - name: Publish Java SDK
+      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
+      with:
+        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
+        build-root-directory: ./sdk/java
+        gradle-version: 7.4.1
+    strategy:
+      fail-fast: true
+      matrix:
+        goversion:
+        - 1.19.x
+        javaversion:
+        - "11"
   publish_sdk:
     name: publish_sdk
     needs: publish
@@ -361,12 +416,6 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{matrix.pythonversion}}
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{matrix.javaversion}}
     - name: Download python SDK
       uses: actions/download-artifact@v2
       with:
@@ -391,28 +440,11 @@ jobs:
     - name: Uncompress nodejs SDK
       run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
         ${{github.workspace}}/sdk/nodejs
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
     - run: python -m pip install pip twine
     - env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       name: Publish SDKs
       run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3
@@ -427,8 +459,6 @@ jobs:
         - 3.1.301
         goversion:
         - 1.19.x
-        javaversion:
-        - "11"
         nodeversion:
         - 16.x
         pythonversion:

--- a/provider-ci/providers/databricks/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/databricks/repo/.github/workflows/release.yml
@@ -337,6 +337,61 @@ jobs:
         - 16.x
         pythonversion:
         - "3.9"
+  publish_java_sdk:
+    continue-on-error: true
+    name: publish_java_sdk
+    needs: publish
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout Repo
+      uses: actions/checkout@v3
+    - name: Checkout Scripts Repo
+      uses: actions/checkout@v3
+      with:
+        path: ci-scripts
+        repository: pulumi/scripts
+    - name: Unshallow clone for tags
+      run: git fetch --prune --unshallow --tags
+    - name: Install Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: ${{matrix.goversion}}
+    - name: Install pulumictl
+      uses: jaxxstorm/action-install-gh-release@v1.5.0
+      with:
+        repo: pulumi/pulumictl
+    - name: Install Pulumi CLI
+      uses: pulumi/action-install-pulumi-cli@v2
+    - name: Setup Java
+      uses: actions/setup-java@v3
+      with:
+        cache: gradle
+        distribution: temurin
+        java-version: ${{matrix.javaversion}}
+    - name: Download java SDK
+      uses: actions/download-artifact@v2
+      with:
+        name: java-sdk.tar.gz
+        path: ${{ github.workspace}}/sdk/
+    - name: Uncompress java SDK
+      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
+        ${{github.workspace}}/sdk/java
+    - name: Set PACKAGE_VERSION to Env
+      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
+        $GITHUB_ENV
+    - name: Publish Java SDK
+      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
+      with:
+        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
+        build-root-directory: ./sdk/java
+        gradle-version: 7.4.1
+    strategy:
+      fail-fast: true
+      matrix:
+        goversion:
+        - 1.19.x
+        javaversion:
+        - "11"
   publish_sdk:
     name: publish_sdk
     needs: publish
@@ -374,12 +429,6 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{matrix.pythonversion}}
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{matrix.javaversion}}
     - name: Download python SDK
       uses: actions/download-artifact@v2
       with:
@@ -404,28 +453,11 @@ jobs:
     - name: Uncompress nodejs SDK
       run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
         ${{github.workspace}}/sdk/nodejs
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
     - run: python -m pip install pip twine
     - env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       name: Publish SDKs
       run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3
@@ -440,8 +472,6 @@ jobs:
         - 3.1.301
         goversion:
         - 1.19.x
-        javaversion:
-        - "11"
         nodeversion:
         - 16.x
         pythonversion:

--- a/provider-ci/providers/datadog/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/datadog/repo/.github/workflows/main.yml
@@ -301,6 +301,61 @@ jobs:
         - 16.x
         pythonversion:
         - "3.9"
+  publish_java_sdk:
+    continue-on-error: true
+    name: publish_java_sdk
+    needs: publish
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout Repo
+      uses: actions/checkout@v3
+    - name: Checkout Scripts Repo
+      uses: actions/checkout@v3
+      with:
+        path: ci-scripts
+        repository: pulumi/scripts
+    - name: Unshallow clone for tags
+      run: git fetch --prune --unshallow --tags
+    - name: Install Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: ${{matrix.goversion}}
+    - name: Install pulumictl
+      uses: jaxxstorm/action-install-gh-release@v1.5.0
+      with:
+        repo: pulumi/pulumictl
+    - name: Install Pulumi CLI
+      uses: pulumi/action-install-pulumi-cli@v2
+    - name: Setup Java
+      uses: actions/setup-java@v3
+      with:
+        cache: gradle
+        distribution: temurin
+        java-version: ${{matrix.javaversion}}
+    - name: Download java SDK
+      uses: actions/download-artifact@v2
+      with:
+        name: java-sdk.tar.gz
+        path: ${{ github.workspace}}/sdk/
+    - name: Uncompress java SDK
+      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
+        ${{github.workspace}}/sdk/java
+    - name: Set PACKAGE_VERSION to Env
+      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
+        $GITHUB_ENV
+    - name: Publish Java SDK
+      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
+      with:
+        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
+        build-root-directory: ./sdk/java
+        gradle-version: 7.4.1
+    strategy:
+      fail-fast: true
+      matrix:
+        goversion:
+        - 1.19.x
+        javaversion:
+        - "11"
   publish_sdk:
     name: publish_sdk
     needs: publish
@@ -338,12 +393,6 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{matrix.pythonversion}}
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{matrix.javaversion}}
     - name: Download python SDK
       uses: actions/download-artifact@v2
       with:
@@ -368,28 +417,11 @@ jobs:
     - name: Uncompress nodejs SDK
       run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
         ${{github.workspace}}/sdk/nodejs
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
     - run: python -m pip install pip twine
     - env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       name: Publish SDKs
       run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3
@@ -404,8 +436,6 @@ jobs:
         - 3.1.301
         goversion:
         - 1.19.x
-        javaversion:
-        - "11"
         nodeversion:
         - 16.x
         pythonversion:

--- a/provider-ci/providers/datadog/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/datadog/repo/.github/workflows/master.yml
@@ -301,6 +301,61 @@ jobs:
         - 16.x
         pythonversion:
         - "3.9"
+  publish_java_sdk:
+    continue-on-error: true
+    name: publish_java_sdk
+    needs: publish
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout Repo
+      uses: actions/checkout@v3
+    - name: Checkout Scripts Repo
+      uses: actions/checkout@v3
+      with:
+        path: ci-scripts
+        repository: pulumi/scripts
+    - name: Unshallow clone for tags
+      run: git fetch --prune --unshallow --tags
+    - name: Install Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: ${{matrix.goversion}}
+    - name: Install pulumictl
+      uses: jaxxstorm/action-install-gh-release@v1.5.0
+      with:
+        repo: pulumi/pulumictl
+    - name: Install Pulumi CLI
+      uses: pulumi/action-install-pulumi-cli@v2
+    - name: Setup Java
+      uses: actions/setup-java@v3
+      with:
+        cache: gradle
+        distribution: temurin
+        java-version: ${{matrix.javaversion}}
+    - name: Download java SDK
+      uses: actions/download-artifact@v2
+      with:
+        name: java-sdk.tar.gz
+        path: ${{ github.workspace}}/sdk/
+    - name: Uncompress java SDK
+      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
+        ${{github.workspace}}/sdk/java
+    - name: Set PACKAGE_VERSION to Env
+      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
+        $GITHUB_ENV
+    - name: Publish Java SDK
+      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
+      with:
+        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
+        build-root-directory: ./sdk/java
+        gradle-version: 7.4.1
+    strategy:
+      fail-fast: true
+      matrix:
+        goversion:
+        - 1.19.x
+        javaversion:
+        - "11"
   publish_sdk:
     name: publish_sdk
     needs: publish
@@ -338,12 +393,6 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{matrix.pythonversion}}
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{matrix.javaversion}}
     - name: Download python SDK
       uses: actions/download-artifact@v2
       with:
@@ -368,28 +417,11 @@ jobs:
     - name: Uncompress nodejs SDK
       run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
         ${{github.workspace}}/sdk/nodejs
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
     - run: python -m pip install pip twine
     - env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       name: Publish SDKs
       run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3
@@ -404,8 +436,6 @@ jobs:
         - 3.1.301
         goversion:
         - 1.19.x
-        javaversion:
-        - "11"
         nodeversion:
         - 16.x
         pythonversion:

--- a/provider-ci/providers/datadog/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/datadog/repo/.github/workflows/prerelease.yml
@@ -245,6 +245,61 @@ jobs:
         - 16.x
         pythonversion:
         - "3.9"
+  publish_java_sdk:
+    continue-on-error: true
+    name: publish_java_sdk
+    needs: publish
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout Repo
+      uses: actions/checkout@v3
+    - name: Checkout Scripts Repo
+      uses: actions/checkout@v3
+      with:
+        path: ci-scripts
+        repository: pulumi/scripts
+    - name: Unshallow clone for tags
+      run: git fetch --prune --unshallow --tags
+    - name: Install Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: ${{matrix.goversion}}
+    - name: Install pulumictl
+      uses: jaxxstorm/action-install-gh-release@v1.5.0
+      with:
+        repo: pulumi/pulumictl
+    - name: Install Pulumi CLI
+      uses: pulumi/action-install-pulumi-cli@v2
+    - name: Setup Java
+      uses: actions/setup-java@v3
+      with:
+        cache: gradle
+        distribution: temurin
+        java-version: ${{matrix.javaversion}}
+    - name: Download java SDK
+      uses: actions/download-artifact@v2
+      with:
+        name: java-sdk.tar.gz
+        path: ${{ github.workspace}}/sdk/
+    - name: Uncompress java SDK
+      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
+        ${{github.workspace}}/sdk/java
+    - name: Set PACKAGE_VERSION to Env
+      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
+        $GITHUB_ENV
+    - name: Publish Java SDK
+      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
+      with:
+        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
+        build-root-directory: ./sdk/java
+        gradle-version: 7.4.1
+    strategy:
+      fail-fast: true
+      matrix:
+        goversion:
+        - 1.19.x
+        javaversion:
+        - "11"
   publish_sdk:
     name: publish_sdk
     needs: publish
@@ -282,12 +337,6 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{matrix.pythonversion}}
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{matrix.javaversion}}
     - name: Download python SDK
       uses: actions/download-artifact@v2
       with:
@@ -312,28 +361,11 @@ jobs:
     - name: Uncompress nodejs SDK
       run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
         ${{github.workspace}}/sdk/nodejs
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
     - run: python -m pip install pip twine
     - env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       name: Publish SDKs
       run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3
@@ -348,8 +380,6 @@ jobs:
         - 3.1.301
         goversion:
         - 1.19.x
-        javaversion:
-        - "11"
         nodeversion:
         - 16.x
         pythonversion:

--- a/provider-ci/providers/datadog/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/datadog/repo/.github/workflows/release.yml
@@ -258,6 +258,61 @@ jobs:
         - 16.x
         pythonversion:
         - "3.9"
+  publish_java_sdk:
+    continue-on-error: true
+    name: publish_java_sdk
+    needs: publish
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout Repo
+      uses: actions/checkout@v3
+    - name: Checkout Scripts Repo
+      uses: actions/checkout@v3
+      with:
+        path: ci-scripts
+        repository: pulumi/scripts
+    - name: Unshallow clone for tags
+      run: git fetch --prune --unshallow --tags
+    - name: Install Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: ${{matrix.goversion}}
+    - name: Install pulumictl
+      uses: jaxxstorm/action-install-gh-release@v1.5.0
+      with:
+        repo: pulumi/pulumictl
+    - name: Install Pulumi CLI
+      uses: pulumi/action-install-pulumi-cli@v2
+    - name: Setup Java
+      uses: actions/setup-java@v3
+      with:
+        cache: gradle
+        distribution: temurin
+        java-version: ${{matrix.javaversion}}
+    - name: Download java SDK
+      uses: actions/download-artifact@v2
+      with:
+        name: java-sdk.tar.gz
+        path: ${{ github.workspace}}/sdk/
+    - name: Uncompress java SDK
+      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
+        ${{github.workspace}}/sdk/java
+    - name: Set PACKAGE_VERSION to Env
+      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
+        $GITHUB_ENV
+    - name: Publish Java SDK
+      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
+      with:
+        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
+        build-root-directory: ./sdk/java
+        gradle-version: 7.4.1
+    strategy:
+      fail-fast: true
+      matrix:
+        goversion:
+        - 1.19.x
+        javaversion:
+        - "11"
   publish_sdk:
     name: publish_sdk
     needs: publish
@@ -295,12 +350,6 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{matrix.pythonversion}}
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{matrix.javaversion}}
     - name: Download python SDK
       uses: actions/download-artifact@v2
       with:
@@ -325,28 +374,11 @@ jobs:
     - name: Uncompress nodejs SDK
       run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
         ${{github.workspace}}/sdk/nodejs
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
     - run: python -m pip install pip twine
     - env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       name: Publish SDKs
       run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3
@@ -361,8 +393,6 @@ jobs:
         - 3.1.301
         goversion:
         - 1.19.x
-        javaversion:
-        - "11"
         nodeversion:
         - 16.x
         pythonversion:

--- a/provider-ci/providers/digitalocean/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/digitalocean/repo/.github/workflows/main.yml
@@ -377,6 +377,61 @@ jobs:
         - 16.x
         pythonversion:
         - "3.9"
+  publish_java_sdk:
+    continue-on-error: true
+    name: publish_java_sdk
+    needs: publish
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout Repo
+      uses: actions/checkout@v3
+    - name: Checkout Scripts Repo
+      uses: actions/checkout@v3
+      with:
+        path: ci-scripts
+        repository: pulumi/scripts
+    - name: Unshallow clone for tags
+      run: git fetch --prune --unshallow --tags
+    - name: Install Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: ${{matrix.goversion}}
+    - name: Install pulumictl
+      uses: jaxxstorm/action-install-gh-release@v1.5.0
+      with:
+        repo: pulumi/pulumictl
+    - name: Install Pulumi CLI
+      uses: pulumi/action-install-pulumi-cli@v2
+    - name: Setup Java
+      uses: actions/setup-java@v3
+      with:
+        cache: gradle
+        distribution: temurin
+        java-version: ${{matrix.javaversion}}
+    - name: Download java SDK
+      uses: actions/download-artifact@v2
+      with:
+        name: java-sdk.tar.gz
+        path: ${{ github.workspace}}/sdk/
+    - name: Uncompress java SDK
+      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
+        ${{github.workspace}}/sdk/java
+    - name: Set PACKAGE_VERSION to Env
+      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
+        $GITHUB_ENV
+    - name: Publish Java SDK
+      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
+      with:
+        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
+        build-root-directory: ./sdk/java
+        gradle-version: 7.4.1
+    strategy:
+      fail-fast: true
+      matrix:
+        goversion:
+        - 1.19.x
+        javaversion:
+        - "11"
   publish_sdk:
     name: publish_sdk
     needs: publish
@@ -414,12 +469,6 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{matrix.pythonversion}}
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{matrix.javaversion}}
     - name: Download python SDK
       uses: actions/download-artifact@v2
       with:
@@ -444,28 +493,11 @@ jobs:
     - name: Uncompress nodejs SDK
       run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
         ${{github.workspace}}/sdk/nodejs
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
     - run: python -m pip install pip twine
     - env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       name: Publish SDKs
       run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3
@@ -480,8 +512,6 @@ jobs:
         - 3.1.301
         goversion:
         - 1.19.x
-        javaversion:
-        - "11"
         nodeversion:
         - 16.x
         pythonversion:

--- a/provider-ci/providers/digitalocean/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/digitalocean/repo/.github/workflows/master.yml
@@ -377,6 +377,61 @@ jobs:
         - 16.x
         pythonversion:
         - "3.9"
+  publish_java_sdk:
+    continue-on-error: true
+    name: publish_java_sdk
+    needs: publish
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout Repo
+      uses: actions/checkout@v3
+    - name: Checkout Scripts Repo
+      uses: actions/checkout@v3
+      with:
+        path: ci-scripts
+        repository: pulumi/scripts
+    - name: Unshallow clone for tags
+      run: git fetch --prune --unshallow --tags
+    - name: Install Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: ${{matrix.goversion}}
+    - name: Install pulumictl
+      uses: jaxxstorm/action-install-gh-release@v1.5.0
+      with:
+        repo: pulumi/pulumictl
+    - name: Install Pulumi CLI
+      uses: pulumi/action-install-pulumi-cli@v2
+    - name: Setup Java
+      uses: actions/setup-java@v3
+      with:
+        cache: gradle
+        distribution: temurin
+        java-version: ${{matrix.javaversion}}
+    - name: Download java SDK
+      uses: actions/download-artifact@v2
+      with:
+        name: java-sdk.tar.gz
+        path: ${{ github.workspace}}/sdk/
+    - name: Uncompress java SDK
+      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
+        ${{github.workspace}}/sdk/java
+    - name: Set PACKAGE_VERSION to Env
+      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
+        $GITHUB_ENV
+    - name: Publish Java SDK
+      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
+      with:
+        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
+        build-root-directory: ./sdk/java
+        gradle-version: 7.4.1
+    strategy:
+      fail-fast: true
+      matrix:
+        goversion:
+        - 1.19.x
+        javaversion:
+        - "11"
   publish_sdk:
     name: publish_sdk
     needs: publish
@@ -414,12 +469,6 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{matrix.pythonversion}}
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{matrix.javaversion}}
     - name: Download python SDK
       uses: actions/download-artifact@v2
       with:
@@ -444,28 +493,11 @@ jobs:
     - name: Uncompress nodejs SDK
       run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
         ${{github.workspace}}/sdk/nodejs
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
     - run: python -m pip install pip twine
     - env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       name: Publish SDKs
       run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3
@@ -480,8 +512,6 @@ jobs:
         - 3.1.301
         goversion:
         - 1.19.x
-        javaversion:
-        - "11"
         nodeversion:
         - 16.x
         pythonversion:

--- a/provider-ci/providers/digitalocean/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/digitalocean/repo/.github/workflows/prerelease.yml
@@ -321,6 +321,61 @@ jobs:
         - 16.x
         pythonversion:
         - "3.9"
+  publish_java_sdk:
+    continue-on-error: true
+    name: publish_java_sdk
+    needs: publish
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout Repo
+      uses: actions/checkout@v3
+    - name: Checkout Scripts Repo
+      uses: actions/checkout@v3
+      with:
+        path: ci-scripts
+        repository: pulumi/scripts
+    - name: Unshallow clone for tags
+      run: git fetch --prune --unshallow --tags
+    - name: Install Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: ${{matrix.goversion}}
+    - name: Install pulumictl
+      uses: jaxxstorm/action-install-gh-release@v1.5.0
+      with:
+        repo: pulumi/pulumictl
+    - name: Install Pulumi CLI
+      uses: pulumi/action-install-pulumi-cli@v2
+    - name: Setup Java
+      uses: actions/setup-java@v3
+      with:
+        cache: gradle
+        distribution: temurin
+        java-version: ${{matrix.javaversion}}
+    - name: Download java SDK
+      uses: actions/download-artifact@v2
+      with:
+        name: java-sdk.tar.gz
+        path: ${{ github.workspace}}/sdk/
+    - name: Uncompress java SDK
+      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
+        ${{github.workspace}}/sdk/java
+    - name: Set PACKAGE_VERSION to Env
+      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
+        $GITHUB_ENV
+    - name: Publish Java SDK
+      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
+      with:
+        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
+        build-root-directory: ./sdk/java
+        gradle-version: 7.4.1
+    strategy:
+      fail-fast: true
+      matrix:
+        goversion:
+        - 1.19.x
+        javaversion:
+        - "11"
   publish_sdk:
     name: publish_sdk
     needs: publish
@@ -358,12 +413,6 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{matrix.pythonversion}}
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{matrix.javaversion}}
     - name: Download python SDK
       uses: actions/download-artifact@v2
       with:
@@ -388,28 +437,11 @@ jobs:
     - name: Uncompress nodejs SDK
       run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
         ${{github.workspace}}/sdk/nodejs
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
     - run: python -m pip install pip twine
     - env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       name: Publish SDKs
       run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3
@@ -424,8 +456,6 @@ jobs:
         - 3.1.301
         goversion:
         - 1.19.x
-        javaversion:
-        - "11"
         nodeversion:
         - 16.x
         pythonversion:

--- a/provider-ci/providers/digitalocean/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/digitalocean/repo/.github/workflows/release.yml
@@ -334,6 +334,61 @@ jobs:
         - 16.x
         pythonversion:
         - "3.9"
+  publish_java_sdk:
+    continue-on-error: true
+    name: publish_java_sdk
+    needs: publish
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout Repo
+      uses: actions/checkout@v3
+    - name: Checkout Scripts Repo
+      uses: actions/checkout@v3
+      with:
+        path: ci-scripts
+        repository: pulumi/scripts
+    - name: Unshallow clone for tags
+      run: git fetch --prune --unshallow --tags
+    - name: Install Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: ${{matrix.goversion}}
+    - name: Install pulumictl
+      uses: jaxxstorm/action-install-gh-release@v1.5.0
+      with:
+        repo: pulumi/pulumictl
+    - name: Install Pulumi CLI
+      uses: pulumi/action-install-pulumi-cli@v2
+    - name: Setup Java
+      uses: actions/setup-java@v3
+      with:
+        cache: gradle
+        distribution: temurin
+        java-version: ${{matrix.javaversion}}
+    - name: Download java SDK
+      uses: actions/download-artifact@v2
+      with:
+        name: java-sdk.tar.gz
+        path: ${{ github.workspace}}/sdk/
+    - name: Uncompress java SDK
+      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
+        ${{github.workspace}}/sdk/java
+    - name: Set PACKAGE_VERSION to Env
+      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
+        $GITHUB_ENV
+    - name: Publish Java SDK
+      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
+      with:
+        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
+        build-root-directory: ./sdk/java
+        gradle-version: 7.4.1
+    strategy:
+      fail-fast: true
+      matrix:
+        goversion:
+        - 1.19.x
+        javaversion:
+        - "11"
   publish_sdk:
     name: publish_sdk
     needs: publish
@@ -371,12 +426,6 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{matrix.pythonversion}}
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{matrix.javaversion}}
     - name: Download python SDK
       uses: actions/download-artifact@v2
       with:
@@ -401,28 +450,11 @@ jobs:
     - name: Uncompress nodejs SDK
       run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
         ${{github.workspace}}/sdk/nodejs
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
     - run: python -m pip install pip twine
     - env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       name: Publish SDKs
       run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3
@@ -437,8 +469,6 @@ jobs:
         - 3.1.301
         goversion:
         - 1.19.x
-        javaversion:
-        - "11"
         nodeversion:
         - 16.x
         pythonversion:

--- a/provider-ci/providers/dnsimple/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/dnsimple/repo/.github/workflows/main.yml
@@ -378,6 +378,61 @@ jobs:
         - 16.x
         pythonversion:
         - "3.9"
+  publish_java_sdk:
+    continue-on-error: true
+    name: publish_java_sdk
+    needs: publish
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout Repo
+      uses: actions/checkout@v3
+    - name: Checkout Scripts Repo
+      uses: actions/checkout@v3
+      with:
+        path: ci-scripts
+        repository: pulumi/scripts
+    - name: Unshallow clone for tags
+      run: git fetch --prune --unshallow --tags
+    - name: Install Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: ${{matrix.goversion}}
+    - name: Install pulumictl
+      uses: jaxxstorm/action-install-gh-release@v1.5.0
+      with:
+        repo: pulumi/pulumictl
+    - name: Install Pulumi CLI
+      uses: pulumi/action-install-pulumi-cli@v2
+    - name: Setup Java
+      uses: actions/setup-java@v3
+      with:
+        cache: gradle
+        distribution: temurin
+        java-version: ${{matrix.javaversion}}
+    - name: Download java SDK
+      uses: actions/download-artifact@v2
+      with:
+        name: java-sdk.tar.gz
+        path: ${{ github.workspace}}/sdk/
+    - name: Uncompress java SDK
+      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
+        ${{github.workspace}}/sdk/java
+    - name: Set PACKAGE_VERSION to Env
+      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
+        $GITHUB_ENV
+    - name: Publish Java SDK
+      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
+      with:
+        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
+        build-root-directory: ./sdk/java
+        gradle-version: 7.4.1
+    strategy:
+      fail-fast: true
+      matrix:
+        goversion:
+        - 1.19.x
+        javaversion:
+        - "11"
   publish_sdk:
     name: publish_sdk
     needs: publish
@@ -415,12 +470,6 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{matrix.pythonversion}}
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{matrix.javaversion}}
     - name: Download python SDK
       uses: actions/download-artifact@v2
       with:
@@ -445,28 +494,11 @@ jobs:
     - name: Uncompress nodejs SDK
       run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
         ${{github.workspace}}/sdk/nodejs
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
     - run: python -m pip install pip twine
     - env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       name: Publish SDKs
       run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3
@@ -481,8 +513,6 @@ jobs:
         - 3.1.301
         goversion:
         - 1.19.x
-        javaversion:
-        - "11"
         nodeversion:
         - 16.x
         pythonversion:

--- a/provider-ci/providers/dnsimple/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/dnsimple/repo/.github/workflows/master.yml
@@ -378,6 +378,61 @@ jobs:
         - 16.x
         pythonversion:
         - "3.9"
+  publish_java_sdk:
+    continue-on-error: true
+    name: publish_java_sdk
+    needs: publish
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout Repo
+      uses: actions/checkout@v3
+    - name: Checkout Scripts Repo
+      uses: actions/checkout@v3
+      with:
+        path: ci-scripts
+        repository: pulumi/scripts
+    - name: Unshallow clone for tags
+      run: git fetch --prune --unshallow --tags
+    - name: Install Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: ${{matrix.goversion}}
+    - name: Install pulumictl
+      uses: jaxxstorm/action-install-gh-release@v1.5.0
+      with:
+        repo: pulumi/pulumictl
+    - name: Install Pulumi CLI
+      uses: pulumi/action-install-pulumi-cli@v2
+    - name: Setup Java
+      uses: actions/setup-java@v3
+      with:
+        cache: gradle
+        distribution: temurin
+        java-version: ${{matrix.javaversion}}
+    - name: Download java SDK
+      uses: actions/download-artifact@v2
+      with:
+        name: java-sdk.tar.gz
+        path: ${{ github.workspace}}/sdk/
+    - name: Uncompress java SDK
+      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
+        ${{github.workspace}}/sdk/java
+    - name: Set PACKAGE_VERSION to Env
+      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
+        $GITHUB_ENV
+    - name: Publish Java SDK
+      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
+      with:
+        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
+        build-root-directory: ./sdk/java
+        gradle-version: 7.4.1
+    strategy:
+      fail-fast: true
+      matrix:
+        goversion:
+        - 1.19.x
+        javaversion:
+        - "11"
   publish_sdk:
     name: publish_sdk
     needs: publish
@@ -415,12 +470,6 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{matrix.pythonversion}}
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{matrix.javaversion}}
     - name: Download python SDK
       uses: actions/download-artifact@v2
       with:
@@ -445,28 +494,11 @@ jobs:
     - name: Uncompress nodejs SDK
       run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
         ${{github.workspace}}/sdk/nodejs
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
     - run: python -m pip install pip twine
     - env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       name: Publish SDKs
       run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3
@@ -481,8 +513,6 @@ jobs:
         - 3.1.301
         goversion:
         - 1.19.x
-        javaversion:
-        - "11"
         nodeversion:
         - 16.x
         pythonversion:

--- a/provider-ci/providers/dnsimple/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/dnsimple/repo/.github/workflows/prerelease.yml
@@ -322,6 +322,61 @@ jobs:
         - 16.x
         pythonversion:
         - "3.9"
+  publish_java_sdk:
+    continue-on-error: true
+    name: publish_java_sdk
+    needs: publish
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout Repo
+      uses: actions/checkout@v3
+    - name: Checkout Scripts Repo
+      uses: actions/checkout@v3
+      with:
+        path: ci-scripts
+        repository: pulumi/scripts
+    - name: Unshallow clone for tags
+      run: git fetch --prune --unshallow --tags
+    - name: Install Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: ${{matrix.goversion}}
+    - name: Install pulumictl
+      uses: jaxxstorm/action-install-gh-release@v1.5.0
+      with:
+        repo: pulumi/pulumictl
+    - name: Install Pulumi CLI
+      uses: pulumi/action-install-pulumi-cli@v2
+    - name: Setup Java
+      uses: actions/setup-java@v3
+      with:
+        cache: gradle
+        distribution: temurin
+        java-version: ${{matrix.javaversion}}
+    - name: Download java SDK
+      uses: actions/download-artifact@v2
+      with:
+        name: java-sdk.tar.gz
+        path: ${{ github.workspace}}/sdk/
+    - name: Uncompress java SDK
+      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
+        ${{github.workspace}}/sdk/java
+    - name: Set PACKAGE_VERSION to Env
+      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
+        $GITHUB_ENV
+    - name: Publish Java SDK
+      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
+      with:
+        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
+        build-root-directory: ./sdk/java
+        gradle-version: 7.4.1
+    strategy:
+      fail-fast: true
+      matrix:
+        goversion:
+        - 1.19.x
+        javaversion:
+        - "11"
   publish_sdk:
     name: publish_sdk
     needs: publish
@@ -359,12 +414,6 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{matrix.pythonversion}}
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{matrix.javaversion}}
     - name: Download python SDK
       uses: actions/download-artifact@v2
       with:
@@ -389,28 +438,11 @@ jobs:
     - name: Uncompress nodejs SDK
       run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
         ${{github.workspace}}/sdk/nodejs
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
     - run: python -m pip install pip twine
     - env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       name: Publish SDKs
       run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3
@@ -425,8 +457,6 @@ jobs:
         - 3.1.301
         goversion:
         - 1.19.x
-        javaversion:
-        - "11"
         nodeversion:
         - 16.x
         pythonversion:

--- a/provider-ci/providers/dnsimple/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/dnsimple/repo/.github/workflows/release.yml
@@ -335,6 +335,61 @@ jobs:
         - 16.x
         pythonversion:
         - "3.9"
+  publish_java_sdk:
+    continue-on-error: true
+    name: publish_java_sdk
+    needs: publish
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout Repo
+      uses: actions/checkout@v3
+    - name: Checkout Scripts Repo
+      uses: actions/checkout@v3
+      with:
+        path: ci-scripts
+        repository: pulumi/scripts
+    - name: Unshallow clone for tags
+      run: git fetch --prune --unshallow --tags
+    - name: Install Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: ${{matrix.goversion}}
+    - name: Install pulumictl
+      uses: jaxxstorm/action-install-gh-release@v1.5.0
+      with:
+        repo: pulumi/pulumictl
+    - name: Install Pulumi CLI
+      uses: pulumi/action-install-pulumi-cli@v2
+    - name: Setup Java
+      uses: actions/setup-java@v3
+      with:
+        cache: gradle
+        distribution: temurin
+        java-version: ${{matrix.javaversion}}
+    - name: Download java SDK
+      uses: actions/download-artifact@v2
+      with:
+        name: java-sdk.tar.gz
+        path: ${{ github.workspace}}/sdk/
+    - name: Uncompress java SDK
+      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
+        ${{github.workspace}}/sdk/java
+    - name: Set PACKAGE_VERSION to Env
+      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
+        $GITHUB_ENV
+    - name: Publish Java SDK
+      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
+      with:
+        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
+        build-root-directory: ./sdk/java
+        gradle-version: 7.4.1
+    strategy:
+      fail-fast: true
+      matrix:
+        goversion:
+        - 1.19.x
+        javaversion:
+        - "11"
   publish_sdk:
     name: publish_sdk
     needs: publish
@@ -372,12 +427,6 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{matrix.pythonversion}}
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{matrix.javaversion}}
     - name: Download python SDK
       uses: actions/download-artifact@v2
       with:
@@ -402,28 +451,11 @@ jobs:
     - name: Uncompress nodejs SDK
       run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
         ${{github.workspace}}/sdk/nodejs
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
     - run: python -m pip install pip twine
     - env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       name: Publish SDKs
       run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3
@@ -438,8 +470,6 @@ jobs:
         - 3.1.301
         goversion:
         - 1.19.x
-        javaversion:
-        - "11"
         nodeversion:
         - 16.x
         pythonversion:

--- a/provider-ci/providers/docker/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/docker/repo/.github/workflows/main.yml
@@ -382,6 +382,61 @@ jobs:
         - 16.x
         pythonversion:
         - "3.9"
+  publish_java_sdk:
+    continue-on-error: true
+    name: publish_java_sdk
+    needs: publish
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout Repo
+      uses: actions/checkout@v3
+    - name: Checkout Scripts Repo
+      uses: actions/checkout@v3
+      with:
+        path: ci-scripts
+        repository: pulumi/scripts
+    - name: Unshallow clone for tags
+      run: git fetch --prune --unshallow --tags
+    - name: Install Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: ${{matrix.goversion}}
+    - name: Install pulumictl
+      uses: jaxxstorm/action-install-gh-release@v1.5.0
+      with:
+        repo: pulumi/pulumictl
+    - name: Install Pulumi CLI
+      uses: pulumi/action-install-pulumi-cli@v2
+    - name: Setup Java
+      uses: actions/setup-java@v3
+      with:
+        cache: gradle
+        distribution: temurin
+        java-version: ${{matrix.javaversion}}
+    - name: Download java SDK
+      uses: actions/download-artifact@v2
+      with:
+        name: java-sdk.tar.gz
+        path: ${{ github.workspace}}/sdk/
+    - name: Uncompress java SDK
+      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
+        ${{github.workspace}}/sdk/java
+    - name: Set PACKAGE_VERSION to Env
+      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
+        $GITHUB_ENV
+    - name: Publish Java SDK
+      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
+      with:
+        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
+        build-root-directory: ./sdk/java
+        gradle-version: 7.4.1
+    strategy:
+      fail-fast: true
+      matrix:
+        goversion:
+        - 1.19.x
+        javaversion:
+        - "11"
   publish_sdk:
     name: publish_sdk
     needs: publish
@@ -419,12 +474,6 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{matrix.pythonversion}}
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{matrix.javaversion}}
     - name: Download python SDK
       uses: actions/download-artifact@v2
       with:
@@ -449,28 +498,11 @@ jobs:
     - name: Uncompress nodejs SDK
       run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
         ${{github.workspace}}/sdk/nodejs
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
     - run: python -m pip install pip twine
     - env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       name: Publish SDKs
       run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3
@@ -485,8 +517,6 @@ jobs:
         - 3.1.301
         goversion:
         - 1.19.x
-        javaversion:
-        - "11"
         nodeversion:
         - 16.x
         pythonversion:

--- a/provider-ci/providers/docker/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/docker/repo/.github/workflows/master.yml
@@ -382,6 +382,61 @@ jobs:
         - 16.x
         pythonversion:
         - "3.9"
+  publish_java_sdk:
+    continue-on-error: true
+    name: publish_java_sdk
+    needs: publish
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout Repo
+      uses: actions/checkout@v3
+    - name: Checkout Scripts Repo
+      uses: actions/checkout@v3
+      with:
+        path: ci-scripts
+        repository: pulumi/scripts
+    - name: Unshallow clone for tags
+      run: git fetch --prune --unshallow --tags
+    - name: Install Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: ${{matrix.goversion}}
+    - name: Install pulumictl
+      uses: jaxxstorm/action-install-gh-release@v1.5.0
+      with:
+        repo: pulumi/pulumictl
+    - name: Install Pulumi CLI
+      uses: pulumi/action-install-pulumi-cli@v2
+    - name: Setup Java
+      uses: actions/setup-java@v3
+      with:
+        cache: gradle
+        distribution: temurin
+        java-version: ${{matrix.javaversion}}
+    - name: Download java SDK
+      uses: actions/download-artifact@v2
+      with:
+        name: java-sdk.tar.gz
+        path: ${{ github.workspace}}/sdk/
+    - name: Uncompress java SDK
+      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
+        ${{github.workspace}}/sdk/java
+    - name: Set PACKAGE_VERSION to Env
+      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
+        $GITHUB_ENV
+    - name: Publish Java SDK
+      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
+      with:
+        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
+        build-root-directory: ./sdk/java
+        gradle-version: 7.4.1
+    strategy:
+      fail-fast: true
+      matrix:
+        goversion:
+        - 1.19.x
+        javaversion:
+        - "11"
   publish_sdk:
     name: publish_sdk
     needs: publish
@@ -419,12 +474,6 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{matrix.pythonversion}}
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{matrix.javaversion}}
     - name: Download python SDK
       uses: actions/download-artifact@v2
       with:
@@ -449,28 +498,11 @@ jobs:
     - name: Uncompress nodejs SDK
       run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
         ${{github.workspace}}/sdk/nodejs
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
     - run: python -m pip install pip twine
     - env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       name: Publish SDKs
       run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3
@@ -485,8 +517,6 @@ jobs:
         - 3.1.301
         goversion:
         - 1.19.x
-        javaversion:
-        - "11"
         nodeversion:
         - 16.x
         pythonversion:

--- a/provider-ci/providers/docker/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/docker/repo/.github/workflows/prerelease.yml
@@ -326,6 +326,61 @@ jobs:
         - 16.x
         pythonversion:
         - "3.9"
+  publish_java_sdk:
+    continue-on-error: true
+    name: publish_java_sdk
+    needs: publish
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout Repo
+      uses: actions/checkout@v3
+    - name: Checkout Scripts Repo
+      uses: actions/checkout@v3
+      with:
+        path: ci-scripts
+        repository: pulumi/scripts
+    - name: Unshallow clone for tags
+      run: git fetch --prune --unshallow --tags
+    - name: Install Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: ${{matrix.goversion}}
+    - name: Install pulumictl
+      uses: jaxxstorm/action-install-gh-release@v1.5.0
+      with:
+        repo: pulumi/pulumictl
+    - name: Install Pulumi CLI
+      uses: pulumi/action-install-pulumi-cli@v2
+    - name: Setup Java
+      uses: actions/setup-java@v3
+      with:
+        cache: gradle
+        distribution: temurin
+        java-version: ${{matrix.javaversion}}
+    - name: Download java SDK
+      uses: actions/download-artifact@v2
+      with:
+        name: java-sdk.tar.gz
+        path: ${{ github.workspace}}/sdk/
+    - name: Uncompress java SDK
+      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
+        ${{github.workspace}}/sdk/java
+    - name: Set PACKAGE_VERSION to Env
+      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
+        $GITHUB_ENV
+    - name: Publish Java SDK
+      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
+      with:
+        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
+        build-root-directory: ./sdk/java
+        gradle-version: 7.4.1
+    strategy:
+      fail-fast: true
+      matrix:
+        goversion:
+        - 1.19.x
+        javaversion:
+        - "11"
   publish_sdk:
     name: publish_sdk
     needs: publish
@@ -363,12 +418,6 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{matrix.pythonversion}}
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{matrix.javaversion}}
     - name: Download python SDK
       uses: actions/download-artifact@v2
       with:
@@ -393,28 +442,11 @@ jobs:
     - name: Uncompress nodejs SDK
       run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
         ${{github.workspace}}/sdk/nodejs
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
     - run: python -m pip install pip twine
     - env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       name: Publish SDKs
       run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3
@@ -429,8 +461,6 @@ jobs:
         - 3.1.301
         goversion:
         - 1.19.x
-        javaversion:
-        - "11"
         nodeversion:
         - 16.x
         pythonversion:

--- a/provider-ci/providers/docker/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/docker/repo/.github/workflows/release.yml
@@ -339,6 +339,61 @@ jobs:
         - 16.x
         pythonversion:
         - "3.9"
+  publish_java_sdk:
+    continue-on-error: true
+    name: publish_java_sdk
+    needs: publish
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout Repo
+      uses: actions/checkout@v3
+    - name: Checkout Scripts Repo
+      uses: actions/checkout@v3
+      with:
+        path: ci-scripts
+        repository: pulumi/scripts
+    - name: Unshallow clone for tags
+      run: git fetch --prune --unshallow --tags
+    - name: Install Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: ${{matrix.goversion}}
+    - name: Install pulumictl
+      uses: jaxxstorm/action-install-gh-release@v1.5.0
+      with:
+        repo: pulumi/pulumictl
+    - name: Install Pulumi CLI
+      uses: pulumi/action-install-pulumi-cli@v2
+    - name: Setup Java
+      uses: actions/setup-java@v3
+      with:
+        cache: gradle
+        distribution: temurin
+        java-version: ${{matrix.javaversion}}
+    - name: Download java SDK
+      uses: actions/download-artifact@v2
+      with:
+        name: java-sdk.tar.gz
+        path: ${{ github.workspace}}/sdk/
+    - name: Uncompress java SDK
+      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
+        ${{github.workspace}}/sdk/java
+    - name: Set PACKAGE_VERSION to Env
+      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
+        $GITHUB_ENV
+    - name: Publish Java SDK
+      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
+      with:
+        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
+        build-root-directory: ./sdk/java
+        gradle-version: 7.4.1
+    strategy:
+      fail-fast: true
+      matrix:
+        goversion:
+        - 1.19.x
+        javaversion:
+        - "11"
   publish_sdk:
     name: publish_sdk
     needs: publish
@@ -376,12 +431,6 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{matrix.pythonversion}}
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{matrix.javaversion}}
     - name: Download python SDK
       uses: actions/download-artifact@v2
       with:
@@ -406,28 +455,11 @@ jobs:
     - name: Uncompress nodejs SDK
       run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
         ${{github.workspace}}/sdk/nodejs
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
     - run: python -m pip install pip twine
     - env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       name: Publish SDKs
       run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3
@@ -442,8 +474,6 @@ jobs:
         - 3.1.301
         goversion:
         - 1.19.x
-        javaversion:
-        - "11"
         nodeversion:
         - 16.x
         pythonversion:

--- a/provider-ci/providers/ec/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/ec/repo/.github/workflows/main.yml
@@ -377,6 +377,61 @@ jobs:
         - 16.x
         pythonversion:
         - "3.9"
+  publish_java_sdk:
+    continue-on-error: true
+    name: publish_java_sdk
+    needs: publish
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout Repo
+      uses: actions/checkout@v3
+    - name: Checkout Scripts Repo
+      uses: actions/checkout@v3
+      with:
+        path: ci-scripts
+        repository: pulumi/scripts
+    - name: Unshallow clone for tags
+      run: git fetch --prune --unshallow --tags
+    - name: Install Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: ${{matrix.goversion}}
+    - name: Install pulumictl
+      uses: jaxxstorm/action-install-gh-release@v1.5.0
+      with:
+        repo: pulumi/pulumictl
+    - name: Install Pulumi CLI
+      uses: pulumi/action-install-pulumi-cli@v2
+    - name: Setup Java
+      uses: actions/setup-java@v3
+      with:
+        cache: gradle
+        distribution: temurin
+        java-version: ${{matrix.javaversion}}
+    - name: Download java SDK
+      uses: actions/download-artifact@v2
+      with:
+        name: java-sdk.tar.gz
+        path: ${{ github.workspace}}/sdk/
+    - name: Uncompress java SDK
+      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
+        ${{github.workspace}}/sdk/java
+    - name: Set PACKAGE_VERSION to Env
+      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
+        $GITHUB_ENV
+    - name: Publish Java SDK
+      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
+      with:
+        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
+        build-root-directory: ./sdk/java
+        gradle-version: 7.4.1
+    strategy:
+      fail-fast: true
+      matrix:
+        goversion:
+        - 1.19.x
+        javaversion:
+        - "11"
   publish_sdk:
     name: publish_sdk
     needs: publish
@@ -414,12 +469,6 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{matrix.pythonversion}}
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{matrix.javaversion}}
     - name: Download python SDK
       uses: actions/download-artifact@v2
       with:
@@ -444,28 +493,11 @@ jobs:
     - name: Uncompress nodejs SDK
       run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
         ${{github.workspace}}/sdk/nodejs
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
     - run: python -m pip install pip twine
     - env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       name: Publish SDKs
       run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3
@@ -480,8 +512,6 @@ jobs:
         - 3.1.301
         goversion:
         - 1.19.x
-        javaversion:
-        - "11"
         nodeversion:
         - 16.x
         pythonversion:

--- a/provider-ci/providers/ec/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/ec/repo/.github/workflows/master.yml
@@ -377,6 +377,61 @@ jobs:
         - 16.x
         pythonversion:
         - "3.9"
+  publish_java_sdk:
+    continue-on-error: true
+    name: publish_java_sdk
+    needs: publish
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout Repo
+      uses: actions/checkout@v3
+    - name: Checkout Scripts Repo
+      uses: actions/checkout@v3
+      with:
+        path: ci-scripts
+        repository: pulumi/scripts
+    - name: Unshallow clone for tags
+      run: git fetch --prune --unshallow --tags
+    - name: Install Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: ${{matrix.goversion}}
+    - name: Install pulumictl
+      uses: jaxxstorm/action-install-gh-release@v1.5.0
+      with:
+        repo: pulumi/pulumictl
+    - name: Install Pulumi CLI
+      uses: pulumi/action-install-pulumi-cli@v2
+    - name: Setup Java
+      uses: actions/setup-java@v3
+      with:
+        cache: gradle
+        distribution: temurin
+        java-version: ${{matrix.javaversion}}
+    - name: Download java SDK
+      uses: actions/download-artifact@v2
+      with:
+        name: java-sdk.tar.gz
+        path: ${{ github.workspace}}/sdk/
+    - name: Uncompress java SDK
+      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
+        ${{github.workspace}}/sdk/java
+    - name: Set PACKAGE_VERSION to Env
+      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
+        $GITHUB_ENV
+    - name: Publish Java SDK
+      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
+      with:
+        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
+        build-root-directory: ./sdk/java
+        gradle-version: 7.4.1
+    strategy:
+      fail-fast: true
+      matrix:
+        goversion:
+        - 1.19.x
+        javaversion:
+        - "11"
   publish_sdk:
     name: publish_sdk
     needs: publish
@@ -414,12 +469,6 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{matrix.pythonversion}}
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{matrix.javaversion}}
     - name: Download python SDK
       uses: actions/download-artifact@v2
       with:
@@ -444,28 +493,11 @@ jobs:
     - name: Uncompress nodejs SDK
       run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
         ${{github.workspace}}/sdk/nodejs
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
     - run: python -m pip install pip twine
     - env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       name: Publish SDKs
       run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3
@@ -480,8 +512,6 @@ jobs:
         - 3.1.301
         goversion:
         - 1.19.x
-        javaversion:
-        - "11"
         nodeversion:
         - 16.x
         pythonversion:

--- a/provider-ci/providers/ec/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/ec/repo/.github/workflows/prerelease.yml
@@ -321,6 +321,61 @@ jobs:
         - 16.x
         pythonversion:
         - "3.9"
+  publish_java_sdk:
+    continue-on-error: true
+    name: publish_java_sdk
+    needs: publish
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout Repo
+      uses: actions/checkout@v3
+    - name: Checkout Scripts Repo
+      uses: actions/checkout@v3
+      with:
+        path: ci-scripts
+        repository: pulumi/scripts
+    - name: Unshallow clone for tags
+      run: git fetch --prune --unshallow --tags
+    - name: Install Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: ${{matrix.goversion}}
+    - name: Install pulumictl
+      uses: jaxxstorm/action-install-gh-release@v1.5.0
+      with:
+        repo: pulumi/pulumictl
+    - name: Install Pulumi CLI
+      uses: pulumi/action-install-pulumi-cli@v2
+    - name: Setup Java
+      uses: actions/setup-java@v3
+      with:
+        cache: gradle
+        distribution: temurin
+        java-version: ${{matrix.javaversion}}
+    - name: Download java SDK
+      uses: actions/download-artifact@v2
+      with:
+        name: java-sdk.tar.gz
+        path: ${{ github.workspace}}/sdk/
+    - name: Uncompress java SDK
+      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
+        ${{github.workspace}}/sdk/java
+    - name: Set PACKAGE_VERSION to Env
+      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
+        $GITHUB_ENV
+    - name: Publish Java SDK
+      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
+      with:
+        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
+        build-root-directory: ./sdk/java
+        gradle-version: 7.4.1
+    strategy:
+      fail-fast: true
+      matrix:
+        goversion:
+        - 1.19.x
+        javaversion:
+        - "11"
   publish_sdk:
     name: publish_sdk
     needs: publish
@@ -358,12 +413,6 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{matrix.pythonversion}}
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{matrix.javaversion}}
     - name: Download python SDK
       uses: actions/download-artifact@v2
       with:
@@ -388,28 +437,11 @@ jobs:
     - name: Uncompress nodejs SDK
       run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
         ${{github.workspace}}/sdk/nodejs
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
     - run: python -m pip install pip twine
     - env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       name: Publish SDKs
       run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3
@@ -424,8 +456,6 @@ jobs:
         - 3.1.301
         goversion:
         - 1.19.x
-        javaversion:
-        - "11"
         nodeversion:
         - 16.x
         pythonversion:

--- a/provider-ci/providers/ec/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/ec/repo/.github/workflows/release.yml
@@ -334,6 +334,61 @@ jobs:
         - 16.x
         pythonversion:
         - "3.9"
+  publish_java_sdk:
+    continue-on-error: true
+    name: publish_java_sdk
+    needs: publish
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout Repo
+      uses: actions/checkout@v3
+    - name: Checkout Scripts Repo
+      uses: actions/checkout@v3
+      with:
+        path: ci-scripts
+        repository: pulumi/scripts
+    - name: Unshallow clone for tags
+      run: git fetch --prune --unshallow --tags
+    - name: Install Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: ${{matrix.goversion}}
+    - name: Install pulumictl
+      uses: jaxxstorm/action-install-gh-release@v1.5.0
+      with:
+        repo: pulumi/pulumictl
+    - name: Install Pulumi CLI
+      uses: pulumi/action-install-pulumi-cli@v2
+    - name: Setup Java
+      uses: actions/setup-java@v3
+      with:
+        cache: gradle
+        distribution: temurin
+        java-version: ${{matrix.javaversion}}
+    - name: Download java SDK
+      uses: actions/download-artifact@v2
+      with:
+        name: java-sdk.tar.gz
+        path: ${{ github.workspace}}/sdk/
+    - name: Uncompress java SDK
+      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
+        ${{github.workspace}}/sdk/java
+    - name: Set PACKAGE_VERSION to Env
+      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
+        $GITHUB_ENV
+    - name: Publish Java SDK
+      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
+      with:
+        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
+        build-root-directory: ./sdk/java
+        gradle-version: 7.4.1
+    strategy:
+      fail-fast: true
+      matrix:
+        goversion:
+        - 1.19.x
+        javaversion:
+        - "11"
   publish_sdk:
     name: publish_sdk
     needs: publish
@@ -371,12 +426,6 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{matrix.pythonversion}}
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{matrix.javaversion}}
     - name: Download python SDK
       uses: actions/download-artifact@v2
       with:
@@ -401,28 +450,11 @@ jobs:
     - name: Uncompress nodejs SDK
       run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
         ${{github.workspace}}/sdk/nodejs
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
     - run: python -m pip install pip twine
     - env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       name: Publish SDKs
       run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3
@@ -437,8 +469,6 @@ jobs:
         - 3.1.301
         goversion:
         - 1.19.x
-        javaversion:
-        - "11"
         nodeversion:
         - 16.x
         pythonversion:

--- a/provider-ci/providers/equinix-metal/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/equinix-metal/repo/.github/workflows/main.yml
@@ -302,6 +302,61 @@ jobs:
         - 16.x
         pythonversion:
         - "3.9"
+  publish_java_sdk:
+    continue-on-error: true
+    name: publish_java_sdk
+    needs: publish
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout Repo
+      uses: actions/checkout@v3
+    - name: Checkout Scripts Repo
+      uses: actions/checkout@v3
+      with:
+        path: ci-scripts
+        repository: pulumi/scripts
+    - name: Unshallow clone for tags
+      run: git fetch --prune --unshallow --tags
+    - name: Install Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: ${{matrix.goversion}}
+    - name: Install pulumictl
+      uses: jaxxstorm/action-install-gh-release@v1.5.0
+      with:
+        repo: pulumi/pulumictl
+    - name: Install Pulumi CLI
+      uses: pulumi/action-install-pulumi-cli@v2
+    - name: Setup Java
+      uses: actions/setup-java@v3
+      with:
+        cache: gradle
+        distribution: temurin
+        java-version: ${{matrix.javaversion}}
+    - name: Download java SDK
+      uses: actions/download-artifact@v2
+      with:
+        name: java-sdk.tar.gz
+        path: ${{ github.workspace}}/sdk/
+    - name: Uncompress java SDK
+      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
+        ${{github.workspace}}/sdk/java
+    - name: Set PACKAGE_VERSION to Env
+      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
+        $GITHUB_ENV
+    - name: Publish Java SDK
+      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
+      with:
+        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
+        build-root-directory: ./sdk/java
+        gradle-version: 7.4.1
+    strategy:
+      fail-fast: true
+      matrix:
+        goversion:
+        - 1.19.x
+        javaversion:
+        - "11"
   publish_sdk:
     name: publish_sdk
     needs: publish
@@ -339,12 +394,6 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{matrix.pythonversion}}
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{matrix.javaversion}}
     - name: Download python SDK
       uses: actions/download-artifact@v2
       with:
@@ -369,28 +418,11 @@ jobs:
     - name: Uncompress nodejs SDK
       run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
         ${{github.workspace}}/sdk/nodejs
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
     - run: python -m pip install pip twine
     - env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       name: Publish SDKs
       run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3
@@ -405,8 +437,6 @@ jobs:
         - 3.1.301
         goversion:
         - 1.19.x
-        javaversion:
-        - "11"
         nodeversion:
         - 16.x
         pythonversion:

--- a/provider-ci/providers/equinix-metal/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/equinix-metal/repo/.github/workflows/master.yml
@@ -302,6 +302,61 @@ jobs:
         - 16.x
         pythonversion:
         - "3.9"
+  publish_java_sdk:
+    continue-on-error: true
+    name: publish_java_sdk
+    needs: publish
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout Repo
+      uses: actions/checkout@v3
+    - name: Checkout Scripts Repo
+      uses: actions/checkout@v3
+      with:
+        path: ci-scripts
+        repository: pulumi/scripts
+    - name: Unshallow clone for tags
+      run: git fetch --prune --unshallow --tags
+    - name: Install Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: ${{matrix.goversion}}
+    - name: Install pulumictl
+      uses: jaxxstorm/action-install-gh-release@v1.5.0
+      with:
+        repo: pulumi/pulumictl
+    - name: Install Pulumi CLI
+      uses: pulumi/action-install-pulumi-cli@v2
+    - name: Setup Java
+      uses: actions/setup-java@v3
+      with:
+        cache: gradle
+        distribution: temurin
+        java-version: ${{matrix.javaversion}}
+    - name: Download java SDK
+      uses: actions/download-artifact@v2
+      with:
+        name: java-sdk.tar.gz
+        path: ${{ github.workspace}}/sdk/
+    - name: Uncompress java SDK
+      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
+        ${{github.workspace}}/sdk/java
+    - name: Set PACKAGE_VERSION to Env
+      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
+        $GITHUB_ENV
+    - name: Publish Java SDK
+      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
+      with:
+        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
+        build-root-directory: ./sdk/java
+        gradle-version: 7.4.1
+    strategy:
+      fail-fast: true
+      matrix:
+        goversion:
+        - 1.19.x
+        javaversion:
+        - "11"
   publish_sdk:
     name: publish_sdk
     needs: publish
@@ -339,12 +394,6 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{matrix.pythonversion}}
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{matrix.javaversion}}
     - name: Download python SDK
       uses: actions/download-artifact@v2
       with:
@@ -369,28 +418,11 @@ jobs:
     - name: Uncompress nodejs SDK
       run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
         ${{github.workspace}}/sdk/nodejs
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
     - run: python -m pip install pip twine
     - env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       name: Publish SDKs
       run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3
@@ -405,8 +437,6 @@ jobs:
         - 3.1.301
         goversion:
         - 1.19.x
-        javaversion:
-        - "11"
         nodeversion:
         - 16.x
         pythonversion:

--- a/provider-ci/providers/equinix-metal/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/equinix-metal/repo/.github/workflows/prerelease.yml
@@ -246,6 +246,61 @@ jobs:
         - 16.x
         pythonversion:
         - "3.9"
+  publish_java_sdk:
+    continue-on-error: true
+    name: publish_java_sdk
+    needs: publish
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout Repo
+      uses: actions/checkout@v3
+    - name: Checkout Scripts Repo
+      uses: actions/checkout@v3
+      with:
+        path: ci-scripts
+        repository: pulumi/scripts
+    - name: Unshallow clone for tags
+      run: git fetch --prune --unshallow --tags
+    - name: Install Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: ${{matrix.goversion}}
+    - name: Install pulumictl
+      uses: jaxxstorm/action-install-gh-release@v1.5.0
+      with:
+        repo: pulumi/pulumictl
+    - name: Install Pulumi CLI
+      uses: pulumi/action-install-pulumi-cli@v2
+    - name: Setup Java
+      uses: actions/setup-java@v3
+      with:
+        cache: gradle
+        distribution: temurin
+        java-version: ${{matrix.javaversion}}
+    - name: Download java SDK
+      uses: actions/download-artifact@v2
+      with:
+        name: java-sdk.tar.gz
+        path: ${{ github.workspace}}/sdk/
+    - name: Uncompress java SDK
+      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
+        ${{github.workspace}}/sdk/java
+    - name: Set PACKAGE_VERSION to Env
+      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
+        $GITHUB_ENV
+    - name: Publish Java SDK
+      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
+      with:
+        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
+        build-root-directory: ./sdk/java
+        gradle-version: 7.4.1
+    strategy:
+      fail-fast: true
+      matrix:
+        goversion:
+        - 1.19.x
+        javaversion:
+        - "11"
   publish_sdk:
     name: publish_sdk
     needs: publish
@@ -283,12 +338,6 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{matrix.pythonversion}}
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{matrix.javaversion}}
     - name: Download python SDK
       uses: actions/download-artifact@v2
       with:
@@ -313,28 +362,11 @@ jobs:
     - name: Uncompress nodejs SDK
       run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
         ${{github.workspace}}/sdk/nodejs
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
     - run: python -m pip install pip twine
     - env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       name: Publish SDKs
       run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3
@@ -349,8 +381,6 @@ jobs:
         - 3.1.301
         goversion:
         - 1.19.x
-        javaversion:
-        - "11"
         nodeversion:
         - 16.x
         pythonversion:

--- a/provider-ci/providers/equinix-metal/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/equinix-metal/repo/.github/workflows/release.yml
@@ -259,6 +259,61 @@ jobs:
         - 16.x
         pythonversion:
         - "3.9"
+  publish_java_sdk:
+    continue-on-error: true
+    name: publish_java_sdk
+    needs: publish
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout Repo
+      uses: actions/checkout@v3
+    - name: Checkout Scripts Repo
+      uses: actions/checkout@v3
+      with:
+        path: ci-scripts
+        repository: pulumi/scripts
+    - name: Unshallow clone for tags
+      run: git fetch --prune --unshallow --tags
+    - name: Install Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: ${{matrix.goversion}}
+    - name: Install pulumictl
+      uses: jaxxstorm/action-install-gh-release@v1.5.0
+      with:
+        repo: pulumi/pulumictl
+    - name: Install Pulumi CLI
+      uses: pulumi/action-install-pulumi-cli@v2
+    - name: Setup Java
+      uses: actions/setup-java@v3
+      with:
+        cache: gradle
+        distribution: temurin
+        java-version: ${{matrix.javaversion}}
+    - name: Download java SDK
+      uses: actions/download-artifact@v2
+      with:
+        name: java-sdk.tar.gz
+        path: ${{ github.workspace}}/sdk/
+    - name: Uncompress java SDK
+      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
+        ${{github.workspace}}/sdk/java
+    - name: Set PACKAGE_VERSION to Env
+      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
+        $GITHUB_ENV
+    - name: Publish Java SDK
+      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
+      with:
+        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
+        build-root-directory: ./sdk/java
+        gradle-version: 7.4.1
+    strategy:
+      fail-fast: true
+      matrix:
+        goversion:
+        - 1.19.x
+        javaversion:
+        - "11"
   publish_sdk:
     name: publish_sdk
     needs: publish
@@ -296,12 +351,6 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{matrix.pythonversion}}
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{matrix.javaversion}}
     - name: Download python SDK
       uses: actions/download-artifact@v2
       with:
@@ -326,28 +375,11 @@ jobs:
     - name: Uncompress nodejs SDK
       run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
         ${{github.workspace}}/sdk/nodejs
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
     - run: python -m pip install pip twine
     - env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       name: Publish SDKs
       run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3
@@ -362,8 +394,6 @@ jobs:
         - 3.1.301
         goversion:
         - 1.19.x
-        javaversion:
-        - "11"
         nodeversion:
         - 16.x
         pythonversion:

--- a/provider-ci/providers/f5bigip/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/f5bigip/repo/.github/workflows/main.yml
@@ -380,6 +380,61 @@ jobs:
         - 16.x
         pythonversion:
         - "3.9"
+  publish_java_sdk:
+    continue-on-error: true
+    name: publish_java_sdk
+    needs: publish
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout Repo
+      uses: actions/checkout@v3
+    - name: Checkout Scripts Repo
+      uses: actions/checkout@v3
+      with:
+        path: ci-scripts
+        repository: pulumi/scripts
+    - name: Unshallow clone for tags
+      run: git fetch --prune --unshallow --tags
+    - name: Install Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: ${{matrix.goversion}}
+    - name: Install pulumictl
+      uses: jaxxstorm/action-install-gh-release@v1.5.0
+      with:
+        repo: pulumi/pulumictl
+    - name: Install Pulumi CLI
+      uses: pulumi/action-install-pulumi-cli@v2
+    - name: Setup Java
+      uses: actions/setup-java@v3
+      with:
+        cache: gradle
+        distribution: temurin
+        java-version: ${{matrix.javaversion}}
+    - name: Download java SDK
+      uses: actions/download-artifact@v2
+      with:
+        name: java-sdk.tar.gz
+        path: ${{ github.workspace}}/sdk/
+    - name: Uncompress java SDK
+      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
+        ${{github.workspace}}/sdk/java
+    - name: Set PACKAGE_VERSION to Env
+      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
+        $GITHUB_ENV
+    - name: Publish Java SDK
+      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
+      with:
+        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
+        build-root-directory: ./sdk/java
+        gradle-version: 7.4.1
+    strategy:
+      fail-fast: true
+      matrix:
+        goversion:
+        - 1.19.x
+        javaversion:
+        - "11"
   publish_sdk:
     name: publish_sdk
     needs: publish
@@ -417,12 +472,6 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{matrix.pythonversion}}
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{matrix.javaversion}}
     - name: Download python SDK
       uses: actions/download-artifact@v2
       with:
@@ -447,28 +496,11 @@ jobs:
     - name: Uncompress nodejs SDK
       run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
         ${{github.workspace}}/sdk/nodejs
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
     - run: python -m pip install pip twine
     - env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       name: Publish SDKs
       run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3
@@ -483,8 +515,6 @@ jobs:
         - 3.1.301
         goversion:
         - 1.19.x
-        javaversion:
-        - "11"
         nodeversion:
         - 16.x
         pythonversion:

--- a/provider-ci/providers/f5bigip/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/f5bigip/repo/.github/workflows/master.yml
@@ -380,6 +380,61 @@ jobs:
         - 16.x
         pythonversion:
         - "3.9"
+  publish_java_sdk:
+    continue-on-error: true
+    name: publish_java_sdk
+    needs: publish
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout Repo
+      uses: actions/checkout@v3
+    - name: Checkout Scripts Repo
+      uses: actions/checkout@v3
+      with:
+        path: ci-scripts
+        repository: pulumi/scripts
+    - name: Unshallow clone for tags
+      run: git fetch --prune --unshallow --tags
+    - name: Install Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: ${{matrix.goversion}}
+    - name: Install pulumictl
+      uses: jaxxstorm/action-install-gh-release@v1.5.0
+      with:
+        repo: pulumi/pulumictl
+    - name: Install Pulumi CLI
+      uses: pulumi/action-install-pulumi-cli@v2
+    - name: Setup Java
+      uses: actions/setup-java@v3
+      with:
+        cache: gradle
+        distribution: temurin
+        java-version: ${{matrix.javaversion}}
+    - name: Download java SDK
+      uses: actions/download-artifact@v2
+      with:
+        name: java-sdk.tar.gz
+        path: ${{ github.workspace}}/sdk/
+    - name: Uncompress java SDK
+      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
+        ${{github.workspace}}/sdk/java
+    - name: Set PACKAGE_VERSION to Env
+      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
+        $GITHUB_ENV
+    - name: Publish Java SDK
+      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
+      with:
+        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
+        build-root-directory: ./sdk/java
+        gradle-version: 7.4.1
+    strategy:
+      fail-fast: true
+      matrix:
+        goversion:
+        - 1.19.x
+        javaversion:
+        - "11"
   publish_sdk:
     name: publish_sdk
     needs: publish
@@ -417,12 +472,6 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{matrix.pythonversion}}
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{matrix.javaversion}}
     - name: Download python SDK
       uses: actions/download-artifact@v2
       with:
@@ -447,28 +496,11 @@ jobs:
     - name: Uncompress nodejs SDK
       run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
         ${{github.workspace}}/sdk/nodejs
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
     - run: python -m pip install pip twine
     - env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       name: Publish SDKs
       run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3
@@ -483,8 +515,6 @@ jobs:
         - 3.1.301
         goversion:
         - 1.19.x
-        javaversion:
-        - "11"
         nodeversion:
         - 16.x
         pythonversion:

--- a/provider-ci/providers/f5bigip/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/f5bigip/repo/.github/workflows/prerelease.yml
@@ -324,6 +324,61 @@ jobs:
         - 16.x
         pythonversion:
         - "3.9"
+  publish_java_sdk:
+    continue-on-error: true
+    name: publish_java_sdk
+    needs: publish
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout Repo
+      uses: actions/checkout@v3
+    - name: Checkout Scripts Repo
+      uses: actions/checkout@v3
+      with:
+        path: ci-scripts
+        repository: pulumi/scripts
+    - name: Unshallow clone for tags
+      run: git fetch --prune --unshallow --tags
+    - name: Install Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: ${{matrix.goversion}}
+    - name: Install pulumictl
+      uses: jaxxstorm/action-install-gh-release@v1.5.0
+      with:
+        repo: pulumi/pulumictl
+    - name: Install Pulumi CLI
+      uses: pulumi/action-install-pulumi-cli@v2
+    - name: Setup Java
+      uses: actions/setup-java@v3
+      with:
+        cache: gradle
+        distribution: temurin
+        java-version: ${{matrix.javaversion}}
+    - name: Download java SDK
+      uses: actions/download-artifact@v2
+      with:
+        name: java-sdk.tar.gz
+        path: ${{ github.workspace}}/sdk/
+    - name: Uncompress java SDK
+      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
+        ${{github.workspace}}/sdk/java
+    - name: Set PACKAGE_VERSION to Env
+      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
+        $GITHUB_ENV
+    - name: Publish Java SDK
+      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
+      with:
+        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
+        build-root-directory: ./sdk/java
+        gradle-version: 7.4.1
+    strategy:
+      fail-fast: true
+      matrix:
+        goversion:
+        - 1.19.x
+        javaversion:
+        - "11"
   publish_sdk:
     name: publish_sdk
     needs: publish
@@ -361,12 +416,6 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{matrix.pythonversion}}
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{matrix.javaversion}}
     - name: Download python SDK
       uses: actions/download-artifact@v2
       with:
@@ -391,28 +440,11 @@ jobs:
     - name: Uncompress nodejs SDK
       run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
         ${{github.workspace}}/sdk/nodejs
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
     - run: python -m pip install pip twine
     - env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       name: Publish SDKs
       run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3
@@ -427,8 +459,6 @@ jobs:
         - 3.1.301
         goversion:
         - 1.19.x
-        javaversion:
-        - "11"
         nodeversion:
         - 16.x
         pythonversion:

--- a/provider-ci/providers/f5bigip/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/f5bigip/repo/.github/workflows/release.yml
@@ -337,6 +337,61 @@ jobs:
         - 16.x
         pythonversion:
         - "3.9"
+  publish_java_sdk:
+    continue-on-error: true
+    name: publish_java_sdk
+    needs: publish
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout Repo
+      uses: actions/checkout@v3
+    - name: Checkout Scripts Repo
+      uses: actions/checkout@v3
+      with:
+        path: ci-scripts
+        repository: pulumi/scripts
+    - name: Unshallow clone for tags
+      run: git fetch --prune --unshallow --tags
+    - name: Install Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: ${{matrix.goversion}}
+    - name: Install pulumictl
+      uses: jaxxstorm/action-install-gh-release@v1.5.0
+      with:
+        repo: pulumi/pulumictl
+    - name: Install Pulumi CLI
+      uses: pulumi/action-install-pulumi-cli@v2
+    - name: Setup Java
+      uses: actions/setup-java@v3
+      with:
+        cache: gradle
+        distribution: temurin
+        java-version: ${{matrix.javaversion}}
+    - name: Download java SDK
+      uses: actions/download-artifact@v2
+      with:
+        name: java-sdk.tar.gz
+        path: ${{ github.workspace}}/sdk/
+    - name: Uncompress java SDK
+      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
+        ${{github.workspace}}/sdk/java
+    - name: Set PACKAGE_VERSION to Env
+      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
+        $GITHUB_ENV
+    - name: Publish Java SDK
+      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
+      with:
+        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
+        build-root-directory: ./sdk/java
+        gradle-version: 7.4.1
+    strategy:
+      fail-fast: true
+      matrix:
+        goversion:
+        - 1.19.x
+        javaversion:
+        - "11"
   publish_sdk:
     name: publish_sdk
     needs: publish
@@ -374,12 +429,6 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{matrix.pythonversion}}
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{matrix.javaversion}}
     - name: Download python SDK
       uses: actions/download-artifact@v2
       with:
@@ -404,28 +453,11 @@ jobs:
     - name: Uncompress nodejs SDK
       run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
         ${{github.workspace}}/sdk/nodejs
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
     - run: python -m pip install pip twine
     - env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       name: Publish SDKs
       run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3
@@ -440,8 +472,6 @@ jobs:
         - 3.1.301
         goversion:
         - 1.19.x
-        javaversion:
-        - "11"
         nodeversion:
         - 16.x
         pythonversion:

--- a/provider-ci/providers/fastly/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/fastly/repo/.github/workflows/main.yml
@@ -377,6 +377,61 @@ jobs:
         - 16.x
         pythonversion:
         - "3.9"
+  publish_java_sdk:
+    continue-on-error: true
+    name: publish_java_sdk
+    needs: publish
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout Repo
+      uses: actions/checkout@v3
+    - name: Checkout Scripts Repo
+      uses: actions/checkout@v3
+      with:
+        path: ci-scripts
+        repository: pulumi/scripts
+    - name: Unshallow clone for tags
+      run: git fetch --prune --unshallow --tags
+    - name: Install Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: ${{matrix.goversion}}
+    - name: Install pulumictl
+      uses: jaxxstorm/action-install-gh-release@v1.5.0
+      with:
+        repo: pulumi/pulumictl
+    - name: Install Pulumi CLI
+      uses: pulumi/action-install-pulumi-cli@v2
+    - name: Setup Java
+      uses: actions/setup-java@v3
+      with:
+        cache: gradle
+        distribution: temurin
+        java-version: ${{matrix.javaversion}}
+    - name: Download java SDK
+      uses: actions/download-artifact@v2
+      with:
+        name: java-sdk.tar.gz
+        path: ${{ github.workspace}}/sdk/
+    - name: Uncompress java SDK
+      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
+        ${{github.workspace}}/sdk/java
+    - name: Set PACKAGE_VERSION to Env
+      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
+        $GITHUB_ENV
+    - name: Publish Java SDK
+      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
+      with:
+        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
+        build-root-directory: ./sdk/java
+        gradle-version: 7.4.1
+    strategy:
+      fail-fast: true
+      matrix:
+        goversion:
+        - 1.19.x
+        javaversion:
+        - "11"
   publish_sdk:
     name: publish_sdk
     needs: publish
@@ -414,12 +469,6 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{matrix.pythonversion}}
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{matrix.javaversion}}
     - name: Download python SDK
       uses: actions/download-artifact@v2
       with:
@@ -444,28 +493,11 @@ jobs:
     - name: Uncompress nodejs SDK
       run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
         ${{github.workspace}}/sdk/nodejs
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
     - run: python -m pip install pip twine
     - env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       name: Publish SDKs
       run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3
@@ -480,8 +512,6 @@ jobs:
         - 3.1.301
         goversion:
         - 1.19.x
-        javaversion:
-        - "11"
         nodeversion:
         - 16.x
         pythonversion:

--- a/provider-ci/providers/fastly/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/fastly/repo/.github/workflows/master.yml
@@ -377,6 +377,61 @@ jobs:
         - 16.x
         pythonversion:
         - "3.9"
+  publish_java_sdk:
+    continue-on-error: true
+    name: publish_java_sdk
+    needs: publish
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout Repo
+      uses: actions/checkout@v3
+    - name: Checkout Scripts Repo
+      uses: actions/checkout@v3
+      with:
+        path: ci-scripts
+        repository: pulumi/scripts
+    - name: Unshallow clone for tags
+      run: git fetch --prune --unshallow --tags
+    - name: Install Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: ${{matrix.goversion}}
+    - name: Install pulumictl
+      uses: jaxxstorm/action-install-gh-release@v1.5.0
+      with:
+        repo: pulumi/pulumictl
+    - name: Install Pulumi CLI
+      uses: pulumi/action-install-pulumi-cli@v2
+    - name: Setup Java
+      uses: actions/setup-java@v3
+      with:
+        cache: gradle
+        distribution: temurin
+        java-version: ${{matrix.javaversion}}
+    - name: Download java SDK
+      uses: actions/download-artifact@v2
+      with:
+        name: java-sdk.tar.gz
+        path: ${{ github.workspace}}/sdk/
+    - name: Uncompress java SDK
+      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
+        ${{github.workspace}}/sdk/java
+    - name: Set PACKAGE_VERSION to Env
+      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
+        $GITHUB_ENV
+    - name: Publish Java SDK
+      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
+      with:
+        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
+        build-root-directory: ./sdk/java
+        gradle-version: 7.4.1
+    strategy:
+      fail-fast: true
+      matrix:
+        goversion:
+        - 1.19.x
+        javaversion:
+        - "11"
   publish_sdk:
     name: publish_sdk
     needs: publish
@@ -414,12 +469,6 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{matrix.pythonversion}}
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{matrix.javaversion}}
     - name: Download python SDK
       uses: actions/download-artifact@v2
       with:
@@ -444,28 +493,11 @@ jobs:
     - name: Uncompress nodejs SDK
       run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
         ${{github.workspace}}/sdk/nodejs
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
     - run: python -m pip install pip twine
     - env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       name: Publish SDKs
       run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3
@@ -480,8 +512,6 @@ jobs:
         - 3.1.301
         goversion:
         - 1.19.x
-        javaversion:
-        - "11"
         nodeversion:
         - 16.x
         pythonversion:

--- a/provider-ci/providers/fastly/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/fastly/repo/.github/workflows/prerelease.yml
@@ -321,6 +321,61 @@ jobs:
         - 16.x
         pythonversion:
         - "3.9"
+  publish_java_sdk:
+    continue-on-error: true
+    name: publish_java_sdk
+    needs: publish
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout Repo
+      uses: actions/checkout@v3
+    - name: Checkout Scripts Repo
+      uses: actions/checkout@v3
+      with:
+        path: ci-scripts
+        repository: pulumi/scripts
+    - name: Unshallow clone for tags
+      run: git fetch --prune --unshallow --tags
+    - name: Install Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: ${{matrix.goversion}}
+    - name: Install pulumictl
+      uses: jaxxstorm/action-install-gh-release@v1.5.0
+      with:
+        repo: pulumi/pulumictl
+    - name: Install Pulumi CLI
+      uses: pulumi/action-install-pulumi-cli@v2
+    - name: Setup Java
+      uses: actions/setup-java@v3
+      with:
+        cache: gradle
+        distribution: temurin
+        java-version: ${{matrix.javaversion}}
+    - name: Download java SDK
+      uses: actions/download-artifact@v2
+      with:
+        name: java-sdk.tar.gz
+        path: ${{ github.workspace}}/sdk/
+    - name: Uncompress java SDK
+      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
+        ${{github.workspace}}/sdk/java
+    - name: Set PACKAGE_VERSION to Env
+      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
+        $GITHUB_ENV
+    - name: Publish Java SDK
+      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
+      with:
+        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
+        build-root-directory: ./sdk/java
+        gradle-version: 7.4.1
+    strategy:
+      fail-fast: true
+      matrix:
+        goversion:
+        - 1.19.x
+        javaversion:
+        - "11"
   publish_sdk:
     name: publish_sdk
     needs: publish
@@ -358,12 +413,6 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{matrix.pythonversion}}
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{matrix.javaversion}}
     - name: Download python SDK
       uses: actions/download-artifact@v2
       with:
@@ -388,28 +437,11 @@ jobs:
     - name: Uncompress nodejs SDK
       run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
         ${{github.workspace}}/sdk/nodejs
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
     - run: python -m pip install pip twine
     - env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       name: Publish SDKs
       run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3
@@ -424,8 +456,6 @@ jobs:
         - 3.1.301
         goversion:
         - 1.19.x
-        javaversion:
-        - "11"
         nodeversion:
         - 16.x
         pythonversion:

--- a/provider-ci/providers/fastly/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/fastly/repo/.github/workflows/release.yml
@@ -334,6 +334,61 @@ jobs:
         - 16.x
         pythonversion:
         - "3.9"
+  publish_java_sdk:
+    continue-on-error: true
+    name: publish_java_sdk
+    needs: publish
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout Repo
+      uses: actions/checkout@v3
+    - name: Checkout Scripts Repo
+      uses: actions/checkout@v3
+      with:
+        path: ci-scripts
+        repository: pulumi/scripts
+    - name: Unshallow clone for tags
+      run: git fetch --prune --unshallow --tags
+    - name: Install Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: ${{matrix.goversion}}
+    - name: Install pulumictl
+      uses: jaxxstorm/action-install-gh-release@v1.5.0
+      with:
+        repo: pulumi/pulumictl
+    - name: Install Pulumi CLI
+      uses: pulumi/action-install-pulumi-cli@v2
+    - name: Setup Java
+      uses: actions/setup-java@v3
+      with:
+        cache: gradle
+        distribution: temurin
+        java-version: ${{matrix.javaversion}}
+    - name: Download java SDK
+      uses: actions/download-artifact@v2
+      with:
+        name: java-sdk.tar.gz
+        path: ${{ github.workspace}}/sdk/
+    - name: Uncompress java SDK
+      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
+        ${{github.workspace}}/sdk/java
+    - name: Set PACKAGE_VERSION to Env
+      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
+        $GITHUB_ENV
+    - name: Publish Java SDK
+      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
+      with:
+        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
+        build-root-directory: ./sdk/java
+        gradle-version: 7.4.1
+    strategy:
+      fail-fast: true
+      matrix:
+        goversion:
+        - 1.19.x
+        javaversion:
+        - "11"
   publish_sdk:
     name: publish_sdk
     needs: publish
@@ -371,12 +426,6 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{matrix.pythonversion}}
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{matrix.javaversion}}
     - name: Download python SDK
       uses: actions/download-artifact@v2
       with:
@@ -401,28 +450,11 @@ jobs:
     - name: Uncompress nodejs SDK
       run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
         ${{github.workspace}}/sdk/nodejs
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
     - run: python -m pip install pip twine
     - env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       name: Publish SDKs
       run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3
@@ -437,8 +469,6 @@ jobs:
         - 3.1.301
         goversion:
         - 1.19.x
-        javaversion:
-        - "11"
         nodeversion:
         - 16.x
         pythonversion:

--- a/provider-ci/providers/gcp/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/gcp/repo/.github/workflows/main.yml
@@ -309,6 +309,61 @@ jobs:
         - 16.x
         pythonversion:
         - "3.9"
+  publish_java_sdk:
+    continue-on-error: true
+    name: publish_java_sdk
+    needs: publish
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout Repo
+      uses: actions/checkout@v3
+    - name: Checkout Scripts Repo
+      uses: actions/checkout@v3
+      with:
+        path: ci-scripts
+        repository: pulumi/scripts
+    - name: Unshallow clone for tags
+      run: git fetch --prune --unshallow --tags
+    - name: Install Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: ${{matrix.goversion}}
+    - name: Install pulumictl
+      uses: jaxxstorm/action-install-gh-release@v1.5.0
+      with:
+        repo: pulumi/pulumictl
+    - name: Install Pulumi CLI
+      uses: pulumi/action-install-pulumi-cli@v2
+    - name: Setup Java
+      uses: actions/setup-java@v3
+      with:
+        cache: gradle
+        distribution: temurin
+        java-version: ${{matrix.javaversion}}
+    - name: Download java SDK
+      uses: actions/download-artifact@v2
+      with:
+        name: java-sdk.tar.gz
+        path: ${{ github.workspace}}/sdk/
+    - name: Uncompress java SDK
+      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
+        ${{github.workspace}}/sdk/java
+    - name: Set PACKAGE_VERSION to Env
+      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
+        $GITHUB_ENV
+    - name: Publish Java SDK
+      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
+      with:
+        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
+        build-root-directory: ./sdk/java
+        gradle-version: 7.4.1
+    strategy:
+      fail-fast: true
+      matrix:
+        goversion:
+        - 1.19.x
+        javaversion:
+        - "11"
   publish_sdk:
     name: publish_sdk
     needs: publish
@@ -346,12 +401,6 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{matrix.pythonversion}}
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{matrix.javaversion}}
     - name: Download python SDK
       uses: actions/download-artifact@v2
       with:
@@ -376,28 +425,11 @@ jobs:
     - name: Uncompress nodejs SDK
       run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
         ${{github.workspace}}/sdk/nodejs
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
     - run: python -m pip install pip twine
     - env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       name: Publish SDKs
       run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3
@@ -412,8 +444,6 @@ jobs:
         - 3.1.301
         goversion:
         - 1.19.x
-        javaversion:
-        - "11"
         nodeversion:
         - 16.x
         pythonversion:

--- a/provider-ci/providers/gcp/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/gcp/repo/.github/workflows/master.yml
@@ -309,6 +309,61 @@ jobs:
         - 16.x
         pythonversion:
         - "3.9"
+  publish_java_sdk:
+    continue-on-error: true
+    name: publish_java_sdk
+    needs: publish
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout Repo
+      uses: actions/checkout@v3
+    - name: Checkout Scripts Repo
+      uses: actions/checkout@v3
+      with:
+        path: ci-scripts
+        repository: pulumi/scripts
+    - name: Unshallow clone for tags
+      run: git fetch --prune --unshallow --tags
+    - name: Install Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: ${{matrix.goversion}}
+    - name: Install pulumictl
+      uses: jaxxstorm/action-install-gh-release@v1.5.0
+      with:
+        repo: pulumi/pulumictl
+    - name: Install Pulumi CLI
+      uses: pulumi/action-install-pulumi-cli@v2
+    - name: Setup Java
+      uses: actions/setup-java@v3
+      with:
+        cache: gradle
+        distribution: temurin
+        java-version: ${{matrix.javaversion}}
+    - name: Download java SDK
+      uses: actions/download-artifact@v2
+      with:
+        name: java-sdk.tar.gz
+        path: ${{ github.workspace}}/sdk/
+    - name: Uncompress java SDK
+      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
+        ${{github.workspace}}/sdk/java
+    - name: Set PACKAGE_VERSION to Env
+      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
+        $GITHUB_ENV
+    - name: Publish Java SDK
+      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
+      with:
+        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
+        build-root-directory: ./sdk/java
+        gradle-version: 7.4.1
+    strategy:
+      fail-fast: true
+      matrix:
+        goversion:
+        - 1.19.x
+        javaversion:
+        - "11"
   publish_sdk:
     name: publish_sdk
     needs: publish
@@ -346,12 +401,6 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{matrix.pythonversion}}
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{matrix.javaversion}}
     - name: Download python SDK
       uses: actions/download-artifact@v2
       with:
@@ -376,28 +425,11 @@ jobs:
     - name: Uncompress nodejs SDK
       run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
         ${{github.workspace}}/sdk/nodejs
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
     - run: python -m pip install pip twine
     - env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       name: Publish SDKs
       run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3
@@ -412,8 +444,6 @@ jobs:
         - 3.1.301
         goversion:
         - 1.19.x
-        javaversion:
-        - "11"
         nodeversion:
         - 16.x
         pythonversion:

--- a/provider-ci/providers/gcp/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/gcp/repo/.github/workflows/prerelease.yml
@@ -253,6 +253,61 @@ jobs:
         - 16.x
         pythonversion:
         - "3.9"
+  publish_java_sdk:
+    continue-on-error: true
+    name: publish_java_sdk
+    needs: publish
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout Repo
+      uses: actions/checkout@v3
+    - name: Checkout Scripts Repo
+      uses: actions/checkout@v3
+      with:
+        path: ci-scripts
+        repository: pulumi/scripts
+    - name: Unshallow clone for tags
+      run: git fetch --prune --unshallow --tags
+    - name: Install Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: ${{matrix.goversion}}
+    - name: Install pulumictl
+      uses: jaxxstorm/action-install-gh-release@v1.5.0
+      with:
+        repo: pulumi/pulumictl
+    - name: Install Pulumi CLI
+      uses: pulumi/action-install-pulumi-cli@v2
+    - name: Setup Java
+      uses: actions/setup-java@v3
+      with:
+        cache: gradle
+        distribution: temurin
+        java-version: ${{matrix.javaversion}}
+    - name: Download java SDK
+      uses: actions/download-artifact@v2
+      with:
+        name: java-sdk.tar.gz
+        path: ${{ github.workspace}}/sdk/
+    - name: Uncompress java SDK
+      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
+        ${{github.workspace}}/sdk/java
+    - name: Set PACKAGE_VERSION to Env
+      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
+        $GITHUB_ENV
+    - name: Publish Java SDK
+      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
+      with:
+        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
+        build-root-directory: ./sdk/java
+        gradle-version: 7.4.1
+    strategy:
+      fail-fast: true
+      matrix:
+        goversion:
+        - 1.19.x
+        javaversion:
+        - "11"
   publish_sdk:
     name: publish_sdk
     needs: publish
@@ -290,12 +345,6 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{matrix.pythonversion}}
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{matrix.javaversion}}
     - name: Download python SDK
       uses: actions/download-artifact@v2
       with:
@@ -320,28 +369,11 @@ jobs:
     - name: Uncompress nodejs SDK
       run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
         ${{github.workspace}}/sdk/nodejs
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
     - run: python -m pip install pip twine
     - env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       name: Publish SDKs
       run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3
@@ -356,8 +388,6 @@ jobs:
         - 3.1.301
         goversion:
         - 1.19.x
-        javaversion:
-        - "11"
         nodeversion:
         - 16.x
         pythonversion:

--- a/provider-ci/providers/gcp/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/gcp/repo/.github/workflows/release.yml
@@ -266,6 +266,61 @@ jobs:
         - 16.x
         pythonversion:
         - "3.9"
+  publish_java_sdk:
+    continue-on-error: true
+    name: publish_java_sdk
+    needs: publish
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout Repo
+      uses: actions/checkout@v3
+    - name: Checkout Scripts Repo
+      uses: actions/checkout@v3
+      with:
+        path: ci-scripts
+        repository: pulumi/scripts
+    - name: Unshallow clone for tags
+      run: git fetch --prune --unshallow --tags
+    - name: Install Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: ${{matrix.goversion}}
+    - name: Install pulumictl
+      uses: jaxxstorm/action-install-gh-release@v1.5.0
+      with:
+        repo: pulumi/pulumictl
+    - name: Install Pulumi CLI
+      uses: pulumi/action-install-pulumi-cli@v2
+    - name: Setup Java
+      uses: actions/setup-java@v3
+      with:
+        cache: gradle
+        distribution: temurin
+        java-version: ${{matrix.javaversion}}
+    - name: Download java SDK
+      uses: actions/download-artifact@v2
+      with:
+        name: java-sdk.tar.gz
+        path: ${{ github.workspace}}/sdk/
+    - name: Uncompress java SDK
+      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
+        ${{github.workspace}}/sdk/java
+    - name: Set PACKAGE_VERSION to Env
+      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
+        $GITHUB_ENV
+    - name: Publish Java SDK
+      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
+      with:
+        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
+        build-root-directory: ./sdk/java
+        gradle-version: 7.4.1
+    strategy:
+      fail-fast: true
+      matrix:
+        goversion:
+        - 1.19.x
+        javaversion:
+        - "11"
   publish_sdk:
     name: publish_sdk
     needs: publish
@@ -303,12 +358,6 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{matrix.pythonversion}}
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{matrix.javaversion}}
     - name: Download python SDK
       uses: actions/download-artifact@v2
       with:
@@ -333,28 +382,11 @@ jobs:
     - name: Uncompress nodejs SDK
       run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
         ${{github.workspace}}/sdk/nodejs
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
     - run: python -m pip install pip twine
     - env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       name: Publish SDKs
       run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3
@@ -369,8 +401,6 @@ jobs:
         - 3.1.301
         goversion:
         - 1.19.x
-        javaversion:
-        - "11"
         nodeversion:
         - 16.x
         pythonversion:

--- a/provider-ci/providers/github/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/github/repo/.github/workflows/main.yml
@@ -378,6 +378,61 @@ jobs:
         - 16.x
         pythonversion:
         - "3.9"
+  publish_java_sdk:
+    continue-on-error: true
+    name: publish_java_sdk
+    needs: publish
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout Repo
+      uses: actions/checkout@v3
+    - name: Checkout Scripts Repo
+      uses: actions/checkout@v3
+      with:
+        path: ci-scripts
+        repository: pulumi/scripts
+    - name: Unshallow clone for tags
+      run: git fetch --prune --unshallow --tags
+    - name: Install Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: ${{matrix.goversion}}
+    - name: Install pulumictl
+      uses: jaxxstorm/action-install-gh-release@v1.5.0
+      with:
+        repo: pulumi/pulumictl
+    - name: Install Pulumi CLI
+      uses: pulumi/action-install-pulumi-cli@v2
+    - name: Setup Java
+      uses: actions/setup-java@v3
+      with:
+        cache: gradle
+        distribution: temurin
+        java-version: ${{matrix.javaversion}}
+    - name: Download java SDK
+      uses: actions/download-artifact@v2
+      with:
+        name: java-sdk.tar.gz
+        path: ${{ github.workspace}}/sdk/
+    - name: Uncompress java SDK
+      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
+        ${{github.workspace}}/sdk/java
+    - name: Set PACKAGE_VERSION to Env
+      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
+        $GITHUB_ENV
+    - name: Publish Java SDK
+      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
+      with:
+        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
+        build-root-directory: ./sdk/java
+        gradle-version: 7.4.1
+    strategy:
+      fail-fast: true
+      matrix:
+        goversion:
+        - 1.19.x
+        javaversion:
+        - "11"
   publish_sdk:
     name: publish_sdk
     needs: publish
@@ -415,12 +470,6 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{matrix.pythonversion}}
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{matrix.javaversion}}
     - name: Download python SDK
       uses: actions/download-artifact@v2
       with:
@@ -445,28 +494,11 @@ jobs:
     - name: Uncompress nodejs SDK
       run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
         ${{github.workspace}}/sdk/nodejs
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
     - run: python -m pip install pip twine
     - env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       name: Publish SDKs
       run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3
@@ -481,8 +513,6 @@ jobs:
         - 3.1.301
         goversion:
         - 1.19.x
-        javaversion:
-        - "11"
         nodeversion:
         - 16.x
         pythonversion:

--- a/provider-ci/providers/github/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/github/repo/.github/workflows/master.yml
@@ -378,6 +378,61 @@ jobs:
         - 16.x
         pythonversion:
         - "3.9"
+  publish_java_sdk:
+    continue-on-error: true
+    name: publish_java_sdk
+    needs: publish
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout Repo
+      uses: actions/checkout@v3
+    - name: Checkout Scripts Repo
+      uses: actions/checkout@v3
+      with:
+        path: ci-scripts
+        repository: pulumi/scripts
+    - name: Unshallow clone for tags
+      run: git fetch --prune --unshallow --tags
+    - name: Install Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: ${{matrix.goversion}}
+    - name: Install pulumictl
+      uses: jaxxstorm/action-install-gh-release@v1.5.0
+      with:
+        repo: pulumi/pulumictl
+    - name: Install Pulumi CLI
+      uses: pulumi/action-install-pulumi-cli@v2
+    - name: Setup Java
+      uses: actions/setup-java@v3
+      with:
+        cache: gradle
+        distribution: temurin
+        java-version: ${{matrix.javaversion}}
+    - name: Download java SDK
+      uses: actions/download-artifact@v2
+      with:
+        name: java-sdk.tar.gz
+        path: ${{ github.workspace}}/sdk/
+    - name: Uncompress java SDK
+      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
+        ${{github.workspace}}/sdk/java
+    - name: Set PACKAGE_VERSION to Env
+      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
+        $GITHUB_ENV
+    - name: Publish Java SDK
+      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
+      with:
+        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
+        build-root-directory: ./sdk/java
+        gradle-version: 7.4.1
+    strategy:
+      fail-fast: true
+      matrix:
+        goversion:
+        - 1.19.x
+        javaversion:
+        - "11"
   publish_sdk:
     name: publish_sdk
     needs: publish
@@ -415,12 +470,6 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{matrix.pythonversion}}
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{matrix.javaversion}}
     - name: Download python SDK
       uses: actions/download-artifact@v2
       with:
@@ -445,28 +494,11 @@ jobs:
     - name: Uncompress nodejs SDK
       run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
         ${{github.workspace}}/sdk/nodejs
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
     - run: python -m pip install pip twine
     - env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       name: Publish SDKs
       run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3
@@ -481,8 +513,6 @@ jobs:
         - 3.1.301
         goversion:
         - 1.19.x
-        javaversion:
-        - "11"
         nodeversion:
         - 16.x
         pythonversion:

--- a/provider-ci/providers/github/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/github/repo/.github/workflows/prerelease.yml
@@ -322,6 +322,61 @@ jobs:
         - 16.x
         pythonversion:
         - "3.9"
+  publish_java_sdk:
+    continue-on-error: true
+    name: publish_java_sdk
+    needs: publish
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout Repo
+      uses: actions/checkout@v3
+    - name: Checkout Scripts Repo
+      uses: actions/checkout@v3
+      with:
+        path: ci-scripts
+        repository: pulumi/scripts
+    - name: Unshallow clone for tags
+      run: git fetch --prune --unshallow --tags
+    - name: Install Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: ${{matrix.goversion}}
+    - name: Install pulumictl
+      uses: jaxxstorm/action-install-gh-release@v1.5.0
+      with:
+        repo: pulumi/pulumictl
+    - name: Install Pulumi CLI
+      uses: pulumi/action-install-pulumi-cli@v2
+    - name: Setup Java
+      uses: actions/setup-java@v3
+      with:
+        cache: gradle
+        distribution: temurin
+        java-version: ${{matrix.javaversion}}
+    - name: Download java SDK
+      uses: actions/download-artifact@v2
+      with:
+        name: java-sdk.tar.gz
+        path: ${{ github.workspace}}/sdk/
+    - name: Uncompress java SDK
+      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
+        ${{github.workspace}}/sdk/java
+    - name: Set PACKAGE_VERSION to Env
+      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
+        $GITHUB_ENV
+    - name: Publish Java SDK
+      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
+      with:
+        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
+        build-root-directory: ./sdk/java
+        gradle-version: 7.4.1
+    strategy:
+      fail-fast: true
+      matrix:
+        goversion:
+        - 1.19.x
+        javaversion:
+        - "11"
   publish_sdk:
     name: publish_sdk
     needs: publish
@@ -359,12 +414,6 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{matrix.pythonversion}}
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{matrix.javaversion}}
     - name: Download python SDK
       uses: actions/download-artifact@v2
       with:
@@ -389,28 +438,11 @@ jobs:
     - name: Uncompress nodejs SDK
       run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
         ${{github.workspace}}/sdk/nodejs
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
     - run: python -m pip install pip twine
     - env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       name: Publish SDKs
       run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3
@@ -425,8 +457,6 @@ jobs:
         - 3.1.301
         goversion:
         - 1.19.x
-        javaversion:
-        - "11"
         nodeversion:
         - 16.x
         pythonversion:

--- a/provider-ci/providers/github/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/github/repo/.github/workflows/release.yml
@@ -335,6 +335,61 @@ jobs:
         - 16.x
         pythonversion:
         - "3.9"
+  publish_java_sdk:
+    continue-on-error: true
+    name: publish_java_sdk
+    needs: publish
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout Repo
+      uses: actions/checkout@v3
+    - name: Checkout Scripts Repo
+      uses: actions/checkout@v3
+      with:
+        path: ci-scripts
+        repository: pulumi/scripts
+    - name: Unshallow clone for tags
+      run: git fetch --prune --unshallow --tags
+    - name: Install Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: ${{matrix.goversion}}
+    - name: Install pulumictl
+      uses: jaxxstorm/action-install-gh-release@v1.5.0
+      with:
+        repo: pulumi/pulumictl
+    - name: Install Pulumi CLI
+      uses: pulumi/action-install-pulumi-cli@v2
+    - name: Setup Java
+      uses: actions/setup-java@v3
+      with:
+        cache: gradle
+        distribution: temurin
+        java-version: ${{matrix.javaversion}}
+    - name: Download java SDK
+      uses: actions/download-artifact@v2
+      with:
+        name: java-sdk.tar.gz
+        path: ${{ github.workspace}}/sdk/
+    - name: Uncompress java SDK
+      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
+        ${{github.workspace}}/sdk/java
+    - name: Set PACKAGE_VERSION to Env
+      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
+        $GITHUB_ENV
+    - name: Publish Java SDK
+      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
+      with:
+        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
+        build-root-directory: ./sdk/java
+        gradle-version: 7.4.1
+    strategy:
+      fail-fast: true
+      matrix:
+        goversion:
+        - 1.19.x
+        javaversion:
+        - "11"
   publish_sdk:
     name: publish_sdk
     needs: publish
@@ -372,12 +427,6 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{matrix.pythonversion}}
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{matrix.javaversion}}
     - name: Download python SDK
       uses: actions/download-artifact@v2
       with:
@@ -402,28 +451,11 @@ jobs:
     - name: Uncompress nodejs SDK
       run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
         ${{github.workspace}}/sdk/nodejs
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
     - run: python -m pip install pip twine
     - env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       name: Publish SDKs
       run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3
@@ -438,8 +470,6 @@ jobs:
         - 3.1.301
         goversion:
         - 1.19.x
-        javaversion:
-        - "11"
         nodeversion:
         - 16.x
         pythonversion:

--- a/provider-ci/providers/gitlab/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/gitlab/repo/.github/workflows/main.yml
@@ -377,6 +377,61 @@ jobs:
         - 16.x
         pythonversion:
         - "3.9"
+  publish_java_sdk:
+    continue-on-error: true
+    name: publish_java_sdk
+    needs: publish
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout Repo
+      uses: actions/checkout@v3
+    - name: Checkout Scripts Repo
+      uses: actions/checkout@v3
+      with:
+        path: ci-scripts
+        repository: pulumi/scripts
+    - name: Unshallow clone for tags
+      run: git fetch --prune --unshallow --tags
+    - name: Install Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: ${{matrix.goversion}}
+    - name: Install pulumictl
+      uses: jaxxstorm/action-install-gh-release@v1.5.0
+      with:
+        repo: pulumi/pulumictl
+    - name: Install Pulumi CLI
+      uses: pulumi/action-install-pulumi-cli@v2
+    - name: Setup Java
+      uses: actions/setup-java@v3
+      with:
+        cache: gradle
+        distribution: temurin
+        java-version: ${{matrix.javaversion}}
+    - name: Download java SDK
+      uses: actions/download-artifact@v2
+      with:
+        name: java-sdk.tar.gz
+        path: ${{ github.workspace}}/sdk/
+    - name: Uncompress java SDK
+      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
+        ${{github.workspace}}/sdk/java
+    - name: Set PACKAGE_VERSION to Env
+      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
+        $GITHUB_ENV
+    - name: Publish Java SDK
+      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
+      with:
+        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
+        build-root-directory: ./sdk/java
+        gradle-version: 7.4.1
+    strategy:
+      fail-fast: true
+      matrix:
+        goversion:
+        - 1.19.x
+        javaversion:
+        - "11"
   publish_sdk:
     name: publish_sdk
     needs: publish
@@ -414,12 +469,6 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{matrix.pythonversion}}
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{matrix.javaversion}}
     - name: Download python SDK
       uses: actions/download-artifact@v2
       with:
@@ -444,28 +493,11 @@ jobs:
     - name: Uncompress nodejs SDK
       run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
         ${{github.workspace}}/sdk/nodejs
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
     - run: python -m pip install pip twine
     - env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       name: Publish SDKs
       run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3
@@ -480,8 +512,6 @@ jobs:
         - 3.1.301
         goversion:
         - 1.19.x
-        javaversion:
-        - "11"
         nodeversion:
         - 16.x
         pythonversion:

--- a/provider-ci/providers/gitlab/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/gitlab/repo/.github/workflows/master.yml
@@ -377,6 +377,61 @@ jobs:
         - 16.x
         pythonversion:
         - "3.9"
+  publish_java_sdk:
+    continue-on-error: true
+    name: publish_java_sdk
+    needs: publish
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout Repo
+      uses: actions/checkout@v3
+    - name: Checkout Scripts Repo
+      uses: actions/checkout@v3
+      with:
+        path: ci-scripts
+        repository: pulumi/scripts
+    - name: Unshallow clone for tags
+      run: git fetch --prune --unshallow --tags
+    - name: Install Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: ${{matrix.goversion}}
+    - name: Install pulumictl
+      uses: jaxxstorm/action-install-gh-release@v1.5.0
+      with:
+        repo: pulumi/pulumictl
+    - name: Install Pulumi CLI
+      uses: pulumi/action-install-pulumi-cli@v2
+    - name: Setup Java
+      uses: actions/setup-java@v3
+      with:
+        cache: gradle
+        distribution: temurin
+        java-version: ${{matrix.javaversion}}
+    - name: Download java SDK
+      uses: actions/download-artifact@v2
+      with:
+        name: java-sdk.tar.gz
+        path: ${{ github.workspace}}/sdk/
+    - name: Uncompress java SDK
+      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
+        ${{github.workspace}}/sdk/java
+    - name: Set PACKAGE_VERSION to Env
+      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
+        $GITHUB_ENV
+    - name: Publish Java SDK
+      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
+      with:
+        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
+        build-root-directory: ./sdk/java
+        gradle-version: 7.4.1
+    strategy:
+      fail-fast: true
+      matrix:
+        goversion:
+        - 1.19.x
+        javaversion:
+        - "11"
   publish_sdk:
     name: publish_sdk
     needs: publish
@@ -414,12 +469,6 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{matrix.pythonversion}}
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{matrix.javaversion}}
     - name: Download python SDK
       uses: actions/download-artifact@v2
       with:
@@ -444,28 +493,11 @@ jobs:
     - name: Uncompress nodejs SDK
       run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
         ${{github.workspace}}/sdk/nodejs
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
     - run: python -m pip install pip twine
     - env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       name: Publish SDKs
       run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3
@@ -480,8 +512,6 @@ jobs:
         - 3.1.301
         goversion:
         - 1.19.x
-        javaversion:
-        - "11"
         nodeversion:
         - 16.x
         pythonversion:

--- a/provider-ci/providers/gitlab/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/gitlab/repo/.github/workflows/prerelease.yml
@@ -321,6 +321,61 @@ jobs:
         - 16.x
         pythonversion:
         - "3.9"
+  publish_java_sdk:
+    continue-on-error: true
+    name: publish_java_sdk
+    needs: publish
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout Repo
+      uses: actions/checkout@v3
+    - name: Checkout Scripts Repo
+      uses: actions/checkout@v3
+      with:
+        path: ci-scripts
+        repository: pulumi/scripts
+    - name: Unshallow clone for tags
+      run: git fetch --prune --unshallow --tags
+    - name: Install Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: ${{matrix.goversion}}
+    - name: Install pulumictl
+      uses: jaxxstorm/action-install-gh-release@v1.5.0
+      with:
+        repo: pulumi/pulumictl
+    - name: Install Pulumi CLI
+      uses: pulumi/action-install-pulumi-cli@v2
+    - name: Setup Java
+      uses: actions/setup-java@v3
+      with:
+        cache: gradle
+        distribution: temurin
+        java-version: ${{matrix.javaversion}}
+    - name: Download java SDK
+      uses: actions/download-artifact@v2
+      with:
+        name: java-sdk.tar.gz
+        path: ${{ github.workspace}}/sdk/
+    - name: Uncompress java SDK
+      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
+        ${{github.workspace}}/sdk/java
+    - name: Set PACKAGE_VERSION to Env
+      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
+        $GITHUB_ENV
+    - name: Publish Java SDK
+      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
+      with:
+        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
+        build-root-directory: ./sdk/java
+        gradle-version: 7.4.1
+    strategy:
+      fail-fast: true
+      matrix:
+        goversion:
+        - 1.19.x
+        javaversion:
+        - "11"
   publish_sdk:
     name: publish_sdk
     needs: publish
@@ -358,12 +413,6 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{matrix.pythonversion}}
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{matrix.javaversion}}
     - name: Download python SDK
       uses: actions/download-artifact@v2
       with:
@@ -388,28 +437,11 @@ jobs:
     - name: Uncompress nodejs SDK
       run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
         ${{github.workspace}}/sdk/nodejs
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
     - run: python -m pip install pip twine
     - env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       name: Publish SDKs
       run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3
@@ -424,8 +456,6 @@ jobs:
         - 3.1.301
         goversion:
         - 1.19.x
-        javaversion:
-        - "11"
         nodeversion:
         - 16.x
         pythonversion:

--- a/provider-ci/providers/gitlab/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/gitlab/repo/.github/workflows/release.yml
@@ -334,6 +334,61 @@ jobs:
         - 16.x
         pythonversion:
         - "3.9"
+  publish_java_sdk:
+    continue-on-error: true
+    name: publish_java_sdk
+    needs: publish
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout Repo
+      uses: actions/checkout@v3
+    - name: Checkout Scripts Repo
+      uses: actions/checkout@v3
+      with:
+        path: ci-scripts
+        repository: pulumi/scripts
+    - name: Unshallow clone for tags
+      run: git fetch --prune --unshallow --tags
+    - name: Install Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: ${{matrix.goversion}}
+    - name: Install pulumictl
+      uses: jaxxstorm/action-install-gh-release@v1.5.0
+      with:
+        repo: pulumi/pulumictl
+    - name: Install Pulumi CLI
+      uses: pulumi/action-install-pulumi-cli@v2
+    - name: Setup Java
+      uses: actions/setup-java@v3
+      with:
+        cache: gradle
+        distribution: temurin
+        java-version: ${{matrix.javaversion}}
+    - name: Download java SDK
+      uses: actions/download-artifact@v2
+      with:
+        name: java-sdk.tar.gz
+        path: ${{ github.workspace}}/sdk/
+    - name: Uncompress java SDK
+      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
+        ${{github.workspace}}/sdk/java
+    - name: Set PACKAGE_VERSION to Env
+      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
+        $GITHUB_ENV
+    - name: Publish Java SDK
+      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
+      with:
+        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
+        build-root-directory: ./sdk/java
+        gradle-version: 7.4.1
+    strategy:
+      fail-fast: true
+      matrix:
+        goversion:
+        - 1.19.x
+        javaversion:
+        - "11"
   publish_sdk:
     name: publish_sdk
     needs: publish
@@ -371,12 +426,6 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{matrix.pythonversion}}
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{matrix.javaversion}}
     - name: Download python SDK
       uses: actions/download-artifact@v2
       with:
@@ -401,28 +450,11 @@ jobs:
     - name: Uncompress nodejs SDK
       run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
         ${{github.workspace}}/sdk/nodejs
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
     - run: python -m pip install pip twine
     - env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       name: Publish SDKs
       run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3
@@ -437,8 +469,6 @@ jobs:
         - 3.1.301
         goversion:
         - 1.19.x
-        javaversion:
-        - "11"
         nodeversion:
         - 16.x
         pythonversion:

--- a/provider-ci/providers/hcloud/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/hcloud/repo/.github/workflows/main.yml
@@ -377,6 +377,61 @@ jobs:
         - 16.x
         pythonversion:
         - "3.9"
+  publish_java_sdk:
+    continue-on-error: true
+    name: publish_java_sdk
+    needs: publish
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout Repo
+      uses: actions/checkout@v3
+    - name: Checkout Scripts Repo
+      uses: actions/checkout@v3
+      with:
+        path: ci-scripts
+        repository: pulumi/scripts
+    - name: Unshallow clone for tags
+      run: git fetch --prune --unshallow --tags
+    - name: Install Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: ${{matrix.goversion}}
+    - name: Install pulumictl
+      uses: jaxxstorm/action-install-gh-release@v1.5.0
+      with:
+        repo: pulumi/pulumictl
+    - name: Install Pulumi CLI
+      uses: pulumi/action-install-pulumi-cli@v2
+    - name: Setup Java
+      uses: actions/setup-java@v3
+      with:
+        cache: gradle
+        distribution: temurin
+        java-version: ${{matrix.javaversion}}
+    - name: Download java SDK
+      uses: actions/download-artifact@v2
+      with:
+        name: java-sdk.tar.gz
+        path: ${{ github.workspace}}/sdk/
+    - name: Uncompress java SDK
+      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
+        ${{github.workspace}}/sdk/java
+    - name: Set PACKAGE_VERSION to Env
+      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
+        $GITHUB_ENV
+    - name: Publish Java SDK
+      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
+      with:
+        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
+        build-root-directory: ./sdk/java
+        gradle-version: 7.4.1
+    strategy:
+      fail-fast: true
+      matrix:
+        goversion:
+        - 1.19.x
+        javaversion:
+        - "11"
   publish_sdk:
     name: publish_sdk
     needs: publish
@@ -414,12 +469,6 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{matrix.pythonversion}}
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{matrix.javaversion}}
     - name: Download python SDK
       uses: actions/download-artifact@v2
       with:
@@ -444,28 +493,11 @@ jobs:
     - name: Uncompress nodejs SDK
       run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
         ${{github.workspace}}/sdk/nodejs
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
     - run: python -m pip install pip twine
     - env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       name: Publish SDKs
       run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3
@@ -480,8 +512,6 @@ jobs:
         - 3.1.301
         goversion:
         - 1.19.x
-        javaversion:
-        - "11"
         nodeversion:
         - 16.x
         pythonversion:

--- a/provider-ci/providers/hcloud/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/hcloud/repo/.github/workflows/master.yml
@@ -377,6 +377,61 @@ jobs:
         - 16.x
         pythonversion:
         - "3.9"
+  publish_java_sdk:
+    continue-on-error: true
+    name: publish_java_sdk
+    needs: publish
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout Repo
+      uses: actions/checkout@v3
+    - name: Checkout Scripts Repo
+      uses: actions/checkout@v3
+      with:
+        path: ci-scripts
+        repository: pulumi/scripts
+    - name: Unshallow clone for tags
+      run: git fetch --prune --unshallow --tags
+    - name: Install Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: ${{matrix.goversion}}
+    - name: Install pulumictl
+      uses: jaxxstorm/action-install-gh-release@v1.5.0
+      with:
+        repo: pulumi/pulumictl
+    - name: Install Pulumi CLI
+      uses: pulumi/action-install-pulumi-cli@v2
+    - name: Setup Java
+      uses: actions/setup-java@v3
+      with:
+        cache: gradle
+        distribution: temurin
+        java-version: ${{matrix.javaversion}}
+    - name: Download java SDK
+      uses: actions/download-artifact@v2
+      with:
+        name: java-sdk.tar.gz
+        path: ${{ github.workspace}}/sdk/
+    - name: Uncompress java SDK
+      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
+        ${{github.workspace}}/sdk/java
+    - name: Set PACKAGE_VERSION to Env
+      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
+        $GITHUB_ENV
+    - name: Publish Java SDK
+      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
+      with:
+        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
+        build-root-directory: ./sdk/java
+        gradle-version: 7.4.1
+    strategy:
+      fail-fast: true
+      matrix:
+        goversion:
+        - 1.19.x
+        javaversion:
+        - "11"
   publish_sdk:
     name: publish_sdk
     needs: publish
@@ -414,12 +469,6 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{matrix.pythonversion}}
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{matrix.javaversion}}
     - name: Download python SDK
       uses: actions/download-artifact@v2
       with:
@@ -444,28 +493,11 @@ jobs:
     - name: Uncompress nodejs SDK
       run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
         ${{github.workspace}}/sdk/nodejs
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
     - run: python -m pip install pip twine
     - env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       name: Publish SDKs
       run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3
@@ -480,8 +512,6 @@ jobs:
         - 3.1.301
         goversion:
         - 1.19.x
-        javaversion:
-        - "11"
         nodeversion:
         - 16.x
         pythonversion:

--- a/provider-ci/providers/hcloud/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/hcloud/repo/.github/workflows/prerelease.yml
@@ -321,6 +321,61 @@ jobs:
         - 16.x
         pythonversion:
         - "3.9"
+  publish_java_sdk:
+    continue-on-error: true
+    name: publish_java_sdk
+    needs: publish
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout Repo
+      uses: actions/checkout@v3
+    - name: Checkout Scripts Repo
+      uses: actions/checkout@v3
+      with:
+        path: ci-scripts
+        repository: pulumi/scripts
+    - name: Unshallow clone for tags
+      run: git fetch --prune --unshallow --tags
+    - name: Install Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: ${{matrix.goversion}}
+    - name: Install pulumictl
+      uses: jaxxstorm/action-install-gh-release@v1.5.0
+      with:
+        repo: pulumi/pulumictl
+    - name: Install Pulumi CLI
+      uses: pulumi/action-install-pulumi-cli@v2
+    - name: Setup Java
+      uses: actions/setup-java@v3
+      with:
+        cache: gradle
+        distribution: temurin
+        java-version: ${{matrix.javaversion}}
+    - name: Download java SDK
+      uses: actions/download-artifact@v2
+      with:
+        name: java-sdk.tar.gz
+        path: ${{ github.workspace}}/sdk/
+    - name: Uncompress java SDK
+      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
+        ${{github.workspace}}/sdk/java
+    - name: Set PACKAGE_VERSION to Env
+      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
+        $GITHUB_ENV
+    - name: Publish Java SDK
+      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
+      with:
+        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
+        build-root-directory: ./sdk/java
+        gradle-version: 7.4.1
+    strategy:
+      fail-fast: true
+      matrix:
+        goversion:
+        - 1.19.x
+        javaversion:
+        - "11"
   publish_sdk:
     name: publish_sdk
     needs: publish
@@ -358,12 +413,6 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{matrix.pythonversion}}
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{matrix.javaversion}}
     - name: Download python SDK
       uses: actions/download-artifact@v2
       with:
@@ -388,28 +437,11 @@ jobs:
     - name: Uncompress nodejs SDK
       run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
         ${{github.workspace}}/sdk/nodejs
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
     - run: python -m pip install pip twine
     - env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       name: Publish SDKs
       run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3
@@ -424,8 +456,6 @@ jobs:
         - 3.1.301
         goversion:
         - 1.19.x
-        javaversion:
-        - "11"
         nodeversion:
         - 16.x
         pythonversion:

--- a/provider-ci/providers/hcloud/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/hcloud/repo/.github/workflows/release.yml
@@ -334,6 +334,61 @@ jobs:
         - 16.x
         pythonversion:
         - "3.9"
+  publish_java_sdk:
+    continue-on-error: true
+    name: publish_java_sdk
+    needs: publish
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout Repo
+      uses: actions/checkout@v3
+    - name: Checkout Scripts Repo
+      uses: actions/checkout@v3
+      with:
+        path: ci-scripts
+        repository: pulumi/scripts
+    - name: Unshallow clone for tags
+      run: git fetch --prune --unshallow --tags
+    - name: Install Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: ${{matrix.goversion}}
+    - name: Install pulumictl
+      uses: jaxxstorm/action-install-gh-release@v1.5.0
+      with:
+        repo: pulumi/pulumictl
+    - name: Install Pulumi CLI
+      uses: pulumi/action-install-pulumi-cli@v2
+    - name: Setup Java
+      uses: actions/setup-java@v3
+      with:
+        cache: gradle
+        distribution: temurin
+        java-version: ${{matrix.javaversion}}
+    - name: Download java SDK
+      uses: actions/download-artifact@v2
+      with:
+        name: java-sdk.tar.gz
+        path: ${{ github.workspace}}/sdk/
+    - name: Uncompress java SDK
+      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
+        ${{github.workspace}}/sdk/java
+    - name: Set PACKAGE_VERSION to Env
+      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
+        $GITHUB_ENV
+    - name: Publish Java SDK
+      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
+      with:
+        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
+        build-root-directory: ./sdk/java
+        gradle-version: 7.4.1
+    strategy:
+      fail-fast: true
+      matrix:
+        goversion:
+        - 1.19.x
+        javaversion:
+        - "11"
   publish_sdk:
     name: publish_sdk
     needs: publish
@@ -371,12 +426,6 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{matrix.pythonversion}}
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{matrix.javaversion}}
     - name: Download python SDK
       uses: actions/download-artifact@v2
       with:
@@ -401,28 +450,11 @@ jobs:
     - name: Uncompress nodejs SDK
       run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
         ${{github.workspace}}/sdk/nodejs
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
     - run: python -m pip install pip twine
     - env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       name: Publish SDKs
       run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3
@@ -437,8 +469,6 @@ jobs:
         - 3.1.301
         goversion:
         - 1.19.x
-        javaversion:
-        - "11"
         nodeversion:
         - 16.x
         pythonversion:

--- a/provider-ci/providers/kafka/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/kafka/repo/.github/workflows/main.yml
@@ -376,6 +376,61 @@ jobs:
         - 16.x
         pythonversion:
         - "3.9"
+  publish_java_sdk:
+    continue-on-error: true
+    name: publish_java_sdk
+    needs: publish
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout Repo
+      uses: actions/checkout@v3
+    - name: Checkout Scripts Repo
+      uses: actions/checkout@v3
+      with:
+        path: ci-scripts
+        repository: pulumi/scripts
+    - name: Unshallow clone for tags
+      run: git fetch --prune --unshallow --tags
+    - name: Install Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: ${{matrix.goversion}}
+    - name: Install pulumictl
+      uses: jaxxstorm/action-install-gh-release@v1.5.0
+      with:
+        repo: pulumi/pulumictl
+    - name: Install Pulumi CLI
+      uses: pulumi/action-install-pulumi-cli@v2
+    - name: Setup Java
+      uses: actions/setup-java@v3
+      with:
+        cache: gradle
+        distribution: temurin
+        java-version: ${{matrix.javaversion}}
+    - name: Download java SDK
+      uses: actions/download-artifact@v2
+      with:
+        name: java-sdk.tar.gz
+        path: ${{ github.workspace}}/sdk/
+    - name: Uncompress java SDK
+      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
+        ${{github.workspace}}/sdk/java
+    - name: Set PACKAGE_VERSION to Env
+      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
+        $GITHUB_ENV
+    - name: Publish Java SDK
+      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
+      with:
+        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
+        build-root-directory: ./sdk/java
+        gradle-version: 7.4.1
+    strategy:
+      fail-fast: true
+      matrix:
+        goversion:
+        - 1.19.x
+        javaversion:
+        - "11"
   publish_sdk:
     name: publish_sdk
     needs: publish
@@ -413,12 +468,6 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{matrix.pythonversion}}
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{matrix.javaversion}}
     - name: Download python SDK
       uses: actions/download-artifact@v2
       with:
@@ -443,28 +492,11 @@ jobs:
     - name: Uncompress nodejs SDK
       run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
         ${{github.workspace}}/sdk/nodejs
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
     - run: python -m pip install pip twine
     - env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       name: Publish SDKs
       run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3
@@ -479,8 +511,6 @@ jobs:
         - 3.1.301
         goversion:
         - 1.19.x
-        javaversion:
-        - "11"
         nodeversion:
         - 16.x
         pythonversion:

--- a/provider-ci/providers/kafka/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/kafka/repo/.github/workflows/master.yml
@@ -376,6 +376,61 @@ jobs:
         - 16.x
         pythonversion:
         - "3.9"
+  publish_java_sdk:
+    continue-on-error: true
+    name: publish_java_sdk
+    needs: publish
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout Repo
+      uses: actions/checkout@v3
+    - name: Checkout Scripts Repo
+      uses: actions/checkout@v3
+      with:
+        path: ci-scripts
+        repository: pulumi/scripts
+    - name: Unshallow clone for tags
+      run: git fetch --prune --unshallow --tags
+    - name: Install Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: ${{matrix.goversion}}
+    - name: Install pulumictl
+      uses: jaxxstorm/action-install-gh-release@v1.5.0
+      with:
+        repo: pulumi/pulumictl
+    - name: Install Pulumi CLI
+      uses: pulumi/action-install-pulumi-cli@v2
+    - name: Setup Java
+      uses: actions/setup-java@v3
+      with:
+        cache: gradle
+        distribution: temurin
+        java-version: ${{matrix.javaversion}}
+    - name: Download java SDK
+      uses: actions/download-artifact@v2
+      with:
+        name: java-sdk.tar.gz
+        path: ${{ github.workspace}}/sdk/
+    - name: Uncompress java SDK
+      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
+        ${{github.workspace}}/sdk/java
+    - name: Set PACKAGE_VERSION to Env
+      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
+        $GITHUB_ENV
+    - name: Publish Java SDK
+      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
+      with:
+        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
+        build-root-directory: ./sdk/java
+        gradle-version: 7.4.1
+    strategy:
+      fail-fast: true
+      matrix:
+        goversion:
+        - 1.19.x
+        javaversion:
+        - "11"
   publish_sdk:
     name: publish_sdk
     needs: publish
@@ -413,12 +468,6 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{matrix.pythonversion}}
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{matrix.javaversion}}
     - name: Download python SDK
       uses: actions/download-artifact@v2
       with:
@@ -443,28 +492,11 @@ jobs:
     - name: Uncompress nodejs SDK
       run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
         ${{github.workspace}}/sdk/nodejs
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
     - run: python -m pip install pip twine
     - env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       name: Publish SDKs
       run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3
@@ -479,8 +511,6 @@ jobs:
         - 3.1.301
         goversion:
         - 1.19.x
-        javaversion:
-        - "11"
         nodeversion:
         - 16.x
         pythonversion:

--- a/provider-ci/providers/kafka/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/kafka/repo/.github/workflows/prerelease.yml
@@ -320,6 +320,61 @@ jobs:
         - 16.x
         pythonversion:
         - "3.9"
+  publish_java_sdk:
+    continue-on-error: true
+    name: publish_java_sdk
+    needs: publish
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout Repo
+      uses: actions/checkout@v3
+    - name: Checkout Scripts Repo
+      uses: actions/checkout@v3
+      with:
+        path: ci-scripts
+        repository: pulumi/scripts
+    - name: Unshallow clone for tags
+      run: git fetch --prune --unshallow --tags
+    - name: Install Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: ${{matrix.goversion}}
+    - name: Install pulumictl
+      uses: jaxxstorm/action-install-gh-release@v1.5.0
+      with:
+        repo: pulumi/pulumictl
+    - name: Install Pulumi CLI
+      uses: pulumi/action-install-pulumi-cli@v2
+    - name: Setup Java
+      uses: actions/setup-java@v3
+      with:
+        cache: gradle
+        distribution: temurin
+        java-version: ${{matrix.javaversion}}
+    - name: Download java SDK
+      uses: actions/download-artifact@v2
+      with:
+        name: java-sdk.tar.gz
+        path: ${{ github.workspace}}/sdk/
+    - name: Uncompress java SDK
+      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
+        ${{github.workspace}}/sdk/java
+    - name: Set PACKAGE_VERSION to Env
+      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
+        $GITHUB_ENV
+    - name: Publish Java SDK
+      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
+      with:
+        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
+        build-root-directory: ./sdk/java
+        gradle-version: 7.4.1
+    strategy:
+      fail-fast: true
+      matrix:
+        goversion:
+        - 1.19.x
+        javaversion:
+        - "11"
   publish_sdk:
     name: publish_sdk
     needs: publish
@@ -357,12 +412,6 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{matrix.pythonversion}}
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{matrix.javaversion}}
     - name: Download python SDK
       uses: actions/download-artifact@v2
       with:
@@ -387,28 +436,11 @@ jobs:
     - name: Uncompress nodejs SDK
       run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
         ${{github.workspace}}/sdk/nodejs
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
     - run: python -m pip install pip twine
     - env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       name: Publish SDKs
       run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3
@@ -423,8 +455,6 @@ jobs:
         - 3.1.301
         goversion:
         - 1.19.x
-        javaversion:
-        - "11"
         nodeversion:
         - 16.x
         pythonversion:

--- a/provider-ci/providers/kafka/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/kafka/repo/.github/workflows/release.yml
@@ -333,6 +333,61 @@ jobs:
         - 16.x
         pythonversion:
         - "3.9"
+  publish_java_sdk:
+    continue-on-error: true
+    name: publish_java_sdk
+    needs: publish
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout Repo
+      uses: actions/checkout@v3
+    - name: Checkout Scripts Repo
+      uses: actions/checkout@v3
+      with:
+        path: ci-scripts
+        repository: pulumi/scripts
+    - name: Unshallow clone for tags
+      run: git fetch --prune --unshallow --tags
+    - name: Install Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: ${{matrix.goversion}}
+    - name: Install pulumictl
+      uses: jaxxstorm/action-install-gh-release@v1.5.0
+      with:
+        repo: pulumi/pulumictl
+    - name: Install Pulumi CLI
+      uses: pulumi/action-install-pulumi-cli@v2
+    - name: Setup Java
+      uses: actions/setup-java@v3
+      with:
+        cache: gradle
+        distribution: temurin
+        java-version: ${{matrix.javaversion}}
+    - name: Download java SDK
+      uses: actions/download-artifact@v2
+      with:
+        name: java-sdk.tar.gz
+        path: ${{ github.workspace}}/sdk/
+    - name: Uncompress java SDK
+      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
+        ${{github.workspace}}/sdk/java
+    - name: Set PACKAGE_VERSION to Env
+      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
+        $GITHUB_ENV
+    - name: Publish Java SDK
+      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
+      with:
+        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
+        build-root-directory: ./sdk/java
+        gradle-version: 7.4.1
+    strategy:
+      fail-fast: true
+      matrix:
+        goversion:
+        - 1.19.x
+        javaversion:
+        - "11"
   publish_sdk:
     name: publish_sdk
     needs: publish
@@ -370,12 +425,6 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{matrix.pythonversion}}
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{matrix.javaversion}}
     - name: Download python SDK
       uses: actions/download-artifact@v2
       with:
@@ -400,28 +449,11 @@ jobs:
     - name: Uncompress nodejs SDK
       run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
         ${{github.workspace}}/sdk/nodejs
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
     - run: python -m pip install pip twine
     - env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       name: Publish SDKs
       run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3
@@ -436,8 +468,6 @@ jobs:
         - 3.1.301
         goversion:
         - 1.19.x
-        javaversion:
-        - "11"
         nodeversion:
         - 16.x
         pythonversion:

--- a/provider-ci/providers/keycloak/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/keycloak/repo/.github/workflows/main.yml
@@ -381,6 +381,61 @@ jobs:
         - 16.x
         pythonversion:
         - "3.9"
+  publish_java_sdk:
+    continue-on-error: true
+    name: publish_java_sdk
+    needs: publish
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout Repo
+      uses: actions/checkout@v3
+    - name: Checkout Scripts Repo
+      uses: actions/checkout@v3
+      with:
+        path: ci-scripts
+        repository: pulumi/scripts
+    - name: Unshallow clone for tags
+      run: git fetch --prune --unshallow --tags
+    - name: Install Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: ${{matrix.goversion}}
+    - name: Install pulumictl
+      uses: jaxxstorm/action-install-gh-release@v1.5.0
+      with:
+        repo: pulumi/pulumictl
+    - name: Install Pulumi CLI
+      uses: pulumi/action-install-pulumi-cli@v2
+    - name: Setup Java
+      uses: actions/setup-java@v3
+      with:
+        cache: gradle
+        distribution: temurin
+        java-version: ${{matrix.javaversion}}
+    - name: Download java SDK
+      uses: actions/download-artifact@v2
+      with:
+        name: java-sdk.tar.gz
+        path: ${{ github.workspace}}/sdk/
+    - name: Uncompress java SDK
+      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
+        ${{github.workspace}}/sdk/java
+    - name: Set PACKAGE_VERSION to Env
+      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
+        $GITHUB_ENV
+    - name: Publish Java SDK
+      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
+      with:
+        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
+        build-root-directory: ./sdk/java
+        gradle-version: 7.4.1
+    strategy:
+      fail-fast: true
+      matrix:
+        goversion:
+        - 1.19.x
+        javaversion:
+        - "11"
   publish_sdk:
     name: publish_sdk
     needs: publish
@@ -418,12 +473,6 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{matrix.pythonversion}}
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{matrix.javaversion}}
     - name: Download python SDK
       uses: actions/download-artifact@v2
       with:
@@ -448,28 +497,11 @@ jobs:
     - name: Uncompress nodejs SDK
       run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
         ${{github.workspace}}/sdk/nodejs
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
     - run: python -m pip install pip twine
     - env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       name: Publish SDKs
       run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3
@@ -484,8 +516,6 @@ jobs:
         - 3.1.301
         goversion:
         - 1.19.x
-        javaversion:
-        - "11"
         nodeversion:
         - 16.x
         pythonversion:

--- a/provider-ci/providers/keycloak/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/keycloak/repo/.github/workflows/master.yml
@@ -381,6 +381,61 @@ jobs:
         - 16.x
         pythonversion:
         - "3.9"
+  publish_java_sdk:
+    continue-on-error: true
+    name: publish_java_sdk
+    needs: publish
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout Repo
+      uses: actions/checkout@v3
+    - name: Checkout Scripts Repo
+      uses: actions/checkout@v3
+      with:
+        path: ci-scripts
+        repository: pulumi/scripts
+    - name: Unshallow clone for tags
+      run: git fetch --prune --unshallow --tags
+    - name: Install Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: ${{matrix.goversion}}
+    - name: Install pulumictl
+      uses: jaxxstorm/action-install-gh-release@v1.5.0
+      with:
+        repo: pulumi/pulumictl
+    - name: Install Pulumi CLI
+      uses: pulumi/action-install-pulumi-cli@v2
+    - name: Setup Java
+      uses: actions/setup-java@v3
+      with:
+        cache: gradle
+        distribution: temurin
+        java-version: ${{matrix.javaversion}}
+    - name: Download java SDK
+      uses: actions/download-artifact@v2
+      with:
+        name: java-sdk.tar.gz
+        path: ${{ github.workspace}}/sdk/
+    - name: Uncompress java SDK
+      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
+        ${{github.workspace}}/sdk/java
+    - name: Set PACKAGE_VERSION to Env
+      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
+        $GITHUB_ENV
+    - name: Publish Java SDK
+      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
+      with:
+        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
+        build-root-directory: ./sdk/java
+        gradle-version: 7.4.1
+    strategy:
+      fail-fast: true
+      matrix:
+        goversion:
+        - 1.19.x
+        javaversion:
+        - "11"
   publish_sdk:
     name: publish_sdk
     needs: publish
@@ -418,12 +473,6 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{matrix.pythonversion}}
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{matrix.javaversion}}
     - name: Download python SDK
       uses: actions/download-artifact@v2
       with:
@@ -448,28 +497,11 @@ jobs:
     - name: Uncompress nodejs SDK
       run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
         ${{github.workspace}}/sdk/nodejs
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
     - run: python -m pip install pip twine
     - env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       name: Publish SDKs
       run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3
@@ -484,8 +516,6 @@ jobs:
         - 3.1.301
         goversion:
         - 1.19.x
-        javaversion:
-        - "11"
         nodeversion:
         - 16.x
         pythonversion:

--- a/provider-ci/providers/keycloak/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/keycloak/repo/.github/workflows/prerelease.yml
@@ -325,6 +325,61 @@ jobs:
         - 16.x
         pythonversion:
         - "3.9"
+  publish_java_sdk:
+    continue-on-error: true
+    name: publish_java_sdk
+    needs: publish
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout Repo
+      uses: actions/checkout@v3
+    - name: Checkout Scripts Repo
+      uses: actions/checkout@v3
+      with:
+        path: ci-scripts
+        repository: pulumi/scripts
+    - name: Unshallow clone for tags
+      run: git fetch --prune --unshallow --tags
+    - name: Install Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: ${{matrix.goversion}}
+    - name: Install pulumictl
+      uses: jaxxstorm/action-install-gh-release@v1.5.0
+      with:
+        repo: pulumi/pulumictl
+    - name: Install Pulumi CLI
+      uses: pulumi/action-install-pulumi-cli@v2
+    - name: Setup Java
+      uses: actions/setup-java@v3
+      with:
+        cache: gradle
+        distribution: temurin
+        java-version: ${{matrix.javaversion}}
+    - name: Download java SDK
+      uses: actions/download-artifact@v2
+      with:
+        name: java-sdk.tar.gz
+        path: ${{ github.workspace}}/sdk/
+    - name: Uncompress java SDK
+      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
+        ${{github.workspace}}/sdk/java
+    - name: Set PACKAGE_VERSION to Env
+      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
+        $GITHUB_ENV
+    - name: Publish Java SDK
+      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
+      with:
+        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
+        build-root-directory: ./sdk/java
+        gradle-version: 7.4.1
+    strategy:
+      fail-fast: true
+      matrix:
+        goversion:
+        - 1.19.x
+        javaversion:
+        - "11"
   publish_sdk:
     name: publish_sdk
     needs: publish
@@ -362,12 +417,6 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{matrix.pythonversion}}
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{matrix.javaversion}}
     - name: Download python SDK
       uses: actions/download-artifact@v2
       with:
@@ -392,28 +441,11 @@ jobs:
     - name: Uncompress nodejs SDK
       run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
         ${{github.workspace}}/sdk/nodejs
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
     - run: python -m pip install pip twine
     - env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       name: Publish SDKs
       run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3
@@ -428,8 +460,6 @@ jobs:
         - 3.1.301
         goversion:
         - 1.19.x
-        javaversion:
-        - "11"
         nodeversion:
         - 16.x
         pythonversion:

--- a/provider-ci/providers/keycloak/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/keycloak/repo/.github/workflows/release.yml
@@ -338,6 +338,61 @@ jobs:
         - 16.x
         pythonversion:
         - "3.9"
+  publish_java_sdk:
+    continue-on-error: true
+    name: publish_java_sdk
+    needs: publish
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout Repo
+      uses: actions/checkout@v3
+    - name: Checkout Scripts Repo
+      uses: actions/checkout@v3
+      with:
+        path: ci-scripts
+        repository: pulumi/scripts
+    - name: Unshallow clone for tags
+      run: git fetch --prune --unshallow --tags
+    - name: Install Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: ${{matrix.goversion}}
+    - name: Install pulumictl
+      uses: jaxxstorm/action-install-gh-release@v1.5.0
+      with:
+        repo: pulumi/pulumictl
+    - name: Install Pulumi CLI
+      uses: pulumi/action-install-pulumi-cli@v2
+    - name: Setup Java
+      uses: actions/setup-java@v3
+      with:
+        cache: gradle
+        distribution: temurin
+        java-version: ${{matrix.javaversion}}
+    - name: Download java SDK
+      uses: actions/download-artifact@v2
+      with:
+        name: java-sdk.tar.gz
+        path: ${{ github.workspace}}/sdk/
+    - name: Uncompress java SDK
+      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
+        ${{github.workspace}}/sdk/java
+    - name: Set PACKAGE_VERSION to Env
+      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
+        $GITHUB_ENV
+    - name: Publish Java SDK
+      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
+      with:
+        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
+        build-root-directory: ./sdk/java
+        gradle-version: 7.4.1
+    strategy:
+      fail-fast: true
+      matrix:
+        goversion:
+        - 1.19.x
+        javaversion:
+        - "11"
   publish_sdk:
     name: publish_sdk
     needs: publish
@@ -375,12 +430,6 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{matrix.pythonversion}}
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{matrix.javaversion}}
     - name: Download python SDK
       uses: actions/download-artifact@v2
       with:
@@ -405,28 +454,11 @@ jobs:
     - name: Uncompress nodejs SDK
       run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
         ${{github.workspace}}/sdk/nodejs
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
     - run: python -m pip install pip twine
     - env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       name: Publish SDKs
       run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3
@@ -441,8 +473,6 @@ jobs:
         - 3.1.301
         goversion:
         - 1.19.x
-        javaversion:
-        - "11"
         nodeversion:
         - 16.x
         pythonversion:

--- a/provider-ci/providers/kong/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/kong/repo/.github/workflows/main.yml
@@ -376,6 +376,61 @@ jobs:
         - 16.x
         pythonversion:
         - "3.9"
+  publish_java_sdk:
+    continue-on-error: true
+    name: publish_java_sdk
+    needs: publish
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout Repo
+      uses: actions/checkout@v3
+    - name: Checkout Scripts Repo
+      uses: actions/checkout@v3
+      with:
+        path: ci-scripts
+        repository: pulumi/scripts
+    - name: Unshallow clone for tags
+      run: git fetch --prune --unshallow --tags
+    - name: Install Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: ${{matrix.goversion}}
+    - name: Install pulumictl
+      uses: jaxxstorm/action-install-gh-release@v1.5.0
+      with:
+        repo: pulumi/pulumictl
+    - name: Install Pulumi CLI
+      uses: pulumi/action-install-pulumi-cli@v2
+    - name: Setup Java
+      uses: actions/setup-java@v3
+      with:
+        cache: gradle
+        distribution: temurin
+        java-version: ${{matrix.javaversion}}
+    - name: Download java SDK
+      uses: actions/download-artifact@v2
+      with:
+        name: java-sdk.tar.gz
+        path: ${{ github.workspace}}/sdk/
+    - name: Uncompress java SDK
+      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
+        ${{github.workspace}}/sdk/java
+    - name: Set PACKAGE_VERSION to Env
+      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
+        $GITHUB_ENV
+    - name: Publish Java SDK
+      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
+      with:
+        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
+        build-root-directory: ./sdk/java
+        gradle-version: 7.4.1
+    strategy:
+      fail-fast: true
+      matrix:
+        goversion:
+        - 1.19.x
+        javaversion:
+        - "11"
   publish_sdk:
     name: publish_sdk
     needs: publish
@@ -413,12 +468,6 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{matrix.pythonversion}}
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{matrix.javaversion}}
     - name: Download python SDK
       uses: actions/download-artifact@v2
       with:
@@ -443,28 +492,11 @@ jobs:
     - name: Uncompress nodejs SDK
       run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
         ${{github.workspace}}/sdk/nodejs
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
     - run: python -m pip install pip twine
     - env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       name: Publish SDKs
       run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3
@@ -479,8 +511,6 @@ jobs:
         - 3.1.301
         goversion:
         - 1.19.x
-        javaversion:
-        - "11"
         nodeversion:
         - 16.x
         pythonversion:

--- a/provider-ci/providers/kong/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/kong/repo/.github/workflows/master.yml
@@ -376,6 +376,61 @@ jobs:
         - 16.x
         pythonversion:
         - "3.9"
+  publish_java_sdk:
+    continue-on-error: true
+    name: publish_java_sdk
+    needs: publish
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout Repo
+      uses: actions/checkout@v3
+    - name: Checkout Scripts Repo
+      uses: actions/checkout@v3
+      with:
+        path: ci-scripts
+        repository: pulumi/scripts
+    - name: Unshallow clone for tags
+      run: git fetch --prune --unshallow --tags
+    - name: Install Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: ${{matrix.goversion}}
+    - name: Install pulumictl
+      uses: jaxxstorm/action-install-gh-release@v1.5.0
+      with:
+        repo: pulumi/pulumictl
+    - name: Install Pulumi CLI
+      uses: pulumi/action-install-pulumi-cli@v2
+    - name: Setup Java
+      uses: actions/setup-java@v3
+      with:
+        cache: gradle
+        distribution: temurin
+        java-version: ${{matrix.javaversion}}
+    - name: Download java SDK
+      uses: actions/download-artifact@v2
+      with:
+        name: java-sdk.tar.gz
+        path: ${{ github.workspace}}/sdk/
+    - name: Uncompress java SDK
+      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
+        ${{github.workspace}}/sdk/java
+    - name: Set PACKAGE_VERSION to Env
+      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
+        $GITHUB_ENV
+    - name: Publish Java SDK
+      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
+      with:
+        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
+        build-root-directory: ./sdk/java
+        gradle-version: 7.4.1
+    strategy:
+      fail-fast: true
+      matrix:
+        goversion:
+        - 1.19.x
+        javaversion:
+        - "11"
   publish_sdk:
     name: publish_sdk
     needs: publish
@@ -413,12 +468,6 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{matrix.pythonversion}}
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{matrix.javaversion}}
     - name: Download python SDK
       uses: actions/download-artifact@v2
       with:
@@ -443,28 +492,11 @@ jobs:
     - name: Uncompress nodejs SDK
       run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
         ${{github.workspace}}/sdk/nodejs
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
     - run: python -m pip install pip twine
     - env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       name: Publish SDKs
       run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3
@@ -479,8 +511,6 @@ jobs:
         - 3.1.301
         goversion:
         - 1.19.x
-        javaversion:
-        - "11"
         nodeversion:
         - 16.x
         pythonversion:

--- a/provider-ci/providers/kong/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/kong/repo/.github/workflows/prerelease.yml
@@ -320,6 +320,61 @@ jobs:
         - 16.x
         pythonversion:
         - "3.9"
+  publish_java_sdk:
+    continue-on-error: true
+    name: publish_java_sdk
+    needs: publish
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout Repo
+      uses: actions/checkout@v3
+    - name: Checkout Scripts Repo
+      uses: actions/checkout@v3
+      with:
+        path: ci-scripts
+        repository: pulumi/scripts
+    - name: Unshallow clone for tags
+      run: git fetch --prune --unshallow --tags
+    - name: Install Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: ${{matrix.goversion}}
+    - name: Install pulumictl
+      uses: jaxxstorm/action-install-gh-release@v1.5.0
+      with:
+        repo: pulumi/pulumictl
+    - name: Install Pulumi CLI
+      uses: pulumi/action-install-pulumi-cli@v2
+    - name: Setup Java
+      uses: actions/setup-java@v3
+      with:
+        cache: gradle
+        distribution: temurin
+        java-version: ${{matrix.javaversion}}
+    - name: Download java SDK
+      uses: actions/download-artifact@v2
+      with:
+        name: java-sdk.tar.gz
+        path: ${{ github.workspace}}/sdk/
+    - name: Uncompress java SDK
+      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
+        ${{github.workspace}}/sdk/java
+    - name: Set PACKAGE_VERSION to Env
+      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
+        $GITHUB_ENV
+    - name: Publish Java SDK
+      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
+      with:
+        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
+        build-root-directory: ./sdk/java
+        gradle-version: 7.4.1
+    strategy:
+      fail-fast: true
+      matrix:
+        goversion:
+        - 1.19.x
+        javaversion:
+        - "11"
   publish_sdk:
     name: publish_sdk
     needs: publish
@@ -357,12 +412,6 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{matrix.pythonversion}}
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{matrix.javaversion}}
     - name: Download python SDK
       uses: actions/download-artifact@v2
       with:
@@ -387,28 +436,11 @@ jobs:
     - name: Uncompress nodejs SDK
       run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
         ${{github.workspace}}/sdk/nodejs
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
     - run: python -m pip install pip twine
     - env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       name: Publish SDKs
       run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3
@@ -423,8 +455,6 @@ jobs:
         - 3.1.301
         goversion:
         - 1.19.x
-        javaversion:
-        - "11"
         nodeversion:
         - 16.x
         pythonversion:

--- a/provider-ci/providers/kong/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/kong/repo/.github/workflows/release.yml
@@ -333,6 +333,61 @@ jobs:
         - 16.x
         pythonversion:
         - "3.9"
+  publish_java_sdk:
+    continue-on-error: true
+    name: publish_java_sdk
+    needs: publish
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout Repo
+      uses: actions/checkout@v3
+    - name: Checkout Scripts Repo
+      uses: actions/checkout@v3
+      with:
+        path: ci-scripts
+        repository: pulumi/scripts
+    - name: Unshallow clone for tags
+      run: git fetch --prune --unshallow --tags
+    - name: Install Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: ${{matrix.goversion}}
+    - name: Install pulumictl
+      uses: jaxxstorm/action-install-gh-release@v1.5.0
+      with:
+        repo: pulumi/pulumictl
+    - name: Install Pulumi CLI
+      uses: pulumi/action-install-pulumi-cli@v2
+    - name: Setup Java
+      uses: actions/setup-java@v3
+      with:
+        cache: gradle
+        distribution: temurin
+        java-version: ${{matrix.javaversion}}
+    - name: Download java SDK
+      uses: actions/download-artifact@v2
+      with:
+        name: java-sdk.tar.gz
+        path: ${{ github.workspace}}/sdk/
+    - name: Uncompress java SDK
+      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
+        ${{github.workspace}}/sdk/java
+    - name: Set PACKAGE_VERSION to Env
+      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
+        $GITHUB_ENV
+    - name: Publish Java SDK
+      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
+      with:
+        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
+        build-root-directory: ./sdk/java
+        gradle-version: 7.4.1
+    strategy:
+      fail-fast: true
+      matrix:
+        goversion:
+        - 1.19.x
+        javaversion:
+        - "11"
   publish_sdk:
     name: publish_sdk
     needs: publish
@@ -370,12 +425,6 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{matrix.pythonversion}}
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{matrix.javaversion}}
     - name: Download python SDK
       uses: actions/download-artifact@v2
       with:
@@ -400,28 +449,11 @@ jobs:
     - name: Uncompress nodejs SDK
       run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
         ${{github.workspace}}/sdk/nodejs
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
     - run: python -m pip install pip twine
     - env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       name: Publish SDKs
       run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3
@@ -436,8 +468,6 @@ jobs:
         - 3.1.301
         goversion:
         - 1.19.x
-        javaversion:
-        - "11"
         nodeversion:
         - 16.x
         pythonversion:

--- a/provider-ci/providers/libvirt/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/libvirt/repo/.github/workflows/main.yml
@@ -377,6 +377,61 @@ jobs:
         - 16.x
         pythonversion:
         - "3.9"
+  publish_java_sdk:
+    continue-on-error: true
+    name: publish_java_sdk
+    needs: publish
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout Repo
+      uses: actions/checkout@v3
+    - name: Checkout Scripts Repo
+      uses: actions/checkout@v3
+      with:
+        path: ci-scripts
+        repository: pulumi/scripts
+    - name: Unshallow clone for tags
+      run: git fetch --prune --unshallow --tags
+    - name: Install Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: ${{matrix.goversion}}
+    - name: Install pulumictl
+      uses: jaxxstorm/action-install-gh-release@v1.5.0
+      with:
+        repo: pulumi/pulumictl
+    - name: Install Pulumi CLI
+      uses: pulumi/action-install-pulumi-cli@v2
+    - name: Setup Java
+      uses: actions/setup-java@v3
+      with:
+        cache: gradle
+        distribution: temurin
+        java-version: ${{matrix.javaversion}}
+    - name: Download java SDK
+      uses: actions/download-artifact@v2
+      with:
+        name: java-sdk.tar.gz
+        path: ${{ github.workspace}}/sdk/
+    - name: Uncompress java SDK
+      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
+        ${{github.workspace}}/sdk/java
+    - name: Set PACKAGE_VERSION to Env
+      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
+        $GITHUB_ENV
+    - name: Publish Java SDK
+      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
+      with:
+        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
+        build-root-directory: ./sdk/java
+        gradle-version: 7.4.1
+    strategy:
+      fail-fast: true
+      matrix:
+        goversion:
+        - 1.19.x
+        javaversion:
+        - "11"
   publish_sdk:
     name: publish_sdk
     needs: publish
@@ -414,12 +469,6 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{matrix.pythonversion}}
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{matrix.javaversion}}
     - name: Download python SDK
       uses: actions/download-artifact@v2
       with:
@@ -444,28 +493,11 @@ jobs:
     - name: Uncompress nodejs SDK
       run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
         ${{github.workspace}}/sdk/nodejs
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
     - run: python -m pip install pip twine
     - env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       name: Publish SDKs
       run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3
@@ -480,8 +512,6 @@ jobs:
         - 3.1.301
         goversion:
         - 1.19.x
-        javaversion:
-        - "11"
         nodeversion:
         - 16.x
         pythonversion:

--- a/provider-ci/providers/libvirt/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/libvirt/repo/.github/workflows/master.yml
@@ -377,6 +377,61 @@ jobs:
         - 16.x
         pythonversion:
         - "3.9"
+  publish_java_sdk:
+    continue-on-error: true
+    name: publish_java_sdk
+    needs: publish
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout Repo
+      uses: actions/checkout@v3
+    - name: Checkout Scripts Repo
+      uses: actions/checkout@v3
+      with:
+        path: ci-scripts
+        repository: pulumi/scripts
+    - name: Unshallow clone for tags
+      run: git fetch --prune --unshallow --tags
+    - name: Install Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: ${{matrix.goversion}}
+    - name: Install pulumictl
+      uses: jaxxstorm/action-install-gh-release@v1.5.0
+      with:
+        repo: pulumi/pulumictl
+    - name: Install Pulumi CLI
+      uses: pulumi/action-install-pulumi-cli@v2
+    - name: Setup Java
+      uses: actions/setup-java@v3
+      with:
+        cache: gradle
+        distribution: temurin
+        java-version: ${{matrix.javaversion}}
+    - name: Download java SDK
+      uses: actions/download-artifact@v2
+      with:
+        name: java-sdk.tar.gz
+        path: ${{ github.workspace}}/sdk/
+    - name: Uncompress java SDK
+      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
+        ${{github.workspace}}/sdk/java
+    - name: Set PACKAGE_VERSION to Env
+      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
+        $GITHUB_ENV
+    - name: Publish Java SDK
+      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
+      with:
+        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
+        build-root-directory: ./sdk/java
+        gradle-version: 7.4.1
+    strategy:
+      fail-fast: true
+      matrix:
+        goversion:
+        - 1.19.x
+        javaversion:
+        - "11"
   publish_sdk:
     name: publish_sdk
     needs: publish
@@ -414,12 +469,6 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{matrix.pythonversion}}
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{matrix.javaversion}}
     - name: Download python SDK
       uses: actions/download-artifact@v2
       with:
@@ -444,28 +493,11 @@ jobs:
     - name: Uncompress nodejs SDK
       run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
         ${{github.workspace}}/sdk/nodejs
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
     - run: python -m pip install pip twine
     - env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       name: Publish SDKs
       run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3
@@ -480,8 +512,6 @@ jobs:
         - 3.1.301
         goversion:
         - 1.19.x
-        javaversion:
-        - "11"
         nodeversion:
         - 16.x
         pythonversion:

--- a/provider-ci/providers/libvirt/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/libvirt/repo/.github/workflows/prerelease.yml
@@ -321,6 +321,61 @@ jobs:
         - 16.x
         pythonversion:
         - "3.9"
+  publish_java_sdk:
+    continue-on-error: true
+    name: publish_java_sdk
+    needs: publish
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout Repo
+      uses: actions/checkout@v3
+    - name: Checkout Scripts Repo
+      uses: actions/checkout@v3
+      with:
+        path: ci-scripts
+        repository: pulumi/scripts
+    - name: Unshallow clone for tags
+      run: git fetch --prune --unshallow --tags
+    - name: Install Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: ${{matrix.goversion}}
+    - name: Install pulumictl
+      uses: jaxxstorm/action-install-gh-release@v1.5.0
+      with:
+        repo: pulumi/pulumictl
+    - name: Install Pulumi CLI
+      uses: pulumi/action-install-pulumi-cli@v2
+    - name: Setup Java
+      uses: actions/setup-java@v3
+      with:
+        cache: gradle
+        distribution: temurin
+        java-version: ${{matrix.javaversion}}
+    - name: Download java SDK
+      uses: actions/download-artifact@v2
+      with:
+        name: java-sdk.tar.gz
+        path: ${{ github.workspace}}/sdk/
+    - name: Uncompress java SDK
+      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
+        ${{github.workspace}}/sdk/java
+    - name: Set PACKAGE_VERSION to Env
+      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
+        $GITHUB_ENV
+    - name: Publish Java SDK
+      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
+      with:
+        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
+        build-root-directory: ./sdk/java
+        gradle-version: 7.4.1
+    strategy:
+      fail-fast: true
+      matrix:
+        goversion:
+        - 1.19.x
+        javaversion:
+        - "11"
   publish_sdk:
     name: publish_sdk
     needs: publish
@@ -358,12 +413,6 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{matrix.pythonversion}}
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{matrix.javaversion}}
     - name: Download python SDK
       uses: actions/download-artifact@v2
       with:
@@ -388,28 +437,11 @@ jobs:
     - name: Uncompress nodejs SDK
       run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
         ${{github.workspace}}/sdk/nodejs
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
     - run: python -m pip install pip twine
     - env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       name: Publish SDKs
       run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3
@@ -424,8 +456,6 @@ jobs:
         - 3.1.301
         goversion:
         - 1.19.x
-        javaversion:
-        - "11"
         nodeversion:
         - 16.x
         pythonversion:

--- a/provider-ci/providers/libvirt/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/libvirt/repo/.github/workflows/release.yml
@@ -334,6 +334,61 @@ jobs:
         - 16.x
         pythonversion:
         - "3.9"
+  publish_java_sdk:
+    continue-on-error: true
+    name: publish_java_sdk
+    needs: publish
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout Repo
+      uses: actions/checkout@v3
+    - name: Checkout Scripts Repo
+      uses: actions/checkout@v3
+      with:
+        path: ci-scripts
+        repository: pulumi/scripts
+    - name: Unshallow clone for tags
+      run: git fetch --prune --unshallow --tags
+    - name: Install Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: ${{matrix.goversion}}
+    - name: Install pulumictl
+      uses: jaxxstorm/action-install-gh-release@v1.5.0
+      with:
+        repo: pulumi/pulumictl
+    - name: Install Pulumi CLI
+      uses: pulumi/action-install-pulumi-cli@v2
+    - name: Setup Java
+      uses: actions/setup-java@v3
+      with:
+        cache: gradle
+        distribution: temurin
+        java-version: ${{matrix.javaversion}}
+    - name: Download java SDK
+      uses: actions/download-artifact@v2
+      with:
+        name: java-sdk.tar.gz
+        path: ${{ github.workspace}}/sdk/
+    - name: Uncompress java SDK
+      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
+        ${{github.workspace}}/sdk/java
+    - name: Set PACKAGE_VERSION to Env
+      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
+        $GITHUB_ENV
+    - name: Publish Java SDK
+      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
+      with:
+        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
+        build-root-directory: ./sdk/java
+        gradle-version: 7.4.1
+    strategy:
+      fail-fast: true
+      matrix:
+        goversion:
+        - 1.19.x
+        javaversion:
+        - "11"
   publish_sdk:
     name: publish_sdk
     needs: publish
@@ -371,12 +426,6 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{matrix.pythonversion}}
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{matrix.javaversion}}
     - name: Download python SDK
       uses: actions/download-artifact@v2
       with:
@@ -401,28 +450,11 @@ jobs:
     - name: Uncompress nodejs SDK
       run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
         ${{github.workspace}}/sdk/nodejs
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
     - run: python -m pip install pip twine
     - env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       name: Publish SDKs
       run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3
@@ -437,8 +469,6 @@ jobs:
         - 3.1.301
         goversion:
         - 1.19.x
-        javaversion:
-        - "11"
         nodeversion:
         - 16.x
         pythonversion:

--- a/provider-ci/providers/linode/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/linode/repo/.github/workflows/main.yml
@@ -377,6 +377,61 @@ jobs:
         - 16.x
         pythonversion:
         - "3.9"
+  publish_java_sdk:
+    continue-on-error: true
+    name: publish_java_sdk
+    needs: publish
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout Repo
+      uses: actions/checkout@v3
+    - name: Checkout Scripts Repo
+      uses: actions/checkout@v3
+      with:
+        path: ci-scripts
+        repository: pulumi/scripts
+    - name: Unshallow clone for tags
+      run: git fetch --prune --unshallow --tags
+    - name: Install Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: ${{matrix.goversion}}
+    - name: Install pulumictl
+      uses: jaxxstorm/action-install-gh-release@v1.5.0
+      with:
+        repo: pulumi/pulumictl
+    - name: Install Pulumi CLI
+      uses: pulumi/action-install-pulumi-cli@v2
+    - name: Setup Java
+      uses: actions/setup-java@v3
+      with:
+        cache: gradle
+        distribution: temurin
+        java-version: ${{matrix.javaversion}}
+    - name: Download java SDK
+      uses: actions/download-artifact@v2
+      with:
+        name: java-sdk.tar.gz
+        path: ${{ github.workspace}}/sdk/
+    - name: Uncompress java SDK
+      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
+        ${{github.workspace}}/sdk/java
+    - name: Set PACKAGE_VERSION to Env
+      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
+        $GITHUB_ENV
+    - name: Publish Java SDK
+      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
+      with:
+        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
+        build-root-directory: ./sdk/java
+        gradle-version: 7.4.1
+    strategy:
+      fail-fast: true
+      matrix:
+        goversion:
+        - 1.19.x
+        javaversion:
+        - "11"
   publish_sdk:
     name: publish_sdk
     needs: publish
@@ -414,12 +469,6 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{matrix.pythonversion}}
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{matrix.javaversion}}
     - name: Download python SDK
       uses: actions/download-artifact@v2
       with:
@@ -444,28 +493,11 @@ jobs:
     - name: Uncompress nodejs SDK
       run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
         ${{github.workspace}}/sdk/nodejs
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
     - run: python -m pip install pip twine
     - env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       name: Publish SDKs
       run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3
@@ -480,8 +512,6 @@ jobs:
         - 3.1.301
         goversion:
         - 1.19.x
-        javaversion:
-        - "11"
         nodeversion:
         - 16.x
         pythonversion:

--- a/provider-ci/providers/linode/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/linode/repo/.github/workflows/master.yml
@@ -377,6 +377,61 @@ jobs:
         - 16.x
         pythonversion:
         - "3.9"
+  publish_java_sdk:
+    continue-on-error: true
+    name: publish_java_sdk
+    needs: publish
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout Repo
+      uses: actions/checkout@v3
+    - name: Checkout Scripts Repo
+      uses: actions/checkout@v3
+      with:
+        path: ci-scripts
+        repository: pulumi/scripts
+    - name: Unshallow clone for tags
+      run: git fetch --prune --unshallow --tags
+    - name: Install Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: ${{matrix.goversion}}
+    - name: Install pulumictl
+      uses: jaxxstorm/action-install-gh-release@v1.5.0
+      with:
+        repo: pulumi/pulumictl
+    - name: Install Pulumi CLI
+      uses: pulumi/action-install-pulumi-cli@v2
+    - name: Setup Java
+      uses: actions/setup-java@v3
+      with:
+        cache: gradle
+        distribution: temurin
+        java-version: ${{matrix.javaversion}}
+    - name: Download java SDK
+      uses: actions/download-artifact@v2
+      with:
+        name: java-sdk.tar.gz
+        path: ${{ github.workspace}}/sdk/
+    - name: Uncompress java SDK
+      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
+        ${{github.workspace}}/sdk/java
+    - name: Set PACKAGE_VERSION to Env
+      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
+        $GITHUB_ENV
+    - name: Publish Java SDK
+      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
+      with:
+        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
+        build-root-directory: ./sdk/java
+        gradle-version: 7.4.1
+    strategy:
+      fail-fast: true
+      matrix:
+        goversion:
+        - 1.19.x
+        javaversion:
+        - "11"
   publish_sdk:
     name: publish_sdk
     needs: publish
@@ -414,12 +469,6 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{matrix.pythonversion}}
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{matrix.javaversion}}
     - name: Download python SDK
       uses: actions/download-artifact@v2
       with:
@@ -444,28 +493,11 @@ jobs:
     - name: Uncompress nodejs SDK
       run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
         ${{github.workspace}}/sdk/nodejs
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
     - run: python -m pip install pip twine
     - env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       name: Publish SDKs
       run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3
@@ -480,8 +512,6 @@ jobs:
         - 3.1.301
         goversion:
         - 1.19.x
-        javaversion:
-        - "11"
         nodeversion:
         - 16.x
         pythonversion:

--- a/provider-ci/providers/linode/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/linode/repo/.github/workflows/prerelease.yml
@@ -321,6 +321,61 @@ jobs:
         - 16.x
         pythonversion:
         - "3.9"
+  publish_java_sdk:
+    continue-on-error: true
+    name: publish_java_sdk
+    needs: publish
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout Repo
+      uses: actions/checkout@v3
+    - name: Checkout Scripts Repo
+      uses: actions/checkout@v3
+      with:
+        path: ci-scripts
+        repository: pulumi/scripts
+    - name: Unshallow clone for tags
+      run: git fetch --prune --unshallow --tags
+    - name: Install Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: ${{matrix.goversion}}
+    - name: Install pulumictl
+      uses: jaxxstorm/action-install-gh-release@v1.5.0
+      with:
+        repo: pulumi/pulumictl
+    - name: Install Pulumi CLI
+      uses: pulumi/action-install-pulumi-cli@v2
+    - name: Setup Java
+      uses: actions/setup-java@v3
+      with:
+        cache: gradle
+        distribution: temurin
+        java-version: ${{matrix.javaversion}}
+    - name: Download java SDK
+      uses: actions/download-artifact@v2
+      with:
+        name: java-sdk.tar.gz
+        path: ${{ github.workspace}}/sdk/
+    - name: Uncompress java SDK
+      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
+        ${{github.workspace}}/sdk/java
+    - name: Set PACKAGE_VERSION to Env
+      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
+        $GITHUB_ENV
+    - name: Publish Java SDK
+      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
+      with:
+        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
+        build-root-directory: ./sdk/java
+        gradle-version: 7.4.1
+    strategy:
+      fail-fast: true
+      matrix:
+        goversion:
+        - 1.19.x
+        javaversion:
+        - "11"
   publish_sdk:
     name: publish_sdk
     needs: publish
@@ -358,12 +413,6 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{matrix.pythonversion}}
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{matrix.javaversion}}
     - name: Download python SDK
       uses: actions/download-artifact@v2
       with:
@@ -388,28 +437,11 @@ jobs:
     - name: Uncompress nodejs SDK
       run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
         ${{github.workspace}}/sdk/nodejs
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
     - run: python -m pip install pip twine
     - env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       name: Publish SDKs
       run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3
@@ -424,8 +456,6 @@ jobs:
         - 3.1.301
         goversion:
         - 1.19.x
-        javaversion:
-        - "11"
         nodeversion:
         - 16.x
         pythonversion:

--- a/provider-ci/providers/linode/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/linode/repo/.github/workflows/release.yml
@@ -334,6 +334,61 @@ jobs:
         - 16.x
         pythonversion:
         - "3.9"
+  publish_java_sdk:
+    continue-on-error: true
+    name: publish_java_sdk
+    needs: publish
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout Repo
+      uses: actions/checkout@v3
+    - name: Checkout Scripts Repo
+      uses: actions/checkout@v3
+      with:
+        path: ci-scripts
+        repository: pulumi/scripts
+    - name: Unshallow clone for tags
+      run: git fetch --prune --unshallow --tags
+    - name: Install Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: ${{matrix.goversion}}
+    - name: Install pulumictl
+      uses: jaxxstorm/action-install-gh-release@v1.5.0
+      with:
+        repo: pulumi/pulumictl
+    - name: Install Pulumi CLI
+      uses: pulumi/action-install-pulumi-cli@v2
+    - name: Setup Java
+      uses: actions/setup-java@v3
+      with:
+        cache: gradle
+        distribution: temurin
+        java-version: ${{matrix.javaversion}}
+    - name: Download java SDK
+      uses: actions/download-artifact@v2
+      with:
+        name: java-sdk.tar.gz
+        path: ${{ github.workspace}}/sdk/
+    - name: Uncompress java SDK
+      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
+        ${{github.workspace}}/sdk/java
+    - name: Set PACKAGE_VERSION to Env
+      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
+        $GITHUB_ENV
+    - name: Publish Java SDK
+      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
+      with:
+        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
+        build-root-directory: ./sdk/java
+        gradle-version: 7.4.1
+    strategy:
+      fail-fast: true
+      matrix:
+        goversion:
+        - 1.19.x
+        javaversion:
+        - "11"
   publish_sdk:
     name: publish_sdk
     needs: publish
@@ -371,12 +426,6 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{matrix.pythonversion}}
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{matrix.javaversion}}
     - name: Download python SDK
       uses: actions/download-artifact@v2
       with:
@@ -401,28 +450,11 @@ jobs:
     - name: Uncompress nodejs SDK
       run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
         ${{github.workspace}}/sdk/nodejs
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
     - run: python -m pip install pip twine
     - env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       name: Publish SDKs
       run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3
@@ -437,8 +469,6 @@ jobs:
         - 3.1.301
         goversion:
         - 1.19.x
-        javaversion:
-        - "11"
         nodeversion:
         - 16.x
         pythonversion:

--- a/provider-ci/providers/mailgun/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/mailgun/repo/.github/workflows/main.yml
@@ -377,6 +377,61 @@ jobs:
         - 16.x
         pythonversion:
         - "3.9"
+  publish_java_sdk:
+    continue-on-error: true
+    name: publish_java_sdk
+    needs: publish
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout Repo
+      uses: actions/checkout@v3
+    - name: Checkout Scripts Repo
+      uses: actions/checkout@v3
+      with:
+        path: ci-scripts
+        repository: pulumi/scripts
+    - name: Unshallow clone for tags
+      run: git fetch --prune --unshallow --tags
+    - name: Install Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: ${{matrix.goversion}}
+    - name: Install pulumictl
+      uses: jaxxstorm/action-install-gh-release@v1.5.0
+      with:
+        repo: pulumi/pulumictl
+    - name: Install Pulumi CLI
+      uses: pulumi/action-install-pulumi-cli@v2
+    - name: Setup Java
+      uses: actions/setup-java@v3
+      with:
+        cache: gradle
+        distribution: temurin
+        java-version: ${{matrix.javaversion}}
+    - name: Download java SDK
+      uses: actions/download-artifact@v2
+      with:
+        name: java-sdk.tar.gz
+        path: ${{ github.workspace}}/sdk/
+    - name: Uncompress java SDK
+      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
+        ${{github.workspace}}/sdk/java
+    - name: Set PACKAGE_VERSION to Env
+      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
+        $GITHUB_ENV
+    - name: Publish Java SDK
+      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
+      with:
+        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
+        build-root-directory: ./sdk/java
+        gradle-version: 7.4.1
+    strategy:
+      fail-fast: true
+      matrix:
+        goversion:
+        - 1.19.x
+        javaversion:
+        - "11"
   publish_sdk:
     name: publish_sdk
     needs: publish
@@ -414,12 +469,6 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{matrix.pythonversion}}
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{matrix.javaversion}}
     - name: Download python SDK
       uses: actions/download-artifact@v2
       with:
@@ -444,28 +493,11 @@ jobs:
     - name: Uncompress nodejs SDK
       run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
         ${{github.workspace}}/sdk/nodejs
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
     - run: python -m pip install pip twine
     - env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       name: Publish SDKs
       run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3
@@ -480,8 +512,6 @@ jobs:
         - 3.1.301
         goversion:
         - 1.19.x
-        javaversion:
-        - "11"
         nodeversion:
         - 16.x
         pythonversion:

--- a/provider-ci/providers/mailgun/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/mailgun/repo/.github/workflows/master.yml
@@ -377,6 +377,61 @@ jobs:
         - 16.x
         pythonversion:
         - "3.9"
+  publish_java_sdk:
+    continue-on-error: true
+    name: publish_java_sdk
+    needs: publish
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout Repo
+      uses: actions/checkout@v3
+    - name: Checkout Scripts Repo
+      uses: actions/checkout@v3
+      with:
+        path: ci-scripts
+        repository: pulumi/scripts
+    - name: Unshallow clone for tags
+      run: git fetch --prune --unshallow --tags
+    - name: Install Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: ${{matrix.goversion}}
+    - name: Install pulumictl
+      uses: jaxxstorm/action-install-gh-release@v1.5.0
+      with:
+        repo: pulumi/pulumictl
+    - name: Install Pulumi CLI
+      uses: pulumi/action-install-pulumi-cli@v2
+    - name: Setup Java
+      uses: actions/setup-java@v3
+      with:
+        cache: gradle
+        distribution: temurin
+        java-version: ${{matrix.javaversion}}
+    - name: Download java SDK
+      uses: actions/download-artifact@v2
+      with:
+        name: java-sdk.tar.gz
+        path: ${{ github.workspace}}/sdk/
+    - name: Uncompress java SDK
+      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
+        ${{github.workspace}}/sdk/java
+    - name: Set PACKAGE_VERSION to Env
+      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
+        $GITHUB_ENV
+    - name: Publish Java SDK
+      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
+      with:
+        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
+        build-root-directory: ./sdk/java
+        gradle-version: 7.4.1
+    strategy:
+      fail-fast: true
+      matrix:
+        goversion:
+        - 1.19.x
+        javaversion:
+        - "11"
   publish_sdk:
     name: publish_sdk
     needs: publish
@@ -414,12 +469,6 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{matrix.pythonversion}}
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{matrix.javaversion}}
     - name: Download python SDK
       uses: actions/download-artifact@v2
       with:
@@ -444,28 +493,11 @@ jobs:
     - name: Uncompress nodejs SDK
       run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
         ${{github.workspace}}/sdk/nodejs
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
     - run: python -m pip install pip twine
     - env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       name: Publish SDKs
       run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3
@@ -480,8 +512,6 @@ jobs:
         - 3.1.301
         goversion:
         - 1.19.x
-        javaversion:
-        - "11"
         nodeversion:
         - 16.x
         pythonversion:

--- a/provider-ci/providers/mailgun/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/mailgun/repo/.github/workflows/prerelease.yml
@@ -321,6 +321,61 @@ jobs:
         - 16.x
         pythonversion:
         - "3.9"
+  publish_java_sdk:
+    continue-on-error: true
+    name: publish_java_sdk
+    needs: publish
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout Repo
+      uses: actions/checkout@v3
+    - name: Checkout Scripts Repo
+      uses: actions/checkout@v3
+      with:
+        path: ci-scripts
+        repository: pulumi/scripts
+    - name: Unshallow clone for tags
+      run: git fetch --prune --unshallow --tags
+    - name: Install Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: ${{matrix.goversion}}
+    - name: Install pulumictl
+      uses: jaxxstorm/action-install-gh-release@v1.5.0
+      with:
+        repo: pulumi/pulumictl
+    - name: Install Pulumi CLI
+      uses: pulumi/action-install-pulumi-cli@v2
+    - name: Setup Java
+      uses: actions/setup-java@v3
+      with:
+        cache: gradle
+        distribution: temurin
+        java-version: ${{matrix.javaversion}}
+    - name: Download java SDK
+      uses: actions/download-artifact@v2
+      with:
+        name: java-sdk.tar.gz
+        path: ${{ github.workspace}}/sdk/
+    - name: Uncompress java SDK
+      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
+        ${{github.workspace}}/sdk/java
+    - name: Set PACKAGE_VERSION to Env
+      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
+        $GITHUB_ENV
+    - name: Publish Java SDK
+      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
+      with:
+        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
+        build-root-directory: ./sdk/java
+        gradle-version: 7.4.1
+    strategy:
+      fail-fast: true
+      matrix:
+        goversion:
+        - 1.19.x
+        javaversion:
+        - "11"
   publish_sdk:
     name: publish_sdk
     needs: publish
@@ -358,12 +413,6 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{matrix.pythonversion}}
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{matrix.javaversion}}
     - name: Download python SDK
       uses: actions/download-artifact@v2
       with:
@@ -388,28 +437,11 @@ jobs:
     - name: Uncompress nodejs SDK
       run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
         ${{github.workspace}}/sdk/nodejs
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
     - run: python -m pip install pip twine
     - env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       name: Publish SDKs
       run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3
@@ -424,8 +456,6 @@ jobs:
         - 3.1.301
         goversion:
         - 1.19.x
-        javaversion:
-        - "11"
         nodeversion:
         - 16.x
         pythonversion:

--- a/provider-ci/providers/mailgun/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/mailgun/repo/.github/workflows/release.yml
@@ -334,6 +334,61 @@ jobs:
         - 16.x
         pythonversion:
         - "3.9"
+  publish_java_sdk:
+    continue-on-error: true
+    name: publish_java_sdk
+    needs: publish
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout Repo
+      uses: actions/checkout@v3
+    - name: Checkout Scripts Repo
+      uses: actions/checkout@v3
+      with:
+        path: ci-scripts
+        repository: pulumi/scripts
+    - name: Unshallow clone for tags
+      run: git fetch --prune --unshallow --tags
+    - name: Install Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: ${{matrix.goversion}}
+    - name: Install pulumictl
+      uses: jaxxstorm/action-install-gh-release@v1.5.0
+      with:
+        repo: pulumi/pulumictl
+    - name: Install Pulumi CLI
+      uses: pulumi/action-install-pulumi-cli@v2
+    - name: Setup Java
+      uses: actions/setup-java@v3
+      with:
+        cache: gradle
+        distribution: temurin
+        java-version: ${{matrix.javaversion}}
+    - name: Download java SDK
+      uses: actions/download-artifact@v2
+      with:
+        name: java-sdk.tar.gz
+        path: ${{ github.workspace}}/sdk/
+    - name: Uncompress java SDK
+      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
+        ${{github.workspace}}/sdk/java
+    - name: Set PACKAGE_VERSION to Env
+      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
+        $GITHUB_ENV
+    - name: Publish Java SDK
+      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
+      with:
+        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
+        build-root-directory: ./sdk/java
+        gradle-version: 7.4.1
+    strategy:
+      fail-fast: true
+      matrix:
+        goversion:
+        - 1.19.x
+        javaversion:
+        - "11"
   publish_sdk:
     name: publish_sdk
     needs: publish
@@ -371,12 +426,6 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{matrix.pythonversion}}
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{matrix.javaversion}}
     - name: Download python SDK
       uses: actions/download-artifact@v2
       with:
@@ -401,28 +450,11 @@ jobs:
     - name: Uncompress nodejs SDK
       run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
         ${{github.workspace}}/sdk/nodejs
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
     - run: python -m pip install pip twine
     - env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       name: Publish SDKs
       run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3
@@ -437,8 +469,6 @@ jobs:
         - 3.1.301
         goversion:
         - 1.19.x
-        javaversion:
-        - "11"
         nodeversion:
         - 16.x
         pythonversion:

--- a/provider-ci/providers/minio/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/minio/repo/.github/workflows/main.yml
@@ -380,6 +380,61 @@ jobs:
         - 16.x
         pythonversion:
         - "3.9"
+  publish_java_sdk:
+    continue-on-error: true
+    name: publish_java_sdk
+    needs: publish
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout Repo
+      uses: actions/checkout@v3
+    - name: Checkout Scripts Repo
+      uses: actions/checkout@v3
+      with:
+        path: ci-scripts
+        repository: pulumi/scripts
+    - name: Unshallow clone for tags
+      run: git fetch --prune --unshallow --tags
+    - name: Install Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: ${{matrix.goversion}}
+    - name: Install pulumictl
+      uses: jaxxstorm/action-install-gh-release@v1.5.0
+      with:
+        repo: pulumi/pulumictl
+    - name: Install Pulumi CLI
+      uses: pulumi/action-install-pulumi-cli@v2
+    - name: Setup Java
+      uses: actions/setup-java@v3
+      with:
+        cache: gradle
+        distribution: temurin
+        java-version: ${{matrix.javaversion}}
+    - name: Download java SDK
+      uses: actions/download-artifact@v2
+      with:
+        name: java-sdk.tar.gz
+        path: ${{ github.workspace}}/sdk/
+    - name: Uncompress java SDK
+      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
+        ${{github.workspace}}/sdk/java
+    - name: Set PACKAGE_VERSION to Env
+      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
+        $GITHUB_ENV
+    - name: Publish Java SDK
+      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
+      with:
+        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
+        build-root-directory: ./sdk/java
+        gradle-version: 7.4.1
+    strategy:
+      fail-fast: true
+      matrix:
+        goversion:
+        - 1.19.x
+        javaversion:
+        - "11"
   publish_sdk:
     name: publish_sdk
     needs: publish
@@ -417,12 +472,6 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{matrix.pythonversion}}
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{matrix.javaversion}}
     - name: Download python SDK
       uses: actions/download-artifact@v2
       with:
@@ -447,28 +496,11 @@ jobs:
     - name: Uncompress nodejs SDK
       run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
         ${{github.workspace}}/sdk/nodejs
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
     - run: python -m pip install pip twine
     - env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       name: Publish SDKs
       run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3
@@ -483,8 +515,6 @@ jobs:
         - 3.1.301
         goversion:
         - 1.19.x
-        javaversion:
-        - "11"
         nodeversion:
         - 16.x
         pythonversion:

--- a/provider-ci/providers/minio/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/minio/repo/.github/workflows/master.yml
@@ -380,6 +380,61 @@ jobs:
         - 16.x
         pythonversion:
         - "3.9"
+  publish_java_sdk:
+    continue-on-error: true
+    name: publish_java_sdk
+    needs: publish
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout Repo
+      uses: actions/checkout@v3
+    - name: Checkout Scripts Repo
+      uses: actions/checkout@v3
+      with:
+        path: ci-scripts
+        repository: pulumi/scripts
+    - name: Unshallow clone for tags
+      run: git fetch --prune --unshallow --tags
+    - name: Install Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: ${{matrix.goversion}}
+    - name: Install pulumictl
+      uses: jaxxstorm/action-install-gh-release@v1.5.0
+      with:
+        repo: pulumi/pulumictl
+    - name: Install Pulumi CLI
+      uses: pulumi/action-install-pulumi-cli@v2
+    - name: Setup Java
+      uses: actions/setup-java@v3
+      with:
+        cache: gradle
+        distribution: temurin
+        java-version: ${{matrix.javaversion}}
+    - name: Download java SDK
+      uses: actions/download-artifact@v2
+      with:
+        name: java-sdk.tar.gz
+        path: ${{ github.workspace}}/sdk/
+    - name: Uncompress java SDK
+      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
+        ${{github.workspace}}/sdk/java
+    - name: Set PACKAGE_VERSION to Env
+      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
+        $GITHUB_ENV
+    - name: Publish Java SDK
+      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
+      with:
+        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
+        build-root-directory: ./sdk/java
+        gradle-version: 7.4.1
+    strategy:
+      fail-fast: true
+      matrix:
+        goversion:
+        - 1.19.x
+        javaversion:
+        - "11"
   publish_sdk:
     name: publish_sdk
     needs: publish
@@ -417,12 +472,6 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{matrix.pythonversion}}
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{matrix.javaversion}}
     - name: Download python SDK
       uses: actions/download-artifact@v2
       with:
@@ -447,28 +496,11 @@ jobs:
     - name: Uncompress nodejs SDK
       run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
         ${{github.workspace}}/sdk/nodejs
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
     - run: python -m pip install pip twine
     - env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       name: Publish SDKs
       run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3
@@ -483,8 +515,6 @@ jobs:
         - 3.1.301
         goversion:
         - 1.19.x
-        javaversion:
-        - "11"
         nodeversion:
         - 16.x
         pythonversion:

--- a/provider-ci/providers/minio/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/minio/repo/.github/workflows/prerelease.yml
@@ -324,6 +324,61 @@ jobs:
         - 16.x
         pythonversion:
         - "3.9"
+  publish_java_sdk:
+    continue-on-error: true
+    name: publish_java_sdk
+    needs: publish
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout Repo
+      uses: actions/checkout@v3
+    - name: Checkout Scripts Repo
+      uses: actions/checkout@v3
+      with:
+        path: ci-scripts
+        repository: pulumi/scripts
+    - name: Unshallow clone for tags
+      run: git fetch --prune --unshallow --tags
+    - name: Install Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: ${{matrix.goversion}}
+    - name: Install pulumictl
+      uses: jaxxstorm/action-install-gh-release@v1.5.0
+      with:
+        repo: pulumi/pulumictl
+    - name: Install Pulumi CLI
+      uses: pulumi/action-install-pulumi-cli@v2
+    - name: Setup Java
+      uses: actions/setup-java@v3
+      with:
+        cache: gradle
+        distribution: temurin
+        java-version: ${{matrix.javaversion}}
+    - name: Download java SDK
+      uses: actions/download-artifact@v2
+      with:
+        name: java-sdk.tar.gz
+        path: ${{ github.workspace}}/sdk/
+    - name: Uncompress java SDK
+      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
+        ${{github.workspace}}/sdk/java
+    - name: Set PACKAGE_VERSION to Env
+      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
+        $GITHUB_ENV
+    - name: Publish Java SDK
+      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
+      with:
+        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
+        build-root-directory: ./sdk/java
+        gradle-version: 7.4.1
+    strategy:
+      fail-fast: true
+      matrix:
+        goversion:
+        - 1.19.x
+        javaversion:
+        - "11"
   publish_sdk:
     name: publish_sdk
     needs: publish
@@ -361,12 +416,6 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{matrix.pythonversion}}
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{matrix.javaversion}}
     - name: Download python SDK
       uses: actions/download-artifact@v2
       with:
@@ -391,28 +440,11 @@ jobs:
     - name: Uncompress nodejs SDK
       run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
         ${{github.workspace}}/sdk/nodejs
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
     - run: python -m pip install pip twine
     - env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       name: Publish SDKs
       run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3
@@ -427,8 +459,6 @@ jobs:
         - 3.1.301
         goversion:
         - 1.19.x
-        javaversion:
-        - "11"
         nodeversion:
         - 16.x
         pythonversion:

--- a/provider-ci/providers/minio/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/minio/repo/.github/workflows/release.yml
@@ -337,6 +337,61 @@ jobs:
         - 16.x
         pythonversion:
         - "3.9"
+  publish_java_sdk:
+    continue-on-error: true
+    name: publish_java_sdk
+    needs: publish
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout Repo
+      uses: actions/checkout@v3
+    - name: Checkout Scripts Repo
+      uses: actions/checkout@v3
+      with:
+        path: ci-scripts
+        repository: pulumi/scripts
+    - name: Unshallow clone for tags
+      run: git fetch --prune --unshallow --tags
+    - name: Install Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: ${{matrix.goversion}}
+    - name: Install pulumictl
+      uses: jaxxstorm/action-install-gh-release@v1.5.0
+      with:
+        repo: pulumi/pulumictl
+    - name: Install Pulumi CLI
+      uses: pulumi/action-install-pulumi-cli@v2
+    - name: Setup Java
+      uses: actions/setup-java@v3
+      with:
+        cache: gradle
+        distribution: temurin
+        java-version: ${{matrix.javaversion}}
+    - name: Download java SDK
+      uses: actions/download-artifact@v2
+      with:
+        name: java-sdk.tar.gz
+        path: ${{ github.workspace}}/sdk/
+    - name: Uncompress java SDK
+      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
+        ${{github.workspace}}/sdk/java
+    - name: Set PACKAGE_VERSION to Env
+      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
+        $GITHUB_ENV
+    - name: Publish Java SDK
+      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
+      with:
+        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
+        build-root-directory: ./sdk/java
+        gradle-version: 7.4.1
+    strategy:
+      fail-fast: true
+      matrix:
+        goversion:
+        - 1.19.x
+        javaversion:
+        - "11"
   publish_sdk:
     name: publish_sdk
     needs: publish
@@ -374,12 +429,6 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{matrix.pythonversion}}
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{matrix.javaversion}}
     - name: Download python SDK
       uses: actions/download-artifact@v2
       with:
@@ -404,28 +453,11 @@ jobs:
     - name: Uncompress nodejs SDK
       run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
         ${{github.workspace}}/sdk/nodejs
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
     - run: python -m pip install pip twine
     - env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       name: Publish SDKs
       run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3
@@ -440,8 +472,6 @@ jobs:
         - 3.1.301
         goversion:
         - 1.19.x
-        javaversion:
-        - "11"
         nodeversion:
         - 16.x
         pythonversion:

--- a/provider-ci/providers/mongodbatlas/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/mongodbatlas/repo/.github/workflows/main.yml
@@ -379,6 +379,61 @@ jobs:
         - 16.x
         pythonversion:
         - "3.9"
+  publish_java_sdk:
+    continue-on-error: true
+    name: publish_java_sdk
+    needs: publish
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout Repo
+      uses: actions/checkout@v3
+    - name: Checkout Scripts Repo
+      uses: actions/checkout@v3
+      with:
+        path: ci-scripts
+        repository: pulumi/scripts
+    - name: Unshallow clone for tags
+      run: git fetch --prune --unshallow --tags
+    - name: Install Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: ${{matrix.goversion}}
+    - name: Install pulumictl
+      uses: jaxxstorm/action-install-gh-release@v1.5.0
+      with:
+        repo: pulumi/pulumictl
+    - name: Install Pulumi CLI
+      uses: pulumi/action-install-pulumi-cli@v2
+    - name: Setup Java
+      uses: actions/setup-java@v3
+      with:
+        cache: gradle
+        distribution: temurin
+        java-version: ${{matrix.javaversion}}
+    - name: Download java SDK
+      uses: actions/download-artifact@v2
+      with:
+        name: java-sdk.tar.gz
+        path: ${{ github.workspace}}/sdk/
+    - name: Uncompress java SDK
+      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
+        ${{github.workspace}}/sdk/java
+    - name: Set PACKAGE_VERSION to Env
+      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
+        $GITHUB_ENV
+    - name: Publish Java SDK
+      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
+      with:
+        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
+        build-root-directory: ./sdk/java
+        gradle-version: 7.4.1
+    strategy:
+      fail-fast: true
+      matrix:
+        goversion:
+        - 1.19.x
+        javaversion:
+        - "11"
   publish_sdk:
     name: publish_sdk
     needs: publish
@@ -416,12 +471,6 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{matrix.pythonversion}}
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{matrix.javaversion}}
     - name: Download python SDK
       uses: actions/download-artifact@v2
       with:
@@ -446,28 +495,11 @@ jobs:
     - name: Uncompress nodejs SDK
       run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
         ${{github.workspace}}/sdk/nodejs
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
     - run: python -m pip install pip twine
     - env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       name: Publish SDKs
       run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3
@@ -482,8 +514,6 @@ jobs:
         - 3.1.301
         goversion:
         - 1.19.x
-        javaversion:
-        - "11"
         nodeversion:
         - 16.x
         pythonversion:

--- a/provider-ci/providers/mongodbatlas/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/mongodbatlas/repo/.github/workflows/master.yml
@@ -379,6 +379,61 @@ jobs:
         - 16.x
         pythonversion:
         - "3.9"
+  publish_java_sdk:
+    continue-on-error: true
+    name: publish_java_sdk
+    needs: publish
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout Repo
+      uses: actions/checkout@v3
+    - name: Checkout Scripts Repo
+      uses: actions/checkout@v3
+      with:
+        path: ci-scripts
+        repository: pulumi/scripts
+    - name: Unshallow clone for tags
+      run: git fetch --prune --unshallow --tags
+    - name: Install Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: ${{matrix.goversion}}
+    - name: Install pulumictl
+      uses: jaxxstorm/action-install-gh-release@v1.5.0
+      with:
+        repo: pulumi/pulumictl
+    - name: Install Pulumi CLI
+      uses: pulumi/action-install-pulumi-cli@v2
+    - name: Setup Java
+      uses: actions/setup-java@v3
+      with:
+        cache: gradle
+        distribution: temurin
+        java-version: ${{matrix.javaversion}}
+    - name: Download java SDK
+      uses: actions/download-artifact@v2
+      with:
+        name: java-sdk.tar.gz
+        path: ${{ github.workspace}}/sdk/
+    - name: Uncompress java SDK
+      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
+        ${{github.workspace}}/sdk/java
+    - name: Set PACKAGE_VERSION to Env
+      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
+        $GITHUB_ENV
+    - name: Publish Java SDK
+      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
+      with:
+        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
+        build-root-directory: ./sdk/java
+        gradle-version: 7.4.1
+    strategy:
+      fail-fast: true
+      matrix:
+        goversion:
+        - 1.19.x
+        javaversion:
+        - "11"
   publish_sdk:
     name: publish_sdk
     needs: publish
@@ -416,12 +471,6 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{matrix.pythonversion}}
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{matrix.javaversion}}
     - name: Download python SDK
       uses: actions/download-artifact@v2
       with:
@@ -446,28 +495,11 @@ jobs:
     - name: Uncompress nodejs SDK
       run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
         ${{github.workspace}}/sdk/nodejs
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
     - run: python -m pip install pip twine
     - env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       name: Publish SDKs
       run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3
@@ -482,8 +514,6 @@ jobs:
         - 3.1.301
         goversion:
         - 1.19.x
-        javaversion:
-        - "11"
         nodeversion:
         - 16.x
         pythonversion:

--- a/provider-ci/providers/mongodbatlas/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/mongodbatlas/repo/.github/workflows/prerelease.yml
@@ -323,6 +323,61 @@ jobs:
         - 16.x
         pythonversion:
         - "3.9"
+  publish_java_sdk:
+    continue-on-error: true
+    name: publish_java_sdk
+    needs: publish
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout Repo
+      uses: actions/checkout@v3
+    - name: Checkout Scripts Repo
+      uses: actions/checkout@v3
+      with:
+        path: ci-scripts
+        repository: pulumi/scripts
+    - name: Unshallow clone for tags
+      run: git fetch --prune --unshallow --tags
+    - name: Install Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: ${{matrix.goversion}}
+    - name: Install pulumictl
+      uses: jaxxstorm/action-install-gh-release@v1.5.0
+      with:
+        repo: pulumi/pulumictl
+    - name: Install Pulumi CLI
+      uses: pulumi/action-install-pulumi-cli@v2
+    - name: Setup Java
+      uses: actions/setup-java@v3
+      with:
+        cache: gradle
+        distribution: temurin
+        java-version: ${{matrix.javaversion}}
+    - name: Download java SDK
+      uses: actions/download-artifact@v2
+      with:
+        name: java-sdk.tar.gz
+        path: ${{ github.workspace}}/sdk/
+    - name: Uncompress java SDK
+      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
+        ${{github.workspace}}/sdk/java
+    - name: Set PACKAGE_VERSION to Env
+      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
+        $GITHUB_ENV
+    - name: Publish Java SDK
+      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
+      with:
+        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
+        build-root-directory: ./sdk/java
+        gradle-version: 7.4.1
+    strategy:
+      fail-fast: true
+      matrix:
+        goversion:
+        - 1.19.x
+        javaversion:
+        - "11"
   publish_sdk:
     name: publish_sdk
     needs: publish
@@ -360,12 +415,6 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{matrix.pythonversion}}
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{matrix.javaversion}}
     - name: Download python SDK
       uses: actions/download-artifact@v2
       with:
@@ -390,28 +439,11 @@ jobs:
     - name: Uncompress nodejs SDK
       run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
         ${{github.workspace}}/sdk/nodejs
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
     - run: python -m pip install pip twine
     - env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       name: Publish SDKs
       run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3
@@ -426,8 +458,6 @@ jobs:
         - 3.1.301
         goversion:
         - 1.19.x
-        javaversion:
-        - "11"
         nodeversion:
         - 16.x
         pythonversion:

--- a/provider-ci/providers/mongodbatlas/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/mongodbatlas/repo/.github/workflows/release.yml
@@ -336,6 +336,61 @@ jobs:
         - 16.x
         pythonversion:
         - "3.9"
+  publish_java_sdk:
+    continue-on-error: true
+    name: publish_java_sdk
+    needs: publish
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout Repo
+      uses: actions/checkout@v3
+    - name: Checkout Scripts Repo
+      uses: actions/checkout@v3
+      with:
+        path: ci-scripts
+        repository: pulumi/scripts
+    - name: Unshallow clone for tags
+      run: git fetch --prune --unshallow --tags
+    - name: Install Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: ${{matrix.goversion}}
+    - name: Install pulumictl
+      uses: jaxxstorm/action-install-gh-release@v1.5.0
+      with:
+        repo: pulumi/pulumictl
+    - name: Install Pulumi CLI
+      uses: pulumi/action-install-pulumi-cli@v2
+    - name: Setup Java
+      uses: actions/setup-java@v3
+      with:
+        cache: gradle
+        distribution: temurin
+        java-version: ${{matrix.javaversion}}
+    - name: Download java SDK
+      uses: actions/download-artifact@v2
+      with:
+        name: java-sdk.tar.gz
+        path: ${{ github.workspace}}/sdk/
+    - name: Uncompress java SDK
+      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
+        ${{github.workspace}}/sdk/java
+    - name: Set PACKAGE_VERSION to Env
+      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
+        $GITHUB_ENV
+    - name: Publish Java SDK
+      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
+      with:
+        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
+        build-root-directory: ./sdk/java
+        gradle-version: 7.4.1
+    strategy:
+      fail-fast: true
+      matrix:
+        goversion:
+        - 1.19.x
+        javaversion:
+        - "11"
   publish_sdk:
     name: publish_sdk
     needs: publish
@@ -373,12 +428,6 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{matrix.pythonversion}}
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{matrix.javaversion}}
     - name: Download python SDK
       uses: actions/download-artifact@v2
       with:
@@ -403,28 +452,11 @@ jobs:
     - name: Uncompress nodejs SDK
       run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
         ${{github.workspace}}/sdk/nodejs
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
     - run: python -m pip install pip twine
     - env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       name: Publish SDKs
       run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3
@@ -439,8 +471,6 @@ jobs:
         - 3.1.301
         goversion:
         - 1.19.x
-        javaversion:
-        - "11"
         nodeversion:
         - 16.x
         pythonversion:

--- a/provider-ci/providers/mysql/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/mysql/repo/.github/workflows/main.yml
@@ -376,6 +376,61 @@ jobs:
         - 16.x
         pythonversion:
         - "3.9"
+  publish_java_sdk:
+    continue-on-error: true
+    name: publish_java_sdk
+    needs: publish
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout Repo
+      uses: actions/checkout@v3
+    - name: Checkout Scripts Repo
+      uses: actions/checkout@v3
+      with:
+        path: ci-scripts
+        repository: pulumi/scripts
+    - name: Unshallow clone for tags
+      run: git fetch --prune --unshallow --tags
+    - name: Install Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: ${{matrix.goversion}}
+    - name: Install pulumictl
+      uses: jaxxstorm/action-install-gh-release@v1.5.0
+      with:
+        repo: pulumi/pulumictl
+    - name: Install Pulumi CLI
+      uses: pulumi/action-install-pulumi-cli@v2
+    - name: Setup Java
+      uses: actions/setup-java@v3
+      with:
+        cache: gradle
+        distribution: temurin
+        java-version: ${{matrix.javaversion}}
+    - name: Download java SDK
+      uses: actions/download-artifact@v2
+      with:
+        name: java-sdk.tar.gz
+        path: ${{ github.workspace}}/sdk/
+    - name: Uncompress java SDK
+      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
+        ${{github.workspace}}/sdk/java
+    - name: Set PACKAGE_VERSION to Env
+      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
+        $GITHUB_ENV
+    - name: Publish Java SDK
+      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
+      with:
+        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
+        build-root-directory: ./sdk/java
+        gradle-version: 7.4.1
+    strategy:
+      fail-fast: true
+      matrix:
+        goversion:
+        - 1.19.x
+        javaversion:
+        - "11"
   publish_sdk:
     name: publish_sdk
     needs: publish
@@ -413,12 +468,6 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{matrix.pythonversion}}
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{matrix.javaversion}}
     - name: Download python SDK
       uses: actions/download-artifact@v2
       with:
@@ -443,28 +492,11 @@ jobs:
     - name: Uncompress nodejs SDK
       run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
         ${{github.workspace}}/sdk/nodejs
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
     - run: python -m pip install pip twine
     - env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       name: Publish SDKs
       run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3
@@ -479,8 +511,6 @@ jobs:
         - 3.1.301
         goversion:
         - 1.19.x
-        javaversion:
-        - "11"
         nodeversion:
         - 16.x
         pythonversion:

--- a/provider-ci/providers/mysql/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/mysql/repo/.github/workflows/master.yml
@@ -376,6 +376,61 @@ jobs:
         - 16.x
         pythonversion:
         - "3.9"
+  publish_java_sdk:
+    continue-on-error: true
+    name: publish_java_sdk
+    needs: publish
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout Repo
+      uses: actions/checkout@v3
+    - name: Checkout Scripts Repo
+      uses: actions/checkout@v3
+      with:
+        path: ci-scripts
+        repository: pulumi/scripts
+    - name: Unshallow clone for tags
+      run: git fetch --prune --unshallow --tags
+    - name: Install Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: ${{matrix.goversion}}
+    - name: Install pulumictl
+      uses: jaxxstorm/action-install-gh-release@v1.5.0
+      with:
+        repo: pulumi/pulumictl
+    - name: Install Pulumi CLI
+      uses: pulumi/action-install-pulumi-cli@v2
+    - name: Setup Java
+      uses: actions/setup-java@v3
+      with:
+        cache: gradle
+        distribution: temurin
+        java-version: ${{matrix.javaversion}}
+    - name: Download java SDK
+      uses: actions/download-artifact@v2
+      with:
+        name: java-sdk.tar.gz
+        path: ${{ github.workspace}}/sdk/
+    - name: Uncompress java SDK
+      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
+        ${{github.workspace}}/sdk/java
+    - name: Set PACKAGE_VERSION to Env
+      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
+        $GITHUB_ENV
+    - name: Publish Java SDK
+      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
+      with:
+        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
+        build-root-directory: ./sdk/java
+        gradle-version: 7.4.1
+    strategy:
+      fail-fast: true
+      matrix:
+        goversion:
+        - 1.19.x
+        javaversion:
+        - "11"
   publish_sdk:
     name: publish_sdk
     needs: publish
@@ -413,12 +468,6 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{matrix.pythonversion}}
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{matrix.javaversion}}
     - name: Download python SDK
       uses: actions/download-artifact@v2
       with:
@@ -443,28 +492,11 @@ jobs:
     - name: Uncompress nodejs SDK
       run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
         ${{github.workspace}}/sdk/nodejs
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
     - run: python -m pip install pip twine
     - env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       name: Publish SDKs
       run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3
@@ -479,8 +511,6 @@ jobs:
         - 3.1.301
         goversion:
         - 1.19.x
-        javaversion:
-        - "11"
         nodeversion:
         - 16.x
         pythonversion:

--- a/provider-ci/providers/mysql/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/mysql/repo/.github/workflows/prerelease.yml
@@ -320,6 +320,61 @@ jobs:
         - 16.x
         pythonversion:
         - "3.9"
+  publish_java_sdk:
+    continue-on-error: true
+    name: publish_java_sdk
+    needs: publish
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout Repo
+      uses: actions/checkout@v3
+    - name: Checkout Scripts Repo
+      uses: actions/checkout@v3
+      with:
+        path: ci-scripts
+        repository: pulumi/scripts
+    - name: Unshallow clone for tags
+      run: git fetch --prune --unshallow --tags
+    - name: Install Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: ${{matrix.goversion}}
+    - name: Install pulumictl
+      uses: jaxxstorm/action-install-gh-release@v1.5.0
+      with:
+        repo: pulumi/pulumictl
+    - name: Install Pulumi CLI
+      uses: pulumi/action-install-pulumi-cli@v2
+    - name: Setup Java
+      uses: actions/setup-java@v3
+      with:
+        cache: gradle
+        distribution: temurin
+        java-version: ${{matrix.javaversion}}
+    - name: Download java SDK
+      uses: actions/download-artifact@v2
+      with:
+        name: java-sdk.tar.gz
+        path: ${{ github.workspace}}/sdk/
+    - name: Uncompress java SDK
+      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
+        ${{github.workspace}}/sdk/java
+    - name: Set PACKAGE_VERSION to Env
+      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
+        $GITHUB_ENV
+    - name: Publish Java SDK
+      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
+      with:
+        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
+        build-root-directory: ./sdk/java
+        gradle-version: 7.4.1
+    strategy:
+      fail-fast: true
+      matrix:
+        goversion:
+        - 1.19.x
+        javaversion:
+        - "11"
   publish_sdk:
     name: publish_sdk
     needs: publish
@@ -357,12 +412,6 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{matrix.pythonversion}}
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{matrix.javaversion}}
     - name: Download python SDK
       uses: actions/download-artifact@v2
       with:
@@ -387,28 +436,11 @@ jobs:
     - name: Uncompress nodejs SDK
       run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
         ${{github.workspace}}/sdk/nodejs
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
     - run: python -m pip install pip twine
     - env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       name: Publish SDKs
       run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3
@@ -423,8 +455,6 @@ jobs:
         - 3.1.301
         goversion:
         - 1.19.x
-        javaversion:
-        - "11"
         nodeversion:
         - 16.x
         pythonversion:

--- a/provider-ci/providers/mysql/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/mysql/repo/.github/workflows/release.yml
@@ -333,6 +333,61 @@ jobs:
         - 16.x
         pythonversion:
         - "3.9"
+  publish_java_sdk:
+    continue-on-error: true
+    name: publish_java_sdk
+    needs: publish
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout Repo
+      uses: actions/checkout@v3
+    - name: Checkout Scripts Repo
+      uses: actions/checkout@v3
+      with:
+        path: ci-scripts
+        repository: pulumi/scripts
+    - name: Unshallow clone for tags
+      run: git fetch --prune --unshallow --tags
+    - name: Install Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: ${{matrix.goversion}}
+    - name: Install pulumictl
+      uses: jaxxstorm/action-install-gh-release@v1.5.0
+      with:
+        repo: pulumi/pulumictl
+    - name: Install Pulumi CLI
+      uses: pulumi/action-install-pulumi-cli@v2
+    - name: Setup Java
+      uses: actions/setup-java@v3
+      with:
+        cache: gradle
+        distribution: temurin
+        java-version: ${{matrix.javaversion}}
+    - name: Download java SDK
+      uses: actions/download-artifact@v2
+      with:
+        name: java-sdk.tar.gz
+        path: ${{ github.workspace}}/sdk/
+    - name: Uncompress java SDK
+      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
+        ${{github.workspace}}/sdk/java
+    - name: Set PACKAGE_VERSION to Env
+      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
+        $GITHUB_ENV
+    - name: Publish Java SDK
+      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
+      with:
+        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
+        build-root-directory: ./sdk/java
+        gradle-version: 7.4.1
+    strategy:
+      fail-fast: true
+      matrix:
+        goversion:
+        - 1.19.x
+        javaversion:
+        - "11"
   publish_sdk:
     name: publish_sdk
     needs: publish
@@ -370,12 +425,6 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{matrix.pythonversion}}
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{matrix.javaversion}}
     - name: Download python SDK
       uses: actions/download-artifact@v2
       with:
@@ -400,28 +449,11 @@ jobs:
     - name: Uncompress nodejs SDK
       run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
         ${{github.workspace}}/sdk/nodejs
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
     - run: python -m pip install pip twine
     - env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       name: Publish SDKs
       run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3
@@ -436,8 +468,6 @@ jobs:
         - 3.1.301
         goversion:
         - 1.19.x
-        javaversion:
-        - "11"
         nodeversion:
         - 16.x
         pythonversion:

--- a/provider-ci/providers/newrelic/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/newrelic/repo/.github/workflows/main.yml
@@ -378,6 +378,61 @@ jobs:
         - 16.x
         pythonversion:
         - "3.9"
+  publish_java_sdk:
+    continue-on-error: true
+    name: publish_java_sdk
+    needs: publish
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout Repo
+      uses: actions/checkout@v3
+    - name: Checkout Scripts Repo
+      uses: actions/checkout@v3
+      with:
+        path: ci-scripts
+        repository: pulumi/scripts
+    - name: Unshallow clone for tags
+      run: git fetch --prune --unshallow --tags
+    - name: Install Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: ${{matrix.goversion}}
+    - name: Install pulumictl
+      uses: jaxxstorm/action-install-gh-release@v1.5.0
+      with:
+        repo: pulumi/pulumictl
+    - name: Install Pulumi CLI
+      uses: pulumi/action-install-pulumi-cli@v2
+    - name: Setup Java
+      uses: actions/setup-java@v3
+      with:
+        cache: gradle
+        distribution: temurin
+        java-version: ${{matrix.javaversion}}
+    - name: Download java SDK
+      uses: actions/download-artifact@v2
+      with:
+        name: java-sdk.tar.gz
+        path: ${{ github.workspace}}/sdk/
+    - name: Uncompress java SDK
+      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
+        ${{github.workspace}}/sdk/java
+    - name: Set PACKAGE_VERSION to Env
+      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
+        $GITHUB_ENV
+    - name: Publish Java SDK
+      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
+      with:
+        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
+        build-root-directory: ./sdk/java
+        gradle-version: 7.4.1
+    strategy:
+      fail-fast: true
+      matrix:
+        goversion:
+        - 1.19.x
+        javaversion:
+        - "11"
   publish_sdk:
     name: publish_sdk
     needs: publish
@@ -415,12 +470,6 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{matrix.pythonversion}}
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{matrix.javaversion}}
     - name: Download python SDK
       uses: actions/download-artifact@v2
       with:
@@ -445,28 +494,11 @@ jobs:
     - name: Uncompress nodejs SDK
       run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
         ${{github.workspace}}/sdk/nodejs
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
     - run: python -m pip install pip twine
     - env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       name: Publish SDKs
       run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3
@@ -481,8 +513,6 @@ jobs:
         - 3.1.301
         goversion:
         - 1.19.x
-        javaversion:
-        - "11"
         nodeversion:
         - 16.x
         pythonversion:

--- a/provider-ci/providers/newrelic/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/newrelic/repo/.github/workflows/master.yml
@@ -378,6 +378,61 @@ jobs:
         - 16.x
         pythonversion:
         - "3.9"
+  publish_java_sdk:
+    continue-on-error: true
+    name: publish_java_sdk
+    needs: publish
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout Repo
+      uses: actions/checkout@v3
+    - name: Checkout Scripts Repo
+      uses: actions/checkout@v3
+      with:
+        path: ci-scripts
+        repository: pulumi/scripts
+    - name: Unshallow clone for tags
+      run: git fetch --prune --unshallow --tags
+    - name: Install Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: ${{matrix.goversion}}
+    - name: Install pulumictl
+      uses: jaxxstorm/action-install-gh-release@v1.5.0
+      with:
+        repo: pulumi/pulumictl
+    - name: Install Pulumi CLI
+      uses: pulumi/action-install-pulumi-cli@v2
+    - name: Setup Java
+      uses: actions/setup-java@v3
+      with:
+        cache: gradle
+        distribution: temurin
+        java-version: ${{matrix.javaversion}}
+    - name: Download java SDK
+      uses: actions/download-artifact@v2
+      with:
+        name: java-sdk.tar.gz
+        path: ${{ github.workspace}}/sdk/
+    - name: Uncompress java SDK
+      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
+        ${{github.workspace}}/sdk/java
+    - name: Set PACKAGE_VERSION to Env
+      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
+        $GITHUB_ENV
+    - name: Publish Java SDK
+      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
+      with:
+        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
+        build-root-directory: ./sdk/java
+        gradle-version: 7.4.1
+    strategy:
+      fail-fast: true
+      matrix:
+        goversion:
+        - 1.19.x
+        javaversion:
+        - "11"
   publish_sdk:
     name: publish_sdk
     needs: publish
@@ -415,12 +470,6 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{matrix.pythonversion}}
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{matrix.javaversion}}
     - name: Download python SDK
       uses: actions/download-artifact@v2
       with:
@@ -445,28 +494,11 @@ jobs:
     - name: Uncompress nodejs SDK
       run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
         ${{github.workspace}}/sdk/nodejs
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
     - run: python -m pip install pip twine
     - env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       name: Publish SDKs
       run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3
@@ -481,8 +513,6 @@ jobs:
         - 3.1.301
         goversion:
         - 1.19.x
-        javaversion:
-        - "11"
         nodeversion:
         - 16.x
         pythonversion:

--- a/provider-ci/providers/newrelic/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/newrelic/repo/.github/workflows/prerelease.yml
@@ -322,6 +322,61 @@ jobs:
         - 16.x
         pythonversion:
         - "3.9"
+  publish_java_sdk:
+    continue-on-error: true
+    name: publish_java_sdk
+    needs: publish
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout Repo
+      uses: actions/checkout@v3
+    - name: Checkout Scripts Repo
+      uses: actions/checkout@v3
+      with:
+        path: ci-scripts
+        repository: pulumi/scripts
+    - name: Unshallow clone for tags
+      run: git fetch --prune --unshallow --tags
+    - name: Install Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: ${{matrix.goversion}}
+    - name: Install pulumictl
+      uses: jaxxstorm/action-install-gh-release@v1.5.0
+      with:
+        repo: pulumi/pulumictl
+    - name: Install Pulumi CLI
+      uses: pulumi/action-install-pulumi-cli@v2
+    - name: Setup Java
+      uses: actions/setup-java@v3
+      with:
+        cache: gradle
+        distribution: temurin
+        java-version: ${{matrix.javaversion}}
+    - name: Download java SDK
+      uses: actions/download-artifact@v2
+      with:
+        name: java-sdk.tar.gz
+        path: ${{ github.workspace}}/sdk/
+    - name: Uncompress java SDK
+      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
+        ${{github.workspace}}/sdk/java
+    - name: Set PACKAGE_VERSION to Env
+      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
+        $GITHUB_ENV
+    - name: Publish Java SDK
+      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
+      with:
+        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
+        build-root-directory: ./sdk/java
+        gradle-version: 7.4.1
+    strategy:
+      fail-fast: true
+      matrix:
+        goversion:
+        - 1.19.x
+        javaversion:
+        - "11"
   publish_sdk:
     name: publish_sdk
     needs: publish
@@ -359,12 +414,6 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{matrix.pythonversion}}
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{matrix.javaversion}}
     - name: Download python SDK
       uses: actions/download-artifact@v2
       with:
@@ -389,28 +438,11 @@ jobs:
     - name: Uncompress nodejs SDK
       run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
         ${{github.workspace}}/sdk/nodejs
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
     - run: python -m pip install pip twine
     - env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       name: Publish SDKs
       run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3
@@ -425,8 +457,6 @@ jobs:
         - 3.1.301
         goversion:
         - 1.19.x
-        javaversion:
-        - "11"
         nodeversion:
         - 16.x
         pythonversion:

--- a/provider-ci/providers/newrelic/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/newrelic/repo/.github/workflows/release.yml
@@ -335,6 +335,61 @@ jobs:
         - 16.x
         pythonversion:
         - "3.9"
+  publish_java_sdk:
+    continue-on-error: true
+    name: publish_java_sdk
+    needs: publish
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout Repo
+      uses: actions/checkout@v3
+    - name: Checkout Scripts Repo
+      uses: actions/checkout@v3
+      with:
+        path: ci-scripts
+        repository: pulumi/scripts
+    - name: Unshallow clone for tags
+      run: git fetch --prune --unshallow --tags
+    - name: Install Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: ${{matrix.goversion}}
+    - name: Install pulumictl
+      uses: jaxxstorm/action-install-gh-release@v1.5.0
+      with:
+        repo: pulumi/pulumictl
+    - name: Install Pulumi CLI
+      uses: pulumi/action-install-pulumi-cli@v2
+    - name: Setup Java
+      uses: actions/setup-java@v3
+      with:
+        cache: gradle
+        distribution: temurin
+        java-version: ${{matrix.javaversion}}
+    - name: Download java SDK
+      uses: actions/download-artifact@v2
+      with:
+        name: java-sdk.tar.gz
+        path: ${{ github.workspace}}/sdk/
+    - name: Uncompress java SDK
+      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
+        ${{github.workspace}}/sdk/java
+    - name: Set PACKAGE_VERSION to Env
+      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
+        $GITHUB_ENV
+    - name: Publish Java SDK
+      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
+      with:
+        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
+        build-root-directory: ./sdk/java
+        gradle-version: 7.4.1
+    strategy:
+      fail-fast: true
+      matrix:
+        goversion:
+        - 1.19.x
+        javaversion:
+        - "11"
   publish_sdk:
     name: publish_sdk
     needs: publish
@@ -372,12 +427,6 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{matrix.pythonversion}}
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{matrix.javaversion}}
     - name: Download python SDK
       uses: actions/download-artifact@v2
       with:
@@ -402,28 +451,11 @@ jobs:
     - name: Uncompress nodejs SDK
       run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
         ${{github.workspace}}/sdk/nodejs
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
     - run: python -m pip install pip twine
     - env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       name: Publish SDKs
       run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3
@@ -438,8 +470,6 @@ jobs:
         - 3.1.301
         goversion:
         - 1.19.x
-        javaversion:
-        - "11"
         nodeversion:
         - 16.x
         pythonversion:

--- a/provider-ci/providers/nomad/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/nomad/repo/.github/workflows/main.yml
@@ -377,6 +377,61 @@ jobs:
         - 16.x
         pythonversion:
         - "3.9"
+  publish_java_sdk:
+    continue-on-error: true
+    name: publish_java_sdk
+    needs: publish
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout Repo
+      uses: actions/checkout@v3
+    - name: Checkout Scripts Repo
+      uses: actions/checkout@v3
+      with:
+        path: ci-scripts
+        repository: pulumi/scripts
+    - name: Unshallow clone for tags
+      run: git fetch --prune --unshallow --tags
+    - name: Install Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: ${{matrix.goversion}}
+    - name: Install pulumictl
+      uses: jaxxstorm/action-install-gh-release@v1.5.0
+      with:
+        repo: pulumi/pulumictl
+    - name: Install Pulumi CLI
+      uses: pulumi/action-install-pulumi-cli@v2
+    - name: Setup Java
+      uses: actions/setup-java@v3
+      with:
+        cache: gradle
+        distribution: temurin
+        java-version: ${{matrix.javaversion}}
+    - name: Download java SDK
+      uses: actions/download-artifact@v2
+      with:
+        name: java-sdk.tar.gz
+        path: ${{ github.workspace}}/sdk/
+    - name: Uncompress java SDK
+      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
+        ${{github.workspace}}/sdk/java
+    - name: Set PACKAGE_VERSION to Env
+      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
+        $GITHUB_ENV
+    - name: Publish Java SDK
+      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
+      with:
+        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
+        build-root-directory: ./sdk/java
+        gradle-version: 7.4.1
+    strategy:
+      fail-fast: true
+      matrix:
+        goversion:
+        - 1.19.x
+        javaversion:
+        - "11"
   publish_sdk:
     name: publish_sdk
     needs: publish
@@ -414,12 +469,6 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{matrix.pythonversion}}
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{matrix.javaversion}}
     - name: Download python SDK
       uses: actions/download-artifact@v2
       with:
@@ -444,28 +493,11 @@ jobs:
     - name: Uncompress nodejs SDK
       run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
         ${{github.workspace}}/sdk/nodejs
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
     - run: python -m pip install pip twine
     - env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       name: Publish SDKs
       run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3
@@ -480,8 +512,6 @@ jobs:
         - 3.1.301
         goversion:
         - 1.19.x
-        javaversion:
-        - "11"
         nodeversion:
         - 16.x
         pythonversion:

--- a/provider-ci/providers/nomad/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/nomad/repo/.github/workflows/master.yml
@@ -377,6 +377,61 @@ jobs:
         - 16.x
         pythonversion:
         - "3.9"
+  publish_java_sdk:
+    continue-on-error: true
+    name: publish_java_sdk
+    needs: publish
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout Repo
+      uses: actions/checkout@v3
+    - name: Checkout Scripts Repo
+      uses: actions/checkout@v3
+      with:
+        path: ci-scripts
+        repository: pulumi/scripts
+    - name: Unshallow clone for tags
+      run: git fetch --prune --unshallow --tags
+    - name: Install Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: ${{matrix.goversion}}
+    - name: Install pulumictl
+      uses: jaxxstorm/action-install-gh-release@v1.5.0
+      with:
+        repo: pulumi/pulumictl
+    - name: Install Pulumi CLI
+      uses: pulumi/action-install-pulumi-cli@v2
+    - name: Setup Java
+      uses: actions/setup-java@v3
+      with:
+        cache: gradle
+        distribution: temurin
+        java-version: ${{matrix.javaversion}}
+    - name: Download java SDK
+      uses: actions/download-artifact@v2
+      with:
+        name: java-sdk.tar.gz
+        path: ${{ github.workspace}}/sdk/
+    - name: Uncompress java SDK
+      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
+        ${{github.workspace}}/sdk/java
+    - name: Set PACKAGE_VERSION to Env
+      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
+        $GITHUB_ENV
+    - name: Publish Java SDK
+      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
+      with:
+        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
+        build-root-directory: ./sdk/java
+        gradle-version: 7.4.1
+    strategy:
+      fail-fast: true
+      matrix:
+        goversion:
+        - 1.19.x
+        javaversion:
+        - "11"
   publish_sdk:
     name: publish_sdk
     needs: publish
@@ -414,12 +469,6 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{matrix.pythonversion}}
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{matrix.javaversion}}
     - name: Download python SDK
       uses: actions/download-artifact@v2
       with:
@@ -444,28 +493,11 @@ jobs:
     - name: Uncompress nodejs SDK
       run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
         ${{github.workspace}}/sdk/nodejs
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
     - run: python -m pip install pip twine
     - env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       name: Publish SDKs
       run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3
@@ -480,8 +512,6 @@ jobs:
         - 3.1.301
         goversion:
         - 1.19.x
-        javaversion:
-        - "11"
         nodeversion:
         - 16.x
         pythonversion:

--- a/provider-ci/providers/nomad/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/nomad/repo/.github/workflows/prerelease.yml
@@ -321,6 +321,61 @@ jobs:
         - 16.x
         pythonversion:
         - "3.9"
+  publish_java_sdk:
+    continue-on-error: true
+    name: publish_java_sdk
+    needs: publish
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout Repo
+      uses: actions/checkout@v3
+    - name: Checkout Scripts Repo
+      uses: actions/checkout@v3
+      with:
+        path: ci-scripts
+        repository: pulumi/scripts
+    - name: Unshallow clone for tags
+      run: git fetch --prune --unshallow --tags
+    - name: Install Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: ${{matrix.goversion}}
+    - name: Install pulumictl
+      uses: jaxxstorm/action-install-gh-release@v1.5.0
+      with:
+        repo: pulumi/pulumictl
+    - name: Install Pulumi CLI
+      uses: pulumi/action-install-pulumi-cli@v2
+    - name: Setup Java
+      uses: actions/setup-java@v3
+      with:
+        cache: gradle
+        distribution: temurin
+        java-version: ${{matrix.javaversion}}
+    - name: Download java SDK
+      uses: actions/download-artifact@v2
+      with:
+        name: java-sdk.tar.gz
+        path: ${{ github.workspace}}/sdk/
+    - name: Uncompress java SDK
+      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
+        ${{github.workspace}}/sdk/java
+    - name: Set PACKAGE_VERSION to Env
+      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
+        $GITHUB_ENV
+    - name: Publish Java SDK
+      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
+      with:
+        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
+        build-root-directory: ./sdk/java
+        gradle-version: 7.4.1
+    strategy:
+      fail-fast: true
+      matrix:
+        goversion:
+        - 1.19.x
+        javaversion:
+        - "11"
   publish_sdk:
     name: publish_sdk
     needs: publish
@@ -358,12 +413,6 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{matrix.pythonversion}}
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{matrix.javaversion}}
     - name: Download python SDK
       uses: actions/download-artifact@v2
       with:
@@ -388,28 +437,11 @@ jobs:
     - name: Uncompress nodejs SDK
       run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
         ${{github.workspace}}/sdk/nodejs
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
     - run: python -m pip install pip twine
     - env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       name: Publish SDKs
       run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3
@@ -424,8 +456,6 @@ jobs:
         - 3.1.301
         goversion:
         - 1.19.x
-        javaversion:
-        - "11"
         nodeversion:
         - 16.x
         pythonversion:

--- a/provider-ci/providers/nomad/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/nomad/repo/.github/workflows/release.yml
@@ -334,6 +334,61 @@ jobs:
         - 16.x
         pythonversion:
         - "3.9"
+  publish_java_sdk:
+    continue-on-error: true
+    name: publish_java_sdk
+    needs: publish
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout Repo
+      uses: actions/checkout@v3
+    - name: Checkout Scripts Repo
+      uses: actions/checkout@v3
+      with:
+        path: ci-scripts
+        repository: pulumi/scripts
+    - name: Unshallow clone for tags
+      run: git fetch --prune --unshallow --tags
+    - name: Install Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: ${{matrix.goversion}}
+    - name: Install pulumictl
+      uses: jaxxstorm/action-install-gh-release@v1.5.0
+      with:
+        repo: pulumi/pulumictl
+    - name: Install Pulumi CLI
+      uses: pulumi/action-install-pulumi-cli@v2
+    - name: Setup Java
+      uses: actions/setup-java@v3
+      with:
+        cache: gradle
+        distribution: temurin
+        java-version: ${{matrix.javaversion}}
+    - name: Download java SDK
+      uses: actions/download-artifact@v2
+      with:
+        name: java-sdk.tar.gz
+        path: ${{ github.workspace}}/sdk/
+    - name: Uncompress java SDK
+      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
+        ${{github.workspace}}/sdk/java
+    - name: Set PACKAGE_VERSION to Env
+      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
+        $GITHUB_ENV
+    - name: Publish Java SDK
+      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
+      with:
+        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
+        build-root-directory: ./sdk/java
+        gradle-version: 7.4.1
+    strategy:
+      fail-fast: true
+      matrix:
+        goversion:
+        - 1.19.x
+        javaversion:
+        - "11"
   publish_sdk:
     name: publish_sdk
     needs: publish
@@ -371,12 +426,6 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{matrix.pythonversion}}
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{matrix.javaversion}}
     - name: Download python SDK
       uses: actions/download-artifact@v2
       with:
@@ -401,28 +450,11 @@ jobs:
     - name: Uncompress nodejs SDK
       run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
         ${{github.workspace}}/sdk/nodejs
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
     - run: python -m pip install pip twine
     - env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       name: Publish SDKs
       run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3
@@ -437,8 +469,6 @@ jobs:
         - 3.1.301
         goversion:
         - 1.19.x
-        javaversion:
-        - "11"
         nodeversion:
         - 16.x
         pythonversion:

--- a/provider-ci/providers/ns1/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/ns1/repo/.github/workflows/main.yml
@@ -377,6 +377,61 @@ jobs:
         - 16.x
         pythonversion:
         - "3.9"
+  publish_java_sdk:
+    continue-on-error: true
+    name: publish_java_sdk
+    needs: publish
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout Repo
+      uses: actions/checkout@v3
+    - name: Checkout Scripts Repo
+      uses: actions/checkout@v3
+      with:
+        path: ci-scripts
+        repository: pulumi/scripts
+    - name: Unshallow clone for tags
+      run: git fetch --prune --unshallow --tags
+    - name: Install Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: ${{matrix.goversion}}
+    - name: Install pulumictl
+      uses: jaxxstorm/action-install-gh-release@v1.5.0
+      with:
+        repo: pulumi/pulumictl
+    - name: Install Pulumi CLI
+      uses: pulumi/action-install-pulumi-cli@v2
+    - name: Setup Java
+      uses: actions/setup-java@v3
+      with:
+        cache: gradle
+        distribution: temurin
+        java-version: ${{matrix.javaversion}}
+    - name: Download java SDK
+      uses: actions/download-artifact@v2
+      with:
+        name: java-sdk.tar.gz
+        path: ${{ github.workspace}}/sdk/
+    - name: Uncompress java SDK
+      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
+        ${{github.workspace}}/sdk/java
+    - name: Set PACKAGE_VERSION to Env
+      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
+        $GITHUB_ENV
+    - name: Publish Java SDK
+      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
+      with:
+        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
+        build-root-directory: ./sdk/java
+        gradle-version: 7.4.1
+    strategy:
+      fail-fast: true
+      matrix:
+        goversion:
+        - 1.19.x
+        javaversion:
+        - "11"
   publish_sdk:
     name: publish_sdk
     needs: publish
@@ -414,12 +469,6 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{matrix.pythonversion}}
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{matrix.javaversion}}
     - name: Download python SDK
       uses: actions/download-artifact@v2
       with:
@@ -444,28 +493,11 @@ jobs:
     - name: Uncompress nodejs SDK
       run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
         ${{github.workspace}}/sdk/nodejs
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
     - run: python -m pip install pip twine
     - env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       name: Publish SDKs
       run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3
@@ -480,8 +512,6 @@ jobs:
         - 3.1.301
         goversion:
         - 1.19.x
-        javaversion:
-        - "11"
         nodeversion:
         - 16.x
         pythonversion:

--- a/provider-ci/providers/ns1/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/ns1/repo/.github/workflows/master.yml
@@ -377,6 +377,61 @@ jobs:
         - 16.x
         pythonversion:
         - "3.9"
+  publish_java_sdk:
+    continue-on-error: true
+    name: publish_java_sdk
+    needs: publish
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout Repo
+      uses: actions/checkout@v3
+    - name: Checkout Scripts Repo
+      uses: actions/checkout@v3
+      with:
+        path: ci-scripts
+        repository: pulumi/scripts
+    - name: Unshallow clone for tags
+      run: git fetch --prune --unshallow --tags
+    - name: Install Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: ${{matrix.goversion}}
+    - name: Install pulumictl
+      uses: jaxxstorm/action-install-gh-release@v1.5.0
+      with:
+        repo: pulumi/pulumictl
+    - name: Install Pulumi CLI
+      uses: pulumi/action-install-pulumi-cli@v2
+    - name: Setup Java
+      uses: actions/setup-java@v3
+      with:
+        cache: gradle
+        distribution: temurin
+        java-version: ${{matrix.javaversion}}
+    - name: Download java SDK
+      uses: actions/download-artifact@v2
+      with:
+        name: java-sdk.tar.gz
+        path: ${{ github.workspace}}/sdk/
+    - name: Uncompress java SDK
+      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
+        ${{github.workspace}}/sdk/java
+    - name: Set PACKAGE_VERSION to Env
+      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
+        $GITHUB_ENV
+    - name: Publish Java SDK
+      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
+      with:
+        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
+        build-root-directory: ./sdk/java
+        gradle-version: 7.4.1
+    strategy:
+      fail-fast: true
+      matrix:
+        goversion:
+        - 1.19.x
+        javaversion:
+        - "11"
   publish_sdk:
     name: publish_sdk
     needs: publish
@@ -414,12 +469,6 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{matrix.pythonversion}}
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{matrix.javaversion}}
     - name: Download python SDK
       uses: actions/download-artifact@v2
       with:
@@ -444,28 +493,11 @@ jobs:
     - name: Uncompress nodejs SDK
       run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
         ${{github.workspace}}/sdk/nodejs
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
     - run: python -m pip install pip twine
     - env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       name: Publish SDKs
       run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3
@@ -480,8 +512,6 @@ jobs:
         - 3.1.301
         goversion:
         - 1.19.x
-        javaversion:
-        - "11"
         nodeversion:
         - 16.x
         pythonversion:

--- a/provider-ci/providers/ns1/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/ns1/repo/.github/workflows/prerelease.yml
@@ -321,6 +321,61 @@ jobs:
         - 16.x
         pythonversion:
         - "3.9"
+  publish_java_sdk:
+    continue-on-error: true
+    name: publish_java_sdk
+    needs: publish
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout Repo
+      uses: actions/checkout@v3
+    - name: Checkout Scripts Repo
+      uses: actions/checkout@v3
+      with:
+        path: ci-scripts
+        repository: pulumi/scripts
+    - name: Unshallow clone for tags
+      run: git fetch --prune --unshallow --tags
+    - name: Install Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: ${{matrix.goversion}}
+    - name: Install pulumictl
+      uses: jaxxstorm/action-install-gh-release@v1.5.0
+      with:
+        repo: pulumi/pulumictl
+    - name: Install Pulumi CLI
+      uses: pulumi/action-install-pulumi-cli@v2
+    - name: Setup Java
+      uses: actions/setup-java@v3
+      with:
+        cache: gradle
+        distribution: temurin
+        java-version: ${{matrix.javaversion}}
+    - name: Download java SDK
+      uses: actions/download-artifact@v2
+      with:
+        name: java-sdk.tar.gz
+        path: ${{ github.workspace}}/sdk/
+    - name: Uncompress java SDK
+      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
+        ${{github.workspace}}/sdk/java
+    - name: Set PACKAGE_VERSION to Env
+      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
+        $GITHUB_ENV
+    - name: Publish Java SDK
+      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
+      with:
+        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
+        build-root-directory: ./sdk/java
+        gradle-version: 7.4.1
+    strategy:
+      fail-fast: true
+      matrix:
+        goversion:
+        - 1.19.x
+        javaversion:
+        - "11"
   publish_sdk:
     name: publish_sdk
     needs: publish
@@ -358,12 +413,6 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{matrix.pythonversion}}
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{matrix.javaversion}}
     - name: Download python SDK
       uses: actions/download-artifact@v2
       with:
@@ -388,28 +437,11 @@ jobs:
     - name: Uncompress nodejs SDK
       run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
         ${{github.workspace}}/sdk/nodejs
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
     - run: python -m pip install pip twine
     - env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       name: Publish SDKs
       run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3
@@ -424,8 +456,6 @@ jobs:
         - 3.1.301
         goversion:
         - 1.19.x
-        javaversion:
-        - "11"
         nodeversion:
         - 16.x
         pythonversion:

--- a/provider-ci/providers/ns1/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/ns1/repo/.github/workflows/release.yml
@@ -334,6 +334,61 @@ jobs:
         - 16.x
         pythonversion:
         - "3.9"
+  publish_java_sdk:
+    continue-on-error: true
+    name: publish_java_sdk
+    needs: publish
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout Repo
+      uses: actions/checkout@v3
+    - name: Checkout Scripts Repo
+      uses: actions/checkout@v3
+      with:
+        path: ci-scripts
+        repository: pulumi/scripts
+    - name: Unshallow clone for tags
+      run: git fetch --prune --unshallow --tags
+    - name: Install Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: ${{matrix.goversion}}
+    - name: Install pulumictl
+      uses: jaxxstorm/action-install-gh-release@v1.5.0
+      with:
+        repo: pulumi/pulumictl
+    - name: Install Pulumi CLI
+      uses: pulumi/action-install-pulumi-cli@v2
+    - name: Setup Java
+      uses: actions/setup-java@v3
+      with:
+        cache: gradle
+        distribution: temurin
+        java-version: ${{matrix.javaversion}}
+    - name: Download java SDK
+      uses: actions/download-artifact@v2
+      with:
+        name: java-sdk.tar.gz
+        path: ${{ github.workspace}}/sdk/
+    - name: Uncompress java SDK
+      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
+        ${{github.workspace}}/sdk/java
+    - name: Set PACKAGE_VERSION to Env
+      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
+        $GITHUB_ENV
+    - name: Publish Java SDK
+      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
+      with:
+        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
+        build-root-directory: ./sdk/java
+        gradle-version: 7.4.1
+    strategy:
+      fail-fast: true
+      matrix:
+        goversion:
+        - 1.19.x
+        javaversion:
+        - "11"
   publish_sdk:
     name: publish_sdk
     needs: publish
@@ -371,12 +426,6 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{matrix.pythonversion}}
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{matrix.javaversion}}
     - name: Download python SDK
       uses: actions/download-artifact@v2
       with:
@@ -401,28 +450,11 @@ jobs:
     - name: Uncompress nodejs SDK
       run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
         ${{github.workspace}}/sdk/nodejs
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
     - run: python -m pip install pip twine
     - env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       name: Publish SDKs
       run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3
@@ -437,8 +469,6 @@ jobs:
         - 3.1.301
         goversion:
         - 1.19.x
-        javaversion:
-        - "11"
         nodeversion:
         - 16.x
         pythonversion:

--- a/provider-ci/providers/oci/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/oci/repo/.github/workflows/main.yml
@@ -305,6 +305,61 @@ jobs:
         - 16.x
         pythonversion:
         - "3.9"
+  publish_java_sdk:
+    continue-on-error: true
+    name: publish_java_sdk
+    needs: publish
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout Repo
+      uses: actions/checkout@v3
+    - name: Checkout Scripts Repo
+      uses: actions/checkout@v3
+      with:
+        path: ci-scripts
+        repository: pulumi/scripts
+    - name: Unshallow clone for tags
+      run: git fetch --prune --unshallow --tags
+    - name: Install Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: ${{matrix.goversion}}
+    - name: Install pulumictl
+      uses: jaxxstorm/action-install-gh-release@v1.5.0
+      with:
+        repo: pulumi/pulumictl
+    - name: Install Pulumi CLI
+      uses: pulumi/action-install-pulumi-cli@v2
+    - name: Setup Java
+      uses: actions/setup-java@v3
+      with:
+        cache: gradle
+        distribution: temurin
+        java-version: ${{matrix.javaversion}}
+    - name: Download java SDK
+      uses: actions/download-artifact@v2
+      with:
+        name: java-sdk.tar.gz
+        path: ${{ github.workspace}}/sdk/
+    - name: Uncompress java SDK
+      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
+        ${{github.workspace}}/sdk/java
+    - name: Set PACKAGE_VERSION to Env
+      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
+        $GITHUB_ENV
+    - name: Publish Java SDK
+      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
+      with:
+        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
+        build-root-directory: ./sdk/java
+        gradle-version: 7.4.1
+    strategy:
+      fail-fast: true
+      matrix:
+        goversion:
+        - 1.19.x
+        javaversion:
+        - "11"
   publish_sdk:
     name: publish_sdk
     needs: publish
@@ -342,12 +397,6 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{matrix.pythonversion}}
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{matrix.javaversion}}
     - name: Download python SDK
       uses: actions/download-artifact@v2
       with:
@@ -372,28 +421,11 @@ jobs:
     - name: Uncompress nodejs SDK
       run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
         ${{github.workspace}}/sdk/nodejs
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
     - run: python -m pip install pip twine
     - env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       name: Publish SDKs
       run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3
@@ -408,8 +440,6 @@ jobs:
         - 3.1.301
         goversion:
         - 1.19.x
-        javaversion:
-        - "11"
         nodeversion:
         - 16.x
         pythonversion:

--- a/provider-ci/providers/oci/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/oci/repo/.github/workflows/master.yml
@@ -305,6 +305,61 @@ jobs:
         - 16.x
         pythonversion:
         - "3.9"
+  publish_java_sdk:
+    continue-on-error: true
+    name: publish_java_sdk
+    needs: publish
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout Repo
+      uses: actions/checkout@v3
+    - name: Checkout Scripts Repo
+      uses: actions/checkout@v3
+      with:
+        path: ci-scripts
+        repository: pulumi/scripts
+    - name: Unshallow clone for tags
+      run: git fetch --prune --unshallow --tags
+    - name: Install Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: ${{matrix.goversion}}
+    - name: Install pulumictl
+      uses: jaxxstorm/action-install-gh-release@v1.5.0
+      with:
+        repo: pulumi/pulumictl
+    - name: Install Pulumi CLI
+      uses: pulumi/action-install-pulumi-cli@v2
+    - name: Setup Java
+      uses: actions/setup-java@v3
+      with:
+        cache: gradle
+        distribution: temurin
+        java-version: ${{matrix.javaversion}}
+    - name: Download java SDK
+      uses: actions/download-artifact@v2
+      with:
+        name: java-sdk.tar.gz
+        path: ${{ github.workspace}}/sdk/
+    - name: Uncompress java SDK
+      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
+        ${{github.workspace}}/sdk/java
+    - name: Set PACKAGE_VERSION to Env
+      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
+        $GITHUB_ENV
+    - name: Publish Java SDK
+      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
+      with:
+        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
+        build-root-directory: ./sdk/java
+        gradle-version: 7.4.1
+    strategy:
+      fail-fast: true
+      matrix:
+        goversion:
+        - 1.19.x
+        javaversion:
+        - "11"
   publish_sdk:
     name: publish_sdk
     needs: publish
@@ -342,12 +397,6 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{matrix.pythonversion}}
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{matrix.javaversion}}
     - name: Download python SDK
       uses: actions/download-artifact@v2
       with:
@@ -372,28 +421,11 @@ jobs:
     - name: Uncompress nodejs SDK
       run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
         ${{github.workspace}}/sdk/nodejs
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
     - run: python -m pip install pip twine
     - env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       name: Publish SDKs
       run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3
@@ -408,8 +440,6 @@ jobs:
         - 3.1.301
         goversion:
         - 1.19.x
-        javaversion:
-        - "11"
         nodeversion:
         - 16.x
         pythonversion:

--- a/provider-ci/providers/oci/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/oci/repo/.github/workflows/prerelease.yml
@@ -249,6 +249,61 @@ jobs:
         - 16.x
         pythonversion:
         - "3.9"
+  publish_java_sdk:
+    continue-on-error: true
+    name: publish_java_sdk
+    needs: publish
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout Repo
+      uses: actions/checkout@v3
+    - name: Checkout Scripts Repo
+      uses: actions/checkout@v3
+      with:
+        path: ci-scripts
+        repository: pulumi/scripts
+    - name: Unshallow clone for tags
+      run: git fetch --prune --unshallow --tags
+    - name: Install Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: ${{matrix.goversion}}
+    - name: Install pulumictl
+      uses: jaxxstorm/action-install-gh-release@v1.5.0
+      with:
+        repo: pulumi/pulumictl
+    - name: Install Pulumi CLI
+      uses: pulumi/action-install-pulumi-cli@v2
+    - name: Setup Java
+      uses: actions/setup-java@v3
+      with:
+        cache: gradle
+        distribution: temurin
+        java-version: ${{matrix.javaversion}}
+    - name: Download java SDK
+      uses: actions/download-artifact@v2
+      with:
+        name: java-sdk.tar.gz
+        path: ${{ github.workspace}}/sdk/
+    - name: Uncompress java SDK
+      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
+        ${{github.workspace}}/sdk/java
+    - name: Set PACKAGE_VERSION to Env
+      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
+        $GITHUB_ENV
+    - name: Publish Java SDK
+      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
+      with:
+        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
+        build-root-directory: ./sdk/java
+        gradle-version: 7.4.1
+    strategy:
+      fail-fast: true
+      matrix:
+        goversion:
+        - 1.19.x
+        javaversion:
+        - "11"
   publish_sdk:
     name: publish_sdk
     needs: publish
@@ -286,12 +341,6 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{matrix.pythonversion}}
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{matrix.javaversion}}
     - name: Download python SDK
       uses: actions/download-artifact@v2
       with:
@@ -316,28 +365,11 @@ jobs:
     - name: Uncompress nodejs SDK
       run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
         ${{github.workspace}}/sdk/nodejs
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
     - run: python -m pip install pip twine
     - env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       name: Publish SDKs
       run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3
@@ -352,8 +384,6 @@ jobs:
         - 3.1.301
         goversion:
         - 1.19.x
-        javaversion:
-        - "11"
         nodeversion:
         - 16.x
         pythonversion:

--- a/provider-ci/providers/oci/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/oci/repo/.github/workflows/release.yml
@@ -262,6 +262,61 @@ jobs:
         - 16.x
         pythonversion:
         - "3.9"
+  publish_java_sdk:
+    continue-on-error: true
+    name: publish_java_sdk
+    needs: publish
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout Repo
+      uses: actions/checkout@v3
+    - name: Checkout Scripts Repo
+      uses: actions/checkout@v3
+      with:
+        path: ci-scripts
+        repository: pulumi/scripts
+    - name: Unshallow clone for tags
+      run: git fetch --prune --unshallow --tags
+    - name: Install Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: ${{matrix.goversion}}
+    - name: Install pulumictl
+      uses: jaxxstorm/action-install-gh-release@v1.5.0
+      with:
+        repo: pulumi/pulumictl
+    - name: Install Pulumi CLI
+      uses: pulumi/action-install-pulumi-cli@v2
+    - name: Setup Java
+      uses: actions/setup-java@v3
+      with:
+        cache: gradle
+        distribution: temurin
+        java-version: ${{matrix.javaversion}}
+    - name: Download java SDK
+      uses: actions/download-artifact@v2
+      with:
+        name: java-sdk.tar.gz
+        path: ${{ github.workspace}}/sdk/
+    - name: Uncompress java SDK
+      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
+        ${{github.workspace}}/sdk/java
+    - name: Set PACKAGE_VERSION to Env
+      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
+        $GITHUB_ENV
+    - name: Publish Java SDK
+      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
+      with:
+        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
+        build-root-directory: ./sdk/java
+        gradle-version: 7.4.1
+    strategy:
+      fail-fast: true
+      matrix:
+        goversion:
+        - 1.19.x
+        javaversion:
+        - "11"
   publish_sdk:
     name: publish_sdk
     needs: publish
@@ -299,12 +354,6 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{matrix.pythonversion}}
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{matrix.javaversion}}
     - name: Download python SDK
       uses: actions/download-artifact@v2
       with:
@@ -329,28 +378,11 @@ jobs:
     - name: Uncompress nodejs SDK
       run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
         ${{github.workspace}}/sdk/nodejs
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
     - run: python -m pip install pip twine
     - env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       name: Publish SDKs
       run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3
@@ -365,8 +397,6 @@ jobs:
         - 3.1.301
         goversion:
         - 1.19.x
-        javaversion:
-        - "11"
         nodeversion:
         - 16.x
         pythonversion:

--- a/provider-ci/providers/okta/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/okta/repo/.github/workflows/main.yml
@@ -379,6 +379,61 @@ jobs:
         - 16.x
         pythonversion:
         - "3.9"
+  publish_java_sdk:
+    continue-on-error: true
+    name: publish_java_sdk
+    needs: publish
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout Repo
+      uses: actions/checkout@v3
+    - name: Checkout Scripts Repo
+      uses: actions/checkout@v3
+      with:
+        path: ci-scripts
+        repository: pulumi/scripts
+    - name: Unshallow clone for tags
+      run: git fetch --prune --unshallow --tags
+    - name: Install Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: ${{matrix.goversion}}
+    - name: Install pulumictl
+      uses: jaxxstorm/action-install-gh-release@v1.5.0
+      with:
+        repo: pulumi/pulumictl
+    - name: Install Pulumi CLI
+      uses: pulumi/action-install-pulumi-cli@v2
+    - name: Setup Java
+      uses: actions/setup-java@v3
+      with:
+        cache: gradle
+        distribution: temurin
+        java-version: ${{matrix.javaversion}}
+    - name: Download java SDK
+      uses: actions/download-artifact@v2
+      with:
+        name: java-sdk.tar.gz
+        path: ${{ github.workspace}}/sdk/
+    - name: Uncompress java SDK
+      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
+        ${{github.workspace}}/sdk/java
+    - name: Set PACKAGE_VERSION to Env
+      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
+        $GITHUB_ENV
+    - name: Publish Java SDK
+      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
+      with:
+        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
+        build-root-directory: ./sdk/java
+        gradle-version: 7.4.1
+    strategy:
+      fail-fast: true
+      matrix:
+        goversion:
+        - 1.19.x
+        javaversion:
+        - "11"
   publish_sdk:
     name: publish_sdk
     needs: publish
@@ -416,12 +471,6 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{matrix.pythonversion}}
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{matrix.javaversion}}
     - name: Download python SDK
       uses: actions/download-artifact@v2
       with:
@@ -446,28 +495,11 @@ jobs:
     - name: Uncompress nodejs SDK
       run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
         ${{github.workspace}}/sdk/nodejs
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
     - run: python -m pip install pip twine
     - env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       name: Publish SDKs
       run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3
@@ -482,8 +514,6 @@ jobs:
         - 3.1.301
         goversion:
         - 1.19.x
-        javaversion:
-        - "11"
         nodeversion:
         - 16.x
         pythonversion:

--- a/provider-ci/providers/okta/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/okta/repo/.github/workflows/master.yml
@@ -379,6 +379,61 @@ jobs:
         - 16.x
         pythonversion:
         - "3.9"
+  publish_java_sdk:
+    continue-on-error: true
+    name: publish_java_sdk
+    needs: publish
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout Repo
+      uses: actions/checkout@v3
+    - name: Checkout Scripts Repo
+      uses: actions/checkout@v3
+      with:
+        path: ci-scripts
+        repository: pulumi/scripts
+    - name: Unshallow clone for tags
+      run: git fetch --prune --unshallow --tags
+    - name: Install Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: ${{matrix.goversion}}
+    - name: Install pulumictl
+      uses: jaxxstorm/action-install-gh-release@v1.5.0
+      with:
+        repo: pulumi/pulumictl
+    - name: Install Pulumi CLI
+      uses: pulumi/action-install-pulumi-cli@v2
+    - name: Setup Java
+      uses: actions/setup-java@v3
+      with:
+        cache: gradle
+        distribution: temurin
+        java-version: ${{matrix.javaversion}}
+    - name: Download java SDK
+      uses: actions/download-artifact@v2
+      with:
+        name: java-sdk.tar.gz
+        path: ${{ github.workspace}}/sdk/
+    - name: Uncompress java SDK
+      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
+        ${{github.workspace}}/sdk/java
+    - name: Set PACKAGE_VERSION to Env
+      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
+        $GITHUB_ENV
+    - name: Publish Java SDK
+      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
+      with:
+        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
+        build-root-directory: ./sdk/java
+        gradle-version: 7.4.1
+    strategy:
+      fail-fast: true
+      matrix:
+        goversion:
+        - 1.19.x
+        javaversion:
+        - "11"
   publish_sdk:
     name: publish_sdk
     needs: publish
@@ -416,12 +471,6 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{matrix.pythonversion}}
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{matrix.javaversion}}
     - name: Download python SDK
       uses: actions/download-artifact@v2
       with:
@@ -446,28 +495,11 @@ jobs:
     - name: Uncompress nodejs SDK
       run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
         ${{github.workspace}}/sdk/nodejs
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
     - run: python -m pip install pip twine
     - env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       name: Publish SDKs
       run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3
@@ -482,8 +514,6 @@ jobs:
         - 3.1.301
         goversion:
         - 1.19.x
-        javaversion:
-        - "11"
         nodeversion:
         - 16.x
         pythonversion:

--- a/provider-ci/providers/okta/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/okta/repo/.github/workflows/prerelease.yml
@@ -323,6 +323,61 @@ jobs:
         - 16.x
         pythonversion:
         - "3.9"
+  publish_java_sdk:
+    continue-on-error: true
+    name: publish_java_sdk
+    needs: publish
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout Repo
+      uses: actions/checkout@v3
+    - name: Checkout Scripts Repo
+      uses: actions/checkout@v3
+      with:
+        path: ci-scripts
+        repository: pulumi/scripts
+    - name: Unshallow clone for tags
+      run: git fetch --prune --unshallow --tags
+    - name: Install Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: ${{matrix.goversion}}
+    - name: Install pulumictl
+      uses: jaxxstorm/action-install-gh-release@v1.5.0
+      with:
+        repo: pulumi/pulumictl
+    - name: Install Pulumi CLI
+      uses: pulumi/action-install-pulumi-cli@v2
+    - name: Setup Java
+      uses: actions/setup-java@v3
+      with:
+        cache: gradle
+        distribution: temurin
+        java-version: ${{matrix.javaversion}}
+    - name: Download java SDK
+      uses: actions/download-artifact@v2
+      with:
+        name: java-sdk.tar.gz
+        path: ${{ github.workspace}}/sdk/
+    - name: Uncompress java SDK
+      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
+        ${{github.workspace}}/sdk/java
+    - name: Set PACKAGE_VERSION to Env
+      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
+        $GITHUB_ENV
+    - name: Publish Java SDK
+      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
+      with:
+        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
+        build-root-directory: ./sdk/java
+        gradle-version: 7.4.1
+    strategy:
+      fail-fast: true
+      matrix:
+        goversion:
+        - 1.19.x
+        javaversion:
+        - "11"
   publish_sdk:
     name: publish_sdk
     needs: publish
@@ -360,12 +415,6 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{matrix.pythonversion}}
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{matrix.javaversion}}
     - name: Download python SDK
       uses: actions/download-artifact@v2
       with:
@@ -390,28 +439,11 @@ jobs:
     - name: Uncompress nodejs SDK
       run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
         ${{github.workspace}}/sdk/nodejs
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
     - run: python -m pip install pip twine
     - env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       name: Publish SDKs
       run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3
@@ -426,8 +458,6 @@ jobs:
         - 3.1.301
         goversion:
         - 1.19.x
-        javaversion:
-        - "11"
         nodeversion:
         - 16.x
         pythonversion:

--- a/provider-ci/providers/okta/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/okta/repo/.github/workflows/release.yml
@@ -336,6 +336,61 @@ jobs:
         - 16.x
         pythonversion:
         - "3.9"
+  publish_java_sdk:
+    continue-on-error: true
+    name: publish_java_sdk
+    needs: publish
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout Repo
+      uses: actions/checkout@v3
+    - name: Checkout Scripts Repo
+      uses: actions/checkout@v3
+      with:
+        path: ci-scripts
+        repository: pulumi/scripts
+    - name: Unshallow clone for tags
+      run: git fetch --prune --unshallow --tags
+    - name: Install Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: ${{matrix.goversion}}
+    - name: Install pulumictl
+      uses: jaxxstorm/action-install-gh-release@v1.5.0
+      with:
+        repo: pulumi/pulumictl
+    - name: Install Pulumi CLI
+      uses: pulumi/action-install-pulumi-cli@v2
+    - name: Setup Java
+      uses: actions/setup-java@v3
+      with:
+        cache: gradle
+        distribution: temurin
+        java-version: ${{matrix.javaversion}}
+    - name: Download java SDK
+      uses: actions/download-artifact@v2
+      with:
+        name: java-sdk.tar.gz
+        path: ${{ github.workspace}}/sdk/
+    - name: Uncompress java SDK
+      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
+        ${{github.workspace}}/sdk/java
+    - name: Set PACKAGE_VERSION to Env
+      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
+        $GITHUB_ENV
+    - name: Publish Java SDK
+      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
+      with:
+        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
+        build-root-directory: ./sdk/java
+        gradle-version: 7.4.1
+    strategy:
+      fail-fast: true
+      matrix:
+        goversion:
+        - 1.19.x
+        javaversion:
+        - "11"
   publish_sdk:
     name: publish_sdk
     needs: publish
@@ -373,12 +428,6 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{matrix.pythonversion}}
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{matrix.javaversion}}
     - name: Download python SDK
       uses: actions/download-artifact@v2
       with:
@@ -403,28 +452,11 @@ jobs:
     - name: Uncompress nodejs SDK
       run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
         ${{github.workspace}}/sdk/nodejs
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
     - run: python -m pip install pip twine
     - env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       name: Publish SDKs
       run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3
@@ -439,8 +471,6 @@ jobs:
         - 3.1.301
         goversion:
         - 1.19.x
-        javaversion:
-        - "11"
         nodeversion:
         - 16.x
         pythonversion:

--- a/provider-ci/providers/onelogin/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/onelogin/repo/.github/workflows/main.yml
@@ -376,6 +376,61 @@ jobs:
         - 16.x
         pythonversion:
         - "3.9"
+  publish_java_sdk:
+    continue-on-error: true
+    name: publish_java_sdk
+    needs: publish
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout Repo
+      uses: actions/checkout@v3
+    - name: Checkout Scripts Repo
+      uses: actions/checkout@v3
+      with:
+        path: ci-scripts
+        repository: pulumi/scripts
+    - name: Unshallow clone for tags
+      run: git fetch --prune --unshallow --tags
+    - name: Install Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: ${{matrix.goversion}}
+    - name: Install pulumictl
+      uses: jaxxstorm/action-install-gh-release@v1.5.0
+      with:
+        repo: pulumi/pulumictl
+    - name: Install Pulumi CLI
+      uses: pulumi/action-install-pulumi-cli@v2
+    - name: Setup Java
+      uses: actions/setup-java@v3
+      with:
+        cache: gradle
+        distribution: temurin
+        java-version: ${{matrix.javaversion}}
+    - name: Download java SDK
+      uses: actions/download-artifact@v2
+      with:
+        name: java-sdk.tar.gz
+        path: ${{ github.workspace}}/sdk/
+    - name: Uncompress java SDK
+      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
+        ${{github.workspace}}/sdk/java
+    - name: Set PACKAGE_VERSION to Env
+      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
+        $GITHUB_ENV
+    - name: Publish Java SDK
+      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
+      with:
+        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
+        build-root-directory: ./sdk/java
+        gradle-version: 7.4.1
+    strategy:
+      fail-fast: true
+      matrix:
+        goversion:
+        - 1.19.x
+        javaversion:
+        - "11"
   publish_sdk:
     name: publish_sdk
     needs: publish
@@ -413,12 +468,6 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{matrix.pythonversion}}
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{matrix.javaversion}}
     - name: Download python SDK
       uses: actions/download-artifact@v2
       with:
@@ -443,28 +492,11 @@ jobs:
     - name: Uncompress nodejs SDK
       run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
         ${{github.workspace}}/sdk/nodejs
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
     - run: python -m pip install pip twine
     - env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       name: Publish SDKs
       run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3
@@ -479,8 +511,6 @@ jobs:
         - 3.1.301
         goversion:
         - 1.19.x
-        javaversion:
-        - "11"
         nodeversion:
         - 16.x
         pythonversion:

--- a/provider-ci/providers/onelogin/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/onelogin/repo/.github/workflows/master.yml
@@ -376,6 +376,61 @@ jobs:
         - 16.x
         pythonversion:
         - "3.9"
+  publish_java_sdk:
+    continue-on-error: true
+    name: publish_java_sdk
+    needs: publish
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout Repo
+      uses: actions/checkout@v3
+    - name: Checkout Scripts Repo
+      uses: actions/checkout@v3
+      with:
+        path: ci-scripts
+        repository: pulumi/scripts
+    - name: Unshallow clone for tags
+      run: git fetch --prune --unshallow --tags
+    - name: Install Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: ${{matrix.goversion}}
+    - name: Install pulumictl
+      uses: jaxxstorm/action-install-gh-release@v1.5.0
+      with:
+        repo: pulumi/pulumictl
+    - name: Install Pulumi CLI
+      uses: pulumi/action-install-pulumi-cli@v2
+    - name: Setup Java
+      uses: actions/setup-java@v3
+      with:
+        cache: gradle
+        distribution: temurin
+        java-version: ${{matrix.javaversion}}
+    - name: Download java SDK
+      uses: actions/download-artifact@v2
+      with:
+        name: java-sdk.tar.gz
+        path: ${{ github.workspace}}/sdk/
+    - name: Uncompress java SDK
+      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
+        ${{github.workspace}}/sdk/java
+    - name: Set PACKAGE_VERSION to Env
+      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
+        $GITHUB_ENV
+    - name: Publish Java SDK
+      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
+      with:
+        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
+        build-root-directory: ./sdk/java
+        gradle-version: 7.4.1
+    strategy:
+      fail-fast: true
+      matrix:
+        goversion:
+        - 1.19.x
+        javaversion:
+        - "11"
   publish_sdk:
     name: publish_sdk
     needs: publish
@@ -413,12 +468,6 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{matrix.pythonversion}}
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{matrix.javaversion}}
     - name: Download python SDK
       uses: actions/download-artifact@v2
       with:
@@ -443,28 +492,11 @@ jobs:
     - name: Uncompress nodejs SDK
       run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
         ${{github.workspace}}/sdk/nodejs
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
     - run: python -m pip install pip twine
     - env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       name: Publish SDKs
       run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3
@@ -479,8 +511,6 @@ jobs:
         - 3.1.301
         goversion:
         - 1.19.x
-        javaversion:
-        - "11"
         nodeversion:
         - 16.x
         pythonversion:

--- a/provider-ci/providers/onelogin/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/onelogin/repo/.github/workflows/prerelease.yml
@@ -320,6 +320,61 @@ jobs:
         - 16.x
         pythonversion:
         - "3.9"
+  publish_java_sdk:
+    continue-on-error: true
+    name: publish_java_sdk
+    needs: publish
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout Repo
+      uses: actions/checkout@v3
+    - name: Checkout Scripts Repo
+      uses: actions/checkout@v3
+      with:
+        path: ci-scripts
+        repository: pulumi/scripts
+    - name: Unshallow clone for tags
+      run: git fetch --prune --unshallow --tags
+    - name: Install Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: ${{matrix.goversion}}
+    - name: Install pulumictl
+      uses: jaxxstorm/action-install-gh-release@v1.5.0
+      with:
+        repo: pulumi/pulumictl
+    - name: Install Pulumi CLI
+      uses: pulumi/action-install-pulumi-cli@v2
+    - name: Setup Java
+      uses: actions/setup-java@v3
+      with:
+        cache: gradle
+        distribution: temurin
+        java-version: ${{matrix.javaversion}}
+    - name: Download java SDK
+      uses: actions/download-artifact@v2
+      with:
+        name: java-sdk.tar.gz
+        path: ${{ github.workspace}}/sdk/
+    - name: Uncompress java SDK
+      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
+        ${{github.workspace}}/sdk/java
+    - name: Set PACKAGE_VERSION to Env
+      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
+        $GITHUB_ENV
+    - name: Publish Java SDK
+      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
+      with:
+        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
+        build-root-directory: ./sdk/java
+        gradle-version: 7.4.1
+    strategy:
+      fail-fast: true
+      matrix:
+        goversion:
+        - 1.19.x
+        javaversion:
+        - "11"
   publish_sdk:
     name: publish_sdk
     needs: publish
@@ -357,12 +412,6 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{matrix.pythonversion}}
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{matrix.javaversion}}
     - name: Download python SDK
       uses: actions/download-artifact@v2
       with:
@@ -387,28 +436,11 @@ jobs:
     - name: Uncompress nodejs SDK
       run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
         ${{github.workspace}}/sdk/nodejs
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
     - run: python -m pip install pip twine
     - env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       name: Publish SDKs
       run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3
@@ -423,8 +455,6 @@ jobs:
         - 3.1.301
         goversion:
         - 1.19.x
-        javaversion:
-        - "11"
         nodeversion:
         - 16.x
         pythonversion:

--- a/provider-ci/providers/onelogin/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/onelogin/repo/.github/workflows/release.yml
@@ -333,6 +333,61 @@ jobs:
         - 16.x
         pythonversion:
         - "3.9"
+  publish_java_sdk:
+    continue-on-error: true
+    name: publish_java_sdk
+    needs: publish
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout Repo
+      uses: actions/checkout@v3
+    - name: Checkout Scripts Repo
+      uses: actions/checkout@v3
+      with:
+        path: ci-scripts
+        repository: pulumi/scripts
+    - name: Unshallow clone for tags
+      run: git fetch --prune --unshallow --tags
+    - name: Install Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: ${{matrix.goversion}}
+    - name: Install pulumictl
+      uses: jaxxstorm/action-install-gh-release@v1.5.0
+      with:
+        repo: pulumi/pulumictl
+    - name: Install Pulumi CLI
+      uses: pulumi/action-install-pulumi-cli@v2
+    - name: Setup Java
+      uses: actions/setup-java@v3
+      with:
+        cache: gradle
+        distribution: temurin
+        java-version: ${{matrix.javaversion}}
+    - name: Download java SDK
+      uses: actions/download-artifact@v2
+      with:
+        name: java-sdk.tar.gz
+        path: ${{ github.workspace}}/sdk/
+    - name: Uncompress java SDK
+      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
+        ${{github.workspace}}/sdk/java
+    - name: Set PACKAGE_VERSION to Env
+      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
+        $GITHUB_ENV
+    - name: Publish Java SDK
+      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
+      with:
+        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
+        build-root-directory: ./sdk/java
+        gradle-version: 7.4.1
+    strategy:
+      fail-fast: true
+      matrix:
+        goversion:
+        - 1.19.x
+        javaversion:
+        - "11"
   publish_sdk:
     name: publish_sdk
     needs: publish
@@ -370,12 +425,6 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{matrix.pythonversion}}
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{matrix.javaversion}}
     - name: Download python SDK
       uses: actions/download-artifact@v2
       with:
@@ -400,28 +449,11 @@ jobs:
     - name: Uncompress nodejs SDK
       run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
         ${{github.workspace}}/sdk/nodejs
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
     - run: python -m pip install pip twine
     - env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       name: Publish SDKs
       run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3
@@ -436,8 +468,6 @@ jobs:
         - 3.1.301
         goversion:
         - 1.19.x
-        javaversion:
-        - "11"
         nodeversion:
         - 16.x
         pythonversion:

--- a/provider-ci/providers/openstack/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/openstack/repo/.github/workflows/main.yml
@@ -385,6 +385,61 @@ jobs:
         - 16.x
         pythonversion:
         - "3.9"
+  publish_java_sdk:
+    continue-on-error: true
+    name: publish_java_sdk
+    needs: publish
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout Repo
+      uses: actions/checkout@v3
+    - name: Checkout Scripts Repo
+      uses: actions/checkout@v3
+      with:
+        path: ci-scripts
+        repository: pulumi/scripts
+    - name: Unshallow clone for tags
+      run: git fetch --prune --unshallow --tags
+    - name: Install Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: ${{matrix.goversion}}
+    - name: Install pulumictl
+      uses: jaxxstorm/action-install-gh-release@v1.5.0
+      with:
+        repo: pulumi/pulumictl
+    - name: Install Pulumi CLI
+      uses: pulumi/action-install-pulumi-cli@v2
+    - name: Setup Java
+      uses: actions/setup-java@v3
+      with:
+        cache: gradle
+        distribution: temurin
+        java-version: ${{matrix.javaversion}}
+    - name: Download java SDK
+      uses: actions/download-artifact@v2
+      with:
+        name: java-sdk.tar.gz
+        path: ${{ github.workspace}}/sdk/
+    - name: Uncompress java SDK
+      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
+        ${{github.workspace}}/sdk/java
+    - name: Set PACKAGE_VERSION to Env
+      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
+        $GITHUB_ENV
+    - name: Publish Java SDK
+      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
+      with:
+        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
+        build-root-directory: ./sdk/java
+        gradle-version: 7.4.1
+    strategy:
+      fail-fast: true
+      matrix:
+        goversion:
+        - 1.19.x
+        javaversion:
+        - "11"
   publish_sdk:
     name: publish_sdk
     needs: publish
@@ -422,12 +477,6 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{matrix.pythonversion}}
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{matrix.javaversion}}
     - name: Download python SDK
       uses: actions/download-artifact@v2
       with:
@@ -452,28 +501,11 @@ jobs:
     - name: Uncompress nodejs SDK
       run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
         ${{github.workspace}}/sdk/nodejs
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
     - run: python -m pip install pip twine
     - env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       name: Publish SDKs
       run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3
@@ -488,8 +520,6 @@ jobs:
         - 3.1.301
         goversion:
         - 1.19.x
-        javaversion:
-        - "11"
         nodeversion:
         - 16.x
         pythonversion:

--- a/provider-ci/providers/openstack/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/openstack/repo/.github/workflows/master.yml
@@ -385,6 +385,61 @@ jobs:
         - 16.x
         pythonversion:
         - "3.9"
+  publish_java_sdk:
+    continue-on-error: true
+    name: publish_java_sdk
+    needs: publish
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout Repo
+      uses: actions/checkout@v3
+    - name: Checkout Scripts Repo
+      uses: actions/checkout@v3
+      with:
+        path: ci-scripts
+        repository: pulumi/scripts
+    - name: Unshallow clone for tags
+      run: git fetch --prune --unshallow --tags
+    - name: Install Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: ${{matrix.goversion}}
+    - name: Install pulumictl
+      uses: jaxxstorm/action-install-gh-release@v1.5.0
+      with:
+        repo: pulumi/pulumictl
+    - name: Install Pulumi CLI
+      uses: pulumi/action-install-pulumi-cli@v2
+    - name: Setup Java
+      uses: actions/setup-java@v3
+      with:
+        cache: gradle
+        distribution: temurin
+        java-version: ${{matrix.javaversion}}
+    - name: Download java SDK
+      uses: actions/download-artifact@v2
+      with:
+        name: java-sdk.tar.gz
+        path: ${{ github.workspace}}/sdk/
+    - name: Uncompress java SDK
+      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
+        ${{github.workspace}}/sdk/java
+    - name: Set PACKAGE_VERSION to Env
+      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
+        $GITHUB_ENV
+    - name: Publish Java SDK
+      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
+      with:
+        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
+        build-root-directory: ./sdk/java
+        gradle-version: 7.4.1
+    strategy:
+      fail-fast: true
+      matrix:
+        goversion:
+        - 1.19.x
+        javaversion:
+        - "11"
   publish_sdk:
     name: publish_sdk
     needs: publish
@@ -422,12 +477,6 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{matrix.pythonversion}}
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{matrix.javaversion}}
     - name: Download python SDK
       uses: actions/download-artifact@v2
       with:
@@ -452,28 +501,11 @@ jobs:
     - name: Uncompress nodejs SDK
       run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
         ${{github.workspace}}/sdk/nodejs
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
     - run: python -m pip install pip twine
     - env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       name: Publish SDKs
       run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3
@@ -488,8 +520,6 @@ jobs:
         - 3.1.301
         goversion:
         - 1.19.x
-        javaversion:
-        - "11"
         nodeversion:
         - 16.x
         pythonversion:

--- a/provider-ci/providers/openstack/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/openstack/repo/.github/workflows/prerelease.yml
@@ -329,6 +329,61 @@ jobs:
         - 16.x
         pythonversion:
         - "3.9"
+  publish_java_sdk:
+    continue-on-error: true
+    name: publish_java_sdk
+    needs: publish
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout Repo
+      uses: actions/checkout@v3
+    - name: Checkout Scripts Repo
+      uses: actions/checkout@v3
+      with:
+        path: ci-scripts
+        repository: pulumi/scripts
+    - name: Unshallow clone for tags
+      run: git fetch --prune --unshallow --tags
+    - name: Install Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: ${{matrix.goversion}}
+    - name: Install pulumictl
+      uses: jaxxstorm/action-install-gh-release@v1.5.0
+      with:
+        repo: pulumi/pulumictl
+    - name: Install Pulumi CLI
+      uses: pulumi/action-install-pulumi-cli@v2
+    - name: Setup Java
+      uses: actions/setup-java@v3
+      with:
+        cache: gradle
+        distribution: temurin
+        java-version: ${{matrix.javaversion}}
+    - name: Download java SDK
+      uses: actions/download-artifact@v2
+      with:
+        name: java-sdk.tar.gz
+        path: ${{ github.workspace}}/sdk/
+    - name: Uncompress java SDK
+      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
+        ${{github.workspace}}/sdk/java
+    - name: Set PACKAGE_VERSION to Env
+      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
+        $GITHUB_ENV
+    - name: Publish Java SDK
+      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
+      with:
+        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
+        build-root-directory: ./sdk/java
+        gradle-version: 7.4.1
+    strategy:
+      fail-fast: true
+      matrix:
+        goversion:
+        - 1.19.x
+        javaversion:
+        - "11"
   publish_sdk:
     name: publish_sdk
     needs: publish
@@ -366,12 +421,6 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{matrix.pythonversion}}
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{matrix.javaversion}}
     - name: Download python SDK
       uses: actions/download-artifact@v2
       with:
@@ -396,28 +445,11 @@ jobs:
     - name: Uncompress nodejs SDK
       run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
         ${{github.workspace}}/sdk/nodejs
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
     - run: python -m pip install pip twine
     - env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       name: Publish SDKs
       run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3
@@ -432,8 +464,6 @@ jobs:
         - 3.1.301
         goversion:
         - 1.19.x
-        javaversion:
-        - "11"
         nodeversion:
         - 16.x
         pythonversion:

--- a/provider-ci/providers/openstack/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/openstack/repo/.github/workflows/release.yml
@@ -342,6 +342,61 @@ jobs:
         - 16.x
         pythonversion:
         - "3.9"
+  publish_java_sdk:
+    continue-on-error: true
+    name: publish_java_sdk
+    needs: publish
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout Repo
+      uses: actions/checkout@v3
+    - name: Checkout Scripts Repo
+      uses: actions/checkout@v3
+      with:
+        path: ci-scripts
+        repository: pulumi/scripts
+    - name: Unshallow clone for tags
+      run: git fetch --prune --unshallow --tags
+    - name: Install Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: ${{matrix.goversion}}
+    - name: Install pulumictl
+      uses: jaxxstorm/action-install-gh-release@v1.5.0
+      with:
+        repo: pulumi/pulumictl
+    - name: Install Pulumi CLI
+      uses: pulumi/action-install-pulumi-cli@v2
+    - name: Setup Java
+      uses: actions/setup-java@v3
+      with:
+        cache: gradle
+        distribution: temurin
+        java-version: ${{matrix.javaversion}}
+    - name: Download java SDK
+      uses: actions/download-artifact@v2
+      with:
+        name: java-sdk.tar.gz
+        path: ${{ github.workspace}}/sdk/
+    - name: Uncompress java SDK
+      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
+        ${{github.workspace}}/sdk/java
+    - name: Set PACKAGE_VERSION to Env
+      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
+        $GITHUB_ENV
+    - name: Publish Java SDK
+      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
+      with:
+        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
+        build-root-directory: ./sdk/java
+        gradle-version: 7.4.1
+    strategy:
+      fail-fast: true
+      matrix:
+        goversion:
+        - 1.19.x
+        javaversion:
+        - "11"
   publish_sdk:
     name: publish_sdk
     needs: publish
@@ -379,12 +434,6 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{matrix.pythonversion}}
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{matrix.javaversion}}
     - name: Download python SDK
       uses: actions/download-artifact@v2
       with:
@@ -409,28 +458,11 @@ jobs:
     - name: Uncompress nodejs SDK
       run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
         ${{github.workspace}}/sdk/nodejs
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
     - run: python -m pip install pip twine
     - env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       name: Publish SDKs
       run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3
@@ -445,8 +477,6 @@ jobs:
         - 3.1.301
         goversion:
         - 1.19.x
-        javaversion:
-        - "11"
         nodeversion:
         - 16.x
         pythonversion:

--- a/provider-ci/providers/opsgenie/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/opsgenie/repo/.github/workflows/main.yml
@@ -377,6 +377,61 @@ jobs:
         - 16.x
         pythonversion:
         - "3.9"
+  publish_java_sdk:
+    continue-on-error: true
+    name: publish_java_sdk
+    needs: publish
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout Repo
+      uses: actions/checkout@v3
+    - name: Checkout Scripts Repo
+      uses: actions/checkout@v3
+      with:
+        path: ci-scripts
+        repository: pulumi/scripts
+    - name: Unshallow clone for tags
+      run: git fetch --prune --unshallow --tags
+    - name: Install Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: ${{matrix.goversion}}
+    - name: Install pulumictl
+      uses: jaxxstorm/action-install-gh-release@v1.5.0
+      with:
+        repo: pulumi/pulumictl
+    - name: Install Pulumi CLI
+      uses: pulumi/action-install-pulumi-cli@v2
+    - name: Setup Java
+      uses: actions/setup-java@v3
+      with:
+        cache: gradle
+        distribution: temurin
+        java-version: ${{matrix.javaversion}}
+    - name: Download java SDK
+      uses: actions/download-artifact@v2
+      with:
+        name: java-sdk.tar.gz
+        path: ${{ github.workspace}}/sdk/
+    - name: Uncompress java SDK
+      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
+        ${{github.workspace}}/sdk/java
+    - name: Set PACKAGE_VERSION to Env
+      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
+        $GITHUB_ENV
+    - name: Publish Java SDK
+      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
+      with:
+        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
+        build-root-directory: ./sdk/java
+        gradle-version: 7.4.1
+    strategy:
+      fail-fast: true
+      matrix:
+        goversion:
+        - 1.19.x
+        javaversion:
+        - "11"
   publish_sdk:
     name: publish_sdk
     needs: publish
@@ -414,12 +469,6 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{matrix.pythonversion}}
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{matrix.javaversion}}
     - name: Download python SDK
       uses: actions/download-artifact@v2
       with:
@@ -444,28 +493,11 @@ jobs:
     - name: Uncompress nodejs SDK
       run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
         ${{github.workspace}}/sdk/nodejs
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
     - run: python -m pip install pip twine
     - env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       name: Publish SDKs
       run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3
@@ -480,8 +512,6 @@ jobs:
         - 3.1.301
         goversion:
         - 1.19.x
-        javaversion:
-        - "11"
         nodeversion:
         - 16.x
         pythonversion:

--- a/provider-ci/providers/opsgenie/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/opsgenie/repo/.github/workflows/master.yml
@@ -377,6 +377,61 @@ jobs:
         - 16.x
         pythonversion:
         - "3.9"
+  publish_java_sdk:
+    continue-on-error: true
+    name: publish_java_sdk
+    needs: publish
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout Repo
+      uses: actions/checkout@v3
+    - name: Checkout Scripts Repo
+      uses: actions/checkout@v3
+      with:
+        path: ci-scripts
+        repository: pulumi/scripts
+    - name: Unshallow clone for tags
+      run: git fetch --prune --unshallow --tags
+    - name: Install Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: ${{matrix.goversion}}
+    - name: Install pulumictl
+      uses: jaxxstorm/action-install-gh-release@v1.5.0
+      with:
+        repo: pulumi/pulumictl
+    - name: Install Pulumi CLI
+      uses: pulumi/action-install-pulumi-cli@v2
+    - name: Setup Java
+      uses: actions/setup-java@v3
+      with:
+        cache: gradle
+        distribution: temurin
+        java-version: ${{matrix.javaversion}}
+    - name: Download java SDK
+      uses: actions/download-artifact@v2
+      with:
+        name: java-sdk.tar.gz
+        path: ${{ github.workspace}}/sdk/
+    - name: Uncompress java SDK
+      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
+        ${{github.workspace}}/sdk/java
+    - name: Set PACKAGE_VERSION to Env
+      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
+        $GITHUB_ENV
+    - name: Publish Java SDK
+      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
+      with:
+        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
+        build-root-directory: ./sdk/java
+        gradle-version: 7.4.1
+    strategy:
+      fail-fast: true
+      matrix:
+        goversion:
+        - 1.19.x
+        javaversion:
+        - "11"
   publish_sdk:
     name: publish_sdk
     needs: publish
@@ -414,12 +469,6 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{matrix.pythonversion}}
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{matrix.javaversion}}
     - name: Download python SDK
       uses: actions/download-artifact@v2
       with:
@@ -444,28 +493,11 @@ jobs:
     - name: Uncompress nodejs SDK
       run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
         ${{github.workspace}}/sdk/nodejs
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
     - run: python -m pip install pip twine
     - env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       name: Publish SDKs
       run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3
@@ -480,8 +512,6 @@ jobs:
         - 3.1.301
         goversion:
         - 1.19.x
-        javaversion:
-        - "11"
         nodeversion:
         - 16.x
         pythonversion:

--- a/provider-ci/providers/opsgenie/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/opsgenie/repo/.github/workflows/prerelease.yml
@@ -321,6 +321,61 @@ jobs:
         - 16.x
         pythonversion:
         - "3.9"
+  publish_java_sdk:
+    continue-on-error: true
+    name: publish_java_sdk
+    needs: publish
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout Repo
+      uses: actions/checkout@v3
+    - name: Checkout Scripts Repo
+      uses: actions/checkout@v3
+      with:
+        path: ci-scripts
+        repository: pulumi/scripts
+    - name: Unshallow clone for tags
+      run: git fetch --prune --unshallow --tags
+    - name: Install Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: ${{matrix.goversion}}
+    - name: Install pulumictl
+      uses: jaxxstorm/action-install-gh-release@v1.5.0
+      with:
+        repo: pulumi/pulumictl
+    - name: Install Pulumi CLI
+      uses: pulumi/action-install-pulumi-cli@v2
+    - name: Setup Java
+      uses: actions/setup-java@v3
+      with:
+        cache: gradle
+        distribution: temurin
+        java-version: ${{matrix.javaversion}}
+    - name: Download java SDK
+      uses: actions/download-artifact@v2
+      with:
+        name: java-sdk.tar.gz
+        path: ${{ github.workspace}}/sdk/
+    - name: Uncompress java SDK
+      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
+        ${{github.workspace}}/sdk/java
+    - name: Set PACKAGE_VERSION to Env
+      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
+        $GITHUB_ENV
+    - name: Publish Java SDK
+      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
+      with:
+        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
+        build-root-directory: ./sdk/java
+        gradle-version: 7.4.1
+    strategy:
+      fail-fast: true
+      matrix:
+        goversion:
+        - 1.19.x
+        javaversion:
+        - "11"
   publish_sdk:
     name: publish_sdk
     needs: publish
@@ -358,12 +413,6 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{matrix.pythonversion}}
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{matrix.javaversion}}
     - name: Download python SDK
       uses: actions/download-artifact@v2
       with:
@@ -388,28 +437,11 @@ jobs:
     - name: Uncompress nodejs SDK
       run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
         ${{github.workspace}}/sdk/nodejs
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
     - run: python -m pip install pip twine
     - env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       name: Publish SDKs
       run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3
@@ -424,8 +456,6 @@ jobs:
         - 3.1.301
         goversion:
         - 1.19.x
-        javaversion:
-        - "11"
         nodeversion:
         - 16.x
         pythonversion:

--- a/provider-ci/providers/opsgenie/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/opsgenie/repo/.github/workflows/release.yml
@@ -334,6 +334,61 @@ jobs:
         - 16.x
         pythonversion:
         - "3.9"
+  publish_java_sdk:
+    continue-on-error: true
+    name: publish_java_sdk
+    needs: publish
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout Repo
+      uses: actions/checkout@v3
+    - name: Checkout Scripts Repo
+      uses: actions/checkout@v3
+      with:
+        path: ci-scripts
+        repository: pulumi/scripts
+    - name: Unshallow clone for tags
+      run: git fetch --prune --unshallow --tags
+    - name: Install Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: ${{matrix.goversion}}
+    - name: Install pulumictl
+      uses: jaxxstorm/action-install-gh-release@v1.5.0
+      with:
+        repo: pulumi/pulumictl
+    - name: Install Pulumi CLI
+      uses: pulumi/action-install-pulumi-cli@v2
+    - name: Setup Java
+      uses: actions/setup-java@v3
+      with:
+        cache: gradle
+        distribution: temurin
+        java-version: ${{matrix.javaversion}}
+    - name: Download java SDK
+      uses: actions/download-artifact@v2
+      with:
+        name: java-sdk.tar.gz
+        path: ${{ github.workspace}}/sdk/
+    - name: Uncompress java SDK
+      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
+        ${{github.workspace}}/sdk/java
+    - name: Set PACKAGE_VERSION to Env
+      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
+        $GITHUB_ENV
+    - name: Publish Java SDK
+      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
+      with:
+        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
+        build-root-directory: ./sdk/java
+        gradle-version: 7.4.1
+    strategy:
+      fail-fast: true
+      matrix:
+        goversion:
+        - 1.19.x
+        javaversion:
+        - "11"
   publish_sdk:
     name: publish_sdk
     needs: publish
@@ -371,12 +426,6 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{matrix.pythonversion}}
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{matrix.javaversion}}
     - name: Download python SDK
       uses: actions/download-artifact@v2
       with:
@@ -401,28 +450,11 @@ jobs:
     - name: Uncompress nodejs SDK
       run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
         ${{github.workspace}}/sdk/nodejs
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
     - run: python -m pip install pip twine
     - env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       name: Publish SDKs
       run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3
@@ -437,8 +469,6 @@ jobs:
         - 3.1.301
         goversion:
         - 1.19.x
-        javaversion:
-        - "11"
         nodeversion:
         - 16.x
         pythonversion:

--- a/provider-ci/providers/pagerduty/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/pagerduty/repo/.github/workflows/main.yml
@@ -377,6 +377,61 @@ jobs:
         - 16.x
         pythonversion:
         - "3.9"
+  publish_java_sdk:
+    continue-on-error: true
+    name: publish_java_sdk
+    needs: publish
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout Repo
+      uses: actions/checkout@v3
+    - name: Checkout Scripts Repo
+      uses: actions/checkout@v3
+      with:
+        path: ci-scripts
+        repository: pulumi/scripts
+    - name: Unshallow clone for tags
+      run: git fetch --prune --unshallow --tags
+    - name: Install Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: ${{matrix.goversion}}
+    - name: Install pulumictl
+      uses: jaxxstorm/action-install-gh-release@v1.5.0
+      with:
+        repo: pulumi/pulumictl
+    - name: Install Pulumi CLI
+      uses: pulumi/action-install-pulumi-cli@v2
+    - name: Setup Java
+      uses: actions/setup-java@v3
+      with:
+        cache: gradle
+        distribution: temurin
+        java-version: ${{matrix.javaversion}}
+    - name: Download java SDK
+      uses: actions/download-artifact@v2
+      with:
+        name: java-sdk.tar.gz
+        path: ${{ github.workspace}}/sdk/
+    - name: Uncompress java SDK
+      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
+        ${{github.workspace}}/sdk/java
+    - name: Set PACKAGE_VERSION to Env
+      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
+        $GITHUB_ENV
+    - name: Publish Java SDK
+      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
+      with:
+        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
+        build-root-directory: ./sdk/java
+        gradle-version: 7.4.1
+    strategy:
+      fail-fast: true
+      matrix:
+        goversion:
+        - 1.19.x
+        javaversion:
+        - "11"
   publish_sdk:
     name: publish_sdk
     needs: publish
@@ -414,12 +469,6 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{matrix.pythonversion}}
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{matrix.javaversion}}
     - name: Download python SDK
       uses: actions/download-artifact@v2
       with:
@@ -444,28 +493,11 @@ jobs:
     - name: Uncompress nodejs SDK
       run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
         ${{github.workspace}}/sdk/nodejs
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
     - run: python -m pip install pip twine
     - env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       name: Publish SDKs
       run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3
@@ -480,8 +512,6 @@ jobs:
         - 3.1.301
         goversion:
         - 1.19.x
-        javaversion:
-        - "11"
         nodeversion:
         - 16.x
         pythonversion:

--- a/provider-ci/providers/pagerduty/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/pagerduty/repo/.github/workflows/master.yml
@@ -377,6 +377,61 @@ jobs:
         - 16.x
         pythonversion:
         - "3.9"
+  publish_java_sdk:
+    continue-on-error: true
+    name: publish_java_sdk
+    needs: publish
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout Repo
+      uses: actions/checkout@v3
+    - name: Checkout Scripts Repo
+      uses: actions/checkout@v3
+      with:
+        path: ci-scripts
+        repository: pulumi/scripts
+    - name: Unshallow clone for tags
+      run: git fetch --prune --unshallow --tags
+    - name: Install Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: ${{matrix.goversion}}
+    - name: Install pulumictl
+      uses: jaxxstorm/action-install-gh-release@v1.5.0
+      with:
+        repo: pulumi/pulumictl
+    - name: Install Pulumi CLI
+      uses: pulumi/action-install-pulumi-cli@v2
+    - name: Setup Java
+      uses: actions/setup-java@v3
+      with:
+        cache: gradle
+        distribution: temurin
+        java-version: ${{matrix.javaversion}}
+    - name: Download java SDK
+      uses: actions/download-artifact@v2
+      with:
+        name: java-sdk.tar.gz
+        path: ${{ github.workspace}}/sdk/
+    - name: Uncompress java SDK
+      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
+        ${{github.workspace}}/sdk/java
+    - name: Set PACKAGE_VERSION to Env
+      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
+        $GITHUB_ENV
+    - name: Publish Java SDK
+      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
+      with:
+        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
+        build-root-directory: ./sdk/java
+        gradle-version: 7.4.1
+    strategy:
+      fail-fast: true
+      matrix:
+        goversion:
+        - 1.19.x
+        javaversion:
+        - "11"
   publish_sdk:
     name: publish_sdk
     needs: publish
@@ -414,12 +469,6 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{matrix.pythonversion}}
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{matrix.javaversion}}
     - name: Download python SDK
       uses: actions/download-artifact@v2
       with:
@@ -444,28 +493,11 @@ jobs:
     - name: Uncompress nodejs SDK
       run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
         ${{github.workspace}}/sdk/nodejs
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
     - run: python -m pip install pip twine
     - env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       name: Publish SDKs
       run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3
@@ -480,8 +512,6 @@ jobs:
         - 3.1.301
         goversion:
         - 1.19.x
-        javaversion:
-        - "11"
         nodeversion:
         - 16.x
         pythonversion:

--- a/provider-ci/providers/pagerduty/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/pagerduty/repo/.github/workflows/prerelease.yml
@@ -321,6 +321,61 @@ jobs:
         - 16.x
         pythonversion:
         - "3.9"
+  publish_java_sdk:
+    continue-on-error: true
+    name: publish_java_sdk
+    needs: publish
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout Repo
+      uses: actions/checkout@v3
+    - name: Checkout Scripts Repo
+      uses: actions/checkout@v3
+      with:
+        path: ci-scripts
+        repository: pulumi/scripts
+    - name: Unshallow clone for tags
+      run: git fetch --prune --unshallow --tags
+    - name: Install Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: ${{matrix.goversion}}
+    - name: Install pulumictl
+      uses: jaxxstorm/action-install-gh-release@v1.5.0
+      with:
+        repo: pulumi/pulumictl
+    - name: Install Pulumi CLI
+      uses: pulumi/action-install-pulumi-cli@v2
+    - name: Setup Java
+      uses: actions/setup-java@v3
+      with:
+        cache: gradle
+        distribution: temurin
+        java-version: ${{matrix.javaversion}}
+    - name: Download java SDK
+      uses: actions/download-artifact@v2
+      with:
+        name: java-sdk.tar.gz
+        path: ${{ github.workspace}}/sdk/
+    - name: Uncompress java SDK
+      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
+        ${{github.workspace}}/sdk/java
+    - name: Set PACKAGE_VERSION to Env
+      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
+        $GITHUB_ENV
+    - name: Publish Java SDK
+      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
+      with:
+        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
+        build-root-directory: ./sdk/java
+        gradle-version: 7.4.1
+    strategy:
+      fail-fast: true
+      matrix:
+        goversion:
+        - 1.19.x
+        javaversion:
+        - "11"
   publish_sdk:
     name: publish_sdk
     needs: publish
@@ -358,12 +413,6 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{matrix.pythonversion}}
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{matrix.javaversion}}
     - name: Download python SDK
       uses: actions/download-artifact@v2
       with:
@@ -388,28 +437,11 @@ jobs:
     - name: Uncompress nodejs SDK
       run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
         ${{github.workspace}}/sdk/nodejs
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
     - run: python -m pip install pip twine
     - env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       name: Publish SDKs
       run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3
@@ -424,8 +456,6 @@ jobs:
         - 3.1.301
         goversion:
         - 1.19.x
-        javaversion:
-        - "11"
         nodeversion:
         - 16.x
         pythonversion:

--- a/provider-ci/providers/pagerduty/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/pagerduty/repo/.github/workflows/release.yml
@@ -334,6 +334,61 @@ jobs:
         - 16.x
         pythonversion:
         - "3.9"
+  publish_java_sdk:
+    continue-on-error: true
+    name: publish_java_sdk
+    needs: publish
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout Repo
+      uses: actions/checkout@v3
+    - name: Checkout Scripts Repo
+      uses: actions/checkout@v3
+      with:
+        path: ci-scripts
+        repository: pulumi/scripts
+    - name: Unshallow clone for tags
+      run: git fetch --prune --unshallow --tags
+    - name: Install Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: ${{matrix.goversion}}
+    - name: Install pulumictl
+      uses: jaxxstorm/action-install-gh-release@v1.5.0
+      with:
+        repo: pulumi/pulumictl
+    - name: Install Pulumi CLI
+      uses: pulumi/action-install-pulumi-cli@v2
+    - name: Setup Java
+      uses: actions/setup-java@v3
+      with:
+        cache: gradle
+        distribution: temurin
+        java-version: ${{matrix.javaversion}}
+    - name: Download java SDK
+      uses: actions/download-artifact@v2
+      with:
+        name: java-sdk.tar.gz
+        path: ${{ github.workspace}}/sdk/
+    - name: Uncompress java SDK
+      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
+        ${{github.workspace}}/sdk/java
+    - name: Set PACKAGE_VERSION to Env
+      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
+        $GITHUB_ENV
+    - name: Publish Java SDK
+      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
+      with:
+        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
+        build-root-directory: ./sdk/java
+        gradle-version: 7.4.1
+    strategy:
+      fail-fast: true
+      matrix:
+        goversion:
+        - 1.19.x
+        javaversion:
+        - "11"
   publish_sdk:
     name: publish_sdk
     needs: publish
@@ -371,12 +426,6 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{matrix.pythonversion}}
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{matrix.javaversion}}
     - name: Download python SDK
       uses: actions/download-artifact@v2
       with:
@@ -401,28 +450,11 @@ jobs:
     - name: Uncompress nodejs SDK
       run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
         ${{github.workspace}}/sdk/nodejs
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
     - run: python -m pip install pip twine
     - env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       name: Publish SDKs
       run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3
@@ -437,8 +469,6 @@ jobs:
         - 3.1.301
         goversion:
         - 1.19.x
-        javaversion:
-        - "11"
         nodeversion:
         - 16.x
         pythonversion:

--- a/provider-ci/providers/postgresql/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/postgresql/repo/.github/workflows/main.yml
@@ -376,6 +376,61 @@ jobs:
         - 16.x
         pythonversion:
         - "3.9"
+  publish_java_sdk:
+    continue-on-error: true
+    name: publish_java_sdk
+    needs: publish
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout Repo
+      uses: actions/checkout@v3
+    - name: Checkout Scripts Repo
+      uses: actions/checkout@v3
+      with:
+        path: ci-scripts
+        repository: pulumi/scripts
+    - name: Unshallow clone for tags
+      run: git fetch --prune --unshallow --tags
+    - name: Install Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: ${{matrix.goversion}}
+    - name: Install pulumictl
+      uses: jaxxstorm/action-install-gh-release@v1.5.0
+      with:
+        repo: pulumi/pulumictl
+    - name: Install Pulumi CLI
+      uses: pulumi/action-install-pulumi-cli@v2
+    - name: Setup Java
+      uses: actions/setup-java@v3
+      with:
+        cache: gradle
+        distribution: temurin
+        java-version: ${{matrix.javaversion}}
+    - name: Download java SDK
+      uses: actions/download-artifact@v2
+      with:
+        name: java-sdk.tar.gz
+        path: ${{ github.workspace}}/sdk/
+    - name: Uncompress java SDK
+      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
+        ${{github.workspace}}/sdk/java
+    - name: Set PACKAGE_VERSION to Env
+      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
+        $GITHUB_ENV
+    - name: Publish Java SDK
+      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
+      with:
+        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
+        build-root-directory: ./sdk/java
+        gradle-version: 7.4.1
+    strategy:
+      fail-fast: true
+      matrix:
+        goversion:
+        - 1.19.x
+        javaversion:
+        - "11"
   publish_sdk:
     name: publish_sdk
     needs: publish
@@ -413,12 +468,6 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{matrix.pythonversion}}
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{matrix.javaversion}}
     - name: Download python SDK
       uses: actions/download-artifact@v2
       with:
@@ -443,28 +492,11 @@ jobs:
     - name: Uncompress nodejs SDK
       run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
         ${{github.workspace}}/sdk/nodejs
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
     - run: python -m pip install pip twine
     - env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       name: Publish SDKs
       run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3
@@ -479,8 +511,6 @@ jobs:
         - 3.1.301
         goversion:
         - 1.19.x
-        javaversion:
-        - "11"
         nodeversion:
         - 16.x
         pythonversion:

--- a/provider-ci/providers/postgresql/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/postgresql/repo/.github/workflows/master.yml
@@ -376,6 +376,61 @@ jobs:
         - 16.x
         pythonversion:
         - "3.9"
+  publish_java_sdk:
+    continue-on-error: true
+    name: publish_java_sdk
+    needs: publish
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout Repo
+      uses: actions/checkout@v3
+    - name: Checkout Scripts Repo
+      uses: actions/checkout@v3
+      with:
+        path: ci-scripts
+        repository: pulumi/scripts
+    - name: Unshallow clone for tags
+      run: git fetch --prune --unshallow --tags
+    - name: Install Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: ${{matrix.goversion}}
+    - name: Install pulumictl
+      uses: jaxxstorm/action-install-gh-release@v1.5.0
+      with:
+        repo: pulumi/pulumictl
+    - name: Install Pulumi CLI
+      uses: pulumi/action-install-pulumi-cli@v2
+    - name: Setup Java
+      uses: actions/setup-java@v3
+      with:
+        cache: gradle
+        distribution: temurin
+        java-version: ${{matrix.javaversion}}
+    - name: Download java SDK
+      uses: actions/download-artifact@v2
+      with:
+        name: java-sdk.tar.gz
+        path: ${{ github.workspace}}/sdk/
+    - name: Uncompress java SDK
+      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
+        ${{github.workspace}}/sdk/java
+    - name: Set PACKAGE_VERSION to Env
+      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
+        $GITHUB_ENV
+    - name: Publish Java SDK
+      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
+      with:
+        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
+        build-root-directory: ./sdk/java
+        gradle-version: 7.4.1
+    strategy:
+      fail-fast: true
+      matrix:
+        goversion:
+        - 1.19.x
+        javaversion:
+        - "11"
   publish_sdk:
     name: publish_sdk
     needs: publish
@@ -413,12 +468,6 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{matrix.pythonversion}}
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{matrix.javaversion}}
     - name: Download python SDK
       uses: actions/download-artifact@v2
       with:
@@ -443,28 +492,11 @@ jobs:
     - name: Uncompress nodejs SDK
       run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
         ${{github.workspace}}/sdk/nodejs
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
     - run: python -m pip install pip twine
     - env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       name: Publish SDKs
       run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3
@@ -479,8 +511,6 @@ jobs:
         - 3.1.301
         goversion:
         - 1.19.x
-        javaversion:
-        - "11"
         nodeversion:
         - 16.x
         pythonversion:

--- a/provider-ci/providers/postgresql/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/postgresql/repo/.github/workflows/prerelease.yml
@@ -320,6 +320,61 @@ jobs:
         - 16.x
         pythonversion:
         - "3.9"
+  publish_java_sdk:
+    continue-on-error: true
+    name: publish_java_sdk
+    needs: publish
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout Repo
+      uses: actions/checkout@v3
+    - name: Checkout Scripts Repo
+      uses: actions/checkout@v3
+      with:
+        path: ci-scripts
+        repository: pulumi/scripts
+    - name: Unshallow clone for tags
+      run: git fetch --prune --unshallow --tags
+    - name: Install Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: ${{matrix.goversion}}
+    - name: Install pulumictl
+      uses: jaxxstorm/action-install-gh-release@v1.5.0
+      with:
+        repo: pulumi/pulumictl
+    - name: Install Pulumi CLI
+      uses: pulumi/action-install-pulumi-cli@v2
+    - name: Setup Java
+      uses: actions/setup-java@v3
+      with:
+        cache: gradle
+        distribution: temurin
+        java-version: ${{matrix.javaversion}}
+    - name: Download java SDK
+      uses: actions/download-artifact@v2
+      with:
+        name: java-sdk.tar.gz
+        path: ${{ github.workspace}}/sdk/
+    - name: Uncompress java SDK
+      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
+        ${{github.workspace}}/sdk/java
+    - name: Set PACKAGE_VERSION to Env
+      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
+        $GITHUB_ENV
+    - name: Publish Java SDK
+      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
+      with:
+        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
+        build-root-directory: ./sdk/java
+        gradle-version: 7.4.1
+    strategy:
+      fail-fast: true
+      matrix:
+        goversion:
+        - 1.19.x
+        javaversion:
+        - "11"
   publish_sdk:
     name: publish_sdk
     needs: publish
@@ -357,12 +412,6 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{matrix.pythonversion}}
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{matrix.javaversion}}
     - name: Download python SDK
       uses: actions/download-artifact@v2
       with:
@@ -387,28 +436,11 @@ jobs:
     - name: Uncompress nodejs SDK
       run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
         ${{github.workspace}}/sdk/nodejs
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
     - run: python -m pip install pip twine
     - env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       name: Publish SDKs
       run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3
@@ -423,8 +455,6 @@ jobs:
         - 3.1.301
         goversion:
         - 1.19.x
-        javaversion:
-        - "11"
         nodeversion:
         - 16.x
         pythonversion:

--- a/provider-ci/providers/postgresql/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/postgresql/repo/.github/workflows/release.yml
@@ -333,6 +333,61 @@ jobs:
         - 16.x
         pythonversion:
         - "3.9"
+  publish_java_sdk:
+    continue-on-error: true
+    name: publish_java_sdk
+    needs: publish
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout Repo
+      uses: actions/checkout@v3
+    - name: Checkout Scripts Repo
+      uses: actions/checkout@v3
+      with:
+        path: ci-scripts
+        repository: pulumi/scripts
+    - name: Unshallow clone for tags
+      run: git fetch --prune --unshallow --tags
+    - name: Install Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: ${{matrix.goversion}}
+    - name: Install pulumictl
+      uses: jaxxstorm/action-install-gh-release@v1.5.0
+      with:
+        repo: pulumi/pulumictl
+    - name: Install Pulumi CLI
+      uses: pulumi/action-install-pulumi-cli@v2
+    - name: Setup Java
+      uses: actions/setup-java@v3
+      with:
+        cache: gradle
+        distribution: temurin
+        java-version: ${{matrix.javaversion}}
+    - name: Download java SDK
+      uses: actions/download-artifact@v2
+      with:
+        name: java-sdk.tar.gz
+        path: ${{ github.workspace}}/sdk/
+    - name: Uncompress java SDK
+      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
+        ${{github.workspace}}/sdk/java
+    - name: Set PACKAGE_VERSION to Env
+      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
+        $GITHUB_ENV
+    - name: Publish Java SDK
+      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
+      with:
+        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
+        build-root-directory: ./sdk/java
+        gradle-version: 7.4.1
+    strategy:
+      fail-fast: true
+      matrix:
+        goversion:
+        - 1.19.x
+        javaversion:
+        - "11"
   publish_sdk:
     name: publish_sdk
     needs: publish
@@ -370,12 +425,6 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{matrix.pythonversion}}
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{matrix.javaversion}}
     - name: Download python SDK
       uses: actions/download-artifact@v2
       with:
@@ -400,28 +449,11 @@ jobs:
     - name: Uncompress nodejs SDK
       run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
         ${{github.workspace}}/sdk/nodejs
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
     - run: python -m pip install pip twine
     - env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       name: Publish SDKs
       run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3
@@ -436,8 +468,6 @@ jobs:
         - 3.1.301
         goversion:
         - 1.19.x
-        javaversion:
-        - "11"
         nodeversion:
         - 16.x
         pythonversion:

--- a/provider-ci/providers/rabbitmq/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/rabbitmq/repo/.github/workflows/main.yml
@@ -376,6 +376,61 @@ jobs:
         - 16.x
         pythonversion:
         - "3.9"
+  publish_java_sdk:
+    continue-on-error: true
+    name: publish_java_sdk
+    needs: publish
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout Repo
+      uses: actions/checkout@v3
+    - name: Checkout Scripts Repo
+      uses: actions/checkout@v3
+      with:
+        path: ci-scripts
+        repository: pulumi/scripts
+    - name: Unshallow clone for tags
+      run: git fetch --prune --unshallow --tags
+    - name: Install Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: ${{matrix.goversion}}
+    - name: Install pulumictl
+      uses: jaxxstorm/action-install-gh-release@v1.5.0
+      with:
+        repo: pulumi/pulumictl
+    - name: Install Pulumi CLI
+      uses: pulumi/action-install-pulumi-cli@v2
+    - name: Setup Java
+      uses: actions/setup-java@v3
+      with:
+        cache: gradle
+        distribution: temurin
+        java-version: ${{matrix.javaversion}}
+    - name: Download java SDK
+      uses: actions/download-artifact@v2
+      with:
+        name: java-sdk.tar.gz
+        path: ${{ github.workspace}}/sdk/
+    - name: Uncompress java SDK
+      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
+        ${{github.workspace}}/sdk/java
+    - name: Set PACKAGE_VERSION to Env
+      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
+        $GITHUB_ENV
+    - name: Publish Java SDK
+      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
+      with:
+        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
+        build-root-directory: ./sdk/java
+        gradle-version: 7.4.1
+    strategy:
+      fail-fast: true
+      matrix:
+        goversion:
+        - 1.19.x
+        javaversion:
+        - "11"
   publish_sdk:
     name: publish_sdk
     needs: publish
@@ -413,12 +468,6 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{matrix.pythonversion}}
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{matrix.javaversion}}
     - name: Download python SDK
       uses: actions/download-artifact@v2
       with:
@@ -443,28 +492,11 @@ jobs:
     - name: Uncompress nodejs SDK
       run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
         ${{github.workspace}}/sdk/nodejs
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
     - run: python -m pip install pip twine
     - env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       name: Publish SDKs
       run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3
@@ -479,8 +511,6 @@ jobs:
         - 3.1.301
         goversion:
         - 1.19.x
-        javaversion:
-        - "11"
         nodeversion:
         - 16.x
         pythonversion:

--- a/provider-ci/providers/rabbitmq/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/rabbitmq/repo/.github/workflows/master.yml
@@ -376,6 +376,61 @@ jobs:
         - 16.x
         pythonversion:
         - "3.9"
+  publish_java_sdk:
+    continue-on-error: true
+    name: publish_java_sdk
+    needs: publish
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout Repo
+      uses: actions/checkout@v3
+    - name: Checkout Scripts Repo
+      uses: actions/checkout@v3
+      with:
+        path: ci-scripts
+        repository: pulumi/scripts
+    - name: Unshallow clone for tags
+      run: git fetch --prune --unshallow --tags
+    - name: Install Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: ${{matrix.goversion}}
+    - name: Install pulumictl
+      uses: jaxxstorm/action-install-gh-release@v1.5.0
+      with:
+        repo: pulumi/pulumictl
+    - name: Install Pulumi CLI
+      uses: pulumi/action-install-pulumi-cli@v2
+    - name: Setup Java
+      uses: actions/setup-java@v3
+      with:
+        cache: gradle
+        distribution: temurin
+        java-version: ${{matrix.javaversion}}
+    - name: Download java SDK
+      uses: actions/download-artifact@v2
+      with:
+        name: java-sdk.tar.gz
+        path: ${{ github.workspace}}/sdk/
+    - name: Uncompress java SDK
+      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
+        ${{github.workspace}}/sdk/java
+    - name: Set PACKAGE_VERSION to Env
+      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
+        $GITHUB_ENV
+    - name: Publish Java SDK
+      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
+      with:
+        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
+        build-root-directory: ./sdk/java
+        gradle-version: 7.4.1
+    strategy:
+      fail-fast: true
+      matrix:
+        goversion:
+        - 1.19.x
+        javaversion:
+        - "11"
   publish_sdk:
     name: publish_sdk
     needs: publish
@@ -413,12 +468,6 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{matrix.pythonversion}}
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{matrix.javaversion}}
     - name: Download python SDK
       uses: actions/download-artifact@v2
       with:
@@ -443,28 +492,11 @@ jobs:
     - name: Uncompress nodejs SDK
       run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
         ${{github.workspace}}/sdk/nodejs
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
     - run: python -m pip install pip twine
     - env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       name: Publish SDKs
       run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3
@@ -479,8 +511,6 @@ jobs:
         - 3.1.301
         goversion:
         - 1.19.x
-        javaversion:
-        - "11"
         nodeversion:
         - 16.x
         pythonversion:

--- a/provider-ci/providers/rabbitmq/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/rabbitmq/repo/.github/workflows/prerelease.yml
@@ -320,6 +320,61 @@ jobs:
         - 16.x
         pythonversion:
         - "3.9"
+  publish_java_sdk:
+    continue-on-error: true
+    name: publish_java_sdk
+    needs: publish
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout Repo
+      uses: actions/checkout@v3
+    - name: Checkout Scripts Repo
+      uses: actions/checkout@v3
+      with:
+        path: ci-scripts
+        repository: pulumi/scripts
+    - name: Unshallow clone for tags
+      run: git fetch --prune --unshallow --tags
+    - name: Install Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: ${{matrix.goversion}}
+    - name: Install pulumictl
+      uses: jaxxstorm/action-install-gh-release@v1.5.0
+      with:
+        repo: pulumi/pulumictl
+    - name: Install Pulumi CLI
+      uses: pulumi/action-install-pulumi-cli@v2
+    - name: Setup Java
+      uses: actions/setup-java@v3
+      with:
+        cache: gradle
+        distribution: temurin
+        java-version: ${{matrix.javaversion}}
+    - name: Download java SDK
+      uses: actions/download-artifact@v2
+      with:
+        name: java-sdk.tar.gz
+        path: ${{ github.workspace}}/sdk/
+    - name: Uncompress java SDK
+      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
+        ${{github.workspace}}/sdk/java
+    - name: Set PACKAGE_VERSION to Env
+      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
+        $GITHUB_ENV
+    - name: Publish Java SDK
+      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
+      with:
+        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
+        build-root-directory: ./sdk/java
+        gradle-version: 7.4.1
+    strategy:
+      fail-fast: true
+      matrix:
+        goversion:
+        - 1.19.x
+        javaversion:
+        - "11"
   publish_sdk:
     name: publish_sdk
     needs: publish
@@ -357,12 +412,6 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{matrix.pythonversion}}
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{matrix.javaversion}}
     - name: Download python SDK
       uses: actions/download-artifact@v2
       with:
@@ -387,28 +436,11 @@ jobs:
     - name: Uncompress nodejs SDK
       run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
         ${{github.workspace}}/sdk/nodejs
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
     - run: python -m pip install pip twine
     - env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       name: Publish SDKs
       run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3
@@ -423,8 +455,6 @@ jobs:
         - 3.1.301
         goversion:
         - 1.19.x
-        javaversion:
-        - "11"
         nodeversion:
         - 16.x
         pythonversion:

--- a/provider-ci/providers/rabbitmq/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/rabbitmq/repo/.github/workflows/release.yml
@@ -333,6 +333,61 @@ jobs:
         - 16.x
         pythonversion:
         - "3.9"
+  publish_java_sdk:
+    continue-on-error: true
+    name: publish_java_sdk
+    needs: publish
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout Repo
+      uses: actions/checkout@v3
+    - name: Checkout Scripts Repo
+      uses: actions/checkout@v3
+      with:
+        path: ci-scripts
+        repository: pulumi/scripts
+    - name: Unshallow clone for tags
+      run: git fetch --prune --unshallow --tags
+    - name: Install Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: ${{matrix.goversion}}
+    - name: Install pulumictl
+      uses: jaxxstorm/action-install-gh-release@v1.5.0
+      with:
+        repo: pulumi/pulumictl
+    - name: Install Pulumi CLI
+      uses: pulumi/action-install-pulumi-cli@v2
+    - name: Setup Java
+      uses: actions/setup-java@v3
+      with:
+        cache: gradle
+        distribution: temurin
+        java-version: ${{matrix.javaversion}}
+    - name: Download java SDK
+      uses: actions/download-artifact@v2
+      with:
+        name: java-sdk.tar.gz
+        path: ${{ github.workspace}}/sdk/
+    - name: Uncompress java SDK
+      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
+        ${{github.workspace}}/sdk/java
+    - name: Set PACKAGE_VERSION to Env
+      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
+        $GITHUB_ENV
+    - name: Publish Java SDK
+      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
+      with:
+        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
+        build-root-directory: ./sdk/java
+        gradle-version: 7.4.1
+    strategy:
+      fail-fast: true
+      matrix:
+        goversion:
+        - 1.19.x
+        javaversion:
+        - "11"
   publish_sdk:
     name: publish_sdk
     needs: publish
@@ -370,12 +425,6 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{matrix.pythonversion}}
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{matrix.javaversion}}
     - name: Download python SDK
       uses: actions/download-artifact@v2
       with:
@@ -400,28 +449,11 @@ jobs:
     - name: Uncompress nodejs SDK
       run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
         ${{github.workspace}}/sdk/nodejs
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
     - run: python -m pip install pip twine
     - env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       name: Publish SDKs
       run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3
@@ -436,8 +468,6 @@ jobs:
         - 3.1.301
         goversion:
         - 1.19.x
-        javaversion:
-        - "11"
         nodeversion:
         - 16.x
         pythonversion:

--- a/provider-ci/providers/rancher2/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/rancher2/repo/.github/workflows/main.yml
@@ -303,6 +303,61 @@ jobs:
         - 16.x
         pythonversion:
         - "3.9"
+  publish_java_sdk:
+    continue-on-error: true
+    name: publish_java_sdk
+    needs: publish
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout Repo
+      uses: actions/checkout@v3
+    - name: Checkout Scripts Repo
+      uses: actions/checkout@v3
+      with:
+        path: ci-scripts
+        repository: pulumi/scripts
+    - name: Unshallow clone for tags
+      run: git fetch --prune --unshallow --tags
+    - name: Install Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: ${{matrix.goversion}}
+    - name: Install pulumictl
+      uses: jaxxstorm/action-install-gh-release@v1.5.0
+      with:
+        repo: pulumi/pulumictl
+    - name: Install Pulumi CLI
+      uses: pulumi/action-install-pulumi-cli@v2
+    - name: Setup Java
+      uses: actions/setup-java@v3
+      with:
+        cache: gradle
+        distribution: temurin
+        java-version: ${{matrix.javaversion}}
+    - name: Download java SDK
+      uses: actions/download-artifact@v2
+      with:
+        name: java-sdk.tar.gz
+        path: ${{ github.workspace}}/sdk/
+    - name: Uncompress java SDK
+      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
+        ${{github.workspace}}/sdk/java
+    - name: Set PACKAGE_VERSION to Env
+      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
+        $GITHUB_ENV
+    - name: Publish Java SDK
+      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
+      with:
+        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
+        build-root-directory: ./sdk/java
+        gradle-version: 7.4.1
+    strategy:
+      fail-fast: true
+      matrix:
+        goversion:
+        - 1.19.x
+        javaversion:
+        - "11"
   publish_sdk:
     name: publish_sdk
     needs: publish
@@ -340,12 +395,6 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{matrix.pythonversion}}
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{matrix.javaversion}}
     - name: Download python SDK
       uses: actions/download-artifact@v2
       with:
@@ -370,28 +419,11 @@ jobs:
     - name: Uncompress nodejs SDK
       run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
         ${{github.workspace}}/sdk/nodejs
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
     - run: python -m pip install pip twine
     - env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       name: Publish SDKs
       run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3
@@ -406,8 +438,6 @@ jobs:
         - 3.1.301
         goversion:
         - 1.19.x
-        javaversion:
-        - "11"
         nodeversion:
         - 16.x
         pythonversion:

--- a/provider-ci/providers/rancher2/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/rancher2/repo/.github/workflows/master.yml
@@ -303,6 +303,61 @@ jobs:
         - 16.x
         pythonversion:
         - "3.9"
+  publish_java_sdk:
+    continue-on-error: true
+    name: publish_java_sdk
+    needs: publish
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout Repo
+      uses: actions/checkout@v3
+    - name: Checkout Scripts Repo
+      uses: actions/checkout@v3
+      with:
+        path: ci-scripts
+        repository: pulumi/scripts
+    - name: Unshallow clone for tags
+      run: git fetch --prune --unshallow --tags
+    - name: Install Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: ${{matrix.goversion}}
+    - name: Install pulumictl
+      uses: jaxxstorm/action-install-gh-release@v1.5.0
+      with:
+        repo: pulumi/pulumictl
+    - name: Install Pulumi CLI
+      uses: pulumi/action-install-pulumi-cli@v2
+    - name: Setup Java
+      uses: actions/setup-java@v3
+      with:
+        cache: gradle
+        distribution: temurin
+        java-version: ${{matrix.javaversion}}
+    - name: Download java SDK
+      uses: actions/download-artifact@v2
+      with:
+        name: java-sdk.tar.gz
+        path: ${{ github.workspace}}/sdk/
+    - name: Uncompress java SDK
+      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
+        ${{github.workspace}}/sdk/java
+    - name: Set PACKAGE_VERSION to Env
+      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
+        $GITHUB_ENV
+    - name: Publish Java SDK
+      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
+      with:
+        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
+        build-root-directory: ./sdk/java
+        gradle-version: 7.4.1
+    strategy:
+      fail-fast: true
+      matrix:
+        goversion:
+        - 1.19.x
+        javaversion:
+        - "11"
   publish_sdk:
     name: publish_sdk
     needs: publish
@@ -340,12 +395,6 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{matrix.pythonversion}}
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{matrix.javaversion}}
     - name: Download python SDK
       uses: actions/download-artifact@v2
       with:
@@ -370,28 +419,11 @@ jobs:
     - name: Uncompress nodejs SDK
       run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
         ${{github.workspace}}/sdk/nodejs
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
     - run: python -m pip install pip twine
     - env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       name: Publish SDKs
       run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3
@@ -406,8 +438,6 @@ jobs:
         - 3.1.301
         goversion:
         - 1.19.x
-        javaversion:
-        - "11"
         nodeversion:
         - 16.x
         pythonversion:

--- a/provider-ci/providers/rancher2/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/rancher2/repo/.github/workflows/prerelease.yml
@@ -247,6 +247,61 @@ jobs:
         - 16.x
         pythonversion:
         - "3.9"
+  publish_java_sdk:
+    continue-on-error: true
+    name: publish_java_sdk
+    needs: publish
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout Repo
+      uses: actions/checkout@v3
+    - name: Checkout Scripts Repo
+      uses: actions/checkout@v3
+      with:
+        path: ci-scripts
+        repository: pulumi/scripts
+    - name: Unshallow clone for tags
+      run: git fetch --prune --unshallow --tags
+    - name: Install Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: ${{matrix.goversion}}
+    - name: Install pulumictl
+      uses: jaxxstorm/action-install-gh-release@v1.5.0
+      with:
+        repo: pulumi/pulumictl
+    - name: Install Pulumi CLI
+      uses: pulumi/action-install-pulumi-cli@v2
+    - name: Setup Java
+      uses: actions/setup-java@v3
+      with:
+        cache: gradle
+        distribution: temurin
+        java-version: ${{matrix.javaversion}}
+    - name: Download java SDK
+      uses: actions/download-artifact@v2
+      with:
+        name: java-sdk.tar.gz
+        path: ${{ github.workspace}}/sdk/
+    - name: Uncompress java SDK
+      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
+        ${{github.workspace}}/sdk/java
+    - name: Set PACKAGE_VERSION to Env
+      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
+        $GITHUB_ENV
+    - name: Publish Java SDK
+      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
+      with:
+        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
+        build-root-directory: ./sdk/java
+        gradle-version: 7.4.1
+    strategy:
+      fail-fast: true
+      matrix:
+        goversion:
+        - 1.19.x
+        javaversion:
+        - "11"
   publish_sdk:
     name: publish_sdk
     needs: publish
@@ -284,12 +339,6 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{matrix.pythonversion}}
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{matrix.javaversion}}
     - name: Download python SDK
       uses: actions/download-artifact@v2
       with:
@@ -314,28 +363,11 @@ jobs:
     - name: Uncompress nodejs SDK
       run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
         ${{github.workspace}}/sdk/nodejs
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
     - run: python -m pip install pip twine
     - env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       name: Publish SDKs
       run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3
@@ -350,8 +382,6 @@ jobs:
         - 3.1.301
         goversion:
         - 1.19.x
-        javaversion:
-        - "11"
         nodeversion:
         - 16.x
         pythonversion:

--- a/provider-ci/providers/rancher2/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/rancher2/repo/.github/workflows/release.yml
@@ -260,6 +260,61 @@ jobs:
         - 16.x
         pythonversion:
         - "3.9"
+  publish_java_sdk:
+    continue-on-error: true
+    name: publish_java_sdk
+    needs: publish
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout Repo
+      uses: actions/checkout@v3
+    - name: Checkout Scripts Repo
+      uses: actions/checkout@v3
+      with:
+        path: ci-scripts
+        repository: pulumi/scripts
+    - name: Unshallow clone for tags
+      run: git fetch --prune --unshallow --tags
+    - name: Install Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: ${{matrix.goversion}}
+    - name: Install pulumictl
+      uses: jaxxstorm/action-install-gh-release@v1.5.0
+      with:
+        repo: pulumi/pulumictl
+    - name: Install Pulumi CLI
+      uses: pulumi/action-install-pulumi-cli@v2
+    - name: Setup Java
+      uses: actions/setup-java@v3
+      with:
+        cache: gradle
+        distribution: temurin
+        java-version: ${{matrix.javaversion}}
+    - name: Download java SDK
+      uses: actions/download-artifact@v2
+      with:
+        name: java-sdk.tar.gz
+        path: ${{ github.workspace}}/sdk/
+    - name: Uncompress java SDK
+      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
+        ${{github.workspace}}/sdk/java
+    - name: Set PACKAGE_VERSION to Env
+      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
+        $GITHUB_ENV
+    - name: Publish Java SDK
+      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
+      with:
+        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
+        build-root-directory: ./sdk/java
+        gradle-version: 7.4.1
+    strategy:
+      fail-fast: true
+      matrix:
+        goversion:
+        - 1.19.x
+        javaversion:
+        - "11"
   publish_sdk:
     name: publish_sdk
     needs: publish
@@ -297,12 +352,6 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{matrix.pythonversion}}
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{matrix.javaversion}}
     - name: Download python SDK
       uses: actions/download-artifact@v2
       with:
@@ -327,28 +376,11 @@ jobs:
     - name: Uncompress nodejs SDK
       run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
         ${{github.workspace}}/sdk/nodejs
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
     - run: python -m pip install pip twine
     - env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       name: Publish SDKs
       run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3
@@ -363,8 +395,6 @@ jobs:
         - 3.1.301
         goversion:
         - 1.19.x
-        javaversion:
-        - "11"
         nodeversion:
         - 16.x
         pythonversion:

--- a/provider-ci/providers/random/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/random/repo/.github/workflows/main.yml
@@ -376,6 +376,61 @@ jobs:
         - 16.x
         pythonversion:
         - "3.9"
+  publish_java_sdk:
+    continue-on-error: true
+    name: publish_java_sdk
+    needs: publish
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout Repo
+      uses: actions/checkout@v3
+    - name: Checkout Scripts Repo
+      uses: actions/checkout@v3
+      with:
+        path: ci-scripts
+        repository: pulumi/scripts
+    - name: Unshallow clone for tags
+      run: git fetch --prune --unshallow --tags
+    - name: Install Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: ${{matrix.goversion}}
+    - name: Install pulumictl
+      uses: jaxxstorm/action-install-gh-release@v1.5.0
+      with:
+        repo: pulumi/pulumictl
+    - name: Install Pulumi CLI
+      uses: pulumi/action-install-pulumi-cli@v2
+    - name: Setup Java
+      uses: actions/setup-java@v3
+      with:
+        cache: gradle
+        distribution: temurin
+        java-version: ${{matrix.javaversion}}
+    - name: Download java SDK
+      uses: actions/download-artifact@v2
+      with:
+        name: java-sdk.tar.gz
+        path: ${{ github.workspace}}/sdk/
+    - name: Uncompress java SDK
+      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
+        ${{github.workspace}}/sdk/java
+    - name: Set PACKAGE_VERSION to Env
+      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
+        $GITHUB_ENV
+    - name: Publish Java SDK
+      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
+      with:
+        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
+        build-root-directory: ./sdk/java
+        gradle-version: 7.4.1
+    strategy:
+      fail-fast: true
+      matrix:
+        goversion:
+        - 1.19.x
+        javaversion:
+        - "11"
   publish_sdk:
     name: publish_sdk
     needs: publish
@@ -413,12 +468,6 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{matrix.pythonversion}}
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{matrix.javaversion}}
     - name: Download python SDK
       uses: actions/download-artifact@v2
       with:
@@ -443,28 +492,11 @@ jobs:
     - name: Uncompress nodejs SDK
       run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
         ${{github.workspace}}/sdk/nodejs
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
     - run: python -m pip install pip twine
     - env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       name: Publish SDKs
       run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3
@@ -479,8 +511,6 @@ jobs:
         - 3.1.301
         goversion:
         - 1.19.x
-        javaversion:
-        - "11"
         nodeversion:
         - 16.x
         pythonversion:

--- a/provider-ci/providers/random/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/random/repo/.github/workflows/master.yml
@@ -376,6 +376,61 @@ jobs:
         - 16.x
         pythonversion:
         - "3.9"
+  publish_java_sdk:
+    continue-on-error: true
+    name: publish_java_sdk
+    needs: publish
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout Repo
+      uses: actions/checkout@v3
+    - name: Checkout Scripts Repo
+      uses: actions/checkout@v3
+      with:
+        path: ci-scripts
+        repository: pulumi/scripts
+    - name: Unshallow clone for tags
+      run: git fetch --prune --unshallow --tags
+    - name: Install Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: ${{matrix.goversion}}
+    - name: Install pulumictl
+      uses: jaxxstorm/action-install-gh-release@v1.5.0
+      with:
+        repo: pulumi/pulumictl
+    - name: Install Pulumi CLI
+      uses: pulumi/action-install-pulumi-cli@v2
+    - name: Setup Java
+      uses: actions/setup-java@v3
+      with:
+        cache: gradle
+        distribution: temurin
+        java-version: ${{matrix.javaversion}}
+    - name: Download java SDK
+      uses: actions/download-artifact@v2
+      with:
+        name: java-sdk.tar.gz
+        path: ${{ github.workspace}}/sdk/
+    - name: Uncompress java SDK
+      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
+        ${{github.workspace}}/sdk/java
+    - name: Set PACKAGE_VERSION to Env
+      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
+        $GITHUB_ENV
+    - name: Publish Java SDK
+      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
+      with:
+        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
+        build-root-directory: ./sdk/java
+        gradle-version: 7.4.1
+    strategy:
+      fail-fast: true
+      matrix:
+        goversion:
+        - 1.19.x
+        javaversion:
+        - "11"
   publish_sdk:
     name: publish_sdk
     needs: publish
@@ -413,12 +468,6 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{matrix.pythonversion}}
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{matrix.javaversion}}
     - name: Download python SDK
       uses: actions/download-artifact@v2
       with:
@@ -443,28 +492,11 @@ jobs:
     - name: Uncompress nodejs SDK
       run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
         ${{github.workspace}}/sdk/nodejs
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
     - run: python -m pip install pip twine
     - env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       name: Publish SDKs
       run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3
@@ -479,8 +511,6 @@ jobs:
         - 3.1.301
         goversion:
         - 1.19.x
-        javaversion:
-        - "11"
         nodeversion:
         - 16.x
         pythonversion:

--- a/provider-ci/providers/random/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/random/repo/.github/workflows/prerelease.yml
@@ -320,6 +320,61 @@ jobs:
         - 16.x
         pythonversion:
         - "3.9"
+  publish_java_sdk:
+    continue-on-error: true
+    name: publish_java_sdk
+    needs: publish
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout Repo
+      uses: actions/checkout@v3
+    - name: Checkout Scripts Repo
+      uses: actions/checkout@v3
+      with:
+        path: ci-scripts
+        repository: pulumi/scripts
+    - name: Unshallow clone for tags
+      run: git fetch --prune --unshallow --tags
+    - name: Install Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: ${{matrix.goversion}}
+    - name: Install pulumictl
+      uses: jaxxstorm/action-install-gh-release@v1.5.0
+      with:
+        repo: pulumi/pulumictl
+    - name: Install Pulumi CLI
+      uses: pulumi/action-install-pulumi-cli@v2
+    - name: Setup Java
+      uses: actions/setup-java@v3
+      with:
+        cache: gradle
+        distribution: temurin
+        java-version: ${{matrix.javaversion}}
+    - name: Download java SDK
+      uses: actions/download-artifact@v2
+      with:
+        name: java-sdk.tar.gz
+        path: ${{ github.workspace}}/sdk/
+    - name: Uncompress java SDK
+      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
+        ${{github.workspace}}/sdk/java
+    - name: Set PACKAGE_VERSION to Env
+      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
+        $GITHUB_ENV
+    - name: Publish Java SDK
+      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
+      with:
+        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
+        build-root-directory: ./sdk/java
+        gradle-version: 7.4.1
+    strategy:
+      fail-fast: true
+      matrix:
+        goversion:
+        - 1.19.x
+        javaversion:
+        - "11"
   publish_sdk:
     name: publish_sdk
     needs: publish
@@ -357,12 +412,6 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{matrix.pythonversion}}
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{matrix.javaversion}}
     - name: Download python SDK
       uses: actions/download-artifact@v2
       with:
@@ -387,28 +436,11 @@ jobs:
     - name: Uncompress nodejs SDK
       run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
         ${{github.workspace}}/sdk/nodejs
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
     - run: python -m pip install pip twine
     - env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       name: Publish SDKs
       run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3
@@ -423,8 +455,6 @@ jobs:
         - 3.1.301
         goversion:
         - 1.19.x
-        javaversion:
-        - "11"
         nodeversion:
         - 16.x
         pythonversion:

--- a/provider-ci/providers/random/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/random/repo/.github/workflows/release.yml
@@ -333,6 +333,61 @@ jobs:
         - 16.x
         pythonversion:
         - "3.9"
+  publish_java_sdk:
+    continue-on-error: true
+    name: publish_java_sdk
+    needs: publish
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout Repo
+      uses: actions/checkout@v3
+    - name: Checkout Scripts Repo
+      uses: actions/checkout@v3
+      with:
+        path: ci-scripts
+        repository: pulumi/scripts
+    - name: Unshallow clone for tags
+      run: git fetch --prune --unshallow --tags
+    - name: Install Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: ${{matrix.goversion}}
+    - name: Install pulumictl
+      uses: jaxxstorm/action-install-gh-release@v1.5.0
+      with:
+        repo: pulumi/pulumictl
+    - name: Install Pulumi CLI
+      uses: pulumi/action-install-pulumi-cli@v2
+    - name: Setup Java
+      uses: actions/setup-java@v3
+      with:
+        cache: gradle
+        distribution: temurin
+        java-version: ${{matrix.javaversion}}
+    - name: Download java SDK
+      uses: actions/download-artifact@v2
+      with:
+        name: java-sdk.tar.gz
+        path: ${{ github.workspace}}/sdk/
+    - name: Uncompress java SDK
+      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
+        ${{github.workspace}}/sdk/java
+    - name: Set PACKAGE_VERSION to Env
+      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
+        $GITHUB_ENV
+    - name: Publish Java SDK
+      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
+      with:
+        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
+        build-root-directory: ./sdk/java
+        gradle-version: 7.4.1
+    strategy:
+      fail-fast: true
+      matrix:
+        goversion:
+        - 1.19.x
+        javaversion:
+        - "11"
   publish_sdk:
     name: publish_sdk
     needs: publish
@@ -370,12 +425,6 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{matrix.pythonversion}}
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{matrix.javaversion}}
     - name: Download python SDK
       uses: actions/download-artifact@v2
       with:
@@ -400,28 +449,11 @@ jobs:
     - name: Uncompress nodejs SDK
       run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
         ${{github.workspace}}/sdk/nodejs
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
     - run: python -m pip install pip twine
     - env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       name: Publish SDKs
       run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3
@@ -436,8 +468,6 @@ jobs:
         - 3.1.301
         goversion:
         - 1.19.x
-        javaversion:
-        - "11"
         nodeversion:
         - 16.x
         pythonversion:

--- a/provider-ci/providers/rke/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/rke/repo/.github/workflows/main.yml
@@ -377,6 +377,61 @@ jobs:
         - 16.x
         pythonversion:
         - "3.9"
+  publish_java_sdk:
+    continue-on-error: true
+    name: publish_java_sdk
+    needs: publish
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout Repo
+      uses: actions/checkout@v3
+    - name: Checkout Scripts Repo
+      uses: actions/checkout@v3
+      with:
+        path: ci-scripts
+        repository: pulumi/scripts
+    - name: Unshallow clone for tags
+      run: git fetch --prune --unshallow --tags
+    - name: Install Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: ${{matrix.goversion}}
+    - name: Install pulumictl
+      uses: jaxxstorm/action-install-gh-release@v1.5.0
+      with:
+        repo: pulumi/pulumictl
+    - name: Install Pulumi CLI
+      uses: pulumi/action-install-pulumi-cli@v2
+    - name: Setup Java
+      uses: actions/setup-java@v3
+      with:
+        cache: gradle
+        distribution: temurin
+        java-version: ${{matrix.javaversion}}
+    - name: Download java SDK
+      uses: actions/download-artifact@v2
+      with:
+        name: java-sdk.tar.gz
+        path: ${{ github.workspace}}/sdk/
+    - name: Uncompress java SDK
+      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
+        ${{github.workspace}}/sdk/java
+    - name: Set PACKAGE_VERSION to Env
+      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
+        $GITHUB_ENV
+    - name: Publish Java SDK
+      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
+      with:
+        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
+        build-root-directory: ./sdk/java
+        gradle-version: 7.4.1
+    strategy:
+      fail-fast: true
+      matrix:
+        goversion:
+        - 1.19.x
+        javaversion:
+        - "11"
   publish_sdk:
     name: publish_sdk
     needs: publish
@@ -414,12 +469,6 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{matrix.pythonversion}}
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{matrix.javaversion}}
     - name: Download python SDK
       uses: actions/download-artifact@v2
       with:
@@ -444,28 +493,11 @@ jobs:
     - name: Uncompress nodejs SDK
       run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
         ${{github.workspace}}/sdk/nodejs
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
     - run: python -m pip install pip twine
     - env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       name: Publish SDKs
       run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3
@@ -480,8 +512,6 @@ jobs:
         - 3.1.301
         goversion:
         - 1.19.x
-        javaversion:
-        - "11"
         nodeversion:
         - 16.x
         pythonversion:

--- a/provider-ci/providers/rke/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/rke/repo/.github/workflows/master.yml
@@ -377,6 +377,61 @@ jobs:
         - 16.x
         pythonversion:
         - "3.9"
+  publish_java_sdk:
+    continue-on-error: true
+    name: publish_java_sdk
+    needs: publish
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout Repo
+      uses: actions/checkout@v3
+    - name: Checkout Scripts Repo
+      uses: actions/checkout@v3
+      with:
+        path: ci-scripts
+        repository: pulumi/scripts
+    - name: Unshallow clone for tags
+      run: git fetch --prune --unshallow --tags
+    - name: Install Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: ${{matrix.goversion}}
+    - name: Install pulumictl
+      uses: jaxxstorm/action-install-gh-release@v1.5.0
+      with:
+        repo: pulumi/pulumictl
+    - name: Install Pulumi CLI
+      uses: pulumi/action-install-pulumi-cli@v2
+    - name: Setup Java
+      uses: actions/setup-java@v3
+      with:
+        cache: gradle
+        distribution: temurin
+        java-version: ${{matrix.javaversion}}
+    - name: Download java SDK
+      uses: actions/download-artifact@v2
+      with:
+        name: java-sdk.tar.gz
+        path: ${{ github.workspace}}/sdk/
+    - name: Uncompress java SDK
+      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
+        ${{github.workspace}}/sdk/java
+    - name: Set PACKAGE_VERSION to Env
+      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
+        $GITHUB_ENV
+    - name: Publish Java SDK
+      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
+      with:
+        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
+        build-root-directory: ./sdk/java
+        gradle-version: 7.4.1
+    strategy:
+      fail-fast: true
+      matrix:
+        goversion:
+        - 1.19.x
+        javaversion:
+        - "11"
   publish_sdk:
     name: publish_sdk
     needs: publish
@@ -414,12 +469,6 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{matrix.pythonversion}}
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{matrix.javaversion}}
     - name: Download python SDK
       uses: actions/download-artifact@v2
       with:
@@ -444,28 +493,11 @@ jobs:
     - name: Uncompress nodejs SDK
       run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
         ${{github.workspace}}/sdk/nodejs
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
     - run: python -m pip install pip twine
     - env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       name: Publish SDKs
       run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3
@@ -480,8 +512,6 @@ jobs:
         - 3.1.301
         goversion:
         - 1.19.x
-        javaversion:
-        - "11"
         nodeversion:
         - 16.x
         pythonversion:

--- a/provider-ci/providers/rke/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/rke/repo/.github/workflows/prerelease.yml
@@ -321,6 +321,61 @@ jobs:
         - 16.x
         pythonversion:
         - "3.9"
+  publish_java_sdk:
+    continue-on-error: true
+    name: publish_java_sdk
+    needs: publish
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout Repo
+      uses: actions/checkout@v3
+    - name: Checkout Scripts Repo
+      uses: actions/checkout@v3
+      with:
+        path: ci-scripts
+        repository: pulumi/scripts
+    - name: Unshallow clone for tags
+      run: git fetch --prune --unshallow --tags
+    - name: Install Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: ${{matrix.goversion}}
+    - name: Install pulumictl
+      uses: jaxxstorm/action-install-gh-release@v1.5.0
+      with:
+        repo: pulumi/pulumictl
+    - name: Install Pulumi CLI
+      uses: pulumi/action-install-pulumi-cli@v2
+    - name: Setup Java
+      uses: actions/setup-java@v3
+      with:
+        cache: gradle
+        distribution: temurin
+        java-version: ${{matrix.javaversion}}
+    - name: Download java SDK
+      uses: actions/download-artifact@v2
+      with:
+        name: java-sdk.tar.gz
+        path: ${{ github.workspace}}/sdk/
+    - name: Uncompress java SDK
+      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
+        ${{github.workspace}}/sdk/java
+    - name: Set PACKAGE_VERSION to Env
+      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
+        $GITHUB_ENV
+    - name: Publish Java SDK
+      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
+      with:
+        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
+        build-root-directory: ./sdk/java
+        gradle-version: 7.4.1
+    strategy:
+      fail-fast: true
+      matrix:
+        goversion:
+        - 1.19.x
+        javaversion:
+        - "11"
   publish_sdk:
     name: publish_sdk
     needs: publish
@@ -358,12 +413,6 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{matrix.pythonversion}}
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{matrix.javaversion}}
     - name: Download python SDK
       uses: actions/download-artifact@v2
       with:
@@ -388,28 +437,11 @@ jobs:
     - name: Uncompress nodejs SDK
       run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
         ${{github.workspace}}/sdk/nodejs
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
     - run: python -m pip install pip twine
     - env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       name: Publish SDKs
       run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3
@@ -424,8 +456,6 @@ jobs:
         - 3.1.301
         goversion:
         - 1.19.x
-        javaversion:
-        - "11"
         nodeversion:
         - 16.x
         pythonversion:

--- a/provider-ci/providers/rke/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/rke/repo/.github/workflows/release.yml
@@ -334,6 +334,61 @@ jobs:
         - 16.x
         pythonversion:
         - "3.9"
+  publish_java_sdk:
+    continue-on-error: true
+    name: publish_java_sdk
+    needs: publish
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout Repo
+      uses: actions/checkout@v3
+    - name: Checkout Scripts Repo
+      uses: actions/checkout@v3
+      with:
+        path: ci-scripts
+        repository: pulumi/scripts
+    - name: Unshallow clone for tags
+      run: git fetch --prune --unshallow --tags
+    - name: Install Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: ${{matrix.goversion}}
+    - name: Install pulumictl
+      uses: jaxxstorm/action-install-gh-release@v1.5.0
+      with:
+        repo: pulumi/pulumictl
+    - name: Install Pulumi CLI
+      uses: pulumi/action-install-pulumi-cli@v2
+    - name: Setup Java
+      uses: actions/setup-java@v3
+      with:
+        cache: gradle
+        distribution: temurin
+        java-version: ${{matrix.javaversion}}
+    - name: Download java SDK
+      uses: actions/download-artifact@v2
+      with:
+        name: java-sdk.tar.gz
+        path: ${{ github.workspace}}/sdk/
+    - name: Uncompress java SDK
+      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
+        ${{github.workspace}}/sdk/java
+    - name: Set PACKAGE_VERSION to Env
+      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
+        $GITHUB_ENV
+    - name: Publish Java SDK
+      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
+      with:
+        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
+        build-root-directory: ./sdk/java
+        gradle-version: 7.4.1
+    strategy:
+      fail-fast: true
+      matrix:
+        goversion:
+        - 1.19.x
+        javaversion:
+        - "11"
   publish_sdk:
     name: publish_sdk
     needs: publish
@@ -371,12 +426,6 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{matrix.pythonversion}}
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{matrix.javaversion}}
     - name: Download python SDK
       uses: actions/download-artifact@v2
       with:
@@ -401,28 +450,11 @@ jobs:
     - name: Uncompress nodejs SDK
       run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
         ${{github.workspace}}/sdk/nodejs
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
     - run: python -m pip install pip twine
     - env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       name: Publish SDKs
       run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3
@@ -437,8 +469,6 @@ jobs:
         - 3.1.301
         goversion:
         - 1.19.x
-        javaversion:
-        - "11"
         nodeversion:
         - 16.x
         pythonversion:

--- a/provider-ci/providers/signalfx/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/signalfx/repo/.github/workflows/main.yml
@@ -376,6 +376,61 @@ jobs:
         - 16.x
         pythonversion:
         - "3.9"
+  publish_java_sdk:
+    continue-on-error: true
+    name: publish_java_sdk
+    needs: publish
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout Repo
+      uses: actions/checkout@v3
+    - name: Checkout Scripts Repo
+      uses: actions/checkout@v3
+      with:
+        path: ci-scripts
+        repository: pulumi/scripts
+    - name: Unshallow clone for tags
+      run: git fetch --prune --unshallow --tags
+    - name: Install Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: ${{matrix.goversion}}
+    - name: Install pulumictl
+      uses: jaxxstorm/action-install-gh-release@v1.5.0
+      with:
+        repo: pulumi/pulumictl
+    - name: Install Pulumi CLI
+      uses: pulumi/action-install-pulumi-cli@v2
+    - name: Setup Java
+      uses: actions/setup-java@v3
+      with:
+        cache: gradle
+        distribution: temurin
+        java-version: ${{matrix.javaversion}}
+    - name: Download java SDK
+      uses: actions/download-artifact@v2
+      with:
+        name: java-sdk.tar.gz
+        path: ${{ github.workspace}}/sdk/
+    - name: Uncompress java SDK
+      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
+        ${{github.workspace}}/sdk/java
+    - name: Set PACKAGE_VERSION to Env
+      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
+        $GITHUB_ENV
+    - name: Publish Java SDK
+      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
+      with:
+        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
+        build-root-directory: ./sdk/java
+        gradle-version: 7.4.1
+    strategy:
+      fail-fast: true
+      matrix:
+        goversion:
+        - 1.19.x
+        javaversion:
+        - "11"
   publish_sdk:
     name: publish_sdk
     needs: publish
@@ -413,12 +468,6 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{matrix.pythonversion}}
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{matrix.javaversion}}
     - name: Download python SDK
       uses: actions/download-artifact@v2
       with:
@@ -443,28 +492,11 @@ jobs:
     - name: Uncompress nodejs SDK
       run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
         ${{github.workspace}}/sdk/nodejs
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
     - run: python -m pip install pip twine
     - env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       name: Publish SDKs
       run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3
@@ -479,8 +511,6 @@ jobs:
         - 3.1.301
         goversion:
         - 1.19.x
-        javaversion:
-        - "11"
         nodeversion:
         - 16.x
         pythonversion:

--- a/provider-ci/providers/signalfx/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/signalfx/repo/.github/workflows/master.yml
@@ -376,6 +376,61 @@ jobs:
         - 16.x
         pythonversion:
         - "3.9"
+  publish_java_sdk:
+    continue-on-error: true
+    name: publish_java_sdk
+    needs: publish
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout Repo
+      uses: actions/checkout@v3
+    - name: Checkout Scripts Repo
+      uses: actions/checkout@v3
+      with:
+        path: ci-scripts
+        repository: pulumi/scripts
+    - name: Unshallow clone for tags
+      run: git fetch --prune --unshallow --tags
+    - name: Install Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: ${{matrix.goversion}}
+    - name: Install pulumictl
+      uses: jaxxstorm/action-install-gh-release@v1.5.0
+      with:
+        repo: pulumi/pulumictl
+    - name: Install Pulumi CLI
+      uses: pulumi/action-install-pulumi-cli@v2
+    - name: Setup Java
+      uses: actions/setup-java@v3
+      with:
+        cache: gradle
+        distribution: temurin
+        java-version: ${{matrix.javaversion}}
+    - name: Download java SDK
+      uses: actions/download-artifact@v2
+      with:
+        name: java-sdk.tar.gz
+        path: ${{ github.workspace}}/sdk/
+    - name: Uncompress java SDK
+      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
+        ${{github.workspace}}/sdk/java
+    - name: Set PACKAGE_VERSION to Env
+      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
+        $GITHUB_ENV
+    - name: Publish Java SDK
+      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
+      with:
+        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
+        build-root-directory: ./sdk/java
+        gradle-version: 7.4.1
+    strategy:
+      fail-fast: true
+      matrix:
+        goversion:
+        - 1.19.x
+        javaversion:
+        - "11"
   publish_sdk:
     name: publish_sdk
     needs: publish
@@ -413,12 +468,6 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{matrix.pythonversion}}
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{matrix.javaversion}}
     - name: Download python SDK
       uses: actions/download-artifact@v2
       with:
@@ -443,28 +492,11 @@ jobs:
     - name: Uncompress nodejs SDK
       run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
         ${{github.workspace}}/sdk/nodejs
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
     - run: python -m pip install pip twine
     - env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       name: Publish SDKs
       run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3
@@ -479,8 +511,6 @@ jobs:
         - 3.1.301
         goversion:
         - 1.19.x
-        javaversion:
-        - "11"
         nodeversion:
         - 16.x
         pythonversion:

--- a/provider-ci/providers/signalfx/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/signalfx/repo/.github/workflows/prerelease.yml
@@ -320,6 +320,61 @@ jobs:
         - 16.x
         pythonversion:
         - "3.9"
+  publish_java_sdk:
+    continue-on-error: true
+    name: publish_java_sdk
+    needs: publish
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout Repo
+      uses: actions/checkout@v3
+    - name: Checkout Scripts Repo
+      uses: actions/checkout@v3
+      with:
+        path: ci-scripts
+        repository: pulumi/scripts
+    - name: Unshallow clone for tags
+      run: git fetch --prune --unshallow --tags
+    - name: Install Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: ${{matrix.goversion}}
+    - name: Install pulumictl
+      uses: jaxxstorm/action-install-gh-release@v1.5.0
+      with:
+        repo: pulumi/pulumictl
+    - name: Install Pulumi CLI
+      uses: pulumi/action-install-pulumi-cli@v2
+    - name: Setup Java
+      uses: actions/setup-java@v3
+      with:
+        cache: gradle
+        distribution: temurin
+        java-version: ${{matrix.javaversion}}
+    - name: Download java SDK
+      uses: actions/download-artifact@v2
+      with:
+        name: java-sdk.tar.gz
+        path: ${{ github.workspace}}/sdk/
+    - name: Uncompress java SDK
+      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
+        ${{github.workspace}}/sdk/java
+    - name: Set PACKAGE_VERSION to Env
+      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
+        $GITHUB_ENV
+    - name: Publish Java SDK
+      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
+      with:
+        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
+        build-root-directory: ./sdk/java
+        gradle-version: 7.4.1
+    strategy:
+      fail-fast: true
+      matrix:
+        goversion:
+        - 1.19.x
+        javaversion:
+        - "11"
   publish_sdk:
     name: publish_sdk
     needs: publish
@@ -357,12 +412,6 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{matrix.pythonversion}}
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{matrix.javaversion}}
     - name: Download python SDK
       uses: actions/download-artifact@v2
       with:
@@ -387,28 +436,11 @@ jobs:
     - name: Uncompress nodejs SDK
       run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
         ${{github.workspace}}/sdk/nodejs
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
     - run: python -m pip install pip twine
     - env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       name: Publish SDKs
       run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3
@@ -423,8 +455,6 @@ jobs:
         - 3.1.301
         goversion:
         - 1.19.x
-        javaversion:
-        - "11"
         nodeversion:
         - 16.x
         pythonversion:

--- a/provider-ci/providers/signalfx/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/signalfx/repo/.github/workflows/release.yml
@@ -333,6 +333,61 @@ jobs:
         - 16.x
         pythonversion:
         - "3.9"
+  publish_java_sdk:
+    continue-on-error: true
+    name: publish_java_sdk
+    needs: publish
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout Repo
+      uses: actions/checkout@v3
+    - name: Checkout Scripts Repo
+      uses: actions/checkout@v3
+      with:
+        path: ci-scripts
+        repository: pulumi/scripts
+    - name: Unshallow clone for tags
+      run: git fetch --prune --unshallow --tags
+    - name: Install Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: ${{matrix.goversion}}
+    - name: Install pulumictl
+      uses: jaxxstorm/action-install-gh-release@v1.5.0
+      with:
+        repo: pulumi/pulumictl
+    - name: Install Pulumi CLI
+      uses: pulumi/action-install-pulumi-cli@v2
+    - name: Setup Java
+      uses: actions/setup-java@v3
+      with:
+        cache: gradle
+        distribution: temurin
+        java-version: ${{matrix.javaversion}}
+    - name: Download java SDK
+      uses: actions/download-artifact@v2
+      with:
+        name: java-sdk.tar.gz
+        path: ${{ github.workspace}}/sdk/
+    - name: Uncompress java SDK
+      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
+        ${{github.workspace}}/sdk/java
+    - name: Set PACKAGE_VERSION to Env
+      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
+        $GITHUB_ENV
+    - name: Publish Java SDK
+      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
+      with:
+        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
+        build-root-directory: ./sdk/java
+        gradle-version: 7.4.1
+    strategy:
+      fail-fast: true
+      matrix:
+        goversion:
+        - 1.19.x
+        javaversion:
+        - "11"
   publish_sdk:
     name: publish_sdk
     needs: publish
@@ -370,12 +425,6 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{matrix.pythonversion}}
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{matrix.javaversion}}
     - name: Download python SDK
       uses: actions/download-artifact@v2
       with:
@@ -400,28 +449,11 @@ jobs:
     - name: Uncompress nodejs SDK
       run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
         ${{github.workspace}}/sdk/nodejs
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
     - run: python -m pip install pip twine
     - env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       name: Publish SDKs
       run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3
@@ -436,8 +468,6 @@ jobs:
         - 3.1.301
         goversion:
         - 1.19.x
-        javaversion:
-        - "11"
         nodeversion:
         - 16.x
         pythonversion:

--- a/provider-ci/providers/slack/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/slack/repo/.github/workflows/main.yml
@@ -377,6 +377,61 @@ jobs:
         - 16.x
         pythonversion:
         - "3.9"
+  publish_java_sdk:
+    continue-on-error: true
+    name: publish_java_sdk
+    needs: publish
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout Repo
+      uses: actions/checkout@v3
+    - name: Checkout Scripts Repo
+      uses: actions/checkout@v3
+      with:
+        path: ci-scripts
+        repository: pulumi/scripts
+    - name: Unshallow clone for tags
+      run: git fetch --prune --unshallow --tags
+    - name: Install Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: ${{matrix.goversion}}
+    - name: Install pulumictl
+      uses: jaxxstorm/action-install-gh-release@v1.5.0
+      with:
+        repo: pulumi/pulumictl
+    - name: Install Pulumi CLI
+      uses: pulumi/action-install-pulumi-cli@v2
+    - name: Setup Java
+      uses: actions/setup-java@v3
+      with:
+        cache: gradle
+        distribution: temurin
+        java-version: ${{matrix.javaversion}}
+    - name: Download java SDK
+      uses: actions/download-artifact@v2
+      with:
+        name: java-sdk.tar.gz
+        path: ${{ github.workspace}}/sdk/
+    - name: Uncompress java SDK
+      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
+        ${{github.workspace}}/sdk/java
+    - name: Set PACKAGE_VERSION to Env
+      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
+        $GITHUB_ENV
+    - name: Publish Java SDK
+      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
+      with:
+        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
+        build-root-directory: ./sdk/java
+        gradle-version: 7.4.1
+    strategy:
+      fail-fast: true
+      matrix:
+        goversion:
+        - 1.19.x
+        javaversion:
+        - "11"
   publish_sdk:
     name: publish_sdk
     needs: publish
@@ -414,12 +469,6 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{matrix.pythonversion}}
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{matrix.javaversion}}
     - name: Download python SDK
       uses: actions/download-artifact@v2
       with:
@@ -444,28 +493,11 @@ jobs:
     - name: Uncompress nodejs SDK
       run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
         ${{github.workspace}}/sdk/nodejs
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
     - run: python -m pip install pip twine
     - env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       name: Publish SDKs
       run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3
@@ -480,8 +512,6 @@ jobs:
         - 3.1.301
         goversion:
         - 1.19.x
-        javaversion:
-        - "11"
         nodeversion:
         - 16.x
         pythonversion:

--- a/provider-ci/providers/slack/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/slack/repo/.github/workflows/master.yml
@@ -377,6 +377,61 @@ jobs:
         - 16.x
         pythonversion:
         - "3.9"
+  publish_java_sdk:
+    continue-on-error: true
+    name: publish_java_sdk
+    needs: publish
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout Repo
+      uses: actions/checkout@v3
+    - name: Checkout Scripts Repo
+      uses: actions/checkout@v3
+      with:
+        path: ci-scripts
+        repository: pulumi/scripts
+    - name: Unshallow clone for tags
+      run: git fetch --prune --unshallow --tags
+    - name: Install Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: ${{matrix.goversion}}
+    - name: Install pulumictl
+      uses: jaxxstorm/action-install-gh-release@v1.5.0
+      with:
+        repo: pulumi/pulumictl
+    - name: Install Pulumi CLI
+      uses: pulumi/action-install-pulumi-cli@v2
+    - name: Setup Java
+      uses: actions/setup-java@v3
+      with:
+        cache: gradle
+        distribution: temurin
+        java-version: ${{matrix.javaversion}}
+    - name: Download java SDK
+      uses: actions/download-artifact@v2
+      with:
+        name: java-sdk.tar.gz
+        path: ${{ github.workspace}}/sdk/
+    - name: Uncompress java SDK
+      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
+        ${{github.workspace}}/sdk/java
+    - name: Set PACKAGE_VERSION to Env
+      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
+        $GITHUB_ENV
+    - name: Publish Java SDK
+      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
+      with:
+        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
+        build-root-directory: ./sdk/java
+        gradle-version: 7.4.1
+    strategy:
+      fail-fast: true
+      matrix:
+        goversion:
+        - 1.19.x
+        javaversion:
+        - "11"
   publish_sdk:
     name: publish_sdk
     needs: publish
@@ -414,12 +469,6 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{matrix.pythonversion}}
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{matrix.javaversion}}
     - name: Download python SDK
       uses: actions/download-artifact@v2
       with:
@@ -444,28 +493,11 @@ jobs:
     - name: Uncompress nodejs SDK
       run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
         ${{github.workspace}}/sdk/nodejs
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
     - run: python -m pip install pip twine
     - env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       name: Publish SDKs
       run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3
@@ -480,8 +512,6 @@ jobs:
         - 3.1.301
         goversion:
         - 1.19.x
-        javaversion:
-        - "11"
         nodeversion:
         - 16.x
         pythonversion:

--- a/provider-ci/providers/slack/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/slack/repo/.github/workflows/prerelease.yml
@@ -321,6 +321,61 @@ jobs:
         - 16.x
         pythonversion:
         - "3.9"
+  publish_java_sdk:
+    continue-on-error: true
+    name: publish_java_sdk
+    needs: publish
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout Repo
+      uses: actions/checkout@v3
+    - name: Checkout Scripts Repo
+      uses: actions/checkout@v3
+      with:
+        path: ci-scripts
+        repository: pulumi/scripts
+    - name: Unshallow clone for tags
+      run: git fetch --prune --unshallow --tags
+    - name: Install Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: ${{matrix.goversion}}
+    - name: Install pulumictl
+      uses: jaxxstorm/action-install-gh-release@v1.5.0
+      with:
+        repo: pulumi/pulumictl
+    - name: Install Pulumi CLI
+      uses: pulumi/action-install-pulumi-cli@v2
+    - name: Setup Java
+      uses: actions/setup-java@v3
+      with:
+        cache: gradle
+        distribution: temurin
+        java-version: ${{matrix.javaversion}}
+    - name: Download java SDK
+      uses: actions/download-artifact@v2
+      with:
+        name: java-sdk.tar.gz
+        path: ${{ github.workspace}}/sdk/
+    - name: Uncompress java SDK
+      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
+        ${{github.workspace}}/sdk/java
+    - name: Set PACKAGE_VERSION to Env
+      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
+        $GITHUB_ENV
+    - name: Publish Java SDK
+      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
+      with:
+        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
+        build-root-directory: ./sdk/java
+        gradle-version: 7.4.1
+    strategy:
+      fail-fast: true
+      matrix:
+        goversion:
+        - 1.19.x
+        javaversion:
+        - "11"
   publish_sdk:
     name: publish_sdk
     needs: publish
@@ -358,12 +413,6 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{matrix.pythonversion}}
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{matrix.javaversion}}
     - name: Download python SDK
       uses: actions/download-artifact@v2
       with:
@@ -388,28 +437,11 @@ jobs:
     - name: Uncompress nodejs SDK
       run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
         ${{github.workspace}}/sdk/nodejs
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
     - run: python -m pip install pip twine
     - env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       name: Publish SDKs
       run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3
@@ -424,8 +456,6 @@ jobs:
         - 3.1.301
         goversion:
         - 1.19.x
-        javaversion:
-        - "11"
         nodeversion:
         - 16.x
         pythonversion:

--- a/provider-ci/providers/slack/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/slack/repo/.github/workflows/release.yml
@@ -334,6 +334,61 @@ jobs:
         - 16.x
         pythonversion:
         - "3.9"
+  publish_java_sdk:
+    continue-on-error: true
+    name: publish_java_sdk
+    needs: publish
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout Repo
+      uses: actions/checkout@v3
+    - name: Checkout Scripts Repo
+      uses: actions/checkout@v3
+      with:
+        path: ci-scripts
+        repository: pulumi/scripts
+    - name: Unshallow clone for tags
+      run: git fetch --prune --unshallow --tags
+    - name: Install Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: ${{matrix.goversion}}
+    - name: Install pulumictl
+      uses: jaxxstorm/action-install-gh-release@v1.5.0
+      with:
+        repo: pulumi/pulumictl
+    - name: Install Pulumi CLI
+      uses: pulumi/action-install-pulumi-cli@v2
+    - name: Setup Java
+      uses: actions/setup-java@v3
+      with:
+        cache: gradle
+        distribution: temurin
+        java-version: ${{matrix.javaversion}}
+    - name: Download java SDK
+      uses: actions/download-artifact@v2
+      with:
+        name: java-sdk.tar.gz
+        path: ${{ github.workspace}}/sdk/
+    - name: Uncompress java SDK
+      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
+        ${{github.workspace}}/sdk/java
+    - name: Set PACKAGE_VERSION to Env
+      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
+        $GITHUB_ENV
+    - name: Publish Java SDK
+      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
+      with:
+        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
+        build-root-directory: ./sdk/java
+        gradle-version: 7.4.1
+    strategy:
+      fail-fast: true
+      matrix:
+        goversion:
+        - 1.19.x
+        javaversion:
+        - "11"
   publish_sdk:
     name: publish_sdk
     needs: publish
@@ -371,12 +426,6 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{matrix.pythonversion}}
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{matrix.javaversion}}
     - name: Download python SDK
       uses: actions/download-artifact@v2
       with:
@@ -401,28 +450,11 @@ jobs:
     - name: Uncompress nodejs SDK
       run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
         ${{github.workspace}}/sdk/nodejs
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
     - run: python -m pip install pip twine
     - env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       name: Publish SDKs
       run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3
@@ -437,8 +469,6 @@ jobs:
         - 3.1.301
         goversion:
         - 1.19.x
-        javaversion:
-        - "11"
         nodeversion:
         - 16.x
         pythonversion:

--- a/provider-ci/providers/snowflake/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/snowflake/repo/.github/workflows/main.yml
@@ -381,6 +381,61 @@ jobs:
         - 16.x
         pythonversion:
         - "3.9"
+  publish_java_sdk:
+    continue-on-error: true
+    name: publish_java_sdk
+    needs: publish
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout Repo
+      uses: actions/checkout@v3
+    - name: Checkout Scripts Repo
+      uses: actions/checkout@v3
+      with:
+        path: ci-scripts
+        repository: pulumi/scripts
+    - name: Unshallow clone for tags
+      run: git fetch --prune --unshallow --tags
+    - name: Install Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: ${{matrix.goversion}}
+    - name: Install pulumictl
+      uses: jaxxstorm/action-install-gh-release@v1.5.0
+      with:
+        repo: pulumi/pulumictl
+    - name: Install Pulumi CLI
+      uses: pulumi/action-install-pulumi-cli@v2
+    - name: Setup Java
+      uses: actions/setup-java@v3
+      with:
+        cache: gradle
+        distribution: temurin
+        java-version: ${{matrix.javaversion}}
+    - name: Download java SDK
+      uses: actions/download-artifact@v2
+      with:
+        name: java-sdk.tar.gz
+        path: ${{ github.workspace}}/sdk/
+    - name: Uncompress java SDK
+      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
+        ${{github.workspace}}/sdk/java
+    - name: Set PACKAGE_VERSION to Env
+      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
+        $GITHUB_ENV
+    - name: Publish Java SDK
+      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
+      with:
+        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
+        build-root-directory: ./sdk/java
+        gradle-version: 7.4.1
+    strategy:
+      fail-fast: true
+      matrix:
+        goversion:
+        - 1.19.x
+        javaversion:
+        - "11"
   publish_sdk:
     name: publish_sdk
     needs: publish
@@ -418,12 +473,6 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{matrix.pythonversion}}
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{matrix.javaversion}}
     - name: Download python SDK
       uses: actions/download-artifact@v2
       with:
@@ -448,28 +497,11 @@ jobs:
     - name: Uncompress nodejs SDK
       run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
         ${{github.workspace}}/sdk/nodejs
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
     - run: python -m pip install pip twine
     - env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       name: Publish SDKs
       run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3
@@ -484,8 +516,6 @@ jobs:
         - 3.1.301
         goversion:
         - 1.19.x
-        javaversion:
-        - "11"
         nodeversion:
         - 16.x
         pythonversion:

--- a/provider-ci/providers/snowflake/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/snowflake/repo/.github/workflows/master.yml
@@ -381,6 +381,61 @@ jobs:
         - 16.x
         pythonversion:
         - "3.9"
+  publish_java_sdk:
+    continue-on-error: true
+    name: publish_java_sdk
+    needs: publish
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout Repo
+      uses: actions/checkout@v3
+    - name: Checkout Scripts Repo
+      uses: actions/checkout@v3
+      with:
+        path: ci-scripts
+        repository: pulumi/scripts
+    - name: Unshallow clone for tags
+      run: git fetch --prune --unshallow --tags
+    - name: Install Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: ${{matrix.goversion}}
+    - name: Install pulumictl
+      uses: jaxxstorm/action-install-gh-release@v1.5.0
+      with:
+        repo: pulumi/pulumictl
+    - name: Install Pulumi CLI
+      uses: pulumi/action-install-pulumi-cli@v2
+    - name: Setup Java
+      uses: actions/setup-java@v3
+      with:
+        cache: gradle
+        distribution: temurin
+        java-version: ${{matrix.javaversion}}
+    - name: Download java SDK
+      uses: actions/download-artifact@v2
+      with:
+        name: java-sdk.tar.gz
+        path: ${{ github.workspace}}/sdk/
+    - name: Uncompress java SDK
+      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
+        ${{github.workspace}}/sdk/java
+    - name: Set PACKAGE_VERSION to Env
+      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
+        $GITHUB_ENV
+    - name: Publish Java SDK
+      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
+      with:
+        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
+        build-root-directory: ./sdk/java
+        gradle-version: 7.4.1
+    strategy:
+      fail-fast: true
+      matrix:
+        goversion:
+        - 1.19.x
+        javaversion:
+        - "11"
   publish_sdk:
     name: publish_sdk
     needs: publish
@@ -418,12 +473,6 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{matrix.pythonversion}}
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{matrix.javaversion}}
     - name: Download python SDK
       uses: actions/download-artifact@v2
       with:
@@ -448,28 +497,11 @@ jobs:
     - name: Uncompress nodejs SDK
       run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
         ${{github.workspace}}/sdk/nodejs
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
     - run: python -m pip install pip twine
     - env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       name: Publish SDKs
       run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3
@@ -484,8 +516,6 @@ jobs:
         - 3.1.301
         goversion:
         - 1.19.x
-        javaversion:
-        - "11"
         nodeversion:
         - 16.x
         pythonversion:

--- a/provider-ci/providers/snowflake/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/snowflake/repo/.github/workflows/prerelease.yml
@@ -325,6 +325,61 @@ jobs:
         - 16.x
         pythonversion:
         - "3.9"
+  publish_java_sdk:
+    continue-on-error: true
+    name: publish_java_sdk
+    needs: publish
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout Repo
+      uses: actions/checkout@v3
+    - name: Checkout Scripts Repo
+      uses: actions/checkout@v3
+      with:
+        path: ci-scripts
+        repository: pulumi/scripts
+    - name: Unshallow clone for tags
+      run: git fetch --prune --unshallow --tags
+    - name: Install Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: ${{matrix.goversion}}
+    - name: Install pulumictl
+      uses: jaxxstorm/action-install-gh-release@v1.5.0
+      with:
+        repo: pulumi/pulumictl
+    - name: Install Pulumi CLI
+      uses: pulumi/action-install-pulumi-cli@v2
+    - name: Setup Java
+      uses: actions/setup-java@v3
+      with:
+        cache: gradle
+        distribution: temurin
+        java-version: ${{matrix.javaversion}}
+    - name: Download java SDK
+      uses: actions/download-artifact@v2
+      with:
+        name: java-sdk.tar.gz
+        path: ${{ github.workspace}}/sdk/
+    - name: Uncompress java SDK
+      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
+        ${{github.workspace}}/sdk/java
+    - name: Set PACKAGE_VERSION to Env
+      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
+        $GITHUB_ENV
+    - name: Publish Java SDK
+      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
+      with:
+        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
+        build-root-directory: ./sdk/java
+        gradle-version: 7.4.1
+    strategy:
+      fail-fast: true
+      matrix:
+        goversion:
+        - 1.19.x
+        javaversion:
+        - "11"
   publish_sdk:
     name: publish_sdk
     needs: publish
@@ -362,12 +417,6 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{matrix.pythonversion}}
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{matrix.javaversion}}
     - name: Download python SDK
       uses: actions/download-artifact@v2
       with:
@@ -392,28 +441,11 @@ jobs:
     - name: Uncompress nodejs SDK
       run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
         ${{github.workspace}}/sdk/nodejs
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
     - run: python -m pip install pip twine
     - env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       name: Publish SDKs
       run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3
@@ -428,8 +460,6 @@ jobs:
         - 3.1.301
         goversion:
         - 1.19.x
-        javaversion:
-        - "11"
         nodeversion:
         - 16.x
         pythonversion:

--- a/provider-ci/providers/snowflake/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/snowflake/repo/.github/workflows/release.yml
@@ -338,6 +338,61 @@ jobs:
         - 16.x
         pythonversion:
         - "3.9"
+  publish_java_sdk:
+    continue-on-error: true
+    name: publish_java_sdk
+    needs: publish
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout Repo
+      uses: actions/checkout@v3
+    - name: Checkout Scripts Repo
+      uses: actions/checkout@v3
+      with:
+        path: ci-scripts
+        repository: pulumi/scripts
+    - name: Unshallow clone for tags
+      run: git fetch --prune --unshallow --tags
+    - name: Install Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: ${{matrix.goversion}}
+    - name: Install pulumictl
+      uses: jaxxstorm/action-install-gh-release@v1.5.0
+      with:
+        repo: pulumi/pulumictl
+    - name: Install Pulumi CLI
+      uses: pulumi/action-install-pulumi-cli@v2
+    - name: Setup Java
+      uses: actions/setup-java@v3
+      with:
+        cache: gradle
+        distribution: temurin
+        java-version: ${{matrix.javaversion}}
+    - name: Download java SDK
+      uses: actions/download-artifact@v2
+      with:
+        name: java-sdk.tar.gz
+        path: ${{ github.workspace}}/sdk/
+    - name: Uncompress java SDK
+      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
+        ${{github.workspace}}/sdk/java
+    - name: Set PACKAGE_VERSION to Env
+      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
+        $GITHUB_ENV
+    - name: Publish Java SDK
+      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
+      with:
+        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
+        build-root-directory: ./sdk/java
+        gradle-version: 7.4.1
+    strategy:
+      fail-fast: true
+      matrix:
+        goversion:
+        - 1.19.x
+        javaversion:
+        - "11"
   publish_sdk:
     name: publish_sdk
     needs: publish
@@ -375,12 +430,6 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{matrix.pythonversion}}
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{matrix.javaversion}}
     - name: Download python SDK
       uses: actions/download-artifact@v2
       with:
@@ -405,28 +454,11 @@ jobs:
     - name: Uncompress nodejs SDK
       run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
         ${{github.workspace}}/sdk/nodejs
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
     - run: python -m pip install pip twine
     - env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       name: Publish SDKs
       run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3
@@ -441,8 +473,6 @@ jobs:
         - 3.1.301
         goversion:
         - 1.19.x
-        javaversion:
-        - "11"
         nodeversion:
         - 16.x
         pythonversion:

--- a/provider-ci/providers/splunk/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/splunk/repo/.github/workflows/main.yml
@@ -379,6 +379,61 @@ jobs:
         - 16.x
         pythonversion:
         - "3.9"
+  publish_java_sdk:
+    continue-on-error: true
+    name: publish_java_sdk
+    needs: publish
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout Repo
+      uses: actions/checkout@v3
+    - name: Checkout Scripts Repo
+      uses: actions/checkout@v3
+      with:
+        path: ci-scripts
+        repository: pulumi/scripts
+    - name: Unshallow clone for tags
+      run: git fetch --prune --unshallow --tags
+    - name: Install Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: ${{matrix.goversion}}
+    - name: Install pulumictl
+      uses: jaxxstorm/action-install-gh-release@v1.5.0
+      with:
+        repo: pulumi/pulumictl
+    - name: Install Pulumi CLI
+      uses: pulumi/action-install-pulumi-cli@v2
+    - name: Setup Java
+      uses: actions/setup-java@v3
+      with:
+        cache: gradle
+        distribution: temurin
+        java-version: ${{matrix.javaversion}}
+    - name: Download java SDK
+      uses: actions/download-artifact@v2
+      with:
+        name: java-sdk.tar.gz
+        path: ${{ github.workspace}}/sdk/
+    - name: Uncompress java SDK
+      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
+        ${{github.workspace}}/sdk/java
+    - name: Set PACKAGE_VERSION to Env
+      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
+        $GITHUB_ENV
+    - name: Publish Java SDK
+      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
+      with:
+        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
+        build-root-directory: ./sdk/java
+        gradle-version: 7.4.1
+    strategy:
+      fail-fast: true
+      matrix:
+        goversion:
+        - 1.19.x
+        javaversion:
+        - "11"
   publish_sdk:
     name: publish_sdk
     needs: publish
@@ -416,12 +471,6 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{matrix.pythonversion}}
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{matrix.javaversion}}
     - name: Download python SDK
       uses: actions/download-artifact@v2
       with:
@@ -446,28 +495,11 @@ jobs:
     - name: Uncompress nodejs SDK
       run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
         ${{github.workspace}}/sdk/nodejs
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
     - run: python -m pip install pip twine
     - env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       name: Publish SDKs
       run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3
@@ -482,8 +514,6 @@ jobs:
         - 3.1.301
         goversion:
         - 1.19.x
-        javaversion:
-        - "11"
         nodeversion:
         - 16.x
         pythonversion:

--- a/provider-ci/providers/splunk/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/splunk/repo/.github/workflows/master.yml
@@ -379,6 +379,61 @@ jobs:
         - 16.x
         pythonversion:
         - "3.9"
+  publish_java_sdk:
+    continue-on-error: true
+    name: publish_java_sdk
+    needs: publish
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout Repo
+      uses: actions/checkout@v3
+    - name: Checkout Scripts Repo
+      uses: actions/checkout@v3
+      with:
+        path: ci-scripts
+        repository: pulumi/scripts
+    - name: Unshallow clone for tags
+      run: git fetch --prune --unshallow --tags
+    - name: Install Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: ${{matrix.goversion}}
+    - name: Install pulumictl
+      uses: jaxxstorm/action-install-gh-release@v1.5.0
+      with:
+        repo: pulumi/pulumictl
+    - name: Install Pulumi CLI
+      uses: pulumi/action-install-pulumi-cli@v2
+    - name: Setup Java
+      uses: actions/setup-java@v3
+      with:
+        cache: gradle
+        distribution: temurin
+        java-version: ${{matrix.javaversion}}
+    - name: Download java SDK
+      uses: actions/download-artifact@v2
+      with:
+        name: java-sdk.tar.gz
+        path: ${{ github.workspace}}/sdk/
+    - name: Uncompress java SDK
+      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
+        ${{github.workspace}}/sdk/java
+    - name: Set PACKAGE_VERSION to Env
+      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
+        $GITHUB_ENV
+    - name: Publish Java SDK
+      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
+      with:
+        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
+        build-root-directory: ./sdk/java
+        gradle-version: 7.4.1
+    strategy:
+      fail-fast: true
+      matrix:
+        goversion:
+        - 1.19.x
+        javaversion:
+        - "11"
   publish_sdk:
     name: publish_sdk
     needs: publish
@@ -416,12 +471,6 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{matrix.pythonversion}}
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{matrix.javaversion}}
     - name: Download python SDK
       uses: actions/download-artifact@v2
       with:
@@ -446,28 +495,11 @@ jobs:
     - name: Uncompress nodejs SDK
       run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
         ${{github.workspace}}/sdk/nodejs
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
     - run: python -m pip install pip twine
     - env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       name: Publish SDKs
       run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3
@@ -482,8 +514,6 @@ jobs:
         - 3.1.301
         goversion:
         - 1.19.x
-        javaversion:
-        - "11"
         nodeversion:
         - 16.x
         pythonversion:

--- a/provider-ci/providers/splunk/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/splunk/repo/.github/workflows/prerelease.yml
@@ -323,6 +323,61 @@ jobs:
         - 16.x
         pythonversion:
         - "3.9"
+  publish_java_sdk:
+    continue-on-error: true
+    name: publish_java_sdk
+    needs: publish
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout Repo
+      uses: actions/checkout@v3
+    - name: Checkout Scripts Repo
+      uses: actions/checkout@v3
+      with:
+        path: ci-scripts
+        repository: pulumi/scripts
+    - name: Unshallow clone for tags
+      run: git fetch --prune --unshallow --tags
+    - name: Install Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: ${{matrix.goversion}}
+    - name: Install pulumictl
+      uses: jaxxstorm/action-install-gh-release@v1.5.0
+      with:
+        repo: pulumi/pulumictl
+    - name: Install Pulumi CLI
+      uses: pulumi/action-install-pulumi-cli@v2
+    - name: Setup Java
+      uses: actions/setup-java@v3
+      with:
+        cache: gradle
+        distribution: temurin
+        java-version: ${{matrix.javaversion}}
+    - name: Download java SDK
+      uses: actions/download-artifact@v2
+      with:
+        name: java-sdk.tar.gz
+        path: ${{ github.workspace}}/sdk/
+    - name: Uncompress java SDK
+      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
+        ${{github.workspace}}/sdk/java
+    - name: Set PACKAGE_VERSION to Env
+      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
+        $GITHUB_ENV
+    - name: Publish Java SDK
+      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
+      with:
+        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
+        build-root-directory: ./sdk/java
+        gradle-version: 7.4.1
+    strategy:
+      fail-fast: true
+      matrix:
+        goversion:
+        - 1.19.x
+        javaversion:
+        - "11"
   publish_sdk:
     name: publish_sdk
     needs: publish
@@ -360,12 +415,6 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{matrix.pythonversion}}
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{matrix.javaversion}}
     - name: Download python SDK
       uses: actions/download-artifact@v2
       with:
@@ -390,28 +439,11 @@ jobs:
     - name: Uncompress nodejs SDK
       run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
         ${{github.workspace}}/sdk/nodejs
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
     - run: python -m pip install pip twine
     - env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       name: Publish SDKs
       run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3
@@ -426,8 +458,6 @@ jobs:
         - 3.1.301
         goversion:
         - 1.19.x
-        javaversion:
-        - "11"
         nodeversion:
         - 16.x
         pythonversion:

--- a/provider-ci/providers/splunk/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/splunk/repo/.github/workflows/release.yml
@@ -336,6 +336,61 @@ jobs:
         - 16.x
         pythonversion:
         - "3.9"
+  publish_java_sdk:
+    continue-on-error: true
+    name: publish_java_sdk
+    needs: publish
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout Repo
+      uses: actions/checkout@v3
+    - name: Checkout Scripts Repo
+      uses: actions/checkout@v3
+      with:
+        path: ci-scripts
+        repository: pulumi/scripts
+    - name: Unshallow clone for tags
+      run: git fetch --prune --unshallow --tags
+    - name: Install Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: ${{matrix.goversion}}
+    - name: Install pulumictl
+      uses: jaxxstorm/action-install-gh-release@v1.5.0
+      with:
+        repo: pulumi/pulumictl
+    - name: Install Pulumi CLI
+      uses: pulumi/action-install-pulumi-cli@v2
+    - name: Setup Java
+      uses: actions/setup-java@v3
+      with:
+        cache: gradle
+        distribution: temurin
+        java-version: ${{matrix.javaversion}}
+    - name: Download java SDK
+      uses: actions/download-artifact@v2
+      with:
+        name: java-sdk.tar.gz
+        path: ${{ github.workspace}}/sdk/
+    - name: Uncompress java SDK
+      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
+        ${{github.workspace}}/sdk/java
+    - name: Set PACKAGE_VERSION to Env
+      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
+        $GITHUB_ENV
+    - name: Publish Java SDK
+      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
+      with:
+        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
+        build-root-directory: ./sdk/java
+        gradle-version: 7.4.1
+    strategy:
+      fail-fast: true
+      matrix:
+        goversion:
+        - 1.19.x
+        javaversion:
+        - "11"
   publish_sdk:
     name: publish_sdk
     needs: publish
@@ -373,12 +428,6 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{matrix.pythonversion}}
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{matrix.javaversion}}
     - name: Download python SDK
       uses: actions/download-artifact@v2
       with:
@@ -403,28 +452,11 @@ jobs:
     - name: Uncompress nodejs SDK
       run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
         ${{github.workspace}}/sdk/nodejs
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
     - run: python -m pip install pip twine
     - env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       name: Publish SDKs
       run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3
@@ -439,8 +471,6 @@ jobs:
         - 3.1.301
         goversion:
         - 1.19.x
-        javaversion:
-        - "11"
         nodeversion:
         - 16.x
         pythonversion:

--- a/provider-ci/providers/spotinst/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/spotinst/repo/.github/workflows/main.yml
@@ -379,6 +379,61 @@ jobs:
         - 16.x
         pythonversion:
         - "3.9"
+  publish_java_sdk:
+    continue-on-error: true
+    name: publish_java_sdk
+    needs: publish
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout Repo
+      uses: actions/checkout@v3
+    - name: Checkout Scripts Repo
+      uses: actions/checkout@v3
+      with:
+        path: ci-scripts
+        repository: pulumi/scripts
+    - name: Unshallow clone for tags
+      run: git fetch --prune --unshallow --tags
+    - name: Install Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: ${{matrix.goversion}}
+    - name: Install pulumictl
+      uses: jaxxstorm/action-install-gh-release@v1.5.0
+      with:
+        repo: pulumi/pulumictl
+    - name: Install Pulumi CLI
+      uses: pulumi/action-install-pulumi-cli@v2
+    - name: Setup Java
+      uses: actions/setup-java@v3
+      with:
+        cache: gradle
+        distribution: temurin
+        java-version: ${{matrix.javaversion}}
+    - name: Download java SDK
+      uses: actions/download-artifact@v2
+      with:
+        name: java-sdk.tar.gz
+        path: ${{ github.workspace}}/sdk/
+    - name: Uncompress java SDK
+      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
+        ${{github.workspace}}/sdk/java
+    - name: Set PACKAGE_VERSION to Env
+      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
+        $GITHUB_ENV
+    - name: Publish Java SDK
+      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
+      with:
+        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
+        build-root-directory: ./sdk/java
+        gradle-version: 7.4.1
+    strategy:
+      fail-fast: true
+      matrix:
+        goversion:
+        - 1.19.x
+        javaversion:
+        - "11"
   publish_sdk:
     name: publish_sdk
     needs: publish
@@ -416,12 +471,6 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{matrix.pythonversion}}
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{matrix.javaversion}}
     - name: Download python SDK
       uses: actions/download-artifact@v2
       with:
@@ -446,28 +495,11 @@ jobs:
     - name: Uncompress nodejs SDK
       run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
         ${{github.workspace}}/sdk/nodejs
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
     - run: python -m pip install pip twine
     - env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       name: Publish SDKs
       run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3
@@ -482,8 +514,6 @@ jobs:
         - 3.1.301
         goversion:
         - 1.19.x
-        javaversion:
-        - "11"
         nodeversion:
         - 16.x
         pythonversion:

--- a/provider-ci/providers/spotinst/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/spotinst/repo/.github/workflows/master.yml
@@ -379,6 +379,61 @@ jobs:
         - 16.x
         pythonversion:
         - "3.9"
+  publish_java_sdk:
+    continue-on-error: true
+    name: publish_java_sdk
+    needs: publish
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout Repo
+      uses: actions/checkout@v3
+    - name: Checkout Scripts Repo
+      uses: actions/checkout@v3
+      with:
+        path: ci-scripts
+        repository: pulumi/scripts
+    - name: Unshallow clone for tags
+      run: git fetch --prune --unshallow --tags
+    - name: Install Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: ${{matrix.goversion}}
+    - name: Install pulumictl
+      uses: jaxxstorm/action-install-gh-release@v1.5.0
+      with:
+        repo: pulumi/pulumictl
+    - name: Install Pulumi CLI
+      uses: pulumi/action-install-pulumi-cli@v2
+    - name: Setup Java
+      uses: actions/setup-java@v3
+      with:
+        cache: gradle
+        distribution: temurin
+        java-version: ${{matrix.javaversion}}
+    - name: Download java SDK
+      uses: actions/download-artifact@v2
+      with:
+        name: java-sdk.tar.gz
+        path: ${{ github.workspace}}/sdk/
+    - name: Uncompress java SDK
+      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
+        ${{github.workspace}}/sdk/java
+    - name: Set PACKAGE_VERSION to Env
+      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
+        $GITHUB_ENV
+    - name: Publish Java SDK
+      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
+      with:
+        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
+        build-root-directory: ./sdk/java
+        gradle-version: 7.4.1
+    strategy:
+      fail-fast: true
+      matrix:
+        goversion:
+        - 1.19.x
+        javaversion:
+        - "11"
   publish_sdk:
     name: publish_sdk
     needs: publish
@@ -416,12 +471,6 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{matrix.pythonversion}}
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{matrix.javaversion}}
     - name: Download python SDK
       uses: actions/download-artifact@v2
       with:
@@ -446,28 +495,11 @@ jobs:
     - name: Uncompress nodejs SDK
       run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
         ${{github.workspace}}/sdk/nodejs
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
     - run: python -m pip install pip twine
     - env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       name: Publish SDKs
       run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3
@@ -482,8 +514,6 @@ jobs:
         - 3.1.301
         goversion:
         - 1.19.x
-        javaversion:
-        - "11"
         nodeversion:
         - 16.x
         pythonversion:

--- a/provider-ci/providers/spotinst/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/spotinst/repo/.github/workflows/prerelease.yml
@@ -323,6 +323,61 @@ jobs:
         - 16.x
         pythonversion:
         - "3.9"
+  publish_java_sdk:
+    continue-on-error: true
+    name: publish_java_sdk
+    needs: publish
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout Repo
+      uses: actions/checkout@v3
+    - name: Checkout Scripts Repo
+      uses: actions/checkout@v3
+      with:
+        path: ci-scripts
+        repository: pulumi/scripts
+    - name: Unshallow clone for tags
+      run: git fetch --prune --unshallow --tags
+    - name: Install Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: ${{matrix.goversion}}
+    - name: Install pulumictl
+      uses: jaxxstorm/action-install-gh-release@v1.5.0
+      with:
+        repo: pulumi/pulumictl
+    - name: Install Pulumi CLI
+      uses: pulumi/action-install-pulumi-cli@v2
+    - name: Setup Java
+      uses: actions/setup-java@v3
+      with:
+        cache: gradle
+        distribution: temurin
+        java-version: ${{matrix.javaversion}}
+    - name: Download java SDK
+      uses: actions/download-artifact@v2
+      with:
+        name: java-sdk.tar.gz
+        path: ${{ github.workspace}}/sdk/
+    - name: Uncompress java SDK
+      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
+        ${{github.workspace}}/sdk/java
+    - name: Set PACKAGE_VERSION to Env
+      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
+        $GITHUB_ENV
+    - name: Publish Java SDK
+      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
+      with:
+        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
+        build-root-directory: ./sdk/java
+        gradle-version: 7.4.1
+    strategy:
+      fail-fast: true
+      matrix:
+        goversion:
+        - 1.19.x
+        javaversion:
+        - "11"
   publish_sdk:
     name: publish_sdk
     needs: publish
@@ -360,12 +415,6 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{matrix.pythonversion}}
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{matrix.javaversion}}
     - name: Download python SDK
       uses: actions/download-artifact@v2
       with:
@@ -390,28 +439,11 @@ jobs:
     - name: Uncompress nodejs SDK
       run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
         ${{github.workspace}}/sdk/nodejs
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
     - run: python -m pip install pip twine
     - env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       name: Publish SDKs
       run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3
@@ -426,8 +458,6 @@ jobs:
         - 3.1.301
         goversion:
         - 1.19.x
-        javaversion:
-        - "11"
         nodeversion:
         - 16.x
         pythonversion:

--- a/provider-ci/providers/spotinst/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/spotinst/repo/.github/workflows/release.yml
@@ -336,6 +336,61 @@ jobs:
         - 16.x
         pythonversion:
         - "3.9"
+  publish_java_sdk:
+    continue-on-error: true
+    name: publish_java_sdk
+    needs: publish
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout Repo
+      uses: actions/checkout@v3
+    - name: Checkout Scripts Repo
+      uses: actions/checkout@v3
+      with:
+        path: ci-scripts
+        repository: pulumi/scripts
+    - name: Unshallow clone for tags
+      run: git fetch --prune --unshallow --tags
+    - name: Install Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: ${{matrix.goversion}}
+    - name: Install pulumictl
+      uses: jaxxstorm/action-install-gh-release@v1.5.0
+      with:
+        repo: pulumi/pulumictl
+    - name: Install Pulumi CLI
+      uses: pulumi/action-install-pulumi-cli@v2
+    - name: Setup Java
+      uses: actions/setup-java@v3
+      with:
+        cache: gradle
+        distribution: temurin
+        java-version: ${{matrix.javaversion}}
+    - name: Download java SDK
+      uses: actions/download-artifact@v2
+      with:
+        name: java-sdk.tar.gz
+        path: ${{ github.workspace}}/sdk/
+    - name: Uncompress java SDK
+      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
+        ${{github.workspace}}/sdk/java
+    - name: Set PACKAGE_VERSION to Env
+      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
+        $GITHUB_ENV
+    - name: Publish Java SDK
+      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
+      with:
+        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
+        build-root-directory: ./sdk/java
+        gradle-version: 7.4.1
+    strategy:
+      fail-fast: true
+      matrix:
+        goversion:
+        - 1.19.x
+        javaversion:
+        - "11"
   publish_sdk:
     name: publish_sdk
     needs: publish
@@ -373,12 +428,6 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{matrix.pythonversion}}
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{matrix.javaversion}}
     - name: Download python SDK
       uses: actions/download-artifact@v2
       with:
@@ -403,28 +452,11 @@ jobs:
     - name: Uncompress nodejs SDK
       run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
         ${{github.workspace}}/sdk/nodejs
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
     - run: python -m pip install pip twine
     - env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       name: Publish SDKs
       run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3
@@ -439,8 +471,6 @@ jobs:
         - 3.1.301
         goversion:
         - 1.19.x
-        javaversion:
-        - "11"
         nodeversion:
         - 16.x
         pythonversion:

--- a/provider-ci/providers/sumologic/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/sumologic/repo/.github/workflows/main.yml
@@ -379,6 +379,61 @@ jobs:
         - 16.x
         pythonversion:
         - "3.9"
+  publish_java_sdk:
+    continue-on-error: true
+    name: publish_java_sdk
+    needs: publish
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout Repo
+      uses: actions/checkout@v3
+    - name: Checkout Scripts Repo
+      uses: actions/checkout@v3
+      with:
+        path: ci-scripts
+        repository: pulumi/scripts
+    - name: Unshallow clone for tags
+      run: git fetch --prune --unshallow --tags
+    - name: Install Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: ${{matrix.goversion}}
+    - name: Install pulumictl
+      uses: jaxxstorm/action-install-gh-release@v1.5.0
+      with:
+        repo: pulumi/pulumictl
+    - name: Install Pulumi CLI
+      uses: pulumi/action-install-pulumi-cli@v2
+    - name: Setup Java
+      uses: actions/setup-java@v3
+      with:
+        cache: gradle
+        distribution: temurin
+        java-version: ${{matrix.javaversion}}
+    - name: Download java SDK
+      uses: actions/download-artifact@v2
+      with:
+        name: java-sdk.tar.gz
+        path: ${{ github.workspace}}/sdk/
+    - name: Uncompress java SDK
+      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
+        ${{github.workspace}}/sdk/java
+    - name: Set PACKAGE_VERSION to Env
+      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
+        $GITHUB_ENV
+    - name: Publish Java SDK
+      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
+      with:
+        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
+        build-root-directory: ./sdk/java
+        gradle-version: 7.4.1
+    strategy:
+      fail-fast: true
+      matrix:
+        goversion:
+        - 1.19.x
+        javaversion:
+        - "11"
   publish_sdk:
     name: publish_sdk
     needs: publish
@@ -416,12 +471,6 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{matrix.pythonversion}}
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{matrix.javaversion}}
     - name: Download python SDK
       uses: actions/download-artifact@v2
       with:
@@ -446,28 +495,11 @@ jobs:
     - name: Uncompress nodejs SDK
       run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
         ${{github.workspace}}/sdk/nodejs
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
     - run: python -m pip install pip twine
     - env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       name: Publish SDKs
       run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3
@@ -482,8 +514,6 @@ jobs:
         - 3.1.301
         goversion:
         - 1.19.x
-        javaversion:
-        - "11"
         nodeversion:
         - 16.x
         pythonversion:

--- a/provider-ci/providers/sumologic/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/sumologic/repo/.github/workflows/master.yml
@@ -379,6 +379,61 @@ jobs:
         - 16.x
         pythonversion:
         - "3.9"
+  publish_java_sdk:
+    continue-on-error: true
+    name: publish_java_sdk
+    needs: publish
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout Repo
+      uses: actions/checkout@v3
+    - name: Checkout Scripts Repo
+      uses: actions/checkout@v3
+      with:
+        path: ci-scripts
+        repository: pulumi/scripts
+    - name: Unshallow clone for tags
+      run: git fetch --prune --unshallow --tags
+    - name: Install Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: ${{matrix.goversion}}
+    - name: Install pulumictl
+      uses: jaxxstorm/action-install-gh-release@v1.5.0
+      with:
+        repo: pulumi/pulumictl
+    - name: Install Pulumi CLI
+      uses: pulumi/action-install-pulumi-cli@v2
+    - name: Setup Java
+      uses: actions/setup-java@v3
+      with:
+        cache: gradle
+        distribution: temurin
+        java-version: ${{matrix.javaversion}}
+    - name: Download java SDK
+      uses: actions/download-artifact@v2
+      with:
+        name: java-sdk.tar.gz
+        path: ${{ github.workspace}}/sdk/
+    - name: Uncompress java SDK
+      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
+        ${{github.workspace}}/sdk/java
+    - name: Set PACKAGE_VERSION to Env
+      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
+        $GITHUB_ENV
+    - name: Publish Java SDK
+      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
+      with:
+        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
+        build-root-directory: ./sdk/java
+        gradle-version: 7.4.1
+    strategy:
+      fail-fast: true
+      matrix:
+        goversion:
+        - 1.19.x
+        javaversion:
+        - "11"
   publish_sdk:
     name: publish_sdk
     needs: publish
@@ -416,12 +471,6 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{matrix.pythonversion}}
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{matrix.javaversion}}
     - name: Download python SDK
       uses: actions/download-artifact@v2
       with:
@@ -446,28 +495,11 @@ jobs:
     - name: Uncompress nodejs SDK
       run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
         ${{github.workspace}}/sdk/nodejs
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
     - run: python -m pip install pip twine
     - env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       name: Publish SDKs
       run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3
@@ -482,8 +514,6 @@ jobs:
         - 3.1.301
         goversion:
         - 1.19.x
-        javaversion:
-        - "11"
         nodeversion:
         - 16.x
         pythonversion:

--- a/provider-ci/providers/sumologic/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/sumologic/repo/.github/workflows/prerelease.yml
@@ -323,6 +323,61 @@ jobs:
         - 16.x
         pythonversion:
         - "3.9"
+  publish_java_sdk:
+    continue-on-error: true
+    name: publish_java_sdk
+    needs: publish
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout Repo
+      uses: actions/checkout@v3
+    - name: Checkout Scripts Repo
+      uses: actions/checkout@v3
+      with:
+        path: ci-scripts
+        repository: pulumi/scripts
+    - name: Unshallow clone for tags
+      run: git fetch --prune --unshallow --tags
+    - name: Install Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: ${{matrix.goversion}}
+    - name: Install pulumictl
+      uses: jaxxstorm/action-install-gh-release@v1.5.0
+      with:
+        repo: pulumi/pulumictl
+    - name: Install Pulumi CLI
+      uses: pulumi/action-install-pulumi-cli@v2
+    - name: Setup Java
+      uses: actions/setup-java@v3
+      with:
+        cache: gradle
+        distribution: temurin
+        java-version: ${{matrix.javaversion}}
+    - name: Download java SDK
+      uses: actions/download-artifact@v2
+      with:
+        name: java-sdk.tar.gz
+        path: ${{ github.workspace}}/sdk/
+    - name: Uncompress java SDK
+      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
+        ${{github.workspace}}/sdk/java
+    - name: Set PACKAGE_VERSION to Env
+      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
+        $GITHUB_ENV
+    - name: Publish Java SDK
+      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
+      with:
+        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
+        build-root-directory: ./sdk/java
+        gradle-version: 7.4.1
+    strategy:
+      fail-fast: true
+      matrix:
+        goversion:
+        - 1.19.x
+        javaversion:
+        - "11"
   publish_sdk:
     name: publish_sdk
     needs: publish
@@ -360,12 +415,6 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{matrix.pythonversion}}
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{matrix.javaversion}}
     - name: Download python SDK
       uses: actions/download-artifact@v2
       with:
@@ -390,28 +439,11 @@ jobs:
     - name: Uncompress nodejs SDK
       run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
         ${{github.workspace}}/sdk/nodejs
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
     - run: python -m pip install pip twine
     - env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       name: Publish SDKs
       run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3
@@ -426,8 +458,6 @@ jobs:
         - 3.1.301
         goversion:
         - 1.19.x
-        javaversion:
-        - "11"
         nodeversion:
         - 16.x
         pythonversion:

--- a/provider-ci/providers/sumologic/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/sumologic/repo/.github/workflows/release.yml
@@ -336,6 +336,61 @@ jobs:
         - 16.x
         pythonversion:
         - "3.9"
+  publish_java_sdk:
+    continue-on-error: true
+    name: publish_java_sdk
+    needs: publish
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout Repo
+      uses: actions/checkout@v3
+    - name: Checkout Scripts Repo
+      uses: actions/checkout@v3
+      with:
+        path: ci-scripts
+        repository: pulumi/scripts
+    - name: Unshallow clone for tags
+      run: git fetch --prune --unshallow --tags
+    - name: Install Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: ${{matrix.goversion}}
+    - name: Install pulumictl
+      uses: jaxxstorm/action-install-gh-release@v1.5.0
+      with:
+        repo: pulumi/pulumictl
+    - name: Install Pulumi CLI
+      uses: pulumi/action-install-pulumi-cli@v2
+    - name: Setup Java
+      uses: actions/setup-java@v3
+      with:
+        cache: gradle
+        distribution: temurin
+        java-version: ${{matrix.javaversion}}
+    - name: Download java SDK
+      uses: actions/download-artifact@v2
+      with:
+        name: java-sdk.tar.gz
+        path: ${{ github.workspace}}/sdk/
+    - name: Uncompress java SDK
+      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
+        ${{github.workspace}}/sdk/java
+    - name: Set PACKAGE_VERSION to Env
+      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
+        $GITHUB_ENV
+    - name: Publish Java SDK
+      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
+      with:
+        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
+        build-root-directory: ./sdk/java
+        gradle-version: 7.4.1
+    strategy:
+      fail-fast: true
+      matrix:
+        goversion:
+        - 1.19.x
+        javaversion:
+        - "11"
   publish_sdk:
     name: publish_sdk
     needs: publish
@@ -373,12 +428,6 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{matrix.pythonversion}}
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{matrix.javaversion}}
     - name: Download python SDK
       uses: actions/download-artifact@v2
       with:
@@ -403,28 +452,11 @@ jobs:
     - name: Uncompress nodejs SDK
       run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
         ${{github.workspace}}/sdk/nodejs
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
     - run: python -m pip install pip twine
     - env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       name: Publish SDKs
       run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3
@@ -439,8 +471,6 @@ jobs:
         - 3.1.301
         goversion:
         - 1.19.x
-        javaversion:
-        - "11"
         nodeversion:
         - 16.x
         pythonversion:

--- a/provider-ci/providers/tailscale/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/tailscale/repo/.github/workflows/main.yml
@@ -378,6 +378,61 @@ jobs:
         - 16.x
         pythonversion:
         - "3.9"
+  publish_java_sdk:
+    continue-on-error: true
+    name: publish_java_sdk
+    needs: publish
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout Repo
+      uses: actions/checkout@v3
+    - name: Checkout Scripts Repo
+      uses: actions/checkout@v3
+      with:
+        path: ci-scripts
+        repository: pulumi/scripts
+    - name: Unshallow clone for tags
+      run: git fetch --prune --unshallow --tags
+    - name: Install Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: ${{matrix.goversion}}
+    - name: Install pulumictl
+      uses: jaxxstorm/action-install-gh-release@v1.5.0
+      with:
+        repo: pulumi/pulumictl
+    - name: Install Pulumi CLI
+      uses: pulumi/action-install-pulumi-cli@v2
+    - name: Setup Java
+      uses: actions/setup-java@v3
+      with:
+        cache: gradle
+        distribution: temurin
+        java-version: ${{matrix.javaversion}}
+    - name: Download java SDK
+      uses: actions/download-artifact@v2
+      with:
+        name: java-sdk.tar.gz
+        path: ${{ github.workspace}}/sdk/
+    - name: Uncompress java SDK
+      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
+        ${{github.workspace}}/sdk/java
+    - name: Set PACKAGE_VERSION to Env
+      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
+        $GITHUB_ENV
+    - name: Publish Java SDK
+      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
+      with:
+        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
+        build-root-directory: ./sdk/java
+        gradle-version: 7.4.1
+    strategy:
+      fail-fast: true
+      matrix:
+        goversion:
+        - 1.19.x
+        javaversion:
+        - "11"
   publish_sdk:
     name: publish_sdk
     needs: publish
@@ -415,12 +470,6 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{matrix.pythonversion}}
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{matrix.javaversion}}
     - name: Download python SDK
       uses: actions/download-artifact@v2
       with:
@@ -445,28 +494,11 @@ jobs:
     - name: Uncompress nodejs SDK
       run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
         ${{github.workspace}}/sdk/nodejs
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
     - run: python -m pip install pip twine
     - env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       name: Publish SDKs
       run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3
@@ -481,8 +513,6 @@ jobs:
         - 3.1.301
         goversion:
         - 1.19.x
-        javaversion:
-        - "11"
         nodeversion:
         - 16.x
         pythonversion:

--- a/provider-ci/providers/tailscale/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/tailscale/repo/.github/workflows/master.yml
@@ -378,6 +378,61 @@ jobs:
         - 16.x
         pythonversion:
         - "3.9"
+  publish_java_sdk:
+    continue-on-error: true
+    name: publish_java_sdk
+    needs: publish
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout Repo
+      uses: actions/checkout@v3
+    - name: Checkout Scripts Repo
+      uses: actions/checkout@v3
+      with:
+        path: ci-scripts
+        repository: pulumi/scripts
+    - name: Unshallow clone for tags
+      run: git fetch --prune --unshallow --tags
+    - name: Install Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: ${{matrix.goversion}}
+    - name: Install pulumictl
+      uses: jaxxstorm/action-install-gh-release@v1.5.0
+      with:
+        repo: pulumi/pulumictl
+    - name: Install Pulumi CLI
+      uses: pulumi/action-install-pulumi-cli@v2
+    - name: Setup Java
+      uses: actions/setup-java@v3
+      with:
+        cache: gradle
+        distribution: temurin
+        java-version: ${{matrix.javaversion}}
+    - name: Download java SDK
+      uses: actions/download-artifact@v2
+      with:
+        name: java-sdk.tar.gz
+        path: ${{ github.workspace}}/sdk/
+    - name: Uncompress java SDK
+      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
+        ${{github.workspace}}/sdk/java
+    - name: Set PACKAGE_VERSION to Env
+      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
+        $GITHUB_ENV
+    - name: Publish Java SDK
+      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
+      with:
+        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
+        build-root-directory: ./sdk/java
+        gradle-version: 7.4.1
+    strategy:
+      fail-fast: true
+      matrix:
+        goversion:
+        - 1.19.x
+        javaversion:
+        - "11"
   publish_sdk:
     name: publish_sdk
     needs: publish
@@ -415,12 +470,6 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{matrix.pythonversion}}
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{matrix.javaversion}}
     - name: Download python SDK
       uses: actions/download-artifact@v2
       with:
@@ -445,28 +494,11 @@ jobs:
     - name: Uncompress nodejs SDK
       run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
         ${{github.workspace}}/sdk/nodejs
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
     - run: python -m pip install pip twine
     - env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       name: Publish SDKs
       run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3
@@ -481,8 +513,6 @@ jobs:
         - 3.1.301
         goversion:
         - 1.19.x
-        javaversion:
-        - "11"
         nodeversion:
         - 16.x
         pythonversion:

--- a/provider-ci/providers/tailscale/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/tailscale/repo/.github/workflows/prerelease.yml
@@ -322,6 +322,61 @@ jobs:
         - 16.x
         pythonversion:
         - "3.9"
+  publish_java_sdk:
+    continue-on-error: true
+    name: publish_java_sdk
+    needs: publish
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout Repo
+      uses: actions/checkout@v3
+    - name: Checkout Scripts Repo
+      uses: actions/checkout@v3
+      with:
+        path: ci-scripts
+        repository: pulumi/scripts
+    - name: Unshallow clone for tags
+      run: git fetch --prune --unshallow --tags
+    - name: Install Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: ${{matrix.goversion}}
+    - name: Install pulumictl
+      uses: jaxxstorm/action-install-gh-release@v1.5.0
+      with:
+        repo: pulumi/pulumictl
+    - name: Install Pulumi CLI
+      uses: pulumi/action-install-pulumi-cli@v2
+    - name: Setup Java
+      uses: actions/setup-java@v3
+      with:
+        cache: gradle
+        distribution: temurin
+        java-version: ${{matrix.javaversion}}
+    - name: Download java SDK
+      uses: actions/download-artifact@v2
+      with:
+        name: java-sdk.tar.gz
+        path: ${{ github.workspace}}/sdk/
+    - name: Uncompress java SDK
+      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
+        ${{github.workspace}}/sdk/java
+    - name: Set PACKAGE_VERSION to Env
+      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
+        $GITHUB_ENV
+    - name: Publish Java SDK
+      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
+      with:
+        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
+        build-root-directory: ./sdk/java
+        gradle-version: 7.4.1
+    strategy:
+      fail-fast: true
+      matrix:
+        goversion:
+        - 1.19.x
+        javaversion:
+        - "11"
   publish_sdk:
     name: publish_sdk
     needs: publish
@@ -359,12 +414,6 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{matrix.pythonversion}}
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{matrix.javaversion}}
     - name: Download python SDK
       uses: actions/download-artifact@v2
       with:
@@ -389,28 +438,11 @@ jobs:
     - name: Uncompress nodejs SDK
       run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
         ${{github.workspace}}/sdk/nodejs
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
     - run: python -m pip install pip twine
     - env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       name: Publish SDKs
       run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3
@@ -425,8 +457,6 @@ jobs:
         - 3.1.301
         goversion:
         - 1.19.x
-        javaversion:
-        - "11"
         nodeversion:
         - 16.x
         pythonversion:

--- a/provider-ci/providers/tailscale/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/tailscale/repo/.github/workflows/release.yml
@@ -335,6 +335,61 @@ jobs:
         - 16.x
         pythonversion:
         - "3.9"
+  publish_java_sdk:
+    continue-on-error: true
+    name: publish_java_sdk
+    needs: publish
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout Repo
+      uses: actions/checkout@v3
+    - name: Checkout Scripts Repo
+      uses: actions/checkout@v3
+      with:
+        path: ci-scripts
+        repository: pulumi/scripts
+    - name: Unshallow clone for tags
+      run: git fetch --prune --unshallow --tags
+    - name: Install Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: ${{matrix.goversion}}
+    - name: Install pulumictl
+      uses: jaxxstorm/action-install-gh-release@v1.5.0
+      with:
+        repo: pulumi/pulumictl
+    - name: Install Pulumi CLI
+      uses: pulumi/action-install-pulumi-cli@v2
+    - name: Setup Java
+      uses: actions/setup-java@v3
+      with:
+        cache: gradle
+        distribution: temurin
+        java-version: ${{matrix.javaversion}}
+    - name: Download java SDK
+      uses: actions/download-artifact@v2
+      with:
+        name: java-sdk.tar.gz
+        path: ${{ github.workspace}}/sdk/
+    - name: Uncompress java SDK
+      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
+        ${{github.workspace}}/sdk/java
+    - name: Set PACKAGE_VERSION to Env
+      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
+        $GITHUB_ENV
+    - name: Publish Java SDK
+      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
+      with:
+        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
+        build-root-directory: ./sdk/java
+        gradle-version: 7.4.1
+    strategy:
+      fail-fast: true
+      matrix:
+        goversion:
+        - 1.19.x
+        javaversion:
+        - "11"
   publish_sdk:
     name: publish_sdk
     needs: publish
@@ -372,12 +427,6 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{matrix.pythonversion}}
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{matrix.javaversion}}
     - name: Download python SDK
       uses: actions/download-artifact@v2
       with:
@@ -402,28 +451,11 @@ jobs:
     - name: Uncompress nodejs SDK
       run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
         ${{github.workspace}}/sdk/nodejs
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
     - run: python -m pip install pip twine
     - env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       name: Publish SDKs
       run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3
@@ -438,8 +470,6 @@ jobs:
         - 3.1.301
         goversion:
         - 1.19.x
-        javaversion:
-        - "11"
         nodeversion:
         - 16.x
         pythonversion:

--- a/provider-ci/providers/tls/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/tls/repo/.github/workflows/main.yml
@@ -376,6 +376,61 @@ jobs:
         - 16.x
         pythonversion:
         - "3.9"
+  publish_java_sdk:
+    continue-on-error: true
+    name: publish_java_sdk
+    needs: publish
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout Repo
+      uses: actions/checkout@v3
+    - name: Checkout Scripts Repo
+      uses: actions/checkout@v3
+      with:
+        path: ci-scripts
+        repository: pulumi/scripts
+    - name: Unshallow clone for tags
+      run: git fetch --prune --unshallow --tags
+    - name: Install Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: ${{matrix.goversion}}
+    - name: Install pulumictl
+      uses: jaxxstorm/action-install-gh-release@v1.5.0
+      with:
+        repo: pulumi/pulumictl
+    - name: Install Pulumi CLI
+      uses: pulumi/action-install-pulumi-cli@v2
+    - name: Setup Java
+      uses: actions/setup-java@v3
+      with:
+        cache: gradle
+        distribution: temurin
+        java-version: ${{matrix.javaversion}}
+    - name: Download java SDK
+      uses: actions/download-artifact@v2
+      with:
+        name: java-sdk.tar.gz
+        path: ${{ github.workspace}}/sdk/
+    - name: Uncompress java SDK
+      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
+        ${{github.workspace}}/sdk/java
+    - name: Set PACKAGE_VERSION to Env
+      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
+        $GITHUB_ENV
+    - name: Publish Java SDK
+      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
+      with:
+        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
+        build-root-directory: ./sdk/java
+        gradle-version: 7.4.1
+    strategy:
+      fail-fast: true
+      matrix:
+        goversion:
+        - 1.19.x
+        javaversion:
+        - "11"
   publish_sdk:
     name: publish_sdk
     needs: publish
@@ -413,12 +468,6 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{matrix.pythonversion}}
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{matrix.javaversion}}
     - name: Download python SDK
       uses: actions/download-artifact@v2
       with:
@@ -443,28 +492,11 @@ jobs:
     - name: Uncompress nodejs SDK
       run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
         ${{github.workspace}}/sdk/nodejs
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
     - run: python -m pip install pip twine
     - env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       name: Publish SDKs
       run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3
@@ -479,8 +511,6 @@ jobs:
         - 3.1.301
         goversion:
         - 1.19.x
-        javaversion:
-        - "11"
         nodeversion:
         - 16.x
         pythonversion:

--- a/provider-ci/providers/tls/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/tls/repo/.github/workflows/master.yml
@@ -376,6 +376,61 @@ jobs:
         - 16.x
         pythonversion:
         - "3.9"
+  publish_java_sdk:
+    continue-on-error: true
+    name: publish_java_sdk
+    needs: publish
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout Repo
+      uses: actions/checkout@v3
+    - name: Checkout Scripts Repo
+      uses: actions/checkout@v3
+      with:
+        path: ci-scripts
+        repository: pulumi/scripts
+    - name: Unshallow clone for tags
+      run: git fetch --prune --unshallow --tags
+    - name: Install Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: ${{matrix.goversion}}
+    - name: Install pulumictl
+      uses: jaxxstorm/action-install-gh-release@v1.5.0
+      with:
+        repo: pulumi/pulumictl
+    - name: Install Pulumi CLI
+      uses: pulumi/action-install-pulumi-cli@v2
+    - name: Setup Java
+      uses: actions/setup-java@v3
+      with:
+        cache: gradle
+        distribution: temurin
+        java-version: ${{matrix.javaversion}}
+    - name: Download java SDK
+      uses: actions/download-artifact@v2
+      with:
+        name: java-sdk.tar.gz
+        path: ${{ github.workspace}}/sdk/
+    - name: Uncompress java SDK
+      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
+        ${{github.workspace}}/sdk/java
+    - name: Set PACKAGE_VERSION to Env
+      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
+        $GITHUB_ENV
+    - name: Publish Java SDK
+      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
+      with:
+        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
+        build-root-directory: ./sdk/java
+        gradle-version: 7.4.1
+    strategy:
+      fail-fast: true
+      matrix:
+        goversion:
+        - 1.19.x
+        javaversion:
+        - "11"
   publish_sdk:
     name: publish_sdk
     needs: publish
@@ -413,12 +468,6 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{matrix.pythonversion}}
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{matrix.javaversion}}
     - name: Download python SDK
       uses: actions/download-artifact@v2
       with:
@@ -443,28 +492,11 @@ jobs:
     - name: Uncompress nodejs SDK
       run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
         ${{github.workspace}}/sdk/nodejs
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
     - run: python -m pip install pip twine
     - env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       name: Publish SDKs
       run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3
@@ -479,8 +511,6 @@ jobs:
         - 3.1.301
         goversion:
         - 1.19.x
-        javaversion:
-        - "11"
         nodeversion:
         - 16.x
         pythonversion:

--- a/provider-ci/providers/tls/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/tls/repo/.github/workflows/prerelease.yml
@@ -320,6 +320,61 @@ jobs:
         - 16.x
         pythonversion:
         - "3.9"
+  publish_java_sdk:
+    continue-on-error: true
+    name: publish_java_sdk
+    needs: publish
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout Repo
+      uses: actions/checkout@v3
+    - name: Checkout Scripts Repo
+      uses: actions/checkout@v3
+      with:
+        path: ci-scripts
+        repository: pulumi/scripts
+    - name: Unshallow clone for tags
+      run: git fetch --prune --unshallow --tags
+    - name: Install Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: ${{matrix.goversion}}
+    - name: Install pulumictl
+      uses: jaxxstorm/action-install-gh-release@v1.5.0
+      with:
+        repo: pulumi/pulumictl
+    - name: Install Pulumi CLI
+      uses: pulumi/action-install-pulumi-cli@v2
+    - name: Setup Java
+      uses: actions/setup-java@v3
+      with:
+        cache: gradle
+        distribution: temurin
+        java-version: ${{matrix.javaversion}}
+    - name: Download java SDK
+      uses: actions/download-artifact@v2
+      with:
+        name: java-sdk.tar.gz
+        path: ${{ github.workspace}}/sdk/
+    - name: Uncompress java SDK
+      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
+        ${{github.workspace}}/sdk/java
+    - name: Set PACKAGE_VERSION to Env
+      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
+        $GITHUB_ENV
+    - name: Publish Java SDK
+      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
+      with:
+        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
+        build-root-directory: ./sdk/java
+        gradle-version: 7.4.1
+    strategy:
+      fail-fast: true
+      matrix:
+        goversion:
+        - 1.19.x
+        javaversion:
+        - "11"
   publish_sdk:
     name: publish_sdk
     needs: publish
@@ -357,12 +412,6 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{matrix.pythonversion}}
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{matrix.javaversion}}
     - name: Download python SDK
       uses: actions/download-artifact@v2
       with:
@@ -387,28 +436,11 @@ jobs:
     - name: Uncompress nodejs SDK
       run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
         ${{github.workspace}}/sdk/nodejs
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
     - run: python -m pip install pip twine
     - env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       name: Publish SDKs
       run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3
@@ -423,8 +455,6 @@ jobs:
         - 3.1.301
         goversion:
         - 1.19.x
-        javaversion:
-        - "11"
         nodeversion:
         - 16.x
         pythonversion:

--- a/provider-ci/providers/tls/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/tls/repo/.github/workflows/release.yml
@@ -333,6 +333,61 @@ jobs:
         - 16.x
         pythonversion:
         - "3.9"
+  publish_java_sdk:
+    continue-on-error: true
+    name: publish_java_sdk
+    needs: publish
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout Repo
+      uses: actions/checkout@v3
+    - name: Checkout Scripts Repo
+      uses: actions/checkout@v3
+      with:
+        path: ci-scripts
+        repository: pulumi/scripts
+    - name: Unshallow clone for tags
+      run: git fetch --prune --unshallow --tags
+    - name: Install Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: ${{matrix.goversion}}
+    - name: Install pulumictl
+      uses: jaxxstorm/action-install-gh-release@v1.5.0
+      with:
+        repo: pulumi/pulumictl
+    - name: Install Pulumi CLI
+      uses: pulumi/action-install-pulumi-cli@v2
+    - name: Setup Java
+      uses: actions/setup-java@v3
+      with:
+        cache: gradle
+        distribution: temurin
+        java-version: ${{matrix.javaversion}}
+    - name: Download java SDK
+      uses: actions/download-artifact@v2
+      with:
+        name: java-sdk.tar.gz
+        path: ${{ github.workspace}}/sdk/
+    - name: Uncompress java SDK
+      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
+        ${{github.workspace}}/sdk/java
+    - name: Set PACKAGE_VERSION to Env
+      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
+        $GITHUB_ENV
+    - name: Publish Java SDK
+      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
+      with:
+        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
+        build-root-directory: ./sdk/java
+        gradle-version: 7.4.1
+    strategy:
+      fail-fast: true
+      matrix:
+        goversion:
+        - 1.19.x
+        javaversion:
+        - "11"
   publish_sdk:
     name: publish_sdk
     needs: publish
@@ -370,12 +425,6 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{matrix.pythonversion}}
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{matrix.javaversion}}
     - name: Download python SDK
       uses: actions/download-artifact@v2
       with:
@@ -400,28 +449,11 @@ jobs:
     - name: Uncompress nodejs SDK
       run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
         ${{github.workspace}}/sdk/nodejs
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
     - run: python -m pip install pip twine
     - env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       name: Publish SDKs
       run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3
@@ -436,8 +468,6 @@ jobs:
         - 3.1.301
         goversion:
         - 1.19.x
-        javaversion:
-        - "11"
         nodeversion:
         - 16.x
         pythonversion:

--- a/provider-ci/providers/vault/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/vault/repo/.github/workflows/main.yml
@@ -376,6 +376,61 @@ jobs:
         - 16.x
         pythonversion:
         - "3.9"
+  publish_java_sdk:
+    continue-on-error: true
+    name: publish_java_sdk
+    needs: publish
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout Repo
+      uses: actions/checkout@v3
+    - name: Checkout Scripts Repo
+      uses: actions/checkout@v3
+      with:
+        path: ci-scripts
+        repository: pulumi/scripts
+    - name: Unshallow clone for tags
+      run: git fetch --prune --unshallow --tags
+    - name: Install Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: ${{matrix.goversion}}
+    - name: Install pulumictl
+      uses: jaxxstorm/action-install-gh-release@v1.5.0
+      with:
+        repo: pulumi/pulumictl
+    - name: Install Pulumi CLI
+      uses: pulumi/action-install-pulumi-cli@v2
+    - name: Setup Java
+      uses: actions/setup-java@v3
+      with:
+        cache: gradle
+        distribution: temurin
+        java-version: ${{matrix.javaversion}}
+    - name: Download java SDK
+      uses: actions/download-artifact@v2
+      with:
+        name: java-sdk.tar.gz
+        path: ${{ github.workspace}}/sdk/
+    - name: Uncompress java SDK
+      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
+        ${{github.workspace}}/sdk/java
+    - name: Set PACKAGE_VERSION to Env
+      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
+        $GITHUB_ENV
+    - name: Publish Java SDK
+      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
+      with:
+        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
+        build-root-directory: ./sdk/java
+        gradle-version: 7.4.1
+    strategy:
+      fail-fast: true
+      matrix:
+        goversion:
+        - 1.19.x
+        javaversion:
+        - "11"
   publish_sdk:
     name: publish_sdk
     needs: publish
@@ -413,12 +468,6 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{matrix.pythonversion}}
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{matrix.javaversion}}
     - name: Download python SDK
       uses: actions/download-artifact@v2
       with:
@@ -443,28 +492,11 @@ jobs:
     - name: Uncompress nodejs SDK
       run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
         ${{github.workspace}}/sdk/nodejs
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
     - run: python -m pip install pip twine
     - env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       name: Publish SDKs
       run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3
@@ -479,8 +511,6 @@ jobs:
         - 3.1.301
         goversion:
         - 1.19.x
-        javaversion:
-        - "11"
         nodeversion:
         - 16.x
         pythonversion:

--- a/provider-ci/providers/vault/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/vault/repo/.github/workflows/master.yml
@@ -376,6 +376,61 @@ jobs:
         - 16.x
         pythonversion:
         - "3.9"
+  publish_java_sdk:
+    continue-on-error: true
+    name: publish_java_sdk
+    needs: publish
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout Repo
+      uses: actions/checkout@v3
+    - name: Checkout Scripts Repo
+      uses: actions/checkout@v3
+      with:
+        path: ci-scripts
+        repository: pulumi/scripts
+    - name: Unshallow clone for tags
+      run: git fetch --prune --unshallow --tags
+    - name: Install Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: ${{matrix.goversion}}
+    - name: Install pulumictl
+      uses: jaxxstorm/action-install-gh-release@v1.5.0
+      with:
+        repo: pulumi/pulumictl
+    - name: Install Pulumi CLI
+      uses: pulumi/action-install-pulumi-cli@v2
+    - name: Setup Java
+      uses: actions/setup-java@v3
+      with:
+        cache: gradle
+        distribution: temurin
+        java-version: ${{matrix.javaversion}}
+    - name: Download java SDK
+      uses: actions/download-artifact@v2
+      with:
+        name: java-sdk.tar.gz
+        path: ${{ github.workspace}}/sdk/
+    - name: Uncompress java SDK
+      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
+        ${{github.workspace}}/sdk/java
+    - name: Set PACKAGE_VERSION to Env
+      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
+        $GITHUB_ENV
+    - name: Publish Java SDK
+      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
+      with:
+        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
+        build-root-directory: ./sdk/java
+        gradle-version: 7.4.1
+    strategy:
+      fail-fast: true
+      matrix:
+        goversion:
+        - 1.19.x
+        javaversion:
+        - "11"
   publish_sdk:
     name: publish_sdk
     needs: publish
@@ -413,12 +468,6 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{matrix.pythonversion}}
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{matrix.javaversion}}
     - name: Download python SDK
       uses: actions/download-artifact@v2
       with:
@@ -443,28 +492,11 @@ jobs:
     - name: Uncompress nodejs SDK
       run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
         ${{github.workspace}}/sdk/nodejs
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
     - run: python -m pip install pip twine
     - env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       name: Publish SDKs
       run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3
@@ -479,8 +511,6 @@ jobs:
         - 3.1.301
         goversion:
         - 1.19.x
-        javaversion:
-        - "11"
         nodeversion:
         - 16.x
         pythonversion:

--- a/provider-ci/providers/vault/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/vault/repo/.github/workflows/prerelease.yml
@@ -320,6 +320,61 @@ jobs:
         - 16.x
         pythonversion:
         - "3.9"
+  publish_java_sdk:
+    continue-on-error: true
+    name: publish_java_sdk
+    needs: publish
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout Repo
+      uses: actions/checkout@v3
+    - name: Checkout Scripts Repo
+      uses: actions/checkout@v3
+      with:
+        path: ci-scripts
+        repository: pulumi/scripts
+    - name: Unshallow clone for tags
+      run: git fetch --prune --unshallow --tags
+    - name: Install Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: ${{matrix.goversion}}
+    - name: Install pulumictl
+      uses: jaxxstorm/action-install-gh-release@v1.5.0
+      with:
+        repo: pulumi/pulumictl
+    - name: Install Pulumi CLI
+      uses: pulumi/action-install-pulumi-cli@v2
+    - name: Setup Java
+      uses: actions/setup-java@v3
+      with:
+        cache: gradle
+        distribution: temurin
+        java-version: ${{matrix.javaversion}}
+    - name: Download java SDK
+      uses: actions/download-artifact@v2
+      with:
+        name: java-sdk.tar.gz
+        path: ${{ github.workspace}}/sdk/
+    - name: Uncompress java SDK
+      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
+        ${{github.workspace}}/sdk/java
+    - name: Set PACKAGE_VERSION to Env
+      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
+        $GITHUB_ENV
+    - name: Publish Java SDK
+      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
+      with:
+        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
+        build-root-directory: ./sdk/java
+        gradle-version: 7.4.1
+    strategy:
+      fail-fast: true
+      matrix:
+        goversion:
+        - 1.19.x
+        javaversion:
+        - "11"
   publish_sdk:
     name: publish_sdk
     needs: publish
@@ -357,12 +412,6 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{matrix.pythonversion}}
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{matrix.javaversion}}
     - name: Download python SDK
       uses: actions/download-artifact@v2
       with:
@@ -387,28 +436,11 @@ jobs:
     - name: Uncompress nodejs SDK
       run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
         ${{github.workspace}}/sdk/nodejs
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
     - run: python -m pip install pip twine
     - env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       name: Publish SDKs
       run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3
@@ -423,8 +455,6 @@ jobs:
         - 3.1.301
         goversion:
         - 1.19.x
-        javaversion:
-        - "11"
         nodeversion:
         - 16.x
         pythonversion:

--- a/provider-ci/providers/vault/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/vault/repo/.github/workflows/release.yml
@@ -333,6 +333,61 @@ jobs:
         - 16.x
         pythonversion:
         - "3.9"
+  publish_java_sdk:
+    continue-on-error: true
+    name: publish_java_sdk
+    needs: publish
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout Repo
+      uses: actions/checkout@v3
+    - name: Checkout Scripts Repo
+      uses: actions/checkout@v3
+      with:
+        path: ci-scripts
+        repository: pulumi/scripts
+    - name: Unshallow clone for tags
+      run: git fetch --prune --unshallow --tags
+    - name: Install Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: ${{matrix.goversion}}
+    - name: Install pulumictl
+      uses: jaxxstorm/action-install-gh-release@v1.5.0
+      with:
+        repo: pulumi/pulumictl
+    - name: Install Pulumi CLI
+      uses: pulumi/action-install-pulumi-cli@v2
+    - name: Setup Java
+      uses: actions/setup-java@v3
+      with:
+        cache: gradle
+        distribution: temurin
+        java-version: ${{matrix.javaversion}}
+    - name: Download java SDK
+      uses: actions/download-artifact@v2
+      with:
+        name: java-sdk.tar.gz
+        path: ${{ github.workspace}}/sdk/
+    - name: Uncompress java SDK
+      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
+        ${{github.workspace}}/sdk/java
+    - name: Set PACKAGE_VERSION to Env
+      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
+        $GITHUB_ENV
+    - name: Publish Java SDK
+      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
+      with:
+        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
+        build-root-directory: ./sdk/java
+        gradle-version: 7.4.1
+    strategy:
+      fail-fast: true
+      matrix:
+        goversion:
+        - 1.19.x
+        javaversion:
+        - "11"
   publish_sdk:
     name: publish_sdk
     needs: publish
@@ -370,12 +425,6 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{matrix.pythonversion}}
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{matrix.javaversion}}
     - name: Download python SDK
       uses: actions/download-artifact@v2
       with:
@@ -400,28 +449,11 @@ jobs:
     - name: Uncompress nodejs SDK
       run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
         ${{github.workspace}}/sdk/nodejs
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
     - run: python -m pip install pip twine
     - env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       name: Publish SDKs
       run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3
@@ -436,8 +468,6 @@ jobs:
         - 3.1.301
         goversion:
         - 1.19.x
-        javaversion:
-        - "11"
         nodeversion:
         - 16.x
         pythonversion:

--- a/provider-ci/providers/venafi/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/venafi/repo/.github/workflows/main.yml
@@ -379,6 +379,61 @@ jobs:
         - 16.x
         pythonversion:
         - "3.9"
+  publish_java_sdk:
+    continue-on-error: true
+    name: publish_java_sdk
+    needs: publish
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout Repo
+      uses: actions/checkout@v3
+    - name: Checkout Scripts Repo
+      uses: actions/checkout@v3
+      with:
+        path: ci-scripts
+        repository: pulumi/scripts
+    - name: Unshallow clone for tags
+      run: git fetch --prune --unshallow --tags
+    - name: Install Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: ${{matrix.goversion}}
+    - name: Install pulumictl
+      uses: jaxxstorm/action-install-gh-release@v1.5.0
+      with:
+        repo: pulumi/pulumictl
+    - name: Install Pulumi CLI
+      uses: pulumi/action-install-pulumi-cli@v2
+    - name: Setup Java
+      uses: actions/setup-java@v3
+      with:
+        cache: gradle
+        distribution: temurin
+        java-version: ${{matrix.javaversion}}
+    - name: Download java SDK
+      uses: actions/download-artifact@v2
+      with:
+        name: java-sdk.tar.gz
+        path: ${{ github.workspace}}/sdk/
+    - name: Uncompress java SDK
+      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
+        ${{github.workspace}}/sdk/java
+    - name: Set PACKAGE_VERSION to Env
+      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
+        $GITHUB_ENV
+    - name: Publish Java SDK
+      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
+      with:
+        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
+        build-root-directory: ./sdk/java
+        gradle-version: 7.4.1
+    strategy:
+      fail-fast: true
+      matrix:
+        goversion:
+        - 1.19.x
+        javaversion:
+        - "11"
   publish_sdk:
     name: publish_sdk
     needs: publish
@@ -416,12 +471,6 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{matrix.pythonversion}}
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{matrix.javaversion}}
     - name: Download python SDK
       uses: actions/download-artifact@v2
       with:
@@ -446,28 +495,11 @@ jobs:
     - name: Uncompress nodejs SDK
       run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
         ${{github.workspace}}/sdk/nodejs
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
     - run: python -m pip install pip twine
     - env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       name: Publish SDKs
       run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3
@@ -482,8 +514,6 @@ jobs:
         - 3.1.301
         goversion:
         - 1.19.x
-        javaversion:
-        - "11"
         nodeversion:
         - 16.x
         pythonversion:

--- a/provider-ci/providers/venafi/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/venafi/repo/.github/workflows/master.yml
@@ -379,6 +379,61 @@ jobs:
         - 16.x
         pythonversion:
         - "3.9"
+  publish_java_sdk:
+    continue-on-error: true
+    name: publish_java_sdk
+    needs: publish
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout Repo
+      uses: actions/checkout@v3
+    - name: Checkout Scripts Repo
+      uses: actions/checkout@v3
+      with:
+        path: ci-scripts
+        repository: pulumi/scripts
+    - name: Unshallow clone for tags
+      run: git fetch --prune --unshallow --tags
+    - name: Install Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: ${{matrix.goversion}}
+    - name: Install pulumictl
+      uses: jaxxstorm/action-install-gh-release@v1.5.0
+      with:
+        repo: pulumi/pulumictl
+    - name: Install Pulumi CLI
+      uses: pulumi/action-install-pulumi-cli@v2
+    - name: Setup Java
+      uses: actions/setup-java@v3
+      with:
+        cache: gradle
+        distribution: temurin
+        java-version: ${{matrix.javaversion}}
+    - name: Download java SDK
+      uses: actions/download-artifact@v2
+      with:
+        name: java-sdk.tar.gz
+        path: ${{ github.workspace}}/sdk/
+    - name: Uncompress java SDK
+      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
+        ${{github.workspace}}/sdk/java
+    - name: Set PACKAGE_VERSION to Env
+      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
+        $GITHUB_ENV
+    - name: Publish Java SDK
+      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
+      with:
+        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
+        build-root-directory: ./sdk/java
+        gradle-version: 7.4.1
+    strategy:
+      fail-fast: true
+      matrix:
+        goversion:
+        - 1.19.x
+        javaversion:
+        - "11"
   publish_sdk:
     name: publish_sdk
     needs: publish
@@ -416,12 +471,6 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{matrix.pythonversion}}
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{matrix.javaversion}}
     - name: Download python SDK
       uses: actions/download-artifact@v2
       with:
@@ -446,28 +495,11 @@ jobs:
     - name: Uncompress nodejs SDK
       run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
         ${{github.workspace}}/sdk/nodejs
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
     - run: python -m pip install pip twine
     - env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       name: Publish SDKs
       run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3
@@ -482,8 +514,6 @@ jobs:
         - 3.1.301
         goversion:
         - 1.19.x
-        javaversion:
-        - "11"
         nodeversion:
         - 16.x
         pythonversion:

--- a/provider-ci/providers/venafi/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/venafi/repo/.github/workflows/prerelease.yml
@@ -323,6 +323,61 @@ jobs:
         - 16.x
         pythonversion:
         - "3.9"
+  publish_java_sdk:
+    continue-on-error: true
+    name: publish_java_sdk
+    needs: publish
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout Repo
+      uses: actions/checkout@v3
+    - name: Checkout Scripts Repo
+      uses: actions/checkout@v3
+      with:
+        path: ci-scripts
+        repository: pulumi/scripts
+    - name: Unshallow clone for tags
+      run: git fetch --prune --unshallow --tags
+    - name: Install Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: ${{matrix.goversion}}
+    - name: Install pulumictl
+      uses: jaxxstorm/action-install-gh-release@v1.5.0
+      with:
+        repo: pulumi/pulumictl
+    - name: Install Pulumi CLI
+      uses: pulumi/action-install-pulumi-cli@v2
+    - name: Setup Java
+      uses: actions/setup-java@v3
+      with:
+        cache: gradle
+        distribution: temurin
+        java-version: ${{matrix.javaversion}}
+    - name: Download java SDK
+      uses: actions/download-artifact@v2
+      with:
+        name: java-sdk.tar.gz
+        path: ${{ github.workspace}}/sdk/
+    - name: Uncompress java SDK
+      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
+        ${{github.workspace}}/sdk/java
+    - name: Set PACKAGE_VERSION to Env
+      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
+        $GITHUB_ENV
+    - name: Publish Java SDK
+      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
+      with:
+        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
+        build-root-directory: ./sdk/java
+        gradle-version: 7.4.1
+    strategy:
+      fail-fast: true
+      matrix:
+        goversion:
+        - 1.19.x
+        javaversion:
+        - "11"
   publish_sdk:
     name: publish_sdk
     needs: publish
@@ -360,12 +415,6 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{matrix.pythonversion}}
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{matrix.javaversion}}
     - name: Download python SDK
       uses: actions/download-artifact@v2
       with:
@@ -390,28 +439,11 @@ jobs:
     - name: Uncompress nodejs SDK
       run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
         ${{github.workspace}}/sdk/nodejs
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
     - run: python -m pip install pip twine
     - env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       name: Publish SDKs
       run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3
@@ -426,8 +458,6 @@ jobs:
         - 3.1.301
         goversion:
         - 1.19.x
-        javaversion:
-        - "11"
         nodeversion:
         - 16.x
         pythonversion:

--- a/provider-ci/providers/venafi/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/venafi/repo/.github/workflows/release.yml
@@ -336,6 +336,61 @@ jobs:
         - 16.x
         pythonversion:
         - "3.9"
+  publish_java_sdk:
+    continue-on-error: true
+    name: publish_java_sdk
+    needs: publish
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout Repo
+      uses: actions/checkout@v3
+    - name: Checkout Scripts Repo
+      uses: actions/checkout@v3
+      with:
+        path: ci-scripts
+        repository: pulumi/scripts
+    - name: Unshallow clone for tags
+      run: git fetch --prune --unshallow --tags
+    - name: Install Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: ${{matrix.goversion}}
+    - name: Install pulumictl
+      uses: jaxxstorm/action-install-gh-release@v1.5.0
+      with:
+        repo: pulumi/pulumictl
+    - name: Install Pulumi CLI
+      uses: pulumi/action-install-pulumi-cli@v2
+    - name: Setup Java
+      uses: actions/setup-java@v3
+      with:
+        cache: gradle
+        distribution: temurin
+        java-version: ${{matrix.javaversion}}
+    - name: Download java SDK
+      uses: actions/download-artifact@v2
+      with:
+        name: java-sdk.tar.gz
+        path: ${{ github.workspace}}/sdk/
+    - name: Uncompress java SDK
+      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
+        ${{github.workspace}}/sdk/java
+    - name: Set PACKAGE_VERSION to Env
+      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
+        $GITHUB_ENV
+    - name: Publish Java SDK
+      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
+      with:
+        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
+        build-root-directory: ./sdk/java
+        gradle-version: 7.4.1
+    strategy:
+      fail-fast: true
+      matrix:
+        goversion:
+        - 1.19.x
+        javaversion:
+        - "11"
   publish_sdk:
     name: publish_sdk
     needs: publish
@@ -373,12 +428,6 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{matrix.pythonversion}}
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{matrix.javaversion}}
     - name: Download python SDK
       uses: actions/download-artifact@v2
       with:
@@ -403,28 +452,11 @@ jobs:
     - name: Uncompress nodejs SDK
       run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
         ${{github.workspace}}/sdk/nodejs
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
     - run: python -m pip install pip twine
     - env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       name: Publish SDKs
       run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3
@@ -439,8 +471,6 @@ jobs:
         - 3.1.301
         goversion:
         - 1.19.x
-        javaversion:
-        - "11"
         nodeversion:
         - 16.x
         pythonversion:

--- a/provider-ci/providers/vsphere/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/vsphere/repo/.github/workflows/main.yml
@@ -376,6 +376,61 @@ jobs:
         - 16.x
         pythonversion:
         - "3.9"
+  publish_java_sdk:
+    continue-on-error: true
+    name: publish_java_sdk
+    needs: publish
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout Repo
+      uses: actions/checkout@v3
+    - name: Checkout Scripts Repo
+      uses: actions/checkout@v3
+      with:
+        path: ci-scripts
+        repository: pulumi/scripts
+    - name: Unshallow clone for tags
+      run: git fetch --prune --unshallow --tags
+    - name: Install Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: ${{matrix.goversion}}
+    - name: Install pulumictl
+      uses: jaxxstorm/action-install-gh-release@v1.5.0
+      with:
+        repo: pulumi/pulumictl
+    - name: Install Pulumi CLI
+      uses: pulumi/action-install-pulumi-cli@v2
+    - name: Setup Java
+      uses: actions/setup-java@v3
+      with:
+        cache: gradle
+        distribution: temurin
+        java-version: ${{matrix.javaversion}}
+    - name: Download java SDK
+      uses: actions/download-artifact@v2
+      with:
+        name: java-sdk.tar.gz
+        path: ${{ github.workspace}}/sdk/
+    - name: Uncompress java SDK
+      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
+        ${{github.workspace}}/sdk/java
+    - name: Set PACKAGE_VERSION to Env
+      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
+        $GITHUB_ENV
+    - name: Publish Java SDK
+      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
+      with:
+        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
+        build-root-directory: ./sdk/java
+        gradle-version: 7.4.1
+    strategy:
+      fail-fast: true
+      matrix:
+        goversion:
+        - 1.19.x
+        javaversion:
+        - "11"
   publish_sdk:
     name: publish_sdk
     needs: publish
@@ -413,12 +468,6 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{matrix.pythonversion}}
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{matrix.javaversion}}
     - name: Download python SDK
       uses: actions/download-artifact@v2
       with:
@@ -443,28 +492,11 @@ jobs:
     - name: Uncompress nodejs SDK
       run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
         ${{github.workspace}}/sdk/nodejs
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
     - run: python -m pip install pip twine
     - env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       name: Publish SDKs
       run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3
@@ -479,8 +511,6 @@ jobs:
         - 3.1.301
         goversion:
         - 1.19.x
-        javaversion:
-        - "11"
         nodeversion:
         - 16.x
         pythonversion:

--- a/provider-ci/providers/vsphere/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/vsphere/repo/.github/workflows/master.yml
@@ -376,6 +376,61 @@ jobs:
         - 16.x
         pythonversion:
         - "3.9"
+  publish_java_sdk:
+    continue-on-error: true
+    name: publish_java_sdk
+    needs: publish
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout Repo
+      uses: actions/checkout@v3
+    - name: Checkout Scripts Repo
+      uses: actions/checkout@v3
+      with:
+        path: ci-scripts
+        repository: pulumi/scripts
+    - name: Unshallow clone for tags
+      run: git fetch --prune --unshallow --tags
+    - name: Install Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: ${{matrix.goversion}}
+    - name: Install pulumictl
+      uses: jaxxstorm/action-install-gh-release@v1.5.0
+      with:
+        repo: pulumi/pulumictl
+    - name: Install Pulumi CLI
+      uses: pulumi/action-install-pulumi-cli@v2
+    - name: Setup Java
+      uses: actions/setup-java@v3
+      with:
+        cache: gradle
+        distribution: temurin
+        java-version: ${{matrix.javaversion}}
+    - name: Download java SDK
+      uses: actions/download-artifact@v2
+      with:
+        name: java-sdk.tar.gz
+        path: ${{ github.workspace}}/sdk/
+    - name: Uncompress java SDK
+      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
+        ${{github.workspace}}/sdk/java
+    - name: Set PACKAGE_VERSION to Env
+      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
+        $GITHUB_ENV
+    - name: Publish Java SDK
+      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
+      with:
+        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
+        build-root-directory: ./sdk/java
+        gradle-version: 7.4.1
+    strategy:
+      fail-fast: true
+      matrix:
+        goversion:
+        - 1.19.x
+        javaversion:
+        - "11"
   publish_sdk:
     name: publish_sdk
     needs: publish
@@ -413,12 +468,6 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{matrix.pythonversion}}
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{matrix.javaversion}}
     - name: Download python SDK
       uses: actions/download-artifact@v2
       with:
@@ -443,28 +492,11 @@ jobs:
     - name: Uncompress nodejs SDK
       run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
         ${{github.workspace}}/sdk/nodejs
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
     - run: python -m pip install pip twine
     - env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       name: Publish SDKs
       run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3
@@ -479,8 +511,6 @@ jobs:
         - 3.1.301
         goversion:
         - 1.19.x
-        javaversion:
-        - "11"
         nodeversion:
         - 16.x
         pythonversion:

--- a/provider-ci/providers/vsphere/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/vsphere/repo/.github/workflows/prerelease.yml
@@ -320,6 +320,61 @@ jobs:
         - 16.x
         pythonversion:
         - "3.9"
+  publish_java_sdk:
+    continue-on-error: true
+    name: publish_java_sdk
+    needs: publish
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout Repo
+      uses: actions/checkout@v3
+    - name: Checkout Scripts Repo
+      uses: actions/checkout@v3
+      with:
+        path: ci-scripts
+        repository: pulumi/scripts
+    - name: Unshallow clone for tags
+      run: git fetch --prune --unshallow --tags
+    - name: Install Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: ${{matrix.goversion}}
+    - name: Install pulumictl
+      uses: jaxxstorm/action-install-gh-release@v1.5.0
+      with:
+        repo: pulumi/pulumictl
+    - name: Install Pulumi CLI
+      uses: pulumi/action-install-pulumi-cli@v2
+    - name: Setup Java
+      uses: actions/setup-java@v3
+      with:
+        cache: gradle
+        distribution: temurin
+        java-version: ${{matrix.javaversion}}
+    - name: Download java SDK
+      uses: actions/download-artifact@v2
+      with:
+        name: java-sdk.tar.gz
+        path: ${{ github.workspace}}/sdk/
+    - name: Uncompress java SDK
+      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
+        ${{github.workspace}}/sdk/java
+    - name: Set PACKAGE_VERSION to Env
+      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
+        $GITHUB_ENV
+    - name: Publish Java SDK
+      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
+      with:
+        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
+        build-root-directory: ./sdk/java
+        gradle-version: 7.4.1
+    strategy:
+      fail-fast: true
+      matrix:
+        goversion:
+        - 1.19.x
+        javaversion:
+        - "11"
   publish_sdk:
     name: publish_sdk
     needs: publish
@@ -357,12 +412,6 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{matrix.pythonversion}}
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{matrix.javaversion}}
     - name: Download python SDK
       uses: actions/download-artifact@v2
       with:
@@ -387,28 +436,11 @@ jobs:
     - name: Uncompress nodejs SDK
       run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
         ${{github.workspace}}/sdk/nodejs
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
     - run: python -m pip install pip twine
     - env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       name: Publish SDKs
       run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3
@@ -423,8 +455,6 @@ jobs:
         - 3.1.301
         goversion:
         - 1.19.x
-        javaversion:
-        - "11"
         nodeversion:
         - 16.x
         pythonversion:

--- a/provider-ci/providers/vsphere/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/vsphere/repo/.github/workflows/release.yml
@@ -333,6 +333,61 @@ jobs:
         - 16.x
         pythonversion:
         - "3.9"
+  publish_java_sdk:
+    continue-on-error: true
+    name: publish_java_sdk
+    needs: publish
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout Repo
+      uses: actions/checkout@v3
+    - name: Checkout Scripts Repo
+      uses: actions/checkout@v3
+      with:
+        path: ci-scripts
+        repository: pulumi/scripts
+    - name: Unshallow clone for tags
+      run: git fetch --prune --unshallow --tags
+    - name: Install Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: ${{matrix.goversion}}
+    - name: Install pulumictl
+      uses: jaxxstorm/action-install-gh-release@v1.5.0
+      with:
+        repo: pulumi/pulumictl
+    - name: Install Pulumi CLI
+      uses: pulumi/action-install-pulumi-cli@v2
+    - name: Setup Java
+      uses: actions/setup-java@v3
+      with:
+        cache: gradle
+        distribution: temurin
+        java-version: ${{matrix.javaversion}}
+    - name: Download java SDK
+      uses: actions/download-artifact@v2
+      with:
+        name: java-sdk.tar.gz
+        path: ${{ github.workspace}}/sdk/
+    - name: Uncompress java SDK
+      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
+        ${{github.workspace}}/sdk/java
+    - name: Set PACKAGE_VERSION to Env
+      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
+        $GITHUB_ENV
+    - name: Publish Java SDK
+      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
+      with:
+        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
+        build-root-directory: ./sdk/java
+        gradle-version: 7.4.1
+    strategy:
+      fail-fast: true
+      matrix:
+        goversion:
+        - 1.19.x
+        javaversion:
+        - "11"
   publish_sdk:
     name: publish_sdk
     needs: publish
@@ -370,12 +425,6 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{matrix.pythonversion}}
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{matrix.javaversion}}
     - name: Download python SDK
       uses: actions/download-artifact@v2
       with:
@@ -400,28 +449,11 @@ jobs:
     - name: Uncompress nodejs SDK
       run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
         ${{github.workspace}}/sdk/nodejs
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
     - run: python -m pip install pip twine
     - env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       name: Publish SDKs
       run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3
@@ -436,8 +468,6 @@ jobs:
         - 3.1.301
         goversion:
         - 1.19.x
-        javaversion:
-        - "11"
         nodeversion:
         - 16.x
         pythonversion:

--- a/provider-ci/providers/wavefront/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/wavefront/repo/.github/workflows/main.yml
@@ -378,6 +378,61 @@ jobs:
         - 16.x
         pythonversion:
         - "3.9"
+  publish_java_sdk:
+    continue-on-error: true
+    name: publish_java_sdk
+    needs: publish
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout Repo
+      uses: actions/checkout@v3
+    - name: Checkout Scripts Repo
+      uses: actions/checkout@v3
+      with:
+        path: ci-scripts
+        repository: pulumi/scripts
+    - name: Unshallow clone for tags
+      run: git fetch --prune --unshallow --tags
+    - name: Install Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: ${{matrix.goversion}}
+    - name: Install pulumictl
+      uses: jaxxstorm/action-install-gh-release@v1.5.0
+      with:
+        repo: pulumi/pulumictl
+    - name: Install Pulumi CLI
+      uses: pulumi/action-install-pulumi-cli@v2
+    - name: Setup Java
+      uses: actions/setup-java@v3
+      with:
+        cache: gradle
+        distribution: temurin
+        java-version: ${{matrix.javaversion}}
+    - name: Download java SDK
+      uses: actions/download-artifact@v2
+      with:
+        name: java-sdk.tar.gz
+        path: ${{ github.workspace}}/sdk/
+    - name: Uncompress java SDK
+      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
+        ${{github.workspace}}/sdk/java
+    - name: Set PACKAGE_VERSION to Env
+      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
+        $GITHUB_ENV
+    - name: Publish Java SDK
+      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
+      with:
+        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
+        build-root-directory: ./sdk/java
+        gradle-version: 7.4.1
+    strategy:
+      fail-fast: true
+      matrix:
+        goversion:
+        - 1.19.x
+        javaversion:
+        - "11"
   publish_sdk:
     name: publish_sdk
     needs: publish
@@ -415,12 +470,6 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{matrix.pythonversion}}
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{matrix.javaversion}}
     - name: Download python SDK
       uses: actions/download-artifact@v2
       with:
@@ -445,28 +494,11 @@ jobs:
     - name: Uncompress nodejs SDK
       run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
         ${{github.workspace}}/sdk/nodejs
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
     - run: python -m pip install pip twine
     - env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       name: Publish SDKs
       run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3
@@ -481,8 +513,6 @@ jobs:
         - 3.1.301
         goversion:
         - 1.19.x
-        javaversion:
-        - "11"
         nodeversion:
         - 16.x
         pythonversion:

--- a/provider-ci/providers/wavefront/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/wavefront/repo/.github/workflows/master.yml
@@ -378,6 +378,61 @@ jobs:
         - 16.x
         pythonversion:
         - "3.9"
+  publish_java_sdk:
+    continue-on-error: true
+    name: publish_java_sdk
+    needs: publish
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout Repo
+      uses: actions/checkout@v3
+    - name: Checkout Scripts Repo
+      uses: actions/checkout@v3
+      with:
+        path: ci-scripts
+        repository: pulumi/scripts
+    - name: Unshallow clone for tags
+      run: git fetch --prune --unshallow --tags
+    - name: Install Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: ${{matrix.goversion}}
+    - name: Install pulumictl
+      uses: jaxxstorm/action-install-gh-release@v1.5.0
+      with:
+        repo: pulumi/pulumictl
+    - name: Install Pulumi CLI
+      uses: pulumi/action-install-pulumi-cli@v2
+    - name: Setup Java
+      uses: actions/setup-java@v3
+      with:
+        cache: gradle
+        distribution: temurin
+        java-version: ${{matrix.javaversion}}
+    - name: Download java SDK
+      uses: actions/download-artifact@v2
+      with:
+        name: java-sdk.tar.gz
+        path: ${{ github.workspace}}/sdk/
+    - name: Uncompress java SDK
+      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
+        ${{github.workspace}}/sdk/java
+    - name: Set PACKAGE_VERSION to Env
+      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
+        $GITHUB_ENV
+    - name: Publish Java SDK
+      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
+      with:
+        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
+        build-root-directory: ./sdk/java
+        gradle-version: 7.4.1
+    strategy:
+      fail-fast: true
+      matrix:
+        goversion:
+        - 1.19.x
+        javaversion:
+        - "11"
   publish_sdk:
     name: publish_sdk
     needs: publish
@@ -415,12 +470,6 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{matrix.pythonversion}}
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{matrix.javaversion}}
     - name: Download python SDK
       uses: actions/download-artifact@v2
       with:
@@ -445,28 +494,11 @@ jobs:
     - name: Uncompress nodejs SDK
       run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
         ${{github.workspace}}/sdk/nodejs
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
     - run: python -m pip install pip twine
     - env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       name: Publish SDKs
       run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3
@@ -481,8 +513,6 @@ jobs:
         - 3.1.301
         goversion:
         - 1.19.x
-        javaversion:
-        - "11"
         nodeversion:
         - 16.x
         pythonversion:

--- a/provider-ci/providers/wavefront/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/wavefront/repo/.github/workflows/prerelease.yml
@@ -322,6 +322,61 @@ jobs:
         - 16.x
         pythonversion:
         - "3.9"
+  publish_java_sdk:
+    continue-on-error: true
+    name: publish_java_sdk
+    needs: publish
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout Repo
+      uses: actions/checkout@v3
+    - name: Checkout Scripts Repo
+      uses: actions/checkout@v3
+      with:
+        path: ci-scripts
+        repository: pulumi/scripts
+    - name: Unshallow clone for tags
+      run: git fetch --prune --unshallow --tags
+    - name: Install Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: ${{matrix.goversion}}
+    - name: Install pulumictl
+      uses: jaxxstorm/action-install-gh-release@v1.5.0
+      with:
+        repo: pulumi/pulumictl
+    - name: Install Pulumi CLI
+      uses: pulumi/action-install-pulumi-cli@v2
+    - name: Setup Java
+      uses: actions/setup-java@v3
+      with:
+        cache: gradle
+        distribution: temurin
+        java-version: ${{matrix.javaversion}}
+    - name: Download java SDK
+      uses: actions/download-artifact@v2
+      with:
+        name: java-sdk.tar.gz
+        path: ${{ github.workspace}}/sdk/
+    - name: Uncompress java SDK
+      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
+        ${{github.workspace}}/sdk/java
+    - name: Set PACKAGE_VERSION to Env
+      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
+        $GITHUB_ENV
+    - name: Publish Java SDK
+      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
+      with:
+        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
+        build-root-directory: ./sdk/java
+        gradle-version: 7.4.1
+    strategy:
+      fail-fast: true
+      matrix:
+        goversion:
+        - 1.19.x
+        javaversion:
+        - "11"
   publish_sdk:
     name: publish_sdk
     needs: publish
@@ -359,12 +414,6 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{matrix.pythonversion}}
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{matrix.javaversion}}
     - name: Download python SDK
       uses: actions/download-artifact@v2
       with:
@@ -389,28 +438,11 @@ jobs:
     - name: Uncompress nodejs SDK
       run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
         ${{github.workspace}}/sdk/nodejs
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
     - run: python -m pip install pip twine
     - env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       name: Publish SDKs
       run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3
@@ -425,8 +457,6 @@ jobs:
         - 3.1.301
         goversion:
         - 1.19.x
-        javaversion:
-        - "11"
         nodeversion:
         - 16.x
         pythonversion:

--- a/provider-ci/providers/wavefront/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/wavefront/repo/.github/workflows/release.yml
@@ -335,6 +335,61 @@ jobs:
         - 16.x
         pythonversion:
         - "3.9"
+  publish_java_sdk:
+    continue-on-error: true
+    name: publish_java_sdk
+    needs: publish
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout Repo
+      uses: actions/checkout@v3
+    - name: Checkout Scripts Repo
+      uses: actions/checkout@v3
+      with:
+        path: ci-scripts
+        repository: pulumi/scripts
+    - name: Unshallow clone for tags
+      run: git fetch --prune --unshallow --tags
+    - name: Install Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: ${{matrix.goversion}}
+    - name: Install pulumictl
+      uses: jaxxstorm/action-install-gh-release@v1.5.0
+      with:
+        repo: pulumi/pulumictl
+    - name: Install Pulumi CLI
+      uses: pulumi/action-install-pulumi-cli@v2
+    - name: Setup Java
+      uses: actions/setup-java@v3
+      with:
+        cache: gradle
+        distribution: temurin
+        java-version: ${{matrix.javaversion}}
+    - name: Download java SDK
+      uses: actions/download-artifact@v2
+      with:
+        name: java-sdk.tar.gz
+        path: ${{ github.workspace}}/sdk/
+    - name: Uncompress java SDK
+      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
+        ${{github.workspace}}/sdk/java
+    - name: Set PACKAGE_VERSION to Env
+      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
+        $GITHUB_ENV
+    - name: Publish Java SDK
+      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
+      with:
+        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
+        build-root-directory: ./sdk/java
+        gradle-version: 7.4.1
+    strategy:
+      fail-fast: true
+      matrix:
+        goversion:
+        - 1.19.x
+        javaversion:
+        - "11"
   publish_sdk:
     name: publish_sdk
     needs: publish
@@ -372,12 +427,6 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{matrix.pythonversion}}
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{matrix.javaversion}}
     - name: Download python SDK
       uses: actions/download-artifact@v2
       with:
@@ -402,28 +451,11 @@ jobs:
     - name: Uncompress nodejs SDK
       run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
         ${{github.workspace}}/sdk/nodejs
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
     - run: python -m pip install pip twine
     - env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       name: Publish SDKs
       run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3
@@ -438,8 +470,6 @@ jobs:
         - 3.1.301
         goversion:
         - 1.19.x
-        javaversion:
-        - "11"
         nodeversion:
         - 16.x
         pythonversion:


### PR DESCRIPTION
Fixes: #256

While the Java project is in preview, we should not fail
the release jobs if the java sdk is not released. By failing the job,
we may have already released the node|dotnet|python packages as
well as the binaries. Failing the job means we don't cut a
Go SDK or create a docs release so the release job isn't correct

We are going to silently continue with the java sdk job. When the
Java SDK is in GA, we can combine these jobs again
