### PR TITLE
Fix to allow safe automerge

### DIFF
--- a/.github/workflows/update-workflows-bridged-providers.yml
+++ b/.github/workflows/update-workflows-bridged-providers.yml
@@ -63,9 +63,9 @@ jobs:
           title: "Update GitHub Actions workflows."
           path: pulumi-${{ matrix.provider }}
           token: ${{ secrets.PULUMI_BOT_TOKEN }}
-      # - name: Set PR to auto-merge
-      #   if: steps.create-pr.outputs.pull-request-operation == 'created' && github.event.inputs.automerge == 'true'
-      #   run: "gh pr merge --auto --squash ${{ steps.create-pr.outputs.pull-request-url }}"
+      - name: Add auto-merge label to PR
+        if: steps.create-pr.outputs.pull-request-operation == 'created' && github.event.inputs.automerge == 'true'
+        run: "gh pr edit ${{ steps.create-pr.outputs.pull-request-url }} --add-label 'auto-merge'"
       # See: https://docs.github.com/en/rest/guides/best-practices-for-integrators#dealing-with-secondary-rate-limits
       - name: Sleep to prevent hitting secondary rate limits
         run: sleep 1

--- a/.github/workflows/update-workflows-bridged-providers.yml
+++ b/.github/workflows/update-workflows-bridged-providers.yml
@@ -63,9 +63,9 @@ jobs:
           title: "Update GitHub Actions workflows."
           path: pulumi-${{ matrix.provider }}
           token: ${{ secrets.PULUMI_BOT_TOKEN }}
-      - name: Set PR to auto-merge
-        if: steps.create-pr.outputs.pull-request-operation == 'created' && github.event.inputs.automerge == 'true'
-        run: "gh pr merge --auto --squash ${{ steps.create-pr.outputs.pull-request-url }}"
+      # - name: Set PR to auto-merge
+      #   if: steps.create-pr.outputs.pull-request-operation == 'created' && github.event.inputs.automerge == 'true'
+      #   run: "gh pr merge --auto --squash ${{ steps.create-pr.outputs.pull-request-url }}"
       # See: https://docs.github.com/en/rest/guides/best-practices-for-integrators#dealing-with-secondary-rate-limits
       - name: Sleep to prevent hitting secondary rate limits
         run: sleep 1

--- a/.github/workflows/update-workflows-single-bridged-provider.yml
+++ b/.github/workflows/update-workflows-single-bridged-provider.yml
@@ -50,6 +50,6 @@ jobs:
           token: ${{ secrets.PULUMI_BOT_TOKEN }}
       - name: test
         run: echo ${{ github.repository }}
-      - name: Set PR to auto-merge
-        if: steps.create-pr.outputs.pull-request-operation == 'created' && github.event.inputs.automerge == 'true'
-        run: "gh pr merge --auto --squash ${{ steps.create-pr.outputs.pull-request-url }}"
+      # - name: Set PR to auto-merge
+      #   if: steps.create-pr.outputs.pull-request-operation == 'created' && github.event.inputs.automerge == 'true'
+      #   run: "gh pr merge --auto --squash ${{ steps.create-pr.outputs.pull-request-url }}"

--- a/.github/workflows/update-workflows-single-bridged-provider.yml
+++ b/.github/workflows/update-workflows-single-bridged-provider.yml
@@ -50,6 +50,6 @@ jobs:
           token: ${{ secrets.PULUMI_BOT_TOKEN }}
       - name: test
         run: echo ${{ github.repository }}
-      # - name: Set PR to auto-merge
-      #   if: steps.create-pr.outputs.pull-request-operation == 'created' && github.event.inputs.automerge == 'true'
-      #   run: "gh pr merge --auto --squash ${{ steps.create-pr.outputs.pull-request-url }}"
+      - name: Add auto-merge label to PR
+        if: steps.create-pr.outputs.pull-request-operation == 'created' && github.event.inputs.automerge == 'true'
+        run: "gh pr edit ${{ steps.create-pr.outputs.pull-request-url }} --add-label 'auto-merge'"

--- a/provider-ci/providers/aiven/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/aiven/repo/.github/workflows/run-acceptance-tests.yml
@@ -230,8 +230,9 @@ jobs:
         GITHUB_TOKEN: ${{secrets.PULUMI_BOT_TOKEN}}
         PR_URL: ${{github.event.pull_request.html_url}}
       id: enable-automerge
-      if: github.event.pull_request.user.login == 'pulumi-bot'
-      name: Enable automerge if successful for bot PRs
+      if: github.event.pull_request.user.login == 'pulumi-bot' &&
+        contains(toJson(github.event.pull_request.labels.*.name), 'auto-merge')
+      name: Enable automerge if successful for bot PRs with 'auto-merge' label
       run: gh pr merge --auto --squash $PR_URL
   test:
     if: github.event_name == 'repository_dispatch' ||

--- a/provider-ci/providers/aiven/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/aiven/repo/.github/workflows/run-acceptance-tests.yml
@@ -226,8 +226,13 @@ jobs:
     - test
     runs-on: ubuntu-latest
     steps:
-    - name: Is workflow a success
-      run: echo yes
+    - env:
+        GITHUB_TOKEN: ${{secrets.PULUMI_BOT_TOKEN}}
+        PR_URL: ${{github.event.pull_request.html_url}}
+      id: enable-automerge
+      if: github.event.pull_request.user.login == 'pulumi-bot'
+      name: Enable automerge if successful for bot PRs
+      run: gh pr merge --auto --squash $PR_URL
   test:
     if: github.event_name == 'repository_dispatch' ||
       github.event.pull_request.head.repo.full_name == github.repository

--- a/provider-ci/providers/aiven/repo/.github/workflows/update-bridge.yml
+++ b/provider-ci/providers/aiven/repo/.github/workflows/update-bridge.yml
@@ -66,10 +66,6 @@ jobs:
         title: Update pulumi-terraform-bridge to v${{ github.event.inputs.bridge_version
           }}
         token: ${{ secrets.PULUMI_BOT_TOKEN }}
-    - if: steps.create-pr.outputs.pull-request-operation == 'created' &&
-        github.event.inputs.automerge == 'true'
-      run: gh pr merge --auto --squash ${{ steps.create-pr.outputs.pull-request-number
-        }}
     strategy:
       fail-fast: true
       matrix:
@@ -85,11 +81,6 @@ name: Update pulumi-terraform-bridge
 on:
   workflow_dispatch:
     inputs:
-      automerge:
-        default: false
-        description: Mark created PR for auto-merging?
-        required: true
-        type: boolean
       bridge_version:
         description: The version of pulumi/pulumi-terraform-bridge to update to. Do not
           include the 'v' prefix. Must be major version 3.

--- a/provider-ci/providers/aiven/repo/.github/workflows/update-upstream-provider.yml
+++ b/provider-ci/providers/aiven/repo/.github/workflows/update-upstream-provider.yml
@@ -144,11 +144,6 @@ name: Update upstream provider
 on:
   workflow_dispatch:
     inputs:
-      automerge:
-        default: false
-        description: Mark created PR for auto-merging?
-        required: true
-        type: boolean
       linked_issue_number:
         description: The issue number of a PR in this repository to which the generated
           pull request should be linked.

--- a/provider-ci/providers/akamai/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/akamai/repo/.github/workflows/run-acceptance-tests.yml
@@ -232,8 +232,9 @@ jobs:
         GITHUB_TOKEN: ${{secrets.PULUMI_BOT_TOKEN}}
         PR_URL: ${{github.event.pull_request.html_url}}
       id: enable-automerge
-      if: github.event.pull_request.user.login == 'pulumi-bot'
-      name: Enable automerge if successful for bot PRs
+      if: github.event.pull_request.user.login == 'pulumi-bot' &&
+        contains(toJson(github.event.pull_request.labels.*.name), 'auto-merge')
+      name: Enable automerge if successful for bot PRs with 'auto-merge' label
       run: gh pr merge --auto --squash $PR_URL
   test:
     if: github.event_name == 'repository_dispatch' ||

--- a/provider-ci/providers/akamai/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/akamai/repo/.github/workflows/run-acceptance-tests.yml
@@ -228,8 +228,13 @@ jobs:
     - test
     runs-on: ubuntu-latest
     steps:
-    - name: Is workflow a success
-      run: echo yes
+    - env:
+        GITHUB_TOKEN: ${{secrets.PULUMI_BOT_TOKEN}}
+        PR_URL: ${{github.event.pull_request.html_url}}
+      id: enable-automerge
+      if: github.event.pull_request.user.login == 'pulumi-bot'
+      name: Enable automerge if successful for bot PRs
+      run: gh pr merge --auto --squash $PR_URL
   test:
     if: github.event_name == 'repository_dispatch' ||
       github.event.pull_request.head.repo.full_name == github.repository

--- a/provider-ci/providers/akamai/repo/.github/workflows/update-bridge.yml
+++ b/provider-ci/providers/akamai/repo/.github/workflows/update-bridge.yml
@@ -66,10 +66,6 @@ jobs:
         title: Update pulumi-terraform-bridge to v${{ github.event.inputs.bridge_version
           }}
         token: ${{ secrets.PULUMI_BOT_TOKEN }}
-    - if: steps.create-pr.outputs.pull-request-operation == 'created' &&
-        github.event.inputs.automerge == 'true'
-      run: gh pr merge --auto --squash ${{ steps.create-pr.outputs.pull-request-number
-        }}
     strategy:
       fail-fast: true
       matrix:
@@ -85,11 +81,6 @@ name: Update pulumi-terraform-bridge
 on:
   workflow_dispatch:
     inputs:
-      automerge:
-        default: false
-        description: Mark created PR for auto-merging?
-        required: true
-        type: boolean
       bridge_version:
         description: The version of pulumi/pulumi-terraform-bridge to update to. Do not
           include the 'v' prefix. Must be major version 3.

--- a/provider-ci/providers/akamai/repo/.github/workflows/update-upstream-provider.yml
+++ b/provider-ci/providers/akamai/repo/.github/workflows/update-upstream-provider.yml
@@ -146,11 +146,6 @@ name: Update upstream provider
 on:
   workflow_dispatch:
     inputs:
-      automerge:
-        default: false
-        description: Mark created PR for auto-merging?
-        required: true
-        type: boolean
       linked_issue_number:
         description: The issue number of a PR in this repository to which the generated
           pull request should be linked.

--- a/provider-ci/providers/alicloud/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/alicloud/repo/.github/workflows/run-acceptance-tests.yml
@@ -227,8 +227,13 @@ jobs:
     - test
     runs-on: ubuntu-latest
     steps:
-    - name: Is workflow a success
-      run: echo yes
+    - env:
+        GITHUB_TOKEN: ${{secrets.PULUMI_BOT_TOKEN}}
+        PR_URL: ${{github.event.pull_request.html_url}}
+      id: enable-automerge
+      if: github.event.pull_request.user.login == 'pulumi-bot'
+      name: Enable automerge if successful for bot PRs
+      run: gh pr merge --auto --squash $PR_URL
   test:
     if: github.event_name == 'repository_dispatch' ||
       github.event.pull_request.head.repo.full_name == github.repository

--- a/provider-ci/providers/alicloud/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/alicloud/repo/.github/workflows/run-acceptance-tests.yml
@@ -231,8 +231,9 @@ jobs:
         GITHUB_TOKEN: ${{secrets.PULUMI_BOT_TOKEN}}
         PR_URL: ${{github.event.pull_request.html_url}}
       id: enable-automerge
-      if: github.event.pull_request.user.login == 'pulumi-bot'
-      name: Enable automerge if successful for bot PRs
+      if: github.event.pull_request.user.login == 'pulumi-bot' &&
+        contains(toJson(github.event.pull_request.labels.*.name), 'auto-merge')
+      name: Enable automerge if successful for bot PRs with 'auto-merge' label
       run: gh pr merge --auto --squash $PR_URL
   test:
     if: github.event_name == 'repository_dispatch' ||

--- a/provider-ci/providers/alicloud/repo/.github/workflows/update-bridge.yml
+++ b/provider-ci/providers/alicloud/repo/.github/workflows/update-bridge.yml
@@ -66,10 +66,6 @@ jobs:
         title: Update pulumi-terraform-bridge to v${{ github.event.inputs.bridge_version
           }}
         token: ${{ secrets.PULUMI_BOT_TOKEN }}
-    - if: steps.create-pr.outputs.pull-request-operation == 'created' &&
-        github.event.inputs.automerge == 'true'
-      run: gh pr merge --auto --squash ${{ steps.create-pr.outputs.pull-request-number
-        }}
     strategy:
       fail-fast: true
       matrix:
@@ -85,11 +81,6 @@ name: Update pulumi-terraform-bridge
 on:
   workflow_dispatch:
     inputs:
-      automerge:
-        default: false
-        description: Mark created PR for auto-merging?
-        required: true
-        type: boolean
       bridge_version:
         description: The version of pulumi/pulumi-terraform-bridge to update to. Do not
           include the 'v' prefix. Must be major version 3.

--- a/provider-ci/providers/alicloud/repo/.github/workflows/update-upstream-provider.yml
+++ b/provider-ci/providers/alicloud/repo/.github/workflows/update-upstream-provider.yml
@@ -145,11 +145,6 @@ name: Update upstream provider
 on:
   workflow_dispatch:
     inputs:
-      automerge:
-        default: false
-        description: Mark created PR for auto-merging?
-        required: true
-        type: boolean
       linked_issue_number:
         description: The issue number of a PR in this repository to which the generated
           pull request should be linked.

--- a/provider-ci/providers/artifactory/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/artifactory/repo/.github/workflows/run-acceptance-tests.yml
@@ -316,8 +316,9 @@ jobs:
         GITHUB_TOKEN: ${{secrets.PULUMI_BOT_TOKEN}}
         PR_URL: ${{github.event.pull_request.html_url}}
       id: enable-automerge
-      if: github.event.pull_request.user.login == 'pulumi-bot'
-      name: Enable automerge if successful for bot PRs
+      if: github.event.pull_request.user.login == 'pulumi-bot' &&
+        contains(toJson(github.event.pull_request.labels.*.name), 'auto-merge')
+      name: Enable automerge if successful for bot PRs with 'auto-merge' label
       run: gh pr merge --auto --squash $PR_URL
   test:
     if: github.event_name == 'repository_dispatch' ||

--- a/provider-ci/providers/artifactory/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/artifactory/repo/.github/workflows/run-acceptance-tests.yml
@@ -312,8 +312,13 @@ jobs:
     - lint_sdk
     runs-on: ubuntu-latest
     steps:
-    - name: Is workflow a success
-      run: echo yes
+    - env:
+        GITHUB_TOKEN: ${{secrets.PULUMI_BOT_TOKEN}}
+        PR_URL: ${{github.event.pull_request.html_url}}
+      id: enable-automerge
+      if: github.event.pull_request.user.login == 'pulumi-bot'
+      name: Enable automerge if successful for bot PRs
+      run: gh pr merge --auto --squash $PR_URL
   test:
     if: github.event_name == 'repository_dispatch' ||
       github.event.pull_request.head.repo.full_name == github.repository

--- a/provider-ci/providers/artifactory/repo/.github/workflows/update-bridge.yml
+++ b/provider-ci/providers/artifactory/repo/.github/workflows/update-bridge.yml
@@ -66,10 +66,6 @@ jobs:
         title: Update pulumi-terraform-bridge to v${{ github.event.inputs.bridge_version
           }}
         token: ${{ secrets.PULUMI_BOT_TOKEN }}
-    - if: steps.create-pr.outputs.pull-request-operation == 'created' &&
-        github.event.inputs.automerge == 'true'
-      run: gh pr merge --auto --squash ${{ steps.create-pr.outputs.pull-request-number
-        }}
     strategy:
       fail-fast: true
       matrix:
@@ -85,11 +81,6 @@ name: Update pulumi-terraform-bridge
 on:
   workflow_dispatch:
     inputs:
-      automerge:
-        default: false
-        description: Mark created PR for auto-merging?
-        required: true
-        type: boolean
       bridge_version:
         description: The version of pulumi/pulumi-terraform-bridge to update to. Do not
           include the 'v' prefix. Must be major version 3.

--- a/provider-ci/providers/artifactory/repo/.github/workflows/update-upstream-provider.yml
+++ b/provider-ci/providers/artifactory/repo/.github/workflows/update-upstream-provider.yml
@@ -145,11 +145,6 @@ name: Update upstream provider
 on:
   workflow_dispatch:
     inputs:
-      automerge:
-        default: false
-        description: Mark created PR for auto-merging?
-        required: true
-        type: boolean
       linked_issue_number:
         description: The issue number of a PR in this repository to which the generated
           pull request should be linked.

--- a/provider-ci/providers/auth0/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/auth0/repo/.github/workflows/run-acceptance-tests.yml
@@ -316,8 +316,9 @@ jobs:
         GITHUB_TOKEN: ${{secrets.PULUMI_BOT_TOKEN}}
         PR_URL: ${{github.event.pull_request.html_url}}
       id: enable-automerge
-      if: github.event.pull_request.user.login == 'pulumi-bot'
-      name: Enable automerge if successful for bot PRs
+      if: github.event.pull_request.user.login == 'pulumi-bot' &&
+        contains(toJson(github.event.pull_request.labels.*.name), 'auto-merge')
+      name: Enable automerge if successful for bot PRs with 'auto-merge' label
       run: gh pr merge --auto --squash $PR_URL
   test:
     if: github.event_name == 'repository_dispatch' ||

--- a/provider-ci/providers/auth0/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/auth0/repo/.github/workflows/run-acceptance-tests.yml
@@ -312,8 +312,13 @@ jobs:
     - lint_sdk
     runs-on: ubuntu-latest
     steps:
-    - name: Is workflow a success
-      run: echo yes
+    - env:
+        GITHUB_TOKEN: ${{secrets.PULUMI_BOT_TOKEN}}
+        PR_URL: ${{github.event.pull_request.html_url}}
+      id: enable-automerge
+      if: github.event.pull_request.user.login == 'pulumi-bot'
+      name: Enable automerge if successful for bot PRs
+      run: gh pr merge --auto --squash $PR_URL
   test:
     if: github.event_name == 'repository_dispatch' ||
       github.event.pull_request.head.repo.full_name == github.repository

--- a/provider-ci/providers/auth0/repo/.github/workflows/update-bridge.yml
+++ b/provider-ci/providers/auth0/repo/.github/workflows/update-bridge.yml
@@ -66,10 +66,6 @@ jobs:
         title: Update pulumi-terraform-bridge to v${{ github.event.inputs.bridge_version
           }}
         token: ${{ secrets.PULUMI_BOT_TOKEN }}
-    - if: steps.create-pr.outputs.pull-request-operation == 'created' &&
-        github.event.inputs.automerge == 'true'
-      run: gh pr merge --auto --squash ${{ steps.create-pr.outputs.pull-request-number
-        }}
     strategy:
       fail-fast: true
       matrix:
@@ -85,11 +81,6 @@ name: Update pulumi-terraform-bridge
 on:
   workflow_dispatch:
     inputs:
-      automerge:
-        default: false
-        description: Mark created PR for auto-merging?
-        required: true
-        type: boolean
       bridge_version:
         description: The version of pulumi/pulumi-terraform-bridge to update to. Do not
           include the 'v' prefix. Must be major version 3.

--- a/provider-ci/providers/auth0/repo/.github/workflows/update-upstream-provider.yml
+++ b/provider-ci/providers/auth0/repo/.github/workflows/update-upstream-provider.yml
@@ -145,11 +145,6 @@ name: Update upstream provider
 on:
   workflow_dispatch:
     inputs:
-      automerge:
-        default: false
-        description: Mark created PR for auto-merging?
-        required: true
-        type: boolean
       linked_issue_number:
         description: The issue number of a PR in this repository to which the generated
           pull request should be linked.

--- a/provider-ci/providers/aws/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/aws/repo/.github/workflows/run-acceptance-tests.yml
@@ -230,8 +230,9 @@ jobs:
         GITHUB_TOKEN: ${{secrets.PULUMI_BOT_TOKEN}}
         PR_URL: ${{github.event.pull_request.html_url}}
       id: enable-automerge
-      if: github.event.pull_request.user.login == 'pulumi-bot'
-      name: Enable automerge if successful for bot PRs
+      if: github.event.pull_request.user.login == 'pulumi-bot' &&
+        contains(toJson(github.event.pull_request.labels.*.name), 'auto-merge')
+      name: Enable automerge if successful for bot PRs with 'auto-merge' label
       run: gh pr merge --auto --squash $PR_URL
   test:
     if: github.event_name == 'repository_dispatch' ||

--- a/provider-ci/providers/aws/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/aws/repo/.github/workflows/run-acceptance-tests.yml
@@ -226,8 +226,13 @@ jobs:
     - test
     runs-on: ubuntu-latest
     steps:
-    - name: Is workflow a success
-      run: echo yes
+    - env:
+        GITHUB_TOKEN: ${{secrets.PULUMI_BOT_TOKEN}}
+        PR_URL: ${{github.event.pull_request.html_url}}
+      id: enable-automerge
+      if: github.event.pull_request.user.login == 'pulumi-bot'
+      name: Enable automerge if successful for bot PRs
+      run: gh pr merge --auto --squash $PR_URL
   test:
     if: github.event_name == 'repository_dispatch' ||
       github.event.pull_request.head.repo.full_name == github.repository

--- a/provider-ci/providers/aws/repo/.github/workflows/update-bridge.yml
+++ b/provider-ci/providers/aws/repo/.github/workflows/update-bridge.yml
@@ -66,10 +66,6 @@ jobs:
         title: Update pulumi-terraform-bridge to v${{ github.event.inputs.bridge_version
           }}
         token: ${{ secrets.PULUMI_BOT_TOKEN }}
-    - if: steps.create-pr.outputs.pull-request-operation == 'created' &&
-        github.event.inputs.automerge == 'true'
-      run: gh pr merge --auto --squash ${{ steps.create-pr.outputs.pull-request-number
-        }}
     strategy:
       fail-fast: true
       matrix:
@@ -85,11 +81,6 @@ name: Update pulumi-terraform-bridge
 on:
   workflow_dispatch:
     inputs:
-      automerge:
-        default: false
-        description: Mark created PR for auto-merging?
-        required: true
-        type: boolean
       bridge_version:
         description: The version of pulumi/pulumi-terraform-bridge to update to. Do not
           include the 'v' prefix. Must be major version 3.

--- a/provider-ci/providers/aws/repo/.github/workflows/update-upstream-provider.yml
+++ b/provider-ci/providers/aws/repo/.github/workflows/update-upstream-provider.yml
@@ -144,11 +144,6 @@ name: Update upstream provider
 on:
   workflow_dispatch:
     inputs:
-      automerge:
-        default: false
-        description: Mark created PR for auto-merging?
-        required: true
-        type: boolean
       linked_issue_number:
         description: The issue number of a PR in this repository to which the generated
           pull request should be linked.

--- a/provider-ci/providers/azure/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/azure/repo/.github/workflows/run-acceptance-tests.yml
@@ -231,8 +231,13 @@ jobs:
     - test
     runs-on: ubuntu-latest
     steps:
-    - name: Is workflow a success
-      run: echo yes
+    - env:
+        GITHUB_TOKEN: ${{secrets.PULUMI_BOT_TOKEN}}
+        PR_URL: ${{github.event.pull_request.html_url}}
+      id: enable-automerge
+      if: github.event.pull_request.user.login == 'pulumi-bot'
+      name: Enable automerge if successful for bot PRs
+      run: gh pr merge --auto --squash $PR_URL
   test:
     if: github.event_name == 'repository_dispatch' ||
       github.event.pull_request.head.repo.full_name == github.repository

--- a/provider-ci/providers/azure/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/azure/repo/.github/workflows/run-acceptance-tests.yml
@@ -235,8 +235,9 @@ jobs:
         GITHUB_TOKEN: ${{secrets.PULUMI_BOT_TOKEN}}
         PR_URL: ${{github.event.pull_request.html_url}}
       id: enable-automerge
-      if: github.event.pull_request.user.login == 'pulumi-bot'
-      name: Enable automerge if successful for bot PRs
+      if: github.event.pull_request.user.login == 'pulumi-bot' &&
+        contains(toJson(github.event.pull_request.labels.*.name), 'auto-merge')
+      name: Enable automerge if successful for bot PRs with 'auto-merge' label
       run: gh pr merge --auto --squash $PR_URL
   test:
     if: github.event_name == 'repository_dispatch' ||

--- a/provider-ci/providers/azure/repo/.github/workflows/update-bridge.yml
+++ b/provider-ci/providers/azure/repo/.github/workflows/update-bridge.yml
@@ -66,10 +66,6 @@ jobs:
         title: Update pulumi-terraform-bridge to v${{ github.event.inputs.bridge_version
           }}
         token: ${{ secrets.PULUMI_BOT_TOKEN }}
-    - if: steps.create-pr.outputs.pull-request-operation == 'created' &&
-        github.event.inputs.automerge == 'true'
-      run: gh pr merge --auto --squash ${{ steps.create-pr.outputs.pull-request-number
-        }}
     strategy:
       fail-fast: true
       matrix:
@@ -85,11 +81,6 @@ name: Update pulumi-terraform-bridge
 on:
   workflow_dispatch:
     inputs:
-      automerge:
-        default: false
-        description: Mark created PR for auto-merging?
-        required: true
-        type: boolean
       bridge_version:
         description: The version of pulumi/pulumi-terraform-bridge to update to. Do not
           include the 'v' prefix. Must be major version 3.

--- a/provider-ci/providers/azure/repo/.github/workflows/update-upstream-provider.yml
+++ b/provider-ci/providers/azure/repo/.github/workflows/update-upstream-provider.yml
@@ -149,11 +149,6 @@ name: Update upstream provider
 on:
   workflow_dispatch:
     inputs:
-      automerge:
-        default: false
-        description: Mark created PR for auto-merging?
-        required: true
-        type: boolean
       linked_issue_number:
         description: The issue number of a PR in this repository to which the generated
           pull request should be linked.

--- a/provider-ci/providers/azuread/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/azuread/repo/.github/workflows/run-acceptance-tests.yml
@@ -318,8 +318,9 @@ jobs:
         GITHUB_TOKEN: ${{secrets.PULUMI_BOT_TOKEN}}
         PR_URL: ${{github.event.pull_request.html_url}}
       id: enable-automerge
-      if: github.event.pull_request.user.login == 'pulumi-bot'
-      name: Enable automerge if successful for bot PRs
+      if: github.event.pull_request.user.login == 'pulumi-bot' &&
+        contains(toJson(github.event.pull_request.labels.*.name), 'auto-merge')
+      name: Enable automerge if successful for bot PRs with 'auto-merge' label
       run: gh pr merge --auto --squash $PR_URL
   test:
     if: github.event_name == 'repository_dispatch' ||

--- a/provider-ci/providers/azuread/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/azuread/repo/.github/workflows/run-acceptance-tests.yml
@@ -314,8 +314,13 @@ jobs:
     - lint_sdk
     runs-on: ubuntu-latest
     steps:
-    - name: Is workflow a success
-      run: echo yes
+    - env:
+        GITHUB_TOKEN: ${{secrets.PULUMI_BOT_TOKEN}}
+        PR_URL: ${{github.event.pull_request.html_url}}
+      id: enable-automerge
+      if: github.event.pull_request.user.login == 'pulumi-bot'
+      name: Enable automerge if successful for bot PRs
+      run: gh pr merge --auto --squash $PR_URL
   test:
     if: github.event_name == 'repository_dispatch' ||
       github.event.pull_request.head.repo.full_name == github.repository

--- a/provider-ci/providers/azuread/repo/.github/workflows/update-bridge.yml
+++ b/provider-ci/providers/azuread/repo/.github/workflows/update-bridge.yml
@@ -66,10 +66,6 @@ jobs:
         title: Update pulumi-terraform-bridge to v${{ github.event.inputs.bridge_version
           }}
         token: ${{ secrets.PULUMI_BOT_TOKEN }}
-    - if: steps.create-pr.outputs.pull-request-operation == 'created' &&
-        github.event.inputs.automerge == 'true'
-      run: gh pr merge --auto --squash ${{ steps.create-pr.outputs.pull-request-number
-        }}
     strategy:
       fail-fast: true
       matrix:
@@ -85,11 +81,6 @@ name: Update pulumi-terraform-bridge
 on:
   workflow_dispatch:
     inputs:
-      automerge:
-        default: false
-        description: Mark created PR for auto-merging?
-        required: true
-        type: boolean
       bridge_version:
         description: The version of pulumi/pulumi-terraform-bridge to update to. Do not
           include the 'v' prefix. Must be major version 3.

--- a/provider-ci/providers/azuread/repo/.github/workflows/update-upstream-provider.yml
+++ b/provider-ci/providers/azuread/repo/.github/workflows/update-upstream-provider.yml
@@ -147,11 +147,6 @@ name: Update upstream provider
 on:
   workflow_dispatch:
     inputs:
-      automerge:
-        default: false
-        description: Mark created PR for auto-merging?
-        required: true
-        type: boolean
       linked_issue_number:
         description: The issue number of a PR in this repository to which the generated
           pull request should be linked.

--- a/provider-ci/providers/azuredevops/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/azuredevops/repo/.github/workflows/run-acceptance-tests.yml
@@ -230,8 +230,9 @@ jobs:
         GITHUB_TOKEN: ${{secrets.PULUMI_BOT_TOKEN}}
         PR_URL: ${{github.event.pull_request.html_url}}
       id: enable-automerge
-      if: github.event.pull_request.user.login == 'pulumi-bot'
-      name: Enable automerge if successful for bot PRs
+      if: github.event.pull_request.user.login == 'pulumi-bot' &&
+        contains(toJson(github.event.pull_request.labels.*.name), 'auto-merge')
+      name: Enable automerge if successful for bot PRs with 'auto-merge' label
       run: gh pr merge --auto --squash $PR_URL
   test:
     if: github.event_name == 'repository_dispatch' ||

--- a/provider-ci/providers/azuredevops/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/azuredevops/repo/.github/workflows/run-acceptance-tests.yml
@@ -226,8 +226,13 @@ jobs:
     - test
     runs-on: ubuntu-latest
     steps:
-    - name: Is workflow a success
-      run: echo yes
+    - env:
+        GITHUB_TOKEN: ${{secrets.PULUMI_BOT_TOKEN}}
+        PR_URL: ${{github.event.pull_request.html_url}}
+      id: enable-automerge
+      if: github.event.pull_request.user.login == 'pulumi-bot'
+      name: Enable automerge if successful for bot PRs
+      run: gh pr merge --auto --squash $PR_URL
   test:
     if: github.event_name == 'repository_dispatch' ||
       github.event.pull_request.head.repo.full_name == github.repository

--- a/provider-ci/providers/azuredevops/repo/.github/workflows/update-bridge.yml
+++ b/provider-ci/providers/azuredevops/repo/.github/workflows/update-bridge.yml
@@ -66,10 +66,6 @@ jobs:
         title: Update pulumi-terraform-bridge to v${{ github.event.inputs.bridge_version
           }}
         token: ${{ secrets.PULUMI_BOT_TOKEN }}
-    - if: steps.create-pr.outputs.pull-request-operation == 'created' &&
-        github.event.inputs.automerge == 'true'
-      run: gh pr merge --auto --squash ${{ steps.create-pr.outputs.pull-request-number
-        }}
     strategy:
       fail-fast: true
       matrix:
@@ -85,11 +81,6 @@ name: Update pulumi-terraform-bridge
 on:
   workflow_dispatch:
     inputs:
-      automerge:
-        default: false
-        description: Mark created PR for auto-merging?
-        required: true
-        type: boolean
       bridge_version:
         description: The version of pulumi/pulumi-terraform-bridge to update to. Do not
           include the 'v' prefix. Must be major version 3.

--- a/provider-ci/providers/azuredevops/repo/.github/workflows/update-upstream-provider.yml
+++ b/provider-ci/providers/azuredevops/repo/.github/workflows/update-upstream-provider.yml
@@ -144,11 +144,6 @@ name: Update upstream provider
 on:
   workflow_dispatch:
     inputs:
-      automerge:
-        default: false
-        description: Mark created PR for auto-merging?
-        required: true
-        type: boolean
       linked_issue_number:
         description: The issue number of a PR in this repository to which the generated
           pull request should be linked.

--- a/provider-ci/providers/civo/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/civo/repo/.github/workflows/run-acceptance-tests.yml
@@ -310,8 +310,13 @@ jobs:
     - lint_sdk
     runs-on: ubuntu-latest
     steps:
-    - name: Is workflow a success
-      run: echo yes
+    - env:
+        GITHUB_TOKEN: ${{secrets.PULUMI_BOT_TOKEN}}
+        PR_URL: ${{github.event.pull_request.html_url}}
+      id: enable-automerge
+      if: github.event.pull_request.user.login == 'pulumi-bot'
+      name: Enable automerge if successful for bot PRs
+      run: gh pr merge --auto --squash $PR_URL
   test:
     if: github.event_name == 'repository_dispatch' ||
       github.event.pull_request.head.repo.full_name == github.repository

--- a/provider-ci/providers/civo/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/civo/repo/.github/workflows/run-acceptance-tests.yml
@@ -314,8 +314,9 @@ jobs:
         GITHUB_TOKEN: ${{secrets.PULUMI_BOT_TOKEN}}
         PR_URL: ${{github.event.pull_request.html_url}}
       id: enable-automerge
-      if: github.event.pull_request.user.login == 'pulumi-bot'
-      name: Enable automerge if successful for bot PRs
+      if: github.event.pull_request.user.login == 'pulumi-bot' &&
+        contains(toJson(github.event.pull_request.labels.*.name), 'auto-merge')
+      name: Enable automerge if successful for bot PRs with 'auto-merge' label
       run: gh pr merge --auto --squash $PR_URL
   test:
     if: github.event_name == 'repository_dispatch' ||

--- a/provider-ci/providers/civo/repo/.github/workflows/update-bridge.yml
+++ b/provider-ci/providers/civo/repo/.github/workflows/update-bridge.yml
@@ -66,10 +66,6 @@ jobs:
         title: Update pulumi-terraform-bridge to v${{ github.event.inputs.bridge_version
           }}
         token: ${{ secrets.PULUMI_BOT_TOKEN }}
-    - if: steps.create-pr.outputs.pull-request-operation == 'created' &&
-        github.event.inputs.automerge == 'true'
-      run: gh pr merge --auto --squash ${{ steps.create-pr.outputs.pull-request-number
-        }}
     strategy:
       fail-fast: true
       matrix:
@@ -85,11 +81,6 @@ name: Update pulumi-terraform-bridge
 on:
   workflow_dispatch:
     inputs:
-      automerge:
-        default: false
-        description: Mark created PR for auto-merging?
-        required: true
-        type: boolean
       bridge_version:
         description: The version of pulumi/pulumi-terraform-bridge to update to. Do not
           include the 'v' prefix. Must be major version 3.

--- a/provider-ci/providers/civo/repo/.github/workflows/update-upstream-provider.yml
+++ b/provider-ci/providers/civo/repo/.github/workflows/update-upstream-provider.yml
@@ -143,11 +143,6 @@ name: Update upstream provider
 on:
   workflow_dispatch:
     inputs:
-      automerge:
-        default: false
-        description: Mark created PR for auto-merging?
-        required: true
-        type: boolean
       linked_issue_number:
         description: The issue number of a PR in this repository to which the generated
           pull request should be linked.

--- a/provider-ci/providers/cloudamqp/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/cloudamqp/repo/.github/workflows/run-acceptance-tests.yml
@@ -313,8 +313,9 @@ jobs:
         GITHUB_TOKEN: ${{secrets.PULUMI_BOT_TOKEN}}
         PR_URL: ${{github.event.pull_request.html_url}}
       id: enable-automerge
-      if: github.event.pull_request.user.login == 'pulumi-bot'
-      name: Enable automerge if successful for bot PRs
+      if: github.event.pull_request.user.login == 'pulumi-bot' &&
+        contains(toJson(github.event.pull_request.labels.*.name), 'auto-merge')
+      name: Enable automerge if successful for bot PRs with 'auto-merge' label
       run: gh pr merge --auto --squash $PR_URL
   test:
     if: github.event_name == 'repository_dispatch' ||

--- a/provider-ci/providers/cloudamqp/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/cloudamqp/repo/.github/workflows/run-acceptance-tests.yml
@@ -309,8 +309,13 @@ jobs:
     - lint_sdk
     runs-on: ubuntu-latest
     steps:
-    - name: Is workflow a success
-      run: echo yes
+    - env:
+        GITHUB_TOKEN: ${{secrets.PULUMI_BOT_TOKEN}}
+        PR_URL: ${{github.event.pull_request.html_url}}
+      id: enable-automerge
+      if: github.event.pull_request.user.login == 'pulumi-bot'
+      name: Enable automerge if successful for bot PRs
+      run: gh pr merge --auto --squash $PR_URL
   test:
     if: github.event_name == 'repository_dispatch' ||
       github.event.pull_request.head.repo.full_name == github.repository

--- a/provider-ci/providers/cloudamqp/repo/.github/workflows/update-bridge.yml
+++ b/provider-ci/providers/cloudamqp/repo/.github/workflows/update-bridge.yml
@@ -66,10 +66,6 @@ jobs:
         title: Update pulumi-terraform-bridge to v${{ github.event.inputs.bridge_version
           }}
         token: ${{ secrets.PULUMI_BOT_TOKEN }}
-    - if: steps.create-pr.outputs.pull-request-operation == 'created' &&
-        github.event.inputs.automerge == 'true'
-      run: gh pr merge --auto --squash ${{ steps.create-pr.outputs.pull-request-number
-        }}
     strategy:
       fail-fast: true
       matrix:
@@ -85,11 +81,6 @@ name: Update pulumi-terraform-bridge
 on:
   workflow_dispatch:
     inputs:
-      automerge:
-        default: false
-        description: Mark created PR for auto-merging?
-        required: true
-        type: boolean
       bridge_version:
         description: The version of pulumi/pulumi-terraform-bridge to update to. Do not
           include the 'v' prefix. Must be major version 3.

--- a/provider-ci/providers/cloudamqp/repo/.github/workflows/update-upstream-provider.yml
+++ b/provider-ci/providers/cloudamqp/repo/.github/workflows/update-upstream-provider.yml
@@ -142,11 +142,6 @@ name: Update upstream provider
 on:
   workflow_dispatch:
     inputs:
-      automerge:
-        default: false
-        description: Mark created PR for auto-merging?
-        required: true
-        type: boolean
       linked_issue_number:
         description: The issue number of a PR in this repository to which the generated
           pull request should be linked.

--- a/provider-ci/providers/cloudflare/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/cloudflare/repo/.github/workflows/run-acceptance-tests.yml
@@ -313,8 +313,9 @@ jobs:
         GITHUB_TOKEN: ${{secrets.PULUMI_BOT_TOKEN}}
         PR_URL: ${{github.event.pull_request.html_url}}
       id: enable-automerge
-      if: github.event.pull_request.user.login == 'pulumi-bot'
-      name: Enable automerge if successful for bot PRs
+      if: github.event.pull_request.user.login == 'pulumi-bot' &&
+        contains(toJson(github.event.pull_request.labels.*.name), 'auto-merge')
+      name: Enable automerge if successful for bot PRs with 'auto-merge' label
       run: gh pr merge --auto --squash $PR_URL
   test:
     if: github.event_name == 'repository_dispatch' ||

--- a/provider-ci/providers/cloudflare/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/cloudflare/repo/.github/workflows/run-acceptance-tests.yml
@@ -309,8 +309,13 @@ jobs:
     - lint_sdk
     runs-on: ubuntu-latest
     steps:
-    - name: Is workflow a success
-      run: echo yes
+    - env:
+        GITHUB_TOKEN: ${{secrets.PULUMI_BOT_TOKEN}}
+        PR_URL: ${{github.event.pull_request.html_url}}
+      id: enable-automerge
+      if: github.event.pull_request.user.login == 'pulumi-bot'
+      name: Enable automerge if successful for bot PRs
+      run: gh pr merge --auto --squash $PR_URL
   test:
     if: github.event_name == 'repository_dispatch' ||
       github.event.pull_request.head.repo.full_name == github.repository

--- a/provider-ci/providers/cloudflare/repo/.github/workflows/update-bridge.yml
+++ b/provider-ci/providers/cloudflare/repo/.github/workflows/update-bridge.yml
@@ -66,10 +66,6 @@ jobs:
         title: Update pulumi-terraform-bridge to v${{ github.event.inputs.bridge_version
           }}
         token: ${{ secrets.PULUMI_BOT_TOKEN }}
-    - if: steps.create-pr.outputs.pull-request-operation == 'created' &&
-        github.event.inputs.automerge == 'true'
-      run: gh pr merge --auto --squash ${{ steps.create-pr.outputs.pull-request-number
-        }}
     strategy:
       fail-fast: true
       matrix:
@@ -85,11 +81,6 @@ name: Update pulumi-terraform-bridge
 on:
   workflow_dispatch:
     inputs:
-      automerge:
-        default: false
-        description: Mark created PR for auto-merging?
-        required: true
-        type: boolean
       bridge_version:
         description: The version of pulumi/pulumi-terraform-bridge to update to. Do not
           include the 'v' prefix. Must be major version 3.

--- a/provider-ci/providers/cloudflare/repo/.github/workflows/update-upstream-provider.yml
+++ b/provider-ci/providers/cloudflare/repo/.github/workflows/update-upstream-provider.yml
@@ -142,11 +142,6 @@ name: Update upstream provider
 on:
   workflow_dispatch:
     inputs:
-      automerge:
-        default: false
-        description: Mark created PR for auto-merging?
-        required: true
-        type: boolean
       linked_issue_number:
         description: The issue number of a PR in this repository to which the generated
           pull request should be linked.

--- a/provider-ci/providers/cloudinit/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/cloudinit/repo/.github/workflows/run-acceptance-tests.yml
@@ -224,8 +224,13 @@ jobs:
     - test
     runs-on: ubuntu-latest
     steps:
-    - name: Is workflow a success
-      run: echo yes
+    - env:
+        GITHUB_TOKEN: ${{secrets.PULUMI_BOT_TOKEN}}
+        PR_URL: ${{github.event.pull_request.html_url}}
+      id: enable-automerge
+      if: github.event.pull_request.user.login == 'pulumi-bot'
+      name: Enable automerge if successful for bot PRs
+      run: gh pr merge --auto --squash $PR_URL
   test:
     if: github.event_name == 'repository_dispatch' ||
       github.event.pull_request.head.repo.full_name == github.repository

--- a/provider-ci/providers/cloudinit/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/cloudinit/repo/.github/workflows/run-acceptance-tests.yml
@@ -228,8 +228,9 @@ jobs:
         GITHUB_TOKEN: ${{secrets.PULUMI_BOT_TOKEN}}
         PR_URL: ${{github.event.pull_request.html_url}}
       id: enable-automerge
-      if: github.event.pull_request.user.login == 'pulumi-bot'
-      name: Enable automerge if successful for bot PRs
+      if: github.event.pull_request.user.login == 'pulumi-bot' &&
+        contains(toJson(github.event.pull_request.labels.*.name), 'auto-merge')
+      name: Enable automerge if successful for bot PRs with 'auto-merge' label
       run: gh pr merge --auto --squash $PR_URL
   test:
     if: github.event_name == 'repository_dispatch' ||

--- a/provider-ci/providers/cloudinit/repo/.github/workflows/update-bridge.yml
+++ b/provider-ci/providers/cloudinit/repo/.github/workflows/update-bridge.yml
@@ -66,10 +66,6 @@ jobs:
         title: Update pulumi-terraform-bridge to v${{ github.event.inputs.bridge_version
           }}
         token: ${{ secrets.PULUMI_BOT_TOKEN }}
-    - if: steps.create-pr.outputs.pull-request-operation == 'created' &&
-        github.event.inputs.automerge == 'true'
-      run: gh pr merge --auto --squash ${{ steps.create-pr.outputs.pull-request-number
-        }}
     strategy:
       fail-fast: true
       matrix:
@@ -85,11 +81,6 @@ name: Update pulumi-terraform-bridge
 on:
   workflow_dispatch:
     inputs:
-      automerge:
-        default: false
-        description: Mark created PR for auto-merging?
-        required: true
-        type: boolean
       bridge_version:
         description: The version of pulumi/pulumi-terraform-bridge to update to. Do not
           include the 'v' prefix. Must be major version 3.

--- a/provider-ci/providers/cloudinit/repo/.github/workflows/update-upstream-provider.yml
+++ b/provider-ci/providers/cloudinit/repo/.github/workflows/update-upstream-provider.yml
@@ -142,11 +142,6 @@ name: Update upstream provider
 on:
   workflow_dispatch:
     inputs:
-      automerge:
-        default: false
-        description: Mark created PR for auto-merging?
-        required: true
-        type: boolean
       linked_issue_number:
         description: The issue number of a PR in this repository to which the generated
           pull request should be linked.

--- a/provider-ci/providers/confluent/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/confluent/repo/.github/workflows/run-acceptance-tests.yml
@@ -311,8 +311,13 @@ jobs:
     - lint_sdk
     runs-on: ubuntu-latest
     steps:
-    - name: Is workflow a success
-      run: echo yes
+    - env:
+        GITHUB_TOKEN: ${{secrets.PULUMI_BOT_TOKEN}}
+        PR_URL: ${{github.event.pull_request.html_url}}
+      id: enable-automerge
+      if: github.event.pull_request.user.login == 'pulumi-bot'
+      name: Enable automerge if successful for bot PRs
+      run: gh pr merge --auto --squash $PR_URL
   test:
     if: github.event_name == 'repository_dispatch' ||
       github.event.pull_request.head.repo.full_name == github.repository

--- a/provider-ci/providers/confluent/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/confluent/repo/.github/workflows/run-acceptance-tests.yml
@@ -315,8 +315,9 @@ jobs:
         GITHUB_TOKEN: ${{secrets.PULUMI_BOT_TOKEN}}
         PR_URL: ${{github.event.pull_request.html_url}}
       id: enable-automerge
-      if: github.event.pull_request.user.login == 'pulumi-bot'
-      name: Enable automerge if successful for bot PRs
+      if: github.event.pull_request.user.login == 'pulumi-bot' &&
+        contains(toJson(github.event.pull_request.labels.*.name), 'auto-merge')
+      name: Enable automerge if successful for bot PRs with 'auto-merge' label
       run: gh pr merge --auto --squash $PR_URL
   test:
     if: github.event_name == 'repository_dispatch' ||

--- a/provider-ci/providers/confluent/repo/.github/workflows/update-bridge.yml
+++ b/provider-ci/providers/confluent/repo/.github/workflows/update-bridge.yml
@@ -66,10 +66,6 @@ jobs:
         title: Update pulumi-terraform-bridge to v${{ github.event.inputs.bridge_version
           }}
         token: ${{ secrets.PULUMI_BOT_TOKEN }}
-    - if: steps.create-pr.outputs.pull-request-operation == 'created' &&
-        github.event.inputs.automerge == 'true'
-      run: gh pr merge --auto --squash ${{ steps.create-pr.outputs.pull-request-number
-        }}
     strategy:
       fail-fast: true
       matrix:
@@ -85,11 +81,6 @@ name: Update pulumi-terraform-bridge
 on:
   workflow_dispatch:
     inputs:
-      automerge:
-        default: false
-        description: Mark created PR for auto-merging?
-        required: true
-        type: boolean
       bridge_version:
         description: The version of pulumi/pulumi-terraform-bridge to update to. Do not
           include the 'v' prefix. Must be major version 3.

--- a/provider-ci/providers/confluent/repo/.github/workflows/update-upstream-provider.yml
+++ b/provider-ci/providers/confluent/repo/.github/workflows/update-upstream-provider.yml
@@ -144,11 +144,6 @@ name: Update upstream provider
 on:
   workflow_dispatch:
     inputs:
-      automerge:
-        default: false
-        description: Mark created PR for auto-merging?
-        required: true
-        type: boolean
       linked_issue_number:
         description: The issue number of a PR in this repository to which the generated
           pull request should be linked.

--- a/provider-ci/providers/confluentcloud/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/confluentcloud/repo/.github/workflows/run-acceptance-tests.yml
@@ -230,8 +230,9 @@ jobs:
         GITHUB_TOKEN: ${{secrets.PULUMI_BOT_TOKEN}}
         PR_URL: ${{github.event.pull_request.html_url}}
       id: enable-automerge
-      if: github.event.pull_request.user.login == 'pulumi-bot'
-      name: Enable automerge if successful for bot PRs
+      if: github.event.pull_request.user.login == 'pulumi-bot' &&
+        contains(toJson(github.event.pull_request.labels.*.name), 'auto-merge')
+      name: Enable automerge if successful for bot PRs with 'auto-merge' label
       run: gh pr merge --auto --squash $PR_URL
   test:
     if: github.event_name == 'repository_dispatch' ||

--- a/provider-ci/providers/confluentcloud/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/confluentcloud/repo/.github/workflows/run-acceptance-tests.yml
@@ -226,8 +226,13 @@ jobs:
     - test
     runs-on: ubuntu-latest
     steps:
-    - name: Is workflow a success
-      run: echo yes
+    - env:
+        GITHUB_TOKEN: ${{secrets.PULUMI_BOT_TOKEN}}
+        PR_URL: ${{github.event.pull_request.html_url}}
+      id: enable-automerge
+      if: github.event.pull_request.user.login == 'pulumi-bot'
+      name: Enable automerge if successful for bot PRs
+      run: gh pr merge --auto --squash $PR_URL
   test:
     if: github.event_name == 'repository_dispatch' ||
       github.event.pull_request.head.repo.full_name == github.repository

--- a/provider-ci/providers/confluentcloud/repo/.github/workflows/update-bridge.yml
+++ b/provider-ci/providers/confluentcloud/repo/.github/workflows/update-bridge.yml
@@ -66,10 +66,6 @@ jobs:
         title: Update pulumi-terraform-bridge to v${{ github.event.inputs.bridge_version
           }}
         token: ${{ secrets.PULUMI_BOT_TOKEN }}
-    - if: steps.create-pr.outputs.pull-request-operation == 'created' &&
-        github.event.inputs.automerge == 'true'
-      run: gh pr merge --auto --squash ${{ steps.create-pr.outputs.pull-request-number
-        }}
     strategy:
       fail-fast: true
       matrix:
@@ -85,11 +81,6 @@ name: Update pulumi-terraform-bridge
 on:
   workflow_dispatch:
     inputs:
-      automerge:
-        default: false
-        description: Mark created PR for auto-merging?
-        required: true
-        type: boolean
       bridge_version:
         description: The version of pulumi/pulumi-terraform-bridge to update to. Do not
           include the 'v' prefix. Must be major version 3.

--- a/provider-ci/providers/confluentcloud/repo/.github/workflows/update-upstream-provider.yml
+++ b/provider-ci/providers/confluentcloud/repo/.github/workflows/update-upstream-provider.yml
@@ -144,11 +144,6 @@ name: Update upstream provider
 on:
   workflow_dispatch:
     inputs:
-      automerge:
-        default: false
-        description: Mark created PR for auto-merging?
-        required: true
-        type: boolean
       linked_issue_number:
         description: The issue number of a PR in this repository to which the generated
           pull request should be linked.

--- a/provider-ci/providers/consul/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/consul/repo/.github/workflows/run-acceptance-tests.yml
@@ -313,8 +313,9 @@ jobs:
         GITHUB_TOKEN: ${{secrets.PULUMI_BOT_TOKEN}}
         PR_URL: ${{github.event.pull_request.html_url}}
       id: enable-automerge
-      if: github.event.pull_request.user.login == 'pulumi-bot'
-      name: Enable automerge if successful for bot PRs
+      if: github.event.pull_request.user.login == 'pulumi-bot' &&
+        contains(toJson(github.event.pull_request.labels.*.name), 'auto-merge')
+      name: Enable automerge if successful for bot PRs with 'auto-merge' label
       run: gh pr merge --auto --squash $PR_URL
   test:
     if: github.event_name == 'repository_dispatch' ||

--- a/provider-ci/providers/consul/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/consul/repo/.github/workflows/run-acceptance-tests.yml
@@ -309,8 +309,13 @@ jobs:
     - lint_sdk
     runs-on: ubuntu-latest
     steps:
-    - name: Is workflow a success
-      run: echo yes
+    - env:
+        GITHUB_TOKEN: ${{secrets.PULUMI_BOT_TOKEN}}
+        PR_URL: ${{github.event.pull_request.html_url}}
+      id: enable-automerge
+      if: github.event.pull_request.user.login == 'pulumi-bot'
+      name: Enable automerge if successful for bot PRs
+      run: gh pr merge --auto --squash $PR_URL
   test:
     if: github.event_name == 'repository_dispatch' ||
       github.event.pull_request.head.repo.full_name == github.repository

--- a/provider-ci/providers/consul/repo/.github/workflows/update-bridge.yml
+++ b/provider-ci/providers/consul/repo/.github/workflows/update-bridge.yml
@@ -66,10 +66,6 @@ jobs:
         title: Update pulumi-terraform-bridge to v${{ github.event.inputs.bridge_version
           }}
         token: ${{ secrets.PULUMI_BOT_TOKEN }}
-    - if: steps.create-pr.outputs.pull-request-operation == 'created' &&
-        github.event.inputs.automerge == 'true'
-      run: gh pr merge --auto --squash ${{ steps.create-pr.outputs.pull-request-number
-        }}
     strategy:
       fail-fast: true
       matrix:
@@ -85,11 +81,6 @@ name: Update pulumi-terraform-bridge
 on:
   workflow_dispatch:
     inputs:
-      automerge:
-        default: false
-        description: Mark created PR for auto-merging?
-        required: true
-        type: boolean
       bridge_version:
         description: The version of pulumi/pulumi-terraform-bridge to update to. Do not
           include the 'v' prefix. Must be major version 3.

--- a/provider-ci/providers/consul/repo/.github/workflows/update-upstream-provider.yml
+++ b/provider-ci/providers/consul/repo/.github/workflows/update-upstream-provider.yml
@@ -142,11 +142,6 @@ name: Update upstream provider
 on:
   workflow_dispatch:
     inputs:
-      automerge:
-        default: false
-        description: Mark created PR for auto-merging?
-        required: true
-        type: boolean
       linked_issue_number:
         description: The issue number of a PR in this repository to which the generated
           pull request should be linked.

--- a/provider-ci/providers/databricks/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/databricks/repo/.github/workflows/run-acceptance-tests.yml
@@ -317,8 +317,9 @@ jobs:
         GITHUB_TOKEN: ${{secrets.PULUMI_BOT_TOKEN}}
         PR_URL: ${{github.event.pull_request.html_url}}
       id: enable-automerge
-      if: github.event.pull_request.user.login == 'pulumi-bot'
-      name: Enable automerge if successful for bot PRs
+      if: github.event.pull_request.user.login == 'pulumi-bot' &&
+        contains(toJson(github.event.pull_request.labels.*.name), 'auto-merge')
+      name: Enable automerge if successful for bot PRs with 'auto-merge' label
       run: gh pr merge --auto --squash $PR_URL
   test:
     if: github.event_name == 'repository_dispatch' ||

--- a/provider-ci/providers/databricks/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/databricks/repo/.github/workflows/run-acceptance-tests.yml
@@ -313,8 +313,13 @@ jobs:
     - lint_sdk
     runs-on: ubuntu-latest
     steps:
-    - name: Is workflow a success
-      run: echo yes
+    - env:
+        GITHUB_TOKEN: ${{secrets.PULUMI_BOT_TOKEN}}
+        PR_URL: ${{github.event.pull_request.html_url}}
+      id: enable-automerge
+      if: github.event.pull_request.user.login == 'pulumi-bot'
+      name: Enable automerge if successful for bot PRs
+      run: gh pr merge --auto --squash $PR_URL
   test:
     if: github.event_name == 'repository_dispatch' ||
       github.event.pull_request.head.repo.full_name == github.repository

--- a/provider-ci/providers/databricks/repo/.github/workflows/update-bridge.yml
+++ b/provider-ci/providers/databricks/repo/.github/workflows/update-bridge.yml
@@ -66,10 +66,6 @@ jobs:
         title: Update pulumi-terraform-bridge to v${{ github.event.inputs.bridge_version
           }}
         token: ${{ secrets.PULUMI_BOT_TOKEN }}
-    - if: steps.create-pr.outputs.pull-request-operation == 'created' &&
-        github.event.inputs.automerge == 'true'
-      run: gh pr merge --auto --squash ${{ steps.create-pr.outputs.pull-request-number
-        }}
     strategy:
       fail-fast: true
       matrix:
@@ -85,11 +81,6 @@ name: Update pulumi-terraform-bridge
 on:
   workflow_dispatch:
     inputs:
-      automerge:
-        default: false
-        description: Mark created PR for auto-merging?
-        required: true
-        type: boolean
       bridge_version:
         description: The version of pulumi/pulumi-terraform-bridge to update to. Do not
           include the 'v' prefix. Must be major version 3.

--- a/provider-ci/providers/databricks/repo/.github/workflows/update-upstream-provider.yml
+++ b/provider-ci/providers/databricks/repo/.github/workflows/update-upstream-provider.yml
@@ -146,11 +146,6 @@ name: Update upstream provider
 on:
   workflow_dispatch:
     inputs:
-      automerge:
-        default: false
-        description: Mark created PR for auto-merging?
-        required: true
-        type: boolean
       linked_issue_number:
         description: The issue number of a PR in this repository to which the generated
           pull request should be linked.

--- a/provider-ci/providers/datadog/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/datadog/repo/.github/workflows/run-acceptance-tests.yml
@@ -224,8 +224,13 @@ jobs:
     - test
     runs-on: ubuntu-latest
     steps:
-    - name: Is workflow a success
-      run: echo yes
+    - env:
+        GITHUB_TOKEN: ${{secrets.PULUMI_BOT_TOKEN}}
+        PR_URL: ${{github.event.pull_request.html_url}}
+      id: enable-automerge
+      if: github.event.pull_request.user.login == 'pulumi-bot'
+      name: Enable automerge if successful for bot PRs
+      run: gh pr merge --auto --squash $PR_URL
   test:
     if: github.event_name == 'repository_dispatch' ||
       github.event.pull_request.head.repo.full_name == github.repository

--- a/provider-ci/providers/datadog/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/datadog/repo/.github/workflows/run-acceptance-tests.yml
@@ -228,8 +228,9 @@ jobs:
         GITHUB_TOKEN: ${{secrets.PULUMI_BOT_TOKEN}}
         PR_URL: ${{github.event.pull_request.html_url}}
       id: enable-automerge
-      if: github.event.pull_request.user.login == 'pulumi-bot'
-      name: Enable automerge if successful for bot PRs
+      if: github.event.pull_request.user.login == 'pulumi-bot' &&
+        contains(toJson(github.event.pull_request.labels.*.name), 'auto-merge')
+      name: Enable automerge if successful for bot PRs with 'auto-merge' label
       run: gh pr merge --auto --squash $PR_URL
   test:
     if: github.event_name == 'repository_dispatch' ||

--- a/provider-ci/providers/datadog/repo/.github/workflows/update-bridge.yml
+++ b/provider-ci/providers/datadog/repo/.github/workflows/update-bridge.yml
@@ -66,10 +66,6 @@ jobs:
         title: Update pulumi-terraform-bridge to v${{ github.event.inputs.bridge_version
           }}
         token: ${{ secrets.PULUMI_BOT_TOKEN }}
-    - if: steps.create-pr.outputs.pull-request-operation == 'created' &&
-        github.event.inputs.automerge == 'true'
-      run: gh pr merge --auto --squash ${{ steps.create-pr.outputs.pull-request-number
-        }}
     strategy:
       fail-fast: true
       matrix:
@@ -85,11 +81,6 @@ name: Update pulumi-terraform-bridge
 on:
   workflow_dispatch:
     inputs:
-      automerge:
-        default: false
-        description: Mark created PR for auto-merging?
-        required: true
-        type: boolean
       bridge_version:
         description: The version of pulumi/pulumi-terraform-bridge to update to. Do not
           include the 'v' prefix. Must be major version 3.

--- a/provider-ci/providers/datadog/repo/.github/workflows/update-upstream-provider.yml
+++ b/provider-ci/providers/datadog/repo/.github/workflows/update-upstream-provider.yml
@@ -142,11 +142,6 @@ name: Update upstream provider
 on:
   workflow_dispatch:
     inputs:
-      automerge:
-        default: false
-        description: Mark created PR for auto-merging?
-        required: true
-        type: boolean
       linked_issue_number:
         description: The issue number of a PR in this repository to which the generated
           pull request should be linked.

--- a/provider-ci/providers/digitalocean/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/digitalocean/repo/.github/workflows/run-acceptance-tests.yml
@@ -310,8 +310,13 @@ jobs:
     - lint_sdk
     runs-on: ubuntu-latest
     steps:
-    - name: Is workflow a success
-      run: echo yes
+    - env:
+        GITHUB_TOKEN: ${{secrets.PULUMI_BOT_TOKEN}}
+        PR_URL: ${{github.event.pull_request.html_url}}
+      id: enable-automerge
+      if: github.event.pull_request.user.login == 'pulumi-bot'
+      name: Enable automerge if successful for bot PRs
+      run: gh pr merge --auto --squash $PR_URL
   test:
     if: github.event_name == 'repository_dispatch' ||
       github.event.pull_request.head.repo.full_name == github.repository

--- a/provider-ci/providers/digitalocean/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/digitalocean/repo/.github/workflows/run-acceptance-tests.yml
@@ -314,8 +314,9 @@ jobs:
         GITHUB_TOKEN: ${{secrets.PULUMI_BOT_TOKEN}}
         PR_URL: ${{github.event.pull_request.html_url}}
       id: enable-automerge
-      if: github.event.pull_request.user.login == 'pulumi-bot'
-      name: Enable automerge if successful for bot PRs
+      if: github.event.pull_request.user.login == 'pulumi-bot' &&
+        contains(toJson(github.event.pull_request.labels.*.name), 'auto-merge')
+      name: Enable automerge if successful for bot PRs with 'auto-merge' label
       run: gh pr merge --auto --squash $PR_URL
   test:
     if: github.event_name == 'repository_dispatch' ||

--- a/provider-ci/providers/digitalocean/repo/.github/workflows/update-bridge.yml
+++ b/provider-ci/providers/digitalocean/repo/.github/workflows/update-bridge.yml
@@ -66,10 +66,6 @@ jobs:
         title: Update pulumi-terraform-bridge to v${{ github.event.inputs.bridge_version
           }}
         token: ${{ secrets.PULUMI_BOT_TOKEN }}
-    - if: steps.create-pr.outputs.pull-request-operation == 'created' &&
-        github.event.inputs.automerge == 'true'
-      run: gh pr merge --auto --squash ${{ steps.create-pr.outputs.pull-request-number
-        }}
     strategy:
       fail-fast: true
       matrix:
@@ -85,11 +81,6 @@ name: Update pulumi-terraform-bridge
 on:
   workflow_dispatch:
     inputs:
-      automerge:
-        default: false
-        description: Mark created PR for auto-merging?
-        required: true
-        type: boolean
       bridge_version:
         description: The version of pulumi/pulumi-terraform-bridge to update to. Do not
           include the 'v' prefix. Must be major version 3.

--- a/provider-ci/providers/digitalocean/repo/.github/workflows/update-upstream-provider.yml
+++ b/provider-ci/providers/digitalocean/repo/.github/workflows/update-upstream-provider.yml
@@ -143,11 +143,6 @@ name: Update upstream provider
 on:
   workflow_dispatch:
     inputs:
-      automerge:
-        default: false
-        description: Mark created PR for auto-merging?
-        required: true
-        type: boolean
       linked_issue_number:
         description: The issue number of a PR in this repository to which the generated
           pull request should be linked.

--- a/provider-ci/providers/dnsimple/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/dnsimple/repo/.github/workflows/run-acceptance-tests.yml
@@ -311,8 +311,13 @@ jobs:
     - lint_sdk
     runs-on: ubuntu-latest
     steps:
-    - name: Is workflow a success
-      run: echo yes
+    - env:
+        GITHUB_TOKEN: ${{secrets.PULUMI_BOT_TOKEN}}
+        PR_URL: ${{github.event.pull_request.html_url}}
+      id: enable-automerge
+      if: github.event.pull_request.user.login == 'pulumi-bot'
+      name: Enable automerge if successful for bot PRs
+      run: gh pr merge --auto --squash $PR_URL
   test:
     if: github.event_name == 'repository_dispatch' ||
       github.event.pull_request.head.repo.full_name == github.repository

--- a/provider-ci/providers/dnsimple/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/dnsimple/repo/.github/workflows/run-acceptance-tests.yml
@@ -315,8 +315,9 @@ jobs:
         GITHUB_TOKEN: ${{secrets.PULUMI_BOT_TOKEN}}
         PR_URL: ${{github.event.pull_request.html_url}}
       id: enable-automerge
-      if: github.event.pull_request.user.login == 'pulumi-bot'
-      name: Enable automerge if successful for bot PRs
+      if: github.event.pull_request.user.login == 'pulumi-bot' &&
+        contains(toJson(github.event.pull_request.labels.*.name), 'auto-merge')
+      name: Enable automerge if successful for bot PRs with 'auto-merge' label
       run: gh pr merge --auto --squash $PR_URL
   test:
     if: github.event_name == 'repository_dispatch' ||

--- a/provider-ci/providers/dnsimple/repo/.github/workflows/update-bridge.yml
+++ b/provider-ci/providers/dnsimple/repo/.github/workflows/update-bridge.yml
@@ -66,10 +66,6 @@ jobs:
         title: Update pulumi-terraform-bridge to v${{ github.event.inputs.bridge_version
           }}
         token: ${{ secrets.PULUMI_BOT_TOKEN }}
-    - if: steps.create-pr.outputs.pull-request-operation == 'created' &&
-        github.event.inputs.automerge == 'true'
-      run: gh pr merge --auto --squash ${{ steps.create-pr.outputs.pull-request-number
-        }}
     strategy:
       fail-fast: true
       matrix:
@@ -85,11 +81,6 @@ name: Update pulumi-terraform-bridge
 on:
   workflow_dispatch:
     inputs:
-      automerge:
-        default: false
-        description: Mark created PR for auto-merging?
-        required: true
-        type: boolean
       bridge_version:
         description: The version of pulumi/pulumi-terraform-bridge to update to. Do not
           include the 'v' prefix. Must be major version 3.

--- a/provider-ci/providers/dnsimple/repo/.github/workflows/update-upstream-provider.yml
+++ b/provider-ci/providers/dnsimple/repo/.github/workflows/update-upstream-provider.yml
@@ -144,11 +144,6 @@ name: Update upstream provider
 on:
   workflow_dispatch:
     inputs:
-      automerge:
-        default: false
-        description: Mark created PR for auto-merging?
-        required: true
-        type: boolean
       linked_issue_number:
         description: The issue number of a PR in this repository to which the generated
           pull request should be linked.

--- a/provider-ci/providers/docker/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/docker/repo/.github/workflows/run-acceptance-tests.yml
@@ -319,8 +319,9 @@ jobs:
         GITHUB_TOKEN: ${{secrets.PULUMI_BOT_TOKEN}}
         PR_URL: ${{github.event.pull_request.html_url}}
       id: enable-automerge
-      if: github.event.pull_request.user.login == 'pulumi-bot'
-      name: Enable automerge if successful for bot PRs
+      if: github.event.pull_request.user.login == 'pulumi-bot' &&
+        contains(toJson(github.event.pull_request.labels.*.name), 'auto-merge')
+      name: Enable automerge if successful for bot PRs with 'auto-merge' label
       run: gh pr merge --auto --squash $PR_URL
   test:
     if: github.event_name == 'repository_dispatch' ||

--- a/provider-ci/providers/docker/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/docker/repo/.github/workflows/run-acceptance-tests.yml
@@ -315,8 +315,13 @@ jobs:
     - lint_sdk
     runs-on: ubuntu-latest
     steps:
-    - name: Is workflow a success
-      run: echo yes
+    - env:
+        GITHUB_TOKEN: ${{secrets.PULUMI_BOT_TOKEN}}
+        PR_URL: ${{github.event.pull_request.html_url}}
+      id: enable-automerge
+      if: github.event.pull_request.user.login == 'pulumi-bot'
+      name: Enable automerge if successful for bot PRs
+      run: gh pr merge --auto --squash $PR_URL
   test:
     if: github.event_name == 'repository_dispatch' ||
       github.event.pull_request.head.repo.full_name == github.repository

--- a/provider-ci/providers/docker/repo/.github/workflows/update-bridge.yml
+++ b/provider-ci/providers/docker/repo/.github/workflows/update-bridge.yml
@@ -66,10 +66,6 @@ jobs:
         title: Update pulumi-terraform-bridge to v${{ github.event.inputs.bridge_version
           }}
         token: ${{ secrets.PULUMI_BOT_TOKEN }}
-    - if: steps.create-pr.outputs.pull-request-operation == 'created' &&
-        github.event.inputs.automerge == 'true'
-      run: gh pr merge --auto --squash ${{ steps.create-pr.outputs.pull-request-number
-        }}
     strategy:
       fail-fast: true
       matrix:
@@ -85,11 +81,6 @@ name: Update pulumi-terraform-bridge
 on:
   workflow_dispatch:
     inputs:
-      automerge:
-        default: false
-        description: Mark created PR for auto-merging?
-        required: true
-        type: boolean
       bridge_version:
         description: The version of pulumi/pulumi-terraform-bridge to update to. Do not
           include the 'v' prefix. Must be major version 3.

--- a/provider-ci/providers/docker/repo/.github/workflows/update-upstream-provider.yml
+++ b/provider-ci/providers/docker/repo/.github/workflows/update-upstream-provider.yml
@@ -148,11 +148,6 @@ name: Update upstream provider
 on:
   workflow_dispatch:
     inputs:
-      automerge:
-        default: false
-        description: Mark created PR for auto-merging?
-        required: true
-        type: boolean
       linked_issue_number:
         description: The issue number of a PR in this repository to which the generated
           pull request should be linked.

--- a/provider-ci/providers/ec/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/ec/repo/.github/workflows/run-acceptance-tests.yml
@@ -310,8 +310,13 @@ jobs:
     - lint_sdk
     runs-on: ubuntu-latest
     steps:
-    - name: Is workflow a success
-      run: echo yes
+    - env:
+        GITHUB_TOKEN: ${{secrets.PULUMI_BOT_TOKEN}}
+        PR_URL: ${{github.event.pull_request.html_url}}
+      id: enable-automerge
+      if: github.event.pull_request.user.login == 'pulumi-bot'
+      name: Enable automerge if successful for bot PRs
+      run: gh pr merge --auto --squash $PR_URL
   test:
     if: github.event_name == 'repository_dispatch' ||
       github.event.pull_request.head.repo.full_name == github.repository

--- a/provider-ci/providers/ec/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/ec/repo/.github/workflows/run-acceptance-tests.yml
@@ -314,8 +314,9 @@ jobs:
         GITHUB_TOKEN: ${{secrets.PULUMI_BOT_TOKEN}}
         PR_URL: ${{github.event.pull_request.html_url}}
       id: enable-automerge
-      if: github.event.pull_request.user.login == 'pulumi-bot'
-      name: Enable automerge if successful for bot PRs
+      if: github.event.pull_request.user.login == 'pulumi-bot' &&
+        contains(toJson(github.event.pull_request.labels.*.name), 'auto-merge')
+      name: Enable automerge if successful for bot PRs with 'auto-merge' label
       run: gh pr merge --auto --squash $PR_URL
   test:
     if: github.event_name == 'repository_dispatch' ||

--- a/provider-ci/providers/ec/repo/.github/workflows/update-bridge.yml
+++ b/provider-ci/providers/ec/repo/.github/workflows/update-bridge.yml
@@ -66,10 +66,6 @@ jobs:
         title: Update pulumi-terraform-bridge to v${{ github.event.inputs.bridge_version
           }}
         token: ${{ secrets.PULUMI_BOT_TOKEN }}
-    - if: steps.create-pr.outputs.pull-request-operation == 'created' &&
-        github.event.inputs.automerge == 'true'
-      run: gh pr merge --auto --squash ${{ steps.create-pr.outputs.pull-request-number
-        }}
     strategy:
       fail-fast: true
       matrix:
@@ -85,11 +81,6 @@ name: Update pulumi-terraform-bridge
 on:
   workflow_dispatch:
     inputs:
-      automerge:
-        default: false
-        description: Mark created PR for auto-merging?
-        required: true
-        type: boolean
       bridge_version:
         description: The version of pulumi/pulumi-terraform-bridge to update to. Do not
           include the 'v' prefix. Must be major version 3.

--- a/provider-ci/providers/ec/repo/.github/workflows/update-upstream-provider.yml
+++ b/provider-ci/providers/ec/repo/.github/workflows/update-upstream-provider.yml
@@ -143,11 +143,6 @@ name: Update upstream provider
 on:
   workflow_dispatch:
     inputs:
-      automerge:
-        default: false
-        description: Mark created PR for auto-merging?
-        required: true
-        type: boolean
       linked_issue_number:
         description: The issue number of a PR in this repository to which the generated
           pull request should be linked.

--- a/provider-ci/providers/equinix-metal/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/equinix-metal/repo/.github/workflows/run-acceptance-tests.yml
@@ -225,8 +225,13 @@ jobs:
     - test
     runs-on: ubuntu-latest
     steps:
-    - name: Is workflow a success
-      run: echo yes
+    - env:
+        GITHUB_TOKEN: ${{secrets.PULUMI_BOT_TOKEN}}
+        PR_URL: ${{github.event.pull_request.html_url}}
+      id: enable-automerge
+      if: github.event.pull_request.user.login == 'pulumi-bot'
+      name: Enable automerge if successful for bot PRs
+      run: gh pr merge --auto --squash $PR_URL
   test:
     if: github.event_name == 'repository_dispatch' ||
       github.event.pull_request.head.repo.full_name == github.repository

--- a/provider-ci/providers/equinix-metal/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/equinix-metal/repo/.github/workflows/run-acceptance-tests.yml
@@ -229,8 +229,9 @@ jobs:
         GITHUB_TOKEN: ${{secrets.PULUMI_BOT_TOKEN}}
         PR_URL: ${{github.event.pull_request.html_url}}
       id: enable-automerge
-      if: github.event.pull_request.user.login == 'pulumi-bot'
-      name: Enable automerge if successful for bot PRs
+      if: github.event.pull_request.user.login == 'pulumi-bot' &&
+        contains(toJson(github.event.pull_request.labels.*.name), 'auto-merge')
+      name: Enable automerge if successful for bot PRs with 'auto-merge' label
       run: gh pr merge --auto --squash $PR_URL
   test:
     if: github.event_name == 'repository_dispatch' ||

--- a/provider-ci/providers/equinix-metal/repo/.github/workflows/update-bridge.yml
+++ b/provider-ci/providers/equinix-metal/repo/.github/workflows/update-bridge.yml
@@ -66,10 +66,6 @@ jobs:
         title: Update pulumi-terraform-bridge to v${{ github.event.inputs.bridge_version
           }}
         token: ${{ secrets.PULUMI_BOT_TOKEN }}
-    - if: steps.create-pr.outputs.pull-request-operation == 'created' &&
-        github.event.inputs.automerge == 'true'
-      run: gh pr merge --auto --squash ${{ steps.create-pr.outputs.pull-request-number
-        }}
     strategy:
       fail-fast: true
       matrix:
@@ -85,11 +81,6 @@ name: Update pulumi-terraform-bridge
 on:
   workflow_dispatch:
     inputs:
-      automerge:
-        default: false
-        description: Mark created PR for auto-merging?
-        required: true
-        type: boolean
       bridge_version:
         description: The version of pulumi/pulumi-terraform-bridge to update to. Do not
           include the 'v' prefix. Must be major version 3.

--- a/provider-ci/providers/equinix-metal/repo/.github/workflows/update-upstream-provider.yml
+++ b/provider-ci/providers/equinix-metal/repo/.github/workflows/update-upstream-provider.yml
@@ -143,11 +143,6 @@ name: Update upstream provider
 on:
   workflow_dispatch:
     inputs:
-      automerge:
-        default: false
-        description: Mark created PR for auto-merging?
-        required: true
-        type: boolean
       linked_issue_number:
         description: The issue number of a PR in this repository to which the generated
           pull request should be linked.

--- a/provider-ci/providers/f5bigip/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/f5bigip/repo/.github/workflows/run-acceptance-tests.yml
@@ -317,8 +317,9 @@ jobs:
         GITHUB_TOKEN: ${{secrets.PULUMI_BOT_TOKEN}}
         PR_URL: ${{github.event.pull_request.html_url}}
       id: enable-automerge
-      if: github.event.pull_request.user.login == 'pulumi-bot'
-      name: Enable automerge if successful for bot PRs
+      if: github.event.pull_request.user.login == 'pulumi-bot' &&
+        contains(toJson(github.event.pull_request.labels.*.name), 'auto-merge')
+      name: Enable automerge if successful for bot PRs with 'auto-merge' label
       run: gh pr merge --auto --squash $PR_URL
   test:
     if: github.event_name == 'repository_dispatch' ||

--- a/provider-ci/providers/f5bigip/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/f5bigip/repo/.github/workflows/run-acceptance-tests.yml
@@ -313,8 +313,13 @@ jobs:
     - lint_sdk
     runs-on: ubuntu-latest
     steps:
-    - name: Is workflow a success
-      run: echo yes
+    - env:
+        GITHUB_TOKEN: ${{secrets.PULUMI_BOT_TOKEN}}
+        PR_URL: ${{github.event.pull_request.html_url}}
+      id: enable-automerge
+      if: github.event.pull_request.user.login == 'pulumi-bot'
+      name: Enable automerge if successful for bot PRs
+      run: gh pr merge --auto --squash $PR_URL
   test:
     if: github.event_name == 'repository_dispatch' ||
       github.event.pull_request.head.repo.full_name == github.repository

--- a/provider-ci/providers/f5bigip/repo/.github/workflows/update-bridge.yml
+++ b/provider-ci/providers/f5bigip/repo/.github/workflows/update-bridge.yml
@@ -66,10 +66,6 @@ jobs:
         title: Update pulumi-terraform-bridge to v${{ github.event.inputs.bridge_version
           }}
         token: ${{ secrets.PULUMI_BOT_TOKEN }}
-    - if: steps.create-pr.outputs.pull-request-operation == 'created' &&
-        github.event.inputs.automerge == 'true'
-      run: gh pr merge --auto --squash ${{ steps.create-pr.outputs.pull-request-number
-        }}
     strategy:
       fail-fast: true
       matrix:
@@ -85,11 +81,6 @@ name: Update pulumi-terraform-bridge
 on:
   workflow_dispatch:
     inputs:
-      automerge:
-        default: false
-        description: Mark created PR for auto-merging?
-        required: true
-        type: boolean
       bridge_version:
         description: The version of pulumi/pulumi-terraform-bridge to update to. Do not
           include the 'v' prefix. Must be major version 3.

--- a/provider-ci/providers/f5bigip/repo/.github/workflows/update-upstream-provider.yml
+++ b/provider-ci/providers/f5bigip/repo/.github/workflows/update-upstream-provider.yml
@@ -146,11 +146,6 @@ name: Update upstream provider
 on:
   workflow_dispatch:
     inputs:
-      automerge:
-        default: false
-        description: Mark created PR for auto-merging?
-        required: true
-        type: boolean
       linked_issue_number:
         description: The issue number of a PR in this repository to which the generated
           pull request should be linked.

--- a/provider-ci/providers/fastly/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/fastly/repo/.github/workflows/run-acceptance-tests.yml
@@ -310,8 +310,13 @@ jobs:
     - lint_sdk
     runs-on: ubuntu-latest
     steps:
-    - name: Is workflow a success
-      run: echo yes
+    - env:
+        GITHUB_TOKEN: ${{secrets.PULUMI_BOT_TOKEN}}
+        PR_URL: ${{github.event.pull_request.html_url}}
+      id: enable-automerge
+      if: github.event.pull_request.user.login == 'pulumi-bot'
+      name: Enable automerge if successful for bot PRs
+      run: gh pr merge --auto --squash $PR_URL
   test:
     if: github.event_name == 'repository_dispatch' ||
       github.event.pull_request.head.repo.full_name == github.repository

--- a/provider-ci/providers/fastly/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/fastly/repo/.github/workflows/run-acceptance-tests.yml
@@ -314,8 +314,9 @@ jobs:
         GITHUB_TOKEN: ${{secrets.PULUMI_BOT_TOKEN}}
         PR_URL: ${{github.event.pull_request.html_url}}
       id: enable-automerge
-      if: github.event.pull_request.user.login == 'pulumi-bot'
-      name: Enable automerge if successful for bot PRs
+      if: github.event.pull_request.user.login == 'pulumi-bot' &&
+        contains(toJson(github.event.pull_request.labels.*.name), 'auto-merge')
+      name: Enable automerge if successful for bot PRs with 'auto-merge' label
       run: gh pr merge --auto --squash $PR_URL
   test:
     if: github.event_name == 'repository_dispatch' ||

--- a/provider-ci/providers/fastly/repo/.github/workflows/update-bridge.yml
+++ b/provider-ci/providers/fastly/repo/.github/workflows/update-bridge.yml
@@ -66,10 +66,6 @@ jobs:
         title: Update pulumi-terraform-bridge to v${{ github.event.inputs.bridge_version
           }}
         token: ${{ secrets.PULUMI_BOT_TOKEN }}
-    - if: steps.create-pr.outputs.pull-request-operation == 'created' &&
-        github.event.inputs.automerge == 'true'
-      run: gh pr merge --auto --squash ${{ steps.create-pr.outputs.pull-request-number
-        }}
     strategy:
       fail-fast: true
       matrix:
@@ -85,11 +81,6 @@ name: Update pulumi-terraform-bridge
 on:
   workflow_dispatch:
     inputs:
-      automerge:
-        default: false
-        description: Mark created PR for auto-merging?
-        required: true
-        type: boolean
       bridge_version:
         description: The version of pulumi/pulumi-terraform-bridge to update to. Do not
           include the 'v' prefix. Must be major version 3.

--- a/provider-ci/providers/fastly/repo/.github/workflows/update-upstream-provider.yml
+++ b/provider-ci/providers/fastly/repo/.github/workflows/update-upstream-provider.yml
@@ -143,11 +143,6 @@ name: Update upstream provider
 on:
   workflow_dispatch:
     inputs:
-      automerge:
-        default: false
-        description: Mark created PR for auto-merging?
-        required: true
-        type: boolean
       linked_issue_number:
         description: The issue number of a PR in this repository to which the generated
           pull request should be linked.

--- a/provider-ci/providers/gcp/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/gcp/repo/.github/workflows/run-acceptance-tests.yml
@@ -236,8 +236,9 @@ jobs:
         GITHUB_TOKEN: ${{secrets.PULUMI_BOT_TOKEN}}
         PR_URL: ${{github.event.pull_request.html_url}}
       id: enable-automerge
-      if: github.event.pull_request.user.login == 'pulumi-bot'
-      name: Enable automerge if successful for bot PRs
+      if: github.event.pull_request.user.login == 'pulumi-bot' &&
+        contains(toJson(github.event.pull_request.labels.*.name), 'auto-merge')
+      name: Enable automerge if successful for bot PRs with 'auto-merge' label
       run: gh pr merge --auto --squash $PR_URL
   test:
     if: github.event_name == 'repository_dispatch' ||

--- a/provider-ci/providers/gcp/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/gcp/repo/.github/workflows/run-acceptance-tests.yml
@@ -232,8 +232,13 @@ jobs:
     - test
     runs-on: ubuntu-latest
     steps:
-    - name: Is workflow a success
-      run: echo yes
+    - env:
+        GITHUB_TOKEN: ${{secrets.PULUMI_BOT_TOKEN}}
+        PR_URL: ${{github.event.pull_request.html_url}}
+      id: enable-automerge
+      if: github.event.pull_request.user.login == 'pulumi-bot'
+      name: Enable automerge if successful for bot PRs
+      run: gh pr merge --auto --squash $PR_URL
   test:
     if: github.event_name == 'repository_dispatch' ||
       github.event.pull_request.head.repo.full_name == github.repository

--- a/provider-ci/providers/gcp/repo/.github/workflows/update-bridge.yml
+++ b/provider-ci/providers/gcp/repo/.github/workflows/update-bridge.yml
@@ -66,10 +66,6 @@ jobs:
         title: Update pulumi-terraform-bridge to v${{ github.event.inputs.bridge_version
           }}
         token: ${{ secrets.PULUMI_BOT_TOKEN }}
-    - if: steps.create-pr.outputs.pull-request-operation == 'created' &&
-        github.event.inputs.automerge == 'true'
-      run: gh pr merge --auto --squash ${{ steps.create-pr.outputs.pull-request-number
-        }}
     strategy:
       fail-fast: true
       matrix:
@@ -85,11 +81,6 @@ name: Update pulumi-terraform-bridge
 on:
   workflow_dispatch:
     inputs:
-      automerge:
-        default: false
-        description: Mark created PR for auto-merging?
-        required: true
-        type: boolean
       bridge_version:
         description: The version of pulumi/pulumi-terraform-bridge to update to. Do not
           include the 'v' prefix. Must be major version 3.

--- a/provider-ci/providers/gcp/repo/.github/workflows/update-upstream-provider.yml
+++ b/provider-ci/providers/gcp/repo/.github/workflows/update-upstream-provider.yml
@@ -150,11 +150,6 @@ name: Update upstream provider
 on:
   workflow_dispatch:
     inputs:
-      automerge:
-        default: false
-        description: Mark created PR for auto-merging?
-        required: true
-        type: boolean
       linked_issue_number:
         description: The issue number of a PR in this repository to which the generated
           pull request should be linked.

--- a/provider-ci/providers/github/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/github/repo/.github/workflows/run-acceptance-tests.yml
@@ -311,8 +311,13 @@ jobs:
     - lint_sdk
     runs-on: ubuntu-latest
     steps:
-    - name: Is workflow a success
-      run: echo yes
+    - env:
+        GITHUB_TOKEN: ${{secrets.PULUMI_BOT_TOKEN}}
+        PR_URL: ${{github.event.pull_request.html_url}}
+      id: enable-automerge
+      if: github.event.pull_request.user.login == 'pulumi-bot'
+      name: Enable automerge if successful for bot PRs
+      run: gh pr merge --auto --squash $PR_URL
   test:
     if: github.event_name == 'repository_dispatch' ||
       github.event.pull_request.head.repo.full_name == github.repository

--- a/provider-ci/providers/github/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/github/repo/.github/workflows/run-acceptance-tests.yml
@@ -315,8 +315,9 @@ jobs:
         GITHUB_TOKEN: ${{secrets.PULUMI_BOT_TOKEN}}
         PR_URL: ${{github.event.pull_request.html_url}}
       id: enable-automerge
-      if: github.event.pull_request.user.login == 'pulumi-bot'
-      name: Enable automerge if successful for bot PRs
+      if: github.event.pull_request.user.login == 'pulumi-bot' &&
+        contains(toJson(github.event.pull_request.labels.*.name), 'auto-merge')
+      name: Enable automerge if successful for bot PRs with 'auto-merge' label
       run: gh pr merge --auto --squash $PR_URL
   test:
     if: github.event_name == 'repository_dispatch' ||

--- a/provider-ci/providers/github/repo/.github/workflows/update-bridge.yml
+++ b/provider-ci/providers/github/repo/.github/workflows/update-bridge.yml
@@ -66,10 +66,6 @@ jobs:
         title: Update pulumi-terraform-bridge to v${{ github.event.inputs.bridge_version
           }}
         token: ${{ secrets.PULUMI_BOT_TOKEN }}
-    - if: steps.create-pr.outputs.pull-request-operation == 'created' &&
-        github.event.inputs.automerge == 'true'
-      run: gh pr merge --auto --squash ${{ steps.create-pr.outputs.pull-request-number
-        }}
     strategy:
       fail-fast: true
       matrix:
@@ -85,11 +81,6 @@ name: Update pulumi-terraform-bridge
 on:
   workflow_dispatch:
     inputs:
-      automerge:
-        default: false
-        description: Mark created PR for auto-merging?
-        required: true
-        type: boolean
       bridge_version:
         description: The version of pulumi/pulumi-terraform-bridge to update to. Do not
           include the 'v' prefix. Must be major version 3.

--- a/provider-ci/providers/github/repo/.github/workflows/update-upstream-provider.yml
+++ b/provider-ci/providers/github/repo/.github/workflows/update-upstream-provider.yml
@@ -144,11 +144,6 @@ name: Update upstream provider
 on:
   workflow_dispatch:
     inputs:
-      automerge:
-        default: false
-        description: Mark created PR for auto-merging?
-        required: true
-        type: boolean
       linked_issue_number:
         description: The issue number of a PR in this repository to which the generated
           pull request should be linked.

--- a/provider-ci/providers/gitlab/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/gitlab/repo/.github/workflows/run-acceptance-tests.yml
@@ -310,8 +310,13 @@ jobs:
     - lint_sdk
     runs-on: ubuntu-latest
     steps:
-    - name: Is workflow a success
-      run: echo yes
+    - env:
+        GITHUB_TOKEN: ${{secrets.PULUMI_BOT_TOKEN}}
+        PR_URL: ${{github.event.pull_request.html_url}}
+      id: enable-automerge
+      if: github.event.pull_request.user.login == 'pulumi-bot'
+      name: Enable automerge if successful for bot PRs
+      run: gh pr merge --auto --squash $PR_URL
   test:
     if: github.event_name == 'repository_dispatch' ||
       github.event.pull_request.head.repo.full_name == github.repository

--- a/provider-ci/providers/gitlab/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/gitlab/repo/.github/workflows/run-acceptance-tests.yml
@@ -314,8 +314,9 @@ jobs:
         GITHUB_TOKEN: ${{secrets.PULUMI_BOT_TOKEN}}
         PR_URL: ${{github.event.pull_request.html_url}}
       id: enable-automerge
-      if: github.event.pull_request.user.login == 'pulumi-bot'
-      name: Enable automerge if successful for bot PRs
+      if: github.event.pull_request.user.login == 'pulumi-bot' &&
+        contains(toJson(github.event.pull_request.labels.*.name), 'auto-merge')
+      name: Enable automerge if successful for bot PRs with 'auto-merge' label
       run: gh pr merge --auto --squash $PR_URL
   test:
     if: github.event_name == 'repository_dispatch' ||

--- a/provider-ci/providers/gitlab/repo/.github/workflows/update-bridge.yml
+++ b/provider-ci/providers/gitlab/repo/.github/workflows/update-bridge.yml
@@ -66,10 +66,6 @@ jobs:
         title: Update pulumi-terraform-bridge to v${{ github.event.inputs.bridge_version
           }}
         token: ${{ secrets.PULUMI_BOT_TOKEN }}
-    - if: steps.create-pr.outputs.pull-request-operation == 'created' &&
-        github.event.inputs.automerge == 'true'
-      run: gh pr merge --auto --squash ${{ steps.create-pr.outputs.pull-request-number
-        }}
     strategy:
       fail-fast: true
       matrix:
@@ -85,11 +81,6 @@ name: Update pulumi-terraform-bridge
 on:
   workflow_dispatch:
     inputs:
-      automerge:
-        default: false
-        description: Mark created PR for auto-merging?
-        required: true
-        type: boolean
       bridge_version:
         description: The version of pulumi/pulumi-terraform-bridge to update to. Do not
           include the 'v' prefix. Must be major version 3.

--- a/provider-ci/providers/gitlab/repo/.github/workflows/update-upstream-provider.yml
+++ b/provider-ci/providers/gitlab/repo/.github/workflows/update-upstream-provider.yml
@@ -143,11 +143,6 @@ name: Update upstream provider
 on:
   workflow_dispatch:
     inputs:
-      automerge:
-        default: false
-        description: Mark created PR for auto-merging?
-        required: true
-        type: boolean
       linked_issue_number:
         description: The issue number of a PR in this repository to which the generated
           pull request should be linked.

--- a/provider-ci/providers/hcloud/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/hcloud/repo/.github/workflows/run-acceptance-tests.yml
@@ -310,8 +310,13 @@ jobs:
     - lint_sdk
     runs-on: ubuntu-latest
     steps:
-    - name: Is workflow a success
-      run: echo yes
+    - env:
+        GITHUB_TOKEN: ${{secrets.PULUMI_BOT_TOKEN}}
+        PR_URL: ${{github.event.pull_request.html_url}}
+      id: enable-automerge
+      if: github.event.pull_request.user.login == 'pulumi-bot'
+      name: Enable automerge if successful for bot PRs
+      run: gh pr merge --auto --squash $PR_URL
   test:
     if: github.event_name == 'repository_dispatch' ||
       github.event.pull_request.head.repo.full_name == github.repository

--- a/provider-ci/providers/hcloud/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/hcloud/repo/.github/workflows/run-acceptance-tests.yml
@@ -314,8 +314,9 @@ jobs:
         GITHUB_TOKEN: ${{secrets.PULUMI_BOT_TOKEN}}
         PR_URL: ${{github.event.pull_request.html_url}}
       id: enable-automerge
-      if: github.event.pull_request.user.login == 'pulumi-bot'
-      name: Enable automerge if successful for bot PRs
+      if: github.event.pull_request.user.login == 'pulumi-bot' &&
+        contains(toJson(github.event.pull_request.labels.*.name), 'auto-merge')
+      name: Enable automerge if successful for bot PRs with 'auto-merge' label
       run: gh pr merge --auto --squash $PR_URL
   test:
     if: github.event_name == 'repository_dispatch' ||

--- a/provider-ci/providers/hcloud/repo/.github/workflows/update-bridge.yml
+++ b/provider-ci/providers/hcloud/repo/.github/workflows/update-bridge.yml
@@ -66,10 +66,6 @@ jobs:
         title: Update pulumi-terraform-bridge to v${{ github.event.inputs.bridge_version
           }}
         token: ${{ secrets.PULUMI_BOT_TOKEN }}
-    - if: steps.create-pr.outputs.pull-request-operation == 'created' &&
-        github.event.inputs.automerge == 'true'
-      run: gh pr merge --auto --squash ${{ steps.create-pr.outputs.pull-request-number
-        }}
     strategy:
       fail-fast: true
       matrix:
@@ -85,11 +81,6 @@ name: Update pulumi-terraform-bridge
 on:
   workflow_dispatch:
     inputs:
-      automerge:
-        default: false
-        description: Mark created PR for auto-merging?
-        required: true
-        type: boolean
       bridge_version:
         description: The version of pulumi/pulumi-terraform-bridge to update to. Do not
           include the 'v' prefix. Must be major version 3.

--- a/provider-ci/providers/hcloud/repo/.github/workflows/update-upstream-provider.yml
+++ b/provider-ci/providers/hcloud/repo/.github/workflows/update-upstream-provider.yml
@@ -143,11 +143,6 @@ name: Update upstream provider
 on:
   workflow_dispatch:
     inputs:
-      automerge:
-        default: false
-        description: Mark created PR for auto-merging?
-        required: true
-        type: boolean
       linked_issue_number:
         description: The issue number of a PR in this repository to which the generated
           pull request should be linked.

--- a/provider-ci/providers/kafka/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/kafka/repo/.github/workflows/run-acceptance-tests.yml
@@ -313,8 +313,9 @@ jobs:
         GITHUB_TOKEN: ${{secrets.PULUMI_BOT_TOKEN}}
         PR_URL: ${{github.event.pull_request.html_url}}
       id: enable-automerge
-      if: github.event.pull_request.user.login == 'pulumi-bot'
-      name: Enable automerge if successful for bot PRs
+      if: github.event.pull_request.user.login == 'pulumi-bot' &&
+        contains(toJson(github.event.pull_request.labels.*.name), 'auto-merge')
+      name: Enable automerge if successful for bot PRs with 'auto-merge' label
       run: gh pr merge --auto --squash $PR_URL
   test:
     if: github.event_name == 'repository_dispatch' ||

--- a/provider-ci/providers/kafka/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/kafka/repo/.github/workflows/run-acceptance-tests.yml
@@ -309,8 +309,13 @@ jobs:
     - lint_sdk
     runs-on: ubuntu-latest
     steps:
-    - name: Is workflow a success
-      run: echo yes
+    - env:
+        GITHUB_TOKEN: ${{secrets.PULUMI_BOT_TOKEN}}
+        PR_URL: ${{github.event.pull_request.html_url}}
+      id: enable-automerge
+      if: github.event.pull_request.user.login == 'pulumi-bot'
+      name: Enable automerge if successful for bot PRs
+      run: gh pr merge --auto --squash $PR_URL
   test:
     if: github.event_name == 'repository_dispatch' ||
       github.event.pull_request.head.repo.full_name == github.repository

--- a/provider-ci/providers/kafka/repo/.github/workflows/update-bridge.yml
+++ b/provider-ci/providers/kafka/repo/.github/workflows/update-bridge.yml
@@ -66,10 +66,6 @@ jobs:
         title: Update pulumi-terraform-bridge to v${{ github.event.inputs.bridge_version
           }}
         token: ${{ secrets.PULUMI_BOT_TOKEN }}
-    - if: steps.create-pr.outputs.pull-request-operation == 'created' &&
-        github.event.inputs.automerge == 'true'
-      run: gh pr merge --auto --squash ${{ steps.create-pr.outputs.pull-request-number
-        }}
     strategy:
       fail-fast: true
       matrix:
@@ -85,11 +81,6 @@ name: Update pulumi-terraform-bridge
 on:
   workflow_dispatch:
     inputs:
-      automerge:
-        default: false
-        description: Mark created PR for auto-merging?
-        required: true
-        type: boolean
       bridge_version:
         description: The version of pulumi/pulumi-terraform-bridge to update to. Do not
           include the 'v' prefix. Must be major version 3.

--- a/provider-ci/providers/kafka/repo/.github/workflows/update-upstream-provider.yml
+++ b/provider-ci/providers/kafka/repo/.github/workflows/update-upstream-provider.yml
@@ -142,11 +142,6 @@ name: Update upstream provider
 on:
   workflow_dispatch:
     inputs:
-      automerge:
-        default: false
-        description: Mark created PR for auto-merging?
-        required: true
-        type: boolean
       linked_issue_number:
         description: The issue number of a PR in this repository to which the generated
           pull request should be linked.

--- a/provider-ci/providers/keycloak/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/keycloak/repo/.github/workflows/run-acceptance-tests.yml
@@ -318,8 +318,9 @@ jobs:
         GITHUB_TOKEN: ${{secrets.PULUMI_BOT_TOKEN}}
         PR_URL: ${{github.event.pull_request.html_url}}
       id: enable-automerge
-      if: github.event.pull_request.user.login == 'pulumi-bot'
-      name: Enable automerge if successful for bot PRs
+      if: github.event.pull_request.user.login == 'pulumi-bot' &&
+        contains(toJson(github.event.pull_request.labels.*.name), 'auto-merge')
+      name: Enable automerge if successful for bot PRs with 'auto-merge' label
       run: gh pr merge --auto --squash $PR_URL
   test:
     if: github.event_name == 'repository_dispatch' ||

--- a/provider-ci/providers/keycloak/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/keycloak/repo/.github/workflows/run-acceptance-tests.yml
@@ -314,8 +314,13 @@ jobs:
     - lint_sdk
     runs-on: ubuntu-latest
     steps:
-    - name: Is workflow a success
-      run: echo yes
+    - env:
+        GITHUB_TOKEN: ${{secrets.PULUMI_BOT_TOKEN}}
+        PR_URL: ${{github.event.pull_request.html_url}}
+      id: enable-automerge
+      if: github.event.pull_request.user.login == 'pulumi-bot'
+      name: Enable automerge if successful for bot PRs
+      run: gh pr merge --auto --squash $PR_URL
   test:
     if: github.event_name == 'repository_dispatch' ||
       github.event.pull_request.head.repo.full_name == github.repository

--- a/provider-ci/providers/keycloak/repo/.github/workflows/update-bridge.yml
+++ b/provider-ci/providers/keycloak/repo/.github/workflows/update-bridge.yml
@@ -66,10 +66,6 @@ jobs:
         title: Update pulumi-terraform-bridge to v${{ github.event.inputs.bridge_version
           }}
         token: ${{ secrets.PULUMI_BOT_TOKEN }}
-    - if: steps.create-pr.outputs.pull-request-operation == 'created' &&
-        github.event.inputs.automerge == 'true'
-      run: gh pr merge --auto --squash ${{ steps.create-pr.outputs.pull-request-number
-        }}
     strategy:
       fail-fast: true
       matrix:
@@ -85,11 +81,6 @@ name: Update pulumi-terraform-bridge
 on:
   workflow_dispatch:
     inputs:
-      automerge:
-        default: false
-        description: Mark created PR for auto-merging?
-        required: true
-        type: boolean
       bridge_version:
         description: The version of pulumi/pulumi-terraform-bridge to update to. Do not
           include the 'v' prefix. Must be major version 3.

--- a/provider-ci/providers/keycloak/repo/.github/workflows/update-upstream-provider.yml
+++ b/provider-ci/providers/keycloak/repo/.github/workflows/update-upstream-provider.yml
@@ -147,11 +147,6 @@ name: Update upstream provider
 on:
   workflow_dispatch:
     inputs:
-      automerge:
-        default: false
-        description: Mark created PR for auto-merging?
-        required: true
-        type: boolean
       linked_issue_number:
         description: The issue number of a PR in this repository to which the generated
           pull request should be linked.

--- a/provider-ci/providers/kong/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/kong/repo/.github/workflows/run-acceptance-tests.yml
@@ -313,8 +313,9 @@ jobs:
         GITHUB_TOKEN: ${{secrets.PULUMI_BOT_TOKEN}}
         PR_URL: ${{github.event.pull_request.html_url}}
       id: enable-automerge
-      if: github.event.pull_request.user.login == 'pulumi-bot'
-      name: Enable automerge if successful for bot PRs
+      if: github.event.pull_request.user.login == 'pulumi-bot' &&
+        contains(toJson(github.event.pull_request.labels.*.name), 'auto-merge')
+      name: Enable automerge if successful for bot PRs with 'auto-merge' label
       run: gh pr merge --auto --squash $PR_URL
   test:
     if: github.event_name == 'repository_dispatch' ||

--- a/provider-ci/providers/kong/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/kong/repo/.github/workflows/run-acceptance-tests.yml
@@ -309,8 +309,13 @@ jobs:
     - lint_sdk
     runs-on: ubuntu-latest
     steps:
-    - name: Is workflow a success
-      run: echo yes
+    - env:
+        GITHUB_TOKEN: ${{secrets.PULUMI_BOT_TOKEN}}
+        PR_URL: ${{github.event.pull_request.html_url}}
+      id: enable-automerge
+      if: github.event.pull_request.user.login == 'pulumi-bot'
+      name: Enable automerge if successful for bot PRs
+      run: gh pr merge --auto --squash $PR_URL
   test:
     if: github.event_name == 'repository_dispatch' ||
       github.event.pull_request.head.repo.full_name == github.repository

--- a/provider-ci/providers/kong/repo/.github/workflows/update-bridge.yml
+++ b/provider-ci/providers/kong/repo/.github/workflows/update-bridge.yml
@@ -66,10 +66,6 @@ jobs:
         title: Update pulumi-terraform-bridge to v${{ github.event.inputs.bridge_version
           }}
         token: ${{ secrets.PULUMI_BOT_TOKEN }}
-    - if: steps.create-pr.outputs.pull-request-operation == 'created' &&
-        github.event.inputs.automerge == 'true'
-      run: gh pr merge --auto --squash ${{ steps.create-pr.outputs.pull-request-number
-        }}
     strategy:
       fail-fast: true
       matrix:
@@ -85,11 +81,6 @@ name: Update pulumi-terraform-bridge
 on:
   workflow_dispatch:
     inputs:
-      automerge:
-        default: false
-        description: Mark created PR for auto-merging?
-        required: true
-        type: boolean
       bridge_version:
         description: The version of pulumi/pulumi-terraform-bridge to update to. Do not
           include the 'v' prefix. Must be major version 3.

--- a/provider-ci/providers/kong/repo/.github/workflows/update-upstream-provider.yml
+++ b/provider-ci/providers/kong/repo/.github/workflows/update-upstream-provider.yml
@@ -142,11 +142,6 @@ name: Update upstream provider
 on:
   workflow_dispatch:
     inputs:
-      automerge:
-        default: false
-        description: Mark created PR for auto-merging?
-        required: true
-        type: boolean
       linked_issue_number:
         description: The issue number of a PR in this repository to which the generated
           pull request should be linked.

--- a/provider-ci/providers/libvirt/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/libvirt/repo/.github/workflows/run-acceptance-tests.yml
@@ -310,8 +310,13 @@ jobs:
     - lint_sdk
     runs-on: ubuntu-latest
     steps:
-    - name: Is workflow a success
-      run: echo yes
+    - env:
+        GITHUB_TOKEN: ${{secrets.PULUMI_BOT_TOKEN}}
+        PR_URL: ${{github.event.pull_request.html_url}}
+      id: enable-automerge
+      if: github.event.pull_request.user.login == 'pulumi-bot'
+      name: Enable automerge if successful for bot PRs
+      run: gh pr merge --auto --squash $PR_URL
   test:
     if: github.event_name == 'repository_dispatch' ||
       github.event.pull_request.head.repo.full_name == github.repository

--- a/provider-ci/providers/libvirt/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/libvirt/repo/.github/workflows/run-acceptance-tests.yml
@@ -314,8 +314,9 @@ jobs:
         GITHUB_TOKEN: ${{secrets.PULUMI_BOT_TOKEN}}
         PR_URL: ${{github.event.pull_request.html_url}}
       id: enable-automerge
-      if: github.event.pull_request.user.login == 'pulumi-bot'
-      name: Enable automerge if successful for bot PRs
+      if: github.event.pull_request.user.login == 'pulumi-bot' &&
+        contains(toJson(github.event.pull_request.labels.*.name), 'auto-merge')
+      name: Enable automerge if successful for bot PRs with 'auto-merge' label
       run: gh pr merge --auto --squash $PR_URL
   test:
     if: github.event_name == 'repository_dispatch' ||

--- a/provider-ci/providers/libvirt/repo/.github/workflows/update-bridge.yml
+++ b/provider-ci/providers/libvirt/repo/.github/workflows/update-bridge.yml
@@ -66,10 +66,6 @@ jobs:
         title: Update pulumi-terraform-bridge to v${{ github.event.inputs.bridge_version
           }}
         token: ${{ secrets.PULUMI_BOT_TOKEN }}
-    - if: steps.create-pr.outputs.pull-request-operation == 'created' &&
-        github.event.inputs.automerge == 'true'
-      run: gh pr merge --auto --squash ${{ steps.create-pr.outputs.pull-request-number
-        }}
     strategy:
       fail-fast: true
       matrix:
@@ -85,11 +81,6 @@ name: Update pulumi-terraform-bridge
 on:
   workflow_dispatch:
     inputs:
-      automerge:
-        default: false
-        description: Mark created PR for auto-merging?
-        required: true
-        type: boolean
       bridge_version:
         description: The version of pulumi/pulumi-terraform-bridge to update to. Do not
           include the 'v' prefix. Must be major version 3.

--- a/provider-ci/providers/libvirt/repo/.github/workflows/update-upstream-provider.yml
+++ b/provider-ci/providers/libvirt/repo/.github/workflows/update-upstream-provider.yml
@@ -143,11 +143,6 @@ name: Update upstream provider
 on:
   workflow_dispatch:
     inputs:
-      automerge:
-        default: false
-        description: Mark created PR for auto-merging?
-        required: true
-        type: boolean
       linked_issue_number:
         description: The issue number of a PR in this repository to which the generated
           pull request should be linked.

--- a/provider-ci/providers/linode/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/linode/repo/.github/workflows/run-acceptance-tests.yml
@@ -310,8 +310,13 @@ jobs:
     - lint_sdk
     runs-on: ubuntu-latest
     steps:
-    - name: Is workflow a success
-      run: echo yes
+    - env:
+        GITHUB_TOKEN: ${{secrets.PULUMI_BOT_TOKEN}}
+        PR_URL: ${{github.event.pull_request.html_url}}
+      id: enable-automerge
+      if: github.event.pull_request.user.login == 'pulumi-bot'
+      name: Enable automerge if successful for bot PRs
+      run: gh pr merge --auto --squash $PR_URL
   test:
     if: github.event_name == 'repository_dispatch' ||
       github.event.pull_request.head.repo.full_name == github.repository

--- a/provider-ci/providers/linode/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/linode/repo/.github/workflows/run-acceptance-tests.yml
@@ -314,8 +314,9 @@ jobs:
         GITHUB_TOKEN: ${{secrets.PULUMI_BOT_TOKEN}}
         PR_URL: ${{github.event.pull_request.html_url}}
       id: enable-automerge
-      if: github.event.pull_request.user.login == 'pulumi-bot'
-      name: Enable automerge if successful for bot PRs
+      if: github.event.pull_request.user.login == 'pulumi-bot' &&
+        contains(toJson(github.event.pull_request.labels.*.name), 'auto-merge')
+      name: Enable automerge if successful for bot PRs with 'auto-merge' label
       run: gh pr merge --auto --squash $PR_URL
   test:
     if: github.event_name == 'repository_dispatch' ||

--- a/provider-ci/providers/linode/repo/.github/workflows/update-bridge.yml
+++ b/provider-ci/providers/linode/repo/.github/workflows/update-bridge.yml
@@ -66,10 +66,6 @@ jobs:
         title: Update pulumi-terraform-bridge to v${{ github.event.inputs.bridge_version
           }}
         token: ${{ secrets.PULUMI_BOT_TOKEN }}
-    - if: steps.create-pr.outputs.pull-request-operation == 'created' &&
-        github.event.inputs.automerge == 'true'
-      run: gh pr merge --auto --squash ${{ steps.create-pr.outputs.pull-request-number
-        }}
     strategy:
       fail-fast: true
       matrix:
@@ -85,11 +81,6 @@ name: Update pulumi-terraform-bridge
 on:
   workflow_dispatch:
     inputs:
-      automerge:
-        default: false
-        description: Mark created PR for auto-merging?
-        required: true
-        type: boolean
       bridge_version:
         description: The version of pulumi/pulumi-terraform-bridge to update to. Do not
           include the 'v' prefix. Must be major version 3.

--- a/provider-ci/providers/linode/repo/.github/workflows/update-upstream-provider.yml
+++ b/provider-ci/providers/linode/repo/.github/workflows/update-upstream-provider.yml
@@ -143,11 +143,6 @@ name: Update upstream provider
 on:
   workflow_dispatch:
     inputs:
-      automerge:
-        default: false
-        description: Mark created PR for auto-merging?
-        required: true
-        type: boolean
       linked_issue_number:
         description: The issue number of a PR in this repository to which the generated
           pull request should be linked.

--- a/provider-ci/providers/mailgun/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/mailgun/repo/.github/workflows/run-acceptance-tests.yml
@@ -310,8 +310,13 @@ jobs:
     - lint_sdk
     runs-on: ubuntu-latest
     steps:
-    - name: Is workflow a success
-      run: echo yes
+    - env:
+        GITHUB_TOKEN: ${{secrets.PULUMI_BOT_TOKEN}}
+        PR_URL: ${{github.event.pull_request.html_url}}
+      id: enable-automerge
+      if: github.event.pull_request.user.login == 'pulumi-bot'
+      name: Enable automerge if successful for bot PRs
+      run: gh pr merge --auto --squash $PR_URL
   test:
     if: github.event_name == 'repository_dispatch' ||
       github.event.pull_request.head.repo.full_name == github.repository

--- a/provider-ci/providers/mailgun/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/mailgun/repo/.github/workflows/run-acceptance-tests.yml
@@ -314,8 +314,9 @@ jobs:
         GITHUB_TOKEN: ${{secrets.PULUMI_BOT_TOKEN}}
         PR_URL: ${{github.event.pull_request.html_url}}
       id: enable-automerge
-      if: github.event.pull_request.user.login == 'pulumi-bot'
-      name: Enable automerge if successful for bot PRs
+      if: github.event.pull_request.user.login == 'pulumi-bot' &&
+        contains(toJson(github.event.pull_request.labels.*.name), 'auto-merge')
+      name: Enable automerge if successful for bot PRs with 'auto-merge' label
       run: gh pr merge --auto --squash $PR_URL
   test:
     if: github.event_name == 'repository_dispatch' ||

--- a/provider-ci/providers/mailgun/repo/.github/workflows/update-bridge.yml
+++ b/provider-ci/providers/mailgun/repo/.github/workflows/update-bridge.yml
@@ -66,10 +66,6 @@ jobs:
         title: Update pulumi-terraform-bridge to v${{ github.event.inputs.bridge_version
           }}
         token: ${{ secrets.PULUMI_BOT_TOKEN }}
-    - if: steps.create-pr.outputs.pull-request-operation == 'created' &&
-        github.event.inputs.automerge == 'true'
-      run: gh pr merge --auto --squash ${{ steps.create-pr.outputs.pull-request-number
-        }}
     strategy:
       fail-fast: true
       matrix:
@@ -85,11 +81,6 @@ name: Update pulumi-terraform-bridge
 on:
   workflow_dispatch:
     inputs:
-      automerge:
-        default: false
-        description: Mark created PR for auto-merging?
-        required: true
-        type: boolean
       bridge_version:
         description: The version of pulumi/pulumi-terraform-bridge to update to. Do not
           include the 'v' prefix. Must be major version 3.

--- a/provider-ci/providers/mailgun/repo/.github/workflows/update-upstream-provider.yml
+++ b/provider-ci/providers/mailgun/repo/.github/workflows/update-upstream-provider.yml
@@ -143,11 +143,6 @@ name: Update upstream provider
 on:
   workflow_dispatch:
     inputs:
-      automerge:
-        default: false
-        description: Mark created PR for auto-merging?
-        required: true
-        type: boolean
       linked_issue_number:
         description: The issue number of a PR in this repository to which the generated
           pull request should be linked.

--- a/provider-ci/providers/minio/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/minio/repo/.github/workflows/run-acceptance-tests.yml
@@ -317,8 +317,9 @@ jobs:
         GITHUB_TOKEN: ${{secrets.PULUMI_BOT_TOKEN}}
         PR_URL: ${{github.event.pull_request.html_url}}
       id: enable-automerge
-      if: github.event.pull_request.user.login == 'pulumi-bot'
-      name: Enable automerge if successful for bot PRs
+      if: github.event.pull_request.user.login == 'pulumi-bot' &&
+        contains(toJson(github.event.pull_request.labels.*.name), 'auto-merge')
+      name: Enable automerge if successful for bot PRs with 'auto-merge' label
       run: gh pr merge --auto --squash $PR_URL
   test:
     if: github.event_name == 'repository_dispatch' ||

--- a/provider-ci/providers/minio/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/minio/repo/.github/workflows/run-acceptance-tests.yml
@@ -313,8 +313,13 @@ jobs:
     - lint_sdk
     runs-on: ubuntu-latest
     steps:
-    - name: Is workflow a success
-      run: echo yes
+    - env:
+        GITHUB_TOKEN: ${{secrets.PULUMI_BOT_TOKEN}}
+        PR_URL: ${{github.event.pull_request.html_url}}
+      id: enable-automerge
+      if: github.event.pull_request.user.login == 'pulumi-bot'
+      name: Enable automerge if successful for bot PRs
+      run: gh pr merge --auto --squash $PR_URL
   test:
     if: github.event_name == 'repository_dispatch' ||
       github.event.pull_request.head.repo.full_name == github.repository

--- a/provider-ci/providers/minio/repo/.github/workflows/update-bridge.yml
+++ b/provider-ci/providers/minio/repo/.github/workflows/update-bridge.yml
@@ -66,10 +66,6 @@ jobs:
         title: Update pulumi-terraform-bridge to v${{ github.event.inputs.bridge_version
           }}
         token: ${{ secrets.PULUMI_BOT_TOKEN }}
-    - if: steps.create-pr.outputs.pull-request-operation == 'created' &&
-        github.event.inputs.automerge == 'true'
-      run: gh pr merge --auto --squash ${{ steps.create-pr.outputs.pull-request-number
-        }}
     strategy:
       fail-fast: true
       matrix:
@@ -85,11 +81,6 @@ name: Update pulumi-terraform-bridge
 on:
   workflow_dispatch:
     inputs:
-      automerge:
-        default: false
-        description: Mark created PR for auto-merging?
-        required: true
-        type: boolean
       bridge_version:
         description: The version of pulumi/pulumi-terraform-bridge to update to. Do not
           include the 'v' prefix. Must be major version 3.

--- a/provider-ci/providers/minio/repo/.github/workflows/update-upstream-provider.yml
+++ b/provider-ci/providers/minio/repo/.github/workflows/update-upstream-provider.yml
@@ -146,11 +146,6 @@ name: Update upstream provider
 on:
   workflow_dispatch:
     inputs:
-      automerge:
-        default: false
-        description: Mark created PR for auto-merging?
-        required: true
-        type: boolean
       linked_issue_number:
         description: The issue number of a PR in this repository to which the generated
           pull request should be linked.

--- a/provider-ci/providers/mongodbatlas/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/mongodbatlas/repo/.github/workflows/run-acceptance-tests.yml
@@ -316,8 +316,9 @@ jobs:
         GITHUB_TOKEN: ${{secrets.PULUMI_BOT_TOKEN}}
         PR_URL: ${{github.event.pull_request.html_url}}
       id: enable-automerge
-      if: github.event.pull_request.user.login == 'pulumi-bot'
-      name: Enable automerge if successful for bot PRs
+      if: github.event.pull_request.user.login == 'pulumi-bot' &&
+        contains(toJson(github.event.pull_request.labels.*.name), 'auto-merge')
+      name: Enable automerge if successful for bot PRs with 'auto-merge' label
       run: gh pr merge --auto --squash $PR_URL
   test:
     if: github.event_name == 'repository_dispatch' ||

--- a/provider-ci/providers/mongodbatlas/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/mongodbatlas/repo/.github/workflows/run-acceptance-tests.yml
@@ -312,8 +312,13 @@ jobs:
     - lint_sdk
     runs-on: ubuntu-latest
     steps:
-    - name: Is workflow a success
-      run: echo yes
+    - env:
+        GITHUB_TOKEN: ${{secrets.PULUMI_BOT_TOKEN}}
+        PR_URL: ${{github.event.pull_request.html_url}}
+      id: enable-automerge
+      if: github.event.pull_request.user.login == 'pulumi-bot'
+      name: Enable automerge if successful for bot PRs
+      run: gh pr merge --auto --squash $PR_URL
   test:
     if: github.event_name == 'repository_dispatch' ||
       github.event.pull_request.head.repo.full_name == github.repository

--- a/provider-ci/providers/mongodbatlas/repo/.github/workflows/update-bridge.yml
+++ b/provider-ci/providers/mongodbatlas/repo/.github/workflows/update-bridge.yml
@@ -66,10 +66,6 @@ jobs:
         title: Update pulumi-terraform-bridge to v${{ github.event.inputs.bridge_version
           }}
         token: ${{ secrets.PULUMI_BOT_TOKEN }}
-    - if: steps.create-pr.outputs.pull-request-operation == 'created' &&
-        github.event.inputs.automerge == 'true'
-      run: gh pr merge --auto --squash ${{ steps.create-pr.outputs.pull-request-number
-        }}
     strategy:
       fail-fast: true
       matrix:
@@ -85,11 +81,6 @@ name: Update pulumi-terraform-bridge
 on:
   workflow_dispatch:
     inputs:
-      automerge:
-        default: false
-        description: Mark created PR for auto-merging?
-        required: true
-        type: boolean
       bridge_version:
         description: The version of pulumi/pulumi-terraform-bridge to update to. Do not
           include the 'v' prefix. Must be major version 3.

--- a/provider-ci/providers/mongodbatlas/repo/.github/workflows/update-upstream-provider.yml
+++ b/provider-ci/providers/mongodbatlas/repo/.github/workflows/update-upstream-provider.yml
@@ -145,11 +145,6 @@ name: Update upstream provider
 on:
   workflow_dispatch:
     inputs:
-      automerge:
-        default: false
-        description: Mark created PR for auto-merging?
-        required: true
-        type: boolean
       linked_issue_number:
         description: The issue number of a PR in this repository to which the generated
           pull request should be linked.

--- a/provider-ci/providers/mysql/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/mysql/repo/.github/workflows/run-acceptance-tests.yml
@@ -313,8 +313,9 @@ jobs:
         GITHUB_TOKEN: ${{secrets.PULUMI_BOT_TOKEN}}
         PR_URL: ${{github.event.pull_request.html_url}}
       id: enable-automerge
-      if: github.event.pull_request.user.login == 'pulumi-bot'
-      name: Enable automerge if successful for bot PRs
+      if: github.event.pull_request.user.login == 'pulumi-bot' &&
+        contains(toJson(github.event.pull_request.labels.*.name), 'auto-merge')
+      name: Enable automerge if successful for bot PRs with 'auto-merge' label
       run: gh pr merge --auto --squash $PR_URL
   test:
     if: github.event_name == 'repository_dispatch' ||

--- a/provider-ci/providers/mysql/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/mysql/repo/.github/workflows/run-acceptance-tests.yml
@@ -309,8 +309,13 @@ jobs:
     - lint_sdk
     runs-on: ubuntu-latest
     steps:
-    - name: Is workflow a success
-      run: echo yes
+    - env:
+        GITHUB_TOKEN: ${{secrets.PULUMI_BOT_TOKEN}}
+        PR_URL: ${{github.event.pull_request.html_url}}
+      id: enable-automerge
+      if: github.event.pull_request.user.login == 'pulumi-bot'
+      name: Enable automerge if successful for bot PRs
+      run: gh pr merge --auto --squash $PR_URL
   test:
     if: github.event_name == 'repository_dispatch' ||
       github.event.pull_request.head.repo.full_name == github.repository

--- a/provider-ci/providers/mysql/repo/.github/workflows/update-bridge.yml
+++ b/provider-ci/providers/mysql/repo/.github/workflows/update-bridge.yml
@@ -66,10 +66,6 @@ jobs:
         title: Update pulumi-terraform-bridge to v${{ github.event.inputs.bridge_version
           }}
         token: ${{ secrets.PULUMI_BOT_TOKEN }}
-    - if: steps.create-pr.outputs.pull-request-operation == 'created' &&
-        github.event.inputs.automerge == 'true'
-      run: gh pr merge --auto --squash ${{ steps.create-pr.outputs.pull-request-number
-        }}
     strategy:
       fail-fast: true
       matrix:
@@ -85,11 +81,6 @@ name: Update pulumi-terraform-bridge
 on:
   workflow_dispatch:
     inputs:
-      automerge:
-        default: false
-        description: Mark created PR for auto-merging?
-        required: true
-        type: boolean
       bridge_version:
         description: The version of pulumi/pulumi-terraform-bridge to update to. Do not
           include the 'v' prefix. Must be major version 3.

--- a/provider-ci/providers/mysql/repo/.github/workflows/update-upstream-provider.yml
+++ b/provider-ci/providers/mysql/repo/.github/workflows/update-upstream-provider.yml
@@ -142,11 +142,6 @@ name: Update upstream provider
 on:
   workflow_dispatch:
     inputs:
-      automerge:
-        default: false
-        description: Mark created PR for auto-merging?
-        required: true
-        type: boolean
       linked_issue_number:
         description: The issue number of a PR in this repository to which the generated
           pull request should be linked.

--- a/provider-ci/providers/newrelic/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/newrelic/repo/.github/workflows/run-acceptance-tests.yml
@@ -311,8 +311,13 @@ jobs:
     - lint_sdk
     runs-on: ubuntu-latest
     steps:
-    - name: Is workflow a success
-      run: echo yes
+    - env:
+        GITHUB_TOKEN: ${{secrets.PULUMI_BOT_TOKEN}}
+        PR_URL: ${{github.event.pull_request.html_url}}
+      id: enable-automerge
+      if: github.event.pull_request.user.login == 'pulumi-bot'
+      name: Enable automerge if successful for bot PRs
+      run: gh pr merge --auto --squash $PR_URL
   test:
     if: github.event_name == 'repository_dispatch' ||
       github.event.pull_request.head.repo.full_name == github.repository

--- a/provider-ci/providers/newrelic/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/newrelic/repo/.github/workflows/run-acceptance-tests.yml
@@ -315,8 +315,9 @@ jobs:
         GITHUB_TOKEN: ${{secrets.PULUMI_BOT_TOKEN}}
         PR_URL: ${{github.event.pull_request.html_url}}
       id: enable-automerge
-      if: github.event.pull_request.user.login == 'pulumi-bot'
-      name: Enable automerge if successful for bot PRs
+      if: github.event.pull_request.user.login == 'pulumi-bot' &&
+        contains(toJson(github.event.pull_request.labels.*.name), 'auto-merge')
+      name: Enable automerge if successful for bot PRs with 'auto-merge' label
       run: gh pr merge --auto --squash $PR_URL
   test:
     if: github.event_name == 'repository_dispatch' ||

--- a/provider-ci/providers/newrelic/repo/.github/workflows/update-bridge.yml
+++ b/provider-ci/providers/newrelic/repo/.github/workflows/update-bridge.yml
@@ -66,10 +66,6 @@ jobs:
         title: Update pulumi-terraform-bridge to v${{ github.event.inputs.bridge_version
           }}
         token: ${{ secrets.PULUMI_BOT_TOKEN }}
-    - if: steps.create-pr.outputs.pull-request-operation == 'created' &&
-        github.event.inputs.automerge == 'true'
-      run: gh pr merge --auto --squash ${{ steps.create-pr.outputs.pull-request-number
-        }}
     strategy:
       fail-fast: true
       matrix:
@@ -85,11 +81,6 @@ name: Update pulumi-terraform-bridge
 on:
   workflow_dispatch:
     inputs:
-      automerge:
-        default: false
-        description: Mark created PR for auto-merging?
-        required: true
-        type: boolean
       bridge_version:
         description: The version of pulumi/pulumi-terraform-bridge to update to. Do not
           include the 'v' prefix. Must be major version 3.

--- a/provider-ci/providers/newrelic/repo/.github/workflows/update-upstream-provider.yml
+++ b/provider-ci/providers/newrelic/repo/.github/workflows/update-upstream-provider.yml
@@ -144,11 +144,6 @@ name: Update upstream provider
 on:
   workflow_dispatch:
     inputs:
-      automerge:
-        default: false
-        description: Mark created PR for auto-merging?
-        required: true
-        type: boolean
       linked_issue_number:
         description: The issue number of a PR in this repository to which the generated
           pull request should be linked.

--- a/provider-ci/providers/nomad/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/nomad/repo/.github/workflows/run-acceptance-tests.yml
@@ -310,8 +310,13 @@ jobs:
     - lint_sdk
     runs-on: ubuntu-latest
     steps:
-    - name: Is workflow a success
-      run: echo yes
+    - env:
+        GITHUB_TOKEN: ${{secrets.PULUMI_BOT_TOKEN}}
+        PR_URL: ${{github.event.pull_request.html_url}}
+      id: enable-automerge
+      if: github.event.pull_request.user.login == 'pulumi-bot'
+      name: Enable automerge if successful for bot PRs
+      run: gh pr merge --auto --squash $PR_URL
   test:
     if: github.event_name == 'repository_dispatch' ||
       github.event.pull_request.head.repo.full_name == github.repository

--- a/provider-ci/providers/nomad/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/nomad/repo/.github/workflows/run-acceptance-tests.yml
@@ -314,8 +314,9 @@ jobs:
         GITHUB_TOKEN: ${{secrets.PULUMI_BOT_TOKEN}}
         PR_URL: ${{github.event.pull_request.html_url}}
       id: enable-automerge
-      if: github.event.pull_request.user.login == 'pulumi-bot'
-      name: Enable automerge if successful for bot PRs
+      if: github.event.pull_request.user.login == 'pulumi-bot' &&
+        contains(toJson(github.event.pull_request.labels.*.name), 'auto-merge')
+      name: Enable automerge if successful for bot PRs with 'auto-merge' label
       run: gh pr merge --auto --squash $PR_URL
   test:
     if: github.event_name == 'repository_dispatch' ||

--- a/provider-ci/providers/nomad/repo/.github/workflows/update-bridge.yml
+++ b/provider-ci/providers/nomad/repo/.github/workflows/update-bridge.yml
@@ -66,10 +66,6 @@ jobs:
         title: Update pulumi-terraform-bridge to v${{ github.event.inputs.bridge_version
           }}
         token: ${{ secrets.PULUMI_BOT_TOKEN }}
-    - if: steps.create-pr.outputs.pull-request-operation == 'created' &&
-        github.event.inputs.automerge == 'true'
-      run: gh pr merge --auto --squash ${{ steps.create-pr.outputs.pull-request-number
-        }}
     strategy:
       fail-fast: true
       matrix:
@@ -85,11 +81,6 @@ name: Update pulumi-terraform-bridge
 on:
   workflow_dispatch:
     inputs:
-      automerge:
-        default: false
-        description: Mark created PR for auto-merging?
-        required: true
-        type: boolean
       bridge_version:
         description: The version of pulumi/pulumi-terraform-bridge to update to. Do not
           include the 'v' prefix. Must be major version 3.

--- a/provider-ci/providers/nomad/repo/.github/workflows/update-upstream-provider.yml
+++ b/provider-ci/providers/nomad/repo/.github/workflows/update-upstream-provider.yml
@@ -143,11 +143,6 @@ name: Update upstream provider
 on:
   workflow_dispatch:
     inputs:
-      automerge:
-        default: false
-        description: Mark created PR for auto-merging?
-        required: true
-        type: boolean
       linked_issue_number:
         description: The issue number of a PR in this repository to which the generated
           pull request should be linked.

--- a/provider-ci/providers/ns1/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/ns1/repo/.github/workflows/run-acceptance-tests.yml
@@ -310,8 +310,13 @@ jobs:
     - lint_sdk
     runs-on: ubuntu-latest
     steps:
-    - name: Is workflow a success
-      run: echo yes
+    - env:
+        GITHUB_TOKEN: ${{secrets.PULUMI_BOT_TOKEN}}
+        PR_URL: ${{github.event.pull_request.html_url}}
+      id: enable-automerge
+      if: github.event.pull_request.user.login == 'pulumi-bot'
+      name: Enable automerge if successful for bot PRs
+      run: gh pr merge --auto --squash $PR_URL
   test:
     if: github.event_name == 'repository_dispatch' ||
       github.event.pull_request.head.repo.full_name == github.repository

--- a/provider-ci/providers/ns1/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/ns1/repo/.github/workflows/run-acceptance-tests.yml
@@ -314,8 +314,9 @@ jobs:
         GITHUB_TOKEN: ${{secrets.PULUMI_BOT_TOKEN}}
         PR_URL: ${{github.event.pull_request.html_url}}
       id: enable-automerge
-      if: github.event.pull_request.user.login == 'pulumi-bot'
-      name: Enable automerge if successful for bot PRs
+      if: github.event.pull_request.user.login == 'pulumi-bot' &&
+        contains(toJson(github.event.pull_request.labels.*.name), 'auto-merge')
+      name: Enable automerge if successful for bot PRs with 'auto-merge' label
       run: gh pr merge --auto --squash $PR_URL
   test:
     if: github.event_name == 'repository_dispatch' ||

--- a/provider-ci/providers/ns1/repo/.github/workflows/update-bridge.yml
+++ b/provider-ci/providers/ns1/repo/.github/workflows/update-bridge.yml
@@ -66,10 +66,6 @@ jobs:
         title: Update pulumi-terraform-bridge to v${{ github.event.inputs.bridge_version
           }}
         token: ${{ secrets.PULUMI_BOT_TOKEN }}
-    - if: steps.create-pr.outputs.pull-request-operation == 'created' &&
-        github.event.inputs.automerge == 'true'
-      run: gh pr merge --auto --squash ${{ steps.create-pr.outputs.pull-request-number
-        }}
     strategy:
       fail-fast: true
       matrix:
@@ -85,11 +81,6 @@ name: Update pulumi-terraform-bridge
 on:
   workflow_dispatch:
     inputs:
-      automerge:
-        default: false
-        description: Mark created PR for auto-merging?
-        required: true
-        type: boolean
       bridge_version:
         description: The version of pulumi/pulumi-terraform-bridge to update to. Do not
           include the 'v' prefix. Must be major version 3.

--- a/provider-ci/providers/ns1/repo/.github/workflows/update-upstream-provider.yml
+++ b/provider-ci/providers/ns1/repo/.github/workflows/update-upstream-provider.yml
@@ -143,11 +143,6 @@ name: Update upstream provider
 on:
   workflow_dispatch:
     inputs:
-      automerge:
-        default: false
-        description: Mark created PR for auto-merging?
-        required: true
-        type: boolean
       linked_issue_number:
         description: The issue number of a PR in this repository to which the generated
           pull request should be linked.

--- a/provider-ci/providers/oci/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/oci/repo/.github/workflows/run-acceptance-tests.yml
@@ -232,8 +232,9 @@ jobs:
         GITHUB_TOKEN: ${{secrets.PULUMI_BOT_TOKEN}}
         PR_URL: ${{github.event.pull_request.html_url}}
       id: enable-automerge
-      if: github.event.pull_request.user.login == 'pulumi-bot'
-      name: Enable automerge if successful for bot PRs
+      if: github.event.pull_request.user.login == 'pulumi-bot' &&
+        contains(toJson(github.event.pull_request.labels.*.name), 'auto-merge')
+      name: Enable automerge if successful for bot PRs with 'auto-merge' label
       run: gh pr merge --auto --squash $PR_URL
   test:
     if: github.event_name == 'repository_dispatch' ||

--- a/provider-ci/providers/oci/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/oci/repo/.github/workflows/run-acceptance-tests.yml
@@ -228,8 +228,13 @@ jobs:
     - test
     runs-on: ubuntu-latest
     steps:
-    - name: Is workflow a success
-      run: echo yes
+    - env:
+        GITHUB_TOKEN: ${{secrets.PULUMI_BOT_TOKEN}}
+        PR_URL: ${{github.event.pull_request.html_url}}
+      id: enable-automerge
+      if: github.event.pull_request.user.login == 'pulumi-bot'
+      name: Enable automerge if successful for bot PRs
+      run: gh pr merge --auto --squash $PR_URL
   test:
     if: github.event_name == 'repository_dispatch' ||
       github.event.pull_request.head.repo.full_name == github.repository

--- a/provider-ci/providers/oci/repo/.github/workflows/update-bridge.yml
+++ b/provider-ci/providers/oci/repo/.github/workflows/update-bridge.yml
@@ -66,10 +66,6 @@ jobs:
         title: Update pulumi-terraform-bridge to v${{ github.event.inputs.bridge_version
           }}
         token: ${{ secrets.PULUMI_BOT_TOKEN }}
-    - if: steps.create-pr.outputs.pull-request-operation == 'created' &&
-        github.event.inputs.automerge == 'true'
-      run: gh pr merge --auto --squash ${{ steps.create-pr.outputs.pull-request-number
-        }}
     strategy:
       fail-fast: true
       matrix:
@@ -85,11 +81,6 @@ name: Update pulumi-terraform-bridge
 on:
   workflow_dispatch:
     inputs:
-      automerge:
-        default: false
-        description: Mark created PR for auto-merging?
-        required: true
-        type: boolean
       bridge_version:
         description: The version of pulumi/pulumi-terraform-bridge to update to. Do not
           include the 'v' prefix. Must be major version 3.

--- a/provider-ci/providers/oci/repo/.github/workflows/update-upstream-provider.yml
+++ b/provider-ci/providers/oci/repo/.github/workflows/update-upstream-provider.yml
@@ -146,11 +146,6 @@ name: Update upstream provider
 on:
   workflow_dispatch:
     inputs:
-      automerge:
-        default: false
-        description: Mark created PR for auto-merging?
-        required: true
-        type: boolean
       linked_issue_number:
         description: The issue number of a PR in this repository to which the generated
           pull request should be linked.

--- a/provider-ci/providers/okta/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/okta/repo/.github/workflows/run-acceptance-tests.yml
@@ -316,8 +316,9 @@ jobs:
         GITHUB_TOKEN: ${{secrets.PULUMI_BOT_TOKEN}}
         PR_URL: ${{github.event.pull_request.html_url}}
       id: enable-automerge
-      if: github.event.pull_request.user.login == 'pulumi-bot'
-      name: Enable automerge if successful for bot PRs
+      if: github.event.pull_request.user.login == 'pulumi-bot' &&
+        contains(toJson(github.event.pull_request.labels.*.name), 'auto-merge')
+      name: Enable automerge if successful for bot PRs with 'auto-merge' label
       run: gh pr merge --auto --squash $PR_URL
   test:
     if: github.event_name == 'repository_dispatch' ||

--- a/provider-ci/providers/okta/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/okta/repo/.github/workflows/run-acceptance-tests.yml
@@ -312,8 +312,13 @@ jobs:
     - lint_sdk
     runs-on: ubuntu-latest
     steps:
-    - name: Is workflow a success
-      run: echo yes
+    - env:
+        GITHUB_TOKEN: ${{secrets.PULUMI_BOT_TOKEN}}
+        PR_URL: ${{github.event.pull_request.html_url}}
+      id: enable-automerge
+      if: github.event.pull_request.user.login == 'pulumi-bot'
+      name: Enable automerge if successful for bot PRs
+      run: gh pr merge --auto --squash $PR_URL
   test:
     if: github.event_name == 'repository_dispatch' ||
       github.event.pull_request.head.repo.full_name == github.repository

--- a/provider-ci/providers/okta/repo/.github/workflows/update-bridge.yml
+++ b/provider-ci/providers/okta/repo/.github/workflows/update-bridge.yml
@@ -66,10 +66,6 @@ jobs:
         title: Update pulumi-terraform-bridge to v${{ github.event.inputs.bridge_version
           }}
         token: ${{ secrets.PULUMI_BOT_TOKEN }}
-    - if: steps.create-pr.outputs.pull-request-operation == 'created' &&
-        github.event.inputs.automerge == 'true'
-      run: gh pr merge --auto --squash ${{ steps.create-pr.outputs.pull-request-number
-        }}
     strategy:
       fail-fast: true
       matrix:
@@ -85,11 +81,6 @@ name: Update pulumi-terraform-bridge
 on:
   workflow_dispatch:
     inputs:
-      automerge:
-        default: false
-        description: Mark created PR for auto-merging?
-        required: true
-        type: boolean
       bridge_version:
         description: The version of pulumi/pulumi-terraform-bridge to update to. Do not
           include the 'v' prefix. Must be major version 3.

--- a/provider-ci/providers/okta/repo/.github/workflows/update-upstream-provider.yml
+++ b/provider-ci/providers/okta/repo/.github/workflows/update-upstream-provider.yml
@@ -145,11 +145,6 @@ name: Update upstream provider
 on:
   workflow_dispatch:
     inputs:
-      automerge:
-        default: false
-        description: Mark created PR for auto-merging?
-        required: true
-        type: boolean
       linked_issue_number:
         description: The issue number of a PR in this repository to which the generated
           pull request should be linked.

--- a/provider-ci/providers/onelogin/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/onelogin/repo/.github/workflows/run-acceptance-tests.yml
@@ -313,8 +313,9 @@ jobs:
         GITHUB_TOKEN: ${{secrets.PULUMI_BOT_TOKEN}}
         PR_URL: ${{github.event.pull_request.html_url}}
       id: enable-automerge
-      if: github.event.pull_request.user.login == 'pulumi-bot'
-      name: Enable automerge if successful for bot PRs
+      if: github.event.pull_request.user.login == 'pulumi-bot' &&
+        contains(toJson(github.event.pull_request.labels.*.name), 'auto-merge')
+      name: Enable automerge if successful for bot PRs with 'auto-merge' label
       run: gh pr merge --auto --squash $PR_URL
   test:
     if: github.event_name == 'repository_dispatch' ||

--- a/provider-ci/providers/onelogin/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/onelogin/repo/.github/workflows/run-acceptance-tests.yml
@@ -309,8 +309,13 @@ jobs:
     - lint_sdk
     runs-on: ubuntu-latest
     steps:
-    - name: Is workflow a success
-      run: echo yes
+    - env:
+        GITHUB_TOKEN: ${{secrets.PULUMI_BOT_TOKEN}}
+        PR_URL: ${{github.event.pull_request.html_url}}
+      id: enable-automerge
+      if: github.event.pull_request.user.login == 'pulumi-bot'
+      name: Enable automerge if successful for bot PRs
+      run: gh pr merge --auto --squash $PR_URL
   test:
     if: github.event_name == 'repository_dispatch' ||
       github.event.pull_request.head.repo.full_name == github.repository

--- a/provider-ci/providers/onelogin/repo/.github/workflows/update-bridge.yml
+++ b/provider-ci/providers/onelogin/repo/.github/workflows/update-bridge.yml
@@ -66,10 +66,6 @@ jobs:
         title: Update pulumi-terraform-bridge to v${{ github.event.inputs.bridge_version
           }}
         token: ${{ secrets.PULUMI_BOT_TOKEN }}
-    - if: steps.create-pr.outputs.pull-request-operation == 'created' &&
-        github.event.inputs.automerge == 'true'
-      run: gh pr merge --auto --squash ${{ steps.create-pr.outputs.pull-request-number
-        }}
     strategy:
       fail-fast: true
       matrix:
@@ -85,11 +81,6 @@ name: Update pulumi-terraform-bridge
 on:
   workflow_dispatch:
     inputs:
-      automerge:
-        default: false
-        description: Mark created PR for auto-merging?
-        required: true
-        type: boolean
       bridge_version:
         description: The version of pulumi/pulumi-terraform-bridge to update to. Do not
           include the 'v' prefix. Must be major version 3.

--- a/provider-ci/providers/onelogin/repo/.github/workflows/update-upstream-provider.yml
+++ b/provider-ci/providers/onelogin/repo/.github/workflows/update-upstream-provider.yml
@@ -142,11 +142,6 @@ name: Update upstream provider
 on:
   workflow_dispatch:
     inputs:
-      automerge:
-        default: false
-        description: Mark created PR for auto-merging?
-        required: true
-        type: boolean
       linked_issue_number:
         description: The issue number of a PR in this repository to which the generated
           pull request should be linked.

--- a/provider-ci/providers/openstack/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/openstack/repo/.github/workflows/run-acceptance-tests.yml
@@ -318,8 +318,13 @@ jobs:
     - lint_sdk
     runs-on: ubuntu-latest
     steps:
-    - name: Is workflow a success
-      run: echo yes
+    - env:
+        GITHUB_TOKEN: ${{secrets.PULUMI_BOT_TOKEN}}
+        PR_URL: ${{github.event.pull_request.html_url}}
+      id: enable-automerge
+      if: github.event.pull_request.user.login == 'pulumi-bot'
+      name: Enable automerge if successful for bot PRs
+      run: gh pr merge --auto --squash $PR_URL
   test:
     if: github.event_name == 'repository_dispatch' ||
       github.event.pull_request.head.repo.full_name == github.repository

--- a/provider-ci/providers/openstack/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/openstack/repo/.github/workflows/run-acceptance-tests.yml
@@ -322,8 +322,9 @@ jobs:
         GITHUB_TOKEN: ${{secrets.PULUMI_BOT_TOKEN}}
         PR_URL: ${{github.event.pull_request.html_url}}
       id: enable-automerge
-      if: github.event.pull_request.user.login == 'pulumi-bot'
-      name: Enable automerge if successful for bot PRs
+      if: github.event.pull_request.user.login == 'pulumi-bot' &&
+        contains(toJson(github.event.pull_request.labels.*.name), 'auto-merge')
+      name: Enable automerge if successful for bot PRs with 'auto-merge' label
       run: gh pr merge --auto --squash $PR_URL
   test:
     if: github.event_name == 'repository_dispatch' ||

--- a/provider-ci/providers/openstack/repo/.github/workflows/update-bridge.yml
+++ b/provider-ci/providers/openstack/repo/.github/workflows/update-bridge.yml
@@ -66,10 +66,6 @@ jobs:
         title: Update pulumi-terraform-bridge to v${{ github.event.inputs.bridge_version
           }}
         token: ${{ secrets.PULUMI_BOT_TOKEN }}
-    - if: steps.create-pr.outputs.pull-request-operation == 'created' &&
-        github.event.inputs.automerge == 'true'
-      run: gh pr merge --auto --squash ${{ steps.create-pr.outputs.pull-request-number
-        }}
     strategy:
       fail-fast: true
       matrix:
@@ -85,11 +81,6 @@ name: Update pulumi-terraform-bridge
 on:
   workflow_dispatch:
     inputs:
-      automerge:
-        default: false
-        description: Mark created PR for auto-merging?
-        required: true
-        type: boolean
       bridge_version:
         description: The version of pulumi/pulumi-terraform-bridge to update to. Do not
           include the 'v' prefix. Must be major version 3.

--- a/provider-ci/providers/openstack/repo/.github/workflows/update-upstream-provider.yml
+++ b/provider-ci/providers/openstack/repo/.github/workflows/update-upstream-provider.yml
@@ -151,11 +151,6 @@ name: Update upstream provider
 on:
   workflow_dispatch:
     inputs:
-      automerge:
-        default: false
-        description: Mark created PR for auto-merging?
-        required: true
-        type: boolean
       linked_issue_number:
         description: The issue number of a PR in this repository to which the generated
           pull request should be linked.

--- a/provider-ci/providers/opsgenie/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/opsgenie/repo/.github/workflows/run-acceptance-tests.yml
@@ -310,8 +310,13 @@ jobs:
     - lint_sdk
     runs-on: ubuntu-latest
     steps:
-    - name: Is workflow a success
-      run: echo yes
+    - env:
+        GITHUB_TOKEN: ${{secrets.PULUMI_BOT_TOKEN}}
+        PR_URL: ${{github.event.pull_request.html_url}}
+      id: enable-automerge
+      if: github.event.pull_request.user.login == 'pulumi-bot'
+      name: Enable automerge if successful for bot PRs
+      run: gh pr merge --auto --squash $PR_URL
   test:
     if: github.event_name == 'repository_dispatch' ||
       github.event.pull_request.head.repo.full_name == github.repository

--- a/provider-ci/providers/opsgenie/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/opsgenie/repo/.github/workflows/run-acceptance-tests.yml
@@ -314,8 +314,9 @@ jobs:
         GITHUB_TOKEN: ${{secrets.PULUMI_BOT_TOKEN}}
         PR_URL: ${{github.event.pull_request.html_url}}
       id: enable-automerge
-      if: github.event.pull_request.user.login == 'pulumi-bot'
-      name: Enable automerge if successful for bot PRs
+      if: github.event.pull_request.user.login == 'pulumi-bot' &&
+        contains(toJson(github.event.pull_request.labels.*.name), 'auto-merge')
+      name: Enable automerge if successful for bot PRs with 'auto-merge' label
       run: gh pr merge --auto --squash $PR_URL
   test:
     if: github.event_name == 'repository_dispatch' ||

--- a/provider-ci/providers/opsgenie/repo/.github/workflows/update-bridge.yml
+++ b/provider-ci/providers/opsgenie/repo/.github/workflows/update-bridge.yml
@@ -66,10 +66,6 @@ jobs:
         title: Update pulumi-terraform-bridge to v${{ github.event.inputs.bridge_version
           }}
         token: ${{ secrets.PULUMI_BOT_TOKEN }}
-    - if: steps.create-pr.outputs.pull-request-operation == 'created' &&
-        github.event.inputs.automerge == 'true'
-      run: gh pr merge --auto --squash ${{ steps.create-pr.outputs.pull-request-number
-        }}
     strategy:
       fail-fast: true
       matrix:
@@ -85,11 +81,6 @@ name: Update pulumi-terraform-bridge
 on:
   workflow_dispatch:
     inputs:
-      automerge:
-        default: false
-        description: Mark created PR for auto-merging?
-        required: true
-        type: boolean
       bridge_version:
         description: The version of pulumi/pulumi-terraform-bridge to update to. Do not
           include the 'v' prefix. Must be major version 3.

--- a/provider-ci/providers/opsgenie/repo/.github/workflows/update-upstream-provider.yml
+++ b/provider-ci/providers/opsgenie/repo/.github/workflows/update-upstream-provider.yml
@@ -143,11 +143,6 @@ name: Update upstream provider
 on:
   workflow_dispatch:
     inputs:
-      automerge:
-        default: false
-        description: Mark created PR for auto-merging?
-        required: true
-        type: boolean
       linked_issue_number:
         description: The issue number of a PR in this repository to which the generated
           pull request should be linked.

--- a/provider-ci/providers/pagerduty/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/pagerduty/repo/.github/workflows/run-acceptance-tests.yml
@@ -310,8 +310,13 @@ jobs:
     - lint_sdk
     runs-on: ubuntu-latest
     steps:
-    - name: Is workflow a success
-      run: echo yes
+    - env:
+        GITHUB_TOKEN: ${{secrets.PULUMI_BOT_TOKEN}}
+        PR_URL: ${{github.event.pull_request.html_url}}
+      id: enable-automerge
+      if: github.event.pull_request.user.login == 'pulumi-bot'
+      name: Enable automerge if successful for bot PRs
+      run: gh pr merge --auto --squash $PR_URL
   test:
     if: github.event_name == 'repository_dispatch' ||
       github.event.pull_request.head.repo.full_name == github.repository

--- a/provider-ci/providers/pagerduty/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/pagerduty/repo/.github/workflows/run-acceptance-tests.yml
@@ -314,8 +314,9 @@ jobs:
         GITHUB_TOKEN: ${{secrets.PULUMI_BOT_TOKEN}}
         PR_URL: ${{github.event.pull_request.html_url}}
       id: enable-automerge
-      if: github.event.pull_request.user.login == 'pulumi-bot'
-      name: Enable automerge if successful for bot PRs
+      if: github.event.pull_request.user.login == 'pulumi-bot' &&
+        contains(toJson(github.event.pull_request.labels.*.name), 'auto-merge')
+      name: Enable automerge if successful for bot PRs with 'auto-merge' label
       run: gh pr merge --auto --squash $PR_URL
   test:
     if: github.event_name == 'repository_dispatch' ||

--- a/provider-ci/providers/pagerduty/repo/.github/workflows/update-bridge.yml
+++ b/provider-ci/providers/pagerduty/repo/.github/workflows/update-bridge.yml
@@ -66,10 +66,6 @@ jobs:
         title: Update pulumi-terraform-bridge to v${{ github.event.inputs.bridge_version
           }}
         token: ${{ secrets.PULUMI_BOT_TOKEN }}
-    - if: steps.create-pr.outputs.pull-request-operation == 'created' &&
-        github.event.inputs.automerge == 'true'
-      run: gh pr merge --auto --squash ${{ steps.create-pr.outputs.pull-request-number
-        }}
     strategy:
       fail-fast: true
       matrix:
@@ -85,11 +81,6 @@ name: Update pulumi-terraform-bridge
 on:
   workflow_dispatch:
     inputs:
-      automerge:
-        default: false
-        description: Mark created PR for auto-merging?
-        required: true
-        type: boolean
       bridge_version:
         description: The version of pulumi/pulumi-terraform-bridge to update to. Do not
           include the 'v' prefix. Must be major version 3.

--- a/provider-ci/providers/pagerduty/repo/.github/workflows/update-upstream-provider.yml
+++ b/provider-ci/providers/pagerduty/repo/.github/workflows/update-upstream-provider.yml
@@ -143,11 +143,6 @@ name: Update upstream provider
 on:
   workflow_dispatch:
     inputs:
-      automerge:
-        default: false
-        description: Mark created PR for auto-merging?
-        required: true
-        type: boolean
       linked_issue_number:
         description: The issue number of a PR in this repository to which the generated
           pull request should be linked.

--- a/provider-ci/providers/postgresql/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/postgresql/repo/.github/workflows/run-acceptance-tests.yml
@@ -313,8 +313,9 @@ jobs:
         GITHUB_TOKEN: ${{secrets.PULUMI_BOT_TOKEN}}
         PR_URL: ${{github.event.pull_request.html_url}}
       id: enable-automerge
-      if: github.event.pull_request.user.login == 'pulumi-bot'
-      name: Enable automerge if successful for bot PRs
+      if: github.event.pull_request.user.login == 'pulumi-bot' &&
+        contains(toJson(github.event.pull_request.labels.*.name), 'auto-merge')
+      name: Enable automerge if successful for bot PRs with 'auto-merge' label
       run: gh pr merge --auto --squash $PR_URL
   test:
     if: github.event_name == 'repository_dispatch' ||

--- a/provider-ci/providers/postgresql/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/postgresql/repo/.github/workflows/run-acceptance-tests.yml
@@ -309,8 +309,13 @@ jobs:
     - lint_sdk
     runs-on: ubuntu-latest
     steps:
-    - name: Is workflow a success
-      run: echo yes
+    - env:
+        GITHUB_TOKEN: ${{secrets.PULUMI_BOT_TOKEN}}
+        PR_URL: ${{github.event.pull_request.html_url}}
+      id: enable-automerge
+      if: github.event.pull_request.user.login == 'pulumi-bot'
+      name: Enable automerge if successful for bot PRs
+      run: gh pr merge --auto --squash $PR_URL
   test:
     if: github.event_name == 'repository_dispatch' ||
       github.event.pull_request.head.repo.full_name == github.repository

--- a/provider-ci/providers/postgresql/repo/.github/workflows/update-bridge.yml
+++ b/provider-ci/providers/postgresql/repo/.github/workflows/update-bridge.yml
@@ -66,10 +66,6 @@ jobs:
         title: Update pulumi-terraform-bridge to v${{ github.event.inputs.bridge_version
           }}
         token: ${{ secrets.PULUMI_BOT_TOKEN }}
-    - if: steps.create-pr.outputs.pull-request-operation == 'created' &&
-        github.event.inputs.automerge == 'true'
-      run: gh pr merge --auto --squash ${{ steps.create-pr.outputs.pull-request-number
-        }}
     strategy:
       fail-fast: true
       matrix:
@@ -85,11 +81,6 @@ name: Update pulumi-terraform-bridge
 on:
   workflow_dispatch:
     inputs:
-      automerge:
-        default: false
-        description: Mark created PR for auto-merging?
-        required: true
-        type: boolean
       bridge_version:
         description: The version of pulumi/pulumi-terraform-bridge to update to. Do not
           include the 'v' prefix. Must be major version 3.

--- a/provider-ci/providers/postgresql/repo/.github/workflows/update-upstream-provider.yml
+++ b/provider-ci/providers/postgresql/repo/.github/workflows/update-upstream-provider.yml
@@ -142,11 +142,6 @@ name: Update upstream provider
 on:
   workflow_dispatch:
     inputs:
-      automerge:
-        default: false
-        description: Mark created PR for auto-merging?
-        required: true
-        type: boolean
       linked_issue_number:
         description: The issue number of a PR in this repository to which the generated
           pull request should be linked.

--- a/provider-ci/providers/rabbitmq/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/rabbitmq/repo/.github/workflows/run-acceptance-tests.yml
@@ -313,8 +313,9 @@ jobs:
         GITHUB_TOKEN: ${{secrets.PULUMI_BOT_TOKEN}}
         PR_URL: ${{github.event.pull_request.html_url}}
       id: enable-automerge
-      if: github.event.pull_request.user.login == 'pulumi-bot'
-      name: Enable automerge if successful for bot PRs
+      if: github.event.pull_request.user.login == 'pulumi-bot' &&
+        contains(toJson(github.event.pull_request.labels.*.name), 'auto-merge')
+      name: Enable automerge if successful for bot PRs with 'auto-merge' label
       run: gh pr merge --auto --squash $PR_URL
   test:
     if: github.event_name == 'repository_dispatch' ||

--- a/provider-ci/providers/rabbitmq/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/rabbitmq/repo/.github/workflows/run-acceptance-tests.yml
@@ -309,8 +309,13 @@ jobs:
     - lint_sdk
     runs-on: ubuntu-latest
     steps:
-    - name: Is workflow a success
-      run: echo yes
+    - env:
+        GITHUB_TOKEN: ${{secrets.PULUMI_BOT_TOKEN}}
+        PR_URL: ${{github.event.pull_request.html_url}}
+      id: enable-automerge
+      if: github.event.pull_request.user.login == 'pulumi-bot'
+      name: Enable automerge if successful for bot PRs
+      run: gh pr merge --auto --squash $PR_URL
   test:
     if: github.event_name == 'repository_dispatch' ||
       github.event.pull_request.head.repo.full_name == github.repository

--- a/provider-ci/providers/rabbitmq/repo/.github/workflows/update-bridge.yml
+++ b/provider-ci/providers/rabbitmq/repo/.github/workflows/update-bridge.yml
@@ -66,10 +66,6 @@ jobs:
         title: Update pulumi-terraform-bridge to v${{ github.event.inputs.bridge_version
           }}
         token: ${{ secrets.PULUMI_BOT_TOKEN }}
-    - if: steps.create-pr.outputs.pull-request-operation == 'created' &&
-        github.event.inputs.automerge == 'true'
-      run: gh pr merge --auto --squash ${{ steps.create-pr.outputs.pull-request-number
-        }}
     strategy:
       fail-fast: true
       matrix:
@@ -85,11 +81,6 @@ name: Update pulumi-terraform-bridge
 on:
   workflow_dispatch:
     inputs:
-      automerge:
-        default: false
-        description: Mark created PR for auto-merging?
-        required: true
-        type: boolean
       bridge_version:
         description: The version of pulumi/pulumi-terraform-bridge to update to. Do not
           include the 'v' prefix. Must be major version 3.

--- a/provider-ci/providers/rabbitmq/repo/.github/workflows/update-upstream-provider.yml
+++ b/provider-ci/providers/rabbitmq/repo/.github/workflows/update-upstream-provider.yml
@@ -142,11 +142,6 @@ name: Update upstream provider
 on:
   workflow_dispatch:
     inputs:
-      automerge:
-        default: false
-        description: Mark created PR for auto-merging?
-        required: true
-        type: boolean
       linked_issue_number:
         description: The issue number of a PR in this repository to which the generated
           pull request should be linked.

--- a/provider-ci/providers/rancher2/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/rancher2/repo/.github/workflows/run-acceptance-tests.yml
@@ -230,8 +230,9 @@ jobs:
         GITHUB_TOKEN: ${{secrets.PULUMI_BOT_TOKEN}}
         PR_URL: ${{github.event.pull_request.html_url}}
       id: enable-automerge
-      if: github.event.pull_request.user.login == 'pulumi-bot'
-      name: Enable automerge if successful for bot PRs
+      if: github.event.pull_request.user.login == 'pulumi-bot' &&
+        contains(toJson(github.event.pull_request.labels.*.name), 'auto-merge')
+      name: Enable automerge if successful for bot PRs with 'auto-merge' label
       run: gh pr merge --auto --squash $PR_URL
   test:
     if: github.event_name == 'repository_dispatch' ||

--- a/provider-ci/providers/rancher2/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/rancher2/repo/.github/workflows/run-acceptance-tests.yml
@@ -226,8 +226,13 @@ jobs:
     - test
     runs-on: ubuntu-latest
     steps:
-    - name: Is workflow a success
-      run: echo yes
+    - env:
+        GITHUB_TOKEN: ${{secrets.PULUMI_BOT_TOKEN}}
+        PR_URL: ${{github.event.pull_request.html_url}}
+      id: enable-automerge
+      if: github.event.pull_request.user.login == 'pulumi-bot'
+      name: Enable automerge if successful for bot PRs
+      run: gh pr merge --auto --squash $PR_URL
   test:
     if: github.event_name == 'repository_dispatch' ||
       github.event.pull_request.head.repo.full_name == github.repository

--- a/provider-ci/providers/rancher2/repo/.github/workflows/update-bridge.yml
+++ b/provider-ci/providers/rancher2/repo/.github/workflows/update-bridge.yml
@@ -66,10 +66,6 @@ jobs:
         title: Update pulumi-terraform-bridge to v${{ github.event.inputs.bridge_version
           }}
         token: ${{ secrets.PULUMI_BOT_TOKEN }}
-    - if: steps.create-pr.outputs.pull-request-operation == 'created' &&
-        github.event.inputs.automerge == 'true'
-      run: gh pr merge --auto --squash ${{ steps.create-pr.outputs.pull-request-number
-        }}
     strategy:
       fail-fast: true
       matrix:
@@ -85,11 +81,6 @@ name: Update pulumi-terraform-bridge
 on:
   workflow_dispatch:
     inputs:
-      automerge:
-        default: false
-        description: Mark created PR for auto-merging?
-        required: true
-        type: boolean
       bridge_version:
         description: The version of pulumi/pulumi-terraform-bridge to update to. Do not
           include the 'v' prefix. Must be major version 3.

--- a/provider-ci/providers/rancher2/repo/.github/workflows/update-upstream-provider.yml
+++ b/provider-ci/providers/rancher2/repo/.github/workflows/update-upstream-provider.yml
@@ -144,11 +144,6 @@ name: Update upstream provider
 on:
   workflow_dispatch:
     inputs:
-      automerge:
-        default: false
-        description: Mark created PR for auto-merging?
-        required: true
-        type: boolean
       linked_issue_number:
         description: The issue number of a PR in this repository to which the generated
           pull request should be linked.

--- a/provider-ci/providers/random/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/random/repo/.github/workflows/run-acceptance-tests.yml
@@ -313,8 +313,9 @@ jobs:
         GITHUB_TOKEN: ${{secrets.PULUMI_BOT_TOKEN}}
         PR_URL: ${{github.event.pull_request.html_url}}
       id: enable-automerge
-      if: github.event.pull_request.user.login == 'pulumi-bot'
-      name: Enable automerge if successful for bot PRs
+      if: github.event.pull_request.user.login == 'pulumi-bot' &&
+        contains(toJson(github.event.pull_request.labels.*.name), 'auto-merge')
+      name: Enable automerge if successful for bot PRs with 'auto-merge' label
       run: gh pr merge --auto --squash $PR_URL
   test:
     if: github.event_name == 'repository_dispatch' ||

--- a/provider-ci/providers/random/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/random/repo/.github/workflows/run-acceptance-tests.yml
@@ -309,8 +309,13 @@ jobs:
     - lint_sdk
     runs-on: ubuntu-latest
     steps:
-    - name: Is workflow a success
-      run: echo yes
+    - env:
+        GITHUB_TOKEN: ${{secrets.PULUMI_BOT_TOKEN}}
+        PR_URL: ${{github.event.pull_request.html_url}}
+      id: enable-automerge
+      if: github.event.pull_request.user.login == 'pulumi-bot'
+      name: Enable automerge if successful for bot PRs
+      run: gh pr merge --auto --squash $PR_URL
   test:
     if: github.event_name == 'repository_dispatch' ||
       github.event.pull_request.head.repo.full_name == github.repository

--- a/provider-ci/providers/random/repo/.github/workflows/update-bridge.yml
+++ b/provider-ci/providers/random/repo/.github/workflows/update-bridge.yml
@@ -66,10 +66,6 @@ jobs:
         title: Update pulumi-terraform-bridge to v${{ github.event.inputs.bridge_version
           }}
         token: ${{ secrets.PULUMI_BOT_TOKEN }}
-    - if: steps.create-pr.outputs.pull-request-operation == 'created' &&
-        github.event.inputs.automerge == 'true'
-      run: gh pr merge --auto --squash ${{ steps.create-pr.outputs.pull-request-number
-        }}
     strategy:
       fail-fast: true
       matrix:
@@ -85,11 +81,6 @@ name: Update pulumi-terraform-bridge
 on:
   workflow_dispatch:
     inputs:
-      automerge:
-        default: false
-        description: Mark created PR for auto-merging?
-        required: true
-        type: boolean
       bridge_version:
         description: The version of pulumi/pulumi-terraform-bridge to update to. Do not
           include the 'v' prefix. Must be major version 3.

--- a/provider-ci/providers/random/repo/.github/workflows/update-upstream-provider.yml
+++ b/provider-ci/providers/random/repo/.github/workflows/update-upstream-provider.yml
@@ -142,11 +142,6 @@ name: Update upstream provider
 on:
   workflow_dispatch:
     inputs:
-      automerge:
-        default: false
-        description: Mark created PR for auto-merging?
-        required: true
-        type: boolean
       linked_issue_number:
         description: The issue number of a PR in this repository to which the generated
           pull request should be linked.

--- a/provider-ci/providers/rke/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/rke/repo/.github/workflows/run-acceptance-tests.yml
@@ -310,8 +310,13 @@ jobs:
     - lint_sdk
     runs-on: ubuntu-latest
     steps:
-    - name: Is workflow a success
-      run: echo yes
+    - env:
+        GITHUB_TOKEN: ${{secrets.PULUMI_BOT_TOKEN}}
+        PR_URL: ${{github.event.pull_request.html_url}}
+      id: enable-automerge
+      if: github.event.pull_request.user.login == 'pulumi-bot'
+      name: Enable automerge if successful for bot PRs
+      run: gh pr merge --auto --squash $PR_URL
   test:
     if: github.event_name == 'repository_dispatch' ||
       github.event.pull_request.head.repo.full_name == github.repository

--- a/provider-ci/providers/rke/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/rke/repo/.github/workflows/run-acceptance-tests.yml
@@ -314,8 +314,9 @@ jobs:
         GITHUB_TOKEN: ${{secrets.PULUMI_BOT_TOKEN}}
         PR_URL: ${{github.event.pull_request.html_url}}
       id: enable-automerge
-      if: github.event.pull_request.user.login == 'pulumi-bot'
-      name: Enable automerge if successful for bot PRs
+      if: github.event.pull_request.user.login == 'pulumi-bot' &&
+        contains(toJson(github.event.pull_request.labels.*.name), 'auto-merge')
+      name: Enable automerge if successful for bot PRs with 'auto-merge' label
       run: gh pr merge --auto --squash $PR_URL
   test:
     if: github.event_name == 'repository_dispatch' ||

--- a/provider-ci/providers/rke/repo/.github/workflows/update-bridge.yml
+++ b/provider-ci/providers/rke/repo/.github/workflows/update-bridge.yml
@@ -66,10 +66,6 @@ jobs:
         title: Update pulumi-terraform-bridge to v${{ github.event.inputs.bridge_version
           }}
         token: ${{ secrets.PULUMI_BOT_TOKEN }}
-    - if: steps.create-pr.outputs.pull-request-operation == 'created' &&
-        github.event.inputs.automerge == 'true'
-      run: gh pr merge --auto --squash ${{ steps.create-pr.outputs.pull-request-number
-        }}
     strategy:
       fail-fast: true
       matrix:
@@ -85,11 +81,6 @@ name: Update pulumi-terraform-bridge
 on:
   workflow_dispatch:
     inputs:
-      automerge:
-        default: false
-        description: Mark created PR for auto-merging?
-        required: true
-        type: boolean
       bridge_version:
         description: The version of pulumi/pulumi-terraform-bridge to update to. Do not
           include the 'v' prefix. Must be major version 3.

--- a/provider-ci/providers/rke/repo/.github/workflows/update-upstream-provider.yml
+++ b/provider-ci/providers/rke/repo/.github/workflows/update-upstream-provider.yml
@@ -143,11 +143,6 @@ name: Update upstream provider
 on:
   workflow_dispatch:
     inputs:
-      automerge:
-        default: false
-        description: Mark created PR for auto-merging?
-        required: true
-        type: boolean
       linked_issue_number:
         description: The issue number of a PR in this repository to which the generated
           pull request should be linked.

--- a/provider-ci/providers/signalfx/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/signalfx/repo/.github/workflows/run-acceptance-tests.yml
@@ -313,8 +313,9 @@ jobs:
         GITHUB_TOKEN: ${{secrets.PULUMI_BOT_TOKEN}}
         PR_URL: ${{github.event.pull_request.html_url}}
       id: enable-automerge
-      if: github.event.pull_request.user.login == 'pulumi-bot'
-      name: Enable automerge if successful for bot PRs
+      if: github.event.pull_request.user.login == 'pulumi-bot' &&
+        contains(toJson(github.event.pull_request.labels.*.name), 'auto-merge')
+      name: Enable automerge if successful for bot PRs with 'auto-merge' label
       run: gh pr merge --auto --squash $PR_URL
   test:
     if: github.event_name == 'repository_dispatch' ||

--- a/provider-ci/providers/signalfx/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/signalfx/repo/.github/workflows/run-acceptance-tests.yml
@@ -309,8 +309,13 @@ jobs:
     - lint_sdk
     runs-on: ubuntu-latest
     steps:
-    - name: Is workflow a success
-      run: echo yes
+    - env:
+        GITHUB_TOKEN: ${{secrets.PULUMI_BOT_TOKEN}}
+        PR_URL: ${{github.event.pull_request.html_url}}
+      id: enable-automerge
+      if: github.event.pull_request.user.login == 'pulumi-bot'
+      name: Enable automerge if successful for bot PRs
+      run: gh pr merge --auto --squash $PR_URL
   test:
     if: github.event_name == 'repository_dispatch' ||
       github.event.pull_request.head.repo.full_name == github.repository

--- a/provider-ci/providers/signalfx/repo/.github/workflows/update-bridge.yml
+++ b/provider-ci/providers/signalfx/repo/.github/workflows/update-bridge.yml
@@ -66,10 +66,6 @@ jobs:
         title: Update pulumi-terraform-bridge to v${{ github.event.inputs.bridge_version
           }}
         token: ${{ secrets.PULUMI_BOT_TOKEN }}
-    - if: steps.create-pr.outputs.pull-request-operation == 'created' &&
-        github.event.inputs.automerge == 'true'
-      run: gh pr merge --auto --squash ${{ steps.create-pr.outputs.pull-request-number
-        }}
     strategy:
       fail-fast: true
       matrix:
@@ -85,11 +81,6 @@ name: Update pulumi-terraform-bridge
 on:
   workflow_dispatch:
     inputs:
-      automerge:
-        default: false
-        description: Mark created PR for auto-merging?
-        required: true
-        type: boolean
       bridge_version:
         description: The version of pulumi/pulumi-terraform-bridge to update to. Do not
           include the 'v' prefix. Must be major version 3.

--- a/provider-ci/providers/signalfx/repo/.github/workflows/update-upstream-provider.yml
+++ b/provider-ci/providers/signalfx/repo/.github/workflows/update-upstream-provider.yml
@@ -142,11 +142,6 @@ name: Update upstream provider
 on:
   workflow_dispatch:
     inputs:
-      automerge:
-        default: false
-        description: Mark created PR for auto-merging?
-        required: true
-        type: boolean
       linked_issue_number:
         description: The issue number of a PR in this repository to which the generated
           pull request should be linked.

--- a/provider-ci/providers/slack/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/slack/repo/.github/workflows/run-acceptance-tests.yml
@@ -310,8 +310,13 @@ jobs:
     - lint_sdk
     runs-on: ubuntu-latest
     steps:
-    - name: Is workflow a success
-      run: echo yes
+    - env:
+        GITHUB_TOKEN: ${{secrets.PULUMI_BOT_TOKEN}}
+        PR_URL: ${{github.event.pull_request.html_url}}
+      id: enable-automerge
+      if: github.event.pull_request.user.login == 'pulumi-bot'
+      name: Enable automerge if successful for bot PRs
+      run: gh pr merge --auto --squash $PR_URL
   test:
     if: github.event_name == 'repository_dispatch' ||
       github.event.pull_request.head.repo.full_name == github.repository

--- a/provider-ci/providers/slack/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/slack/repo/.github/workflows/run-acceptance-tests.yml
@@ -314,8 +314,9 @@ jobs:
         GITHUB_TOKEN: ${{secrets.PULUMI_BOT_TOKEN}}
         PR_URL: ${{github.event.pull_request.html_url}}
       id: enable-automerge
-      if: github.event.pull_request.user.login == 'pulumi-bot'
-      name: Enable automerge if successful for bot PRs
+      if: github.event.pull_request.user.login == 'pulumi-bot' &&
+        contains(toJson(github.event.pull_request.labels.*.name), 'auto-merge')
+      name: Enable automerge if successful for bot PRs with 'auto-merge' label
       run: gh pr merge --auto --squash $PR_URL
   test:
     if: github.event_name == 'repository_dispatch' ||

--- a/provider-ci/providers/slack/repo/.github/workflows/update-bridge.yml
+++ b/provider-ci/providers/slack/repo/.github/workflows/update-bridge.yml
@@ -66,10 +66,6 @@ jobs:
         title: Update pulumi-terraform-bridge to v${{ github.event.inputs.bridge_version
           }}
         token: ${{ secrets.PULUMI_BOT_TOKEN }}
-    - if: steps.create-pr.outputs.pull-request-operation == 'created' &&
-        github.event.inputs.automerge == 'true'
-      run: gh pr merge --auto --squash ${{ steps.create-pr.outputs.pull-request-number
-        }}
     strategy:
       fail-fast: true
       matrix:
@@ -85,11 +81,6 @@ name: Update pulumi-terraform-bridge
 on:
   workflow_dispatch:
     inputs:
-      automerge:
-        default: false
-        description: Mark created PR for auto-merging?
-        required: true
-        type: boolean
       bridge_version:
         description: The version of pulumi/pulumi-terraform-bridge to update to. Do not
           include the 'v' prefix. Must be major version 3.

--- a/provider-ci/providers/slack/repo/.github/workflows/update-upstream-provider.yml
+++ b/provider-ci/providers/slack/repo/.github/workflows/update-upstream-provider.yml
@@ -143,11 +143,6 @@ name: Update upstream provider
 on:
   workflow_dispatch:
     inputs:
-      automerge:
-        default: false
-        description: Mark created PR for auto-merging?
-        required: true
-        type: boolean
       linked_issue_number:
         description: The issue number of a PR in this repository to which the generated
           pull request should be linked.

--- a/provider-ci/providers/snowflake/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/snowflake/repo/.github/workflows/run-acceptance-tests.yml
@@ -318,8 +318,9 @@ jobs:
         GITHUB_TOKEN: ${{secrets.PULUMI_BOT_TOKEN}}
         PR_URL: ${{github.event.pull_request.html_url}}
       id: enable-automerge
-      if: github.event.pull_request.user.login == 'pulumi-bot'
-      name: Enable automerge if successful for bot PRs
+      if: github.event.pull_request.user.login == 'pulumi-bot' &&
+        contains(toJson(github.event.pull_request.labels.*.name), 'auto-merge')
+      name: Enable automerge if successful for bot PRs with 'auto-merge' label
       run: gh pr merge --auto --squash $PR_URL
   test:
     if: github.event_name == 'repository_dispatch' ||

--- a/provider-ci/providers/snowflake/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/snowflake/repo/.github/workflows/run-acceptance-tests.yml
@@ -314,8 +314,13 @@ jobs:
     - lint_sdk
     runs-on: ubuntu-latest
     steps:
-    - name: Is workflow a success
-      run: echo yes
+    - env:
+        GITHUB_TOKEN: ${{secrets.PULUMI_BOT_TOKEN}}
+        PR_URL: ${{github.event.pull_request.html_url}}
+      id: enable-automerge
+      if: github.event.pull_request.user.login == 'pulumi-bot'
+      name: Enable automerge if successful for bot PRs
+      run: gh pr merge --auto --squash $PR_URL
   test:
     if: github.event_name == 'repository_dispatch' ||
       github.event.pull_request.head.repo.full_name == github.repository

--- a/provider-ci/providers/snowflake/repo/.github/workflows/update-bridge.yml
+++ b/provider-ci/providers/snowflake/repo/.github/workflows/update-bridge.yml
@@ -66,10 +66,6 @@ jobs:
         title: Update pulumi-terraform-bridge to v${{ github.event.inputs.bridge_version
           }}
         token: ${{ secrets.PULUMI_BOT_TOKEN }}
-    - if: steps.create-pr.outputs.pull-request-operation == 'created' &&
-        github.event.inputs.automerge == 'true'
-      run: gh pr merge --auto --squash ${{ steps.create-pr.outputs.pull-request-number
-        }}
     strategy:
       fail-fast: true
       matrix:
@@ -85,11 +81,6 @@ name: Update pulumi-terraform-bridge
 on:
   workflow_dispatch:
     inputs:
-      automerge:
-        default: false
-        description: Mark created PR for auto-merging?
-        required: true
-        type: boolean
       bridge_version:
         description: The version of pulumi/pulumi-terraform-bridge to update to. Do not
           include the 'v' prefix. Must be major version 3.

--- a/provider-ci/providers/snowflake/repo/.github/workflows/update-upstream-provider.yml
+++ b/provider-ci/providers/snowflake/repo/.github/workflows/update-upstream-provider.yml
@@ -147,11 +147,6 @@ name: Update upstream provider
 on:
   workflow_dispatch:
     inputs:
-      automerge:
-        default: false
-        description: Mark created PR for auto-merging?
-        required: true
-        type: boolean
       linked_issue_number:
         description: The issue number of a PR in this repository to which the generated
           pull request should be linked.

--- a/provider-ci/providers/splunk/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/splunk/repo/.github/workflows/run-acceptance-tests.yml
@@ -316,8 +316,9 @@ jobs:
         GITHUB_TOKEN: ${{secrets.PULUMI_BOT_TOKEN}}
         PR_URL: ${{github.event.pull_request.html_url}}
       id: enable-automerge
-      if: github.event.pull_request.user.login == 'pulumi-bot'
-      name: Enable automerge if successful for bot PRs
+      if: github.event.pull_request.user.login == 'pulumi-bot' &&
+        contains(toJson(github.event.pull_request.labels.*.name), 'auto-merge')
+      name: Enable automerge if successful for bot PRs with 'auto-merge' label
       run: gh pr merge --auto --squash $PR_URL
   test:
     if: github.event_name == 'repository_dispatch' ||

--- a/provider-ci/providers/splunk/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/splunk/repo/.github/workflows/run-acceptance-tests.yml
@@ -312,8 +312,13 @@ jobs:
     - lint_sdk
     runs-on: ubuntu-latest
     steps:
-    - name: Is workflow a success
-      run: echo yes
+    - env:
+        GITHUB_TOKEN: ${{secrets.PULUMI_BOT_TOKEN}}
+        PR_URL: ${{github.event.pull_request.html_url}}
+      id: enable-automerge
+      if: github.event.pull_request.user.login == 'pulumi-bot'
+      name: Enable automerge if successful for bot PRs
+      run: gh pr merge --auto --squash $PR_URL
   test:
     if: github.event_name == 'repository_dispatch' ||
       github.event.pull_request.head.repo.full_name == github.repository

--- a/provider-ci/providers/splunk/repo/.github/workflows/update-bridge.yml
+++ b/provider-ci/providers/splunk/repo/.github/workflows/update-bridge.yml
@@ -66,10 +66,6 @@ jobs:
         title: Update pulumi-terraform-bridge to v${{ github.event.inputs.bridge_version
           }}
         token: ${{ secrets.PULUMI_BOT_TOKEN }}
-    - if: steps.create-pr.outputs.pull-request-operation == 'created' &&
-        github.event.inputs.automerge == 'true'
-      run: gh pr merge --auto --squash ${{ steps.create-pr.outputs.pull-request-number
-        }}
     strategy:
       fail-fast: true
       matrix:
@@ -85,11 +81,6 @@ name: Update pulumi-terraform-bridge
 on:
   workflow_dispatch:
     inputs:
-      automerge:
-        default: false
-        description: Mark created PR for auto-merging?
-        required: true
-        type: boolean
       bridge_version:
         description: The version of pulumi/pulumi-terraform-bridge to update to. Do not
           include the 'v' prefix. Must be major version 3.

--- a/provider-ci/providers/splunk/repo/.github/workflows/update-upstream-provider.yml
+++ b/provider-ci/providers/splunk/repo/.github/workflows/update-upstream-provider.yml
@@ -145,11 +145,6 @@ name: Update upstream provider
 on:
   workflow_dispatch:
     inputs:
-      automerge:
-        default: false
-        description: Mark created PR for auto-merging?
-        required: true
-        type: boolean
       linked_issue_number:
         description: The issue number of a PR in this repository to which the generated
           pull request should be linked.

--- a/provider-ci/providers/spotinst/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/spotinst/repo/.github/workflows/run-acceptance-tests.yml
@@ -316,8 +316,9 @@ jobs:
         GITHUB_TOKEN: ${{secrets.PULUMI_BOT_TOKEN}}
         PR_URL: ${{github.event.pull_request.html_url}}
       id: enable-automerge
-      if: github.event.pull_request.user.login == 'pulumi-bot'
-      name: Enable automerge if successful for bot PRs
+      if: github.event.pull_request.user.login == 'pulumi-bot' &&
+        contains(toJson(github.event.pull_request.labels.*.name), 'auto-merge')
+      name: Enable automerge if successful for bot PRs with 'auto-merge' label
       run: gh pr merge --auto --squash $PR_URL
   test:
     if: github.event_name == 'repository_dispatch' ||

--- a/provider-ci/providers/spotinst/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/spotinst/repo/.github/workflows/run-acceptance-tests.yml
@@ -312,8 +312,13 @@ jobs:
     - lint_sdk
     runs-on: ubuntu-latest
     steps:
-    - name: Is workflow a success
-      run: echo yes
+    - env:
+        GITHUB_TOKEN: ${{secrets.PULUMI_BOT_TOKEN}}
+        PR_URL: ${{github.event.pull_request.html_url}}
+      id: enable-automerge
+      if: github.event.pull_request.user.login == 'pulumi-bot'
+      name: Enable automerge if successful for bot PRs
+      run: gh pr merge --auto --squash $PR_URL
   test:
     if: github.event_name == 'repository_dispatch' ||
       github.event.pull_request.head.repo.full_name == github.repository

--- a/provider-ci/providers/spotinst/repo/.github/workflows/update-bridge.yml
+++ b/provider-ci/providers/spotinst/repo/.github/workflows/update-bridge.yml
@@ -66,10 +66,6 @@ jobs:
         title: Update pulumi-terraform-bridge to v${{ github.event.inputs.bridge_version
           }}
         token: ${{ secrets.PULUMI_BOT_TOKEN }}
-    - if: steps.create-pr.outputs.pull-request-operation == 'created' &&
-        github.event.inputs.automerge == 'true'
-      run: gh pr merge --auto --squash ${{ steps.create-pr.outputs.pull-request-number
-        }}
     strategy:
       fail-fast: true
       matrix:
@@ -85,11 +81,6 @@ name: Update pulumi-terraform-bridge
 on:
   workflow_dispatch:
     inputs:
-      automerge:
-        default: false
-        description: Mark created PR for auto-merging?
-        required: true
-        type: boolean
       bridge_version:
         description: The version of pulumi/pulumi-terraform-bridge to update to. Do not
           include the 'v' prefix. Must be major version 3.

--- a/provider-ci/providers/spotinst/repo/.github/workflows/update-upstream-provider.yml
+++ b/provider-ci/providers/spotinst/repo/.github/workflows/update-upstream-provider.yml
@@ -145,11 +145,6 @@ name: Update upstream provider
 on:
   workflow_dispatch:
     inputs:
-      automerge:
-        default: false
-        description: Mark created PR for auto-merging?
-        required: true
-        type: boolean
       linked_issue_number:
         description: The issue number of a PR in this repository to which the generated
           pull request should be linked.

--- a/provider-ci/providers/sumologic/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/sumologic/repo/.github/workflows/run-acceptance-tests.yml
@@ -316,8 +316,9 @@ jobs:
         GITHUB_TOKEN: ${{secrets.PULUMI_BOT_TOKEN}}
         PR_URL: ${{github.event.pull_request.html_url}}
       id: enable-automerge
-      if: github.event.pull_request.user.login == 'pulumi-bot'
-      name: Enable automerge if successful for bot PRs
+      if: github.event.pull_request.user.login == 'pulumi-bot' &&
+        contains(toJson(github.event.pull_request.labels.*.name), 'auto-merge')
+      name: Enable automerge if successful for bot PRs with 'auto-merge' label
       run: gh pr merge --auto --squash $PR_URL
   test:
     if: github.event_name == 'repository_dispatch' ||

--- a/provider-ci/providers/sumologic/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/sumologic/repo/.github/workflows/run-acceptance-tests.yml
@@ -312,8 +312,13 @@ jobs:
     - lint_sdk
     runs-on: ubuntu-latest
     steps:
-    - name: Is workflow a success
-      run: echo yes
+    - env:
+        GITHUB_TOKEN: ${{secrets.PULUMI_BOT_TOKEN}}
+        PR_URL: ${{github.event.pull_request.html_url}}
+      id: enable-automerge
+      if: github.event.pull_request.user.login == 'pulumi-bot'
+      name: Enable automerge if successful for bot PRs
+      run: gh pr merge --auto --squash $PR_URL
   test:
     if: github.event_name == 'repository_dispatch' ||
       github.event.pull_request.head.repo.full_name == github.repository

--- a/provider-ci/providers/sumologic/repo/.github/workflows/update-bridge.yml
+++ b/provider-ci/providers/sumologic/repo/.github/workflows/update-bridge.yml
@@ -66,10 +66,6 @@ jobs:
         title: Update pulumi-terraform-bridge to v${{ github.event.inputs.bridge_version
           }}
         token: ${{ secrets.PULUMI_BOT_TOKEN }}
-    - if: steps.create-pr.outputs.pull-request-operation == 'created' &&
-        github.event.inputs.automerge == 'true'
-      run: gh pr merge --auto --squash ${{ steps.create-pr.outputs.pull-request-number
-        }}
     strategy:
       fail-fast: true
       matrix:
@@ -85,11 +81,6 @@ name: Update pulumi-terraform-bridge
 on:
   workflow_dispatch:
     inputs:
-      automerge:
-        default: false
-        description: Mark created PR for auto-merging?
-        required: true
-        type: boolean
       bridge_version:
         description: The version of pulumi/pulumi-terraform-bridge to update to. Do not
           include the 'v' prefix. Must be major version 3.

--- a/provider-ci/providers/sumologic/repo/.github/workflows/update-upstream-provider.yml
+++ b/provider-ci/providers/sumologic/repo/.github/workflows/update-upstream-provider.yml
@@ -145,11 +145,6 @@ name: Update upstream provider
 on:
   workflow_dispatch:
     inputs:
-      automerge:
-        default: false
-        description: Mark created PR for auto-merging?
-        required: true
-        type: boolean
       linked_issue_number:
         description: The issue number of a PR in this repository to which the generated
           pull request should be linked.

--- a/provider-ci/providers/tailscale/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/tailscale/repo/.github/workflows/run-acceptance-tests.yml
@@ -311,8 +311,13 @@ jobs:
     - lint_sdk
     runs-on: ubuntu-latest
     steps:
-    - name: Is workflow a success
-      run: echo yes
+    - env:
+        GITHUB_TOKEN: ${{secrets.PULUMI_BOT_TOKEN}}
+        PR_URL: ${{github.event.pull_request.html_url}}
+      id: enable-automerge
+      if: github.event.pull_request.user.login == 'pulumi-bot'
+      name: Enable automerge if successful for bot PRs
+      run: gh pr merge --auto --squash $PR_URL
   test:
     if: github.event_name == 'repository_dispatch' ||
       github.event.pull_request.head.repo.full_name == github.repository

--- a/provider-ci/providers/tailscale/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/tailscale/repo/.github/workflows/run-acceptance-tests.yml
@@ -315,8 +315,9 @@ jobs:
         GITHUB_TOKEN: ${{secrets.PULUMI_BOT_TOKEN}}
         PR_URL: ${{github.event.pull_request.html_url}}
       id: enable-automerge
-      if: github.event.pull_request.user.login == 'pulumi-bot'
-      name: Enable automerge if successful for bot PRs
+      if: github.event.pull_request.user.login == 'pulumi-bot' &&
+        contains(toJson(github.event.pull_request.labels.*.name), 'auto-merge')
+      name: Enable automerge if successful for bot PRs with 'auto-merge' label
       run: gh pr merge --auto --squash $PR_URL
   test:
     if: github.event_name == 'repository_dispatch' ||

--- a/provider-ci/providers/tailscale/repo/.github/workflows/update-bridge.yml
+++ b/provider-ci/providers/tailscale/repo/.github/workflows/update-bridge.yml
@@ -66,10 +66,6 @@ jobs:
         title: Update pulumi-terraform-bridge to v${{ github.event.inputs.bridge_version
           }}
         token: ${{ secrets.PULUMI_BOT_TOKEN }}
-    - if: steps.create-pr.outputs.pull-request-operation == 'created' &&
-        github.event.inputs.automerge == 'true'
-      run: gh pr merge --auto --squash ${{ steps.create-pr.outputs.pull-request-number
-        }}
     strategy:
       fail-fast: true
       matrix:
@@ -85,11 +81,6 @@ name: Update pulumi-terraform-bridge
 on:
   workflow_dispatch:
     inputs:
-      automerge:
-        default: false
-        description: Mark created PR for auto-merging?
-        required: true
-        type: boolean
       bridge_version:
         description: The version of pulumi/pulumi-terraform-bridge to update to. Do not
           include the 'v' prefix. Must be major version 3.

--- a/provider-ci/providers/tailscale/repo/.github/workflows/update-upstream-provider.yml
+++ b/provider-ci/providers/tailscale/repo/.github/workflows/update-upstream-provider.yml
@@ -144,11 +144,6 @@ name: Update upstream provider
 on:
   workflow_dispatch:
     inputs:
-      automerge:
-        default: false
-        description: Mark created PR for auto-merging?
-        required: true
-        type: boolean
       linked_issue_number:
         description: The issue number of a PR in this repository to which the generated
           pull request should be linked.

--- a/provider-ci/providers/tls/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/tls/repo/.github/workflows/run-acceptance-tests.yml
@@ -313,8 +313,9 @@ jobs:
         GITHUB_TOKEN: ${{secrets.PULUMI_BOT_TOKEN}}
         PR_URL: ${{github.event.pull_request.html_url}}
       id: enable-automerge
-      if: github.event.pull_request.user.login == 'pulumi-bot'
-      name: Enable automerge if successful for bot PRs
+      if: github.event.pull_request.user.login == 'pulumi-bot' &&
+        contains(toJson(github.event.pull_request.labels.*.name), 'auto-merge')
+      name: Enable automerge if successful for bot PRs with 'auto-merge' label
       run: gh pr merge --auto --squash $PR_URL
   test:
     if: github.event_name == 'repository_dispatch' ||

--- a/provider-ci/providers/tls/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/tls/repo/.github/workflows/run-acceptance-tests.yml
@@ -309,8 +309,13 @@ jobs:
     - lint_sdk
     runs-on: ubuntu-latest
     steps:
-    - name: Is workflow a success
-      run: echo yes
+    - env:
+        GITHUB_TOKEN: ${{secrets.PULUMI_BOT_TOKEN}}
+        PR_URL: ${{github.event.pull_request.html_url}}
+      id: enable-automerge
+      if: github.event.pull_request.user.login == 'pulumi-bot'
+      name: Enable automerge if successful for bot PRs
+      run: gh pr merge --auto --squash $PR_URL
   test:
     if: github.event_name == 'repository_dispatch' ||
       github.event.pull_request.head.repo.full_name == github.repository

--- a/provider-ci/providers/tls/repo/.github/workflows/update-bridge.yml
+++ b/provider-ci/providers/tls/repo/.github/workflows/update-bridge.yml
@@ -66,10 +66,6 @@ jobs:
         title: Update pulumi-terraform-bridge to v${{ github.event.inputs.bridge_version
           }}
         token: ${{ secrets.PULUMI_BOT_TOKEN }}
-    - if: steps.create-pr.outputs.pull-request-operation == 'created' &&
-        github.event.inputs.automerge == 'true'
-      run: gh pr merge --auto --squash ${{ steps.create-pr.outputs.pull-request-number
-        }}
     strategy:
       fail-fast: true
       matrix:
@@ -85,11 +81,6 @@ name: Update pulumi-terraform-bridge
 on:
   workflow_dispatch:
     inputs:
-      automerge:
-        default: false
-        description: Mark created PR for auto-merging?
-        required: true
-        type: boolean
       bridge_version:
         description: The version of pulumi/pulumi-terraform-bridge to update to. Do not
           include the 'v' prefix. Must be major version 3.

--- a/provider-ci/providers/tls/repo/.github/workflows/update-upstream-provider.yml
+++ b/provider-ci/providers/tls/repo/.github/workflows/update-upstream-provider.yml
@@ -142,11 +142,6 @@ name: Update upstream provider
 on:
   workflow_dispatch:
     inputs:
-      automerge:
-        default: false
-        description: Mark created PR for auto-merging?
-        required: true
-        type: boolean
       linked_issue_number:
         description: The issue number of a PR in this repository to which the generated
           pull request should be linked.

--- a/provider-ci/providers/vault/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/vault/repo/.github/workflows/run-acceptance-tests.yml
@@ -313,8 +313,9 @@ jobs:
         GITHUB_TOKEN: ${{secrets.PULUMI_BOT_TOKEN}}
         PR_URL: ${{github.event.pull_request.html_url}}
       id: enable-automerge
-      if: github.event.pull_request.user.login == 'pulumi-bot'
-      name: Enable automerge if successful for bot PRs
+      if: github.event.pull_request.user.login == 'pulumi-bot' &&
+        contains(toJson(github.event.pull_request.labels.*.name), 'auto-merge')
+      name: Enable automerge if successful for bot PRs with 'auto-merge' label
       run: gh pr merge --auto --squash $PR_URL
   test:
     if: github.event_name == 'repository_dispatch' ||

--- a/provider-ci/providers/vault/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/vault/repo/.github/workflows/run-acceptance-tests.yml
@@ -309,8 +309,13 @@ jobs:
     - lint_sdk
     runs-on: ubuntu-latest
     steps:
-    - name: Is workflow a success
-      run: echo yes
+    - env:
+        GITHUB_TOKEN: ${{secrets.PULUMI_BOT_TOKEN}}
+        PR_URL: ${{github.event.pull_request.html_url}}
+      id: enable-automerge
+      if: github.event.pull_request.user.login == 'pulumi-bot'
+      name: Enable automerge if successful for bot PRs
+      run: gh pr merge --auto --squash $PR_URL
   test:
     if: github.event_name == 'repository_dispatch' ||
       github.event.pull_request.head.repo.full_name == github.repository

--- a/provider-ci/providers/vault/repo/.github/workflows/update-bridge.yml
+++ b/provider-ci/providers/vault/repo/.github/workflows/update-bridge.yml
@@ -66,10 +66,6 @@ jobs:
         title: Update pulumi-terraform-bridge to v${{ github.event.inputs.bridge_version
           }}
         token: ${{ secrets.PULUMI_BOT_TOKEN }}
-    - if: steps.create-pr.outputs.pull-request-operation == 'created' &&
-        github.event.inputs.automerge == 'true'
-      run: gh pr merge --auto --squash ${{ steps.create-pr.outputs.pull-request-number
-        }}
     strategy:
       fail-fast: true
       matrix:
@@ -85,11 +81,6 @@ name: Update pulumi-terraform-bridge
 on:
   workflow_dispatch:
     inputs:
-      automerge:
-        default: false
-        description: Mark created PR for auto-merging?
-        required: true
-        type: boolean
       bridge_version:
         description: The version of pulumi/pulumi-terraform-bridge to update to. Do not
           include the 'v' prefix. Must be major version 3.

--- a/provider-ci/providers/vault/repo/.github/workflows/update-upstream-provider.yml
+++ b/provider-ci/providers/vault/repo/.github/workflows/update-upstream-provider.yml
@@ -142,11 +142,6 @@ name: Update upstream provider
 on:
   workflow_dispatch:
     inputs:
-      automerge:
-        default: false
-        description: Mark created PR for auto-merging?
-        required: true
-        type: boolean
       linked_issue_number:
         description: The issue number of a PR in this repository to which the generated
           pull request should be linked.

--- a/provider-ci/providers/venafi/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/venafi/repo/.github/workflows/run-acceptance-tests.yml
@@ -316,8 +316,9 @@ jobs:
         GITHUB_TOKEN: ${{secrets.PULUMI_BOT_TOKEN}}
         PR_URL: ${{github.event.pull_request.html_url}}
       id: enable-automerge
-      if: github.event.pull_request.user.login == 'pulumi-bot'
-      name: Enable automerge if successful for bot PRs
+      if: github.event.pull_request.user.login == 'pulumi-bot' &&
+        contains(toJson(github.event.pull_request.labels.*.name), 'auto-merge')
+      name: Enable automerge if successful for bot PRs with 'auto-merge' label
       run: gh pr merge --auto --squash $PR_URL
   test:
     if: github.event_name == 'repository_dispatch' ||

--- a/provider-ci/providers/venafi/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/venafi/repo/.github/workflows/run-acceptance-tests.yml
@@ -312,8 +312,13 @@ jobs:
     - lint_sdk
     runs-on: ubuntu-latest
     steps:
-    - name: Is workflow a success
-      run: echo yes
+    - env:
+        GITHUB_TOKEN: ${{secrets.PULUMI_BOT_TOKEN}}
+        PR_URL: ${{github.event.pull_request.html_url}}
+      id: enable-automerge
+      if: github.event.pull_request.user.login == 'pulumi-bot'
+      name: Enable automerge if successful for bot PRs
+      run: gh pr merge --auto --squash $PR_URL
   test:
     if: github.event_name == 'repository_dispatch' ||
       github.event.pull_request.head.repo.full_name == github.repository

--- a/provider-ci/providers/venafi/repo/.github/workflows/update-bridge.yml
+++ b/provider-ci/providers/venafi/repo/.github/workflows/update-bridge.yml
@@ -66,10 +66,6 @@ jobs:
         title: Update pulumi-terraform-bridge to v${{ github.event.inputs.bridge_version
           }}
         token: ${{ secrets.PULUMI_BOT_TOKEN }}
-    - if: steps.create-pr.outputs.pull-request-operation == 'created' &&
-        github.event.inputs.automerge == 'true'
-      run: gh pr merge --auto --squash ${{ steps.create-pr.outputs.pull-request-number
-        }}
     strategy:
       fail-fast: true
       matrix:
@@ -85,11 +81,6 @@ name: Update pulumi-terraform-bridge
 on:
   workflow_dispatch:
     inputs:
-      automerge:
-        default: false
-        description: Mark created PR for auto-merging?
-        required: true
-        type: boolean
       bridge_version:
         description: The version of pulumi/pulumi-terraform-bridge to update to. Do not
           include the 'v' prefix. Must be major version 3.

--- a/provider-ci/providers/venafi/repo/.github/workflows/update-upstream-provider.yml
+++ b/provider-ci/providers/venafi/repo/.github/workflows/update-upstream-provider.yml
@@ -145,11 +145,6 @@ name: Update upstream provider
 on:
   workflow_dispatch:
     inputs:
-      automerge:
-        default: false
-        description: Mark created PR for auto-merging?
-        required: true
-        type: boolean
       linked_issue_number:
         description: The issue number of a PR in this repository to which the generated
           pull request should be linked.

--- a/provider-ci/providers/vsphere/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/vsphere/repo/.github/workflows/run-acceptance-tests.yml
@@ -313,8 +313,9 @@ jobs:
         GITHUB_TOKEN: ${{secrets.PULUMI_BOT_TOKEN}}
         PR_URL: ${{github.event.pull_request.html_url}}
       id: enable-automerge
-      if: github.event.pull_request.user.login == 'pulumi-bot'
-      name: Enable automerge if successful for bot PRs
+      if: github.event.pull_request.user.login == 'pulumi-bot' &&
+        contains(toJson(github.event.pull_request.labels.*.name), 'auto-merge')
+      name: Enable automerge if successful for bot PRs with 'auto-merge' label
       run: gh pr merge --auto --squash $PR_URL
   test:
     if: github.event_name == 'repository_dispatch' ||

--- a/provider-ci/providers/vsphere/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/vsphere/repo/.github/workflows/run-acceptance-tests.yml
@@ -309,8 +309,13 @@ jobs:
     - lint_sdk
     runs-on: ubuntu-latest
     steps:
-    - name: Is workflow a success
-      run: echo yes
+    - env:
+        GITHUB_TOKEN: ${{secrets.PULUMI_BOT_TOKEN}}
+        PR_URL: ${{github.event.pull_request.html_url}}
+      id: enable-automerge
+      if: github.event.pull_request.user.login == 'pulumi-bot'
+      name: Enable automerge if successful for bot PRs
+      run: gh pr merge --auto --squash $PR_URL
   test:
     if: github.event_name == 'repository_dispatch' ||
       github.event.pull_request.head.repo.full_name == github.repository

--- a/provider-ci/providers/vsphere/repo/.github/workflows/update-bridge.yml
+++ b/provider-ci/providers/vsphere/repo/.github/workflows/update-bridge.yml
@@ -66,10 +66,6 @@ jobs:
         title: Update pulumi-terraform-bridge to v${{ github.event.inputs.bridge_version
           }}
         token: ${{ secrets.PULUMI_BOT_TOKEN }}
-    - if: steps.create-pr.outputs.pull-request-operation == 'created' &&
-        github.event.inputs.automerge == 'true'
-      run: gh pr merge --auto --squash ${{ steps.create-pr.outputs.pull-request-number
-        }}
     strategy:
       fail-fast: true
       matrix:
@@ -85,11 +81,6 @@ name: Update pulumi-terraform-bridge
 on:
   workflow_dispatch:
     inputs:
-      automerge:
-        default: false
-        description: Mark created PR for auto-merging?
-        required: true
-        type: boolean
       bridge_version:
         description: The version of pulumi/pulumi-terraform-bridge to update to. Do not
           include the 'v' prefix. Must be major version 3.

--- a/provider-ci/providers/vsphere/repo/.github/workflows/update-upstream-provider.yml
+++ b/provider-ci/providers/vsphere/repo/.github/workflows/update-upstream-provider.yml
@@ -142,11 +142,6 @@ name: Update upstream provider
 on:
   workflow_dispatch:
     inputs:
-      automerge:
-        default: false
-        description: Mark created PR for auto-merging?
-        required: true
-        type: boolean
       linked_issue_number:
         description: The issue number of a PR in this repository to which the generated
           pull request should be linked.

--- a/provider-ci/providers/wavefront/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/wavefront/repo/.github/workflows/run-acceptance-tests.yml
@@ -311,8 +311,13 @@ jobs:
     - lint_sdk
     runs-on: ubuntu-latest
     steps:
-    - name: Is workflow a success
-      run: echo yes
+    - env:
+        GITHUB_TOKEN: ${{secrets.PULUMI_BOT_TOKEN}}
+        PR_URL: ${{github.event.pull_request.html_url}}
+      id: enable-automerge
+      if: github.event.pull_request.user.login == 'pulumi-bot'
+      name: Enable automerge if successful for bot PRs
+      run: gh pr merge --auto --squash $PR_URL
   test:
     if: github.event_name == 'repository_dispatch' ||
       github.event.pull_request.head.repo.full_name == github.repository

--- a/provider-ci/providers/wavefront/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/wavefront/repo/.github/workflows/run-acceptance-tests.yml
@@ -315,8 +315,9 @@ jobs:
         GITHUB_TOKEN: ${{secrets.PULUMI_BOT_TOKEN}}
         PR_URL: ${{github.event.pull_request.html_url}}
       id: enable-automerge
-      if: github.event.pull_request.user.login == 'pulumi-bot'
-      name: Enable automerge if successful for bot PRs
+      if: github.event.pull_request.user.login == 'pulumi-bot' &&
+        contains(toJson(github.event.pull_request.labels.*.name), 'auto-merge')
+      name: Enable automerge if successful for bot PRs with 'auto-merge' label
       run: gh pr merge --auto --squash $PR_URL
   test:
     if: github.event_name == 'repository_dispatch' ||

--- a/provider-ci/providers/wavefront/repo/.github/workflows/update-bridge.yml
+++ b/provider-ci/providers/wavefront/repo/.github/workflows/update-bridge.yml
@@ -66,10 +66,6 @@ jobs:
         title: Update pulumi-terraform-bridge to v${{ github.event.inputs.bridge_version
           }}
         token: ${{ secrets.PULUMI_BOT_TOKEN }}
-    - if: steps.create-pr.outputs.pull-request-operation == 'created' &&
-        github.event.inputs.automerge == 'true'
-      run: gh pr merge --auto --squash ${{ steps.create-pr.outputs.pull-request-number
-        }}
     strategy:
       fail-fast: true
       matrix:
@@ -85,11 +81,6 @@ name: Update pulumi-terraform-bridge
 on:
   workflow_dispatch:
     inputs:
-      automerge:
-        default: false
-        description: Mark created PR for auto-merging?
-        required: true
-        type: boolean
       bridge_version:
         description: The version of pulumi/pulumi-terraform-bridge to update to. Do not
           include the 'v' prefix. Must be major version 3.

--- a/provider-ci/providers/wavefront/repo/.github/workflows/update-upstream-provider.yml
+++ b/provider-ci/providers/wavefront/repo/.github/workflows/update-upstream-provider.yml
@@ -144,11 +144,6 @@ name: Update upstream provider
 on:
   workflow_dispatch:
     inputs:
-      automerge:
-        default: false
-        description: Mark created PR for auto-merging?
-        required: true
-        type: boolean
       linked_issue_number:
         description: The issue number of a PR in this repository to which the generated
           pull request should be linked.

--- a/provider-ci/src/steps.ts
+++ b/provider-ci/src/steps.ts
@@ -578,8 +578,8 @@ export function CreateCommentsUrlStep(): Step {
 
 export function EnableAutoMerge(): Step {
   return {
-    name: "Enable automerge if successful for bot PRs",
-    if: "github.event.pull_request.user.login == 'pulumi-bot'",
+    name: "Enable automerge if successful for bot PRs with 'auto-merge' label",
+    if: "github.event.pull_request.user.login == 'pulumi-bot' && contains(toJson(github.event.pull_request.labels.*.name), 'auto-merge')",
     id: "enable-automerge",
     run: "gh pr merge --auto --squash $PR_URL",
     env: {

--- a/provider-ci/src/steps.ts
+++ b/provider-ci/src/steps.ts
@@ -576,10 +576,16 @@ export function CreateCommentsUrlStep(): Step {
   };
 }
 
-export function EchoSuccessStep(): Step {
+export function EnableAutoMerge(): Step {
   return {
-    name: "Is workflow a success",
-    run: "echo yes",
+    name: "Enable automerge if successful for bot PRs",
+    if: "github.event.pull_request.user.login == 'pulumi-bot'",
+    id: "enable-automerge",
+    run: "gh pr merge --auto --squash $PR_URL",
+    env: {
+      PR_URL: "${{github.event.pull_request.html_url}}",
+      GITHUB_TOKEN: "${{secrets.PULUMI_BOT_TOKEN}}",
+    },
   };
 }
 

--- a/provider-ci/src/workflows.ts
+++ b/provider-ci/src/workflows.ts
@@ -191,7 +191,7 @@ export function RunAcceptanceTestsWorkflow(
         .addConditional(
           "github.event_name == 'repository_dispatch' || github.event.pull_request.head.repo.full_name == github.repository"
         )
-        .addStep(steps.EchoSuccessStep())
+        .addStep(steps.EnableAutoMerge())
         .addNeeds(calculateSentinelNeeds(opts.lint)),
     },
   };
@@ -259,12 +259,6 @@ export function UpdatePulumiTerraformBridgeWorkflow(
               "The version of pulumi/pulumi/sdk to update to. Do not include the 'v' prefix. Must be major version 3.",
             type: "string",
           },
-          automerge: {
-            description: "Mark created PR for auto-merging?",
-            required: true,
-            type: "boolean",
-            default: false,
-          },
         },
       },
     },
@@ -328,10 +322,6 @@ export function UpdatePulumiTerraformBridgeWorkflow(
             "team-reviewers": "platform-integrations",
             token: "${{ secrets.PULUMI_BOT_TOKEN }}",
           },
-        })
-        .addStep({
-          if: "steps.create-pr.outputs.pull-request-operation == 'created' && github.event.inputs.automerge == 'true'",
-          run: "gh pr merge --auto --squash ${{ steps.create-pr.outputs.pull-request-number }}",
         }),
     },
   };
@@ -479,12 +469,6 @@ export function UpdateUpstreamProviderWorkflow(
             description:
               "The issue number of a PR in this repository to which the generated pull request should be linked.",
             type: "string",
-          },
-          automerge: {
-            description: "Mark created PR for auto-merging?",
-            required: true,
-            type: "boolean",
-            default: false,
           },
         },
       },


### PR DESCRIPTION
Fixes #272

Previously, automergable PRs had automerge enabled externally immediately after the PR was created assuming that only if the sentinel check passed, the PR would work. However, in case of failure in tests the sentinel check is skipped entirely causing the PR to be immediately merged when we don't want.

This change tries to enable automerge from within the sentinel step which will execute when the steps it depends on are successful.