### PR TITLE
Update required steps for automerge workflow

### DIFF
--- a/infra/providers/index.ts
+++ b/infra/providers/index.ts
@@ -12,6 +12,19 @@ const providers = [...tfProviders, ...nativeProviders];
 for (let provider of providers) {
     const contexts: string[] = [
         "Update Changelog",
+        "prerequisites",
+        "lint",
+        "lint-sdk",
+        "build_sdk (dotnet)",
+        "build_sdk (go)",
+        "build_sdk (java)",
+        "build_sdk (nodejs)",
+        "build_sdk (python)",
+        "test (dotnet)",
+        "test (go)",
+        "test (java)",
+        "test (nodejs)",
+        "test (python)",
         "sentinel",
     ];
 


### PR DESCRIPTION
Following https://github.com/pulumi/ci-mgmt/pull/301 , this locks GitHub branch protection to not auto-merge until all the important jobs have passed.

Pondering rollout order here. Perhaps before merging, we need to make sure that all the providers have been upgraded with the results of 301? If we merge this does send some providers into a state where no PRs can't merge until they catch up with 301?