### PR TITLE
Pause automerge in native-providers

### DIFF
--- a/.github/workflows/rollout-native-provider-workflows.yml
+++ b/.github/workflows/rollout-native-provider-workflows.yml
@@ -57,14 +57,14 @@ jobs:
           title: "Update GitHub Actions workflows."
           path: pulumi-${{ matrix.provider }}
           token: ${{ secrets.PULUMI_BOT_TOKEN }}
-      - name: Set PR to auto-merge
-        if: steps.create-pr.outputs.pull-request-operation == 'created'
-        uses: peter-evans/enable-pull-request-automerge@v1
-        with:
-          token: ${{ secrets.PULUMI_BOT_TOKEN }}
-          pull-request-number: ${{ steps.create-pr.outputs.pull-request-number }}
-          repository: pulumi/pulumi-${{ matrix.provider }}
-          merge-method: squash
+      # - name: Set PR to auto-merge
+      #   if: steps.create-pr.outputs.pull-request-operation == 'created'
+      #   uses: peter-evans/enable-pull-request-automerge@v1
+      #   with:
+      #     token: ${{ secrets.PULUMI_BOT_TOKEN }}
+      #     pull-request-number: ${{ steps.create-pr.outputs.pull-request-number }}
+      #     repository: pulumi/pulumi-${{ matrix.provider }}
+      #     merge-method: squash
         # See: https://docs.github.com/en/rest/guides/best-practices-for-integrators#dealing-with-secondary-rate-limits
       - name: Sleep to prevent hitting secondary rate limits
         run: sleep 1

--- a/native-provider-ci/providers/aws-native/repo/.github/workflows/nightly-sdk-generation.yml
+++ b/native-provider-ci/providers/aws-native/repo/.github/workflows/nightly-sdk-generation.yml
@@ -99,14 +99,6 @@ jobs:
           steps.vars.outputs.commit-hash }}
         author_name: pulumi-bot
         source_branch: generate-sdk/${{ github.run_id }}-${{ github.run_number }}
-    - name: Set AutoMerge
-      if: steps.create-pr.outputs.has_changed_files
-      uses: peter-evans/enable-pull-request-automerge@v1
-      with:
-        token: ${{ secrets.PULUMI_BOT_TOKEN }}
-        pull-request-number: ${{ steps.create-pr.outputs.pr_number }}
-        repository: ${{ github.repository }}
-        merge-method: squash
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3

--- a/native-provider-ci/providers/aws-native/repo/.github/workflows/weekly-pulumi-update.yml
+++ b/native-provider-ci/providers/aws-native/repo/.github/workflows/weekly-pulumi-update.yml
@@ -145,12 +145,4 @@ jobs:
         github_token: ${{ secrets.PULUMI_BOT_TOKEN }}
       env:
         GITHUB_TOKEN: ${{ secrets.PULUMI_BOT_TOKEN }}
-    - name: Set AutoMerge
-      if: steps.create-pr.outputs.has_changed_files
-      uses: peter-evans/enable-pull-request-automerge@v1
-      with:
-        token: ${{ secrets.PULUMI_BOT_TOKEN }}
-        pull-request-number: ${{ steps.create-pr.outputs.pr_number }}
-        repository: ${{ github.repository }}
-        merge-method: squash
     name: weekly-pulumi-update

--- a/native-provider-ci/providers/azure-native/repo/.github/workflows/nightly-sdk-generation.yml
+++ b/native-provider-ci/providers/azure-native/repo/.github/workflows/nightly-sdk-generation.yml
@@ -97,14 +97,6 @@ jobs:
           steps.vars.outputs.commit-hash }}
         author_name: pulumi-bot
         source_branch: generate-sdk/${{ github.run_id }}-${{ github.run_number }}
-    - name: Set AutoMerge
-      if: steps.create-pr.outputs.has_changed_files
-      uses: peter-evans/enable-pull-request-automerge@v1
-      with:
-        token: ${{ secrets.PULUMI_BOT_TOKEN }}
-        pull-request-number: ${{ steps.create-pr.outputs.pr_number }}
-        repository: ${{ github.repository }}
-        merge-method: squash
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3

--- a/native-provider-ci/providers/azure-native/repo/.github/workflows/weekly-pulumi-update.yml
+++ b/native-provider-ci/providers/azure-native/repo/.github/workflows/weekly-pulumi-update.yml
@@ -151,12 +151,4 @@ jobs:
         github_token: ${{ secrets.PULUMI_BOT_TOKEN }}
       env:
         GITHUB_TOKEN: ${{ secrets.PULUMI_BOT_TOKEN }}
-    - name: Set AutoMerge
-      if: steps.create-pr.outputs.has_changed_files
-      uses: peter-evans/enable-pull-request-automerge@v1
-      with:
-        token: ${{ secrets.PULUMI_BOT_TOKEN }}
-        pull-request-number: ${{ steps.create-pr.outputs.pr_number }}
-        repository: ${{ github.repository }}
-        merge-method: squash
     name: weekly-pulumi-update

--- a/native-provider-ci/providers/command/repo/.github/workflows/weekly-pulumi-update.yml
+++ b/native-provider-ci/providers/command/repo/.github/workflows/weekly-pulumi-update.yml
@@ -143,12 +143,4 @@ jobs:
         github_token: ${{ secrets.PULUMI_BOT_TOKEN }}
       env:
         GITHUB_TOKEN: ${{ secrets.PULUMI_BOT_TOKEN }}
-    - name: Set AutoMerge
-      if: steps.create-pr.outputs.has_changed_files
-      uses: peter-evans/enable-pull-request-automerge@v1
-      with:
-        token: ${{ secrets.PULUMI_BOT_TOKEN }}
-        pull-request-number: ${{ steps.create-pr.outputs.pr_number }}
-        repository: ${{ github.repository }}
-        merge-method: squash
     name: weekly-pulumi-update

--- a/native-provider-ci/providers/google-native/repo/.github/workflows/nightly-sdk-generation.yml
+++ b/native-provider-ci/providers/google-native/repo/.github/workflows/nightly-sdk-generation.yml
@@ -94,14 +94,6 @@ jobs:
         pr_title: Automated SDK generation
         author_name: pulumi-bot
         source_branch: generate-sdk/${{ github.run_id }}-${{ github.run_number }}
-    - name: Set AutoMerge
-      if: steps.create-pr.outputs.has_changed_files
-      uses: peter-evans/enable-pull-request-automerge@v1
-      with:
-        token: ${{ secrets.PULUMI_BOT_TOKEN }}
-        pull-request-number: ${{ steps.create-pr.outputs.pr_number }}
-        repository: ${{ github.repository }}
-        merge-method: squash
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3

--- a/native-provider-ci/providers/google-native/repo/.github/workflows/weekly-pulumi-update.yml
+++ b/native-provider-ci/providers/google-native/repo/.github/workflows/weekly-pulumi-update.yml
@@ -151,12 +151,4 @@ jobs:
         github_token: ${{ secrets.PULUMI_BOT_TOKEN }}
       env:
         GITHUB_TOKEN: ${{ secrets.PULUMI_BOT_TOKEN }}
-    - name: Set AutoMerge
-      if: steps.create-pr.outputs.has_changed_files
-      uses: peter-evans/enable-pull-request-automerge@v1
-      with:
-        token: ${{ secrets.PULUMI_BOT_TOKEN }}
-        pull-request-number: ${{ steps.create-pr.outputs.pr_number }}
-        repository: ${{ github.repository }}
-        merge-method: squash
     name: weekly-pulumi-update

--- a/native-provider-ci/src/workflows.ts
+++ b/native-provider-ci/src/workflows.ts
@@ -1016,7 +1016,7 @@ export class WeeklyPulumiUpdate implements NormalJob {
       steps.InitializeSubModules(opts.submodules),
       steps.ProviderWithPulumiUpgrade(opts.provider),
       steps.CreateUpdatePulumiPR(),
-      steps.SetPRAutoMerge(opts.provider),
+      // steps.SetPRAutoMerge(opts.provider),
     ].filter((step: Step) => step.uses !== undefined || step.run !== undefined);
     Object.assign(this, { name });
   }
@@ -1049,7 +1049,7 @@ export class NightlySdkGeneration implements NormalJob {
       steps.SetGitSubmoduleCommitHash(opts.provider),
       steps.CommitAutomatedSDKUpdates(opts.provider),
       steps.PullRequestSdkGeneration(opts.provider),
-      steps.SetPRAutoMerge(opts.provider),
+      // steps.SetPRAutoMerge(opts.provider),
       steps.NotifySlack("Failure during automated SDK generation"),
     ].filter((step: Step) => step.uses !== undefined || step.run !== undefined);
     Object.assign(this, { name });


### PR DESCRIPTION
We are experiencing some unpredictable and not as intended automerges in native-providers, pausing the use of the feature for now.