### PR TITLE
Add docs gen Makefile target for hybrid providers

### DIFF
--- a/provider-ci/providers/docker/config.yaml
+++ b/provider-ci/providers/docker/config.yaml
@@ -11,3 +11,5 @@ env:
   PULUMI_GO_DEP_ROOT: /home/runner/work/pulumi-docker
 upstream-provider-org: kreuzwerker
 makeTemplate: bridged
+docsCmd: "cd provider/pkg/docs-gen/examples/ && go run generate.go ./yaml ./"
+hybrid: true

--- a/provider-ci/providers/docker/repo/Makefile
+++ b/provider-ci/providers/docker/repo/Makefile
@@ -78,6 +78,9 @@ cleanup:
 	rm -r $(WORKING_DIR)/bin
 	rm -f provider/cmd/$(PROVIDER)/schema.go
 
+docs: 
+	cd provider/pkg/docs-gen/examples/ && go run generate.go ./yaml ./
+
 help: 
 	@grep '^[^.#]\+:\s\+.*#' Makefile | \
 	sed "s/\(.\+\):\s*\(.*\) #\s*\(.*\)/`printf "\033[93m"`\1`printf "\033[0m"`	\3 [\2]/" | \
@@ -102,7 +105,7 @@ provider: tfgen install_plugins
 test: 
 	cd examples && go test -v -tags=all -parallel $(TESTPARALLELISM) -timeout 2h
 
-tfgen: install_plugins
+tfgen: install_plugins docs
 	(cd provider && go build -p 1 -o $(WORKING_DIR)/bin/$(TFGEN) -ldflags "-X $(PROJECT)/$(VERSION_PATH)=$(VERSION)" $(PROJECT)/$(PROVIDER_PATH)/cmd/$(TFGEN))
 	$(WORKING_DIR)/bin/$(TFGEN) schema --out provider/cmd/$(PROVIDER)
 	(cd provider && VERSION=$(VERSION) go generate cmd/$(PROVIDER)/main.go)
@@ -110,4 +113,4 @@ tfgen: install_plugins
 bin/pulumi-java-gen: 
 	$(shell pulumictl download-binary -n pulumi-language-java -v $(JAVA_GEN_VERSION) -r pulumi/pulumi-java)
 
-.PHONY: development build build_sdks install_go_sdk install_java_sdk install_python_sdk install_sdks only_build build_dotnet build_go build_java build_nodejs build_python clean cleanup help install_dotnet_sdk install_nodejs_sdk install_plugins lint_provider provider test tfgen
+.PHONY: development build build_sdks install_go_sdk install_java_sdk install_python_sdk install_sdks only_build build_dotnet build_go build_java build_nodejs build_python clean cleanup docs help install_dotnet_sdk install_nodejs_sdk install_plugins lint_provider provider test tfgen

--- a/provider-ci/providers/fastly/repo/.goreleaser.prerelease.yml
+++ b/provider-ci/providers/fastly/repo/.goreleaser.prerelease.yml
@@ -28,7 +28,7 @@ builds:
   - linux
   ignore: []
   ldflags:
-  - -X github.com/pulumi/pulumi-fastly/provider/v5/pkg/version.Version={{.Tag}}
+  - -X github.com/pulumi/pulumi-fastly/provider/v6/pkg/version.Version={{.Tag}}
   main: ./cmd/pulumi-resource-fastly/
 changelog:
   skip: true

--- a/provider-ci/providers/fastly/repo/.goreleaser.yml
+++ b/provider-ci/providers/fastly/repo/.goreleaser.yml
@@ -28,7 +28,7 @@ builds:
   - linux
   ignore: []
   ldflags:
-  - -X github.com/pulumi/pulumi-fastly/provider/v5/pkg/version.Version={{.Tag}}
+  - -X github.com/pulumi/pulumi-fastly/provider/v6/pkg/version.Version={{.Tag}}
   main: ./cmd/pulumi-resource-fastly/
 changelog:
   filters:

--- a/provider-ci/providers/fastly/repo/Makefile
+++ b/provider-ci/providers/fastly/repo/Makefile
@@ -3,7 +3,7 @@
 PACK := fastly
 ORG := pulumi
 PROJECT := github.com/$(ORG)/pulumi-$(PACK)
-PROVIDER_PATH := provider/v5
+PROVIDER_PATH := provider/v6
 VERSION_PATH := $(PROVIDER_PATH)/pkg/version.Version
 TFGEN := pulumi-tfgen-$(PACK)
 PROVIDER := pulumi-resource-$(PACK)

--- a/provider-ci/src/config.ts
+++ b/provider-ci/src/config.ts
@@ -41,6 +41,8 @@ const BridgedConfig = z
     plugins: z
       .array(z.object({ name: z.string(), version: z.string() }))
       .optional(),
+    docsCmd: z.string().default(""),
+    hybrid: z.boolean().default(false)
   })
   .transform((input) => {
     if (input["upstream-provider-repo"] !== "") {

--- a/provider-ci/src/make-bridged-provider.ts
+++ b/provider-ci/src/make-bridged-provider.ts
@@ -33,6 +33,19 @@ export function bridgedProvider(config: BridgedConfig): Makefile {
     WORKING_DIR,
   } as const;
 
+
+  const docs: Target = {
+    name: "docs",
+    phony: true,
+  }
+
+  if (config.provider == "docker" ) {
+    console.log("this works")
+    docs.commands = [
+      "cd provider/pkg/docs-gen/examples/ && go run generate.go ./yaml ./"
+    ]
+  }
+
   const install_plugins: Target = {
     name: "install_plugins",
     phony: true,
@@ -43,10 +56,11 @@ export function bridgedProvider(config: BridgedConfig): Makefile {
       ) ?? []),
     ],
   };
+
   const tfgen: Target = {
     name: "tfgen",
     phony: true,
-    dependencies: [install_plugins],
+    dependencies: [install_plugins, docs],
     commands: [
       '(cd provider && go build -p 1 -o $(WORKING_DIR)/bin/$(TFGEN) -ldflags "-X $(PROJECT)/$(VERSION_PATH)=$(VERSION)" $(PROJECT)/$(PROVIDER_PATH)/cmd/$(TFGEN))',
       "$(WORKING_DIR)/bin/$(TFGEN) schema --out provider/cmd/$(PROVIDER)",
@@ -275,6 +289,7 @@ export function bridgedProvider(config: BridgedConfig): Makefile {
       install_nodejs_sdk,
       install_sdks,
       test,
+      docs,
     ],
   };
 }


### PR DESCRIPTION
Hybrid providers are terraform-bridged Pulumi providers that have native resources added to them.
Our currently only example of this is the [Pulumi Docker Provider](https://github.com/pulumi/pulumi-docker).
All native resources need to generate their own documentation, and this PR encodes the process into any hybrid
provider Makefile.
The provider's `config.yaml` will need to contain the `docsCmd` field as well as the `hybrid` field in order to
generate a Makefile with a `docs` target.
See also: https://github.com/pulumi/pulumi-docker/pull/479

- Add logic to add a `docs` Makefile target
- generalize approach to denote a hybrid provider rather than docekr specifically
- Generate all providers. Updates major version for Fastly but does not add any extra targets to non-hybrid providers, as expected.
