### PR TITLE
Update keycloak URL for 4.1.0 (major version)

### DIFF
--- a/provider-ci/providers/keycloak/config.yaml
+++ b/provider-ci/providers/keycloak/config.yaml
@@ -6,7 +6,7 @@ env: # these are in plaintext in the setup script
   KEYCLOAK_CLIENT_ID: "terraform"
   KEYCLOAK_CLIENT_SECRET: "884e0f95-0f42-4a63-9b1f-94274655669e"
   KEYCLOAK_PASSWORD: "password"
-  KEYCLOAK_URL: "http://localhost:8080"
+  KEYCLOAK_URL: "http://localhost:8080/auth"
   KEYCLOAK_USER: "keycloak"
 upstream-provider-org: pulumi
 makeTemplate: bridged

--- a/provider-ci/providers/keycloak/repo/.github/workflows/command-dispatch.yml
+++ b/provider-ci/providers/keycloak/repo/.github/workflows/command-dispatch.yml
@@ -10,7 +10,7 @@ env:
   KEYCLOAK_CLIENT_ID: terraform
   KEYCLOAK_CLIENT_SECRET: 884e0f95-0f42-4a63-9b1f-94274655669e
   KEYCLOAK_PASSWORD: password
-  KEYCLOAK_URL: http://localhost:8080
+  KEYCLOAK_URL: http://localhost:8080/auth
   KEYCLOAK_USER: keycloak
   NODEVERSION: 16.x
   NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/provider-ci/providers/keycloak/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/keycloak/repo/.github/workflows/main.yml
@@ -10,7 +10,7 @@ env:
   KEYCLOAK_CLIENT_ID: terraform
   KEYCLOAK_CLIENT_SECRET: 884e0f95-0f42-4a63-9b1f-94274655669e
   KEYCLOAK_PASSWORD: password
-  KEYCLOAK_URL: http://localhost:8080
+  KEYCLOAK_URL: http://localhost:8080/auth
   KEYCLOAK_USER: keycloak
   NODEVERSION: 16.x
   NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/provider-ci/providers/keycloak/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/keycloak/repo/.github/workflows/master.yml
@@ -10,7 +10,7 @@ env:
   KEYCLOAK_CLIENT_ID: terraform
   KEYCLOAK_CLIENT_SECRET: 884e0f95-0f42-4a63-9b1f-94274655669e
   KEYCLOAK_PASSWORD: password
-  KEYCLOAK_URL: http://localhost:8080
+  KEYCLOAK_URL: http://localhost:8080/auth
   KEYCLOAK_USER: keycloak
   NODEVERSION: 16.x
   NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/provider-ci/providers/keycloak/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/keycloak/repo/.github/workflows/prerelease.yml
@@ -11,7 +11,7 @@ env:
   KEYCLOAK_CLIENT_ID: terraform
   KEYCLOAK_CLIENT_SECRET: 884e0f95-0f42-4a63-9b1f-94274655669e
   KEYCLOAK_PASSWORD: password
-  KEYCLOAK_URL: http://localhost:8080
+  KEYCLOAK_URL: http://localhost:8080/auth
   KEYCLOAK_USER: keycloak
   NODEVERSION: 16.x
   NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/provider-ci/providers/keycloak/repo/.github/workflows/pull-request.yml
+++ b/provider-ci/providers/keycloak/repo/.github/workflows/pull-request.yml
@@ -10,7 +10,7 @@ env:
   KEYCLOAK_CLIENT_ID: terraform
   KEYCLOAK_CLIENT_SECRET: 884e0f95-0f42-4a63-9b1f-94274655669e
   KEYCLOAK_PASSWORD: password
-  KEYCLOAK_URL: http://localhost:8080
+  KEYCLOAK_URL: http://localhost:8080/auth
   KEYCLOAK_USER: keycloak
   NODEVERSION: 16.x
   NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/provider-ci/providers/keycloak/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/keycloak/repo/.github/workflows/release.yml
@@ -10,7 +10,7 @@ env:
   KEYCLOAK_CLIENT_ID: terraform
   KEYCLOAK_CLIENT_SECRET: 884e0f95-0f42-4a63-9b1f-94274655669e
   KEYCLOAK_PASSWORD: password
-  KEYCLOAK_URL: http://localhost:8080
+  KEYCLOAK_URL: http://localhost:8080/auth
   KEYCLOAK_USER: keycloak
   NODEVERSION: 16.x
   NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/provider-ci/providers/keycloak/repo/.github/workflows/resync-build.yml
+++ b/provider-ci/providers/keycloak/repo/.github/workflows/resync-build.yml
@@ -10,7 +10,7 @@ env:
   KEYCLOAK_CLIENT_ID: terraform
   KEYCLOAK_CLIENT_SECRET: 884e0f95-0f42-4a63-9b1f-94274655669e
   KEYCLOAK_PASSWORD: password
-  KEYCLOAK_URL: http://localhost:8080
+  KEYCLOAK_URL: http://localhost:8080/auth
   KEYCLOAK_USER: keycloak
   NODEVERSION: 16.x
   NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/provider-ci/providers/keycloak/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/keycloak/repo/.github/workflows/run-acceptance-tests.yml
@@ -10,7 +10,7 @@ env:
   KEYCLOAK_CLIENT_ID: terraform
   KEYCLOAK_CLIENT_SECRET: 884e0f95-0f42-4a63-9b1f-94274655669e
   KEYCLOAK_PASSWORD: password
-  KEYCLOAK_URL: http://localhost:8080
+  KEYCLOAK_URL: http://localhost:8080/auth
   KEYCLOAK_USER: keycloak
   NODEVERSION: 16.x
   NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/provider-ci/providers/keycloak/repo/.github/workflows/update-upstream-provider.yml
+++ b/provider-ci/providers/keycloak/repo/.github/workflows/update-upstream-provider.yml
@@ -10,7 +10,7 @@ env:
   KEYCLOAK_CLIENT_ID: terraform
   KEYCLOAK_CLIENT_SECRET: 884e0f95-0f42-4a63-9b1f-94274655669e
   KEYCLOAK_PASSWORD: password
-  KEYCLOAK_URL: http://localhost:8080
+  KEYCLOAK_URL: http://localhost:8080/auth
   KEYCLOAK_USER: keycloak
   NODEVERSION: 16.x
   NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
Update KeyCloak for major version 4 update (see https://github.com/pulumi/pulumi-keycloak/pull/162).