### PR TITLE
Fix update upstream provider workflow to be resilient to redirects

### DIFF
--- a/provider-ci/providers/aiven/repo/.github/workflows/update-upstream-provider.yml
+++ b/provider-ci/providers/aiven/repo/.github/workflows/update-upstream-provider.yml
@@ -62,7 +62,7 @@ jobs:
       with:
         python-version: ${{matrix.pythonversion}}
     - name: Get upstream provider sha
-      run: echo "UPSTREAM_PROVIDER_SHA=$(curl https://api.github.com/repos/${{
+      run: echo "UPSTREAM_PROVIDER_SHA=$(curl -L https://api.github.com/repos/${{
         env.UPSTREAM_PROVIDER_ORG }}/${{ env.UPSTREAM_PROVIDER_REPO
         }}/git/ref/tags/v${{ github.event.inputs.version }} | jq .object.sha
         -r)" >> $GITHUB_ENV

--- a/provider-ci/providers/akamai/repo/.github/workflows/update-upstream-provider.yml
+++ b/provider-ci/providers/akamai/repo/.github/workflows/update-upstream-provider.yml
@@ -64,7 +64,7 @@ jobs:
       with:
         python-version: ${{matrix.pythonversion}}
     - name: Get upstream provider sha
-      run: echo "UPSTREAM_PROVIDER_SHA=$(curl https://api.github.com/repos/${{
+      run: echo "UPSTREAM_PROVIDER_SHA=$(curl -L https://api.github.com/repos/${{
         env.UPSTREAM_PROVIDER_ORG }}/${{ env.UPSTREAM_PROVIDER_REPO
         }}/git/ref/tags/v${{ github.event.inputs.version }} | jq .object.sha
         -r)" >> $GITHUB_ENV

--- a/provider-ci/providers/alicloud/repo/.github/workflows/update-upstream-provider.yml
+++ b/provider-ci/providers/alicloud/repo/.github/workflows/update-upstream-provider.yml
@@ -63,7 +63,7 @@ jobs:
       with:
         python-version: ${{matrix.pythonversion}}
     - name: Get upstream provider sha
-      run: echo "UPSTREAM_PROVIDER_SHA=$(curl https://api.github.com/repos/${{
+      run: echo "UPSTREAM_PROVIDER_SHA=$(curl -L https://api.github.com/repos/${{
         env.UPSTREAM_PROVIDER_ORG }}/${{ env.UPSTREAM_PROVIDER_REPO
         }}/git/ref/tags/v${{ github.event.inputs.version }} | jq .object.sha
         -r)" >> $GITHUB_ENV

--- a/provider-ci/providers/artifactory/repo/.github/workflows/update-upstream-provider.yml
+++ b/provider-ci/providers/artifactory/repo/.github/workflows/update-upstream-provider.yml
@@ -63,7 +63,7 @@ jobs:
       with:
         python-version: ${{matrix.pythonversion}}
     - name: Get upstream provider sha
-      run: echo "UPSTREAM_PROVIDER_SHA=$(curl https://api.github.com/repos/${{
+      run: echo "UPSTREAM_PROVIDER_SHA=$(curl -L https://api.github.com/repos/${{
         env.UPSTREAM_PROVIDER_ORG }}/${{ env.UPSTREAM_PROVIDER_REPO
         }}/git/ref/tags/v${{ github.event.inputs.version }} | jq .object.sha
         -r)" >> $GITHUB_ENV

--- a/provider-ci/providers/auth0/repo/.github/workflows/update-upstream-provider.yml
+++ b/provider-ci/providers/auth0/repo/.github/workflows/update-upstream-provider.yml
@@ -63,7 +63,7 @@ jobs:
       with:
         python-version: ${{matrix.pythonversion}}
     - name: Get upstream provider sha
-      run: echo "UPSTREAM_PROVIDER_SHA=$(curl https://api.github.com/repos/${{
+      run: echo "UPSTREAM_PROVIDER_SHA=$(curl -L https://api.github.com/repos/${{
         env.UPSTREAM_PROVIDER_ORG }}/${{ env.UPSTREAM_PROVIDER_REPO
         }}/git/ref/tags/v${{ github.event.inputs.version }} | jq .object.sha
         -r)" >> $GITHUB_ENV

--- a/provider-ci/providers/aws/repo/.github/workflows/update-upstream-provider.yml
+++ b/provider-ci/providers/aws/repo/.github/workflows/update-upstream-provider.yml
@@ -62,7 +62,7 @@ jobs:
       with:
         python-version: ${{matrix.pythonversion}}
     - name: Get upstream provider sha
-      run: echo "UPSTREAM_PROVIDER_SHA=$(curl https://api.github.com/repos/${{
+      run: echo "UPSTREAM_PROVIDER_SHA=$(curl -L https://api.github.com/repos/${{
         env.UPSTREAM_PROVIDER_ORG }}/${{ env.UPSTREAM_PROVIDER_REPO
         }}/git/ref/tags/v${{ github.event.inputs.version }} | jq .object.sha
         -r)" >> $GITHUB_ENV

--- a/provider-ci/providers/azure/repo/.github/workflows/update-upstream-provider.yml
+++ b/provider-ci/providers/azure/repo/.github/workflows/update-upstream-provider.yml
@@ -67,7 +67,7 @@ jobs:
       with:
         python-version: ${{matrix.pythonversion}}
     - name: Get upstream provider sha
-      run: echo "UPSTREAM_PROVIDER_SHA=$(curl https://api.github.com/repos/${{
+      run: echo "UPSTREAM_PROVIDER_SHA=$(curl -L https://api.github.com/repos/${{
         env.UPSTREAM_PROVIDER_ORG }}/${{ env.UPSTREAM_PROVIDER_REPO
         }}/git/ref/tags/v${{ github.event.inputs.version }} | jq .object.sha
         -r)" >> $GITHUB_ENV

--- a/provider-ci/providers/azuread/repo/.github/workflows/update-upstream-provider.yml
+++ b/provider-ci/providers/azuread/repo/.github/workflows/update-upstream-provider.yml
@@ -65,7 +65,7 @@ jobs:
       with:
         python-version: ${{matrix.pythonversion}}
     - name: Get upstream provider sha
-      run: echo "UPSTREAM_PROVIDER_SHA=$(curl https://api.github.com/repos/${{
+      run: echo "UPSTREAM_PROVIDER_SHA=$(curl -L https://api.github.com/repos/${{
         env.UPSTREAM_PROVIDER_ORG }}/${{ env.UPSTREAM_PROVIDER_REPO
         }}/git/ref/tags/v${{ github.event.inputs.version }} | jq .object.sha
         -r)" >> $GITHUB_ENV

--- a/provider-ci/providers/azuredevops/repo/.github/workflows/update-upstream-provider.yml
+++ b/provider-ci/providers/azuredevops/repo/.github/workflows/update-upstream-provider.yml
@@ -62,7 +62,7 @@ jobs:
       with:
         python-version: ${{matrix.pythonversion}}
     - name: Get upstream provider sha
-      run: echo "UPSTREAM_PROVIDER_SHA=$(curl https://api.github.com/repos/${{
+      run: echo "UPSTREAM_PROVIDER_SHA=$(curl -L https://api.github.com/repos/${{
         env.UPSTREAM_PROVIDER_ORG }}/${{ env.UPSTREAM_PROVIDER_REPO
         }}/git/ref/tags/v${{ github.event.inputs.version }} | jq .object.sha
         -r)" >> $GITHUB_ENV

--- a/provider-ci/providers/civo/repo/.github/workflows/update-upstream-provider.yml
+++ b/provider-ci/providers/civo/repo/.github/workflows/update-upstream-provider.yml
@@ -61,7 +61,7 @@ jobs:
       with:
         python-version: ${{matrix.pythonversion}}
     - name: Get upstream provider sha
-      run: echo "UPSTREAM_PROVIDER_SHA=$(curl https://api.github.com/repos/${{
+      run: echo "UPSTREAM_PROVIDER_SHA=$(curl -L https://api.github.com/repos/${{
         env.UPSTREAM_PROVIDER_ORG }}/${{ env.UPSTREAM_PROVIDER_REPO
         }}/git/ref/tags/v${{ github.event.inputs.version }} | jq .object.sha
         -r)" >> $GITHUB_ENV

--- a/provider-ci/providers/cloudamqp/repo/.github/workflows/update-upstream-provider.yml
+++ b/provider-ci/providers/cloudamqp/repo/.github/workflows/update-upstream-provider.yml
@@ -60,7 +60,7 @@ jobs:
       with:
         python-version: ${{matrix.pythonversion}}
     - name: Get upstream provider sha
-      run: echo "UPSTREAM_PROVIDER_SHA=$(curl https://api.github.com/repos/${{
+      run: echo "UPSTREAM_PROVIDER_SHA=$(curl -L https://api.github.com/repos/${{
         env.UPSTREAM_PROVIDER_ORG }}/${{ env.UPSTREAM_PROVIDER_REPO
         }}/git/ref/tags/v${{ github.event.inputs.version }} | jq .object.sha
         -r)" >> $GITHUB_ENV

--- a/provider-ci/providers/cloudflare/repo/.github/workflows/update-upstream-provider.yml
+++ b/provider-ci/providers/cloudflare/repo/.github/workflows/update-upstream-provider.yml
@@ -60,7 +60,7 @@ jobs:
       with:
         python-version: ${{matrix.pythonversion}}
     - name: Get upstream provider sha
-      run: echo "UPSTREAM_PROVIDER_SHA=$(curl https://api.github.com/repos/${{
+      run: echo "UPSTREAM_PROVIDER_SHA=$(curl -L https://api.github.com/repos/${{
         env.UPSTREAM_PROVIDER_ORG }}/${{ env.UPSTREAM_PROVIDER_REPO
         }}/git/ref/tags/v${{ github.event.inputs.version }} | jq .object.sha
         -r)" >> $GITHUB_ENV

--- a/provider-ci/providers/cloudinit/repo/.github/workflows/update-upstream-provider.yml
+++ b/provider-ci/providers/cloudinit/repo/.github/workflows/update-upstream-provider.yml
@@ -60,7 +60,7 @@ jobs:
       with:
         python-version: ${{matrix.pythonversion}}
     - name: Get upstream provider sha
-      run: echo "UPSTREAM_PROVIDER_SHA=$(curl https://api.github.com/repos/${{
+      run: echo "UPSTREAM_PROVIDER_SHA=$(curl -L https://api.github.com/repos/${{
         env.UPSTREAM_PROVIDER_ORG }}/${{ env.UPSTREAM_PROVIDER_REPO
         }}/git/ref/tags/v${{ github.event.inputs.version }} | jq .object.sha
         -r)" >> $GITHUB_ENV

--- a/provider-ci/providers/confluent/repo/.github/workflows/update-upstream-provider.yml
+++ b/provider-ci/providers/confluent/repo/.github/workflows/update-upstream-provider.yml
@@ -62,7 +62,7 @@ jobs:
       with:
         python-version: ${{matrix.pythonversion}}
     - name: Get upstream provider sha
-      run: echo "UPSTREAM_PROVIDER_SHA=$(curl https://api.github.com/repos/${{
+      run: echo "UPSTREAM_PROVIDER_SHA=$(curl -L https://api.github.com/repos/${{
         env.UPSTREAM_PROVIDER_ORG }}/${{ env.UPSTREAM_PROVIDER_REPO
         }}/git/ref/tags/v${{ github.event.inputs.version }} | jq .object.sha
         -r)" >> $GITHUB_ENV

--- a/provider-ci/providers/confluentcloud/repo/.github/workflows/update-upstream-provider.yml
+++ b/provider-ci/providers/confluentcloud/repo/.github/workflows/update-upstream-provider.yml
@@ -62,7 +62,7 @@ jobs:
       with:
         python-version: ${{matrix.pythonversion}}
     - name: Get upstream provider sha
-      run: echo "UPSTREAM_PROVIDER_SHA=$(curl https://api.github.com/repos/${{
+      run: echo "UPSTREAM_PROVIDER_SHA=$(curl -L https://api.github.com/repos/${{
         env.UPSTREAM_PROVIDER_ORG }}/${{ env.UPSTREAM_PROVIDER_REPO
         }}/git/ref/tags/v${{ github.event.inputs.version }} | jq .object.sha
         -r)" >> $GITHUB_ENV

--- a/provider-ci/providers/consul/repo/.github/workflows/update-upstream-provider.yml
+++ b/provider-ci/providers/consul/repo/.github/workflows/update-upstream-provider.yml
@@ -60,7 +60,7 @@ jobs:
       with:
         python-version: ${{matrix.pythonversion}}
     - name: Get upstream provider sha
-      run: echo "UPSTREAM_PROVIDER_SHA=$(curl https://api.github.com/repos/${{
+      run: echo "UPSTREAM_PROVIDER_SHA=$(curl -L https://api.github.com/repos/${{
         env.UPSTREAM_PROVIDER_ORG }}/${{ env.UPSTREAM_PROVIDER_REPO
         }}/git/ref/tags/v${{ github.event.inputs.version }} | jq .object.sha
         -r)" >> $GITHUB_ENV

--- a/provider-ci/providers/databricks/config.yaml
+++ b/provider-ci/providers/databricks/config.yaml
@@ -10,6 +10,6 @@ provider-default-branch: main
 makeTemplate: bridged
 plugins:
   - name: random 
-    version: "4.3.1"
+    version: "4.8.2"
   - name: aws 
-    version: "5.1.0"
+    version: "5.18.0"

--- a/provider-ci/providers/databricks/config.yaml
+++ b/provider-ci/providers/databricks/config.yaml
@@ -5,7 +5,7 @@ env:
   DATABRICKS_PASSWORD: ${{ secrets.DATABRICKS_PASSWORD}}
   DATABRICKS_ACCOUNT_ID: ${{ secrets.DATABRICKS_ACCOUNT_ID}}
   DATABRICKS_HOST: https://accounts.cloud.databricks.com
-upstream-provider-org: databrickslabs
+upstream-provider-org: databricks
 provider-default-branch: main
 makeTemplate: bridged
 plugins:

--- a/provider-ci/providers/databricks/repo/.github/workflows/update-upstream-provider.yml
+++ b/provider-ci/providers/databricks/repo/.github/workflows/update-upstream-provider.yml
@@ -25,7 +25,7 @@ env:
   SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
   TRAVIS_OS_NAME: linux
   UPSTREAM_PROVIDER_MAJOR_VERSION: ""
-  UPSTREAM_PROVIDER_ORG: databrickslabs
+  UPSTREAM_PROVIDER_ORG: databricks
   UPSTREAM_PROVIDER_REPO: terraform-provider-databricks
 jobs:
   update_upstream_provider:

--- a/provider-ci/providers/databricks/repo/.github/workflows/update-upstream-provider.yml
+++ b/provider-ci/providers/databricks/repo/.github/workflows/update-upstream-provider.yml
@@ -64,7 +64,7 @@ jobs:
       with:
         python-version: ${{matrix.pythonversion}}
     - name: Get upstream provider sha
-      run: echo "UPSTREAM_PROVIDER_SHA=$(curl https://api.github.com/repos/${{
+      run: echo "UPSTREAM_PROVIDER_SHA=$(curl -L https://api.github.com/repos/${{
         env.UPSTREAM_PROVIDER_ORG }}/${{ env.UPSTREAM_PROVIDER_REPO
         }}/git/ref/tags/v${{ github.event.inputs.version }} | jq .object.sha
         -r)" >> $GITHUB_ENV

--- a/provider-ci/providers/databricks/repo/Makefile
+++ b/provider-ci/providers/databricks/repo/Makefile
@@ -92,8 +92,8 @@ install_nodejs_sdk:
 
 install_plugins: 
 	[ -x $(shell which pulumi) ] || curl -fsSL https://get.pulumi.com | sh
-	pulumi plugin install resource random 4.3.1
-	pulumi plugin install resource aws 5.1.0
+	pulumi plugin install resource random 4.8.2
+	pulumi plugin install resource aws 5.18.0
 
 lint_provider: provider
 	cd provider && golangci-lint run -c ../.golangci.yml

--- a/provider-ci/providers/datadog/repo/.github/workflows/update-upstream-provider.yml
+++ b/provider-ci/providers/datadog/repo/.github/workflows/update-upstream-provider.yml
@@ -60,7 +60,7 @@ jobs:
       with:
         python-version: ${{matrix.pythonversion}}
     - name: Get upstream provider sha
-      run: echo "UPSTREAM_PROVIDER_SHA=$(curl https://api.github.com/repos/${{
+      run: echo "UPSTREAM_PROVIDER_SHA=$(curl -L https://api.github.com/repos/${{
         env.UPSTREAM_PROVIDER_ORG }}/${{ env.UPSTREAM_PROVIDER_REPO
         }}/git/ref/tags/v${{ github.event.inputs.version }} | jq .object.sha
         -r)" >> $GITHUB_ENV

--- a/provider-ci/providers/digitalocean/repo/.github/workflows/update-upstream-provider.yml
+++ b/provider-ci/providers/digitalocean/repo/.github/workflows/update-upstream-provider.yml
@@ -61,7 +61,7 @@ jobs:
       with:
         python-version: ${{matrix.pythonversion}}
     - name: Get upstream provider sha
-      run: echo "UPSTREAM_PROVIDER_SHA=$(curl https://api.github.com/repos/${{
+      run: echo "UPSTREAM_PROVIDER_SHA=$(curl -L https://api.github.com/repos/${{
         env.UPSTREAM_PROVIDER_ORG }}/${{ env.UPSTREAM_PROVIDER_REPO
         }}/git/ref/tags/v${{ github.event.inputs.version }} | jq .object.sha
         -r)" >> $GITHUB_ENV

--- a/provider-ci/providers/dnsimple/repo/.github/workflows/update-upstream-provider.yml
+++ b/provider-ci/providers/dnsimple/repo/.github/workflows/update-upstream-provider.yml
@@ -62,7 +62,7 @@ jobs:
       with:
         python-version: ${{matrix.pythonversion}}
     - name: Get upstream provider sha
-      run: echo "UPSTREAM_PROVIDER_SHA=$(curl https://api.github.com/repos/${{
+      run: echo "UPSTREAM_PROVIDER_SHA=$(curl -L https://api.github.com/repos/${{
         env.UPSTREAM_PROVIDER_ORG }}/${{ env.UPSTREAM_PROVIDER_REPO
         }}/git/ref/tags/v${{ github.event.inputs.version }} | jq .object.sha
         -r)" >> $GITHUB_ENV

--- a/provider-ci/providers/docker/repo/.github/workflows/update-upstream-provider.yml
+++ b/provider-ci/providers/docker/repo/.github/workflows/update-upstream-provider.yml
@@ -66,7 +66,7 @@ jobs:
       with:
         python-version: ${{matrix.pythonversion}}
     - name: Get upstream provider sha
-      run: echo "UPSTREAM_PROVIDER_SHA=$(curl https://api.github.com/repos/${{
+      run: echo "UPSTREAM_PROVIDER_SHA=$(curl -L https://api.github.com/repos/${{
         env.UPSTREAM_PROVIDER_ORG }}/${{ env.UPSTREAM_PROVIDER_REPO
         }}/git/ref/tags/v${{ github.event.inputs.version }} | jq .object.sha
         -r)" >> $GITHUB_ENV

--- a/provider-ci/providers/ec/repo/.github/workflows/update-upstream-provider.yml
+++ b/provider-ci/providers/ec/repo/.github/workflows/update-upstream-provider.yml
@@ -61,7 +61,7 @@ jobs:
       with:
         python-version: ${{matrix.pythonversion}}
     - name: Get upstream provider sha
-      run: echo "UPSTREAM_PROVIDER_SHA=$(curl https://api.github.com/repos/${{
+      run: echo "UPSTREAM_PROVIDER_SHA=$(curl -L https://api.github.com/repos/${{
         env.UPSTREAM_PROVIDER_ORG }}/${{ env.UPSTREAM_PROVIDER_REPO
         }}/git/ref/tags/v${{ github.event.inputs.version }} | jq .object.sha
         -r)" >> $GITHUB_ENV

--- a/provider-ci/providers/equinix-metal/repo/.github/workflows/update-upstream-provider.yml
+++ b/provider-ci/providers/equinix-metal/repo/.github/workflows/update-upstream-provider.yml
@@ -61,7 +61,7 @@ jobs:
       with:
         python-version: ${{matrix.pythonversion}}
     - name: Get upstream provider sha
-      run: echo "UPSTREAM_PROVIDER_SHA=$(curl https://api.github.com/repos/${{
+      run: echo "UPSTREAM_PROVIDER_SHA=$(curl -L https://api.github.com/repos/${{
         env.UPSTREAM_PROVIDER_ORG }}/${{ env.UPSTREAM_PROVIDER_REPO
         }}/git/ref/tags/v${{ github.event.inputs.version }} | jq .object.sha
         -r)" >> $GITHUB_ENV

--- a/provider-ci/providers/f5bigip/repo/.github/workflows/update-upstream-provider.yml
+++ b/provider-ci/providers/f5bigip/repo/.github/workflows/update-upstream-provider.yml
@@ -64,7 +64,7 @@ jobs:
       with:
         python-version: ${{matrix.pythonversion}}
     - name: Get upstream provider sha
-      run: echo "UPSTREAM_PROVIDER_SHA=$(curl https://api.github.com/repos/${{
+      run: echo "UPSTREAM_PROVIDER_SHA=$(curl -L https://api.github.com/repos/${{
         env.UPSTREAM_PROVIDER_ORG }}/${{ env.UPSTREAM_PROVIDER_REPO
         }}/git/ref/tags/v${{ github.event.inputs.version }} | jq .object.sha
         -r)" >> $GITHUB_ENV

--- a/provider-ci/providers/fastly/repo/.github/workflows/update-upstream-provider.yml
+++ b/provider-ci/providers/fastly/repo/.github/workflows/update-upstream-provider.yml
@@ -61,7 +61,7 @@ jobs:
       with:
         python-version: ${{matrix.pythonversion}}
     - name: Get upstream provider sha
-      run: echo "UPSTREAM_PROVIDER_SHA=$(curl https://api.github.com/repos/${{
+      run: echo "UPSTREAM_PROVIDER_SHA=$(curl -L https://api.github.com/repos/${{
         env.UPSTREAM_PROVIDER_ORG }}/${{ env.UPSTREAM_PROVIDER_REPO
         }}/git/ref/tags/v${{ github.event.inputs.version }} | jq .object.sha
         -r)" >> $GITHUB_ENV

--- a/provider-ci/providers/gcp/repo/.github/workflows/update-upstream-provider.yml
+++ b/provider-ci/providers/gcp/repo/.github/workflows/update-upstream-provider.yml
@@ -68,7 +68,7 @@ jobs:
       with:
         python-version: ${{matrix.pythonversion}}
     - name: Get upstream provider sha
-      run: echo "UPSTREAM_PROVIDER_SHA=$(curl https://api.github.com/repos/${{
+      run: echo "UPSTREAM_PROVIDER_SHA=$(curl -L https://api.github.com/repos/${{
         env.UPSTREAM_PROVIDER_ORG }}/${{ env.UPSTREAM_PROVIDER_REPO
         }}/git/ref/tags/v${{ github.event.inputs.version }} | jq .object.sha
         -r)" >> $GITHUB_ENV

--- a/provider-ci/providers/github/repo/.github/workflows/update-upstream-provider.yml
+++ b/provider-ci/providers/github/repo/.github/workflows/update-upstream-provider.yml
@@ -62,7 +62,7 @@ jobs:
       with:
         python-version: ${{matrix.pythonversion}}
     - name: Get upstream provider sha
-      run: echo "UPSTREAM_PROVIDER_SHA=$(curl https://api.github.com/repos/${{
+      run: echo "UPSTREAM_PROVIDER_SHA=$(curl -L https://api.github.com/repos/${{
         env.UPSTREAM_PROVIDER_ORG }}/${{ env.UPSTREAM_PROVIDER_REPO
         }}/git/ref/tags/v${{ github.event.inputs.version }} | jq .object.sha
         -r)" >> $GITHUB_ENV

--- a/provider-ci/providers/gitlab/repo/.github/workflows/update-upstream-provider.yml
+++ b/provider-ci/providers/gitlab/repo/.github/workflows/update-upstream-provider.yml
@@ -61,7 +61,7 @@ jobs:
       with:
         python-version: ${{matrix.pythonversion}}
     - name: Get upstream provider sha
-      run: echo "UPSTREAM_PROVIDER_SHA=$(curl https://api.github.com/repos/${{
+      run: echo "UPSTREAM_PROVIDER_SHA=$(curl -L https://api.github.com/repos/${{
         env.UPSTREAM_PROVIDER_ORG }}/${{ env.UPSTREAM_PROVIDER_REPO
         }}/git/ref/tags/v${{ github.event.inputs.version }} | jq .object.sha
         -r)" >> $GITHUB_ENV

--- a/provider-ci/providers/hcloud/repo/.github/workflows/update-upstream-provider.yml
+++ b/provider-ci/providers/hcloud/repo/.github/workflows/update-upstream-provider.yml
@@ -61,7 +61,7 @@ jobs:
       with:
         python-version: ${{matrix.pythonversion}}
     - name: Get upstream provider sha
-      run: echo "UPSTREAM_PROVIDER_SHA=$(curl https://api.github.com/repos/${{
+      run: echo "UPSTREAM_PROVIDER_SHA=$(curl -L https://api.github.com/repos/${{
         env.UPSTREAM_PROVIDER_ORG }}/${{ env.UPSTREAM_PROVIDER_REPO
         }}/git/ref/tags/v${{ github.event.inputs.version }} | jq .object.sha
         -r)" >> $GITHUB_ENV

--- a/provider-ci/providers/kafka/repo/.github/workflows/update-upstream-provider.yml
+++ b/provider-ci/providers/kafka/repo/.github/workflows/update-upstream-provider.yml
@@ -60,7 +60,7 @@ jobs:
       with:
         python-version: ${{matrix.pythonversion}}
     - name: Get upstream provider sha
-      run: echo "UPSTREAM_PROVIDER_SHA=$(curl https://api.github.com/repos/${{
+      run: echo "UPSTREAM_PROVIDER_SHA=$(curl -L https://api.github.com/repos/${{
         env.UPSTREAM_PROVIDER_ORG }}/${{ env.UPSTREAM_PROVIDER_REPO
         }}/git/ref/tags/v${{ github.event.inputs.version }} | jq .object.sha
         -r)" >> $GITHUB_ENV

--- a/provider-ci/providers/keycloak/repo/.github/workflows/update-upstream-provider.yml
+++ b/provider-ci/providers/keycloak/repo/.github/workflows/update-upstream-provider.yml
@@ -65,7 +65,7 @@ jobs:
       with:
         python-version: ${{matrix.pythonversion}}
     - name: Get upstream provider sha
-      run: echo "UPSTREAM_PROVIDER_SHA=$(curl https://api.github.com/repos/${{
+      run: echo "UPSTREAM_PROVIDER_SHA=$(curl -L https://api.github.com/repos/${{
         env.UPSTREAM_PROVIDER_ORG }}/${{ env.UPSTREAM_PROVIDER_REPO
         }}/git/ref/tags/v${{ github.event.inputs.version }} | jq .object.sha
         -r)" >> $GITHUB_ENV

--- a/provider-ci/providers/kong/repo/.github/workflows/update-upstream-provider.yml
+++ b/provider-ci/providers/kong/repo/.github/workflows/update-upstream-provider.yml
@@ -60,7 +60,7 @@ jobs:
       with:
         python-version: ${{matrix.pythonversion}}
     - name: Get upstream provider sha
-      run: echo "UPSTREAM_PROVIDER_SHA=$(curl https://api.github.com/repos/${{
+      run: echo "UPSTREAM_PROVIDER_SHA=$(curl -L https://api.github.com/repos/${{
         env.UPSTREAM_PROVIDER_ORG }}/${{ env.UPSTREAM_PROVIDER_REPO
         }}/git/ref/tags/v${{ github.event.inputs.version }} | jq .object.sha
         -r)" >> $GITHUB_ENV

--- a/provider-ci/providers/libvirt/repo/.github/workflows/update-upstream-provider.yml
+++ b/provider-ci/providers/libvirt/repo/.github/workflows/update-upstream-provider.yml
@@ -61,7 +61,7 @@ jobs:
       with:
         python-version: ${{matrix.pythonversion}}
     - name: Get upstream provider sha
-      run: echo "UPSTREAM_PROVIDER_SHA=$(curl https://api.github.com/repos/${{
+      run: echo "UPSTREAM_PROVIDER_SHA=$(curl -L https://api.github.com/repos/${{
         env.UPSTREAM_PROVIDER_ORG }}/${{ env.UPSTREAM_PROVIDER_REPO
         }}/git/ref/tags/v${{ github.event.inputs.version }} | jq .object.sha
         -r)" >> $GITHUB_ENV

--- a/provider-ci/providers/linode/repo/.github/workflows/update-upstream-provider.yml
+++ b/provider-ci/providers/linode/repo/.github/workflows/update-upstream-provider.yml
@@ -61,7 +61,7 @@ jobs:
       with:
         python-version: ${{matrix.pythonversion}}
     - name: Get upstream provider sha
-      run: echo "UPSTREAM_PROVIDER_SHA=$(curl https://api.github.com/repos/${{
+      run: echo "UPSTREAM_PROVIDER_SHA=$(curl -L https://api.github.com/repos/${{
         env.UPSTREAM_PROVIDER_ORG }}/${{ env.UPSTREAM_PROVIDER_REPO
         }}/git/ref/tags/v${{ github.event.inputs.version }} | jq .object.sha
         -r)" >> $GITHUB_ENV

--- a/provider-ci/providers/mailgun/repo/.github/workflows/update-upstream-provider.yml
+++ b/provider-ci/providers/mailgun/repo/.github/workflows/update-upstream-provider.yml
@@ -61,7 +61,7 @@ jobs:
       with:
         python-version: ${{matrix.pythonversion}}
     - name: Get upstream provider sha
-      run: echo "UPSTREAM_PROVIDER_SHA=$(curl https://api.github.com/repos/${{
+      run: echo "UPSTREAM_PROVIDER_SHA=$(curl -L https://api.github.com/repos/${{
         env.UPSTREAM_PROVIDER_ORG }}/${{ env.UPSTREAM_PROVIDER_REPO
         }}/git/ref/tags/v${{ github.event.inputs.version }} | jq .object.sha
         -r)" >> $GITHUB_ENV

--- a/provider-ci/providers/minio/repo/.github/workflows/update-upstream-provider.yml
+++ b/provider-ci/providers/minio/repo/.github/workflows/update-upstream-provider.yml
@@ -64,7 +64,7 @@ jobs:
       with:
         python-version: ${{matrix.pythonversion}}
     - name: Get upstream provider sha
-      run: echo "UPSTREAM_PROVIDER_SHA=$(curl https://api.github.com/repos/${{
+      run: echo "UPSTREAM_PROVIDER_SHA=$(curl -L https://api.github.com/repos/${{
         env.UPSTREAM_PROVIDER_ORG }}/${{ env.UPSTREAM_PROVIDER_REPO
         }}/git/ref/tags/v${{ github.event.inputs.version }} | jq .object.sha
         -r)" >> $GITHUB_ENV

--- a/provider-ci/providers/mongodbatlas/repo/.github/workflows/update-upstream-provider.yml
+++ b/provider-ci/providers/mongodbatlas/repo/.github/workflows/update-upstream-provider.yml
@@ -63,7 +63,7 @@ jobs:
       with:
         python-version: ${{matrix.pythonversion}}
     - name: Get upstream provider sha
-      run: echo "UPSTREAM_PROVIDER_SHA=$(curl https://api.github.com/repos/${{
+      run: echo "UPSTREAM_PROVIDER_SHA=$(curl -L https://api.github.com/repos/${{
         env.UPSTREAM_PROVIDER_ORG }}/${{ env.UPSTREAM_PROVIDER_REPO
         }}/git/ref/tags/v${{ github.event.inputs.version }} | jq .object.sha
         -r)" >> $GITHUB_ENV

--- a/provider-ci/providers/mysql/repo/.github/workflows/update-upstream-provider.yml
+++ b/provider-ci/providers/mysql/repo/.github/workflows/update-upstream-provider.yml
@@ -60,7 +60,7 @@ jobs:
       with:
         python-version: ${{matrix.pythonversion}}
     - name: Get upstream provider sha
-      run: echo "UPSTREAM_PROVIDER_SHA=$(curl https://api.github.com/repos/${{
+      run: echo "UPSTREAM_PROVIDER_SHA=$(curl -L https://api.github.com/repos/${{
         env.UPSTREAM_PROVIDER_ORG }}/${{ env.UPSTREAM_PROVIDER_REPO
         }}/git/ref/tags/v${{ github.event.inputs.version }} | jq .object.sha
         -r)" >> $GITHUB_ENV

--- a/provider-ci/providers/newrelic/repo/.github/workflows/update-upstream-provider.yml
+++ b/provider-ci/providers/newrelic/repo/.github/workflows/update-upstream-provider.yml
@@ -62,7 +62,7 @@ jobs:
       with:
         python-version: ${{matrix.pythonversion}}
     - name: Get upstream provider sha
-      run: echo "UPSTREAM_PROVIDER_SHA=$(curl https://api.github.com/repos/${{
+      run: echo "UPSTREAM_PROVIDER_SHA=$(curl -L https://api.github.com/repos/${{
         env.UPSTREAM_PROVIDER_ORG }}/${{ env.UPSTREAM_PROVIDER_REPO
         }}/git/ref/tags/v${{ github.event.inputs.version }} | jq .object.sha
         -r)" >> $GITHUB_ENV

--- a/provider-ci/providers/nomad/repo/.github/workflows/update-upstream-provider.yml
+++ b/provider-ci/providers/nomad/repo/.github/workflows/update-upstream-provider.yml
@@ -61,7 +61,7 @@ jobs:
       with:
         python-version: ${{matrix.pythonversion}}
     - name: Get upstream provider sha
-      run: echo "UPSTREAM_PROVIDER_SHA=$(curl https://api.github.com/repos/${{
+      run: echo "UPSTREAM_PROVIDER_SHA=$(curl -L https://api.github.com/repos/${{
         env.UPSTREAM_PROVIDER_ORG }}/${{ env.UPSTREAM_PROVIDER_REPO
         }}/git/ref/tags/v${{ github.event.inputs.version }} | jq .object.sha
         -r)" >> $GITHUB_ENV

--- a/provider-ci/providers/ns1/repo/.github/workflows/update-upstream-provider.yml
+++ b/provider-ci/providers/ns1/repo/.github/workflows/update-upstream-provider.yml
@@ -61,7 +61,7 @@ jobs:
       with:
         python-version: ${{matrix.pythonversion}}
     - name: Get upstream provider sha
-      run: echo "UPSTREAM_PROVIDER_SHA=$(curl https://api.github.com/repos/${{
+      run: echo "UPSTREAM_PROVIDER_SHA=$(curl -L https://api.github.com/repos/${{
         env.UPSTREAM_PROVIDER_ORG }}/${{ env.UPSTREAM_PROVIDER_REPO
         }}/git/ref/tags/v${{ github.event.inputs.version }} | jq .object.sha
         -r)" >> $GITHUB_ENV

--- a/provider-ci/providers/oci/repo/.github/workflows/update-upstream-provider.yml
+++ b/provider-ci/providers/oci/repo/.github/workflows/update-upstream-provider.yml
@@ -64,7 +64,7 @@ jobs:
       with:
         python-version: ${{matrix.pythonversion}}
     - name: Get upstream provider sha
-      run: echo "UPSTREAM_PROVIDER_SHA=$(curl https://api.github.com/repos/${{
+      run: echo "UPSTREAM_PROVIDER_SHA=$(curl -L https://api.github.com/repos/${{
         env.UPSTREAM_PROVIDER_ORG }}/${{ env.UPSTREAM_PROVIDER_REPO
         }}/git/ref/tags/v${{ github.event.inputs.version }} | jq .object.sha
         -r)" >> $GITHUB_ENV

--- a/provider-ci/providers/okta/repo/.github/workflows/update-upstream-provider.yml
+++ b/provider-ci/providers/okta/repo/.github/workflows/update-upstream-provider.yml
@@ -63,7 +63,7 @@ jobs:
       with:
         python-version: ${{matrix.pythonversion}}
     - name: Get upstream provider sha
-      run: echo "UPSTREAM_PROVIDER_SHA=$(curl https://api.github.com/repos/${{
+      run: echo "UPSTREAM_PROVIDER_SHA=$(curl -L https://api.github.com/repos/${{
         env.UPSTREAM_PROVIDER_ORG }}/${{ env.UPSTREAM_PROVIDER_REPO
         }}/git/ref/tags/v${{ github.event.inputs.version }} | jq .object.sha
         -r)" >> $GITHUB_ENV

--- a/provider-ci/providers/onelogin/repo/.github/workflows/update-upstream-provider.yml
+++ b/provider-ci/providers/onelogin/repo/.github/workflows/update-upstream-provider.yml
@@ -60,7 +60,7 @@ jobs:
       with:
         python-version: ${{matrix.pythonversion}}
     - name: Get upstream provider sha
-      run: echo "UPSTREAM_PROVIDER_SHA=$(curl https://api.github.com/repos/${{
+      run: echo "UPSTREAM_PROVIDER_SHA=$(curl -L https://api.github.com/repos/${{
         env.UPSTREAM_PROVIDER_ORG }}/${{ env.UPSTREAM_PROVIDER_REPO
         }}/git/ref/tags/v${{ github.event.inputs.version }} | jq .object.sha
         -r)" >> $GITHUB_ENV

--- a/provider-ci/providers/openstack/repo/.github/workflows/update-upstream-provider.yml
+++ b/provider-ci/providers/openstack/repo/.github/workflows/update-upstream-provider.yml
@@ -69,7 +69,7 @@ jobs:
       with:
         python-version: ${{matrix.pythonversion}}
     - name: Get upstream provider sha
-      run: echo "UPSTREAM_PROVIDER_SHA=$(curl https://api.github.com/repos/${{
+      run: echo "UPSTREAM_PROVIDER_SHA=$(curl -L https://api.github.com/repos/${{
         env.UPSTREAM_PROVIDER_ORG }}/${{ env.UPSTREAM_PROVIDER_REPO
         }}/git/ref/tags/v${{ github.event.inputs.version }} | jq .object.sha
         -r)" >> $GITHUB_ENV

--- a/provider-ci/providers/opsgenie/repo/.github/workflows/update-upstream-provider.yml
+++ b/provider-ci/providers/opsgenie/repo/.github/workflows/update-upstream-provider.yml
@@ -61,7 +61,7 @@ jobs:
       with:
         python-version: ${{matrix.pythonversion}}
     - name: Get upstream provider sha
-      run: echo "UPSTREAM_PROVIDER_SHA=$(curl https://api.github.com/repos/${{
+      run: echo "UPSTREAM_PROVIDER_SHA=$(curl -L https://api.github.com/repos/${{
         env.UPSTREAM_PROVIDER_ORG }}/${{ env.UPSTREAM_PROVIDER_REPO
         }}/git/ref/tags/v${{ github.event.inputs.version }} | jq .object.sha
         -r)" >> $GITHUB_ENV

--- a/provider-ci/providers/pagerduty/repo/.github/workflows/update-upstream-provider.yml
+++ b/provider-ci/providers/pagerduty/repo/.github/workflows/update-upstream-provider.yml
@@ -61,7 +61,7 @@ jobs:
       with:
         python-version: ${{matrix.pythonversion}}
     - name: Get upstream provider sha
-      run: echo "UPSTREAM_PROVIDER_SHA=$(curl https://api.github.com/repos/${{
+      run: echo "UPSTREAM_PROVIDER_SHA=$(curl -L https://api.github.com/repos/${{
         env.UPSTREAM_PROVIDER_ORG }}/${{ env.UPSTREAM_PROVIDER_REPO
         }}/git/ref/tags/v${{ github.event.inputs.version }} | jq .object.sha
         -r)" >> $GITHUB_ENV

--- a/provider-ci/providers/postgresql/repo/.github/workflows/update-upstream-provider.yml
+++ b/provider-ci/providers/postgresql/repo/.github/workflows/update-upstream-provider.yml
@@ -60,7 +60,7 @@ jobs:
       with:
         python-version: ${{matrix.pythonversion}}
     - name: Get upstream provider sha
-      run: echo "UPSTREAM_PROVIDER_SHA=$(curl https://api.github.com/repos/${{
+      run: echo "UPSTREAM_PROVIDER_SHA=$(curl -L https://api.github.com/repos/${{
         env.UPSTREAM_PROVIDER_ORG }}/${{ env.UPSTREAM_PROVIDER_REPO
         }}/git/ref/tags/v${{ github.event.inputs.version }} | jq .object.sha
         -r)" >> $GITHUB_ENV

--- a/provider-ci/providers/rabbitmq/repo/.github/workflows/update-upstream-provider.yml
+++ b/provider-ci/providers/rabbitmq/repo/.github/workflows/update-upstream-provider.yml
@@ -60,7 +60,7 @@ jobs:
       with:
         python-version: ${{matrix.pythonversion}}
     - name: Get upstream provider sha
-      run: echo "UPSTREAM_PROVIDER_SHA=$(curl https://api.github.com/repos/${{
+      run: echo "UPSTREAM_PROVIDER_SHA=$(curl -L https://api.github.com/repos/${{
         env.UPSTREAM_PROVIDER_ORG }}/${{ env.UPSTREAM_PROVIDER_REPO
         }}/git/ref/tags/v${{ github.event.inputs.version }} | jq .object.sha
         -r)" >> $GITHUB_ENV

--- a/provider-ci/providers/rancher2/repo/.github/workflows/update-upstream-provider.yml
+++ b/provider-ci/providers/rancher2/repo/.github/workflows/update-upstream-provider.yml
@@ -62,7 +62,7 @@ jobs:
       with:
         python-version: ${{matrix.pythonversion}}
     - name: Get upstream provider sha
-      run: echo "UPSTREAM_PROVIDER_SHA=$(curl https://api.github.com/repos/${{
+      run: echo "UPSTREAM_PROVIDER_SHA=$(curl -L https://api.github.com/repos/${{
         env.UPSTREAM_PROVIDER_ORG }}/${{ env.UPSTREAM_PROVIDER_REPO
         }}/git/ref/tags/v${{ github.event.inputs.version }} | jq .object.sha
         -r)" >> $GITHUB_ENV

--- a/provider-ci/providers/random/repo/.github/workflows/update-upstream-provider.yml
+++ b/provider-ci/providers/random/repo/.github/workflows/update-upstream-provider.yml
@@ -60,7 +60,7 @@ jobs:
       with:
         python-version: ${{matrix.pythonversion}}
     - name: Get upstream provider sha
-      run: echo "UPSTREAM_PROVIDER_SHA=$(curl https://api.github.com/repos/${{
+      run: echo "UPSTREAM_PROVIDER_SHA=$(curl -L https://api.github.com/repos/${{
         env.UPSTREAM_PROVIDER_ORG }}/${{ env.UPSTREAM_PROVIDER_REPO
         }}/git/ref/tags/v${{ github.event.inputs.version }} | jq .object.sha
         -r)" >> $GITHUB_ENV

--- a/provider-ci/providers/rke/repo/.github/workflows/update-upstream-provider.yml
+++ b/provider-ci/providers/rke/repo/.github/workflows/update-upstream-provider.yml
@@ -61,7 +61,7 @@ jobs:
       with:
         python-version: ${{matrix.pythonversion}}
     - name: Get upstream provider sha
-      run: echo "UPSTREAM_PROVIDER_SHA=$(curl https://api.github.com/repos/${{
+      run: echo "UPSTREAM_PROVIDER_SHA=$(curl -L https://api.github.com/repos/${{
         env.UPSTREAM_PROVIDER_ORG }}/${{ env.UPSTREAM_PROVIDER_REPO
         }}/git/ref/tags/v${{ github.event.inputs.version }} | jq .object.sha
         -r)" >> $GITHUB_ENV

--- a/provider-ci/providers/signalfx/repo/.github/workflows/update-upstream-provider.yml
+++ b/provider-ci/providers/signalfx/repo/.github/workflows/update-upstream-provider.yml
@@ -60,7 +60,7 @@ jobs:
       with:
         python-version: ${{matrix.pythonversion}}
     - name: Get upstream provider sha
-      run: echo "UPSTREAM_PROVIDER_SHA=$(curl https://api.github.com/repos/${{
+      run: echo "UPSTREAM_PROVIDER_SHA=$(curl -L https://api.github.com/repos/${{
         env.UPSTREAM_PROVIDER_ORG }}/${{ env.UPSTREAM_PROVIDER_REPO
         }}/git/ref/tags/v${{ github.event.inputs.version }} | jq .object.sha
         -r)" >> $GITHUB_ENV

--- a/provider-ci/providers/slack/repo/.github/workflows/update-upstream-provider.yml
+++ b/provider-ci/providers/slack/repo/.github/workflows/update-upstream-provider.yml
@@ -61,7 +61,7 @@ jobs:
       with:
         python-version: ${{matrix.pythonversion}}
     - name: Get upstream provider sha
-      run: echo "UPSTREAM_PROVIDER_SHA=$(curl https://api.github.com/repos/${{
+      run: echo "UPSTREAM_PROVIDER_SHA=$(curl -L https://api.github.com/repos/${{
         env.UPSTREAM_PROVIDER_ORG }}/${{ env.UPSTREAM_PROVIDER_REPO
         }}/git/ref/tags/v${{ github.event.inputs.version }} | jq .object.sha
         -r)" >> $GITHUB_ENV

--- a/provider-ci/providers/snowflake/repo/.github/workflows/update-upstream-provider.yml
+++ b/provider-ci/providers/snowflake/repo/.github/workflows/update-upstream-provider.yml
@@ -65,7 +65,7 @@ jobs:
       with:
         python-version: ${{matrix.pythonversion}}
     - name: Get upstream provider sha
-      run: echo "UPSTREAM_PROVIDER_SHA=$(curl https://api.github.com/repos/${{
+      run: echo "UPSTREAM_PROVIDER_SHA=$(curl -L https://api.github.com/repos/${{
         env.UPSTREAM_PROVIDER_ORG }}/${{ env.UPSTREAM_PROVIDER_REPO
         }}/git/ref/tags/v${{ github.event.inputs.version }} | jq .object.sha
         -r)" >> $GITHUB_ENV

--- a/provider-ci/providers/splunk/repo/.github/workflows/update-upstream-provider.yml
+++ b/provider-ci/providers/splunk/repo/.github/workflows/update-upstream-provider.yml
@@ -63,7 +63,7 @@ jobs:
       with:
         python-version: ${{matrix.pythonversion}}
     - name: Get upstream provider sha
-      run: echo "UPSTREAM_PROVIDER_SHA=$(curl https://api.github.com/repos/${{
+      run: echo "UPSTREAM_PROVIDER_SHA=$(curl -L https://api.github.com/repos/${{
         env.UPSTREAM_PROVIDER_ORG }}/${{ env.UPSTREAM_PROVIDER_REPO
         }}/git/ref/tags/v${{ github.event.inputs.version }} | jq .object.sha
         -r)" >> $GITHUB_ENV

--- a/provider-ci/providers/spotinst/repo/.github/workflows/update-upstream-provider.yml
+++ b/provider-ci/providers/spotinst/repo/.github/workflows/update-upstream-provider.yml
@@ -63,7 +63,7 @@ jobs:
       with:
         python-version: ${{matrix.pythonversion}}
     - name: Get upstream provider sha
-      run: echo "UPSTREAM_PROVIDER_SHA=$(curl https://api.github.com/repos/${{
+      run: echo "UPSTREAM_PROVIDER_SHA=$(curl -L https://api.github.com/repos/${{
         env.UPSTREAM_PROVIDER_ORG }}/${{ env.UPSTREAM_PROVIDER_REPO
         }}/git/ref/tags/v${{ github.event.inputs.version }} | jq .object.sha
         -r)" >> $GITHUB_ENV

--- a/provider-ci/providers/sumologic/repo/.github/workflows/update-upstream-provider.yml
+++ b/provider-ci/providers/sumologic/repo/.github/workflows/update-upstream-provider.yml
@@ -63,7 +63,7 @@ jobs:
       with:
         python-version: ${{matrix.pythonversion}}
     - name: Get upstream provider sha
-      run: echo "UPSTREAM_PROVIDER_SHA=$(curl https://api.github.com/repos/${{
+      run: echo "UPSTREAM_PROVIDER_SHA=$(curl -L https://api.github.com/repos/${{
         env.UPSTREAM_PROVIDER_ORG }}/${{ env.UPSTREAM_PROVIDER_REPO
         }}/git/ref/tags/v${{ github.event.inputs.version }} | jq .object.sha
         -r)" >> $GITHUB_ENV

--- a/provider-ci/providers/tailscale/repo/.github/workflows/update-upstream-provider.yml
+++ b/provider-ci/providers/tailscale/repo/.github/workflows/update-upstream-provider.yml
@@ -62,7 +62,7 @@ jobs:
       with:
         python-version: ${{matrix.pythonversion}}
     - name: Get upstream provider sha
-      run: echo "UPSTREAM_PROVIDER_SHA=$(curl https://api.github.com/repos/${{
+      run: echo "UPSTREAM_PROVIDER_SHA=$(curl -L https://api.github.com/repos/${{
         env.UPSTREAM_PROVIDER_ORG }}/${{ env.UPSTREAM_PROVIDER_REPO
         }}/git/ref/tags/v${{ github.event.inputs.version }} | jq .object.sha
         -r)" >> $GITHUB_ENV

--- a/provider-ci/providers/tls/repo/.github/workflows/update-upstream-provider.yml
+++ b/provider-ci/providers/tls/repo/.github/workflows/update-upstream-provider.yml
@@ -60,7 +60,7 @@ jobs:
       with:
         python-version: ${{matrix.pythonversion}}
     - name: Get upstream provider sha
-      run: echo "UPSTREAM_PROVIDER_SHA=$(curl https://api.github.com/repos/${{
+      run: echo "UPSTREAM_PROVIDER_SHA=$(curl -L https://api.github.com/repos/${{
         env.UPSTREAM_PROVIDER_ORG }}/${{ env.UPSTREAM_PROVIDER_REPO
         }}/git/ref/tags/v${{ github.event.inputs.version }} | jq .object.sha
         -r)" >> $GITHUB_ENV

--- a/provider-ci/providers/vault/repo/.github/workflows/update-upstream-provider.yml
+++ b/provider-ci/providers/vault/repo/.github/workflows/update-upstream-provider.yml
@@ -60,7 +60,7 @@ jobs:
       with:
         python-version: ${{matrix.pythonversion}}
     - name: Get upstream provider sha
-      run: echo "UPSTREAM_PROVIDER_SHA=$(curl https://api.github.com/repos/${{
+      run: echo "UPSTREAM_PROVIDER_SHA=$(curl -L https://api.github.com/repos/${{
         env.UPSTREAM_PROVIDER_ORG }}/${{ env.UPSTREAM_PROVIDER_REPO
         }}/git/ref/tags/v${{ github.event.inputs.version }} | jq .object.sha
         -r)" >> $GITHUB_ENV

--- a/provider-ci/providers/venafi/repo/.github/workflows/update-upstream-provider.yml
+++ b/provider-ci/providers/venafi/repo/.github/workflows/update-upstream-provider.yml
@@ -63,7 +63,7 @@ jobs:
       with:
         python-version: ${{matrix.pythonversion}}
     - name: Get upstream provider sha
-      run: echo "UPSTREAM_PROVIDER_SHA=$(curl https://api.github.com/repos/${{
+      run: echo "UPSTREAM_PROVIDER_SHA=$(curl -L https://api.github.com/repos/${{
         env.UPSTREAM_PROVIDER_ORG }}/${{ env.UPSTREAM_PROVIDER_REPO
         }}/git/ref/tags/v${{ github.event.inputs.version }} | jq .object.sha
         -r)" >> $GITHUB_ENV

--- a/provider-ci/providers/vsphere/repo/.github/workflows/update-upstream-provider.yml
+++ b/provider-ci/providers/vsphere/repo/.github/workflows/update-upstream-provider.yml
@@ -60,7 +60,7 @@ jobs:
       with:
         python-version: ${{matrix.pythonversion}}
     - name: Get upstream provider sha
-      run: echo "UPSTREAM_PROVIDER_SHA=$(curl https://api.github.com/repos/${{
+      run: echo "UPSTREAM_PROVIDER_SHA=$(curl -L https://api.github.com/repos/${{
         env.UPSTREAM_PROVIDER_ORG }}/${{ env.UPSTREAM_PROVIDER_REPO
         }}/git/ref/tags/v${{ github.event.inputs.version }} | jq .object.sha
         -r)" >> $GITHUB_ENV

--- a/provider-ci/providers/wavefront/repo/.github/workflows/update-upstream-provider.yml
+++ b/provider-ci/providers/wavefront/repo/.github/workflows/update-upstream-provider.yml
@@ -62,7 +62,7 @@ jobs:
       with:
         python-version: ${{matrix.pythonversion}}
     - name: Get upstream provider sha
-      run: echo "UPSTREAM_PROVIDER_SHA=$(curl https://api.github.com/repos/${{
+      run: echo "UPSTREAM_PROVIDER_SHA=$(curl -L https://api.github.com/repos/${{
         env.UPSTREAM_PROVIDER_ORG }}/${{ env.UPSTREAM_PROVIDER_REPO
         }}/git/ref/tags/v${{ github.event.inputs.version }} | jq .object.sha
         -r)" >> $GITHUB_ENV

--- a/provider-ci/src/workflows.ts
+++ b/provider-ci/src/workflows.ts
@@ -522,7 +522,7 @@ export function UpdateUpstreamProviderWorkflow(
         .addStep(steps.InstallPython())
         .addStep({
           name: "Get upstream provider sha",
-          run: 'echo "UPSTREAM_PROVIDER_SHA=$(curl https://api.github.com/repos/${{ env.UPSTREAM_PROVIDER_ORG }}/${{ env.UPSTREAM_PROVIDER_REPO }}/git/ref/tags/v${{ github.event.inputs.version }} | jq .object.sha -r)" >> $GITHUB_ENV',
+          run: 'echo "UPSTREAM_PROVIDER_SHA=$(curl -L https://api.github.com/repos/${{ env.UPSTREAM_PROVIDER_ORG }}/${{ env.UPSTREAM_PROVIDER_REPO }}/git/ref/tags/v${{ github.event.inputs.version }} | jq .object.sha -r)" >> $GITHUB_ENV',
         })
         .addStep({
           name: "Update shim/go.mod",


### PR DESCRIPTION
The curl command used was not resilient to redirects. For instance `curl https://api.github.com/repos/databrickslabs/terraform-provider-databricks/git/ref/tags/v1.6.5` redirects:

```
{
  "message": "Moved Permanently",
  "url": "https://api.github.com/repositories/240289534/git/ref/tags/v1.6.5",
  "documentation_url": "https://docs.github.com/v3/#http-redirects"
}
```

Which would cause the subsequent jq to command to get a `null` value.

The `-L` flag makes sure we follow redirects.