### PR TITLE
Source migrator to upgrade go to 1.19

### DIFF
--- a/tools/sourcemigrator/index.ts
+++ b/tools/sourcemigrator/index.ts
@@ -58,7 +58,7 @@ function updatePulumiCoreRefTo3x(): SourceMigration {
     return sm;
 }
 
-function updateGoTo_1_19(): SourceMigration {
+function updateGo_1_19(): SourceMigration {
     let pattern = new RegExp('^go \\d+[.]\\d+$', 'm');
     let replacement = "go 1.19";
     let sm: SourceMigration = {

--- a/tools/sourcemigrator/index.ts
+++ b/tools/sourcemigrator/index.ts
@@ -117,7 +117,7 @@ function allMigrations(): SourceMigration[] {
     return [
         updateExamplesFromCore31DotNet6(),
         updatePulumiCoreRefTo3x(),
-        updateGoTo_1_19(),
+        updateGo_1_19(),
     ];
 }
 

--- a/tools/sourcemigrator/index.ts
+++ b/tools/sourcemigrator/index.ts
@@ -62,7 +62,7 @@ function updateGo_1_19(): SourceMigration {
     let pattern = new RegExp('^go \\d+[.]\\d+$', 'm');
     let replacement = "go 1.19";
     let sm: SourceMigration = {
-        name: "updateGoTo_1_19",
+        name: "updateGo_1_19",
         execute: (ctx: MigrateContext) => {
             let stdout = child.execSync("git ls-files -- '**/go.mod'", {cwd: ctx.dir});
             let filesEdited = String(stdout).split("\n")


### PR DESCRIPTION
Some of our repositories are on Go 1.14 or some such. This contributes to broken build/test issues. This source migration detects go.mod and makes sure it's 1.19. It does not touch go.mod generated by pulumi/pkg such as sdk/python/go.mod that are installed as placeholders (those are not real go modules). For every go module it updates, it runs `go mod tidy` to re-sync `go.sum`.

To make this work, trigger Actions as needed, they will stand up PRs that apply the migrations as part of the PR.