### PR TITLE
Remove the use of gotestfmt for pulumi-kubernetes

### DIFF
--- a/native-provider-ci/src/steps.ts
+++ b/native-provider-ci/src/steps.ts
@@ -464,8 +464,7 @@ export function RunTests(provider: string): Step {
     return {
       name: "Run tests",
       run:
-        "set -euo pipefail\n" +
-        "cd tests/sdk/${{ matrix.language }} && go test -v -json -count=1 -cover -timeout 2h -parallel 4 ./... 2>&1 | tee /tmp/gotest.log | gotestfmt",
+        "cd tests/sdk/${{ matrix.language }} && go test -v -count=1 -cover -timeout 2h -parallel 4 ./...",
     };
   }
   return {


### PR DESCRIPTION
Using `gotestfmt` appears to be more trouble than it's worth -- see https://github.com/pulumi/pulumi-kubernetes/actions/runs/3490648026/jobs/5842448567 for example, where there are a number of apparent failures for tests that actually passed (note the X by "TestRetry", then search for "PASS: TestRetry"). When I removed gotestfmt from the test command, the tests are represented as passing:  https://github.com/pulumi/pulumi-kubernetes/pull/2239.

This is a conservative change to remove its use just for the pulumi-kubernetes provider. If it's causing problems elsewhere too, we can make a more sweeping change.
