### PR TITLE
Regenerate pulumi-kubernetes build/workflow files

### DIFF
--- a/native-provider-ci/providers/kubernetes/repo/.github/workflows/build.yml
+++ b/native-provider-ci/providers/kubernetes/repo/.github/workflows/build.yml
@@ -378,10 +378,8 @@ jobs:
         version: v2.4.0
         token: ${{ secrets.GITHUB_TOKEN }}
     - name: Run tests
-      run: >-
-        set -euo pipefail
-
-        cd tests/sdk/${{ matrix.language }} && go test -v -json -count=1 -cover -timeout 2h -parallel 4 ./... 2>&1 | tee /tmp/gotest.log | gotestfmt
+      run: cd tests/sdk/${{ matrix.language }} && go test -v -count=1 -cover -timeout
+        2h -parallel 4 ./...
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3

--- a/native-provider-ci/providers/kubernetes/repo/.github/workflows/prerelease.yml
+++ b/native-provider-ci/providers/kubernetes/repo/.github/workflows/prerelease.yml
@@ -369,10 +369,8 @@ jobs:
         version: v2.4.0
         token: ${{ secrets.GITHUB_TOKEN }}
     - name: Run tests
-      run: >-
-        set -euo pipefail
-
-        cd tests/sdk/${{ matrix.language }} && go test -v -json -count=1 -cover -timeout 2h -parallel 4 ./... 2>&1 | tee /tmp/gotest.log | gotestfmt
+      run: cd tests/sdk/${{ matrix.language }} && go test -v -count=1 -cover -timeout
+        2h -parallel 4 ./...
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3

--- a/native-provider-ci/providers/kubernetes/repo/.github/workflows/release.yml
+++ b/native-provider-ci/providers/kubernetes/repo/.github/workflows/release.yml
@@ -370,10 +370,8 @@ jobs:
         version: v2.4.0
         token: ${{ secrets.GITHUB_TOKEN }}
     - name: Run tests
-      run: >-
-        set -euo pipefail
-
-        cd tests/sdk/${{ matrix.language }} && go test -v -json -count=1 -cover -timeout 2h -parallel 4 ./... 2>&1 | tee /tmp/gotest.log | gotestfmt
+      run: cd tests/sdk/${{ matrix.language }} && go test -v -count=1 -cover -timeout
+        2h -parallel 4 ./...
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3

--- a/native-provider-ci/providers/kubernetes/repo/.github/workflows/run-acceptance-tests.yml
+++ b/native-provider-ci/providers/kubernetes/repo/.github/workflows/run-acceptance-tests.yml
@@ -400,10 +400,8 @@ jobs:
         version: v2.4.0
         token: ${{ secrets.GITHUB_TOKEN }}
     - name: Run tests
-      run: >-
-        set -euo pipefail
-
-        cd tests/sdk/${{ matrix.language }} && go test -v -json -count=1 -cover -timeout 2h -parallel 4 ./... 2>&1 | tee /tmp/gotest.log | gotestfmt
+      run: cd tests/sdk/${{ matrix.language }} && go test -v -count=1 -cover -timeout
+        2h -parallel 4 ./...
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3

--- a/native-provider-ci/src/steps.ts
+++ b/native-provider-ci/src/steps.ts
@@ -463,8 +463,7 @@ export function RunTests(provider: string): Step {
   if (provider === "kubernetes") {
     return {
       name: "Run tests",
-      run:
-        "cd tests/sdk/${{ matrix.language }} && go test -v -count=1 -cover -timeout 2h -parallel 4 ./...",
+      run: "cd tests/sdk/${{ matrix.language }} && go test -v -count=1 -cover -timeout 2h -parallel 4 ./...",
     };
   }
   return {


### PR DESCRIPTION
After #288, this regenerates the cached files -- since that PR targeted only pulumi-kubernetes, only those files change here.
