### PR TITLE
Pause automerge universally on TF providers

### DIFF
--- a/.github/workflows/update-workflows-bridged-providers.yml
+++ b/.github/workflows/update-workflows-bridged-providers.yml
@@ -63,14 +63,14 @@ jobs:
           title: "Update GitHub Actions workflows."
           path: pulumi-${{ matrix.provider }}
           token: ${{ secrets.PULUMI_BOT_TOKEN }}
-      - name: Set PR to auto-merge
-        if: steps.create-pr.outputs.pull-request-operation == 'created' && github.event.inputs.automerge == 'true'
-        uses: peter-evans/enable-pull-request-automerge@v1
-        with:
-          token: ${{ secrets.PULUMI_BOT_TOKEN }}
-          pull-request-number: ${{ steps.create-pr.outputs.pull-request-number }}
-          repository: pulumi/pulumi-${{ matrix.provider }}
-          merge-method: squash
+      # - name: Set PR to auto-merge
+      #   if: steps.create-pr.outputs.pull-request-operation == 'created' && github.event.inputs.automerge == 'true'
+      #   uses: peter-evans/enable-pull-request-automerge@v1
+      #  with:
+      #     token: ${{ secrets.PULUMI_BOT_TOKEN }}
+      #     pull-request-number: ${{ steps.create-pr.outputs.pull-request-number }}
+      #     repository: pulumi/pulumi-${{ matrix.provider }}
+      #     merge-method: squash
         # See: https://docs.github.com/en/rest/guides/best-practices-for-integrators#dealing-with-secondary-rate-limits
       - name: Sleep to prevent hitting secondary rate limits
         run: sleep 1

--- a/provider-ci/providers/aiven/repo/.github/workflows/update-bridge.yml
+++ b/provider-ci/providers/aiven/repo/.github/workflows/update-bridge.yml
@@ -66,14 +66,6 @@ jobs:
         title: Update pulumi-terraform-bridge to v${{ github.event.inputs.bridge_version
           }}
         token: ${{ secrets.PULUMI_BOT_TOKEN }}
-    - if: steps.create-pr.outputs.pull-request-operation == 'created'
-      name: Set Automerge
-      uses: peter-evans/enable-pull-request-automerge@v1
-      with:
-        merge-method: squash
-        pull-request-number: ${{ steps.create-pr.outputs.pull-request-number }}
-        repository: ${{ github.repository }}
-        token: ${{ secrets.PULUMI_BOT_TOKEN }}
     strategy:
       fail-fast: true
       matrix:

--- a/provider-ci/providers/akamai/repo/.github/workflows/update-bridge.yml
+++ b/provider-ci/providers/akamai/repo/.github/workflows/update-bridge.yml
@@ -66,14 +66,6 @@ jobs:
         title: Update pulumi-terraform-bridge to v${{ github.event.inputs.bridge_version
           }}
         token: ${{ secrets.PULUMI_BOT_TOKEN }}
-    - if: steps.create-pr.outputs.pull-request-operation == 'created'
-      name: Set Automerge
-      uses: peter-evans/enable-pull-request-automerge@v1
-      with:
-        merge-method: squash
-        pull-request-number: ${{ steps.create-pr.outputs.pull-request-number }}
-        repository: ${{ github.repository }}
-        token: ${{ secrets.PULUMI_BOT_TOKEN }}
     strategy:
       fail-fast: true
       matrix:

--- a/provider-ci/providers/alicloud/repo/.github/workflows/update-bridge.yml
+++ b/provider-ci/providers/alicloud/repo/.github/workflows/update-bridge.yml
@@ -66,14 +66,6 @@ jobs:
         title: Update pulumi-terraform-bridge to v${{ github.event.inputs.bridge_version
           }}
         token: ${{ secrets.PULUMI_BOT_TOKEN }}
-    - if: steps.create-pr.outputs.pull-request-operation == 'created'
-      name: Set Automerge
-      uses: peter-evans/enable-pull-request-automerge@v1
-      with:
-        merge-method: squash
-        pull-request-number: ${{ steps.create-pr.outputs.pull-request-number }}
-        repository: ${{ github.repository }}
-        token: ${{ secrets.PULUMI_BOT_TOKEN }}
     strategy:
       fail-fast: true
       matrix:

--- a/provider-ci/providers/artifactory/repo/.github/workflows/update-bridge.yml
+++ b/provider-ci/providers/artifactory/repo/.github/workflows/update-bridge.yml
@@ -66,14 +66,6 @@ jobs:
         title: Update pulumi-terraform-bridge to v${{ github.event.inputs.bridge_version
           }}
         token: ${{ secrets.PULUMI_BOT_TOKEN }}
-    - if: steps.create-pr.outputs.pull-request-operation == 'created'
-      name: Set Automerge
-      uses: peter-evans/enable-pull-request-automerge@v1
-      with:
-        merge-method: squash
-        pull-request-number: ${{ steps.create-pr.outputs.pull-request-number }}
-        repository: ${{ github.repository }}
-        token: ${{ secrets.PULUMI_BOT_TOKEN }}
     strategy:
       fail-fast: true
       matrix:

--- a/provider-ci/providers/auth0/repo/.github/workflows/update-bridge.yml
+++ b/provider-ci/providers/auth0/repo/.github/workflows/update-bridge.yml
@@ -66,14 +66,6 @@ jobs:
         title: Update pulumi-terraform-bridge to v${{ github.event.inputs.bridge_version
           }}
         token: ${{ secrets.PULUMI_BOT_TOKEN }}
-    - if: steps.create-pr.outputs.pull-request-operation == 'created'
-      name: Set Automerge
-      uses: peter-evans/enable-pull-request-automerge@v1
-      with:
-        merge-method: squash
-        pull-request-number: ${{ steps.create-pr.outputs.pull-request-number }}
-        repository: ${{ github.repository }}
-        token: ${{ secrets.PULUMI_BOT_TOKEN }}
     strategy:
       fail-fast: true
       matrix:

--- a/provider-ci/providers/aws/repo/.github/workflows/update-bridge.yml
+++ b/provider-ci/providers/aws/repo/.github/workflows/update-bridge.yml
@@ -66,14 +66,6 @@ jobs:
         title: Update pulumi-terraform-bridge to v${{ github.event.inputs.bridge_version
           }}
         token: ${{ secrets.PULUMI_BOT_TOKEN }}
-    - if: steps.create-pr.outputs.pull-request-operation == 'created'
-      name: Set Automerge
-      uses: peter-evans/enable-pull-request-automerge@v1
-      with:
-        merge-method: squash
-        pull-request-number: ${{ steps.create-pr.outputs.pull-request-number }}
-        repository: ${{ github.repository }}
-        token: ${{ secrets.PULUMI_BOT_TOKEN }}
     strategy:
       fail-fast: true
       matrix:

--- a/provider-ci/providers/azure/repo/.github/workflows/update-bridge.yml
+++ b/provider-ci/providers/azure/repo/.github/workflows/update-bridge.yml
@@ -66,14 +66,6 @@ jobs:
         title: Update pulumi-terraform-bridge to v${{ github.event.inputs.bridge_version
           }}
         token: ${{ secrets.PULUMI_BOT_TOKEN }}
-    - if: steps.create-pr.outputs.pull-request-operation == 'created'
-      name: Set Automerge
-      uses: peter-evans/enable-pull-request-automerge@v1
-      with:
-        merge-method: squash
-        pull-request-number: ${{ steps.create-pr.outputs.pull-request-number }}
-        repository: ${{ github.repository }}
-        token: ${{ secrets.PULUMI_BOT_TOKEN }}
     strategy:
       fail-fast: true
       matrix:

--- a/provider-ci/providers/azuread/repo/.github/workflows/update-bridge.yml
+++ b/provider-ci/providers/azuread/repo/.github/workflows/update-bridge.yml
@@ -66,14 +66,6 @@ jobs:
         title: Update pulumi-terraform-bridge to v${{ github.event.inputs.bridge_version
           }}
         token: ${{ secrets.PULUMI_BOT_TOKEN }}
-    - if: steps.create-pr.outputs.pull-request-operation == 'created'
-      name: Set Automerge
-      uses: peter-evans/enable-pull-request-automerge@v1
-      with:
-        merge-method: squash
-        pull-request-number: ${{ steps.create-pr.outputs.pull-request-number }}
-        repository: ${{ github.repository }}
-        token: ${{ secrets.PULUMI_BOT_TOKEN }}
     strategy:
       fail-fast: true
       matrix:

--- a/provider-ci/providers/azuredevops/repo/.github/workflows/update-bridge.yml
+++ b/provider-ci/providers/azuredevops/repo/.github/workflows/update-bridge.yml
@@ -66,14 +66,6 @@ jobs:
         title: Update pulumi-terraform-bridge to v${{ github.event.inputs.bridge_version
           }}
         token: ${{ secrets.PULUMI_BOT_TOKEN }}
-    - if: steps.create-pr.outputs.pull-request-operation == 'created'
-      name: Set Automerge
-      uses: peter-evans/enable-pull-request-automerge@v1
-      with:
-        merge-method: squash
-        pull-request-number: ${{ steps.create-pr.outputs.pull-request-number }}
-        repository: ${{ github.repository }}
-        token: ${{ secrets.PULUMI_BOT_TOKEN }}
     strategy:
       fail-fast: true
       matrix:

--- a/provider-ci/providers/civo/repo/.github/workflows/update-bridge.yml
+++ b/provider-ci/providers/civo/repo/.github/workflows/update-bridge.yml
@@ -66,14 +66,6 @@ jobs:
         title: Update pulumi-terraform-bridge to v${{ github.event.inputs.bridge_version
           }}
         token: ${{ secrets.PULUMI_BOT_TOKEN }}
-    - if: steps.create-pr.outputs.pull-request-operation == 'created'
-      name: Set Automerge
-      uses: peter-evans/enable-pull-request-automerge@v1
-      with:
-        merge-method: squash
-        pull-request-number: ${{ steps.create-pr.outputs.pull-request-number }}
-        repository: ${{ github.repository }}
-        token: ${{ secrets.PULUMI_BOT_TOKEN }}
     strategy:
       fail-fast: true
       matrix:

--- a/provider-ci/providers/cloudamqp/repo/.github/workflows/update-bridge.yml
+++ b/provider-ci/providers/cloudamqp/repo/.github/workflows/update-bridge.yml
@@ -66,14 +66,6 @@ jobs:
         title: Update pulumi-terraform-bridge to v${{ github.event.inputs.bridge_version
           }}
         token: ${{ secrets.PULUMI_BOT_TOKEN }}
-    - if: steps.create-pr.outputs.pull-request-operation == 'created'
-      name: Set Automerge
-      uses: peter-evans/enable-pull-request-automerge@v1
-      with:
-        merge-method: squash
-        pull-request-number: ${{ steps.create-pr.outputs.pull-request-number }}
-        repository: ${{ github.repository }}
-        token: ${{ secrets.PULUMI_BOT_TOKEN }}
     strategy:
       fail-fast: true
       matrix:

--- a/provider-ci/providers/cloudflare/repo/.github/workflows/update-bridge.yml
+++ b/provider-ci/providers/cloudflare/repo/.github/workflows/update-bridge.yml
@@ -66,14 +66,6 @@ jobs:
         title: Update pulumi-terraform-bridge to v${{ github.event.inputs.bridge_version
           }}
         token: ${{ secrets.PULUMI_BOT_TOKEN }}
-    - if: steps.create-pr.outputs.pull-request-operation == 'created'
-      name: Set Automerge
-      uses: peter-evans/enable-pull-request-automerge@v1
-      with:
-        merge-method: squash
-        pull-request-number: ${{ steps.create-pr.outputs.pull-request-number }}
-        repository: ${{ github.repository }}
-        token: ${{ secrets.PULUMI_BOT_TOKEN }}
     strategy:
       fail-fast: true
       matrix:

--- a/provider-ci/providers/cloudinit/repo/.github/workflows/update-bridge.yml
+++ b/provider-ci/providers/cloudinit/repo/.github/workflows/update-bridge.yml
@@ -66,14 +66,6 @@ jobs:
         title: Update pulumi-terraform-bridge to v${{ github.event.inputs.bridge_version
           }}
         token: ${{ secrets.PULUMI_BOT_TOKEN }}
-    - if: steps.create-pr.outputs.pull-request-operation == 'created'
-      name: Set Automerge
-      uses: peter-evans/enable-pull-request-automerge@v1
-      with:
-        merge-method: squash
-        pull-request-number: ${{ steps.create-pr.outputs.pull-request-number }}
-        repository: ${{ github.repository }}
-        token: ${{ secrets.PULUMI_BOT_TOKEN }}
     strategy:
       fail-fast: true
       matrix:

--- a/provider-ci/providers/confluent/repo/.github/workflows/update-bridge.yml
+++ b/provider-ci/providers/confluent/repo/.github/workflows/update-bridge.yml
@@ -66,14 +66,6 @@ jobs:
         title: Update pulumi-terraform-bridge to v${{ github.event.inputs.bridge_version
           }}
         token: ${{ secrets.PULUMI_BOT_TOKEN }}
-    - if: steps.create-pr.outputs.pull-request-operation == 'created'
-      name: Set Automerge
-      uses: peter-evans/enable-pull-request-automerge@v1
-      with:
-        merge-method: squash
-        pull-request-number: ${{ steps.create-pr.outputs.pull-request-number }}
-        repository: ${{ github.repository }}
-        token: ${{ secrets.PULUMI_BOT_TOKEN }}
     strategy:
       fail-fast: true
       matrix:

--- a/provider-ci/providers/confluentcloud/repo/.github/workflows/update-bridge.yml
+++ b/provider-ci/providers/confluentcloud/repo/.github/workflows/update-bridge.yml
@@ -66,14 +66,6 @@ jobs:
         title: Update pulumi-terraform-bridge to v${{ github.event.inputs.bridge_version
           }}
         token: ${{ secrets.PULUMI_BOT_TOKEN }}
-    - if: steps.create-pr.outputs.pull-request-operation == 'created'
-      name: Set Automerge
-      uses: peter-evans/enable-pull-request-automerge@v1
-      with:
-        merge-method: squash
-        pull-request-number: ${{ steps.create-pr.outputs.pull-request-number }}
-        repository: ${{ github.repository }}
-        token: ${{ secrets.PULUMI_BOT_TOKEN }}
     strategy:
       fail-fast: true
       matrix:

--- a/provider-ci/providers/consul/repo/.github/workflows/update-bridge.yml
+++ b/provider-ci/providers/consul/repo/.github/workflows/update-bridge.yml
@@ -66,14 +66,6 @@ jobs:
         title: Update pulumi-terraform-bridge to v${{ github.event.inputs.bridge_version
           }}
         token: ${{ secrets.PULUMI_BOT_TOKEN }}
-    - if: steps.create-pr.outputs.pull-request-operation == 'created'
-      name: Set Automerge
-      uses: peter-evans/enable-pull-request-automerge@v1
-      with:
-        merge-method: squash
-        pull-request-number: ${{ steps.create-pr.outputs.pull-request-number }}
-        repository: ${{ github.repository }}
-        token: ${{ secrets.PULUMI_BOT_TOKEN }}
     strategy:
       fail-fast: true
       matrix:

--- a/provider-ci/providers/databricks/repo/.github/workflows/update-bridge.yml
+++ b/provider-ci/providers/databricks/repo/.github/workflows/update-bridge.yml
@@ -66,14 +66,6 @@ jobs:
         title: Update pulumi-terraform-bridge to v${{ github.event.inputs.bridge_version
           }}
         token: ${{ secrets.PULUMI_BOT_TOKEN }}
-    - if: steps.create-pr.outputs.pull-request-operation == 'created'
-      name: Set Automerge
-      uses: peter-evans/enable-pull-request-automerge@v1
-      with:
-        merge-method: squash
-        pull-request-number: ${{ steps.create-pr.outputs.pull-request-number }}
-        repository: ${{ github.repository }}
-        token: ${{ secrets.PULUMI_BOT_TOKEN }}
     strategy:
       fail-fast: true
       matrix:

--- a/provider-ci/providers/datadog/repo/.github/workflows/update-bridge.yml
+++ b/provider-ci/providers/datadog/repo/.github/workflows/update-bridge.yml
@@ -66,14 +66,6 @@ jobs:
         title: Update pulumi-terraform-bridge to v${{ github.event.inputs.bridge_version
           }}
         token: ${{ secrets.PULUMI_BOT_TOKEN }}
-    - if: steps.create-pr.outputs.pull-request-operation == 'created'
-      name: Set Automerge
-      uses: peter-evans/enable-pull-request-automerge@v1
-      with:
-        merge-method: squash
-        pull-request-number: ${{ steps.create-pr.outputs.pull-request-number }}
-        repository: ${{ github.repository }}
-        token: ${{ secrets.PULUMI_BOT_TOKEN }}
     strategy:
       fail-fast: true
       matrix:

--- a/provider-ci/providers/digitalocean/repo/.github/workflows/update-bridge.yml
+++ b/provider-ci/providers/digitalocean/repo/.github/workflows/update-bridge.yml
@@ -66,14 +66,6 @@ jobs:
         title: Update pulumi-terraform-bridge to v${{ github.event.inputs.bridge_version
           }}
         token: ${{ secrets.PULUMI_BOT_TOKEN }}
-    - if: steps.create-pr.outputs.pull-request-operation == 'created'
-      name: Set Automerge
-      uses: peter-evans/enable-pull-request-automerge@v1
-      with:
-        merge-method: squash
-        pull-request-number: ${{ steps.create-pr.outputs.pull-request-number }}
-        repository: ${{ github.repository }}
-        token: ${{ secrets.PULUMI_BOT_TOKEN }}
     strategy:
       fail-fast: true
       matrix:

--- a/provider-ci/providers/dnsimple/repo/.github/workflows/update-bridge.yml
+++ b/provider-ci/providers/dnsimple/repo/.github/workflows/update-bridge.yml
@@ -66,14 +66,6 @@ jobs:
         title: Update pulumi-terraform-bridge to v${{ github.event.inputs.bridge_version
           }}
         token: ${{ secrets.PULUMI_BOT_TOKEN }}
-    - if: steps.create-pr.outputs.pull-request-operation == 'created'
-      name: Set Automerge
-      uses: peter-evans/enable-pull-request-automerge@v1
-      with:
-        merge-method: squash
-        pull-request-number: ${{ steps.create-pr.outputs.pull-request-number }}
-        repository: ${{ github.repository }}
-        token: ${{ secrets.PULUMI_BOT_TOKEN }}
     strategy:
       fail-fast: true
       matrix:

--- a/provider-ci/providers/docker/repo/.github/workflows/update-bridge.yml
+++ b/provider-ci/providers/docker/repo/.github/workflows/update-bridge.yml
@@ -66,14 +66,6 @@ jobs:
         title: Update pulumi-terraform-bridge to v${{ github.event.inputs.bridge_version
           }}
         token: ${{ secrets.PULUMI_BOT_TOKEN }}
-    - if: steps.create-pr.outputs.pull-request-operation == 'created'
-      name: Set Automerge
-      uses: peter-evans/enable-pull-request-automerge@v1
-      with:
-        merge-method: squash
-        pull-request-number: ${{ steps.create-pr.outputs.pull-request-number }}
-        repository: ${{ github.repository }}
-        token: ${{ secrets.PULUMI_BOT_TOKEN }}
     strategy:
       fail-fast: true
       matrix:

--- a/provider-ci/providers/ec/repo/.github/workflows/update-bridge.yml
+++ b/provider-ci/providers/ec/repo/.github/workflows/update-bridge.yml
@@ -66,14 +66,6 @@ jobs:
         title: Update pulumi-terraform-bridge to v${{ github.event.inputs.bridge_version
           }}
         token: ${{ secrets.PULUMI_BOT_TOKEN }}
-    - if: steps.create-pr.outputs.pull-request-operation == 'created'
-      name: Set Automerge
-      uses: peter-evans/enable-pull-request-automerge@v1
-      with:
-        merge-method: squash
-        pull-request-number: ${{ steps.create-pr.outputs.pull-request-number }}
-        repository: ${{ github.repository }}
-        token: ${{ secrets.PULUMI_BOT_TOKEN }}
     strategy:
       fail-fast: true
       matrix:

--- a/provider-ci/providers/equinix-metal/repo/.github/workflows/update-bridge.yml
+++ b/provider-ci/providers/equinix-metal/repo/.github/workflows/update-bridge.yml
@@ -66,14 +66,6 @@ jobs:
         title: Update pulumi-terraform-bridge to v${{ github.event.inputs.bridge_version
           }}
         token: ${{ secrets.PULUMI_BOT_TOKEN }}
-    - if: steps.create-pr.outputs.pull-request-operation == 'created'
-      name: Set Automerge
-      uses: peter-evans/enable-pull-request-automerge@v1
-      with:
-        merge-method: squash
-        pull-request-number: ${{ steps.create-pr.outputs.pull-request-number }}
-        repository: ${{ github.repository }}
-        token: ${{ secrets.PULUMI_BOT_TOKEN }}
     strategy:
       fail-fast: true
       matrix:

--- a/provider-ci/providers/f5bigip/repo/.github/workflows/update-bridge.yml
+++ b/provider-ci/providers/f5bigip/repo/.github/workflows/update-bridge.yml
@@ -66,14 +66,6 @@ jobs:
         title: Update pulumi-terraform-bridge to v${{ github.event.inputs.bridge_version
           }}
         token: ${{ secrets.PULUMI_BOT_TOKEN }}
-    - if: steps.create-pr.outputs.pull-request-operation == 'created'
-      name: Set Automerge
-      uses: peter-evans/enable-pull-request-automerge@v1
-      with:
-        merge-method: squash
-        pull-request-number: ${{ steps.create-pr.outputs.pull-request-number }}
-        repository: ${{ github.repository }}
-        token: ${{ secrets.PULUMI_BOT_TOKEN }}
     strategy:
       fail-fast: true
       matrix:

--- a/provider-ci/providers/fastly/repo/.github/workflows/update-bridge.yml
+++ b/provider-ci/providers/fastly/repo/.github/workflows/update-bridge.yml
@@ -66,14 +66,6 @@ jobs:
         title: Update pulumi-terraform-bridge to v${{ github.event.inputs.bridge_version
           }}
         token: ${{ secrets.PULUMI_BOT_TOKEN }}
-    - if: steps.create-pr.outputs.pull-request-operation == 'created'
-      name: Set Automerge
-      uses: peter-evans/enable-pull-request-automerge@v1
-      with:
-        merge-method: squash
-        pull-request-number: ${{ steps.create-pr.outputs.pull-request-number }}
-        repository: ${{ github.repository }}
-        token: ${{ secrets.PULUMI_BOT_TOKEN }}
     strategy:
       fail-fast: true
       matrix:

--- a/provider-ci/providers/gcp/repo/.github/workflows/update-bridge.yml
+++ b/provider-ci/providers/gcp/repo/.github/workflows/update-bridge.yml
@@ -66,14 +66,6 @@ jobs:
         title: Update pulumi-terraform-bridge to v${{ github.event.inputs.bridge_version
           }}
         token: ${{ secrets.PULUMI_BOT_TOKEN }}
-    - if: steps.create-pr.outputs.pull-request-operation == 'created'
-      name: Set Automerge
-      uses: peter-evans/enable-pull-request-automerge@v1
-      with:
-        merge-method: squash
-        pull-request-number: ${{ steps.create-pr.outputs.pull-request-number }}
-        repository: ${{ github.repository }}
-        token: ${{ secrets.PULUMI_BOT_TOKEN }}
     strategy:
       fail-fast: true
       matrix:

--- a/provider-ci/providers/github/repo/.github/workflows/update-bridge.yml
+++ b/provider-ci/providers/github/repo/.github/workflows/update-bridge.yml
@@ -66,14 +66,6 @@ jobs:
         title: Update pulumi-terraform-bridge to v${{ github.event.inputs.bridge_version
           }}
         token: ${{ secrets.PULUMI_BOT_TOKEN }}
-    - if: steps.create-pr.outputs.pull-request-operation == 'created'
-      name: Set Automerge
-      uses: peter-evans/enable-pull-request-automerge@v1
-      with:
-        merge-method: squash
-        pull-request-number: ${{ steps.create-pr.outputs.pull-request-number }}
-        repository: ${{ github.repository }}
-        token: ${{ secrets.PULUMI_BOT_TOKEN }}
     strategy:
       fail-fast: true
       matrix:

--- a/provider-ci/providers/gitlab/repo/.github/workflows/update-bridge.yml
+++ b/provider-ci/providers/gitlab/repo/.github/workflows/update-bridge.yml
@@ -66,14 +66,6 @@ jobs:
         title: Update pulumi-terraform-bridge to v${{ github.event.inputs.bridge_version
           }}
         token: ${{ secrets.PULUMI_BOT_TOKEN }}
-    - if: steps.create-pr.outputs.pull-request-operation == 'created'
-      name: Set Automerge
-      uses: peter-evans/enable-pull-request-automerge@v1
-      with:
-        merge-method: squash
-        pull-request-number: ${{ steps.create-pr.outputs.pull-request-number }}
-        repository: ${{ github.repository }}
-        token: ${{ secrets.PULUMI_BOT_TOKEN }}
     strategy:
       fail-fast: true
       matrix:

--- a/provider-ci/providers/hcloud/repo/.github/workflows/update-bridge.yml
+++ b/provider-ci/providers/hcloud/repo/.github/workflows/update-bridge.yml
@@ -66,14 +66,6 @@ jobs:
         title: Update pulumi-terraform-bridge to v${{ github.event.inputs.bridge_version
           }}
         token: ${{ secrets.PULUMI_BOT_TOKEN }}
-    - if: steps.create-pr.outputs.pull-request-operation == 'created'
-      name: Set Automerge
-      uses: peter-evans/enable-pull-request-automerge@v1
-      with:
-        merge-method: squash
-        pull-request-number: ${{ steps.create-pr.outputs.pull-request-number }}
-        repository: ${{ github.repository }}
-        token: ${{ secrets.PULUMI_BOT_TOKEN }}
     strategy:
       fail-fast: true
       matrix:

--- a/provider-ci/providers/kafka/repo/.github/workflows/update-bridge.yml
+++ b/provider-ci/providers/kafka/repo/.github/workflows/update-bridge.yml
@@ -66,14 +66,6 @@ jobs:
         title: Update pulumi-terraform-bridge to v${{ github.event.inputs.bridge_version
           }}
         token: ${{ secrets.PULUMI_BOT_TOKEN }}
-    - if: steps.create-pr.outputs.pull-request-operation == 'created'
-      name: Set Automerge
-      uses: peter-evans/enable-pull-request-automerge@v1
-      with:
-        merge-method: squash
-        pull-request-number: ${{ steps.create-pr.outputs.pull-request-number }}
-        repository: ${{ github.repository }}
-        token: ${{ secrets.PULUMI_BOT_TOKEN }}
     strategy:
       fail-fast: true
       matrix:

--- a/provider-ci/providers/keycloak/repo/.github/workflows/update-bridge.yml
+++ b/provider-ci/providers/keycloak/repo/.github/workflows/update-bridge.yml
@@ -66,14 +66,6 @@ jobs:
         title: Update pulumi-terraform-bridge to v${{ github.event.inputs.bridge_version
           }}
         token: ${{ secrets.PULUMI_BOT_TOKEN }}
-    - if: steps.create-pr.outputs.pull-request-operation == 'created'
-      name: Set Automerge
-      uses: peter-evans/enable-pull-request-automerge@v1
-      with:
-        merge-method: squash
-        pull-request-number: ${{ steps.create-pr.outputs.pull-request-number }}
-        repository: ${{ github.repository }}
-        token: ${{ secrets.PULUMI_BOT_TOKEN }}
     strategy:
       fail-fast: true
       matrix:

--- a/provider-ci/providers/kong/repo/.github/workflows/update-bridge.yml
+++ b/provider-ci/providers/kong/repo/.github/workflows/update-bridge.yml
@@ -66,14 +66,6 @@ jobs:
         title: Update pulumi-terraform-bridge to v${{ github.event.inputs.bridge_version
           }}
         token: ${{ secrets.PULUMI_BOT_TOKEN }}
-    - if: steps.create-pr.outputs.pull-request-operation == 'created'
-      name: Set Automerge
-      uses: peter-evans/enable-pull-request-automerge@v1
-      with:
-        merge-method: squash
-        pull-request-number: ${{ steps.create-pr.outputs.pull-request-number }}
-        repository: ${{ github.repository }}
-        token: ${{ secrets.PULUMI_BOT_TOKEN }}
     strategy:
       fail-fast: true
       matrix:

--- a/provider-ci/providers/libvirt/repo/.github/workflows/update-bridge.yml
+++ b/provider-ci/providers/libvirt/repo/.github/workflows/update-bridge.yml
@@ -66,14 +66,6 @@ jobs:
         title: Update pulumi-terraform-bridge to v${{ github.event.inputs.bridge_version
           }}
         token: ${{ secrets.PULUMI_BOT_TOKEN }}
-    - if: steps.create-pr.outputs.pull-request-operation == 'created'
-      name: Set Automerge
-      uses: peter-evans/enable-pull-request-automerge@v1
-      with:
-        merge-method: squash
-        pull-request-number: ${{ steps.create-pr.outputs.pull-request-number }}
-        repository: ${{ github.repository }}
-        token: ${{ secrets.PULUMI_BOT_TOKEN }}
     strategy:
       fail-fast: true
       matrix:

--- a/provider-ci/providers/linode/repo/.github/workflows/update-bridge.yml
+++ b/provider-ci/providers/linode/repo/.github/workflows/update-bridge.yml
@@ -66,14 +66,6 @@ jobs:
         title: Update pulumi-terraform-bridge to v${{ github.event.inputs.bridge_version
           }}
         token: ${{ secrets.PULUMI_BOT_TOKEN }}
-    - if: steps.create-pr.outputs.pull-request-operation == 'created'
-      name: Set Automerge
-      uses: peter-evans/enable-pull-request-automerge@v1
-      with:
-        merge-method: squash
-        pull-request-number: ${{ steps.create-pr.outputs.pull-request-number }}
-        repository: ${{ github.repository }}
-        token: ${{ secrets.PULUMI_BOT_TOKEN }}
     strategy:
       fail-fast: true
       matrix:

--- a/provider-ci/providers/mailgun/repo/.github/workflows/update-bridge.yml
+++ b/provider-ci/providers/mailgun/repo/.github/workflows/update-bridge.yml
@@ -66,14 +66,6 @@ jobs:
         title: Update pulumi-terraform-bridge to v${{ github.event.inputs.bridge_version
           }}
         token: ${{ secrets.PULUMI_BOT_TOKEN }}
-    - if: steps.create-pr.outputs.pull-request-operation == 'created'
-      name: Set Automerge
-      uses: peter-evans/enable-pull-request-automerge@v1
-      with:
-        merge-method: squash
-        pull-request-number: ${{ steps.create-pr.outputs.pull-request-number }}
-        repository: ${{ github.repository }}
-        token: ${{ secrets.PULUMI_BOT_TOKEN }}
     strategy:
       fail-fast: true
       matrix:

--- a/provider-ci/providers/minio/repo/.github/workflows/update-bridge.yml
+++ b/provider-ci/providers/minio/repo/.github/workflows/update-bridge.yml
@@ -66,14 +66,6 @@ jobs:
         title: Update pulumi-terraform-bridge to v${{ github.event.inputs.bridge_version
           }}
         token: ${{ secrets.PULUMI_BOT_TOKEN }}
-    - if: steps.create-pr.outputs.pull-request-operation == 'created'
-      name: Set Automerge
-      uses: peter-evans/enable-pull-request-automerge@v1
-      with:
-        merge-method: squash
-        pull-request-number: ${{ steps.create-pr.outputs.pull-request-number }}
-        repository: ${{ github.repository }}
-        token: ${{ secrets.PULUMI_BOT_TOKEN }}
     strategy:
       fail-fast: true
       matrix:

--- a/provider-ci/providers/mongodbatlas/repo/.github/workflows/update-bridge.yml
+++ b/provider-ci/providers/mongodbatlas/repo/.github/workflows/update-bridge.yml
@@ -66,14 +66,6 @@ jobs:
         title: Update pulumi-terraform-bridge to v${{ github.event.inputs.bridge_version
           }}
         token: ${{ secrets.PULUMI_BOT_TOKEN }}
-    - if: steps.create-pr.outputs.pull-request-operation == 'created'
-      name: Set Automerge
-      uses: peter-evans/enable-pull-request-automerge@v1
-      with:
-        merge-method: squash
-        pull-request-number: ${{ steps.create-pr.outputs.pull-request-number }}
-        repository: ${{ github.repository }}
-        token: ${{ secrets.PULUMI_BOT_TOKEN }}
     strategy:
       fail-fast: true
       matrix:

--- a/provider-ci/providers/mysql/repo/.github/workflows/update-bridge.yml
+++ b/provider-ci/providers/mysql/repo/.github/workflows/update-bridge.yml
@@ -66,14 +66,6 @@ jobs:
         title: Update pulumi-terraform-bridge to v${{ github.event.inputs.bridge_version
           }}
         token: ${{ secrets.PULUMI_BOT_TOKEN }}
-    - if: steps.create-pr.outputs.pull-request-operation == 'created'
-      name: Set Automerge
-      uses: peter-evans/enable-pull-request-automerge@v1
-      with:
-        merge-method: squash
-        pull-request-number: ${{ steps.create-pr.outputs.pull-request-number }}
-        repository: ${{ github.repository }}
-        token: ${{ secrets.PULUMI_BOT_TOKEN }}
     strategy:
       fail-fast: true
       matrix:

--- a/provider-ci/providers/newrelic/repo/.github/workflows/update-bridge.yml
+++ b/provider-ci/providers/newrelic/repo/.github/workflows/update-bridge.yml
@@ -66,14 +66,6 @@ jobs:
         title: Update pulumi-terraform-bridge to v${{ github.event.inputs.bridge_version
           }}
         token: ${{ secrets.PULUMI_BOT_TOKEN }}
-    - if: steps.create-pr.outputs.pull-request-operation == 'created'
-      name: Set Automerge
-      uses: peter-evans/enable-pull-request-automerge@v1
-      with:
-        merge-method: squash
-        pull-request-number: ${{ steps.create-pr.outputs.pull-request-number }}
-        repository: ${{ github.repository }}
-        token: ${{ secrets.PULUMI_BOT_TOKEN }}
     strategy:
       fail-fast: true
       matrix:

--- a/provider-ci/providers/nomad/repo/.github/workflows/update-bridge.yml
+++ b/provider-ci/providers/nomad/repo/.github/workflows/update-bridge.yml
@@ -66,14 +66,6 @@ jobs:
         title: Update pulumi-terraform-bridge to v${{ github.event.inputs.bridge_version
           }}
         token: ${{ secrets.PULUMI_BOT_TOKEN }}
-    - if: steps.create-pr.outputs.pull-request-operation == 'created'
-      name: Set Automerge
-      uses: peter-evans/enable-pull-request-automerge@v1
-      with:
-        merge-method: squash
-        pull-request-number: ${{ steps.create-pr.outputs.pull-request-number }}
-        repository: ${{ github.repository }}
-        token: ${{ secrets.PULUMI_BOT_TOKEN }}
     strategy:
       fail-fast: true
       matrix:

--- a/provider-ci/providers/ns1/repo/.github/workflows/update-bridge.yml
+++ b/provider-ci/providers/ns1/repo/.github/workflows/update-bridge.yml
@@ -66,14 +66,6 @@ jobs:
         title: Update pulumi-terraform-bridge to v${{ github.event.inputs.bridge_version
           }}
         token: ${{ secrets.PULUMI_BOT_TOKEN }}
-    - if: steps.create-pr.outputs.pull-request-operation == 'created'
-      name: Set Automerge
-      uses: peter-evans/enable-pull-request-automerge@v1
-      with:
-        merge-method: squash
-        pull-request-number: ${{ steps.create-pr.outputs.pull-request-number }}
-        repository: ${{ github.repository }}
-        token: ${{ secrets.PULUMI_BOT_TOKEN }}
     strategy:
       fail-fast: true
       matrix:

--- a/provider-ci/providers/oci/repo/.github/workflows/update-bridge.yml
+++ b/provider-ci/providers/oci/repo/.github/workflows/update-bridge.yml
@@ -66,14 +66,6 @@ jobs:
         title: Update pulumi-terraform-bridge to v${{ github.event.inputs.bridge_version
           }}
         token: ${{ secrets.PULUMI_BOT_TOKEN }}
-    - if: steps.create-pr.outputs.pull-request-operation == 'created'
-      name: Set Automerge
-      uses: peter-evans/enable-pull-request-automerge@v1
-      with:
-        merge-method: squash
-        pull-request-number: ${{ steps.create-pr.outputs.pull-request-number }}
-        repository: ${{ github.repository }}
-        token: ${{ secrets.PULUMI_BOT_TOKEN }}
     strategy:
       fail-fast: true
       matrix:

--- a/provider-ci/providers/okta/repo/.github/workflows/update-bridge.yml
+++ b/provider-ci/providers/okta/repo/.github/workflows/update-bridge.yml
@@ -66,14 +66,6 @@ jobs:
         title: Update pulumi-terraform-bridge to v${{ github.event.inputs.bridge_version
           }}
         token: ${{ secrets.PULUMI_BOT_TOKEN }}
-    - if: steps.create-pr.outputs.pull-request-operation == 'created'
-      name: Set Automerge
-      uses: peter-evans/enable-pull-request-automerge@v1
-      with:
-        merge-method: squash
-        pull-request-number: ${{ steps.create-pr.outputs.pull-request-number }}
-        repository: ${{ github.repository }}
-        token: ${{ secrets.PULUMI_BOT_TOKEN }}
     strategy:
       fail-fast: true
       matrix:

--- a/provider-ci/providers/onelogin/repo/.github/workflows/update-bridge.yml
+++ b/provider-ci/providers/onelogin/repo/.github/workflows/update-bridge.yml
@@ -66,14 +66,6 @@ jobs:
         title: Update pulumi-terraform-bridge to v${{ github.event.inputs.bridge_version
           }}
         token: ${{ secrets.PULUMI_BOT_TOKEN }}
-    - if: steps.create-pr.outputs.pull-request-operation == 'created'
-      name: Set Automerge
-      uses: peter-evans/enable-pull-request-automerge@v1
-      with:
-        merge-method: squash
-        pull-request-number: ${{ steps.create-pr.outputs.pull-request-number }}
-        repository: ${{ github.repository }}
-        token: ${{ secrets.PULUMI_BOT_TOKEN }}
     strategy:
       fail-fast: true
       matrix:

--- a/provider-ci/providers/openstack/repo/.github/workflows/update-bridge.yml
+++ b/provider-ci/providers/openstack/repo/.github/workflows/update-bridge.yml
@@ -66,14 +66,6 @@ jobs:
         title: Update pulumi-terraform-bridge to v${{ github.event.inputs.bridge_version
           }}
         token: ${{ secrets.PULUMI_BOT_TOKEN }}
-    - if: steps.create-pr.outputs.pull-request-operation == 'created'
-      name: Set Automerge
-      uses: peter-evans/enable-pull-request-automerge@v1
-      with:
-        merge-method: squash
-        pull-request-number: ${{ steps.create-pr.outputs.pull-request-number }}
-        repository: ${{ github.repository }}
-        token: ${{ secrets.PULUMI_BOT_TOKEN }}
     strategy:
       fail-fast: true
       matrix:

--- a/provider-ci/providers/opsgenie/repo/.github/workflows/update-bridge.yml
+++ b/provider-ci/providers/opsgenie/repo/.github/workflows/update-bridge.yml
@@ -66,14 +66,6 @@ jobs:
         title: Update pulumi-terraform-bridge to v${{ github.event.inputs.bridge_version
           }}
         token: ${{ secrets.PULUMI_BOT_TOKEN }}
-    - if: steps.create-pr.outputs.pull-request-operation == 'created'
-      name: Set Automerge
-      uses: peter-evans/enable-pull-request-automerge@v1
-      with:
-        merge-method: squash
-        pull-request-number: ${{ steps.create-pr.outputs.pull-request-number }}
-        repository: ${{ github.repository }}
-        token: ${{ secrets.PULUMI_BOT_TOKEN }}
     strategy:
       fail-fast: true
       matrix:

--- a/provider-ci/providers/pagerduty/repo/.github/workflows/update-bridge.yml
+++ b/provider-ci/providers/pagerduty/repo/.github/workflows/update-bridge.yml
@@ -66,14 +66,6 @@ jobs:
         title: Update pulumi-terraform-bridge to v${{ github.event.inputs.bridge_version
           }}
         token: ${{ secrets.PULUMI_BOT_TOKEN }}
-    - if: steps.create-pr.outputs.pull-request-operation == 'created'
-      name: Set Automerge
-      uses: peter-evans/enable-pull-request-automerge@v1
-      with:
-        merge-method: squash
-        pull-request-number: ${{ steps.create-pr.outputs.pull-request-number }}
-        repository: ${{ github.repository }}
-        token: ${{ secrets.PULUMI_BOT_TOKEN }}
     strategy:
       fail-fast: true
       matrix:

--- a/provider-ci/providers/postgresql/repo/.github/workflows/update-bridge.yml
+++ b/provider-ci/providers/postgresql/repo/.github/workflows/update-bridge.yml
@@ -66,14 +66,6 @@ jobs:
         title: Update pulumi-terraform-bridge to v${{ github.event.inputs.bridge_version
           }}
         token: ${{ secrets.PULUMI_BOT_TOKEN }}
-    - if: steps.create-pr.outputs.pull-request-operation == 'created'
-      name: Set Automerge
-      uses: peter-evans/enable-pull-request-automerge@v1
-      with:
-        merge-method: squash
-        pull-request-number: ${{ steps.create-pr.outputs.pull-request-number }}
-        repository: ${{ github.repository }}
-        token: ${{ secrets.PULUMI_BOT_TOKEN }}
     strategy:
       fail-fast: true
       matrix:

--- a/provider-ci/providers/rabbitmq/repo/.github/workflows/update-bridge.yml
+++ b/provider-ci/providers/rabbitmq/repo/.github/workflows/update-bridge.yml
@@ -66,14 +66,6 @@ jobs:
         title: Update pulumi-terraform-bridge to v${{ github.event.inputs.bridge_version
           }}
         token: ${{ secrets.PULUMI_BOT_TOKEN }}
-    - if: steps.create-pr.outputs.pull-request-operation == 'created'
-      name: Set Automerge
-      uses: peter-evans/enable-pull-request-automerge@v1
-      with:
-        merge-method: squash
-        pull-request-number: ${{ steps.create-pr.outputs.pull-request-number }}
-        repository: ${{ github.repository }}
-        token: ${{ secrets.PULUMI_BOT_TOKEN }}
     strategy:
       fail-fast: true
       matrix:

--- a/provider-ci/providers/rancher2/repo/.github/workflows/update-bridge.yml
+++ b/provider-ci/providers/rancher2/repo/.github/workflows/update-bridge.yml
@@ -66,14 +66,6 @@ jobs:
         title: Update pulumi-terraform-bridge to v${{ github.event.inputs.bridge_version
           }}
         token: ${{ secrets.PULUMI_BOT_TOKEN }}
-    - if: steps.create-pr.outputs.pull-request-operation == 'created'
-      name: Set Automerge
-      uses: peter-evans/enable-pull-request-automerge@v1
-      with:
-        merge-method: squash
-        pull-request-number: ${{ steps.create-pr.outputs.pull-request-number }}
-        repository: ${{ github.repository }}
-        token: ${{ secrets.PULUMI_BOT_TOKEN }}
     strategy:
       fail-fast: true
       matrix:

--- a/provider-ci/providers/random/repo/.github/workflows/update-bridge.yml
+++ b/provider-ci/providers/random/repo/.github/workflows/update-bridge.yml
@@ -66,14 +66,6 @@ jobs:
         title: Update pulumi-terraform-bridge to v${{ github.event.inputs.bridge_version
           }}
         token: ${{ secrets.PULUMI_BOT_TOKEN }}
-    - if: steps.create-pr.outputs.pull-request-operation == 'created'
-      name: Set Automerge
-      uses: peter-evans/enable-pull-request-automerge@v1
-      with:
-        merge-method: squash
-        pull-request-number: ${{ steps.create-pr.outputs.pull-request-number }}
-        repository: ${{ github.repository }}
-        token: ${{ secrets.PULUMI_BOT_TOKEN }}
     strategy:
       fail-fast: true
       matrix:

--- a/provider-ci/providers/rke/repo/.github/workflows/update-bridge.yml
+++ b/provider-ci/providers/rke/repo/.github/workflows/update-bridge.yml
@@ -66,14 +66,6 @@ jobs:
         title: Update pulumi-terraform-bridge to v${{ github.event.inputs.bridge_version
           }}
         token: ${{ secrets.PULUMI_BOT_TOKEN }}
-    - if: steps.create-pr.outputs.pull-request-operation == 'created'
-      name: Set Automerge
-      uses: peter-evans/enable-pull-request-automerge@v1
-      with:
-        merge-method: squash
-        pull-request-number: ${{ steps.create-pr.outputs.pull-request-number }}
-        repository: ${{ github.repository }}
-        token: ${{ secrets.PULUMI_BOT_TOKEN }}
     strategy:
       fail-fast: true
       matrix:

--- a/provider-ci/providers/signalfx/repo/.github/workflows/update-bridge.yml
+++ b/provider-ci/providers/signalfx/repo/.github/workflows/update-bridge.yml
@@ -66,14 +66,6 @@ jobs:
         title: Update pulumi-terraform-bridge to v${{ github.event.inputs.bridge_version
           }}
         token: ${{ secrets.PULUMI_BOT_TOKEN }}
-    - if: steps.create-pr.outputs.pull-request-operation == 'created'
-      name: Set Automerge
-      uses: peter-evans/enable-pull-request-automerge@v1
-      with:
-        merge-method: squash
-        pull-request-number: ${{ steps.create-pr.outputs.pull-request-number }}
-        repository: ${{ github.repository }}
-        token: ${{ secrets.PULUMI_BOT_TOKEN }}
     strategy:
       fail-fast: true
       matrix:

--- a/provider-ci/providers/slack/repo/.github/workflows/update-bridge.yml
+++ b/provider-ci/providers/slack/repo/.github/workflows/update-bridge.yml
@@ -66,14 +66,6 @@ jobs:
         title: Update pulumi-terraform-bridge to v${{ github.event.inputs.bridge_version
           }}
         token: ${{ secrets.PULUMI_BOT_TOKEN }}
-    - if: steps.create-pr.outputs.pull-request-operation == 'created'
-      name: Set Automerge
-      uses: peter-evans/enable-pull-request-automerge@v1
-      with:
-        merge-method: squash
-        pull-request-number: ${{ steps.create-pr.outputs.pull-request-number }}
-        repository: ${{ github.repository }}
-        token: ${{ secrets.PULUMI_BOT_TOKEN }}
     strategy:
       fail-fast: true
       matrix:

--- a/provider-ci/providers/snowflake/repo/.github/workflows/update-bridge.yml
+++ b/provider-ci/providers/snowflake/repo/.github/workflows/update-bridge.yml
@@ -66,14 +66,6 @@ jobs:
         title: Update pulumi-terraform-bridge to v${{ github.event.inputs.bridge_version
           }}
         token: ${{ secrets.PULUMI_BOT_TOKEN }}
-    - if: steps.create-pr.outputs.pull-request-operation == 'created'
-      name: Set Automerge
-      uses: peter-evans/enable-pull-request-automerge@v1
-      with:
-        merge-method: squash
-        pull-request-number: ${{ steps.create-pr.outputs.pull-request-number }}
-        repository: ${{ github.repository }}
-        token: ${{ secrets.PULUMI_BOT_TOKEN }}
     strategy:
       fail-fast: true
       matrix:

--- a/provider-ci/providers/splunk/repo/.github/workflows/update-bridge.yml
+++ b/provider-ci/providers/splunk/repo/.github/workflows/update-bridge.yml
@@ -66,14 +66,6 @@ jobs:
         title: Update pulumi-terraform-bridge to v${{ github.event.inputs.bridge_version
           }}
         token: ${{ secrets.PULUMI_BOT_TOKEN }}
-    - if: steps.create-pr.outputs.pull-request-operation == 'created'
-      name: Set Automerge
-      uses: peter-evans/enable-pull-request-automerge@v1
-      with:
-        merge-method: squash
-        pull-request-number: ${{ steps.create-pr.outputs.pull-request-number }}
-        repository: ${{ github.repository }}
-        token: ${{ secrets.PULUMI_BOT_TOKEN }}
     strategy:
       fail-fast: true
       matrix:

--- a/provider-ci/providers/spotinst/repo/.github/workflows/update-bridge.yml
+++ b/provider-ci/providers/spotinst/repo/.github/workflows/update-bridge.yml
@@ -66,14 +66,6 @@ jobs:
         title: Update pulumi-terraform-bridge to v${{ github.event.inputs.bridge_version
           }}
         token: ${{ secrets.PULUMI_BOT_TOKEN }}
-    - if: steps.create-pr.outputs.pull-request-operation == 'created'
-      name: Set Automerge
-      uses: peter-evans/enable-pull-request-automerge@v1
-      with:
-        merge-method: squash
-        pull-request-number: ${{ steps.create-pr.outputs.pull-request-number }}
-        repository: ${{ github.repository }}
-        token: ${{ secrets.PULUMI_BOT_TOKEN }}
     strategy:
       fail-fast: true
       matrix:

--- a/provider-ci/providers/sumologic/repo/.github/workflows/update-bridge.yml
+++ b/provider-ci/providers/sumologic/repo/.github/workflows/update-bridge.yml
@@ -66,14 +66,6 @@ jobs:
         title: Update pulumi-terraform-bridge to v${{ github.event.inputs.bridge_version
           }}
         token: ${{ secrets.PULUMI_BOT_TOKEN }}
-    - if: steps.create-pr.outputs.pull-request-operation == 'created'
-      name: Set Automerge
-      uses: peter-evans/enable-pull-request-automerge@v1
-      with:
-        merge-method: squash
-        pull-request-number: ${{ steps.create-pr.outputs.pull-request-number }}
-        repository: ${{ github.repository }}
-        token: ${{ secrets.PULUMI_BOT_TOKEN }}
     strategy:
       fail-fast: true
       matrix:

--- a/provider-ci/providers/tailscale/repo/.github/workflows/update-bridge.yml
+++ b/provider-ci/providers/tailscale/repo/.github/workflows/update-bridge.yml
@@ -66,14 +66,6 @@ jobs:
         title: Update pulumi-terraform-bridge to v${{ github.event.inputs.bridge_version
           }}
         token: ${{ secrets.PULUMI_BOT_TOKEN }}
-    - if: steps.create-pr.outputs.pull-request-operation == 'created'
-      name: Set Automerge
-      uses: peter-evans/enable-pull-request-automerge@v1
-      with:
-        merge-method: squash
-        pull-request-number: ${{ steps.create-pr.outputs.pull-request-number }}
-        repository: ${{ github.repository }}
-        token: ${{ secrets.PULUMI_BOT_TOKEN }}
     strategy:
       fail-fast: true
       matrix:

--- a/provider-ci/providers/tls/repo/.github/workflows/update-bridge.yml
+++ b/provider-ci/providers/tls/repo/.github/workflows/update-bridge.yml
@@ -66,14 +66,6 @@ jobs:
         title: Update pulumi-terraform-bridge to v${{ github.event.inputs.bridge_version
           }}
         token: ${{ secrets.PULUMI_BOT_TOKEN }}
-    - if: steps.create-pr.outputs.pull-request-operation == 'created'
-      name: Set Automerge
-      uses: peter-evans/enable-pull-request-automerge@v1
-      with:
-        merge-method: squash
-        pull-request-number: ${{ steps.create-pr.outputs.pull-request-number }}
-        repository: ${{ github.repository }}
-        token: ${{ secrets.PULUMI_BOT_TOKEN }}
     strategy:
       fail-fast: true
       matrix:

--- a/provider-ci/providers/vault/repo/.github/workflows/update-bridge.yml
+++ b/provider-ci/providers/vault/repo/.github/workflows/update-bridge.yml
@@ -66,14 +66,6 @@ jobs:
         title: Update pulumi-terraform-bridge to v${{ github.event.inputs.bridge_version
           }}
         token: ${{ secrets.PULUMI_BOT_TOKEN }}
-    - if: steps.create-pr.outputs.pull-request-operation == 'created'
-      name: Set Automerge
-      uses: peter-evans/enable-pull-request-automerge@v1
-      with:
-        merge-method: squash
-        pull-request-number: ${{ steps.create-pr.outputs.pull-request-number }}
-        repository: ${{ github.repository }}
-        token: ${{ secrets.PULUMI_BOT_TOKEN }}
     strategy:
       fail-fast: true
       matrix:

--- a/provider-ci/providers/venafi/repo/.github/workflows/update-bridge.yml
+++ b/provider-ci/providers/venafi/repo/.github/workflows/update-bridge.yml
@@ -66,14 +66,6 @@ jobs:
         title: Update pulumi-terraform-bridge to v${{ github.event.inputs.bridge_version
           }}
         token: ${{ secrets.PULUMI_BOT_TOKEN }}
-    - if: steps.create-pr.outputs.pull-request-operation == 'created'
-      name: Set Automerge
-      uses: peter-evans/enable-pull-request-automerge@v1
-      with:
-        merge-method: squash
-        pull-request-number: ${{ steps.create-pr.outputs.pull-request-number }}
-        repository: ${{ github.repository }}
-        token: ${{ secrets.PULUMI_BOT_TOKEN }}
     strategy:
       fail-fast: true
       matrix:

--- a/provider-ci/providers/vsphere/repo/.github/workflows/update-bridge.yml
+++ b/provider-ci/providers/vsphere/repo/.github/workflows/update-bridge.yml
@@ -66,14 +66,6 @@ jobs:
         title: Update pulumi-terraform-bridge to v${{ github.event.inputs.bridge_version
           }}
         token: ${{ secrets.PULUMI_BOT_TOKEN }}
-    - if: steps.create-pr.outputs.pull-request-operation == 'created'
-      name: Set Automerge
-      uses: peter-evans/enable-pull-request-automerge@v1
-      with:
-        merge-method: squash
-        pull-request-number: ${{ steps.create-pr.outputs.pull-request-number }}
-        repository: ${{ github.repository }}
-        token: ${{ secrets.PULUMI_BOT_TOKEN }}
     strategy:
       fail-fast: true
       matrix:

--- a/provider-ci/providers/wavefront/repo/.github/workflows/update-bridge.yml
+++ b/provider-ci/providers/wavefront/repo/.github/workflows/update-bridge.yml
@@ -66,14 +66,6 @@ jobs:
         title: Update pulumi-terraform-bridge to v${{ github.event.inputs.bridge_version
           }}
         token: ${{ secrets.PULUMI_BOT_TOKEN }}
-    - if: steps.create-pr.outputs.pull-request-operation == 'created'
-      name: Set Automerge
-      uses: peter-evans/enable-pull-request-automerge@v1
-      with:
-        merge-method: squash
-        pull-request-number: ${{ steps.create-pr.outputs.pull-request-number }}
-        repository: ${{ github.repository }}
-        token: ${{ secrets.PULUMI_BOT_TOKEN }}
     strategy:
       fail-fast: true
       matrix:

--- a/provider-ci/src/workflows.ts
+++ b/provider-ci/src/workflows.ts
@@ -319,19 +319,19 @@ export function UpdatePulumiTerraformBridgeWorkflow(
             "team-reviewers": "platform-integrations",
             token: "${{ secrets.PULUMI_BOT_TOKEN }}",
           },
-        })
-        .addStep({
-          name: "Set Automerge",
-          if: "steps.create-pr.outputs.pull-request-operation == 'created'",
-          uses: "peter-evans/enable-pull-request-automerge@v1",
-          with: {
-            token: "${{ secrets.PULUMI_BOT_TOKEN }}",
-            "pull-request-number":
-              "${{ steps.create-pr.outputs.pull-request-number }}",
-            repository: "${{ github.repository }}",
-            "merge-method": "squash",
-          },
         }),
+        // .addStep({
+        //   name: "Set Automerge",
+        //   if: "steps.create-pr.outputs.pull-request-operation == 'created'",
+        //   uses: "peter-evans/enable-pull-request-automerge@v1",
+        //   with: {
+        //     token: "${{ secrets.PULUMI_BOT_TOKEN }}",
+        //     "pull-request-number":
+        //       "${{ steps.create-pr.outputs.pull-request-number }}",
+        //     repository: "${{ github.repository }}",
+        //     "merge-method": "squash",
+        //   },
+        // }),
     },
   };
 }


### PR DESCRIPTION
We are seeing TF provider updates also merge aggressively introducing breakages to `main`. This change pauses automerge on TF providers as well. 