### PR TITLE
Add support for patched upstream providers

### DIFF
--- a/provider-ci/providers/aiven/repo/Makefile
+++ b/provider-ci/providers/aiven/repo/Makefile
@@ -144,7 +144,12 @@ else ifeq ("$(wildcard patches/*.patch)","")
 	@echo "patches were expected because upstream exists"
 	@exit 1
 else
+	# Checkout the submodule at the pinned commit.
+	# `--force`: If the submodule is at a different commit, move it to the pinned commit.
+	# `--init`: If the submodule is not initialized, initialize it.
 	git submodule update --force --init
+	# Iterating over the patches folder in sorted order,
+	# apply the patch using a 3-way merge strategy. This mirrors the default behavior of `git merge`
 	cd upstream && \
 		for patch in $(sort $(wildcard patches/*.patch)); do git apply --3way ../$$patch || exit 1; done
 endif

--- a/provider-ci/providers/aiven/repo/Makefile
+++ b/provider-ci/providers/aiven/repo/Makefile
@@ -30,7 +30,7 @@ install_sdks: install_dotnet_sdk install_python_sdk install_nodejs_sdk install_j
 only_build: build
 
 build_dotnet: DOTNET_VERSION := $(shell pulumictl get version --language dotnet)
-build_dotnet:
+build_dotnet: upstream
 	pulumictl get version --language dotnet
 	$(WORKING_DIR)/bin/$(TFGEN) dotnet --out sdk/dotnet/
 	cd sdk/dotnet/ && \
@@ -38,19 +38,19 @@ build_dotnet:
 		echo "$(DOTNET_VERSION)" >version.txt && \
 		dotnet build /p:Version=$(DOTNET_VERSION)
 
-build_go:
+build_go: upstream
 	$(WORKING_DIR)/bin/$(TFGEN) go --out sdk/go/
 	cd sdk && go list `grep -e "^module" go.mod | cut -d ' ' -f 2`/go/... | xargs go build
 
 build_java: PACKAGE_VERSION := $(shell pulumictl get version --language generic)
-build_java: bin/pulumi-java-gen
+build_java: bin/pulumi-java-gen upstream
 	$(WORKING_DIR)/bin/$(JAVA_GEN) generate --schema provider/cmd/$(PROVIDER)/schema.json --out sdk/java  --build gradle-nexus
 	cd sdk/java/ && \
 		echo "module fake_java_module // Exclude this directory from Go tools\n\ngo 1.17" > go.mod && \
 		gradle --console=plain build
 
 build_nodejs: VERSION := $(shell pulumictl get version --language javascript)
-build_nodejs:
+build_nodejs: upstream
 	$(WORKING_DIR)/bin/$(TFGEN) nodejs --out sdk/nodejs/
 	cd sdk/nodejs/ && \
 		echo "module fake_nodejs_module // Exclude this directory from Go tools\n\ngo 1.17" > go.mod && \
@@ -60,7 +60,7 @@ build_nodejs:
 		sed -i.bak -e "s/\$${VERSION}/$(VERSION)/g" ./bin/package.json
 
 build_python: PYPI_VERSION := $(shell pulumictl get version --language python)
-build_python:
+build_python: upstream
 	$(WORKING_DIR)/bin/$(TFGEN) python --out sdk/python/
 	cd sdk/python/ && \
 		echo "module fake_python_module // Exclude this directory from Go tools\n\ngo 1.17" > go.mod && \
@@ -77,6 +77,11 @@ clean:
 cleanup:
 	rm -r $(WORKING_DIR)/bin
 	rm -f provider/cmd/$(PROVIDER)/schema.go
+
+finish-patch:
+	@if [ ! -z "$$(cd upstream && git status --porcelain)" ]; then echo "Please commit your changes before finishing the patch"; exit 1; fi
+	@cd upstream && \
+		git format-patch HEAD~ -o ../patches --start-number $$(($$(ls ../patches | wc -l | xargs)+1))
 
 help:
 	@grep '^[^.#]\+:\s\+.*#' Makefile | \
@@ -99,15 +104,52 @@ lint_provider: provider
 provider: tfgen install_plugins
 	(cd provider && go build -p 1 -o $(WORKING_DIR)/bin/$(PROVIDER) -ldflags "-X $(PROJECT)/$(VERSION_PATH)=$(VERSION)" $(PROJECT)/$(PROVIDER_PATH)/cmd/$(PROVIDER))
 
+start-patch: upstream
+ifeq ("$(wildcard upstream)","")
+	@echo "No upstream found, so upstream can't be patched"
+	@exit 1
+else
+	# To add an additional patch:
+	#
+	#	1. Run this command (`make start-patch`).
+	#
+	#	2. Edit the `upstream` repo, making whatever changes you want to appear in the new
+	#	patch. It's fine to edit multiple files.
+	#
+	#	3. Commit your changes. The slugified first line of your commit description will
+	#	be used to generate the patch file name. Only the diff from the latest commit will
+	#	end up in the final patch.
+	#
+	#	4. Run `make finish-patch`.
+	#
+	# It is safe to run `make start-patch` as many times as you want, but any changes
+	# might be reverted until `make finish-patch` is run.
+	@cd upstream && git commit --quiet -m "existing patches"
+endif
+
 test:
 	cd examples && go test -v -tags=all -parallel $(TESTPARALLELISM) -timeout 2h
 
-tfgen: install_plugins
+tfgen: install_plugins upstream
 	(cd provider && go build -p 1 -o $(WORKING_DIR)/bin/$(TFGEN) -ldflags "-X $(PROJECT)/$(VERSION_PATH)=$(VERSION)" $(PROJECT)/$(PROVIDER_PATH)/cmd/$(TFGEN))
 	$(WORKING_DIR)/bin/$(TFGEN) schema --out provider/cmd/$(PROVIDER)
 	(cd provider && VERSION=$(VERSION) go generate cmd/$(PROVIDER)/main.go)
 
+upstream:
+ifeq ("$(wildcard upstream)","")
+	# upstream doesn't exist, so skip
+else ifeq ("$(wildcard patches/*.patch)","")
+	# upstream exists, but patches don't exist. This is probably an error.
+	@echo "No patches found within the patch operation"
+	@echo "patches were expected because upstream exists"
+	@exit 1
+else
+	git submodule update --force --init
+	cd upstream && \
+		for patch in $(sort $(wildcard patches/*.patch)); do git apply --3way ../$$patch || exit 1; done
+endif
+
 bin/pulumi-java-gen:
 	$(shell pulumictl download-binary -n pulumi-language-java -v $(JAVA_GEN_VERSION) -r pulumi/pulumi-java)
 
-.PHONY: development build build_sdks install_go_sdk install_java_sdk install_python_sdk install_sdks only_build build_dotnet build_go build_java build_nodejs build_python clean cleanup help install_dotnet_sdk install_nodejs_sdk install_plugins lint_provider provider test tfgen
+.PHONY: development build build_sdks install_go_sdk install_java_sdk install_python_sdk install_sdks only_build build_dotnet build_go build_java build_nodejs build_python clean cleanup finish-patch help install_dotnet_sdk install_nodejs_sdk install_plugins lint_provider provider start-patch test tfgen upstream

--- a/provider-ci/providers/akamai/repo/Makefile
+++ b/provider-ci/providers/akamai/repo/Makefile
@@ -144,7 +144,12 @@ else ifeq ("$(wildcard patches/*.patch)","")
 	@echo "patches were expected because upstream exists"
 	@exit 1
 else
+	# Checkout the submodule at the pinned commit.
+	# `--force`: If the submodule is at a different commit, move it to the pinned commit.
+	# `--init`: If the submodule is not initialized, initialize it.
 	git submodule update --force --init
+	# Iterating over the patches folder in sorted order,
+	# apply the patch using a 3-way merge strategy. This mirrors the default behavior of `git merge`
 	cd upstream && \
 		for patch in $(sort $(wildcard patches/*.patch)); do git apply --3way ../$$patch || exit 1; done
 endif

--- a/provider-ci/providers/akamai/repo/Makefile
+++ b/provider-ci/providers/akamai/repo/Makefile
@@ -30,7 +30,7 @@ install_sdks: install_dotnet_sdk install_python_sdk install_nodejs_sdk install_j
 only_build: build
 
 build_dotnet: DOTNET_VERSION := $(shell pulumictl get version --language dotnet)
-build_dotnet:
+build_dotnet: upstream
 	pulumictl get version --language dotnet
 	$(WORKING_DIR)/bin/$(TFGEN) dotnet --out sdk/dotnet/
 	cd sdk/dotnet/ && \
@@ -38,19 +38,19 @@ build_dotnet:
 		echo "$(DOTNET_VERSION)" >version.txt && \
 		dotnet build /p:Version=$(DOTNET_VERSION)
 
-build_go:
+build_go: upstream
 	$(WORKING_DIR)/bin/$(TFGEN) go --out sdk/go/
 	cd sdk && go list `grep -e "^module" go.mod | cut -d ' ' -f 2`/go/... | xargs go build
 
 build_java: PACKAGE_VERSION := $(shell pulumictl get version --language generic)
-build_java: bin/pulumi-java-gen
+build_java: bin/pulumi-java-gen upstream
 	$(WORKING_DIR)/bin/$(JAVA_GEN) generate --schema provider/cmd/$(PROVIDER)/schema.json --out sdk/java  --build gradle-nexus
 	cd sdk/java/ && \
 		echo "module fake_java_module // Exclude this directory from Go tools\n\ngo 1.17" > go.mod && \
 		gradle --console=plain build
 
 build_nodejs: VERSION := $(shell pulumictl get version --language javascript)
-build_nodejs:
+build_nodejs: upstream
 	$(WORKING_DIR)/bin/$(TFGEN) nodejs --out sdk/nodejs/
 	cd sdk/nodejs/ && \
 		echo "module fake_nodejs_module // Exclude this directory from Go tools\n\ngo 1.17" > go.mod && \
@@ -60,7 +60,7 @@ build_nodejs:
 		sed -i.bak -e "s/\$${VERSION}/$(VERSION)/g" ./bin/package.json
 
 build_python: PYPI_VERSION := $(shell pulumictl get version --language python)
-build_python:
+build_python: upstream
 	$(WORKING_DIR)/bin/$(TFGEN) python --out sdk/python/
 	cd sdk/python/ && \
 		echo "module fake_python_module // Exclude this directory from Go tools\n\ngo 1.17" > go.mod && \
@@ -77,6 +77,11 @@ clean:
 cleanup:
 	rm -r $(WORKING_DIR)/bin
 	rm -f provider/cmd/$(PROVIDER)/schema.go
+
+finish-patch:
+	@if [ ! -z "$$(cd upstream && git status --porcelain)" ]; then echo "Please commit your changes before finishing the patch"; exit 1; fi
+	@cd upstream && \
+		git format-patch HEAD~ -o ../patches --start-number $$(($$(ls ../patches | wc -l | xargs)+1))
 
 help:
 	@grep '^[^.#]\+:\s\+.*#' Makefile | \
@@ -99,15 +104,52 @@ lint_provider: provider
 provider: tfgen install_plugins
 	(cd provider && go build -p 1 -o $(WORKING_DIR)/bin/$(PROVIDER) -ldflags "-X $(PROJECT)/$(VERSION_PATH)=$(VERSION)" $(PROJECT)/$(PROVIDER_PATH)/cmd/$(PROVIDER))
 
+start-patch: upstream
+ifeq ("$(wildcard upstream)","")
+	@echo "No upstream found, so upstream can't be patched"
+	@exit 1
+else
+	# To add an additional patch:
+	#
+	#	1. Run this command (`make start-patch`).
+	#
+	#	2. Edit the `upstream` repo, making whatever changes you want to appear in the new
+	#	patch. It's fine to edit multiple files.
+	#
+	#	3. Commit your changes. The slugified first line of your commit description will
+	#	be used to generate the patch file name. Only the diff from the latest commit will
+	#	end up in the final patch.
+	#
+	#	4. Run `make finish-patch`.
+	#
+	# It is safe to run `make start-patch` as many times as you want, but any changes
+	# might be reverted until `make finish-patch` is run.
+	@cd upstream && git commit --quiet -m "existing patches"
+endif
+
 test:
 	cd examples && go test -v -tags=all -parallel $(TESTPARALLELISM) -timeout 2h
 
-tfgen: install_plugins
+tfgen: install_plugins upstream
 	(cd provider && go build -p 1 -o $(WORKING_DIR)/bin/$(TFGEN) -ldflags "-X $(PROJECT)/$(VERSION_PATH)=$(VERSION)" $(PROJECT)/$(PROVIDER_PATH)/cmd/$(TFGEN))
 	$(WORKING_DIR)/bin/$(TFGEN) schema --out provider/cmd/$(PROVIDER)
 	(cd provider && VERSION=$(VERSION) go generate cmd/$(PROVIDER)/main.go)
 
+upstream:
+ifeq ("$(wildcard upstream)","")
+	# upstream doesn't exist, so skip
+else ifeq ("$(wildcard patches/*.patch)","")
+	# upstream exists, but patches don't exist. This is probably an error.
+	@echo "No patches found within the patch operation"
+	@echo "patches were expected because upstream exists"
+	@exit 1
+else
+	git submodule update --force --init
+	cd upstream && \
+		for patch in $(sort $(wildcard patches/*.patch)); do git apply --3way ../$$patch || exit 1; done
+endif
+
 bin/pulumi-java-gen:
 	$(shell pulumictl download-binary -n pulumi-language-java -v $(JAVA_GEN_VERSION) -r pulumi/pulumi-java)
 
-.PHONY: development build build_sdks install_go_sdk install_java_sdk install_python_sdk install_sdks only_build build_dotnet build_go build_java build_nodejs build_python clean cleanup help install_dotnet_sdk install_nodejs_sdk install_plugins lint_provider provider test tfgen
+.PHONY: development build build_sdks install_go_sdk install_java_sdk install_python_sdk install_sdks only_build build_dotnet build_go build_java build_nodejs build_python clean cleanup finish-patch help install_dotnet_sdk install_nodejs_sdk install_plugins lint_provider provider start-patch test tfgen upstream

--- a/provider-ci/providers/alicloud/repo/Makefile
+++ b/provider-ci/providers/alicloud/repo/Makefile
@@ -30,7 +30,7 @@ install_sdks: install_dotnet_sdk install_python_sdk install_nodejs_sdk install_j
 only_build: build
 
 build_dotnet: DOTNET_VERSION := $(shell pulumictl get version --language dotnet)
-build_dotnet:
+build_dotnet: upstream
 	pulumictl get version --language dotnet
 	$(WORKING_DIR)/bin/$(TFGEN) dotnet --out sdk/dotnet/
 	cd sdk/dotnet/ && \
@@ -38,19 +38,19 @@ build_dotnet:
 		echo "$(DOTNET_VERSION)" >version.txt && \
 		dotnet build /p:Version=$(DOTNET_VERSION)
 
-build_go:
+build_go: upstream
 	$(WORKING_DIR)/bin/$(TFGEN) go --out sdk/go/
 	cd sdk && go list `grep -e "^module" go.mod | cut -d ' ' -f 2`/go/... | xargs go build
 
 build_java: PACKAGE_VERSION := $(shell pulumictl get version --language generic)
-build_java: bin/pulumi-java-gen
+build_java: bin/pulumi-java-gen upstream
 	$(WORKING_DIR)/bin/$(JAVA_GEN) generate --schema provider/cmd/$(PROVIDER)/schema.json --out sdk/java  --build gradle-nexus
 	cd sdk/java/ && \
 		echo "module fake_java_module // Exclude this directory from Go tools\n\ngo 1.17" > go.mod && \
 		gradle --console=plain build
 
 build_nodejs: VERSION := $(shell pulumictl get version --language javascript)
-build_nodejs:
+build_nodejs: upstream
 	$(WORKING_DIR)/bin/$(TFGEN) nodejs --out sdk/nodejs/
 	cd sdk/nodejs/ && \
 		echo "module fake_nodejs_module // Exclude this directory from Go tools\n\ngo 1.17" > go.mod && \
@@ -60,7 +60,7 @@ build_nodejs:
 		sed -i.bak -e "s/\$${VERSION}/$(VERSION)/g" ./bin/package.json
 
 build_python: PYPI_VERSION := $(shell pulumictl get version --language python)
-build_python:
+build_python: upstream
 	$(WORKING_DIR)/bin/$(TFGEN) python --out sdk/python/
 	cd sdk/python/ && \
 		echo "module fake_python_module // Exclude this directory from Go tools\n\ngo 1.17" > go.mod && \
@@ -77,6 +77,11 @@ clean:
 cleanup:
 	rm -r $(WORKING_DIR)/bin
 	rm -f provider/cmd/$(PROVIDER)/schema.go
+
+finish-patch:
+	@if [ ! -z "$$(cd upstream && git status --porcelain)" ]; then echo "Please commit your changes before finishing the patch"; exit 1; fi
+	@cd upstream && \
+		git format-patch HEAD~ -o ../patches --start-number $$(($$(ls ../patches | wc -l | xargs)+1))
 
 help:
 	@grep '^[^.#]\+:\s\+.*#' Makefile | \
@@ -100,15 +105,52 @@ lint_provider: provider
 provider: tfgen install_plugins
 	(cd provider && go build -p 1 -o $(WORKING_DIR)/bin/$(PROVIDER) -ldflags "-X $(PROJECT)/$(VERSION_PATH)=$(VERSION)" $(PROJECT)/$(PROVIDER_PATH)/cmd/$(PROVIDER))
 
+start-patch: upstream
+ifeq ("$(wildcard upstream)","")
+	@echo "No upstream found, so upstream can't be patched"
+	@exit 1
+else
+	# To add an additional patch:
+	#
+	#	1. Run this command (`make start-patch`).
+	#
+	#	2. Edit the `upstream` repo, making whatever changes you want to appear in the new
+	#	patch. It's fine to edit multiple files.
+	#
+	#	3. Commit your changes. The slugified first line of your commit description will
+	#	be used to generate the patch file name. Only the diff from the latest commit will
+	#	end up in the final patch.
+	#
+	#	4. Run `make finish-patch`.
+	#
+	# It is safe to run `make start-patch` as many times as you want, but any changes
+	# might be reverted until `make finish-patch` is run.
+	@cd upstream && git commit --quiet -m "existing patches"
+endif
+
 test:
 	cd examples && go test -v -tags=all -parallel $(TESTPARALLELISM) -timeout 2h
 
-tfgen: install_plugins
+tfgen: install_plugins upstream
 	(cd provider && go build -p 1 -o $(WORKING_DIR)/bin/$(TFGEN) -ldflags "-X $(PROJECT)/$(VERSION_PATH)=$(VERSION)" $(PROJECT)/$(PROVIDER_PATH)/cmd/$(TFGEN))
 	$(WORKING_DIR)/bin/$(TFGEN) schema --out provider/cmd/$(PROVIDER)
 	(cd provider && VERSION=$(VERSION) go generate cmd/$(PROVIDER)/main.go)
 
+upstream:
+ifeq ("$(wildcard upstream)","")
+	# upstream doesn't exist, so skip
+else ifeq ("$(wildcard patches/*.patch)","")
+	# upstream exists, but patches don't exist. This is probably an error.
+	@echo "No patches found within the patch operation"
+	@echo "patches were expected because upstream exists"
+	@exit 1
+else
+	git submodule update --force --init
+	cd upstream && \
+		for patch in $(sort $(wildcard patches/*.patch)); do git apply --3way ../$$patch || exit 1; done
+endif
+
 bin/pulumi-java-gen:
 	$(shell pulumictl download-binary -n pulumi-language-java -v $(JAVA_GEN_VERSION) -r pulumi/pulumi-java)
 
-.PHONY: development build build_sdks install_go_sdk install_java_sdk install_python_sdk install_sdks only_build build_dotnet build_go build_java build_nodejs build_python clean cleanup help install_dotnet_sdk install_nodejs_sdk install_plugins lint_provider provider test tfgen
+.PHONY: development build build_sdks install_go_sdk install_java_sdk install_python_sdk install_sdks only_build build_dotnet build_go build_java build_nodejs build_python clean cleanup finish-patch help install_dotnet_sdk install_nodejs_sdk install_plugins lint_provider provider start-patch test tfgen upstream

--- a/provider-ci/providers/alicloud/repo/Makefile
+++ b/provider-ci/providers/alicloud/repo/Makefile
@@ -145,7 +145,12 @@ else ifeq ("$(wildcard patches/*.patch)","")
 	@echo "patches were expected because upstream exists"
 	@exit 1
 else
+	# Checkout the submodule at the pinned commit.
+	# `--force`: If the submodule is at a different commit, move it to the pinned commit.
+	# `--init`: If the submodule is not initialized, initialize it.
 	git submodule update --force --init
+	# Iterating over the patches folder in sorted order,
+	# apply the patch using a 3-way merge strategy. This mirrors the default behavior of `git merge`
 	cd upstream && \
 		for patch in $(sort $(wildcard patches/*.patch)); do git apply --3way ../$$patch || exit 1; done
 endif

--- a/provider-ci/providers/artifactory/repo/Makefile
+++ b/provider-ci/providers/artifactory/repo/Makefile
@@ -30,7 +30,7 @@ install_sdks: install_dotnet_sdk install_python_sdk install_nodejs_sdk install_j
 only_build: build
 
 build_dotnet: DOTNET_VERSION := $(shell pulumictl get version --language dotnet)
-build_dotnet:
+build_dotnet: upstream
 	pulumictl get version --language dotnet
 	$(WORKING_DIR)/bin/$(TFGEN) dotnet --out sdk/dotnet/
 	cd sdk/dotnet/ && \
@@ -38,19 +38,19 @@ build_dotnet:
 		echo "$(DOTNET_VERSION)" >version.txt && \
 		dotnet build /p:Version=$(DOTNET_VERSION)
 
-build_go:
+build_go: upstream
 	$(WORKING_DIR)/bin/$(TFGEN) go --out sdk/go/
 	cd sdk && go list `grep -e "^module" go.mod | cut -d ' ' -f 2`/go/... | xargs go build
 
 build_java: PACKAGE_VERSION := $(shell pulumictl get version --language generic)
-build_java: bin/pulumi-java-gen
+build_java: bin/pulumi-java-gen upstream
 	$(WORKING_DIR)/bin/$(JAVA_GEN) generate --schema provider/cmd/$(PROVIDER)/schema.json --out sdk/java  --build gradle-nexus
 	cd sdk/java/ && \
 		echo "module fake_java_module // Exclude this directory from Go tools\n\ngo 1.17" > go.mod && \
 		gradle --console=plain build
 
 build_nodejs: VERSION := $(shell pulumictl get version --language javascript)
-build_nodejs:
+build_nodejs: upstream
 	$(WORKING_DIR)/bin/$(TFGEN) nodejs --out sdk/nodejs/
 	cd sdk/nodejs/ && \
 		echo "module fake_nodejs_module // Exclude this directory from Go tools\n\ngo 1.17" > go.mod && \
@@ -60,7 +60,7 @@ build_nodejs:
 		sed -i.bak -e "s/\$${VERSION}/$(VERSION)/g" ./bin/package.json
 
 build_python: PYPI_VERSION := $(shell pulumictl get version --language python)
-build_python:
+build_python: upstream
 	$(WORKING_DIR)/bin/$(TFGEN) python --out sdk/python/
 	cd sdk/python/ && \
 		echo "module fake_python_module // Exclude this directory from Go tools\n\ngo 1.17" > go.mod && \
@@ -77,6 +77,11 @@ clean:
 cleanup:
 	rm -r $(WORKING_DIR)/bin
 	rm -f provider/cmd/$(PROVIDER)/schema.go
+
+finish-patch:
+	@if [ ! -z "$$(cd upstream && git status --porcelain)" ]; then echo "Please commit your changes before finishing the patch"; exit 1; fi
+	@cd upstream && \
+		git format-patch HEAD~ -o ../patches --start-number $$(($$(ls ../patches | wc -l | xargs)+1))
 
 help:
 	@grep '^[^.#]\+:\s\+.*#' Makefile | \
@@ -100,15 +105,52 @@ lint_provider: provider
 provider: tfgen install_plugins
 	(cd provider && go build -p 1 -o $(WORKING_DIR)/bin/$(PROVIDER) -ldflags "-X $(PROJECT)/$(VERSION_PATH)=$(VERSION)" $(PROJECT)/$(PROVIDER_PATH)/cmd/$(PROVIDER))
 
+start-patch: upstream
+ifeq ("$(wildcard upstream)","")
+	@echo "No upstream found, so upstream can't be patched"
+	@exit 1
+else
+	# To add an additional patch:
+	#
+	#	1. Run this command (`make start-patch`).
+	#
+	#	2. Edit the `upstream` repo, making whatever changes you want to appear in the new
+	#	patch. It's fine to edit multiple files.
+	#
+	#	3. Commit your changes. The slugified first line of your commit description will
+	#	be used to generate the patch file name. Only the diff from the latest commit will
+	#	end up in the final patch.
+	#
+	#	4. Run `make finish-patch`.
+	#
+	# It is safe to run `make start-patch` as many times as you want, but any changes
+	# might be reverted until `make finish-patch` is run.
+	@cd upstream && git commit --quiet -m "existing patches"
+endif
+
 test:
 	cd examples && go test -v -tags=all -parallel $(TESTPARALLELISM) -timeout 2h
 
-tfgen: install_plugins
+tfgen: install_plugins upstream
 	(cd provider && go build -p 1 -o $(WORKING_DIR)/bin/$(TFGEN) -ldflags "-X $(PROJECT)/$(VERSION_PATH)=$(VERSION)" $(PROJECT)/$(PROVIDER_PATH)/cmd/$(TFGEN))
 	$(WORKING_DIR)/bin/$(TFGEN) schema --out provider/cmd/$(PROVIDER)
 	(cd provider && VERSION=$(VERSION) go generate cmd/$(PROVIDER)/main.go)
 
+upstream:
+ifeq ("$(wildcard upstream)","")
+	# upstream doesn't exist, so skip
+else ifeq ("$(wildcard patches/*.patch)","")
+	# upstream exists, but patches don't exist. This is probably an error.
+	@echo "No patches found within the patch operation"
+	@echo "patches were expected because upstream exists"
+	@exit 1
+else
+	git submodule update --force --init
+	cd upstream && \
+		for patch in $(sort $(wildcard patches/*.patch)); do git apply --3way ../$$patch || exit 1; done
+endif
+
 bin/pulumi-java-gen:
 	$(shell pulumictl download-binary -n pulumi-language-java -v $(JAVA_GEN_VERSION) -r pulumi/pulumi-java)
 
-.PHONY: development build build_sdks install_go_sdk install_java_sdk install_python_sdk install_sdks only_build build_dotnet build_go build_java build_nodejs build_python clean cleanup help install_dotnet_sdk install_nodejs_sdk install_plugins lint_provider provider test tfgen
+.PHONY: development build build_sdks install_go_sdk install_java_sdk install_python_sdk install_sdks only_build build_dotnet build_go build_java build_nodejs build_python clean cleanup finish-patch help install_dotnet_sdk install_nodejs_sdk install_plugins lint_provider provider start-patch test tfgen upstream

--- a/provider-ci/providers/artifactory/repo/Makefile
+++ b/provider-ci/providers/artifactory/repo/Makefile
@@ -145,7 +145,12 @@ else ifeq ("$(wildcard patches/*.patch)","")
 	@echo "patches were expected because upstream exists"
 	@exit 1
 else
+	# Checkout the submodule at the pinned commit.
+	# `--force`: If the submodule is at a different commit, move it to the pinned commit.
+	# `--init`: If the submodule is not initialized, initialize it.
 	git submodule update --force --init
+	# Iterating over the patches folder in sorted order,
+	# apply the patch using a 3-way merge strategy. This mirrors the default behavior of `git merge`
 	cd upstream && \
 		for patch in $(sort $(wildcard patches/*.patch)); do git apply --3way ../$$patch || exit 1; done
 endif

--- a/provider-ci/providers/auth0/repo/Makefile
+++ b/provider-ci/providers/auth0/repo/Makefile
@@ -144,7 +144,12 @@ else ifeq ("$(wildcard patches/*.patch)","")
 	@echo "patches were expected because upstream exists"
 	@exit 1
 else
+	# Checkout the submodule at the pinned commit.
+	# `--force`: If the submodule is at a different commit, move it to the pinned commit.
+	# `--init`: If the submodule is not initialized, initialize it.
 	git submodule update --force --init
+	# Iterating over the patches folder in sorted order,
+	# apply the patch using a 3-way merge strategy. This mirrors the default behavior of `git merge`
 	cd upstream && \
 		for patch in $(sort $(wildcard patches/*.patch)); do git apply --3way ../$$patch || exit 1; done
 endif

--- a/provider-ci/providers/auth0/repo/Makefile
+++ b/provider-ci/providers/auth0/repo/Makefile
@@ -30,7 +30,7 @@ install_sdks: install_dotnet_sdk install_python_sdk install_nodejs_sdk install_j
 only_build: build
 
 build_dotnet: DOTNET_VERSION := $(shell pulumictl get version --language dotnet)
-build_dotnet:
+build_dotnet: upstream
 	pulumictl get version --language dotnet
 	$(WORKING_DIR)/bin/$(TFGEN) dotnet --out sdk/dotnet/
 	cd sdk/dotnet/ && \
@@ -38,19 +38,19 @@ build_dotnet:
 		echo "$(DOTNET_VERSION)" >version.txt && \
 		dotnet build /p:Version=$(DOTNET_VERSION)
 
-build_go:
+build_go: upstream
 	$(WORKING_DIR)/bin/$(TFGEN) go --out sdk/go/
 	cd sdk && go list `grep -e "^module" go.mod | cut -d ' ' -f 2`/go/... | xargs go build
 
 build_java: PACKAGE_VERSION := $(shell pulumictl get version --language generic)
-build_java: bin/pulumi-java-gen
+build_java: bin/pulumi-java-gen upstream
 	$(WORKING_DIR)/bin/$(JAVA_GEN) generate --schema provider/cmd/$(PROVIDER)/schema.json --out sdk/java  --build gradle-nexus
 	cd sdk/java/ && \
 		echo "module fake_java_module // Exclude this directory from Go tools\n\ngo 1.17" > go.mod && \
 		gradle --console=plain build
 
 build_nodejs: VERSION := $(shell pulumictl get version --language javascript)
-build_nodejs:
+build_nodejs: upstream
 	$(WORKING_DIR)/bin/$(TFGEN) nodejs --out sdk/nodejs/
 	cd sdk/nodejs/ && \
 		echo "module fake_nodejs_module // Exclude this directory from Go tools\n\ngo 1.17" > go.mod && \
@@ -60,7 +60,7 @@ build_nodejs:
 		sed -i.bak -e "s/\$${VERSION}/$(VERSION)/g" ./bin/package.json
 
 build_python: PYPI_VERSION := $(shell pulumictl get version --language python)
-build_python:
+build_python: upstream
 	$(WORKING_DIR)/bin/$(TFGEN) python --out sdk/python/
 	cd sdk/python/ && \
 		echo "module fake_python_module // Exclude this directory from Go tools\n\ngo 1.17" > go.mod && \
@@ -77,6 +77,11 @@ clean:
 cleanup:
 	rm -r $(WORKING_DIR)/bin
 	rm -f provider/cmd/$(PROVIDER)/schema.go
+
+finish-patch:
+	@if [ ! -z "$$(cd upstream && git status --porcelain)" ]; then echo "Please commit your changes before finishing the patch"; exit 1; fi
+	@cd upstream && \
+		git format-patch HEAD~ -o ../patches --start-number $$(($$(ls ../patches | wc -l | xargs)+1))
 
 help:
 	@grep '^[^.#]\+:\s\+.*#' Makefile | \
@@ -99,15 +104,52 @@ lint_provider: provider
 provider: tfgen install_plugins
 	(cd provider && go build -p 1 -o $(WORKING_DIR)/bin/$(PROVIDER) -ldflags "-X $(PROJECT)/$(VERSION_PATH)=$(VERSION)" $(PROJECT)/$(PROVIDER_PATH)/cmd/$(PROVIDER))
 
+start-patch: upstream
+ifeq ("$(wildcard upstream)","")
+	@echo "No upstream found, so upstream can't be patched"
+	@exit 1
+else
+	# To add an additional patch:
+	#
+	#	1. Run this command (`make start-patch`).
+	#
+	#	2. Edit the `upstream` repo, making whatever changes you want to appear in the new
+	#	patch. It's fine to edit multiple files.
+	#
+	#	3. Commit your changes. The slugified first line of your commit description will
+	#	be used to generate the patch file name. Only the diff from the latest commit will
+	#	end up in the final patch.
+	#
+	#	4. Run `make finish-patch`.
+	#
+	# It is safe to run `make start-patch` as many times as you want, but any changes
+	# might be reverted until `make finish-patch` is run.
+	@cd upstream && git commit --quiet -m "existing patches"
+endif
+
 test:
 	cd examples && go test -v -tags=all -parallel $(TESTPARALLELISM) -timeout 2h
 
-tfgen: install_plugins
+tfgen: install_plugins upstream
 	(cd provider && go build -p 1 -o $(WORKING_DIR)/bin/$(TFGEN) -ldflags "-X $(PROJECT)/$(VERSION_PATH)=$(VERSION)" $(PROJECT)/$(PROVIDER_PATH)/cmd/$(TFGEN))
 	$(WORKING_DIR)/bin/$(TFGEN) schema --out provider/cmd/$(PROVIDER)
 	(cd provider && VERSION=$(VERSION) go generate cmd/$(PROVIDER)/main.go)
 
+upstream:
+ifeq ("$(wildcard upstream)","")
+	# upstream doesn't exist, so skip
+else ifeq ("$(wildcard patches/*.patch)","")
+	# upstream exists, but patches don't exist. This is probably an error.
+	@echo "No patches found within the patch operation"
+	@echo "patches were expected because upstream exists"
+	@exit 1
+else
+	git submodule update --force --init
+	cd upstream && \
+		for patch in $(sort $(wildcard patches/*.patch)); do git apply --3way ../$$patch || exit 1; done
+endif
+
 bin/pulumi-java-gen:
 	$(shell pulumictl download-binary -n pulumi-language-java -v $(JAVA_GEN_VERSION) -r pulumi/pulumi-java)
 
-.PHONY: development build build_sdks install_go_sdk install_java_sdk install_python_sdk install_sdks only_build build_dotnet build_go build_java build_nodejs build_python clean cleanup help install_dotnet_sdk install_nodejs_sdk install_plugins lint_provider provider test tfgen
+.PHONY: development build build_sdks install_go_sdk install_java_sdk install_python_sdk install_sdks only_build build_dotnet build_go build_java build_nodejs build_python clean cleanup finish-patch help install_dotnet_sdk install_nodejs_sdk install_plugins lint_provider provider start-patch test tfgen upstream

--- a/provider-ci/providers/aws/config.yaml
+++ b/provider-ci/providers/aws/config.yaml
@@ -21,3 +21,4 @@ plugins:
     version: "3.17.0"
   - name: random
     version: "4.8.2"
+team: providers

--- a/provider-ci/providers/azure/config.yaml
+++ b/provider-ci/providers/azure/config.yaml
@@ -21,3 +21,4 @@ plugins:
     version: "4.1.1"
   - name: azuread
     version: "4.0.0"
+team: providers

--- a/provider-ci/providers/azuread/config.yaml
+++ b/provider-ci/providers/azuread/config.yaml
@@ -9,3 +9,4 @@ env:
   ARM_CLIENT_SECRET: ${{ secrets.ARM_CLIENT_SECRET }}
 upstream-provider-org: hashicorp
 makeTemplate: bridged
+team: providers

--- a/provider-ci/providers/azuredevops/config.yaml
+++ b/provider-ci/providers/azuredevops/config.yaml
@@ -5,3 +5,4 @@ env:
   AZDO_PERSONAL_ACCESS_TOKEN: ${{ secrets.AZDO_PERSONAL_ACCESS_TOKEN }}
 upstream-provider-org: pulumi
 makeTemplate: bridged
+team: providers

--- a/provider-ci/providers/civo/repo/Makefile
+++ b/provider-ci/providers/civo/repo/Makefile
@@ -144,7 +144,12 @@ else ifeq ("$(wildcard patches/*.patch)","")
 	@echo "patches were expected because upstream exists"
 	@exit 1
 else
+	# Checkout the submodule at the pinned commit.
+	# `--force`: If the submodule is at a different commit, move it to the pinned commit.
+	# `--init`: If the submodule is not initialized, initialize it.
 	git submodule update --force --init
+	# Iterating over the patches folder in sorted order,
+	# apply the patch using a 3-way merge strategy. This mirrors the default behavior of `git merge`
 	cd upstream && \
 		for patch in $(sort $(wildcard patches/*.patch)); do git apply --3way ../$$patch || exit 1; done
 endif

--- a/provider-ci/providers/civo/repo/Makefile
+++ b/provider-ci/providers/civo/repo/Makefile
@@ -30,7 +30,7 @@ install_sdks: install_dotnet_sdk install_python_sdk install_nodejs_sdk install_j
 only_build: build
 
 build_dotnet: DOTNET_VERSION := $(shell pulumictl get version --language dotnet)
-build_dotnet:
+build_dotnet: upstream
 	pulumictl get version --language dotnet
 	$(WORKING_DIR)/bin/$(TFGEN) dotnet --out sdk/dotnet/
 	cd sdk/dotnet/ && \
@@ -38,19 +38,19 @@ build_dotnet:
 		echo "$(DOTNET_VERSION)" >version.txt && \
 		dotnet build /p:Version=$(DOTNET_VERSION)
 
-build_go:
+build_go: upstream
 	$(WORKING_DIR)/bin/$(TFGEN) go --out sdk/go/
 	cd sdk && go list `grep -e "^module" go.mod | cut -d ' ' -f 2`/go/... | xargs go build
 
 build_java: PACKAGE_VERSION := $(shell pulumictl get version --language generic)
-build_java: bin/pulumi-java-gen
+build_java: bin/pulumi-java-gen upstream
 	$(WORKING_DIR)/bin/$(JAVA_GEN) generate --schema provider/cmd/$(PROVIDER)/schema.json --out sdk/java  --build gradle-nexus
 	cd sdk/java/ && \
 		echo "module fake_java_module // Exclude this directory from Go tools\n\ngo 1.17" > go.mod && \
 		gradle --console=plain build
 
 build_nodejs: VERSION := $(shell pulumictl get version --language javascript)
-build_nodejs:
+build_nodejs: upstream
 	$(WORKING_DIR)/bin/$(TFGEN) nodejs --out sdk/nodejs/
 	cd sdk/nodejs/ && \
 		echo "module fake_nodejs_module // Exclude this directory from Go tools\n\ngo 1.17" > go.mod && \
@@ -60,7 +60,7 @@ build_nodejs:
 		sed -i.bak -e "s/\$${VERSION}/$(VERSION)/g" ./bin/package.json
 
 build_python: PYPI_VERSION := $(shell pulumictl get version --language python)
-build_python:
+build_python: upstream
 	$(WORKING_DIR)/bin/$(TFGEN) python --out sdk/python/
 	cd sdk/python/ && \
 		echo "module fake_python_module // Exclude this directory from Go tools\n\ngo 1.17" > go.mod && \
@@ -77,6 +77,11 @@ clean:
 cleanup:
 	rm -r $(WORKING_DIR)/bin
 	rm -f provider/cmd/$(PROVIDER)/schema.go
+
+finish-patch:
+	@if [ ! -z "$$(cd upstream && git status --porcelain)" ]; then echo "Please commit your changes before finishing the patch"; exit 1; fi
+	@cd upstream && \
+		git format-patch HEAD~ -o ../patches --start-number $$(($$(ls ../patches | wc -l | xargs)+1))
 
 help:
 	@grep '^[^.#]\+:\s\+.*#' Makefile | \
@@ -99,15 +104,52 @@ lint_provider: provider
 provider: tfgen install_plugins
 	(cd provider && go build -p 1 -o $(WORKING_DIR)/bin/$(PROVIDER) -ldflags "-X $(PROJECT)/$(VERSION_PATH)=$(VERSION)" $(PROJECT)/$(PROVIDER_PATH)/cmd/$(PROVIDER))
 
+start-patch: upstream
+ifeq ("$(wildcard upstream)","")
+	@echo "No upstream found, so upstream can't be patched"
+	@exit 1
+else
+	# To add an additional patch:
+	#
+	#	1. Run this command (`make start-patch`).
+	#
+	#	2. Edit the `upstream` repo, making whatever changes you want to appear in the new
+	#	patch. It's fine to edit multiple files.
+	#
+	#	3. Commit your changes. The slugified first line of your commit description will
+	#	be used to generate the patch file name. Only the diff from the latest commit will
+	#	end up in the final patch.
+	#
+	#	4. Run `make finish-patch`.
+	#
+	# It is safe to run `make start-patch` as many times as you want, but any changes
+	# might be reverted until `make finish-patch` is run.
+	@cd upstream && git commit --quiet -m "existing patches"
+endif
+
 test:
 	cd examples && go test -v -tags=all -parallel $(TESTPARALLELISM) -timeout 2h
 
-tfgen: install_plugins
+tfgen: install_plugins upstream
 	(cd provider && go build -p 1 -o $(WORKING_DIR)/bin/$(TFGEN) -ldflags "-X $(PROJECT)/$(VERSION_PATH)=$(VERSION)" $(PROJECT)/$(PROVIDER_PATH)/cmd/$(TFGEN))
 	$(WORKING_DIR)/bin/$(TFGEN) schema --out provider/cmd/$(PROVIDER)
 	(cd provider && VERSION=$(VERSION) go generate cmd/$(PROVIDER)/main.go)
 
+upstream:
+ifeq ("$(wildcard upstream)","")
+	# upstream doesn't exist, so skip
+else ifeq ("$(wildcard patches/*.patch)","")
+	# upstream exists, but patches don't exist. This is probably an error.
+	@echo "No patches found within the patch operation"
+	@echo "patches were expected because upstream exists"
+	@exit 1
+else
+	git submodule update --force --init
+	cd upstream && \
+		for patch in $(sort $(wildcard patches/*.patch)); do git apply --3way ../$$patch || exit 1; done
+endif
+
 bin/pulumi-java-gen:
 	$(shell pulumictl download-binary -n pulumi-language-java -v $(JAVA_GEN_VERSION) -r pulumi/pulumi-java)
 
-.PHONY: development build build_sdks install_go_sdk install_java_sdk install_python_sdk install_sdks only_build build_dotnet build_go build_java build_nodejs build_python clean cleanup help install_dotnet_sdk install_nodejs_sdk install_plugins lint_provider provider test tfgen
+.PHONY: development build build_sdks install_go_sdk install_java_sdk install_python_sdk install_sdks only_build build_dotnet build_go build_java build_nodejs build_python clean cleanup finish-patch help install_dotnet_sdk install_nodejs_sdk install_plugins lint_provider provider start-patch test tfgen upstream

--- a/provider-ci/providers/cloudamqp/repo/Makefile
+++ b/provider-ci/providers/cloudamqp/repo/Makefile
@@ -144,7 +144,12 @@ else ifeq ("$(wildcard patches/*.patch)","")
 	@echo "patches were expected because upstream exists"
 	@exit 1
 else
+	# Checkout the submodule at the pinned commit.
+	# `--force`: If the submodule is at a different commit, move it to the pinned commit.
+	# `--init`: If the submodule is not initialized, initialize it.
 	git submodule update --force --init
+	# Iterating over the patches folder in sorted order,
+	# apply the patch using a 3-way merge strategy. This mirrors the default behavior of `git merge`
 	cd upstream && \
 		for patch in $(sort $(wildcard patches/*.patch)); do git apply --3way ../$$patch || exit 1; done
 endif

--- a/provider-ci/providers/cloudamqp/repo/Makefile
+++ b/provider-ci/providers/cloudamqp/repo/Makefile
@@ -30,7 +30,7 @@ install_sdks: install_dotnet_sdk install_python_sdk install_nodejs_sdk install_j
 only_build: build
 
 build_dotnet: DOTNET_VERSION := $(shell pulumictl get version --language dotnet)
-build_dotnet:
+build_dotnet: upstream
 	pulumictl get version --language dotnet
 	$(WORKING_DIR)/bin/$(TFGEN) dotnet --out sdk/dotnet/
 	cd sdk/dotnet/ && \
@@ -38,19 +38,19 @@ build_dotnet:
 		echo "$(DOTNET_VERSION)" >version.txt && \
 		dotnet build /p:Version=$(DOTNET_VERSION)
 
-build_go:
+build_go: upstream
 	$(WORKING_DIR)/bin/$(TFGEN) go --out sdk/go/
 	cd sdk && go list `grep -e "^module" go.mod | cut -d ' ' -f 2`/go/... | xargs go build
 
 build_java: PACKAGE_VERSION := $(shell pulumictl get version --language generic)
-build_java: bin/pulumi-java-gen
+build_java: bin/pulumi-java-gen upstream
 	$(WORKING_DIR)/bin/$(JAVA_GEN) generate --schema provider/cmd/$(PROVIDER)/schema.json --out sdk/java  --build gradle-nexus
 	cd sdk/java/ && \
 		echo "module fake_java_module // Exclude this directory from Go tools\n\ngo 1.17" > go.mod && \
 		gradle --console=plain build
 
 build_nodejs: VERSION := $(shell pulumictl get version --language javascript)
-build_nodejs:
+build_nodejs: upstream
 	$(WORKING_DIR)/bin/$(TFGEN) nodejs --out sdk/nodejs/
 	cd sdk/nodejs/ && \
 		echo "module fake_nodejs_module // Exclude this directory from Go tools\n\ngo 1.17" > go.mod && \
@@ -60,7 +60,7 @@ build_nodejs:
 		sed -i.bak -e "s/\$${VERSION}/$(VERSION)/g" ./bin/package.json
 
 build_python: PYPI_VERSION := $(shell pulumictl get version --language python)
-build_python:
+build_python: upstream
 	$(WORKING_DIR)/bin/$(TFGEN) python --out sdk/python/
 	cd sdk/python/ && \
 		echo "module fake_python_module // Exclude this directory from Go tools\n\ngo 1.17" > go.mod && \
@@ -77,6 +77,11 @@ clean:
 cleanup:
 	rm -r $(WORKING_DIR)/bin
 	rm -f provider/cmd/$(PROVIDER)/schema.go
+
+finish-patch:
+	@if [ ! -z "$$(cd upstream && git status --porcelain)" ]; then echo "Please commit your changes before finishing the patch"; exit 1; fi
+	@cd upstream && \
+		git format-patch HEAD~ -o ../patches --start-number $$(($$(ls ../patches | wc -l | xargs)+1))
 
 help:
 	@grep '^[^.#]\+:\s\+.*#' Makefile | \
@@ -99,15 +104,52 @@ lint_provider: provider
 provider: tfgen install_plugins
 	(cd provider && go build -p 1 -o $(WORKING_DIR)/bin/$(PROVIDER) -ldflags "-X $(PROJECT)/$(VERSION_PATH)=$(VERSION)" $(PROJECT)/$(PROVIDER_PATH)/cmd/$(PROVIDER))
 
+start-patch: upstream
+ifeq ("$(wildcard upstream)","")
+	@echo "No upstream found, so upstream can't be patched"
+	@exit 1
+else
+	# To add an additional patch:
+	#
+	#	1. Run this command (`make start-patch`).
+	#
+	#	2. Edit the `upstream` repo, making whatever changes you want to appear in the new
+	#	patch. It's fine to edit multiple files.
+	#
+	#	3. Commit your changes. The slugified first line of your commit description will
+	#	be used to generate the patch file name. Only the diff from the latest commit will
+	#	end up in the final patch.
+	#
+	#	4. Run `make finish-patch`.
+	#
+	# It is safe to run `make start-patch` as many times as you want, but any changes
+	# might be reverted until `make finish-patch` is run.
+	@cd upstream && git commit --quiet -m "existing patches"
+endif
+
 test:
 	cd examples && go test -v -tags=all -parallel $(TESTPARALLELISM) -timeout 2h
 
-tfgen: install_plugins
+tfgen: install_plugins upstream
 	(cd provider && go build -p 1 -o $(WORKING_DIR)/bin/$(TFGEN) -ldflags "-X $(PROJECT)/$(VERSION_PATH)=$(VERSION)" $(PROJECT)/$(PROVIDER_PATH)/cmd/$(TFGEN))
 	$(WORKING_DIR)/bin/$(TFGEN) schema --out provider/cmd/$(PROVIDER)
 	(cd provider && VERSION=$(VERSION) go generate cmd/$(PROVIDER)/main.go)
 
+upstream:
+ifeq ("$(wildcard upstream)","")
+	# upstream doesn't exist, so skip
+else ifeq ("$(wildcard patches/*.patch)","")
+	# upstream exists, but patches don't exist. This is probably an error.
+	@echo "No patches found within the patch operation"
+	@echo "patches were expected because upstream exists"
+	@exit 1
+else
+	git submodule update --force --init
+	cd upstream && \
+		for patch in $(sort $(wildcard patches/*.patch)); do git apply --3way ../$$patch || exit 1; done
+endif
+
 bin/pulumi-java-gen:
 	$(shell pulumictl download-binary -n pulumi-language-java -v $(JAVA_GEN_VERSION) -r pulumi/pulumi-java)
 
-.PHONY: development build build_sdks install_go_sdk install_java_sdk install_python_sdk install_sdks only_build build_dotnet build_go build_java build_nodejs build_python clean cleanup help install_dotnet_sdk install_nodejs_sdk install_plugins lint_provider provider test tfgen
+.PHONY: development build build_sdks install_go_sdk install_java_sdk install_python_sdk install_sdks only_build build_dotnet build_go build_java build_nodejs build_python clean cleanup finish-patch help install_dotnet_sdk install_nodejs_sdk install_plugins lint_provider provider start-patch test tfgen upstream

--- a/provider-ci/providers/cloudflare/repo/Makefile
+++ b/provider-ci/providers/cloudflare/repo/Makefile
@@ -146,7 +146,12 @@ else ifeq ("$(wildcard patches/*.patch)","")
 	@echo "patches were expected because upstream exists"
 	@exit 1
 else
+	# Checkout the submodule at the pinned commit.
+	# `--force`: If the submodule is at a different commit, move it to the pinned commit.
+	# `--init`: If the submodule is not initialized, initialize it.
 	git submodule update --force --init
+	# Iterating over the patches folder in sorted order,
+	# apply the patch using a 3-way merge strategy. This mirrors the default behavior of `git merge`
 	cd upstream && \
 		for patch in $(sort $(wildcard patches/*.patch)); do git apply --3way ../$$patch || exit 1; done
 endif

--- a/provider-ci/providers/cloudflare/repo/Makefile
+++ b/provider-ci/providers/cloudflare/repo/Makefile
@@ -30,7 +30,7 @@ install_sdks: install_dotnet_sdk install_python_sdk install_nodejs_sdk install_j
 only_build: build
 
 build_dotnet: DOTNET_VERSION := $(shell pulumictl get version --language dotnet)
-build_dotnet:
+build_dotnet: upstream
 	pulumictl get version --language dotnet
 	$(WORKING_DIR)/bin/$(TFGEN) dotnet --out sdk/dotnet/
 	cd sdk/dotnet/ && \
@@ -38,19 +38,19 @@ build_dotnet:
 		echo "$(DOTNET_VERSION)" >version.txt && \
 		dotnet build /p:Version=$(DOTNET_VERSION)
 
-build_go:
+build_go: upstream
 	$(WORKING_DIR)/bin/$(TFGEN) go --out sdk/go/
 	cd sdk && go list `grep -e "^module" go.mod | cut -d ' ' -f 2`/go/... | xargs go build
 
 build_java: PACKAGE_VERSION := $(shell pulumictl get version --language generic)
-build_java: bin/pulumi-java-gen
+build_java: bin/pulumi-java-gen upstream
 	$(WORKING_DIR)/bin/$(JAVA_GEN) generate --schema provider/cmd/$(PROVIDER)/schema.json --out sdk/java  --build gradle-nexus
 	cd sdk/java/ && \
 		echo "module fake_java_module // Exclude this directory from Go tools\n\ngo 1.17" > go.mod && \
 		gradle --console=plain build
 
 build_nodejs: VERSION := $(shell pulumictl get version --language javascript)
-build_nodejs:
+build_nodejs: upstream
 	$(WORKING_DIR)/bin/$(TFGEN) nodejs --out sdk/nodejs/
 	cd sdk/nodejs/ && \
 		echo "module fake_nodejs_module // Exclude this directory from Go tools\n\ngo 1.17" > go.mod && \
@@ -60,7 +60,7 @@ build_nodejs:
 		sed -i.bak -e "s/\$${VERSION}/$(VERSION)/g" ./bin/package.json
 
 build_python: PYPI_VERSION := $(shell pulumictl get version --language python)
-build_python:
+build_python: upstream
 	$(WORKING_DIR)/bin/$(TFGEN) python --out sdk/python/
 	cd sdk/python/ && \
 		echo "module fake_python_module // Exclude this directory from Go tools\n\ngo 1.17" > go.mod && \
@@ -77,6 +77,11 @@ clean:
 cleanup:
 	rm -r $(WORKING_DIR)/bin
 	rm -f provider/cmd/$(PROVIDER)/schema.go
+
+finish-patch:
+	@if [ ! -z "$$(cd upstream && git status --porcelain)" ]; then echo "Please commit your changes before finishing the patch"; exit 1; fi
+	@cd upstream && \
+		git format-patch HEAD~ -o ../patches --start-number $$(($$(ls ../patches | wc -l | xargs)+1))
 
 help:
 	@grep '^[^.#]\+:\s\+.*#' Makefile | \
@@ -101,15 +106,52 @@ lint_provider: provider
 provider: tfgen install_plugins
 	(cd provider && go build -p 1 -o $(WORKING_DIR)/bin/$(PROVIDER) -ldflags "-X $(PROJECT)/$(VERSION_PATH)=$(VERSION)" $(PROJECT)/$(PROVIDER_PATH)/cmd/$(PROVIDER))
 
+start-patch: upstream
+ifeq ("$(wildcard upstream)","")
+	@echo "No upstream found, so upstream can't be patched"
+	@exit 1
+else
+	# To add an additional patch:
+	#
+	#	1. Run this command (`make start-patch`).
+	#
+	#	2. Edit the `upstream` repo, making whatever changes you want to appear in the new
+	#	patch. It's fine to edit multiple files.
+	#
+	#	3. Commit your changes. The slugified first line of your commit description will
+	#	be used to generate the patch file name. Only the diff from the latest commit will
+	#	end up in the final patch.
+	#
+	#	4. Run `make finish-patch`.
+	#
+	# It is safe to run `make start-patch` as many times as you want, but any changes
+	# might be reverted until `make finish-patch` is run.
+	@cd upstream && git commit --quiet -m "existing patches"
+endif
+
 test:
 	cd examples && go test -v -tags=all -parallel $(TESTPARALLELISM) -timeout 2h
 
-tfgen: install_plugins
+tfgen: install_plugins upstream
 	(cd provider && go build -p 1 -o $(WORKING_DIR)/bin/$(TFGEN) -ldflags "-X $(PROJECT)/$(VERSION_PATH)=$(VERSION)" $(PROJECT)/$(PROVIDER_PATH)/cmd/$(TFGEN))
 	$(WORKING_DIR)/bin/$(TFGEN) schema --out provider/cmd/$(PROVIDER)
 	(cd provider && VERSION=$(VERSION) go generate cmd/$(PROVIDER)/main.go)
 
+upstream:
+ifeq ("$(wildcard upstream)","")
+	# upstream doesn't exist, so skip
+else ifeq ("$(wildcard patches/*.patch)","")
+	# upstream exists, but patches don't exist. This is probably an error.
+	@echo "No patches found within the patch operation"
+	@echo "patches were expected because upstream exists"
+	@exit 1
+else
+	git submodule update --force --init
+	cd upstream && \
+		for patch in $(sort $(wildcard patches/*.patch)); do git apply --3way ../$$patch || exit 1; done
+endif
+
 bin/pulumi-java-gen:
 	$(shell pulumictl download-binary -n pulumi-language-java -v $(JAVA_GEN_VERSION) -r pulumi/pulumi-java)
 
-.PHONY: development build build_sdks install_go_sdk install_java_sdk install_python_sdk install_sdks only_build build_dotnet build_go build_java build_nodejs build_python clean cleanup help install_dotnet_sdk install_nodejs_sdk install_plugins lint_provider provider test tfgen
+.PHONY: development build build_sdks install_go_sdk install_java_sdk install_python_sdk install_sdks only_build build_dotnet build_go build_java build_nodejs build_python clean cleanup finish-patch help install_dotnet_sdk install_nodejs_sdk install_plugins lint_provider provider start-patch test tfgen upstream

--- a/provider-ci/providers/cloudinit/repo/Makefile
+++ b/provider-ci/providers/cloudinit/repo/Makefile
@@ -144,7 +144,12 @@ else ifeq ("$(wildcard patches/*.patch)","")
 	@echo "patches were expected because upstream exists"
 	@exit 1
 else
+	# Checkout the submodule at the pinned commit.
+	# `--force`: If the submodule is at a different commit, move it to the pinned commit.
+	# `--init`: If the submodule is not initialized, initialize it.
 	git submodule update --force --init
+	# Iterating over the patches folder in sorted order,
+	# apply the patch using a 3-way merge strategy. This mirrors the default behavior of `git merge`
 	cd upstream && \
 		for patch in $(sort $(wildcard patches/*.patch)); do git apply --3way ../$$patch || exit 1; done
 endif

--- a/provider-ci/providers/cloudinit/repo/Makefile
+++ b/provider-ci/providers/cloudinit/repo/Makefile
@@ -30,7 +30,7 @@ install_sdks: install_dotnet_sdk install_python_sdk install_nodejs_sdk install_j
 only_build: build
 
 build_dotnet: DOTNET_VERSION := $(shell pulumictl get version --language dotnet)
-build_dotnet:
+build_dotnet: upstream
 	pulumictl get version --language dotnet
 	$(WORKING_DIR)/bin/$(TFGEN) dotnet --out sdk/dotnet/
 	cd sdk/dotnet/ && \
@@ -38,19 +38,19 @@ build_dotnet:
 		echo "$(DOTNET_VERSION)" >version.txt && \
 		dotnet build /p:Version=$(DOTNET_VERSION)
 
-build_go:
+build_go: upstream
 	$(WORKING_DIR)/bin/$(TFGEN) go --out sdk/go/
 	cd sdk && go list `grep -e "^module" go.mod | cut -d ' ' -f 2`/go/... | xargs go build
 
 build_java: PACKAGE_VERSION := $(shell pulumictl get version --language generic)
-build_java: bin/pulumi-java-gen
+build_java: bin/pulumi-java-gen upstream
 	$(WORKING_DIR)/bin/$(JAVA_GEN) generate --schema provider/cmd/$(PROVIDER)/schema.json --out sdk/java  --build gradle-nexus
 	cd sdk/java/ && \
 		echo "module fake_java_module // Exclude this directory from Go tools\n\ngo 1.17" > go.mod && \
 		gradle --console=plain build
 
 build_nodejs: VERSION := $(shell pulumictl get version --language javascript)
-build_nodejs:
+build_nodejs: upstream
 	$(WORKING_DIR)/bin/$(TFGEN) nodejs --out sdk/nodejs/
 	cd sdk/nodejs/ && \
 		echo "module fake_nodejs_module // Exclude this directory from Go tools\n\ngo 1.17" > go.mod && \
@@ -60,7 +60,7 @@ build_nodejs:
 		sed -i.bak -e "s/\$${VERSION}/$(VERSION)/g" ./bin/package.json
 
 build_python: PYPI_VERSION := $(shell pulumictl get version --language python)
-build_python:
+build_python: upstream
 	$(WORKING_DIR)/bin/$(TFGEN) python --out sdk/python/
 	cd sdk/python/ && \
 		echo "module fake_python_module // Exclude this directory from Go tools\n\ngo 1.17" > go.mod && \
@@ -77,6 +77,11 @@ clean:
 cleanup:
 	rm -r $(WORKING_DIR)/bin
 	rm -f provider/cmd/$(PROVIDER)/schema.go
+
+finish-patch:
+	@if [ ! -z "$$(cd upstream && git status --porcelain)" ]; then echo "Please commit your changes before finishing the patch"; exit 1; fi
+	@cd upstream && \
+		git format-patch HEAD~ -o ../patches --start-number $$(($$(ls ../patches | wc -l | xargs)+1))
 
 help:
 	@grep '^[^.#]\+:\s\+.*#' Makefile | \
@@ -99,15 +104,52 @@ lint_provider: provider
 provider: tfgen install_plugins
 	(cd provider && go build -p 1 -o $(WORKING_DIR)/bin/$(PROVIDER) -ldflags "-X $(PROJECT)/$(VERSION_PATH)=$(VERSION)" $(PROJECT)/$(PROVIDER_PATH)/cmd/$(PROVIDER))
 
+start-patch: upstream
+ifeq ("$(wildcard upstream)","")
+	@echo "No upstream found, so upstream can't be patched"
+	@exit 1
+else
+	# To add an additional patch:
+	#
+	#	1. Run this command (`make start-patch`).
+	#
+	#	2. Edit the `upstream` repo, making whatever changes you want to appear in the new
+	#	patch. It's fine to edit multiple files.
+	#
+	#	3. Commit your changes. The slugified first line of your commit description will
+	#	be used to generate the patch file name. Only the diff from the latest commit will
+	#	end up in the final patch.
+	#
+	#	4. Run `make finish-patch`.
+	#
+	# It is safe to run `make start-patch` as many times as you want, but any changes
+	# might be reverted until `make finish-patch` is run.
+	@cd upstream && git commit --quiet -m "existing patches"
+endif
+
 test:
 	cd examples && go test -v -tags=all -parallel $(TESTPARALLELISM) -timeout 2h
 
-tfgen: install_plugins
+tfgen: install_plugins upstream
 	(cd provider && go build -p 1 -o $(WORKING_DIR)/bin/$(TFGEN) -ldflags "-X $(PROJECT)/$(VERSION_PATH)=$(VERSION)" $(PROJECT)/$(PROVIDER_PATH)/cmd/$(TFGEN))
 	$(WORKING_DIR)/bin/$(TFGEN) schema --out provider/cmd/$(PROVIDER)
 	(cd provider && VERSION=$(VERSION) go generate cmd/$(PROVIDER)/main.go)
 
+upstream:
+ifeq ("$(wildcard upstream)","")
+	# upstream doesn't exist, so skip
+else ifeq ("$(wildcard patches/*.patch)","")
+	# upstream exists, but patches don't exist. This is probably an error.
+	@echo "No patches found within the patch operation"
+	@echo "patches were expected because upstream exists"
+	@exit 1
+else
+	git submodule update --force --init
+	cd upstream && \
+		for patch in $(sort $(wildcard patches/*.patch)); do git apply --3way ../$$patch || exit 1; done
+endif
+
 bin/pulumi-java-gen:
 	$(shell pulumictl download-binary -n pulumi-language-java -v $(JAVA_GEN_VERSION) -r pulumi/pulumi-java)
 
-.PHONY: development build build_sdks install_go_sdk install_java_sdk install_python_sdk install_sdks only_build build_dotnet build_go build_java build_nodejs build_python clean cleanup help install_dotnet_sdk install_nodejs_sdk install_plugins lint_provider provider test tfgen
+.PHONY: development build build_sdks install_go_sdk install_java_sdk install_python_sdk install_sdks only_build build_dotnet build_go build_java build_nodejs build_python clean cleanup finish-patch help install_dotnet_sdk install_nodejs_sdk install_plugins lint_provider provider start-patch test tfgen upstream

--- a/provider-ci/providers/confluent/repo/Makefile
+++ b/provider-ci/providers/confluent/repo/Makefile
@@ -30,7 +30,7 @@ install_sdks: install_dotnet_sdk install_python_sdk install_nodejs_sdk install_j
 only_build: build
 
 build_dotnet: DOTNET_VERSION := $(shell pulumictl get version --language dotnet)
-build_dotnet:
+build_dotnet: upstream
 	pulumictl get version --language dotnet
 	$(WORKING_DIR)/bin/$(TFGEN) dotnet --out sdk/dotnet/
 	cd sdk/dotnet/ && \
@@ -38,19 +38,19 @@ build_dotnet:
 		echo "$(DOTNET_VERSION)" >version.txt && \
 		dotnet build /p:Version=$(DOTNET_VERSION)
 
-build_go:
+build_go: upstream
 	$(WORKING_DIR)/bin/$(TFGEN) go --out sdk/go/
 	cd sdk && go list `grep -e "^module" go.mod | cut -d ' ' -f 2`/go/... | xargs go build
 
 build_java: PACKAGE_VERSION := $(shell pulumictl get version --language generic)
-build_java: bin/pulumi-java-gen
+build_java: bin/pulumi-java-gen upstream
 	$(WORKING_DIR)/bin/$(JAVA_GEN) generate --schema provider/cmd/$(PROVIDER)/schema.json --out sdk/java  --build gradle-nexus
 	cd sdk/java/ && \
 		echo "module fake_java_module // Exclude this directory from Go tools\n\ngo 1.17" > go.mod && \
 		gradle --console=plain build
 
 build_nodejs: VERSION := $(shell pulumictl get version --language javascript)
-build_nodejs:
+build_nodejs: upstream
 	$(WORKING_DIR)/bin/$(TFGEN) nodejs --out sdk/nodejs/
 	cd sdk/nodejs/ && \
 		echo "module fake_nodejs_module // Exclude this directory from Go tools\n\ngo 1.17" > go.mod && \
@@ -60,7 +60,7 @@ build_nodejs:
 		sed -i.bak -e "s/\$${VERSION}/$(VERSION)/g" ./bin/package.json
 
 build_python: PYPI_VERSION := $(shell pulumictl get version --language python)
-build_python:
+build_python: upstream
 	$(WORKING_DIR)/bin/$(TFGEN) python --out sdk/python/
 	cd sdk/python/ && \
 		echo "module fake_python_module // Exclude this directory from Go tools\n\ngo 1.17" > go.mod && \
@@ -77,6 +77,11 @@ clean:
 cleanup:
 	rm -r $(WORKING_DIR)/bin
 	rm -f provider/cmd/$(PROVIDER)/schema.go
+
+finish-patch:
+	@if [ ! -z "$$(cd upstream && git status --porcelain)" ]; then echo "Please commit your changes before finishing the patch"; exit 1; fi
+	@cd upstream && \
+		git format-patch HEAD~ -o ../patches --start-number $$(($$(ls ../patches | wc -l | xargs)+1))
 
 help:
 	@grep '^[^.#]\+:\s\+.*#' Makefile | \
@@ -100,15 +105,52 @@ lint_provider: provider
 provider: tfgen install_plugins
 	(cd provider && go build -p 1 -o $(WORKING_DIR)/bin/$(PROVIDER) -ldflags "-X $(PROJECT)/$(VERSION_PATH)=$(VERSION)" $(PROJECT)/$(PROVIDER_PATH)/cmd/$(PROVIDER))
 
+start-patch: upstream
+ifeq ("$(wildcard upstream)","")
+	@echo "No upstream found, so upstream can't be patched"
+	@exit 1
+else
+	# To add an additional patch:
+	#
+	#	1. Run this command (`make start-patch`).
+	#
+	#	2. Edit the `upstream` repo, making whatever changes you want to appear in the new
+	#	patch. It's fine to edit multiple files.
+	#
+	#	3. Commit your changes. The slugified first line of your commit description will
+	#	be used to generate the patch file name. Only the diff from the latest commit will
+	#	end up in the final patch.
+	#
+	#	4. Run `make finish-patch`.
+	#
+	# It is safe to run `make start-patch` as many times as you want, but any changes
+	# might be reverted until `make finish-patch` is run.
+	@cd upstream && git commit --quiet -m "existing patches"
+endif
+
 test:
 	cd examples && go test -v -tags=all -parallel $(TESTPARALLELISM) -timeout 2h
 
-tfgen: install_plugins
+tfgen: install_plugins upstream
 	(cd provider && go build -p 1 -o $(WORKING_DIR)/bin/$(TFGEN) -ldflags "-X $(PROJECT)/$(VERSION_PATH)=$(VERSION)" $(PROJECT)/$(PROVIDER_PATH)/cmd/$(TFGEN))
 	$(WORKING_DIR)/bin/$(TFGEN) schema --out provider/cmd/$(PROVIDER)
 	(cd provider && VERSION=$(VERSION) go generate cmd/$(PROVIDER)/main.go)
 
+upstream:
+ifeq ("$(wildcard upstream)","")
+	# upstream doesn't exist, so skip
+else ifeq ("$(wildcard patches/*.patch)","")
+	# upstream exists, but patches don't exist. This is probably an error.
+	@echo "No patches found within the patch operation"
+	@echo "patches were expected because upstream exists"
+	@exit 1
+else
+	git submodule update --force --init
+	cd upstream && \
+		for patch in $(sort $(wildcard patches/*.patch)); do git apply --3way ../$$patch || exit 1; done
+endif
+
 bin/pulumi-java-gen:
 	$(shell pulumictl download-binary -n pulumi-language-java -v $(JAVA_GEN_VERSION) -r pulumi/pulumi-java)
 
-.PHONY: development build build_sdks install_go_sdk install_java_sdk install_python_sdk install_sdks only_build build_dotnet build_go build_java build_nodejs build_python clean cleanup help install_dotnet_sdk install_nodejs_sdk install_plugins lint_provider provider test tfgen
+.PHONY: development build build_sdks install_go_sdk install_java_sdk install_python_sdk install_sdks only_build build_dotnet build_go build_java build_nodejs build_python clean cleanup finish-patch help install_dotnet_sdk install_nodejs_sdk install_plugins lint_provider provider start-patch test tfgen upstream

--- a/provider-ci/providers/confluent/repo/Makefile
+++ b/provider-ci/providers/confluent/repo/Makefile
@@ -145,7 +145,12 @@ else ifeq ("$(wildcard patches/*.patch)","")
 	@echo "patches were expected because upstream exists"
 	@exit 1
 else
+	# Checkout the submodule at the pinned commit.
+	# `--force`: If the submodule is at a different commit, move it to the pinned commit.
+	# `--init`: If the submodule is not initialized, initialize it.
 	git submodule update --force --init
+	# Iterating over the patches folder in sorted order,
+	# apply the patch using a 3-way merge strategy. This mirrors the default behavior of `git merge`
 	cd upstream && \
 		for patch in $(sort $(wildcard patches/*.patch)); do git apply --3way ../$$patch || exit 1; done
 endif

--- a/provider-ci/providers/confluentcloud/repo/Makefile
+++ b/provider-ci/providers/confluentcloud/repo/Makefile
@@ -30,7 +30,7 @@ install_sdks: install_dotnet_sdk install_python_sdk install_nodejs_sdk install_j
 only_build: build
 
 build_dotnet: DOTNET_VERSION := $(shell pulumictl get version --language dotnet)
-build_dotnet:
+build_dotnet: upstream
 	pulumictl get version --language dotnet
 	$(WORKING_DIR)/bin/$(TFGEN) dotnet --out sdk/dotnet/
 	cd sdk/dotnet/ && \
@@ -38,19 +38,19 @@ build_dotnet:
 		echo "$(DOTNET_VERSION)" >version.txt && \
 		dotnet build /p:Version=$(DOTNET_VERSION)
 
-build_go:
+build_go: upstream
 	$(WORKING_DIR)/bin/$(TFGEN) go --out sdk/go/
 	cd sdk && go list `grep -e "^module" go.mod | cut -d ' ' -f 2`/go/... | xargs go build
 
 build_java: PACKAGE_VERSION := $(shell pulumictl get version --language generic)
-build_java: bin/pulumi-java-gen
+build_java: bin/pulumi-java-gen upstream
 	$(WORKING_DIR)/bin/$(JAVA_GEN) generate --schema provider/cmd/$(PROVIDER)/schema.json --out sdk/java  --build gradle-nexus
 	cd sdk/java/ && \
 		echo "module fake_java_module // Exclude this directory from Go tools\n\ngo 1.17" > go.mod && \
 		gradle --console=plain build
 
 build_nodejs: VERSION := $(shell pulumictl get version --language javascript)
-build_nodejs:
+build_nodejs: upstream
 	$(WORKING_DIR)/bin/$(TFGEN) nodejs --out sdk/nodejs/
 	cd sdk/nodejs/ && \
 		echo "module fake_nodejs_module // Exclude this directory from Go tools\n\ngo 1.17" > go.mod && \
@@ -60,7 +60,7 @@ build_nodejs:
 		sed -i.bak -e "s/\$${VERSION}/$(VERSION)/g" ./bin/package.json
 
 build_python: PYPI_VERSION := $(shell pulumictl get version --language python)
-build_python:
+build_python: upstream
 	$(WORKING_DIR)/bin/$(TFGEN) python --out sdk/python/
 	cd sdk/python/ && \
 		echo "module fake_python_module // Exclude this directory from Go tools\n\ngo 1.17" > go.mod && \
@@ -77,6 +77,11 @@ clean:
 cleanup:
 	rm -r $(WORKING_DIR)/bin
 	rm -f provider/cmd/$(PROVIDER)/schema.go
+
+finish-patch:
+	@if [ ! -z "$$(cd upstream && git status --porcelain)" ]; then echo "Please commit your changes before finishing the patch"; exit 1; fi
+	@cd upstream && \
+		git format-patch HEAD~ -o ../patches --start-number $$(($$(ls ../patches | wc -l | xargs)+1))
 
 help:
 	@grep '^[^.#]\+:\s\+.*#' Makefile | \
@@ -100,15 +105,52 @@ lint_provider: provider
 provider: tfgen install_plugins
 	(cd provider && go build -p 1 -o $(WORKING_DIR)/bin/$(PROVIDER) -ldflags "-X $(PROJECT)/$(VERSION_PATH)=$(VERSION)" $(PROJECT)/$(PROVIDER_PATH)/cmd/$(PROVIDER))
 
+start-patch: upstream
+ifeq ("$(wildcard upstream)","")
+	@echo "No upstream found, so upstream can't be patched"
+	@exit 1
+else
+	# To add an additional patch:
+	#
+	#	1. Run this command (`make start-patch`).
+	#
+	#	2. Edit the `upstream` repo, making whatever changes you want to appear in the new
+	#	patch. It's fine to edit multiple files.
+	#
+	#	3. Commit your changes. The slugified first line of your commit description will
+	#	be used to generate the patch file name. Only the diff from the latest commit will
+	#	end up in the final patch.
+	#
+	#	4. Run `make finish-patch`.
+	#
+	# It is safe to run `make start-patch` as many times as you want, but any changes
+	# might be reverted until `make finish-patch` is run.
+	@cd upstream && git commit --quiet -m "existing patches"
+endif
+
 test:
 	cd examples && go test -v -tags=all -parallel $(TESTPARALLELISM) -timeout 2h
 
-tfgen: install_plugins
+tfgen: install_plugins upstream
 	(cd provider && go build -p 1 -o $(WORKING_DIR)/bin/$(TFGEN) -ldflags "-X $(PROJECT)/$(VERSION_PATH)=$(VERSION)" $(PROJECT)/$(PROVIDER_PATH)/cmd/$(TFGEN))
 	$(WORKING_DIR)/bin/$(TFGEN) schema --out provider/cmd/$(PROVIDER)
 	(cd provider && VERSION=$(VERSION) go generate cmd/$(PROVIDER)/main.go)
 
+upstream:
+ifeq ("$(wildcard upstream)","")
+	# upstream doesn't exist, so skip
+else ifeq ("$(wildcard patches/*.patch)","")
+	# upstream exists, but patches don't exist. This is probably an error.
+	@echo "No patches found within the patch operation"
+	@echo "patches were expected because upstream exists"
+	@exit 1
+else
+	git submodule update --force --init
+	cd upstream && \
+		for patch in $(sort $(wildcard patches/*.patch)); do git apply --3way ../$$patch || exit 1; done
+endif
+
 bin/pulumi-java-gen:
 	$(shell pulumictl download-binary -n pulumi-language-java -v $(JAVA_GEN_VERSION) -r pulumi/pulumi-java)
 
-.PHONY: development build build_sdks install_go_sdk install_java_sdk install_python_sdk install_sdks only_build build_dotnet build_go build_java build_nodejs build_python clean cleanup help install_dotnet_sdk install_nodejs_sdk install_plugins lint_provider provider test tfgen
+.PHONY: development build build_sdks install_go_sdk install_java_sdk install_python_sdk install_sdks only_build build_dotnet build_go build_java build_nodejs build_python clean cleanup finish-patch help install_dotnet_sdk install_nodejs_sdk install_plugins lint_provider provider start-patch test tfgen upstream

--- a/provider-ci/providers/confluentcloud/repo/Makefile
+++ b/provider-ci/providers/confluentcloud/repo/Makefile
@@ -145,7 +145,12 @@ else ifeq ("$(wildcard patches/*.patch)","")
 	@echo "patches were expected because upstream exists"
 	@exit 1
 else
+	# Checkout the submodule at the pinned commit.
+	# `--force`: If the submodule is at a different commit, move it to the pinned commit.
+	# `--init`: If the submodule is not initialized, initialize it.
 	git submodule update --force --init
+	# Iterating over the patches folder in sorted order,
+	# apply the patch using a 3-way merge strategy. This mirrors the default behavior of `git merge`
 	cd upstream && \
 		for patch in $(sort $(wildcard patches/*.patch)); do git apply --3way ../$$patch || exit 1; done
 endif

--- a/provider-ci/providers/consul/repo/Makefile
+++ b/provider-ci/providers/consul/repo/Makefile
@@ -146,7 +146,12 @@ else ifeq ("$(wildcard patches/*.patch)","")
 	@echo "patches were expected because upstream exists"
 	@exit 1
 else
+	# Checkout the submodule at the pinned commit.
+	# `--force`: If the submodule is at a different commit, move it to the pinned commit.
+	# `--init`: If the submodule is not initialized, initialize it.
 	git submodule update --force --init
+	# Iterating over the patches folder in sorted order,
+	# apply the patch using a 3-way merge strategy. This mirrors the default behavior of `git merge`
 	cd upstream && \
 		for patch in $(sort $(wildcard patches/*.patch)); do git apply --3way ../$$patch || exit 1; done
 endif

--- a/provider-ci/providers/consul/repo/Makefile
+++ b/provider-ci/providers/consul/repo/Makefile
@@ -30,7 +30,7 @@ install_sdks: install_dotnet_sdk install_python_sdk install_nodejs_sdk install_j
 only_build: build
 
 build_dotnet: DOTNET_VERSION := $(shell pulumictl get version --language dotnet)
-build_dotnet:
+build_dotnet: upstream
 	pulumictl get version --language dotnet
 	$(WORKING_DIR)/bin/$(TFGEN) dotnet --out sdk/dotnet/
 	cd sdk/dotnet/ && \
@@ -38,19 +38,19 @@ build_dotnet:
 		echo "$(DOTNET_VERSION)" >version.txt && \
 		dotnet build /p:Version=$(DOTNET_VERSION)
 
-build_go:
+build_go: upstream
 	$(WORKING_DIR)/bin/$(TFGEN) go --out sdk/go/
 	cd sdk && go list `grep -e "^module" go.mod | cut -d ' ' -f 2`/go/... | xargs go build
 
 build_java: PACKAGE_VERSION := $(shell pulumictl get version --language generic)
-build_java: bin/pulumi-java-gen
+build_java: bin/pulumi-java-gen upstream
 	$(WORKING_DIR)/bin/$(JAVA_GEN) generate --schema provider/cmd/$(PROVIDER)/schema.json --out sdk/java  --build gradle-nexus
 	cd sdk/java/ && \
 		echo "module fake_java_module // Exclude this directory from Go tools\n\ngo 1.17" > go.mod && \
 		gradle --console=plain build
 
 build_nodejs: VERSION := $(shell pulumictl get version --language javascript)
-build_nodejs:
+build_nodejs: upstream
 	$(WORKING_DIR)/bin/$(TFGEN) nodejs --out sdk/nodejs/
 	cd sdk/nodejs/ && \
 		echo "module fake_nodejs_module // Exclude this directory from Go tools\n\ngo 1.17" > go.mod && \
@@ -60,7 +60,7 @@ build_nodejs:
 		sed -i.bak -e "s/\$${VERSION}/$(VERSION)/g" ./bin/package.json
 
 build_python: PYPI_VERSION := $(shell pulumictl get version --language python)
-build_python:
+build_python: upstream
 	$(WORKING_DIR)/bin/$(TFGEN) python --out sdk/python/
 	cd sdk/python/ && \
 		echo "module fake_python_module // Exclude this directory from Go tools\n\ngo 1.17" > go.mod && \
@@ -77,6 +77,11 @@ clean:
 cleanup:
 	rm -r $(WORKING_DIR)/bin
 	rm -f provider/cmd/$(PROVIDER)/schema.go
+
+finish-patch:
+	@if [ ! -z "$$(cd upstream && git status --porcelain)" ]; then echo "Please commit your changes before finishing the patch"; exit 1; fi
+	@cd upstream && \
+		git format-patch HEAD~ -o ../patches --start-number $$(($$(ls ../patches | wc -l | xargs)+1))
 
 help:
 	@grep '^[^.#]\+:\s\+.*#' Makefile | \
@@ -101,15 +106,52 @@ lint_provider: provider
 provider: tfgen install_plugins
 	(cd provider && go build -p 1 -o $(WORKING_DIR)/bin/$(PROVIDER) -ldflags "-X $(PROJECT)/$(VERSION_PATH)=$(VERSION)" $(PROJECT)/$(PROVIDER_PATH)/cmd/$(PROVIDER))
 
+start-patch: upstream
+ifeq ("$(wildcard upstream)","")
+	@echo "No upstream found, so upstream can't be patched"
+	@exit 1
+else
+	# To add an additional patch:
+	#
+	#	1. Run this command (`make start-patch`).
+	#
+	#	2. Edit the `upstream` repo, making whatever changes you want to appear in the new
+	#	patch. It's fine to edit multiple files.
+	#
+	#	3. Commit your changes. The slugified first line of your commit description will
+	#	be used to generate the patch file name. Only the diff from the latest commit will
+	#	end up in the final patch.
+	#
+	#	4. Run `make finish-patch`.
+	#
+	# It is safe to run `make start-patch` as many times as you want, but any changes
+	# might be reverted until `make finish-patch` is run.
+	@cd upstream && git commit --quiet -m "existing patches"
+endif
+
 test:
 	cd examples && go test -v -tags=all -parallel $(TESTPARALLELISM) -timeout 2h
 
-tfgen: install_plugins
+tfgen: install_plugins upstream
 	(cd provider && go build -p 1 -o $(WORKING_DIR)/bin/$(TFGEN) -ldflags "-X $(PROJECT)/$(VERSION_PATH)=$(VERSION)" $(PROJECT)/$(PROVIDER_PATH)/cmd/$(TFGEN))
 	$(WORKING_DIR)/bin/$(TFGEN) schema --out provider/cmd/$(PROVIDER)
 	(cd provider && VERSION=$(VERSION) go generate cmd/$(PROVIDER)/main.go)
 
+upstream:
+ifeq ("$(wildcard upstream)","")
+	# upstream doesn't exist, so skip
+else ifeq ("$(wildcard patches/*.patch)","")
+	# upstream exists, but patches don't exist. This is probably an error.
+	@echo "No patches found within the patch operation"
+	@echo "patches were expected because upstream exists"
+	@exit 1
+else
+	git submodule update --force --init
+	cd upstream && \
+		for patch in $(sort $(wildcard patches/*.patch)); do git apply --3way ../$$patch || exit 1; done
+endif
+
 bin/pulumi-java-gen:
 	$(shell pulumictl download-binary -n pulumi-language-java -v $(JAVA_GEN_VERSION) -r pulumi/pulumi-java)
 
-.PHONY: development build build_sdks install_go_sdk install_java_sdk install_python_sdk install_sdks only_build build_dotnet build_go build_java build_nodejs build_python clean cleanup help install_dotnet_sdk install_nodejs_sdk install_plugins lint_provider provider test tfgen
+.PHONY: development build build_sdks install_go_sdk install_java_sdk install_python_sdk install_sdks only_build build_dotnet build_go build_java build_nodejs build_python clean cleanup finish-patch help install_dotnet_sdk install_nodejs_sdk install_plugins lint_provider provider start-patch test tfgen upstream

--- a/provider-ci/providers/databricks/repo/Makefile
+++ b/provider-ci/providers/databricks/repo/Makefile
@@ -146,7 +146,12 @@ else ifeq ("$(wildcard patches/*.patch)","")
 	@echo "patches were expected because upstream exists"
 	@exit 1
 else
+	# Checkout the submodule at the pinned commit.
+	# `--force`: If the submodule is at a different commit, move it to the pinned commit.
+	# `--init`: If the submodule is not initialized, initialize it.
 	git submodule update --force --init
+	# Iterating over the patches folder in sorted order,
+	# apply the patch using a 3-way merge strategy. This mirrors the default behavior of `git merge`
 	cd upstream && \
 		for patch in $(sort $(wildcard patches/*.patch)); do git apply --3way ../$$patch || exit 1; done
 endif

--- a/provider-ci/providers/databricks/repo/Makefile
+++ b/provider-ci/providers/databricks/repo/Makefile
@@ -30,7 +30,7 @@ install_sdks: install_dotnet_sdk install_python_sdk install_nodejs_sdk install_j
 only_build: build
 
 build_dotnet: DOTNET_VERSION := $(shell pulumictl get version --language dotnet)
-build_dotnet:
+build_dotnet: upstream
 	pulumictl get version --language dotnet
 	$(WORKING_DIR)/bin/$(TFGEN) dotnet --out sdk/dotnet/
 	cd sdk/dotnet/ && \
@@ -38,19 +38,19 @@ build_dotnet:
 		echo "$(DOTNET_VERSION)" >version.txt && \
 		dotnet build /p:Version=$(DOTNET_VERSION)
 
-build_go:
+build_go: upstream
 	$(WORKING_DIR)/bin/$(TFGEN) go --out sdk/go/
 	cd sdk && go list `grep -e "^module" go.mod | cut -d ' ' -f 2`/go/... | xargs go build
 
 build_java: PACKAGE_VERSION := $(shell pulumictl get version --language generic)
-build_java: bin/pulumi-java-gen
+build_java: bin/pulumi-java-gen upstream
 	$(WORKING_DIR)/bin/$(JAVA_GEN) generate --schema provider/cmd/$(PROVIDER)/schema.json --out sdk/java  --build gradle-nexus
 	cd sdk/java/ && \
 		echo "module fake_java_module // Exclude this directory from Go tools\n\ngo 1.17" > go.mod && \
 		gradle --console=plain build
 
 build_nodejs: VERSION := $(shell pulumictl get version --language javascript)
-build_nodejs:
+build_nodejs: upstream
 	$(WORKING_DIR)/bin/$(TFGEN) nodejs --out sdk/nodejs/
 	cd sdk/nodejs/ && \
 		echo "module fake_nodejs_module // Exclude this directory from Go tools\n\ngo 1.17" > go.mod && \
@@ -60,7 +60,7 @@ build_nodejs:
 		sed -i.bak -e "s/\$${VERSION}/$(VERSION)/g" ./bin/package.json
 
 build_python: PYPI_VERSION := $(shell pulumictl get version --language python)
-build_python:
+build_python: upstream
 	$(WORKING_DIR)/bin/$(TFGEN) python --out sdk/python/
 	cd sdk/python/ && \
 		echo "module fake_python_module // Exclude this directory from Go tools\n\ngo 1.17" > go.mod && \
@@ -77,6 +77,11 @@ clean:
 cleanup:
 	rm -r $(WORKING_DIR)/bin
 	rm -f provider/cmd/$(PROVIDER)/schema.go
+
+finish-patch:
+	@if [ ! -z "$$(cd upstream && git status --porcelain)" ]; then echo "Please commit your changes before finishing the patch"; exit 1; fi
+	@cd upstream && \
+		git format-patch HEAD~ -o ../patches --start-number $$(($$(ls ../patches | wc -l | xargs)+1))
 
 help:
 	@grep '^[^.#]\+:\s\+.*#' Makefile | \
@@ -101,15 +106,52 @@ lint_provider: provider
 provider: tfgen install_plugins
 	(cd provider && go build -p 1 -o $(WORKING_DIR)/bin/$(PROVIDER) -ldflags "-X $(PROJECT)/$(VERSION_PATH)=$(VERSION)" $(PROJECT)/$(PROVIDER_PATH)/cmd/$(PROVIDER))
 
+start-patch: upstream
+ifeq ("$(wildcard upstream)","")
+	@echo "No upstream found, so upstream can't be patched"
+	@exit 1
+else
+	# To add an additional patch:
+	#
+	#	1. Run this command (`make start-patch`).
+	#
+	#	2. Edit the `upstream` repo, making whatever changes you want to appear in the new
+	#	patch. It's fine to edit multiple files.
+	#
+	#	3. Commit your changes. The slugified first line of your commit description will
+	#	be used to generate the patch file name. Only the diff from the latest commit will
+	#	end up in the final patch.
+	#
+	#	4. Run `make finish-patch`.
+	#
+	# It is safe to run `make start-patch` as many times as you want, but any changes
+	# might be reverted until `make finish-patch` is run.
+	@cd upstream && git commit --quiet -m "existing patches"
+endif
+
 test:
 	cd examples && go test -v -tags=all -parallel $(TESTPARALLELISM) -timeout 2h
 
-tfgen: install_plugins
+tfgen: install_plugins upstream
 	(cd provider && go build -p 1 -o $(WORKING_DIR)/bin/$(TFGEN) -ldflags "-X $(PROJECT)/$(VERSION_PATH)=$(VERSION)" $(PROJECT)/$(PROVIDER_PATH)/cmd/$(TFGEN))
 	$(WORKING_DIR)/bin/$(TFGEN) schema --out provider/cmd/$(PROVIDER)
 	(cd provider && VERSION=$(VERSION) go generate cmd/$(PROVIDER)/main.go)
 
+upstream:
+ifeq ("$(wildcard upstream)","")
+	# upstream doesn't exist, so skip
+else ifeq ("$(wildcard patches/*.patch)","")
+	# upstream exists, but patches don't exist. This is probably an error.
+	@echo "No patches found within the patch operation"
+	@echo "patches were expected because upstream exists"
+	@exit 1
+else
+	git submodule update --force --init
+	cd upstream && \
+		for patch in $(sort $(wildcard patches/*.patch)); do git apply --3way ../$$patch || exit 1; done
+endif
+
 bin/pulumi-java-gen:
 	$(shell pulumictl download-binary -n pulumi-language-java -v $(JAVA_GEN_VERSION) -r pulumi/pulumi-java)
 
-.PHONY: development build build_sdks install_go_sdk install_java_sdk install_python_sdk install_sdks only_build build_dotnet build_go build_java build_nodejs build_python clean cleanup help install_dotnet_sdk install_nodejs_sdk install_plugins lint_provider provider test tfgen
+.PHONY: development build build_sdks install_go_sdk install_java_sdk install_python_sdk install_sdks only_build build_dotnet build_go build_java build_nodejs build_python clean cleanup finish-patch help install_dotnet_sdk install_nodejs_sdk install_plugins lint_provider provider start-patch test tfgen upstream

--- a/provider-ci/providers/datadog/repo/Makefile
+++ b/provider-ci/providers/datadog/repo/Makefile
@@ -144,7 +144,12 @@ else ifeq ("$(wildcard patches/*.patch)","")
 	@echo "patches were expected because upstream exists"
 	@exit 1
 else
+	# Checkout the submodule at the pinned commit.
+	# `--force`: If the submodule is at a different commit, move it to the pinned commit.
+	# `--init`: If the submodule is not initialized, initialize it.
 	git submodule update --force --init
+	# Iterating over the patches folder in sorted order,
+	# apply the patch using a 3-way merge strategy. This mirrors the default behavior of `git merge`
 	cd upstream && \
 		for patch in $(sort $(wildcard patches/*.patch)); do git apply --3way ../$$patch || exit 1; done
 endif

--- a/provider-ci/providers/datadog/repo/Makefile
+++ b/provider-ci/providers/datadog/repo/Makefile
@@ -30,7 +30,7 @@ install_sdks: install_dotnet_sdk install_python_sdk install_nodejs_sdk install_j
 only_build: build
 
 build_dotnet: DOTNET_VERSION := $(shell pulumictl get version --language dotnet)
-build_dotnet:
+build_dotnet: upstream
 	pulumictl get version --language dotnet
 	$(WORKING_DIR)/bin/$(TFGEN) dotnet --out sdk/dotnet/
 	cd sdk/dotnet/ && \
@@ -38,19 +38,19 @@ build_dotnet:
 		echo "$(DOTNET_VERSION)" >version.txt && \
 		dotnet build /p:Version=$(DOTNET_VERSION)
 
-build_go:
+build_go: upstream
 	$(WORKING_DIR)/bin/$(TFGEN) go --out sdk/go/
 	cd sdk && go list `grep -e "^module" go.mod | cut -d ' ' -f 2`/go/... | xargs go build
 
 build_java: PACKAGE_VERSION := $(shell pulumictl get version --language generic)
-build_java: bin/pulumi-java-gen
+build_java: bin/pulumi-java-gen upstream
 	$(WORKING_DIR)/bin/$(JAVA_GEN) generate --schema provider/cmd/$(PROVIDER)/schema.json --out sdk/java  --build gradle-nexus
 	cd sdk/java/ && \
 		echo "module fake_java_module // Exclude this directory from Go tools\n\ngo 1.17" > go.mod && \
 		gradle --console=plain build
 
 build_nodejs: VERSION := $(shell pulumictl get version --language javascript)
-build_nodejs:
+build_nodejs: upstream
 	$(WORKING_DIR)/bin/$(TFGEN) nodejs --out sdk/nodejs/
 	cd sdk/nodejs/ && \
 		echo "module fake_nodejs_module // Exclude this directory from Go tools\n\ngo 1.17" > go.mod && \
@@ -60,7 +60,7 @@ build_nodejs:
 		sed -i.bak -e "s/\$${VERSION}/$(VERSION)/g" ./bin/package.json
 
 build_python: PYPI_VERSION := $(shell pulumictl get version --language python)
-build_python:
+build_python: upstream
 	$(WORKING_DIR)/bin/$(TFGEN) python --out sdk/python/
 	cd sdk/python/ && \
 		echo "module fake_python_module // Exclude this directory from Go tools\n\ngo 1.17" > go.mod && \
@@ -77,6 +77,11 @@ clean:
 cleanup:
 	rm -r $(WORKING_DIR)/bin
 	rm -f provider/cmd/$(PROVIDER)/schema.go
+
+finish-patch:
+	@if [ ! -z "$$(cd upstream && git status --porcelain)" ]; then echo "Please commit your changes before finishing the patch"; exit 1; fi
+	@cd upstream && \
+		git format-patch HEAD~ -o ../patches --start-number $$(($$(ls ../patches | wc -l | xargs)+1))
 
 help:
 	@grep '^[^.#]\+:\s\+.*#' Makefile | \
@@ -99,15 +104,52 @@ lint_provider: provider
 provider: tfgen install_plugins
 	(cd provider && go build -p 1 -o $(WORKING_DIR)/bin/$(PROVIDER) -ldflags "-X $(PROJECT)/$(VERSION_PATH)=$(VERSION)" $(PROJECT)/$(PROVIDER_PATH)/cmd/$(PROVIDER))
 
+start-patch: upstream
+ifeq ("$(wildcard upstream)","")
+	@echo "No upstream found, so upstream can't be patched"
+	@exit 1
+else
+	# To add an additional patch:
+	#
+	#	1. Run this command (`make start-patch`).
+	#
+	#	2. Edit the `upstream` repo, making whatever changes you want to appear in the new
+	#	patch. It's fine to edit multiple files.
+	#
+	#	3. Commit your changes. The slugified first line of your commit description will
+	#	be used to generate the patch file name. Only the diff from the latest commit will
+	#	end up in the final patch.
+	#
+	#	4. Run `make finish-patch`.
+	#
+	# It is safe to run `make start-patch` as many times as you want, but any changes
+	# might be reverted until `make finish-patch` is run.
+	@cd upstream && git commit --quiet -m "existing patches"
+endif
+
 test:
 	cd examples && go test -v -tags=all -parallel $(TESTPARALLELISM) -timeout 2h
 
-tfgen: install_plugins
+tfgen: install_plugins upstream
 	(cd provider && go build -p 1 -o $(WORKING_DIR)/bin/$(TFGEN) -ldflags "-X $(PROJECT)/$(VERSION_PATH)=$(VERSION)" $(PROJECT)/$(PROVIDER_PATH)/cmd/$(TFGEN))
 	$(WORKING_DIR)/bin/$(TFGEN) schema --out provider/cmd/$(PROVIDER)
 	(cd provider && VERSION=$(VERSION) go generate cmd/$(PROVIDER)/main.go)
 
+upstream:
+ifeq ("$(wildcard upstream)","")
+	# upstream doesn't exist, so skip
+else ifeq ("$(wildcard patches/*.patch)","")
+	# upstream exists, but patches don't exist. This is probably an error.
+	@echo "No patches found within the patch operation"
+	@echo "patches were expected because upstream exists"
+	@exit 1
+else
+	git submodule update --force --init
+	cd upstream && \
+		for patch in $(sort $(wildcard patches/*.patch)); do git apply --3way ../$$patch || exit 1; done
+endif
+
 bin/pulumi-java-gen:
 	$(shell pulumictl download-binary -n pulumi-language-java -v $(JAVA_GEN_VERSION) -r pulumi/pulumi-java)
 
-.PHONY: development build build_sdks install_go_sdk install_java_sdk install_python_sdk install_sdks only_build build_dotnet build_go build_java build_nodejs build_python clean cleanup help install_dotnet_sdk install_nodejs_sdk install_plugins lint_provider provider test tfgen
+.PHONY: development build build_sdks install_go_sdk install_java_sdk install_python_sdk install_sdks only_build build_dotnet build_go build_java build_nodejs build_python clean cleanup finish-patch help install_dotnet_sdk install_nodejs_sdk install_plugins lint_provider provider start-patch test tfgen upstream

--- a/provider-ci/providers/digitalocean/repo/Makefile
+++ b/provider-ci/providers/digitalocean/repo/Makefile
@@ -30,7 +30,7 @@ install_sdks: install_dotnet_sdk install_python_sdk install_nodejs_sdk install_j
 only_build: build
 
 build_dotnet: DOTNET_VERSION := $(shell pulumictl get version --language dotnet)
-build_dotnet:
+build_dotnet: upstream
 	pulumictl get version --language dotnet
 	$(WORKING_DIR)/bin/$(TFGEN) dotnet --out sdk/dotnet/
 	cd sdk/dotnet/ && \
@@ -38,19 +38,19 @@ build_dotnet:
 		echo "$(DOTNET_VERSION)" >version.txt && \
 		dotnet build /p:Version=$(DOTNET_VERSION)
 
-build_go:
+build_go: upstream
 	$(WORKING_DIR)/bin/$(TFGEN) go --out sdk/go/
 	cd sdk && go list `grep -e "^module" go.mod | cut -d ' ' -f 2`/go/... | xargs go build
 
 build_java: PACKAGE_VERSION := $(shell pulumictl get version --language generic)
-build_java: bin/pulumi-java-gen
+build_java: bin/pulumi-java-gen upstream
 	$(WORKING_DIR)/bin/$(JAVA_GEN) generate --schema provider/cmd/$(PROVIDER)/schema.json --out sdk/java  --build gradle-nexus
 	cd sdk/java/ && \
 		echo "module fake_java_module // Exclude this directory from Go tools\n\ngo 1.17" > go.mod && \
 		gradle --console=plain build
 
 build_nodejs: VERSION := $(shell pulumictl get version --language javascript)
-build_nodejs:
+build_nodejs: upstream
 	$(WORKING_DIR)/bin/$(TFGEN) nodejs --out sdk/nodejs/
 	cd sdk/nodejs/ && \
 		echo "module fake_nodejs_module // Exclude this directory from Go tools\n\ngo 1.17" > go.mod && \
@@ -60,7 +60,7 @@ build_nodejs:
 		sed -i.bak -e "s/\$${VERSION}/$(VERSION)/g" ./bin/package.json
 
 build_python: PYPI_VERSION := $(shell pulumictl get version --language python)
-build_python:
+build_python: upstream
 	$(WORKING_DIR)/bin/$(TFGEN) python --out sdk/python/
 	cd sdk/python/ && \
 		echo "module fake_python_module // Exclude this directory from Go tools\n\ngo 1.17" > go.mod && \
@@ -77,6 +77,11 @@ clean:
 cleanup:
 	rm -r $(WORKING_DIR)/bin
 	rm -f provider/cmd/$(PROVIDER)/schema.go
+
+finish-patch:
+	@if [ ! -z "$$(cd upstream && git status --porcelain)" ]; then echo "Please commit your changes before finishing the patch"; exit 1; fi
+	@cd upstream && \
+		git format-patch HEAD~ -o ../patches --start-number $$(($$(ls ../patches | wc -l | xargs)+1))
 
 help:
 	@grep '^[^.#]\+:\s\+.*#' Makefile | \
@@ -100,15 +105,52 @@ lint_provider: provider
 provider: tfgen install_plugins
 	(cd provider && go build -p 1 -o $(WORKING_DIR)/bin/$(PROVIDER) -ldflags "-X $(PROJECT)/$(VERSION_PATH)=$(VERSION)" $(PROJECT)/$(PROVIDER_PATH)/cmd/$(PROVIDER))
 
+start-patch: upstream
+ifeq ("$(wildcard upstream)","")
+	@echo "No upstream found, so upstream can't be patched"
+	@exit 1
+else
+	# To add an additional patch:
+	#
+	#	1. Run this command (`make start-patch`).
+	#
+	#	2. Edit the `upstream` repo, making whatever changes you want to appear in the new
+	#	patch. It's fine to edit multiple files.
+	#
+	#	3. Commit your changes. The slugified first line of your commit description will
+	#	be used to generate the patch file name. Only the diff from the latest commit will
+	#	end up in the final patch.
+	#
+	#	4. Run `make finish-patch`.
+	#
+	# It is safe to run `make start-patch` as many times as you want, but any changes
+	# might be reverted until `make finish-patch` is run.
+	@cd upstream && git commit --quiet -m "existing patches"
+endif
+
 test:
 	cd examples && go test -v -tags=all -parallel $(TESTPARALLELISM) -timeout 2h
 
-tfgen: install_plugins
+tfgen: install_plugins upstream
 	(cd provider && go build -p 1 -o $(WORKING_DIR)/bin/$(TFGEN) -ldflags "-X $(PROJECT)/$(VERSION_PATH)=$(VERSION)" $(PROJECT)/$(PROVIDER_PATH)/cmd/$(TFGEN))
 	$(WORKING_DIR)/bin/$(TFGEN) schema --out provider/cmd/$(PROVIDER)
 	(cd provider && VERSION=$(VERSION) go generate cmd/$(PROVIDER)/main.go)
 
+upstream:
+ifeq ("$(wildcard upstream)","")
+	# upstream doesn't exist, so skip
+else ifeq ("$(wildcard patches/*.patch)","")
+	# upstream exists, but patches don't exist. This is probably an error.
+	@echo "No patches found within the patch operation"
+	@echo "patches were expected because upstream exists"
+	@exit 1
+else
+	git submodule update --force --init
+	cd upstream && \
+		for patch in $(sort $(wildcard patches/*.patch)); do git apply --3way ../$$patch || exit 1; done
+endif
+
 bin/pulumi-java-gen:
 	$(shell pulumictl download-binary -n pulumi-language-java -v $(JAVA_GEN_VERSION) -r pulumi/pulumi-java)
 
-.PHONY: development build build_sdks install_go_sdk install_java_sdk install_python_sdk install_sdks only_build build_dotnet build_go build_java build_nodejs build_python clean cleanup help install_dotnet_sdk install_nodejs_sdk install_plugins lint_provider provider test tfgen
+.PHONY: development build build_sdks install_go_sdk install_java_sdk install_python_sdk install_sdks only_build build_dotnet build_go build_java build_nodejs build_python clean cleanup finish-patch help install_dotnet_sdk install_nodejs_sdk install_plugins lint_provider provider start-patch test tfgen upstream

--- a/provider-ci/providers/digitalocean/repo/Makefile
+++ b/provider-ci/providers/digitalocean/repo/Makefile
@@ -145,7 +145,12 @@ else ifeq ("$(wildcard patches/*.patch)","")
 	@echo "patches were expected because upstream exists"
 	@exit 1
 else
+	# Checkout the submodule at the pinned commit.
+	# `--force`: If the submodule is at a different commit, move it to the pinned commit.
+	# `--init`: If the submodule is not initialized, initialize it.
 	git submodule update --force --init
+	# Iterating over the patches folder in sorted order,
+	# apply the patch using a 3-way merge strategy. This mirrors the default behavior of `git merge`
 	cd upstream && \
 		for patch in $(sort $(wildcard patches/*.patch)); do git apply --3way ../$$patch || exit 1; done
 endif

--- a/provider-ci/providers/dnsimple/repo/Makefile
+++ b/provider-ci/providers/dnsimple/repo/Makefile
@@ -144,7 +144,12 @@ else ifeq ("$(wildcard patches/*.patch)","")
 	@echo "patches were expected because upstream exists"
 	@exit 1
 else
+	# Checkout the submodule at the pinned commit.
+	# `--force`: If the submodule is at a different commit, move it to the pinned commit.
+	# `--init`: If the submodule is not initialized, initialize it.
 	git submodule update --force --init
+	# Iterating over the patches folder in sorted order,
+	# apply the patch using a 3-way merge strategy. This mirrors the default behavior of `git merge`
 	cd upstream && \
 		for patch in $(sort $(wildcard patches/*.patch)); do git apply --3way ../$$patch || exit 1; done
 endif

--- a/provider-ci/providers/dnsimple/repo/Makefile
+++ b/provider-ci/providers/dnsimple/repo/Makefile
@@ -30,7 +30,7 @@ install_sdks: install_dotnet_sdk install_python_sdk install_nodejs_sdk install_j
 only_build: build
 
 build_dotnet: DOTNET_VERSION := $(shell pulumictl get version --language dotnet)
-build_dotnet:
+build_dotnet: upstream
 	pulumictl get version --language dotnet
 	$(WORKING_DIR)/bin/$(TFGEN) dotnet --out sdk/dotnet/
 	cd sdk/dotnet/ && \
@@ -38,19 +38,19 @@ build_dotnet:
 		echo "$(DOTNET_VERSION)" >version.txt && \
 		dotnet build /p:Version=$(DOTNET_VERSION)
 
-build_go:
+build_go: upstream
 	$(WORKING_DIR)/bin/$(TFGEN) go --out sdk/go/
 	cd sdk && go list `grep -e "^module" go.mod | cut -d ' ' -f 2`/go/... | xargs go build
 
 build_java: PACKAGE_VERSION := $(shell pulumictl get version --language generic)
-build_java: bin/pulumi-java-gen
+build_java: bin/pulumi-java-gen upstream
 	$(WORKING_DIR)/bin/$(JAVA_GEN) generate --schema provider/cmd/$(PROVIDER)/schema.json --out sdk/java  --build gradle-nexus
 	cd sdk/java/ && \
 		echo "module fake_java_module // Exclude this directory from Go tools\n\ngo 1.17" > go.mod && \
 		gradle --console=plain build
 
 build_nodejs: VERSION := $(shell pulumictl get version --language javascript)
-build_nodejs:
+build_nodejs: upstream
 	$(WORKING_DIR)/bin/$(TFGEN) nodejs --out sdk/nodejs/
 	cd sdk/nodejs/ && \
 		echo "module fake_nodejs_module // Exclude this directory from Go tools\n\ngo 1.17" > go.mod && \
@@ -60,7 +60,7 @@ build_nodejs:
 		sed -i.bak -e "s/\$${VERSION}/$(VERSION)/g" ./bin/package.json
 
 build_python: PYPI_VERSION := $(shell pulumictl get version --language python)
-build_python:
+build_python: upstream
 	$(WORKING_DIR)/bin/$(TFGEN) python --out sdk/python/
 	cd sdk/python/ && \
 		echo "module fake_python_module // Exclude this directory from Go tools\n\ngo 1.17" > go.mod && \
@@ -77,6 +77,11 @@ clean:
 cleanup:
 	rm -r $(WORKING_DIR)/bin
 	rm -f provider/cmd/$(PROVIDER)/schema.go
+
+finish-patch:
+	@if [ ! -z "$$(cd upstream && git status --porcelain)" ]; then echo "Please commit your changes before finishing the patch"; exit 1; fi
+	@cd upstream && \
+		git format-patch HEAD~ -o ../patches --start-number $$(($$(ls ../patches | wc -l | xargs)+1))
 
 help:
 	@grep '^[^.#]\+:\s\+.*#' Makefile | \
@@ -99,15 +104,52 @@ lint_provider: provider
 provider: tfgen install_plugins
 	(cd provider && go build -p 1 -o $(WORKING_DIR)/bin/$(PROVIDER) -ldflags "-X $(PROJECT)/$(VERSION_PATH)=$(VERSION)" $(PROJECT)/$(PROVIDER_PATH)/cmd/$(PROVIDER))
 
+start-patch: upstream
+ifeq ("$(wildcard upstream)","")
+	@echo "No upstream found, so upstream can't be patched"
+	@exit 1
+else
+	# To add an additional patch:
+	#
+	#	1. Run this command (`make start-patch`).
+	#
+	#	2. Edit the `upstream` repo, making whatever changes you want to appear in the new
+	#	patch. It's fine to edit multiple files.
+	#
+	#	3. Commit your changes. The slugified first line of your commit description will
+	#	be used to generate the patch file name. Only the diff from the latest commit will
+	#	end up in the final patch.
+	#
+	#	4. Run `make finish-patch`.
+	#
+	# It is safe to run `make start-patch` as many times as you want, but any changes
+	# might be reverted until `make finish-patch` is run.
+	@cd upstream && git commit --quiet -m "existing patches"
+endif
+
 test:
 	cd examples && go test -v -tags=all -parallel $(TESTPARALLELISM) -timeout 2h
 
-tfgen: install_plugins
+tfgen: install_plugins upstream
 	(cd provider && go build -p 1 -o $(WORKING_DIR)/bin/$(TFGEN) -ldflags "-X $(PROJECT)/$(VERSION_PATH)=$(VERSION)" $(PROJECT)/$(PROVIDER_PATH)/cmd/$(TFGEN))
 	$(WORKING_DIR)/bin/$(TFGEN) schema --out provider/cmd/$(PROVIDER)
 	(cd provider && VERSION=$(VERSION) go generate cmd/$(PROVIDER)/main.go)
 
+upstream:
+ifeq ("$(wildcard upstream)","")
+	# upstream doesn't exist, so skip
+else ifeq ("$(wildcard patches/*.patch)","")
+	# upstream exists, but patches don't exist. This is probably an error.
+	@echo "No patches found within the patch operation"
+	@echo "patches were expected because upstream exists"
+	@exit 1
+else
+	git submodule update --force --init
+	cd upstream && \
+		for patch in $(sort $(wildcard patches/*.patch)); do git apply --3way ../$$patch || exit 1; done
+endif
+
 bin/pulumi-java-gen:
 	$(shell pulumictl download-binary -n pulumi-language-java -v $(JAVA_GEN_VERSION) -r pulumi/pulumi-java)
 
-.PHONY: development build build_sdks install_go_sdk install_java_sdk install_python_sdk install_sdks only_build build_dotnet build_go build_java build_nodejs build_python clean cleanup help install_dotnet_sdk install_nodejs_sdk install_plugins lint_provider provider test tfgen
+.PHONY: development build build_sdks install_go_sdk install_java_sdk install_python_sdk install_sdks only_build build_dotnet build_go build_java build_nodejs build_python clean cleanup finish-patch help install_dotnet_sdk install_nodejs_sdk install_plugins lint_provider provider start-patch test tfgen upstream

--- a/provider-ci/providers/docker/repo/Makefile
+++ b/provider-ci/providers/docker/repo/Makefile
@@ -30,7 +30,7 @@ install_sdks: install_dotnet_sdk install_python_sdk install_nodejs_sdk install_j
 only_build: build
 
 build_dotnet: DOTNET_VERSION := $(shell pulumictl get version --language dotnet)
-build_dotnet:
+build_dotnet: upstream
 	pulumictl get version --language dotnet
 	$(WORKING_DIR)/bin/$(TFGEN) dotnet --out sdk/dotnet/
 	cd sdk/dotnet/ && \
@@ -38,19 +38,19 @@ build_dotnet:
 		echo "$(DOTNET_VERSION)" >version.txt && \
 		dotnet build /p:Version=$(DOTNET_VERSION)
 
-build_go:
+build_go: upstream
 	$(WORKING_DIR)/bin/$(TFGEN) go --out sdk/go/
 	cd sdk && go list `grep -e "^module" go.mod | cut -d ' ' -f 2`/go/... | xargs go build
 
 build_java: PACKAGE_VERSION := $(shell pulumictl get version --language generic)
-build_java: bin/pulumi-java-gen
+build_java: bin/pulumi-java-gen upstream
 	$(WORKING_DIR)/bin/$(JAVA_GEN) generate --schema provider/cmd/$(PROVIDER)/schema.json --out sdk/java  --build gradle-nexus
 	cd sdk/java/ && \
 		echo "module fake_java_module // Exclude this directory from Go tools\n\ngo 1.17" > go.mod && \
 		gradle --console=plain build
 
 build_nodejs: VERSION := $(shell pulumictl get version --language javascript)
-build_nodejs:
+build_nodejs: upstream
 	$(WORKING_DIR)/bin/$(TFGEN) nodejs --out sdk/nodejs/
 	cd sdk/nodejs/ && \
 		echo "module fake_nodejs_module // Exclude this directory from Go tools\n\ngo 1.17" > go.mod && \
@@ -60,7 +60,7 @@ build_nodejs:
 		sed -i.bak -e "s/\$${VERSION}/$(VERSION)/g" ./bin/package.json
 
 build_python: PYPI_VERSION := $(shell pulumictl get version --language python)
-build_python:
+build_python: upstream
 	$(WORKING_DIR)/bin/$(TFGEN) python --out sdk/python/
 	cd sdk/python/ && \
 		echo "module fake_python_module // Exclude this directory from Go tools\n\ngo 1.17" > go.mod && \
@@ -80,6 +80,11 @@ cleanup:
 
 docs:
 	cd provider/pkg/docs-gen/examples/ && go run generate.go ./yaml ./
+
+finish-patch:
+	@if [ ! -z "$$(cd upstream && git status --porcelain)" ]; then echo "Please commit your changes before finishing the patch"; exit 1; fi
+	@cd upstream && \
+		git format-patch HEAD~ -o ../patches --start-number $$(($$(ls ../patches | wc -l | xargs)+1))
 
 help:
 	@grep '^[^.#]\+:\s\+.*#' Makefile | \
@@ -102,6 +107,29 @@ lint_provider: provider
 provider: tfgen install_plugins
 	(cd provider && go build -p 1 -o $(WORKING_DIR)/bin/$(PROVIDER) -ldflags "-X $(PROJECT)/$(VERSION_PATH)=$(VERSION)" $(PROJECT)/$(PROVIDER_PATH)/cmd/$(PROVIDER))
 
+start-patch: upstream
+ifeq ("$(wildcard upstream)","")
+	@echo "No upstream found, so upstream can't be patched"
+	@exit 1
+else
+	# To add an additional patch:
+	#
+	#	1. Run this command (`make start-patch`).
+	#
+	#	2. Edit the `upstream` repo, making whatever changes you want to appear in the new
+	#	patch. It's fine to edit multiple files.
+	#
+	#	3. Commit your changes. The slugified first line of your commit description will
+	#	be used to generate the patch file name. Only the diff from the latest commit will
+	#	end up in the final patch.
+	#
+	#	4. Run `make finish-patch`.
+	#
+	# It is safe to run `make start-patch` as many times as you want, but any changes
+	# might be reverted until `make finish-patch` is run.
+	@cd upstream && git commit --quiet -m "existing patches"
+endif
+
 test:
 	cd examples && go test -v -tags=all -parallel $(TESTPARALLELISM) -timeout 2h
 
@@ -110,7 +138,21 @@ tfgen: install_plugins docs
 	$(WORKING_DIR)/bin/$(TFGEN) schema --out provider/cmd/$(PROVIDER)
 	(cd provider && VERSION=$(VERSION) go generate cmd/$(PROVIDER)/main.go)
 
+upstream:
+ifeq ("$(wildcard upstream)","")
+	# upstream doesn't exist, so skip
+else ifeq ("$(wildcard patches/*.patch)","")
+	# upstream exists, but patches don't exist. This is probably an error.
+	@echo "No patches found within the patch operation"
+	@echo "patches were expected because upstream exists"
+	@exit 1
+else
+	git submodule update --force --init
+	cd upstream && \
+		for patch in $(sort $(wildcard patches/*.patch)); do git apply --3way ../$$patch || exit 1; done
+endif
+
 bin/pulumi-java-gen:
 	$(shell pulumictl download-binary -n pulumi-language-java -v $(JAVA_GEN_VERSION) -r pulumi/pulumi-java)
 
-.PHONY: development build build_sdks install_go_sdk install_java_sdk install_python_sdk install_sdks only_build build_dotnet build_go build_java build_nodejs build_python clean cleanup docs help install_dotnet_sdk install_nodejs_sdk install_plugins lint_provider provider test tfgen
+.PHONY: development build build_sdks install_go_sdk install_java_sdk install_python_sdk install_sdks only_build build_dotnet build_go build_java build_nodejs build_python clean cleanup docs finish-patch help install_dotnet_sdk install_nodejs_sdk install_plugins lint_provider provider start-patch test tfgen upstream

--- a/provider-ci/providers/docker/repo/Makefile
+++ b/provider-ci/providers/docker/repo/Makefile
@@ -147,7 +147,12 @@ else ifeq ("$(wildcard patches/*.patch)","")
 	@echo "patches were expected because upstream exists"
 	@exit 1
 else
+	# Checkout the submodule at the pinned commit.
+	# `--force`: If the submodule is at a different commit, move it to the pinned commit.
+	# `--init`: If the submodule is not initialized, initialize it.
 	git submodule update --force --init
+	# Iterating over the patches folder in sorted order,
+	# apply the patch using a 3-way merge strategy. This mirrors the default behavior of `git merge`
 	cd upstream && \
 		for patch in $(sort $(wildcard patches/*.patch)); do git apply --3way ../$$patch || exit 1; done
 endif

--- a/provider-ci/providers/ec/repo/Makefile
+++ b/provider-ci/providers/ec/repo/Makefile
@@ -30,7 +30,7 @@ install_sdks: install_dotnet_sdk install_python_sdk install_nodejs_sdk install_j
 only_build: build
 
 build_dotnet: DOTNET_VERSION := $(shell pulumictl get version --language dotnet)
-build_dotnet:
+build_dotnet: upstream
 	pulumictl get version --language dotnet
 	$(WORKING_DIR)/bin/$(TFGEN) dotnet --out sdk/dotnet/
 	cd sdk/dotnet/ && \
@@ -38,19 +38,19 @@ build_dotnet:
 		echo "$(DOTNET_VERSION)" >version.txt && \
 		dotnet build /p:Version=$(DOTNET_VERSION)
 
-build_go:
+build_go: upstream
 	$(WORKING_DIR)/bin/$(TFGEN) go --out sdk/go/
 	cd sdk && go list `grep -e "^module" go.mod | cut -d ' ' -f 2`/go/... | xargs go build
 
 build_java: PACKAGE_VERSION := $(shell pulumictl get version --language generic)
-build_java: bin/pulumi-java-gen
+build_java: bin/pulumi-java-gen upstream
 	$(WORKING_DIR)/bin/$(JAVA_GEN) generate --schema provider/cmd/$(PROVIDER)/schema.json --out sdk/java  --build gradle-nexus
 	cd sdk/java/ && \
 		echo "module fake_java_module // Exclude this directory from Go tools\n\ngo 1.17" > go.mod && \
 		gradle --console=plain build
 
 build_nodejs: VERSION := $(shell pulumictl get version --language javascript)
-build_nodejs:
+build_nodejs: upstream
 	$(WORKING_DIR)/bin/$(TFGEN) nodejs --out sdk/nodejs/
 	cd sdk/nodejs/ && \
 		echo "module fake_nodejs_module // Exclude this directory from Go tools\n\ngo 1.17" > go.mod && \
@@ -60,7 +60,7 @@ build_nodejs:
 		sed -i.bak -e "s/\$${VERSION}/$(VERSION)/g" ./bin/package.json
 
 build_python: PYPI_VERSION := $(shell pulumictl get version --language python)
-build_python:
+build_python: upstream
 	$(WORKING_DIR)/bin/$(TFGEN) python --out sdk/python/
 	cd sdk/python/ && \
 		echo "module fake_python_module // Exclude this directory from Go tools\n\ngo 1.17" > go.mod && \
@@ -77,6 +77,11 @@ clean:
 cleanup:
 	rm -r $(WORKING_DIR)/bin
 	rm -f provider/cmd/$(PROVIDER)/schema.go
+
+finish-patch:
+	@if [ ! -z "$$(cd upstream && git status --porcelain)" ]; then echo "Please commit your changes before finishing the patch"; exit 1; fi
+	@cd upstream && \
+		git format-patch HEAD~ -o ../patches --start-number $$(($$(ls ../patches | wc -l | xargs)+1))
 
 help:
 	@grep '^[^.#]\+:\s\+.*#' Makefile | \
@@ -100,15 +105,52 @@ lint_provider: provider
 provider: tfgen install_plugins
 	(cd provider && go build -p 1 -o $(WORKING_DIR)/bin/$(PROVIDER) -ldflags "-X $(PROJECT)/$(VERSION_PATH)=$(VERSION)" $(PROJECT)/$(PROVIDER_PATH)/cmd/$(PROVIDER))
 
+start-patch: upstream
+ifeq ("$(wildcard upstream)","")
+	@echo "No upstream found, so upstream can't be patched"
+	@exit 1
+else
+	# To add an additional patch:
+	#
+	#	1. Run this command (`make start-patch`).
+	#
+	#	2. Edit the `upstream` repo, making whatever changes you want to appear in the new
+	#	patch. It's fine to edit multiple files.
+	#
+	#	3. Commit your changes. The slugified first line of your commit description will
+	#	be used to generate the patch file name. Only the diff from the latest commit will
+	#	end up in the final patch.
+	#
+	#	4. Run `make finish-patch`.
+	#
+	# It is safe to run `make start-patch` as many times as you want, but any changes
+	# might be reverted until `make finish-patch` is run.
+	@cd upstream && git commit --quiet -m "existing patches"
+endif
+
 test:
 	cd examples && go test -v -tags=all -parallel $(TESTPARALLELISM) -timeout 2h
 
-tfgen: install_plugins
+tfgen: install_plugins upstream
 	(cd provider && go build -p 1 -o $(WORKING_DIR)/bin/$(TFGEN) -ldflags "-X $(PROJECT)/$(VERSION_PATH)=$(VERSION)" $(PROJECT)/$(PROVIDER_PATH)/cmd/$(TFGEN))
 	$(WORKING_DIR)/bin/$(TFGEN) schema --out provider/cmd/$(PROVIDER)
 	(cd provider && VERSION=$(VERSION) go generate cmd/$(PROVIDER)/main.go)
 
+upstream:
+ifeq ("$(wildcard upstream)","")
+	# upstream doesn't exist, so skip
+else ifeq ("$(wildcard patches/*.patch)","")
+	# upstream exists, but patches don't exist. This is probably an error.
+	@echo "No patches found within the patch operation"
+	@echo "patches were expected because upstream exists"
+	@exit 1
+else
+	git submodule update --force --init
+	cd upstream && \
+		for patch in $(sort $(wildcard patches/*.patch)); do git apply --3way ../$$patch || exit 1; done
+endif
+
 bin/pulumi-java-gen:
 	$(shell pulumictl download-binary -n pulumi-language-java -v $(JAVA_GEN_VERSION) -r pulumi/pulumi-java)
 
-.PHONY: development build build_sdks install_go_sdk install_java_sdk install_python_sdk install_sdks only_build build_dotnet build_go build_java build_nodejs build_python clean cleanup help install_dotnet_sdk install_nodejs_sdk install_plugins lint_provider provider test tfgen
+.PHONY: development build build_sdks install_go_sdk install_java_sdk install_python_sdk install_sdks only_build build_dotnet build_go build_java build_nodejs build_python clean cleanup finish-patch help install_dotnet_sdk install_nodejs_sdk install_plugins lint_provider provider start-patch test tfgen upstream

--- a/provider-ci/providers/ec/repo/Makefile
+++ b/provider-ci/providers/ec/repo/Makefile
@@ -145,7 +145,12 @@ else ifeq ("$(wildcard patches/*.patch)","")
 	@echo "patches were expected because upstream exists"
 	@exit 1
 else
+	# Checkout the submodule at the pinned commit.
+	# `--force`: If the submodule is at a different commit, move it to the pinned commit.
+	# `--init`: If the submodule is not initialized, initialize it.
 	git submodule update --force --init
+	# Iterating over the patches folder in sorted order,
+	# apply the patch using a 3-way merge strategy. This mirrors the default behavior of `git merge`
 	cd upstream && \
 		for patch in $(sort $(wildcard patches/*.patch)); do git apply --3way ../$$patch || exit 1; done
 endif

--- a/provider-ci/providers/equinix-metal/repo/Makefile
+++ b/provider-ci/providers/equinix-metal/repo/Makefile
@@ -144,7 +144,12 @@ else ifeq ("$(wildcard patches/*.patch)","")
 	@echo "patches were expected because upstream exists"
 	@exit 1
 else
+	# Checkout the submodule at the pinned commit.
+	# `--force`: If the submodule is at a different commit, move it to the pinned commit.
+	# `--init`: If the submodule is not initialized, initialize it.
 	git submodule update --force --init
+	# Iterating over the patches folder in sorted order,
+	# apply the patch using a 3-way merge strategy. This mirrors the default behavior of `git merge`
 	cd upstream && \
 		for patch in $(sort $(wildcard patches/*.patch)); do git apply --3way ../$$patch || exit 1; done
 endif

--- a/provider-ci/providers/equinix-metal/repo/Makefile
+++ b/provider-ci/providers/equinix-metal/repo/Makefile
@@ -30,7 +30,7 @@ install_sdks: install_dotnet_sdk install_python_sdk install_nodejs_sdk install_j
 only_build: build
 
 build_dotnet: DOTNET_VERSION := $(shell pulumictl get version --language dotnet)
-build_dotnet:
+build_dotnet: upstream
 	pulumictl get version --language dotnet
 	$(WORKING_DIR)/bin/$(TFGEN) dotnet --out sdk/dotnet/
 	cd sdk/dotnet/ && \
@@ -38,19 +38,19 @@ build_dotnet:
 		echo "$(DOTNET_VERSION)" >version.txt && \
 		dotnet build /p:Version=$(DOTNET_VERSION)
 
-build_go:
+build_go: upstream
 	$(WORKING_DIR)/bin/$(TFGEN) go --out sdk/go/
 	cd sdk && go list `grep -e "^module" go.mod | cut -d ' ' -f 2`/go/... | xargs go build
 
 build_java: PACKAGE_VERSION := $(shell pulumictl get version --language generic)
-build_java: bin/pulumi-java-gen
+build_java: bin/pulumi-java-gen upstream
 	$(WORKING_DIR)/bin/$(JAVA_GEN) generate --schema provider/cmd/$(PROVIDER)/schema.json --out sdk/java  --build gradle-nexus
 	cd sdk/java/ && \
 		echo "module fake_java_module // Exclude this directory from Go tools\n\ngo 1.17" > go.mod && \
 		gradle --console=plain build
 
 build_nodejs: VERSION := $(shell pulumictl get version --language javascript)
-build_nodejs:
+build_nodejs: upstream
 	$(WORKING_DIR)/bin/$(TFGEN) nodejs --out sdk/nodejs/
 	cd sdk/nodejs/ && \
 		echo "module fake_nodejs_module // Exclude this directory from Go tools\n\ngo 1.17" > go.mod && \
@@ -60,7 +60,7 @@ build_nodejs:
 		sed -i.bak -e "s/\$${VERSION}/$(VERSION)/g" ./bin/package.json
 
 build_python: PYPI_VERSION := $(shell pulumictl get version --language python)
-build_python:
+build_python: upstream
 	$(WORKING_DIR)/bin/$(TFGEN) python --out sdk/python/
 	cd sdk/python/ && \
 		echo "module fake_python_module // Exclude this directory from Go tools\n\ngo 1.17" > go.mod && \
@@ -77,6 +77,11 @@ clean:
 cleanup:
 	rm -r $(WORKING_DIR)/bin
 	rm -f provider/cmd/$(PROVIDER)/schema.go
+
+finish-patch:
+	@if [ ! -z "$$(cd upstream && git status --porcelain)" ]; then echo "Please commit your changes before finishing the patch"; exit 1; fi
+	@cd upstream && \
+		git format-patch HEAD~ -o ../patches --start-number $$(($$(ls ../patches | wc -l | xargs)+1))
 
 help:
 	@grep '^[^.#]\+:\s\+.*#' Makefile | \
@@ -99,15 +104,52 @@ lint_provider: provider
 provider: tfgen install_plugins
 	(cd provider && go build -p 1 -o $(WORKING_DIR)/bin/$(PROVIDER) -ldflags "-X $(PROJECT)/$(VERSION_PATH)=$(VERSION)" $(PROJECT)/$(PROVIDER_PATH)/cmd/$(PROVIDER))
 
+start-patch: upstream
+ifeq ("$(wildcard upstream)","")
+	@echo "No upstream found, so upstream can't be patched"
+	@exit 1
+else
+	# To add an additional patch:
+	#
+	#	1. Run this command (`make start-patch`).
+	#
+	#	2. Edit the `upstream` repo, making whatever changes you want to appear in the new
+	#	patch. It's fine to edit multiple files.
+	#
+	#	3. Commit your changes. The slugified first line of your commit description will
+	#	be used to generate the patch file name. Only the diff from the latest commit will
+	#	end up in the final patch.
+	#
+	#	4. Run `make finish-patch`.
+	#
+	# It is safe to run `make start-patch` as many times as you want, but any changes
+	# might be reverted until `make finish-patch` is run.
+	@cd upstream && git commit --quiet -m "existing patches"
+endif
+
 test:
 	cd examples && go test -v -tags=all -parallel $(TESTPARALLELISM) -timeout 2h
 
-tfgen: install_plugins
+tfgen: install_plugins upstream
 	(cd provider && go build -p 1 -o $(WORKING_DIR)/bin/$(TFGEN) -ldflags "-X $(PROJECT)/$(VERSION_PATH)=$(VERSION)" $(PROJECT)/$(PROVIDER_PATH)/cmd/$(TFGEN))
 	$(WORKING_DIR)/bin/$(TFGEN) schema --out provider/cmd/$(PROVIDER)
 	(cd provider && VERSION=$(VERSION) go generate cmd/$(PROVIDER)/main.go)
 
+upstream:
+ifeq ("$(wildcard upstream)","")
+	# upstream doesn't exist, so skip
+else ifeq ("$(wildcard patches/*.patch)","")
+	# upstream exists, but patches don't exist. This is probably an error.
+	@echo "No patches found within the patch operation"
+	@echo "patches were expected because upstream exists"
+	@exit 1
+else
+	git submodule update --force --init
+	cd upstream && \
+		for patch in $(sort $(wildcard patches/*.patch)); do git apply --3way ../$$patch || exit 1; done
+endif
+
 bin/pulumi-java-gen:
 	$(shell pulumictl download-binary -n pulumi-language-java -v $(JAVA_GEN_VERSION) -r pulumi/pulumi-java)
 
-.PHONY: development build build_sdks install_go_sdk install_java_sdk install_python_sdk install_sdks only_build build_dotnet build_go build_java build_nodejs build_python clean cleanup help install_dotnet_sdk install_nodejs_sdk install_plugins lint_provider provider test tfgen
+.PHONY: development build build_sdks install_go_sdk install_java_sdk install_python_sdk install_sdks only_build build_dotnet build_go build_java build_nodejs build_python clean cleanup finish-patch help install_dotnet_sdk install_nodejs_sdk install_plugins lint_provider provider start-patch test tfgen upstream

--- a/provider-ci/providers/f5bigip/repo/Makefile
+++ b/provider-ci/providers/f5bigip/repo/Makefile
@@ -144,7 +144,12 @@ else ifeq ("$(wildcard patches/*.patch)","")
 	@echo "patches were expected because upstream exists"
 	@exit 1
 else
+	# Checkout the submodule at the pinned commit.
+	# `--force`: If the submodule is at a different commit, move it to the pinned commit.
+	# `--init`: If the submodule is not initialized, initialize it.
 	git submodule update --force --init
+	# Iterating over the patches folder in sorted order,
+	# apply the patch using a 3-way merge strategy. This mirrors the default behavior of `git merge`
 	cd upstream && \
 		for patch in $(sort $(wildcard patches/*.patch)); do git apply --3way ../$$patch || exit 1; done
 endif

--- a/provider-ci/providers/f5bigip/repo/Makefile
+++ b/provider-ci/providers/f5bigip/repo/Makefile
@@ -30,7 +30,7 @@ install_sdks: install_dotnet_sdk install_python_sdk install_nodejs_sdk install_j
 only_build: build
 
 build_dotnet: DOTNET_VERSION := $(shell pulumictl get version --language dotnet)
-build_dotnet:
+build_dotnet: upstream
 	pulumictl get version --language dotnet
 	$(WORKING_DIR)/bin/$(TFGEN) dotnet --out sdk/dotnet/
 	cd sdk/dotnet/ && \
@@ -38,19 +38,19 @@ build_dotnet:
 		echo "$(DOTNET_VERSION)" >version.txt && \
 		dotnet build /p:Version=$(DOTNET_VERSION)
 
-build_go:
+build_go: upstream
 	$(WORKING_DIR)/bin/$(TFGEN) go --out sdk/go/
 	cd sdk && go list `grep -e "^module" go.mod | cut -d ' ' -f 2`/go/... | xargs go build
 
 build_java: PACKAGE_VERSION := $(shell pulumictl get version --language generic)
-build_java: bin/pulumi-java-gen
+build_java: bin/pulumi-java-gen upstream
 	$(WORKING_DIR)/bin/$(JAVA_GEN) generate --schema provider/cmd/$(PROVIDER)/schema.json --out sdk/java  --build gradle-nexus
 	cd sdk/java/ && \
 		echo "module fake_java_module // Exclude this directory from Go tools\n\ngo 1.17" > go.mod && \
 		gradle --console=plain build
 
 build_nodejs: VERSION := $(shell pulumictl get version --language javascript)
-build_nodejs:
+build_nodejs: upstream
 	$(WORKING_DIR)/bin/$(TFGEN) nodejs --out sdk/nodejs/
 	cd sdk/nodejs/ && \
 		echo "module fake_nodejs_module // Exclude this directory from Go tools\n\ngo 1.17" > go.mod && \
@@ -60,7 +60,7 @@ build_nodejs:
 		sed -i.bak -e "s/\$${VERSION}/$(VERSION)/g" ./bin/package.json
 
 build_python: PYPI_VERSION := $(shell pulumictl get version --language python)
-build_python:
+build_python: upstream
 	$(WORKING_DIR)/bin/$(TFGEN) python --out sdk/python/
 	cd sdk/python/ && \
 		echo "module fake_python_module // Exclude this directory from Go tools\n\ngo 1.17" > go.mod && \
@@ -77,6 +77,11 @@ clean:
 cleanup:
 	rm -r $(WORKING_DIR)/bin
 	rm -f provider/cmd/$(PROVIDER)/schema.go
+
+finish-patch:
+	@if [ ! -z "$$(cd upstream && git status --porcelain)" ]; then echo "Please commit your changes before finishing the patch"; exit 1; fi
+	@cd upstream && \
+		git format-patch HEAD~ -o ../patches --start-number $$(($$(ls ../patches | wc -l | xargs)+1))
 
 help:
 	@grep '^[^.#]\+:\s\+.*#' Makefile | \
@@ -99,15 +104,52 @@ lint_provider: provider
 provider: tfgen install_plugins
 	(cd provider && go build -p 1 -o $(WORKING_DIR)/bin/$(PROVIDER) -ldflags "-X $(PROJECT)/$(VERSION_PATH)=$(VERSION)" $(PROJECT)/$(PROVIDER_PATH)/cmd/$(PROVIDER))
 
+start-patch: upstream
+ifeq ("$(wildcard upstream)","")
+	@echo "No upstream found, so upstream can't be patched"
+	@exit 1
+else
+	# To add an additional patch:
+	#
+	#	1. Run this command (`make start-patch`).
+	#
+	#	2. Edit the `upstream` repo, making whatever changes you want to appear in the new
+	#	patch. It's fine to edit multiple files.
+	#
+	#	3. Commit your changes. The slugified first line of your commit description will
+	#	be used to generate the patch file name. Only the diff from the latest commit will
+	#	end up in the final patch.
+	#
+	#	4. Run `make finish-patch`.
+	#
+	# It is safe to run `make start-patch` as many times as you want, but any changes
+	# might be reverted until `make finish-patch` is run.
+	@cd upstream && git commit --quiet -m "existing patches"
+endif
+
 test:
 	cd examples && go test -v -tags=all -parallel $(TESTPARALLELISM) -timeout 2h
 
-tfgen: install_plugins
+tfgen: install_plugins upstream
 	(cd provider && go build -p 1 -o $(WORKING_DIR)/bin/$(TFGEN) -ldflags "-X $(PROJECT)/$(VERSION_PATH)=$(VERSION)" $(PROJECT)/$(PROVIDER_PATH)/cmd/$(TFGEN))
 	$(WORKING_DIR)/bin/$(TFGEN) schema --out provider/cmd/$(PROVIDER)
 	(cd provider && VERSION=$(VERSION) go generate cmd/$(PROVIDER)/main.go)
 
+upstream:
+ifeq ("$(wildcard upstream)","")
+	# upstream doesn't exist, so skip
+else ifeq ("$(wildcard patches/*.patch)","")
+	# upstream exists, but patches don't exist. This is probably an error.
+	@echo "No patches found within the patch operation"
+	@echo "patches were expected because upstream exists"
+	@exit 1
+else
+	git submodule update --force --init
+	cd upstream && \
+		for patch in $(sort $(wildcard patches/*.patch)); do git apply --3way ../$$patch || exit 1; done
+endif
+
 bin/pulumi-java-gen:
 	$(shell pulumictl download-binary -n pulumi-language-java -v $(JAVA_GEN_VERSION) -r pulumi/pulumi-java)
 
-.PHONY: development build build_sdks install_go_sdk install_java_sdk install_python_sdk install_sdks only_build build_dotnet build_go build_java build_nodejs build_python clean cleanup help install_dotnet_sdk install_nodejs_sdk install_plugins lint_provider provider test tfgen
+.PHONY: development build build_sdks install_go_sdk install_java_sdk install_python_sdk install_sdks only_build build_dotnet build_go build_java build_nodejs build_python clean cleanup finish-patch help install_dotnet_sdk install_nodejs_sdk install_plugins lint_provider provider start-patch test tfgen upstream

--- a/provider-ci/providers/fastly/repo/Makefile
+++ b/provider-ci/providers/fastly/repo/Makefile
@@ -146,7 +146,12 @@ else ifeq ("$(wildcard patches/*.patch)","")
 	@echo "patches were expected because upstream exists"
 	@exit 1
 else
+	# Checkout the submodule at the pinned commit.
+	# `--force`: If the submodule is at a different commit, move it to the pinned commit.
+	# `--init`: If the submodule is not initialized, initialize it.
 	git submodule update --force --init
+	# Iterating over the patches folder in sorted order,
+	# apply the patch using a 3-way merge strategy. This mirrors the default behavior of `git merge`
 	cd upstream && \
 		for patch in $(sort $(wildcard patches/*.patch)); do git apply --3way ../$$patch || exit 1; done
 endif

--- a/provider-ci/providers/fastly/repo/Makefile
+++ b/provider-ci/providers/fastly/repo/Makefile
@@ -30,7 +30,7 @@ install_sdks: install_dotnet_sdk install_python_sdk install_nodejs_sdk install_j
 only_build: build
 
 build_dotnet: DOTNET_VERSION := $(shell pulumictl get version --language dotnet)
-build_dotnet:
+build_dotnet: upstream
 	pulumictl get version --language dotnet
 	$(WORKING_DIR)/bin/$(TFGEN) dotnet --out sdk/dotnet/
 	cd sdk/dotnet/ && \
@@ -38,19 +38,19 @@ build_dotnet:
 		echo "$(DOTNET_VERSION)" >version.txt && \
 		dotnet build /p:Version=$(DOTNET_VERSION)
 
-build_go:
+build_go: upstream
 	$(WORKING_DIR)/bin/$(TFGEN) go --out sdk/go/
 	cd sdk && go list `grep -e "^module" go.mod | cut -d ' ' -f 2`/go/... | xargs go build
 
 build_java: PACKAGE_VERSION := $(shell pulumictl get version --language generic)
-build_java: bin/pulumi-java-gen
+build_java: bin/pulumi-java-gen upstream
 	$(WORKING_DIR)/bin/$(JAVA_GEN) generate --schema provider/cmd/$(PROVIDER)/schema.json --out sdk/java  --build gradle-nexus
 	cd sdk/java/ && \
 		echo "module fake_java_module // Exclude this directory from Go tools\n\ngo 1.17" > go.mod && \
 		gradle --console=plain build
 
 build_nodejs: VERSION := $(shell pulumictl get version --language javascript)
-build_nodejs:
+build_nodejs: upstream
 	$(WORKING_DIR)/bin/$(TFGEN) nodejs --out sdk/nodejs/
 	cd sdk/nodejs/ && \
 		echo "module fake_nodejs_module // Exclude this directory from Go tools\n\ngo 1.17" > go.mod && \
@@ -60,7 +60,7 @@ build_nodejs:
 		sed -i.bak -e "s/\$${VERSION}/$(VERSION)/g" ./bin/package.json
 
 build_python: PYPI_VERSION := $(shell pulumictl get version --language python)
-build_python:
+build_python: upstream
 	$(WORKING_DIR)/bin/$(TFGEN) python --out sdk/python/
 	cd sdk/python/ && \
 		echo "module fake_python_module // Exclude this directory from Go tools\n\ngo 1.17" > go.mod && \
@@ -77,6 +77,11 @@ clean:
 cleanup:
 	rm -r $(WORKING_DIR)/bin
 	rm -f provider/cmd/$(PROVIDER)/schema.go
+
+finish-patch:
+	@if [ ! -z "$$(cd upstream && git status --porcelain)" ]; then echo "Please commit your changes before finishing the patch"; exit 1; fi
+	@cd upstream && \
+		git format-patch HEAD~ -o ../patches --start-number $$(($$(ls ../patches | wc -l | xargs)+1))
 
 help:
 	@grep '^[^.#]\+:\s\+.*#' Makefile | \
@@ -101,15 +106,52 @@ lint_provider: provider
 provider: tfgen install_plugins
 	(cd provider && go build -p 1 -o $(WORKING_DIR)/bin/$(PROVIDER) -ldflags "-X $(PROJECT)/$(VERSION_PATH)=$(VERSION)" $(PROJECT)/$(PROVIDER_PATH)/cmd/$(PROVIDER))
 
+start-patch: upstream
+ifeq ("$(wildcard upstream)","")
+	@echo "No upstream found, so upstream can't be patched"
+	@exit 1
+else
+	# To add an additional patch:
+	#
+	#	1. Run this command (`make start-patch`).
+	#
+	#	2. Edit the `upstream` repo, making whatever changes you want to appear in the new
+	#	patch. It's fine to edit multiple files.
+	#
+	#	3. Commit your changes. The slugified first line of your commit description will
+	#	be used to generate the patch file name. Only the diff from the latest commit will
+	#	end up in the final patch.
+	#
+	#	4. Run `make finish-patch`.
+	#
+	# It is safe to run `make start-patch` as many times as you want, but any changes
+	# might be reverted until `make finish-patch` is run.
+	@cd upstream && git commit --quiet -m "existing patches"
+endif
+
 test:
 	cd examples && go test -v -tags=all -parallel $(TESTPARALLELISM) -timeout 2h
 
-tfgen: install_plugins
+tfgen: install_plugins upstream
 	(cd provider && go build -p 1 -o $(WORKING_DIR)/bin/$(TFGEN) -ldflags "-X $(PROJECT)/$(VERSION_PATH)=$(VERSION)" $(PROJECT)/$(PROVIDER_PATH)/cmd/$(TFGEN))
 	$(WORKING_DIR)/bin/$(TFGEN) schema --out provider/cmd/$(PROVIDER)
 	(cd provider && VERSION=$(VERSION) go generate cmd/$(PROVIDER)/main.go)
 
+upstream:
+ifeq ("$(wildcard upstream)","")
+	# upstream doesn't exist, so skip
+else ifeq ("$(wildcard patches/*.patch)","")
+	# upstream exists, but patches don't exist. This is probably an error.
+	@echo "No patches found within the patch operation"
+	@echo "patches were expected because upstream exists"
+	@exit 1
+else
+	git submodule update --force --init
+	cd upstream && \
+		for patch in $(sort $(wildcard patches/*.patch)); do git apply --3way ../$$patch || exit 1; done
+endif
+
 bin/pulumi-java-gen:
 	$(shell pulumictl download-binary -n pulumi-language-java -v $(JAVA_GEN_VERSION) -r pulumi/pulumi-java)
 
-.PHONY: development build build_sdks install_go_sdk install_java_sdk install_python_sdk install_sdks only_build build_dotnet build_go build_java build_nodejs build_python clean cleanup help install_dotnet_sdk install_nodejs_sdk install_plugins lint_provider provider test tfgen
+.PHONY: development build build_sdks install_go_sdk install_java_sdk install_python_sdk install_sdks only_build build_dotnet build_go build_java build_nodejs build_python clean cleanup finish-patch help install_dotnet_sdk install_nodejs_sdk install_plugins lint_provider provider start-patch test tfgen upstream

--- a/provider-ci/providers/gcp/config.yaml
+++ b/provider-ci/providers/gcp/config.yaml
@@ -24,3 +24,4 @@ plugins:
     version: "3.20.0"
   - name: tls
     version: "4.6.0"
+team: providers

--- a/provider-ci/providers/github/repo/Makefile
+++ b/provider-ci/providers/github/repo/Makefile
@@ -144,7 +144,12 @@ else ifeq ("$(wildcard patches/*.patch)","")
 	@echo "patches were expected because upstream exists"
 	@exit 1
 else
+	# Checkout the submodule at the pinned commit.
+	# `--force`: If the submodule is at a different commit, move it to the pinned commit.
+	# `--init`: If the submodule is not initialized, initialize it.
 	git submodule update --force --init
+	# Iterating over the patches folder in sorted order,
+	# apply the patch using a 3-way merge strategy. This mirrors the default behavior of `git merge`
 	cd upstream && \
 		for patch in $(sort $(wildcard patches/*.patch)); do git apply --3way ../$$patch || exit 1; done
 endif

--- a/provider-ci/providers/github/repo/Makefile
+++ b/provider-ci/providers/github/repo/Makefile
@@ -30,7 +30,7 @@ install_sdks: install_dotnet_sdk install_python_sdk install_nodejs_sdk install_j
 only_build: build
 
 build_dotnet: DOTNET_VERSION := $(shell pulumictl get version --language dotnet)
-build_dotnet:
+build_dotnet: upstream
 	pulumictl get version --language dotnet
 	$(WORKING_DIR)/bin/$(TFGEN) dotnet --out sdk/dotnet/
 	cd sdk/dotnet/ && \
@@ -38,19 +38,19 @@ build_dotnet:
 		echo "$(DOTNET_VERSION)" >version.txt && \
 		dotnet build /p:Version=$(DOTNET_VERSION)
 
-build_go:
+build_go: upstream
 	$(WORKING_DIR)/bin/$(TFGEN) go --out sdk/go/
 	cd sdk && go list `grep -e "^module" go.mod | cut -d ' ' -f 2`/go/... | xargs go build
 
 build_java: PACKAGE_VERSION := $(shell pulumictl get version --language generic)
-build_java: bin/pulumi-java-gen
+build_java: bin/pulumi-java-gen upstream
 	$(WORKING_DIR)/bin/$(JAVA_GEN) generate --schema provider/cmd/$(PROVIDER)/schema.json --out sdk/java  --build gradle-nexus
 	cd sdk/java/ && \
 		echo "module fake_java_module // Exclude this directory from Go tools\n\ngo 1.17" > go.mod && \
 		gradle --console=plain build
 
 build_nodejs: VERSION := $(shell pulumictl get version --language javascript)
-build_nodejs:
+build_nodejs: upstream
 	$(WORKING_DIR)/bin/$(TFGEN) nodejs --out sdk/nodejs/
 	cd sdk/nodejs/ && \
 		echo "module fake_nodejs_module // Exclude this directory from Go tools\n\ngo 1.17" > go.mod && \
@@ -60,7 +60,7 @@ build_nodejs:
 		sed -i.bak -e "s/\$${VERSION}/$(VERSION)/g" ./bin/package.json
 
 build_python: PYPI_VERSION := $(shell pulumictl get version --language python)
-build_python:
+build_python: upstream
 	$(WORKING_DIR)/bin/$(TFGEN) python --out sdk/python/
 	cd sdk/python/ && \
 		echo "module fake_python_module // Exclude this directory from Go tools\n\ngo 1.17" > go.mod && \
@@ -77,6 +77,11 @@ clean:
 cleanup:
 	rm -r $(WORKING_DIR)/bin
 	rm -f provider/cmd/$(PROVIDER)/schema.go
+
+finish-patch:
+	@if [ ! -z "$$(cd upstream && git status --porcelain)" ]; then echo "Please commit your changes before finishing the patch"; exit 1; fi
+	@cd upstream && \
+		git format-patch HEAD~ -o ../patches --start-number $$(($$(ls ../patches | wc -l | xargs)+1))
 
 help:
 	@grep '^[^.#]\+:\s\+.*#' Makefile | \
@@ -99,15 +104,52 @@ lint_provider: provider
 provider: tfgen install_plugins
 	(cd provider && go build -p 1 -o $(WORKING_DIR)/bin/$(PROVIDER) -ldflags "-X $(PROJECT)/$(VERSION_PATH)=$(VERSION)" $(PROJECT)/$(PROVIDER_PATH)/cmd/$(PROVIDER))
 
+start-patch: upstream
+ifeq ("$(wildcard upstream)","")
+	@echo "No upstream found, so upstream can't be patched"
+	@exit 1
+else
+	# To add an additional patch:
+	#
+	#	1. Run this command (`make start-patch`).
+	#
+	#	2. Edit the `upstream` repo, making whatever changes you want to appear in the new
+	#	patch. It's fine to edit multiple files.
+	#
+	#	3. Commit your changes. The slugified first line of your commit description will
+	#	be used to generate the patch file name. Only the diff from the latest commit will
+	#	end up in the final patch.
+	#
+	#	4. Run `make finish-patch`.
+	#
+	# It is safe to run `make start-patch` as many times as you want, but any changes
+	# might be reverted until `make finish-patch` is run.
+	@cd upstream && git commit --quiet -m "existing patches"
+endif
+
 test:
 	cd examples && go test -v -tags=all -parallel $(TESTPARALLELISM) -timeout 2h
 
-tfgen: install_plugins
+tfgen: install_plugins upstream
 	(cd provider && go build -p 1 -o $(WORKING_DIR)/bin/$(TFGEN) -ldflags "-X $(PROJECT)/$(VERSION_PATH)=$(VERSION)" $(PROJECT)/$(PROVIDER_PATH)/cmd/$(TFGEN))
 	$(WORKING_DIR)/bin/$(TFGEN) schema --out provider/cmd/$(PROVIDER)
 	(cd provider && VERSION=$(VERSION) go generate cmd/$(PROVIDER)/main.go)
 
+upstream:
+ifeq ("$(wildcard upstream)","")
+	# upstream doesn't exist, so skip
+else ifeq ("$(wildcard patches/*.patch)","")
+	# upstream exists, but patches don't exist. This is probably an error.
+	@echo "No patches found within the patch operation"
+	@echo "patches were expected because upstream exists"
+	@exit 1
+else
+	git submodule update --force --init
+	cd upstream && \
+		for patch in $(sort $(wildcard patches/*.patch)); do git apply --3way ../$$patch || exit 1; done
+endif
+
 bin/pulumi-java-gen:
 	$(shell pulumictl download-binary -n pulumi-language-java -v $(JAVA_GEN_VERSION) -r pulumi/pulumi-java)
 
-.PHONY: development build build_sdks install_go_sdk install_java_sdk install_python_sdk install_sdks only_build build_dotnet build_go build_java build_nodejs build_python clean cleanup help install_dotnet_sdk install_nodejs_sdk install_plugins lint_provider provider test tfgen
+.PHONY: development build build_sdks install_go_sdk install_java_sdk install_python_sdk install_sdks only_build build_dotnet build_go build_java build_nodejs build_python clean cleanup finish-patch help install_dotnet_sdk install_nodejs_sdk install_plugins lint_provider provider start-patch test tfgen upstream

--- a/provider-ci/providers/gitlab/repo/Makefile
+++ b/provider-ci/providers/gitlab/repo/Makefile
@@ -144,7 +144,12 @@ else ifeq ("$(wildcard patches/*.patch)","")
 	@echo "patches were expected because upstream exists"
 	@exit 1
 else
+	# Checkout the submodule at the pinned commit.
+	# `--force`: If the submodule is at a different commit, move it to the pinned commit.
+	# `--init`: If the submodule is not initialized, initialize it.
 	git submodule update --force --init
+	# Iterating over the patches folder in sorted order,
+	# apply the patch using a 3-way merge strategy. This mirrors the default behavior of `git merge`
 	cd upstream && \
 		for patch in $(sort $(wildcard patches/*.patch)); do git apply --3way ../$$patch || exit 1; done
 endif

--- a/provider-ci/providers/gitlab/repo/Makefile
+++ b/provider-ci/providers/gitlab/repo/Makefile
@@ -30,7 +30,7 @@ install_sdks: install_dotnet_sdk install_python_sdk install_nodejs_sdk install_j
 only_build: build
 
 build_dotnet: DOTNET_VERSION := $(shell pulumictl get version --language dotnet)
-build_dotnet:
+build_dotnet: upstream
 	pulumictl get version --language dotnet
 	$(WORKING_DIR)/bin/$(TFGEN) dotnet --out sdk/dotnet/
 	cd sdk/dotnet/ && \
@@ -38,19 +38,19 @@ build_dotnet:
 		echo "$(DOTNET_VERSION)" >version.txt && \
 		dotnet build /p:Version=$(DOTNET_VERSION)
 
-build_go:
+build_go: upstream
 	$(WORKING_DIR)/bin/$(TFGEN) go --out sdk/go/
 	cd sdk && go list `grep -e "^module" go.mod | cut -d ' ' -f 2`/go/... | xargs go build
 
 build_java: PACKAGE_VERSION := $(shell pulumictl get version --language generic)
-build_java: bin/pulumi-java-gen
+build_java: bin/pulumi-java-gen upstream
 	$(WORKING_DIR)/bin/$(JAVA_GEN) generate --schema provider/cmd/$(PROVIDER)/schema.json --out sdk/java  --build gradle-nexus
 	cd sdk/java/ && \
 		echo "module fake_java_module // Exclude this directory from Go tools\n\ngo 1.17" > go.mod && \
 		gradle --console=plain build
 
 build_nodejs: VERSION := $(shell pulumictl get version --language javascript)
-build_nodejs:
+build_nodejs: upstream
 	$(WORKING_DIR)/bin/$(TFGEN) nodejs --out sdk/nodejs/
 	cd sdk/nodejs/ && \
 		echo "module fake_nodejs_module // Exclude this directory from Go tools\n\ngo 1.17" > go.mod && \
@@ -60,7 +60,7 @@ build_nodejs:
 		sed -i.bak -e "s/\$${VERSION}/$(VERSION)/g" ./bin/package.json
 
 build_python: PYPI_VERSION := $(shell pulumictl get version --language python)
-build_python:
+build_python: upstream
 	$(WORKING_DIR)/bin/$(TFGEN) python --out sdk/python/
 	cd sdk/python/ && \
 		echo "module fake_python_module // Exclude this directory from Go tools\n\ngo 1.17" > go.mod && \
@@ -77,6 +77,11 @@ clean:
 cleanup:
 	rm -r $(WORKING_DIR)/bin
 	rm -f provider/cmd/$(PROVIDER)/schema.go
+
+finish-patch:
+	@if [ ! -z "$$(cd upstream && git status --porcelain)" ]; then echo "Please commit your changes before finishing the patch"; exit 1; fi
+	@cd upstream && \
+		git format-patch HEAD~ -o ../patches --start-number $$(($$(ls ../patches | wc -l | xargs)+1))
 
 help:
 	@grep '^[^.#]\+:\s\+.*#' Makefile | \
@@ -99,15 +104,52 @@ lint_provider: provider
 provider: tfgen install_plugins
 	(cd provider && go build -p 1 -o $(WORKING_DIR)/bin/$(PROVIDER) -ldflags "-X $(PROJECT)/$(VERSION_PATH)=$(VERSION)" $(PROJECT)/$(PROVIDER_PATH)/cmd/$(PROVIDER))
 
+start-patch: upstream
+ifeq ("$(wildcard upstream)","")
+	@echo "No upstream found, so upstream can't be patched"
+	@exit 1
+else
+	# To add an additional patch:
+	#
+	#	1. Run this command (`make start-patch`).
+	#
+	#	2. Edit the `upstream` repo, making whatever changes you want to appear in the new
+	#	patch. It's fine to edit multiple files.
+	#
+	#	3. Commit your changes. The slugified first line of your commit description will
+	#	be used to generate the patch file name. Only the diff from the latest commit will
+	#	end up in the final patch.
+	#
+	#	4. Run `make finish-patch`.
+	#
+	# It is safe to run `make start-patch` as many times as you want, but any changes
+	# might be reverted until `make finish-patch` is run.
+	@cd upstream && git commit --quiet -m "existing patches"
+endif
+
 test:
 	cd examples && go test -v -tags=all -parallel $(TESTPARALLELISM) -timeout 2h
 
-tfgen: install_plugins
+tfgen: install_plugins upstream
 	(cd provider && go build -p 1 -o $(WORKING_DIR)/bin/$(TFGEN) -ldflags "-X $(PROJECT)/$(VERSION_PATH)=$(VERSION)" $(PROJECT)/$(PROVIDER_PATH)/cmd/$(TFGEN))
 	$(WORKING_DIR)/bin/$(TFGEN) schema --out provider/cmd/$(PROVIDER)
 	(cd provider && VERSION=$(VERSION) go generate cmd/$(PROVIDER)/main.go)
 
+upstream:
+ifeq ("$(wildcard upstream)","")
+	# upstream doesn't exist, so skip
+else ifeq ("$(wildcard patches/*.patch)","")
+	# upstream exists, but patches don't exist. This is probably an error.
+	@echo "No patches found within the patch operation"
+	@echo "patches were expected because upstream exists"
+	@exit 1
+else
+	git submodule update --force --init
+	cd upstream && \
+		for patch in $(sort $(wildcard patches/*.patch)); do git apply --3way ../$$patch || exit 1; done
+endif
+
 bin/pulumi-java-gen:
 	$(shell pulumictl download-binary -n pulumi-language-java -v $(JAVA_GEN_VERSION) -r pulumi/pulumi-java)
 
-.PHONY: development build build_sdks install_go_sdk install_java_sdk install_python_sdk install_sdks only_build build_dotnet build_go build_java build_nodejs build_python clean cleanup help install_dotnet_sdk install_nodejs_sdk install_plugins lint_provider provider test tfgen
+.PHONY: development build build_sdks install_go_sdk install_java_sdk install_python_sdk install_sdks only_build build_dotnet build_go build_java build_nodejs build_python clean cleanup finish-patch help install_dotnet_sdk install_nodejs_sdk install_plugins lint_provider provider start-patch test tfgen upstream

--- a/provider-ci/providers/hcloud/repo/Makefile
+++ b/provider-ci/providers/hcloud/repo/Makefile
@@ -144,7 +144,12 @@ else ifeq ("$(wildcard patches/*.patch)","")
 	@echo "patches were expected because upstream exists"
 	@exit 1
 else
+	# Checkout the submodule at the pinned commit.
+	# `--force`: If the submodule is at a different commit, move it to the pinned commit.
+	# `--init`: If the submodule is not initialized, initialize it.
 	git submodule update --force --init
+	# Iterating over the patches folder in sorted order,
+	# apply the patch using a 3-way merge strategy. This mirrors the default behavior of `git merge`
 	cd upstream && \
 		for patch in $(sort $(wildcard patches/*.patch)); do git apply --3way ../$$patch || exit 1; done
 endif

--- a/provider-ci/providers/hcloud/repo/Makefile
+++ b/provider-ci/providers/hcloud/repo/Makefile
@@ -30,7 +30,7 @@ install_sdks: install_dotnet_sdk install_python_sdk install_nodejs_sdk install_j
 only_build: build
 
 build_dotnet: DOTNET_VERSION := $(shell pulumictl get version --language dotnet)
-build_dotnet:
+build_dotnet: upstream
 	pulumictl get version --language dotnet
 	$(WORKING_DIR)/bin/$(TFGEN) dotnet --out sdk/dotnet/
 	cd sdk/dotnet/ && \
@@ -38,19 +38,19 @@ build_dotnet:
 		echo "$(DOTNET_VERSION)" >version.txt && \
 		dotnet build /p:Version=$(DOTNET_VERSION)
 
-build_go:
+build_go: upstream
 	$(WORKING_DIR)/bin/$(TFGEN) go --out sdk/go/
 	cd sdk && go list `grep -e "^module" go.mod | cut -d ' ' -f 2`/go/... | xargs go build
 
 build_java: PACKAGE_VERSION := $(shell pulumictl get version --language generic)
-build_java: bin/pulumi-java-gen
+build_java: bin/pulumi-java-gen upstream
 	$(WORKING_DIR)/bin/$(JAVA_GEN) generate --schema provider/cmd/$(PROVIDER)/schema.json --out sdk/java  --build gradle-nexus
 	cd sdk/java/ && \
 		echo "module fake_java_module // Exclude this directory from Go tools\n\ngo 1.17" > go.mod && \
 		gradle --console=plain build
 
 build_nodejs: VERSION := $(shell pulumictl get version --language javascript)
-build_nodejs:
+build_nodejs: upstream
 	$(WORKING_DIR)/bin/$(TFGEN) nodejs --out sdk/nodejs/
 	cd sdk/nodejs/ && \
 		echo "module fake_nodejs_module // Exclude this directory from Go tools\n\ngo 1.17" > go.mod && \
@@ -60,7 +60,7 @@ build_nodejs:
 		sed -i.bak -e "s/\$${VERSION}/$(VERSION)/g" ./bin/package.json
 
 build_python: PYPI_VERSION := $(shell pulumictl get version --language python)
-build_python:
+build_python: upstream
 	$(WORKING_DIR)/bin/$(TFGEN) python --out sdk/python/
 	cd sdk/python/ && \
 		echo "module fake_python_module // Exclude this directory from Go tools\n\ngo 1.17" > go.mod && \
@@ -77,6 +77,11 @@ clean:
 cleanup:
 	rm -r $(WORKING_DIR)/bin
 	rm -f provider/cmd/$(PROVIDER)/schema.go
+
+finish-patch:
+	@if [ ! -z "$$(cd upstream && git status --porcelain)" ]; then echo "Please commit your changes before finishing the patch"; exit 1; fi
+	@cd upstream && \
+		git format-patch HEAD~ -o ../patches --start-number $$(($$(ls ../patches | wc -l | xargs)+1))
 
 help:
 	@grep '^[^.#]\+:\s\+.*#' Makefile | \
@@ -99,15 +104,52 @@ lint_provider: provider
 provider: tfgen install_plugins
 	(cd provider && go build -p 1 -o $(WORKING_DIR)/bin/$(PROVIDER) -ldflags "-X $(PROJECT)/$(VERSION_PATH)=$(VERSION)" $(PROJECT)/$(PROVIDER_PATH)/cmd/$(PROVIDER))
 
+start-patch: upstream
+ifeq ("$(wildcard upstream)","")
+	@echo "No upstream found, so upstream can't be patched"
+	@exit 1
+else
+	# To add an additional patch:
+	#
+	#	1. Run this command (`make start-patch`).
+	#
+	#	2. Edit the `upstream` repo, making whatever changes you want to appear in the new
+	#	patch. It's fine to edit multiple files.
+	#
+	#	3. Commit your changes. The slugified first line of your commit description will
+	#	be used to generate the patch file name. Only the diff from the latest commit will
+	#	end up in the final patch.
+	#
+	#	4. Run `make finish-patch`.
+	#
+	# It is safe to run `make start-patch` as many times as you want, but any changes
+	# might be reverted until `make finish-patch` is run.
+	@cd upstream && git commit --quiet -m "existing patches"
+endif
+
 test:
 	cd examples && go test -v -tags=all -parallel $(TESTPARALLELISM) -timeout 2h
 
-tfgen: install_plugins
+tfgen: install_plugins upstream
 	(cd provider && go build -p 1 -o $(WORKING_DIR)/bin/$(TFGEN) -ldflags "-X $(PROJECT)/$(VERSION_PATH)=$(VERSION)" $(PROJECT)/$(PROVIDER_PATH)/cmd/$(TFGEN))
 	$(WORKING_DIR)/bin/$(TFGEN) schema --out provider/cmd/$(PROVIDER)
 	(cd provider && VERSION=$(VERSION) go generate cmd/$(PROVIDER)/main.go)
 
+upstream:
+ifeq ("$(wildcard upstream)","")
+	# upstream doesn't exist, so skip
+else ifeq ("$(wildcard patches/*.patch)","")
+	# upstream exists, but patches don't exist. This is probably an error.
+	@echo "No patches found within the patch operation"
+	@echo "patches were expected because upstream exists"
+	@exit 1
+else
+	git submodule update --force --init
+	cd upstream && \
+		for patch in $(sort $(wildcard patches/*.patch)); do git apply --3way ../$$patch || exit 1; done
+endif
+
 bin/pulumi-java-gen:
 	$(shell pulumictl download-binary -n pulumi-language-java -v $(JAVA_GEN_VERSION) -r pulumi/pulumi-java)
 
-.PHONY: development build build_sdks install_go_sdk install_java_sdk install_python_sdk install_sdks only_build build_dotnet build_go build_java build_nodejs build_python clean cleanup help install_dotnet_sdk install_nodejs_sdk install_plugins lint_provider provider test tfgen
+.PHONY: development build build_sdks install_go_sdk install_java_sdk install_python_sdk install_sdks only_build build_dotnet build_go build_java build_nodejs build_python clean cleanup finish-patch help install_dotnet_sdk install_nodejs_sdk install_plugins lint_provider provider start-patch test tfgen upstream

--- a/provider-ci/providers/kafka/repo/Makefile
+++ b/provider-ci/providers/kafka/repo/Makefile
@@ -144,7 +144,12 @@ else ifeq ("$(wildcard patches/*.patch)","")
 	@echo "patches were expected because upstream exists"
 	@exit 1
 else
+	# Checkout the submodule at the pinned commit.
+	# `--force`: If the submodule is at a different commit, move it to the pinned commit.
+	# `--init`: If the submodule is not initialized, initialize it.
 	git submodule update --force --init
+	# Iterating over the patches folder in sorted order,
+	# apply the patch using a 3-way merge strategy. This mirrors the default behavior of `git merge`
 	cd upstream && \
 		for patch in $(sort $(wildcard patches/*.patch)); do git apply --3way ../$$patch || exit 1; done
 endif

--- a/provider-ci/providers/kafka/repo/Makefile
+++ b/provider-ci/providers/kafka/repo/Makefile
@@ -30,7 +30,7 @@ install_sdks: install_dotnet_sdk install_python_sdk install_nodejs_sdk install_j
 only_build: build
 
 build_dotnet: DOTNET_VERSION := $(shell pulumictl get version --language dotnet)
-build_dotnet:
+build_dotnet: upstream
 	pulumictl get version --language dotnet
 	$(WORKING_DIR)/bin/$(TFGEN) dotnet --out sdk/dotnet/
 	cd sdk/dotnet/ && \
@@ -38,19 +38,19 @@ build_dotnet:
 		echo "$(DOTNET_VERSION)" >version.txt && \
 		dotnet build /p:Version=$(DOTNET_VERSION)
 
-build_go:
+build_go: upstream
 	$(WORKING_DIR)/bin/$(TFGEN) go --out sdk/go/
 	cd sdk && go list `grep -e "^module" go.mod | cut -d ' ' -f 2`/go/... | xargs go build
 
 build_java: PACKAGE_VERSION := $(shell pulumictl get version --language generic)
-build_java: bin/pulumi-java-gen
+build_java: bin/pulumi-java-gen upstream
 	$(WORKING_DIR)/bin/$(JAVA_GEN) generate --schema provider/cmd/$(PROVIDER)/schema.json --out sdk/java  --build gradle-nexus
 	cd sdk/java/ && \
 		echo "module fake_java_module // Exclude this directory from Go tools\n\ngo 1.17" > go.mod && \
 		gradle --console=plain build
 
 build_nodejs: VERSION := $(shell pulumictl get version --language javascript)
-build_nodejs:
+build_nodejs: upstream
 	$(WORKING_DIR)/bin/$(TFGEN) nodejs --out sdk/nodejs/
 	cd sdk/nodejs/ && \
 		echo "module fake_nodejs_module // Exclude this directory from Go tools\n\ngo 1.17" > go.mod && \
@@ -60,7 +60,7 @@ build_nodejs:
 		sed -i.bak -e "s/\$${VERSION}/$(VERSION)/g" ./bin/package.json
 
 build_python: PYPI_VERSION := $(shell pulumictl get version --language python)
-build_python:
+build_python: upstream
 	$(WORKING_DIR)/bin/$(TFGEN) python --out sdk/python/
 	cd sdk/python/ && \
 		echo "module fake_python_module // Exclude this directory from Go tools\n\ngo 1.17" > go.mod && \
@@ -77,6 +77,11 @@ clean:
 cleanup:
 	rm -r $(WORKING_DIR)/bin
 	rm -f provider/cmd/$(PROVIDER)/schema.go
+
+finish-patch:
+	@if [ ! -z "$$(cd upstream && git status --porcelain)" ]; then echo "Please commit your changes before finishing the patch"; exit 1; fi
+	@cd upstream && \
+		git format-patch HEAD~ -o ../patches --start-number $$(($$(ls ../patches | wc -l | xargs)+1))
 
 help:
 	@grep '^[^.#]\+:\s\+.*#' Makefile | \
@@ -99,15 +104,52 @@ lint_provider: provider
 provider: tfgen install_plugins
 	(cd provider && go build -p 1 -o $(WORKING_DIR)/bin/$(PROVIDER) -ldflags "-X $(PROJECT)/$(VERSION_PATH)=$(VERSION)" $(PROJECT)/$(PROVIDER_PATH)/cmd/$(PROVIDER))
 
+start-patch: upstream
+ifeq ("$(wildcard upstream)","")
+	@echo "No upstream found, so upstream can't be patched"
+	@exit 1
+else
+	# To add an additional patch:
+	#
+	#	1. Run this command (`make start-patch`).
+	#
+	#	2. Edit the `upstream` repo, making whatever changes you want to appear in the new
+	#	patch. It's fine to edit multiple files.
+	#
+	#	3. Commit your changes. The slugified first line of your commit description will
+	#	be used to generate the patch file name. Only the diff from the latest commit will
+	#	end up in the final patch.
+	#
+	#	4. Run `make finish-patch`.
+	#
+	# It is safe to run `make start-patch` as many times as you want, but any changes
+	# might be reverted until `make finish-patch` is run.
+	@cd upstream && git commit --quiet -m "existing patches"
+endif
+
 test:
 	cd examples && go test -v -tags=all -parallel $(TESTPARALLELISM) -timeout 2h
 
-tfgen: install_plugins
+tfgen: install_plugins upstream
 	(cd provider && go build -p 1 -o $(WORKING_DIR)/bin/$(TFGEN) -ldflags "-X $(PROJECT)/$(VERSION_PATH)=$(VERSION)" $(PROJECT)/$(PROVIDER_PATH)/cmd/$(TFGEN))
 	$(WORKING_DIR)/bin/$(TFGEN) schema --out provider/cmd/$(PROVIDER)
 	(cd provider && VERSION=$(VERSION) go generate cmd/$(PROVIDER)/main.go)
 
+upstream:
+ifeq ("$(wildcard upstream)","")
+	# upstream doesn't exist, so skip
+else ifeq ("$(wildcard patches/*.patch)","")
+	# upstream exists, but patches don't exist. This is probably an error.
+	@echo "No patches found within the patch operation"
+	@echo "patches were expected because upstream exists"
+	@exit 1
+else
+	git submodule update --force --init
+	cd upstream && \
+		for patch in $(sort $(wildcard patches/*.patch)); do git apply --3way ../$$patch || exit 1; done
+endif
+
 bin/pulumi-java-gen:
 	$(shell pulumictl download-binary -n pulumi-language-java -v $(JAVA_GEN_VERSION) -r pulumi/pulumi-java)
 
-.PHONY: development build build_sdks install_go_sdk install_java_sdk install_python_sdk install_sdks only_build build_dotnet build_go build_java build_nodejs build_python clean cleanup help install_dotnet_sdk install_nodejs_sdk install_plugins lint_provider provider test tfgen
+.PHONY: development build build_sdks install_go_sdk install_java_sdk install_python_sdk install_sdks only_build build_dotnet build_go build_java build_nodejs build_python clean cleanup finish-patch help install_dotnet_sdk install_nodejs_sdk install_plugins lint_provider provider start-patch test tfgen upstream

--- a/provider-ci/providers/keycloak/repo/Makefile
+++ b/provider-ci/providers/keycloak/repo/Makefile
@@ -30,7 +30,7 @@ install_sdks: install_dotnet_sdk install_python_sdk install_nodejs_sdk install_j
 only_build: build
 
 build_dotnet: DOTNET_VERSION := $(shell pulumictl get version --language dotnet)
-build_dotnet:
+build_dotnet: upstream
 	pulumictl get version --language dotnet
 	$(WORKING_DIR)/bin/$(TFGEN) dotnet --out sdk/dotnet/
 	cd sdk/dotnet/ && \
@@ -38,19 +38,19 @@ build_dotnet:
 		echo "$(DOTNET_VERSION)" >version.txt && \
 		dotnet build /p:Version=$(DOTNET_VERSION)
 
-build_go:
+build_go: upstream
 	$(WORKING_DIR)/bin/$(TFGEN) go --out sdk/go/
 	cd sdk && go list `grep -e "^module" go.mod | cut -d ' ' -f 2`/go/... | xargs go build
 
 build_java: PACKAGE_VERSION := $(shell pulumictl get version --language generic)
-build_java: bin/pulumi-java-gen
+build_java: bin/pulumi-java-gen upstream
 	$(WORKING_DIR)/bin/$(JAVA_GEN) generate --schema provider/cmd/$(PROVIDER)/schema.json --out sdk/java  --build gradle-nexus
 	cd sdk/java/ && \
 		echo "module fake_java_module // Exclude this directory from Go tools\n\ngo 1.17" > go.mod && \
 		gradle --console=plain build
 
 build_nodejs: VERSION := $(shell pulumictl get version --language javascript)
-build_nodejs:
+build_nodejs: upstream
 	$(WORKING_DIR)/bin/$(TFGEN) nodejs --out sdk/nodejs/
 	cd sdk/nodejs/ && \
 		echo "module fake_nodejs_module // Exclude this directory from Go tools\n\ngo 1.17" > go.mod && \
@@ -60,7 +60,7 @@ build_nodejs:
 		sed -i.bak -e "s/\$${VERSION}/$(VERSION)/g" ./bin/package.json
 
 build_python: PYPI_VERSION := $(shell pulumictl get version --language python)
-build_python:
+build_python: upstream
 	$(WORKING_DIR)/bin/$(TFGEN) python --out sdk/python/
 	cd sdk/python/ && \
 		echo "module fake_python_module // Exclude this directory from Go tools\n\ngo 1.17" > go.mod && \
@@ -77,6 +77,11 @@ clean:
 cleanup:
 	rm -r $(WORKING_DIR)/bin
 	rm -f provider/cmd/$(PROVIDER)/schema.go
+
+finish-patch:
+	@if [ ! -z "$$(cd upstream && git status --porcelain)" ]; then echo "Please commit your changes before finishing the patch"; exit 1; fi
+	@cd upstream && \
+		git format-patch HEAD~ -o ../patches --start-number $$(($$(ls ../patches | wc -l | xargs)+1))
 
 help:
 	@grep '^[^.#]\+:\s\+.*#' Makefile | \
@@ -100,15 +105,52 @@ lint_provider: provider
 provider: tfgen install_plugins
 	(cd provider && go build -p 1 -o $(WORKING_DIR)/bin/$(PROVIDER) -ldflags "-X $(PROJECT)/$(VERSION_PATH)=$(VERSION)" $(PROJECT)/$(PROVIDER_PATH)/cmd/$(PROVIDER))
 
+start-patch: upstream
+ifeq ("$(wildcard upstream)","")
+	@echo "No upstream found, so upstream can't be patched"
+	@exit 1
+else
+	# To add an additional patch:
+	#
+	#	1. Run this command (`make start-patch`).
+	#
+	#	2. Edit the `upstream` repo, making whatever changes you want to appear in the new
+	#	patch. It's fine to edit multiple files.
+	#
+	#	3. Commit your changes. The slugified first line of your commit description will
+	#	be used to generate the patch file name. Only the diff from the latest commit will
+	#	end up in the final patch.
+	#
+	#	4. Run `make finish-patch`.
+	#
+	# It is safe to run `make start-patch` as many times as you want, but any changes
+	# might be reverted until `make finish-patch` is run.
+	@cd upstream && git commit --quiet -m "existing patches"
+endif
+
 test:
 	cd examples && go test -v -tags=all -parallel $(TESTPARALLELISM) -timeout 2h
 
-tfgen: install_plugins
+tfgen: install_plugins upstream
 	(cd provider && go build -p 1 -o $(WORKING_DIR)/bin/$(TFGEN) -ldflags "-X $(PROJECT)/$(VERSION_PATH)=$(VERSION)" $(PROJECT)/$(PROVIDER_PATH)/cmd/$(TFGEN))
 	$(WORKING_DIR)/bin/$(TFGEN) schema --out provider/cmd/$(PROVIDER)
 	(cd provider && VERSION=$(VERSION) go generate cmd/$(PROVIDER)/main.go)
 
+upstream:
+ifeq ("$(wildcard upstream)","")
+	# upstream doesn't exist, so skip
+else ifeq ("$(wildcard patches/*.patch)","")
+	# upstream exists, but patches don't exist. This is probably an error.
+	@echo "No patches found within the patch operation"
+	@echo "patches were expected because upstream exists"
+	@exit 1
+else
+	git submodule update --force --init
+	cd upstream && \
+		for patch in $(sort $(wildcard patches/*.patch)); do git apply --3way ../$$patch || exit 1; done
+endif
+
 bin/pulumi-java-gen:
 	$(shell pulumictl download-binary -n pulumi-language-java -v $(JAVA_GEN_VERSION) -r pulumi/pulumi-java)
 
-.PHONY: development build build_sdks install_go_sdk install_java_sdk install_python_sdk install_sdks only_build build_dotnet build_go build_java build_nodejs build_python clean cleanup help install_dotnet_sdk install_nodejs_sdk install_plugins lint_provider provider test tfgen
+.PHONY: development build build_sdks install_go_sdk install_java_sdk install_python_sdk install_sdks only_build build_dotnet build_go build_java build_nodejs build_python clean cleanup finish-patch help install_dotnet_sdk install_nodejs_sdk install_plugins lint_provider provider start-patch test tfgen upstream

--- a/provider-ci/providers/keycloak/repo/Makefile
+++ b/provider-ci/providers/keycloak/repo/Makefile
@@ -145,7 +145,12 @@ else ifeq ("$(wildcard patches/*.patch)","")
 	@echo "patches were expected because upstream exists"
 	@exit 1
 else
+	# Checkout the submodule at the pinned commit.
+	# `--force`: If the submodule is at a different commit, move it to the pinned commit.
+	# `--init`: If the submodule is not initialized, initialize it.
 	git submodule update --force --init
+	# Iterating over the patches folder in sorted order,
+	# apply the patch using a 3-way merge strategy. This mirrors the default behavior of `git merge`
 	cd upstream && \
 		for patch in $(sort $(wildcard patches/*.patch)); do git apply --3way ../$$patch || exit 1; done
 endif

--- a/provider-ci/providers/kong/repo/Makefile
+++ b/provider-ci/providers/kong/repo/Makefile
@@ -144,7 +144,12 @@ else ifeq ("$(wildcard patches/*.patch)","")
 	@echo "patches were expected because upstream exists"
 	@exit 1
 else
+	# Checkout the submodule at the pinned commit.
+	# `--force`: If the submodule is at a different commit, move it to the pinned commit.
+	# `--init`: If the submodule is not initialized, initialize it.
 	git submodule update --force --init
+	# Iterating over the patches folder in sorted order,
+	# apply the patch using a 3-way merge strategy. This mirrors the default behavior of `git merge`
 	cd upstream && \
 		for patch in $(sort $(wildcard patches/*.patch)); do git apply --3way ../$$patch || exit 1; done
 endif

--- a/provider-ci/providers/kong/repo/Makefile
+++ b/provider-ci/providers/kong/repo/Makefile
@@ -30,7 +30,7 @@ install_sdks: install_dotnet_sdk install_python_sdk install_nodejs_sdk install_j
 only_build: build
 
 build_dotnet: DOTNET_VERSION := $(shell pulumictl get version --language dotnet)
-build_dotnet:
+build_dotnet: upstream
 	pulumictl get version --language dotnet
 	$(WORKING_DIR)/bin/$(TFGEN) dotnet --out sdk/dotnet/
 	cd sdk/dotnet/ && \
@@ -38,19 +38,19 @@ build_dotnet:
 		echo "$(DOTNET_VERSION)" >version.txt && \
 		dotnet build /p:Version=$(DOTNET_VERSION)
 
-build_go:
+build_go: upstream
 	$(WORKING_DIR)/bin/$(TFGEN) go --out sdk/go/
 	cd sdk && go list `grep -e "^module" go.mod | cut -d ' ' -f 2`/go/... | xargs go build
 
 build_java: PACKAGE_VERSION := $(shell pulumictl get version --language generic)
-build_java: bin/pulumi-java-gen
+build_java: bin/pulumi-java-gen upstream
 	$(WORKING_DIR)/bin/$(JAVA_GEN) generate --schema provider/cmd/$(PROVIDER)/schema.json --out sdk/java  --build gradle-nexus
 	cd sdk/java/ && \
 		echo "module fake_java_module // Exclude this directory from Go tools\n\ngo 1.17" > go.mod && \
 		gradle --console=plain build
 
 build_nodejs: VERSION := $(shell pulumictl get version --language javascript)
-build_nodejs:
+build_nodejs: upstream
 	$(WORKING_DIR)/bin/$(TFGEN) nodejs --out sdk/nodejs/
 	cd sdk/nodejs/ && \
 		echo "module fake_nodejs_module // Exclude this directory from Go tools\n\ngo 1.17" > go.mod && \
@@ -60,7 +60,7 @@ build_nodejs:
 		sed -i.bak -e "s/\$${VERSION}/$(VERSION)/g" ./bin/package.json
 
 build_python: PYPI_VERSION := $(shell pulumictl get version --language python)
-build_python:
+build_python: upstream
 	$(WORKING_DIR)/bin/$(TFGEN) python --out sdk/python/
 	cd sdk/python/ && \
 		echo "module fake_python_module // Exclude this directory from Go tools\n\ngo 1.17" > go.mod && \
@@ -77,6 +77,11 @@ clean:
 cleanup:
 	rm -r $(WORKING_DIR)/bin
 	rm -f provider/cmd/$(PROVIDER)/schema.go
+
+finish-patch:
+	@if [ ! -z "$$(cd upstream && git status --porcelain)" ]; then echo "Please commit your changes before finishing the patch"; exit 1; fi
+	@cd upstream && \
+		git format-patch HEAD~ -o ../patches --start-number $$(($$(ls ../patches | wc -l | xargs)+1))
 
 help:
 	@grep '^[^.#]\+:\s\+.*#' Makefile | \
@@ -99,15 +104,52 @@ lint_provider: provider
 provider: tfgen install_plugins
 	(cd provider && go build -p 1 -o $(WORKING_DIR)/bin/$(PROVIDER) -ldflags "-X $(PROJECT)/$(VERSION_PATH)=$(VERSION)" $(PROJECT)/$(PROVIDER_PATH)/cmd/$(PROVIDER))
 
+start-patch: upstream
+ifeq ("$(wildcard upstream)","")
+	@echo "No upstream found, so upstream can't be patched"
+	@exit 1
+else
+	# To add an additional patch:
+	#
+	#	1. Run this command (`make start-patch`).
+	#
+	#	2. Edit the `upstream` repo, making whatever changes you want to appear in the new
+	#	patch. It's fine to edit multiple files.
+	#
+	#	3. Commit your changes. The slugified first line of your commit description will
+	#	be used to generate the patch file name. Only the diff from the latest commit will
+	#	end up in the final patch.
+	#
+	#	4. Run `make finish-patch`.
+	#
+	# It is safe to run `make start-patch` as many times as you want, but any changes
+	# might be reverted until `make finish-patch` is run.
+	@cd upstream && git commit --quiet -m "existing patches"
+endif
+
 test:
 	cd examples && go test -v -tags=all -parallel $(TESTPARALLELISM) -timeout 2h
 
-tfgen: install_plugins
+tfgen: install_plugins upstream
 	(cd provider && go build -p 1 -o $(WORKING_DIR)/bin/$(TFGEN) -ldflags "-X $(PROJECT)/$(VERSION_PATH)=$(VERSION)" $(PROJECT)/$(PROVIDER_PATH)/cmd/$(TFGEN))
 	$(WORKING_DIR)/bin/$(TFGEN) schema --out provider/cmd/$(PROVIDER)
 	(cd provider && VERSION=$(VERSION) go generate cmd/$(PROVIDER)/main.go)
 
+upstream:
+ifeq ("$(wildcard upstream)","")
+	# upstream doesn't exist, so skip
+else ifeq ("$(wildcard patches/*.patch)","")
+	# upstream exists, but patches don't exist. This is probably an error.
+	@echo "No patches found within the patch operation"
+	@echo "patches were expected because upstream exists"
+	@exit 1
+else
+	git submodule update --force --init
+	cd upstream && \
+		for patch in $(sort $(wildcard patches/*.patch)); do git apply --3way ../$$patch || exit 1; done
+endif
+
 bin/pulumi-java-gen:
 	$(shell pulumictl download-binary -n pulumi-language-java -v $(JAVA_GEN_VERSION) -r pulumi/pulumi-java)
 
-.PHONY: development build build_sdks install_go_sdk install_java_sdk install_python_sdk install_sdks only_build build_dotnet build_go build_java build_nodejs build_python clean cleanup help install_dotnet_sdk install_nodejs_sdk install_plugins lint_provider provider test tfgen
+.PHONY: development build build_sdks install_go_sdk install_java_sdk install_python_sdk install_sdks only_build build_dotnet build_go build_java build_nodejs build_python clean cleanup finish-patch help install_dotnet_sdk install_nodejs_sdk install_plugins lint_provider provider start-patch test tfgen upstream

--- a/provider-ci/providers/libvirt/repo/Makefile
+++ b/provider-ci/providers/libvirt/repo/Makefile
@@ -144,7 +144,12 @@ else ifeq ("$(wildcard patches/*.patch)","")
 	@echo "patches were expected because upstream exists"
 	@exit 1
 else
+	# Checkout the submodule at the pinned commit.
+	# `--force`: If the submodule is at a different commit, move it to the pinned commit.
+	# `--init`: If the submodule is not initialized, initialize it.
 	git submodule update --force --init
+	# Iterating over the patches folder in sorted order,
+	# apply the patch using a 3-way merge strategy. This mirrors the default behavior of `git merge`
 	cd upstream && \
 		for patch in $(sort $(wildcard patches/*.patch)); do git apply --3way ../$$patch || exit 1; done
 endif

--- a/provider-ci/providers/libvirt/repo/Makefile
+++ b/provider-ci/providers/libvirt/repo/Makefile
@@ -30,7 +30,7 @@ install_sdks: install_dotnet_sdk install_python_sdk install_nodejs_sdk install_j
 only_build: build
 
 build_dotnet: DOTNET_VERSION := $(shell pulumictl get version --language dotnet)
-build_dotnet:
+build_dotnet: upstream
 	pulumictl get version --language dotnet
 	$(WORKING_DIR)/bin/$(TFGEN) dotnet --out sdk/dotnet/
 	cd sdk/dotnet/ && \
@@ -38,19 +38,19 @@ build_dotnet:
 		echo "$(DOTNET_VERSION)" >version.txt && \
 		dotnet build /p:Version=$(DOTNET_VERSION)
 
-build_go:
+build_go: upstream
 	$(WORKING_DIR)/bin/$(TFGEN) go --out sdk/go/
 	cd sdk && go list `grep -e "^module" go.mod | cut -d ' ' -f 2`/go/... | xargs go build
 
 build_java: PACKAGE_VERSION := $(shell pulumictl get version --language generic)
-build_java: bin/pulumi-java-gen
+build_java: bin/pulumi-java-gen upstream
 	$(WORKING_DIR)/bin/$(JAVA_GEN) generate --schema provider/cmd/$(PROVIDER)/schema.json --out sdk/java  --build gradle-nexus
 	cd sdk/java/ && \
 		echo "module fake_java_module // Exclude this directory from Go tools\n\ngo 1.17" > go.mod && \
 		gradle --console=plain build
 
 build_nodejs: VERSION := $(shell pulumictl get version --language javascript)
-build_nodejs:
+build_nodejs: upstream
 	$(WORKING_DIR)/bin/$(TFGEN) nodejs --out sdk/nodejs/
 	cd sdk/nodejs/ && \
 		echo "module fake_nodejs_module // Exclude this directory from Go tools\n\ngo 1.17" > go.mod && \
@@ -60,7 +60,7 @@ build_nodejs:
 		sed -i.bak -e "s/\$${VERSION}/$(VERSION)/g" ./bin/package.json
 
 build_python: PYPI_VERSION := $(shell pulumictl get version --language python)
-build_python:
+build_python: upstream
 	$(WORKING_DIR)/bin/$(TFGEN) python --out sdk/python/
 	cd sdk/python/ && \
 		echo "module fake_python_module // Exclude this directory from Go tools\n\ngo 1.17" > go.mod && \
@@ -77,6 +77,11 @@ clean:
 cleanup:
 	rm -r $(WORKING_DIR)/bin
 	rm -f provider/cmd/$(PROVIDER)/schema.go
+
+finish-patch:
+	@if [ ! -z "$$(cd upstream && git status --porcelain)" ]; then echo "Please commit your changes before finishing the patch"; exit 1; fi
+	@cd upstream && \
+		git format-patch HEAD~ -o ../patches --start-number $$(($$(ls ../patches | wc -l | xargs)+1))
 
 help:
 	@grep '^[^.#]\+:\s\+.*#' Makefile | \
@@ -99,15 +104,52 @@ lint_provider: provider
 provider: tfgen install_plugins
 	(cd provider && go build -p 1 -o $(WORKING_DIR)/bin/$(PROVIDER) -ldflags "-X $(PROJECT)/$(VERSION_PATH)=$(VERSION)" $(PROJECT)/$(PROVIDER_PATH)/cmd/$(PROVIDER))
 
+start-patch: upstream
+ifeq ("$(wildcard upstream)","")
+	@echo "No upstream found, so upstream can't be patched"
+	@exit 1
+else
+	# To add an additional patch:
+	#
+	#	1. Run this command (`make start-patch`).
+	#
+	#	2. Edit the `upstream` repo, making whatever changes you want to appear in the new
+	#	patch. It's fine to edit multiple files.
+	#
+	#	3. Commit your changes. The slugified first line of your commit description will
+	#	be used to generate the patch file name. Only the diff from the latest commit will
+	#	end up in the final patch.
+	#
+	#	4. Run `make finish-patch`.
+	#
+	# It is safe to run `make start-patch` as many times as you want, but any changes
+	# might be reverted until `make finish-patch` is run.
+	@cd upstream && git commit --quiet -m "existing patches"
+endif
+
 test:
 	cd examples && go test -v -tags=all -parallel $(TESTPARALLELISM) -timeout 2h
 
-tfgen: install_plugins
+tfgen: install_plugins upstream
 	(cd provider && go build -p 1 -o $(WORKING_DIR)/bin/$(TFGEN) -ldflags "-X $(PROJECT)/$(VERSION_PATH)=$(VERSION)" $(PROJECT)/$(PROVIDER_PATH)/cmd/$(TFGEN))
 	$(WORKING_DIR)/bin/$(TFGEN) schema --out provider/cmd/$(PROVIDER)
 	(cd provider && VERSION=$(VERSION) go generate cmd/$(PROVIDER)/main.go)
 
+upstream:
+ifeq ("$(wildcard upstream)","")
+	# upstream doesn't exist, so skip
+else ifeq ("$(wildcard patches/*.patch)","")
+	# upstream exists, but patches don't exist. This is probably an error.
+	@echo "No patches found within the patch operation"
+	@echo "patches were expected because upstream exists"
+	@exit 1
+else
+	git submodule update --force --init
+	cd upstream && \
+		for patch in $(sort $(wildcard patches/*.patch)); do git apply --3way ../$$patch || exit 1; done
+endif
+
 bin/pulumi-java-gen:
 	$(shell pulumictl download-binary -n pulumi-language-java -v $(JAVA_GEN_VERSION) -r pulumi/pulumi-java)
 
-.PHONY: development build build_sdks install_go_sdk install_java_sdk install_python_sdk install_sdks only_build build_dotnet build_go build_java build_nodejs build_python clean cleanup help install_dotnet_sdk install_nodejs_sdk install_plugins lint_provider provider test tfgen
+.PHONY: development build build_sdks install_go_sdk install_java_sdk install_python_sdk install_sdks only_build build_dotnet build_go build_java build_nodejs build_python clean cleanup finish-patch help install_dotnet_sdk install_nodejs_sdk install_plugins lint_provider provider start-patch test tfgen upstream

--- a/provider-ci/providers/linode/repo/Makefile
+++ b/provider-ci/providers/linode/repo/Makefile
@@ -144,7 +144,12 @@ else ifeq ("$(wildcard patches/*.patch)","")
 	@echo "patches were expected because upstream exists"
 	@exit 1
 else
+	# Checkout the submodule at the pinned commit.
+	# `--force`: If the submodule is at a different commit, move it to the pinned commit.
+	# `--init`: If the submodule is not initialized, initialize it.
 	git submodule update --force --init
+	# Iterating over the patches folder in sorted order,
+	# apply the patch using a 3-way merge strategy. This mirrors the default behavior of `git merge`
 	cd upstream && \
 		for patch in $(sort $(wildcard patches/*.patch)); do git apply --3way ../$$patch || exit 1; done
 endif

--- a/provider-ci/providers/linode/repo/Makefile
+++ b/provider-ci/providers/linode/repo/Makefile
@@ -30,7 +30,7 @@ install_sdks: install_dotnet_sdk install_python_sdk install_nodejs_sdk install_j
 only_build: build
 
 build_dotnet: DOTNET_VERSION := $(shell pulumictl get version --language dotnet)
-build_dotnet:
+build_dotnet: upstream
 	pulumictl get version --language dotnet
 	$(WORKING_DIR)/bin/$(TFGEN) dotnet --out sdk/dotnet/
 	cd sdk/dotnet/ && \
@@ -38,19 +38,19 @@ build_dotnet:
 		echo "$(DOTNET_VERSION)" >version.txt && \
 		dotnet build /p:Version=$(DOTNET_VERSION)
 
-build_go:
+build_go: upstream
 	$(WORKING_DIR)/bin/$(TFGEN) go --out sdk/go/
 	cd sdk && go list `grep -e "^module" go.mod | cut -d ' ' -f 2`/go/... | xargs go build
 
 build_java: PACKAGE_VERSION := $(shell pulumictl get version --language generic)
-build_java: bin/pulumi-java-gen
+build_java: bin/pulumi-java-gen upstream
 	$(WORKING_DIR)/bin/$(JAVA_GEN) generate --schema provider/cmd/$(PROVIDER)/schema.json --out sdk/java  --build gradle-nexus
 	cd sdk/java/ && \
 		echo "module fake_java_module // Exclude this directory from Go tools\n\ngo 1.17" > go.mod && \
 		gradle --console=plain build
 
 build_nodejs: VERSION := $(shell pulumictl get version --language javascript)
-build_nodejs:
+build_nodejs: upstream
 	$(WORKING_DIR)/bin/$(TFGEN) nodejs --out sdk/nodejs/
 	cd sdk/nodejs/ && \
 		echo "module fake_nodejs_module // Exclude this directory from Go tools\n\ngo 1.17" > go.mod && \
@@ -60,7 +60,7 @@ build_nodejs:
 		sed -i.bak -e "s/\$${VERSION}/$(VERSION)/g" ./bin/package.json
 
 build_python: PYPI_VERSION := $(shell pulumictl get version --language python)
-build_python:
+build_python: upstream
 	$(WORKING_DIR)/bin/$(TFGEN) python --out sdk/python/
 	cd sdk/python/ && \
 		echo "module fake_python_module // Exclude this directory from Go tools\n\ngo 1.17" > go.mod && \
@@ -77,6 +77,11 @@ clean:
 cleanup:
 	rm -r $(WORKING_DIR)/bin
 	rm -f provider/cmd/$(PROVIDER)/schema.go
+
+finish-patch:
+	@if [ ! -z "$$(cd upstream && git status --porcelain)" ]; then echo "Please commit your changes before finishing the patch"; exit 1; fi
+	@cd upstream && \
+		git format-patch HEAD~ -o ../patches --start-number $$(($$(ls ../patches | wc -l | xargs)+1))
 
 help:
 	@grep '^[^.#]\+:\s\+.*#' Makefile | \
@@ -99,15 +104,52 @@ lint_provider: provider
 provider: tfgen install_plugins
 	(cd provider && go build -p 1 -o $(WORKING_DIR)/bin/$(PROVIDER) -ldflags "-X $(PROJECT)/$(VERSION_PATH)=$(VERSION)" $(PROJECT)/$(PROVIDER_PATH)/cmd/$(PROVIDER))
 
+start-patch: upstream
+ifeq ("$(wildcard upstream)","")
+	@echo "No upstream found, so upstream can't be patched"
+	@exit 1
+else
+	# To add an additional patch:
+	#
+	#	1. Run this command (`make start-patch`).
+	#
+	#	2. Edit the `upstream` repo, making whatever changes you want to appear in the new
+	#	patch. It's fine to edit multiple files.
+	#
+	#	3. Commit your changes. The slugified first line of your commit description will
+	#	be used to generate the patch file name. Only the diff from the latest commit will
+	#	end up in the final patch.
+	#
+	#	4. Run `make finish-patch`.
+	#
+	# It is safe to run `make start-patch` as many times as you want, but any changes
+	# might be reverted until `make finish-patch` is run.
+	@cd upstream && git commit --quiet -m "existing patches"
+endif
+
 test:
 	cd examples && go test -v -tags=all -parallel $(TESTPARALLELISM) -timeout 2h
 
-tfgen: install_plugins
+tfgen: install_plugins upstream
 	(cd provider && go build -p 1 -o $(WORKING_DIR)/bin/$(TFGEN) -ldflags "-X $(PROJECT)/$(VERSION_PATH)=$(VERSION)" $(PROJECT)/$(PROVIDER_PATH)/cmd/$(TFGEN))
 	$(WORKING_DIR)/bin/$(TFGEN) schema --out provider/cmd/$(PROVIDER)
 	(cd provider && VERSION=$(VERSION) go generate cmd/$(PROVIDER)/main.go)
 
+upstream:
+ifeq ("$(wildcard upstream)","")
+	# upstream doesn't exist, so skip
+else ifeq ("$(wildcard patches/*.patch)","")
+	# upstream exists, but patches don't exist. This is probably an error.
+	@echo "No patches found within the patch operation"
+	@echo "patches were expected because upstream exists"
+	@exit 1
+else
+	git submodule update --force --init
+	cd upstream && \
+		for patch in $(sort $(wildcard patches/*.patch)); do git apply --3way ../$$patch || exit 1; done
+endif
+
 bin/pulumi-java-gen:
 	$(shell pulumictl download-binary -n pulumi-language-java -v $(JAVA_GEN_VERSION) -r pulumi/pulumi-java)
 
-.PHONY: development build build_sdks install_go_sdk install_java_sdk install_python_sdk install_sdks only_build build_dotnet build_go build_java build_nodejs build_python clean cleanup help install_dotnet_sdk install_nodejs_sdk install_plugins lint_provider provider test tfgen
+.PHONY: development build build_sdks install_go_sdk install_java_sdk install_python_sdk install_sdks only_build build_dotnet build_go build_java build_nodejs build_python clean cleanup finish-patch help install_dotnet_sdk install_nodejs_sdk install_plugins lint_provider provider start-patch test tfgen upstream

--- a/provider-ci/providers/mailgun/repo/Makefile
+++ b/provider-ci/providers/mailgun/repo/Makefile
@@ -30,7 +30,7 @@ install_sdks: install_dotnet_sdk install_python_sdk install_nodejs_sdk install_j
 only_build: build
 
 build_dotnet: DOTNET_VERSION := $(shell pulumictl get version --language dotnet)
-build_dotnet:
+build_dotnet: upstream
 	pulumictl get version --language dotnet
 	$(WORKING_DIR)/bin/$(TFGEN) dotnet --out sdk/dotnet/
 	cd sdk/dotnet/ && \
@@ -38,19 +38,19 @@ build_dotnet:
 		echo "$(DOTNET_VERSION)" >version.txt && \
 		dotnet build /p:Version=$(DOTNET_VERSION)
 
-build_go:
+build_go: upstream
 	$(WORKING_DIR)/bin/$(TFGEN) go --out sdk/go/
 	cd sdk && go list `grep -e "^module" go.mod | cut -d ' ' -f 2`/go/... | xargs go build
 
 build_java: PACKAGE_VERSION := $(shell pulumictl get version --language generic)
-build_java: bin/pulumi-java-gen
+build_java: bin/pulumi-java-gen upstream
 	$(WORKING_DIR)/bin/$(JAVA_GEN) generate --schema provider/cmd/$(PROVIDER)/schema.json --out sdk/java  --build gradle-nexus
 	cd sdk/java/ && \
 		echo "module fake_java_module // Exclude this directory from Go tools\n\ngo 1.17" > go.mod && \
 		gradle --console=plain build
 
 build_nodejs: VERSION := $(shell pulumictl get version --language javascript)
-build_nodejs:
+build_nodejs: upstream
 	$(WORKING_DIR)/bin/$(TFGEN) nodejs --out sdk/nodejs/
 	cd sdk/nodejs/ && \
 		echo "module fake_nodejs_module // Exclude this directory from Go tools\n\ngo 1.17" > go.mod && \
@@ -60,7 +60,7 @@ build_nodejs:
 		sed -i.bak -e "s/\$${VERSION}/$(VERSION)/g" ./bin/package.json
 
 build_python: PYPI_VERSION := $(shell pulumictl get version --language python)
-build_python:
+build_python: upstream
 	$(WORKING_DIR)/bin/$(TFGEN) python --out sdk/python/
 	cd sdk/python/ && \
 		echo "module fake_python_module // Exclude this directory from Go tools\n\ngo 1.17" > go.mod && \
@@ -77,6 +77,11 @@ clean:
 cleanup:
 	rm -r $(WORKING_DIR)/bin
 	rm -f provider/cmd/$(PROVIDER)/schema.go
+
+finish-patch:
+	@if [ ! -z "$$(cd upstream && git status --porcelain)" ]; then echo "Please commit your changes before finishing the patch"; exit 1; fi
+	@cd upstream && \
+		git format-patch HEAD~ -o ../patches --start-number $$(($$(ls ../patches | wc -l | xargs)+1))
 
 help:
 	@grep '^[^.#]\+:\s\+.*#' Makefile | \
@@ -100,15 +105,52 @@ lint_provider: provider
 provider: tfgen install_plugins
 	(cd provider && go build -p 1 -o $(WORKING_DIR)/bin/$(PROVIDER) -ldflags "-X $(PROJECT)/$(VERSION_PATH)=$(VERSION)" $(PROJECT)/$(PROVIDER_PATH)/cmd/$(PROVIDER))
 
+start-patch: upstream
+ifeq ("$(wildcard upstream)","")
+	@echo "No upstream found, so upstream can't be patched"
+	@exit 1
+else
+	# To add an additional patch:
+	#
+	#	1. Run this command (`make start-patch`).
+	#
+	#	2. Edit the `upstream` repo, making whatever changes you want to appear in the new
+	#	patch. It's fine to edit multiple files.
+	#
+	#	3. Commit your changes. The slugified first line of your commit description will
+	#	be used to generate the patch file name. Only the diff from the latest commit will
+	#	end up in the final patch.
+	#
+	#	4. Run `make finish-patch`.
+	#
+	# It is safe to run `make start-patch` as many times as you want, but any changes
+	# might be reverted until `make finish-patch` is run.
+	@cd upstream && git commit --quiet -m "existing patches"
+endif
+
 test:
 	cd examples && go test -v -tags=all -parallel $(TESTPARALLELISM) -timeout 2h
 
-tfgen: install_plugins
+tfgen: install_plugins upstream
 	(cd provider && go build -p 1 -o $(WORKING_DIR)/bin/$(TFGEN) -ldflags "-X $(PROJECT)/$(VERSION_PATH)=$(VERSION)" $(PROJECT)/$(PROVIDER_PATH)/cmd/$(TFGEN))
 	$(WORKING_DIR)/bin/$(TFGEN) schema --out provider/cmd/$(PROVIDER)
 	(cd provider && VERSION=$(VERSION) go generate cmd/$(PROVIDER)/main.go)
 
+upstream:
+ifeq ("$(wildcard upstream)","")
+	# upstream doesn't exist, so skip
+else ifeq ("$(wildcard patches/*.patch)","")
+	# upstream exists, but patches don't exist. This is probably an error.
+	@echo "No patches found within the patch operation"
+	@echo "patches were expected because upstream exists"
+	@exit 1
+else
+	git submodule update --force --init
+	cd upstream && \
+		for patch in $(sort $(wildcard patches/*.patch)); do git apply --3way ../$$patch || exit 1; done
+endif
+
 bin/pulumi-java-gen:
 	$(shell pulumictl download-binary -n pulumi-language-java -v $(JAVA_GEN_VERSION) -r pulumi/pulumi-java)
 
-.PHONY: development build build_sdks install_go_sdk install_java_sdk install_python_sdk install_sdks only_build build_dotnet build_go build_java build_nodejs build_python clean cleanup help install_dotnet_sdk install_nodejs_sdk install_plugins lint_provider provider test tfgen
+.PHONY: development build build_sdks install_go_sdk install_java_sdk install_python_sdk install_sdks only_build build_dotnet build_go build_java build_nodejs build_python clean cleanup finish-patch help install_dotnet_sdk install_nodejs_sdk install_plugins lint_provider provider start-patch test tfgen upstream

--- a/provider-ci/providers/mailgun/repo/Makefile
+++ b/provider-ci/providers/mailgun/repo/Makefile
@@ -145,7 +145,12 @@ else ifeq ("$(wildcard patches/*.patch)","")
 	@echo "patches were expected because upstream exists"
 	@exit 1
 else
+	# Checkout the submodule at the pinned commit.
+	# `--force`: If the submodule is at a different commit, move it to the pinned commit.
+	# `--init`: If the submodule is not initialized, initialize it.
 	git submodule update --force --init
+	# Iterating over the patches folder in sorted order,
+	# apply the patch using a 3-way merge strategy. This mirrors the default behavior of `git merge`
 	cd upstream && \
 		for patch in $(sort $(wildcard patches/*.patch)); do git apply --3way ../$$patch || exit 1; done
 endif

--- a/provider-ci/providers/minio/repo/Makefile
+++ b/provider-ci/providers/minio/repo/Makefile
@@ -30,7 +30,7 @@ install_sdks: install_dotnet_sdk install_python_sdk install_nodejs_sdk install_j
 only_build: build
 
 build_dotnet: DOTNET_VERSION := $(shell pulumictl get version --language dotnet)
-build_dotnet:
+build_dotnet: upstream
 	pulumictl get version --language dotnet
 	$(WORKING_DIR)/bin/$(TFGEN) dotnet --out sdk/dotnet/
 	cd sdk/dotnet/ && \
@@ -38,19 +38,19 @@ build_dotnet:
 		echo "$(DOTNET_VERSION)" >version.txt && \
 		dotnet build /p:Version=$(DOTNET_VERSION)
 
-build_go:
+build_go: upstream
 	$(WORKING_DIR)/bin/$(TFGEN) go --out sdk/go/
 	cd sdk && go list `grep -e "^module" go.mod | cut -d ' ' -f 2`/go/... | xargs go build
 
 build_java: PACKAGE_VERSION := $(shell pulumictl get version --language generic)
-build_java: bin/pulumi-java-gen
+build_java: bin/pulumi-java-gen upstream
 	$(WORKING_DIR)/bin/$(JAVA_GEN) generate --schema provider/cmd/$(PROVIDER)/schema.json --out sdk/java  --build gradle-nexus
 	cd sdk/java/ && \
 		echo "module fake_java_module // Exclude this directory from Go tools\n\ngo 1.17" > go.mod && \
 		gradle --console=plain build
 
 build_nodejs: VERSION := $(shell pulumictl get version --language javascript)
-build_nodejs:
+build_nodejs: upstream
 	$(WORKING_DIR)/bin/$(TFGEN) nodejs --out sdk/nodejs/
 	cd sdk/nodejs/ && \
 		echo "module fake_nodejs_module // Exclude this directory from Go tools\n\ngo 1.17" > go.mod && \
@@ -60,7 +60,7 @@ build_nodejs:
 		sed -i.bak -e "s/\$${VERSION}/$(VERSION)/g" ./bin/package.json
 
 build_python: PYPI_VERSION := $(shell pulumictl get version --language python)
-build_python:
+build_python: upstream
 	$(WORKING_DIR)/bin/$(TFGEN) python --out sdk/python/
 	cd sdk/python/ && \
 		echo "module fake_python_module // Exclude this directory from Go tools\n\ngo 1.17" > go.mod && \
@@ -77,6 +77,11 @@ clean:
 cleanup:
 	rm -r $(WORKING_DIR)/bin
 	rm -f provider/cmd/$(PROVIDER)/schema.go
+
+finish-patch:
+	@if [ ! -z "$$(cd upstream && git status --porcelain)" ]; then echo "Please commit your changes before finishing the patch"; exit 1; fi
+	@cd upstream && \
+		git format-patch HEAD~ -o ../patches --start-number $$(($$(ls ../patches | wc -l | xargs)+1))
 
 help:
 	@grep '^[^.#]\+:\s\+.*#' Makefile | \
@@ -100,15 +105,52 @@ lint_provider: provider
 provider: tfgen install_plugins
 	(cd provider && go build -p 1 -o $(WORKING_DIR)/bin/$(PROVIDER) -ldflags "-X $(PROJECT)/$(VERSION_PATH)=$(VERSION)" $(PROJECT)/$(PROVIDER_PATH)/cmd/$(PROVIDER))
 
+start-patch: upstream
+ifeq ("$(wildcard upstream)","")
+	@echo "No upstream found, so upstream can't be patched"
+	@exit 1
+else
+	# To add an additional patch:
+	#
+	#	1. Run this command (`make start-patch`).
+	#
+	#	2. Edit the `upstream` repo, making whatever changes you want to appear in the new
+	#	patch. It's fine to edit multiple files.
+	#
+	#	3. Commit your changes. The slugified first line of your commit description will
+	#	be used to generate the patch file name. Only the diff from the latest commit will
+	#	end up in the final patch.
+	#
+	#	4. Run `make finish-patch`.
+	#
+	# It is safe to run `make start-patch` as many times as you want, but any changes
+	# might be reverted until `make finish-patch` is run.
+	@cd upstream && git commit --quiet -m "existing patches"
+endif
+
 test:
 	cd examples && go test -v -tags=all -parallel $(TESTPARALLELISM) -timeout 2h
 
-tfgen: install_plugins
+tfgen: install_plugins upstream
 	(cd provider && go build -p 1 -o $(WORKING_DIR)/bin/$(TFGEN) -ldflags "-X $(PROJECT)/$(VERSION_PATH)=$(VERSION)" $(PROJECT)/$(PROVIDER_PATH)/cmd/$(TFGEN))
 	$(WORKING_DIR)/bin/$(TFGEN) schema --out provider/cmd/$(PROVIDER)
 	(cd provider && VERSION=$(VERSION) go generate cmd/$(PROVIDER)/main.go)
 
+upstream:
+ifeq ("$(wildcard upstream)","")
+	# upstream doesn't exist, so skip
+else ifeq ("$(wildcard patches/*.patch)","")
+	# upstream exists, but patches don't exist. This is probably an error.
+	@echo "No patches found within the patch operation"
+	@echo "patches were expected because upstream exists"
+	@exit 1
+else
+	git submodule update --force --init
+	cd upstream && \
+		for patch in $(sort $(wildcard patches/*.patch)); do git apply --3way ../$$patch || exit 1; done
+endif
+
 bin/pulumi-java-gen:
 	$(shell pulumictl download-binary -n pulumi-language-java -v $(JAVA_GEN_VERSION) -r pulumi/pulumi-java)
 
-.PHONY: development build build_sdks install_go_sdk install_java_sdk install_python_sdk install_sdks only_build build_dotnet build_go build_java build_nodejs build_python clean cleanup help install_dotnet_sdk install_nodejs_sdk install_plugins lint_provider provider test tfgen
+.PHONY: development build build_sdks install_go_sdk install_java_sdk install_python_sdk install_sdks only_build build_dotnet build_go build_java build_nodejs build_python clean cleanup finish-patch help install_dotnet_sdk install_nodejs_sdk install_plugins lint_provider provider start-patch test tfgen upstream

--- a/provider-ci/providers/minio/repo/Makefile
+++ b/provider-ci/providers/minio/repo/Makefile
@@ -145,7 +145,12 @@ else ifeq ("$(wildcard patches/*.patch)","")
 	@echo "patches were expected because upstream exists"
 	@exit 1
 else
+	# Checkout the submodule at the pinned commit.
+	# `--force`: If the submodule is at a different commit, move it to the pinned commit.
+	# `--init`: If the submodule is not initialized, initialize it.
 	git submodule update --force --init
+	# Iterating over the patches folder in sorted order,
+	# apply the patch using a 3-way merge strategy. This mirrors the default behavior of `git merge`
 	cd upstream && \
 		for patch in $(sort $(wildcard patches/*.patch)); do git apply --3way ../$$patch || exit 1; done
 endif

--- a/provider-ci/providers/mongodbatlas/repo/Makefile
+++ b/provider-ci/providers/mongodbatlas/repo/Makefile
@@ -30,7 +30,7 @@ install_sdks: install_dotnet_sdk install_python_sdk install_nodejs_sdk install_j
 only_build: build
 
 build_dotnet: DOTNET_VERSION := $(shell pulumictl get version --language dotnet)
-build_dotnet:
+build_dotnet: upstream
 	pulumictl get version --language dotnet
 	$(WORKING_DIR)/bin/$(TFGEN) dotnet --out sdk/dotnet/
 	cd sdk/dotnet/ && \
@@ -38,19 +38,19 @@ build_dotnet:
 		echo "$(DOTNET_VERSION)" >version.txt && \
 		dotnet build /p:Version=$(DOTNET_VERSION)
 
-build_go:
+build_go: upstream
 	$(WORKING_DIR)/bin/$(TFGEN) go --out sdk/go/
 	cd sdk && go list `grep -e "^module" go.mod | cut -d ' ' -f 2`/go/... | xargs go build
 
 build_java: PACKAGE_VERSION := $(shell pulumictl get version --language generic)
-build_java: bin/pulumi-java-gen
+build_java: bin/pulumi-java-gen upstream
 	$(WORKING_DIR)/bin/$(JAVA_GEN) generate --schema provider/cmd/$(PROVIDER)/schema.json --out sdk/java  --build gradle-nexus
 	cd sdk/java/ && \
 		echo "module fake_java_module // Exclude this directory from Go tools\n\ngo 1.17" > go.mod && \
 		gradle --console=plain build
 
 build_nodejs: VERSION := $(shell pulumictl get version --language javascript)
-build_nodejs:
+build_nodejs: upstream
 	$(WORKING_DIR)/bin/$(TFGEN) nodejs --out sdk/nodejs/
 	cd sdk/nodejs/ && \
 		echo "module fake_nodejs_module // Exclude this directory from Go tools\n\ngo 1.17" > go.mod && \
@@ -60,7 +60,7 @@ build_nodejs:
 		sed -i.bak -e "s/\$${VERSION}/$(VERSION)/g" ./bin/package.json
 
 build_python: PYPI_VERSION := $(shell pulumictl get version --language python)
-build_python:
+build_python: upstream
 	$(WORKING_DIR)/bin/$(TFGEN) python --out sdk/python/
 	cd sdk/python/ && \
 		echo "module fake_python_module // Exclude this directory from Go tools\n\ngo 1.17" > go.mod && \
@@ -77,6 +77,11 @@ clean:
 cleanup:
 	rm -r $(WORKING_DIR)/bin
 	rm -f provider/cmd/$(PROVIDER)/schema.go
+
+finish-patch:
+	@if [ ! -z "$$(cd upstream && git status --porcelain)" ]; then echo "Please commit your changes before finishing the patch"; exit 1; fi
+	@cd upstream && \
+		git format-patch HEAD~ -o ../patches --start-number $$(($$(ls ../patches | wc -l | xargs)+1))
 
 help:
 	@grep '^[^.#]\+:\s\+.*#' Makefile | \
@@ -102,15 +107,52 @@ lint_provider: provider
 provider: tfgen install_plugins
 	(cd provider && go build -p 1 -o $(WORKING_DIR)/bin/$(PROVIDER) -ldflags "-X $(PROJECT)/$(VERSION_PATH)=$(VERSION)" $(PROJECT)/$(PROVIDER_PATH)/cmd/$(PROVIDER))
 
+start-patch: upstream
+ifeq ("$(wildcard upstream)","")
+	@echo "No upstream found, so upstream can't be patched"
+	@exit 1
+else
+	# To add an additional patch:
+	#
+	#	1. Run this command (`make start-patch`).
+	#
+	#	2. Edit the `upstream` repo, making whatever changes you want to appear in the new
+	#	patch. It's fine to edit multiple files.
+	#
+	#	3. Commit your changes. The slugified first line of your commit description will
+	#	be used to generate the patch file name. Only the diff from the latest commit will
+	#	end up in the final patch.
+	#
+	#	4. Run `make finish-patch`.
+	#
+	# It is safe to run `make start-patch` as many times as you want, but any changes
+	# might be reverted until `make finish-patch` is run.
+	@cd upstream && git commit --quiet -m "existing patches"
+endif
+
 test:
 	cd examples && go test -v -tags=all -parallel $(TESTPARALLELISM) -timeout 2h
 
-tfgen: install_plugins
+tfgen: install_plugins upstream
 	(cd provider && go build -p 1 -o $(WORKING_DIR)/bin/$(TFGEN) -ldflags "-X $(PROJECT)/$(VERSION_PATH)=$(VERSION)" $(PROJECT)/$(PROVIDER_PATH)/cmd/$(TFGEN))
 	$(WORKING_DIR)/bin/$(TFGEN) schema --out provider/cmd/$(PROVIDER)
 	(cd provider && VERSION=$(VERSION) go generate cmd/$(PROVIDER)/main.go)
 
+upstream:
+ifeq ("$(wildcard upstream)","")
+	# upstream doesn't exist, so skip
+else ifeq ("$(wildcard patches/*.patch)","")
+	# upstream exists, but patches don't exist. This is probably an error.
+	@echo "No patches found within the patch operation"
+	@echo "patches were expected because upstream exists"
+	@exit 1
+else
+	git submodule update --force --init
+	cd upstream && \
+		for patch in $(sort $(wildcard patches/*.patch)); do git apply --3way ../$$patch || exit 1; done
+endif
+
 bin/pulumi-java-gen:
 	$(shell pulumictl download-binary -n pulumi-language-java -v $(JAVA_GEN_VERSION) -r pulumi/pulumi-java)
 
-.PHONY: development build build_sdks install_go_sdk install_java_sdk install_python_sdk install_sdks only_build build_dotnet build_go build_java build_nodejs build_python clean cleanup help install_dotnet_sdk install_nodejs_sdk install_plugins lint_provider provider test tfgen
+.PHONY: development build build_sdks install_go_sdk install_java_sdk install_python_sdk install_sdks only_build build_dotnet build_go build_java build_nodejs build_python clean cleanup finish-patch help install_dotnet_sdk install_nodejs_sdk install_plugins lint_provider provider start-patch test tfgen upstream

--- a/provider-ci/providers/mongodbatlas/repo/Makefile
+++ b/provider-ci/providers/mongodbatlas/repo/Makefile
@@ -147,7 +147,12 @@ else ifeq ("$(wildcard patches/*.patch)","")
 	@echo "patches were expected because upstream exists"
 	@exit 1
 else
+	# Checkout the submodule at the pinned commit.
+	# `--force`: If the submodule is at a different commit, move it to the pinned commit.
+	# `--init`: If the submodule is not initialized, initialize it.
 	git submodule update --force --init
+	# Iterating over the patches folder in sorted order,
+	# apply the patch using a 3-way merge strategy. This mirrors the default behavior of `git merge`
 	cd upstream && \
 		for patch in $(sort $(wildcard patches/*.patch)); do git apply --3way ../$$patch || exit 1; done
 endif

--- a/provider-ci/providers/mysql/repo/Makefile
+++ b/provider-ci/providers/mysql/repo/Makefile
@@ -144,7 +144,12 @@ else ifeq ("$(wildcard patches/*.patch)","")
 	@echo "patches were expected because upstream exists"
 	@exit 1
 else
+	# Checkout the submodule at the pinned commit.
+	# `--force`: If the submodule is at a different commit, move it to the pinned commit.
+	# `--init`: If the submodule is not initialized, initialize it.
 	git submodule update --force --init
+	# Iterating over the patches folder in sorted order,
+	# apply the patch using a 3-way merge strategy. This mirrors the default behavior of `git merge`
 	cd upstream && \
 		for patch in $(sort $(wildcard patches/*.patch)); do git apply --3way ../$$patch || exit 1; done
 endif

--- a/provider-ci/providers/mysql/repo/Makefile
+++ b/provider-ci/providers/mysql/repo/Makefile
@@ -30,7 +30,7 @@ install_sdks: install_dotnet_sdk install_python_sdk install_nodejs_sdk install_j
 only_build: build
 
 build_dotnet: DOTNET_VERSION := $(shell pulumictl get version --language dotnet)
-build_dotnet:
+build_dotnet: upstream
 	pulumictl get version --language dotnet
 	$(WORKING_DIR)/bin/$(TFGEN) dotnet --out sdk/dotnet/
 	cd sdk/dotnet/ && \
@@ -38,19 +38,19 @@ build_dotnet:
 		echo "$(DOTNET_VERSION)" >version.txt && \
 		dotnet build /p:Version=$(DOTNET_VERSION)
 
-build_go:
+build_go: upstream
 	$(WORKING_DIR)/bin/$(TFGEN) go --out sdk/go/
 	cd sdk && go list `grep -e "^module" go.mod | cut -d ' ' -f 2`/go/... | xargs go build
 
 build_java: PACKAGE_VERSION := $(shell pulumictl get version --language generic)
-build_java: bin/pulumi-java-gen
+build_java: bin/pulumi-java-gen upstream
 	$(WORKING_DIR)/bin/$(JAVA_GEN) generate --schema provider/cmd/$(PROVIDER)/schema.json --out sdk/java  --build gradle-nexus
 	cd sdk/java/ && \
 		echo "module fake_java_module // Exclude this directory from Go tools\n\ngo 1.17" > go.mod && \
 		gradle --console=plain build
 
 build_nodejs: VERSION := $(shell pulumictl get version --language javascript)
-build_nodejs:
+build_nodejs: upstream
 	$(WORKING_DIR)/bin/$(TFGEN) nodejs --out sdk/nodejs/
 	cd sdk/nodejs/ && \
 		echo "module fake_nodejs_module // Exclude this directory from Go tools\n\ngo 1.17" > go.mod && \
@@ -60,7 +60,7 @@ build_nodejs:
 		sed -i.bak -e "s/\$${VERSION}/$(VERSION)/g" ./bin/package.json
 
 build_python: PYPI_VERSION := $(shell pulumictl get version --language python)
-build_python:
+build_python: upstream
 	$(WORKING_DIR)/bin/$(TFGEN) python --out sdk/python/
 	cd sdk/python/ && \
 		echo "module fake_python_module // Exclude this directory from Go tools\n\ngo 1.17" > go.mod && \
@@ -77,6 +77,11 @@ clean:
 cleanup:
 	rm -r $(WORKING_DIR)/bin
 	rm -f provider/cmd/$(PROVIDER)/schema.go
+
+finish-patch:
+	@if [ ! -z "$$(cd upstream && git status --porcelain)" ]; then echo "Please commit your changes before finishing the patch"; exit 1; fi
+	@cd upstream && \
+		git format-patch HEAD~ -o ../patches --start-number $$(($$(ls ../patches | wc -l | xargs)+1))
 
 help:
 	@grep '^[^.#]\+:\s\+.*#' Makefile | \
@@ -99,15 +104,52 @@ lint_provider: provider
 provider: tfgen install_plugins
 	(cd provider && go build -p 1 -o $(WORKING_DIR)/bin/$(PROVIDER) -ldflags "-X $(PROJECT)/$(VERSION_PATH)=$(VERSION)" $(PROJECT)/$(PROVIDER_PATH)/cmd/$(PROVIDER))
 
+start-patch: upstream
+ifeq ("$(wildcard upstream)","")
+	@echo "No upstream found, so upstream can't be patched"
+	@exit 1
+else
+	# To add an additional patch:
+	#
+	#	1. Run this command (`make start-patch`).
+	#
+	#	2. Edit the `upstream` repo, making whatever changes you want to appear in the new
+	#	patch. It's fine to edit multiple files.
+	#
+	#	3. Commit your changes. The slugified first line of your commit description will
+	#	be used to generate the patch file name. Only the diff from the latest commit will
+	#	end up in the final patch.
+	#
+	#	4. Run `make finish-patch`.
+	#
+	# It is safe to run `make start-patch` as many times as you want, but any changes
+	# might be reverted until `make finish-patch` is run.
+	@cd upstream && git commit --quiet -m "existing patches"
+endif
+
 test:
 	cd examples && go test -v -tags=all -parallel $(TESTPARALLELISM) -timeout 2h
 
-tfgen: install_plugins
+tfgen: install_plugins upstream
 	(cd provider && go build -p 1 -o $(WORKING_DIR)/bin/$(TFGEN) -ldflags "-X $(PROJECT)/$(VERSION_PATH)=$(VERSION)" $(PROJECT)/$(PROVIDER_PATH)/cmd/$(TFGEN))
 	$(WORKING_DIR)/bin/$(TFGEN) schema --out provider/cmd/$(PROVIDER)
 	(cd provider && VERSION=$(VERSION) go generate cmd/$(PROVIDER)/main.go)
 
+upstream:
+ifeq ("$(wildcard upstream)","")
+	# upstream doesn't exist, so skip
+else ifeq ("$(wildcard patches/*.patch)","")
+	# upstream exists, but patches don't exist. This is probably an error.
+	@echo "No patches found within the patch operation"
+	@echo "patches were expected because upstream exists"
+	@exit 1
+else
+	git submodule update --force --init
+	cd upstream && \
+		for patch in $(sort $(wildcard patches/*.patch)); do git apply --3way ../$$patch || exit 1; done
+endif
+
 bin/pulumi-java-gen:
 	$(shell pulumictl download-binary -n pulumi-language-java -v $(JAVA_GEN_VERSION) -r pulumi/pulumi-java)
 
-.PHONY: development build build_sdks install_go_sdk install_java_sdk install_python_sdk install_sdks only_build build_dotnet build_go build_java build_nodejs build_python clean cleanup help install_dotnet_sdk install_nodejs_sdk install_plugins lint_provider provider test tfgen
+.PHONY: development build build_sdks install_go_sdk install_java_sdk install_python_sdk install_sdks only_build build_dotnet build_go build_java build_nodejs build_python clean cleanup finish-patch help install_dotnet_sdk install_nodejs_sdk install_plugins lint_provider provider start-patch test tfgen upstream

--- a/provider-ci/providers/newrelic/repo/Makefile
+++ b/provider-ci/providers/newrelic/repo/Makefile
@@ -144,7 +144,12 @@ else ifeq ("$(wildcard patches/*.patch)","")
 	@echo "patches were expected because upstream exists"
 	@exit 1
 else
+	# Checkout the submodule at the pinned commit.
+	# `--force`: If the submodule is at a different commit, move it to the pinned commit.
+	# `--init`: If the submodule is not initialized, initialize it.
 	git submodule update --force --init
+	# Iterating over the patches folder in sorted order,
+	# apply the patch using a 3-way merge strategy. This mirrors the default behavior of `git merge`
 	cd upstream && \
 		for patch in $(sort $(wildcard patches/*.patch)); do git apply --3way ../$$patch || exit 1; done
 endif

--- a/provider-ci/providers/newrelic/repo/Makefile
+++ b/provider-ci/providers/newrelic/repo/Makefile
@@ -30,7 +30,7 @@ install_sdks: install_dotnet_sdk install_python_sdk install_nodejs_sdk install_j
 only_build: build
 
 build_dotnet: DOTNET_VERSION := $(shell pulumictl get version --language dotnet)
-build_dotnet:
+build_dotnet: upstream
 	pulumictl get version --language dotnet
 	$(WORKING_DIR)/bin/$(TFGEN) dotnet --out sdk/dotnet/
 	cd sdk/dotnet/ && \
@@ -38,19 +38,19 @@ build_dotnet:
 		echo "$(DOTNET_VERSION)" >version.txt && \
 		dotnet build /p:Version=$(DOTNET_VERSION)
 
-build_go:
+build_go: upstream
 	$(WORKING_DIR)/bin/$(TFGEN) go --out sdk/go/
 	cd sdk && go list `grep -e "^module" go.mod | cut -d ' ' -f 2`/go/... | xargs go build
 
 build_java: PACKAGE_VERSION := $(shell pulumictl get version --language generic)
-build_java: bin/pulumi-java-gen
+build_java: bin/pulumi-java-gen upstream
 	$(WORKING_DIR)/bin/$(JAVA_GEN) generate --schema provider/cmd/$(PROVIDER)/schema.json --out sdk/java  --build gradle-nexus
 	cd sdk/java/ && \
 		echo "module fake_java_module // Exclude this directory from Go tools\n\ngo 1.17" > go.mod && \
 		gradle --console=plain build
 
 build_nodejs: VERSION := $(shell pulumictl get version --language javascript)
-build_nodejs:
+build_nodejs: upstream
 	$(WORKING_DIR)/bin/$(TFGEN) nodejs --out sdk/nodejs/
 	cd sdk/nodejs/ && \
 		echo "module fake_nodejs_module // Exclude this directory from Go tools\n\ngo 1.17" > go.mod && \
@@ -60,7 +60,7 @@ build_nodejs:
 		sed -i.bak -e "s/\$${VERSION}/$(VERSION)/g" ./bin/package.json
 
 build_python: PYPI_VERSION := $(shell pulumictl get version --language python)
-build_python:
+build_python: upstream
 	$(WORKING_DIR)/bin/$(TFGEN) python --out sdk/python/
 	cd sdk/python/ && \
 		echo "module fake_python_module // Exclude this directory from Go tools\n\ngo 1.17" > go.mod && \
@@ -77,6 +77,11 @@ clean:
 cleanup:
 	rm -r $(WORKING_DIR)/bin
 	rm -f provider/cmd/$(PROVIDER)/schema.go
+
+finish-patch:
+	@if [ ! -z "$$(cd upstream && git status --porcelain)" ]; then echo "Please commit your changes before finishing the patch"; exit 1; fi
+	@cd upstream && \
+		git format-patch HEAD~ -o ../patches --start-number $$(($$(ls ../patches | wc -l | xargs)+1))
 
 help:
 	@grep '^[^.#]\+:\s\+.*#' Makefile | \
@@ -99,15 +104,52 @@ lint_provider: provider
 provider: tfgen install_plugins
 	(cd provider && go build -p 1 -o $(WORKING_DIR)/bin/$(PROVIDER) -ldflags "-X $(PROJECT)/$(VERSION_PATH)=$(VERSION)" $(PROJECT)/$(PROVIDER_PATH)/cmd/$(PROVIDER))
 
+start-patch: upstream
+ifeq ("$(wildcard upstream)","")
+	@echo "No upstream found, so upstream can't be patched"
+	@exit 1
+else
+	# To add an additional patch:
+	#
+	#	1. Run this command (`make start-patch`).
+	#
+	#	2. Edit the `upstream` repo, making whatever changes you want to appear in the new
+	#	patch. It's fine to edit multiple files.
+	#
+	#	3. Commit your changes. The slugified first line of your commit description will
+	#	be used to generate the patch file name. Only the diff from the latest commit will
+	#	end up in the final patch.
+	#
+	#	4. Run `make finish-patch`.
+	#
+	# It is safe to run `make start-patch` as many times as you want, but any changes
+	# might be reverted until `make finish-patch` is run.
+	@cd upstream && git commit --quiet -m "existing patches"
+endif
+
 test:
 	cd examples && go test -v -tags=all -parallel $(TESTPARALLELISM) -timeout 2h
 
-tfgen: install_plugins
+tfgen: install_plugins upstream
 	(cd provider && go build -p 1 -o $(WORKING_DIR)/bin/$(TFGEN) -ldflags "-X $(PROJECT)/$(VERSION_PATH)=$(VERSION)" $(PROJECT)/$(PROVIDER_PATH)/cmd/$(TFGEN))
 	$(WORKING_DIR)/bin/$(TFGEN) schema --out provider/cmd/$(PROVIDER)
 	(cd provider && VERSION=$(VERSION) go generate cmd/$(PROVIDER)/main.go)
 
+upstream:
+ifeq ("$(wildcard upstream)","")
+	# upstream doesn't exist, so skip
+else ifeq ("$(wildcard patches/*.patch)","")
+	# upstream exists, but patches don't exist. This is probably an error.
+	@echo "No patches found within the patch operation"
+	@echo "patches were expected because upstream exists"
+	@exit 1
+else
+	git submodule update --force --init
+	cd upstream && \
+		for patch in $(sort $(wildcard patches/*.patch)); do git apply --3way ../$$patch || exit 1; done
+endif
+
 bin/pulumi-java-gen:
 	$(shell pulumictl download-binary -n pulumi-language-java -v $(JAVA_GEN_VERSION) -r pulumi/pulumi-java)
 
-.PHONY: development build build_sdks install_go_sdk install_java_sdk install_python_sdk install_sdks only_build build_dotnet build_go build_java build_nodejs build_python clean cleanup help install_dotnet_sdk install_nodejs_sdk install_plugins lint_provider provider test tfgen
+.PHONY: development build build_sdks install_go_sdk install_java_sdk install_python_sdk install_sdks only_build build_dotnet build_go build_java build_nodejs build_python clean cleanup finish-patch help install_dotnet_sdk install_nodejs_sdk install_plugins lint_provider provider start-patch test tfgen upstream

--- a/provider-ci/providers/nomad/repo/Makefile
+++ b/provider-ci/providers/nomad/repo/Makefile
@@ -30,7 +30,7 @@ install_sdks: install_dotnet_sdk install_python_sdk install_nodejs_sdk install_j
 only_build: build
 
 build_dotnet: DOTNET_VERSION := $(shell pulumictl get version --language dotnet)
-build_dotnet:
+build_dotnet: upstream
 	pulumictl get version --language dotnet
 	$(WORKING_DIR)/bin/$(TFGEN) dotnet --out sdk/dotnet/
 	cd sdk/dotnet/ && \
@@ -38,19 +38,19 @@ build_dotnet:
 		echo "$(DOTNET_VERSION)" >version.txt && \
 		dotnet build /p:Version=$(DOTNET_VERSION)
 
-build_go:
+build_go: upstream
 	$(WORKING_DIR)/bin/$(TFGEN) go --out sdk/go/
 	cd sdk && go list `grep -e "^module" go.mod | cut -d ' ' -f 2`/go/... | xargs go build
 
 build_java: PACKAGE_VERSION := $(shell pulumictl get version --language generic)
-build_java: bin/pulumi-java-gen
+build_java: bin/pulumi-java-gen upstream
 	$(WORKING_DIR)/bin/$(JAVA_GEN) generate --schema provider/cmd/$(PROVIDER)/schema.json --out sdk/java  --build gradle-nexus
 	cd sdk/java/ && \
 		echo "module fake_java_module // Exclude this directory from Go tools\n\ngo 1.17" > go.mod && \
 		gradle --console=plain build
 
 build_nodejs: VERSION := $(shell pulumictl get version --language javascript)
-build_nodejs:
+build_nodejs: upstream
 	$(WORKING_DIR)/bin/$(TFGEN) nodejs --out sdk/nodejs/
 	cd sdk/nodejs/ && \
 		echo "module fake_nodejs_module // Exclude this directory from Go tools\n\ngo 1.17" > go.mod && \
@@ -60,7 +60,7 @@ build_nodejs:
 		sed -i.bak -e "s/\$${VERSION}/$(VERSION)/g" ./bin/package.json
 
 build_python: PYPI_VERSION := $(shell pulumictl get version --language python)
-build_python:
+build_python: upstream
 	$(WORKING_DIR)/bin/$(TFGEN) python --out sdk/python/
 	cd sdk/python/ && \
 		echo "module fake_python_module // Exclude this directory from Go tools\n\ngo 1.17" > go.mod && \
@@ -77,6 +77,11 @@ clean:
 cleanup:
 	rm -r $(WORKING_DIR)/bin
 	rm -f provider/cmd/$(PROVIDER)/schema.go
+
+finish-patch:
+	@if [ ! -z "$$(cd upstream && git status --porcelain)" ]; then echo "Please commit your changes before finishing the patch"; exit 1; fi
+	@cd upstream && \
+		git format-patch HEAD~ -o ../patches --start-number $$(($$(ls ../patches | wc -l | xargs)+1))
 
 help:
 	@grep '^[^.#]\+:\s\+.*#' Makefile | \
@@ -100,15 +105,52 @@ lint_provider: provider
 provider: tfgen install_plugins
 	(cd provider && go build -p 1 -o $(WORKING_DIR)/bin/$(PROVIDER) -ldflags "-X $(PROJECT)/$(VERSION_PATH)=$(VERSION)" $(PROJECT)/$(PROVIDER_PATH)/cmd/$(PROVIDER))
 
+start-patch: upstream
+ifeq ("$(wildcard upstream)","")
+	@echo "No upstream found, so upstream can't be patched"
+	@exit 1
+else
+	# To add an additional patch:
+	#
+	#	1. Run this command (`make start-patch`).
+	#
+	#	2. Edit the `upstream` repo, making whatever changes you want to appear in the new
+	#	patch. It's fine to edit multiple files.
+	#
+	#	3. Commit your changes. The slugified first line of your commit description will
+	#	be used to generate the patch file name. Only the diff from the latest commit will
+	#	end up in the final patch.
+	#
+	#	4. Run `make finish-patch`.
+	#
+	# It is safe to run `make start-patch` as many times as you want, but any changes
+	# might be reverted until `make finish-patch` is run.
+	@cd upstream && git commit --quiet -m "existing patches"
+endif
+
 test:
 	cd examples && go test -v -tags=all -parallel $(TESTPARALLELISM) -timeout 2h
 
-tfgen: install_plugins
+tfgen: install_plugins upstream
 	(cd provider && go build -p 1 -o $(WORKING_DIR)/bin/$(TFGEN) -ldflags "-X $(PROJECT)/$(VERSION_PATH)=$(VERSION)" $(PROJECT)/$(PROVIDER_PATH)/cmd/$(TFGEN))
 	$(WORKING_DIR)/bin/$(TFGEN) schema --out provider/cmd/$(PROVIDER)
 	(cd provider && VERSION=$(VERSION) go generate cmd/$(PROVIDER)/main.go)
 
+upstream:
+ifeq ("$(wildcard upstream)","")
+	# upstream doesn't exist, so skip
+else ifeq ("$(wildcard patches/*.patch)","")
+	# upstream exists, but patches don't exist. This is probably an error.
+	@echo "No patches found within the patch operation"
+	@echo "patches were expected because upstream exists"
+	@exit 1
+else
+	git submodule update --force --init
+	cd upstream && \
+		for patch in $(sort $(wildcard patches/*.patch)); do git apply --3way ../$$patch || exit 1; done
+endif
+
 bin/pulumi-java-gen:
 	$(shell pulumictl download-binary -n pulumi-language-java -v $(JAVA_GEN_VERSION) -r pulumi/pulumi-java)
 
-.PHONY: development build build_sdks install_go_sdk install_java_sdk install_python_sdk install_sdks only_build build_dotnet build_go build_java build_nodejs build_python clean cleanup help install_dotnet_sdk install_nodejs_sdk install_plugins lint_provider provider test tfgen
+.PHONY: development build build_sdks install_go_sdk install_java_sdk install_python_sdk install_sdks only_build build_dotnet build_go build_java build_nodejs build_python clean cleanup finish-patch help install_dotnet_sdk install_nodejs_sdk install_plugins lint_provider provider start-patch test tfgen upstream

--- a/provider-ci/providers/nomad/repo/Makefile
+++ b/provider-ci/providers/nomad/repo/Makefile
@@ -145,7 +145,12 @@ else ifeq ("$(wildcard patches/*.patch)","")
 	@echo "patches were expected because upstream exists"
 	@exit 1
 else
+	# Checkout the submodule at the pinned commit.
+	# `--force`: If the submodule is at a different commit, move it to the pinned commit.
+	# `--init`: If the submodule is not initialized, initialize it.
 	git submodule update --force --init
+	# Iterating over the patches folder in sorted order,
+	# apply the patch using a 3-way merge strategy. This mirrors the default behavior of `git merge`
 	cd upstream && \
 		for patch in $(sort $(wildcard patches/*.patch)); do git apply --3way ../$$patch || exit 1; done
 endif

--- a/provider-ci/providers/ns1/repo/Makefile
+++ b/provider-ci/providers/ns1/repo/Makefile
@@ -144,7 +144,12 @@ else ifeq ("$(wildcard patches/*.patch)","")
 	@echo "patches were expected because upstream exists"
 	@exit 1
 else
+	# Checkout the submodule at the pinned commit.
+	# `--force`: If the submodule is at a different commit, move it to the pinned commit.
+	# `--init`: If the submodule is not initialized, initialize it.
 	git submodule update --force --init
+	# Iterating over the patches folder in sorted order,
+	# apply the patch using a 3-way merge strategy. This mirrors the default behavior of `git merge`
 	cd upstream && \
 		for patch in $(sort $(wildcard patches/*.patch)); do git apply --3way ../$$patch || exit 1; done
 endif

--- a/provider-ci/providers/ns1/repo/Makefile
+++ b/provider-ci/providers/ns1/repo/Makefile
@@ -30,7 +30,7 @@ install_sdks: install_dotnet_sdk install_python_sdk install_nodejs_sdk install_j
 only_build: build
 
 build_dotnet: DOTNET_VERSION := $(shell pulumictl get version --language dotnet)
-build_dotnet:
+build_dotnet: upstream
 	pulumictl get version --language dotnet
 	$(WORKING_DIR)/bin/$(TFGEN) dotnet --out sdk/dotnet/
 	cd sdk/dotnet/ && \
@@ -38,19 +38,19 @@ build_dotnet:
 		echo "$(DOTNET_VERSION)" >version.txt && \
 		dotnet build /p:Version=$(DOTNET_VERSION)
 
-build_go:
+build_go: upstream
 	$(WORKING_DIR)/bin/$(TFGEN) go --out sdk/go/
 	cd sdk && go list `grep -e "^module" go.mod | cut -d ' ' -f 2`/go/... | xargs go build
 
 build_java: PACKAGE_VERSION := $(shell pulumictl get version --language generic)
-build_java: bin/pulumi-java-gen
+build_java: bin/pulumi-java-gen upstream
 	$(WORKING_DIR)/bin/$(JAVA_GEN) generate --schema provider/cmd/$(PROVIDER)/schema.json --out sdk/java  --build gradle-nexus
 	cd sdk/java/ && \
 		echo "module fake_java_module // Exclude this directory from Go tools\n\ngo 1.17" > go.mod && \
 		gradle --console=plain build
 
 build_nodejs: VERSION := $(shell pulumictl get version --language javascript)
-build_nodejs:
+build_nodejs: upstream
 	$(WORKING_DIR)/bin/$(TFGEN) nodejs --out sdk/nodejs/
 	cd sdk/nodejs/ && \
 		echo "module fake_nodejs_module // Exclude this directory from Go tools\n\ngo 1.17" > go.mod && \
@@ -60,7 +60,7 @@ build_nodejs:
 		sed -i.bak -e "s/\$${VERSION}/$(VERSION)/g" ./bin/package.json
 
 build_python: PYPI_VERSION := $(shell pulumictl get version --language python)
-build_python:
+build_python: upstream
 	$(WORKING_DIR)/bin/$(TFGEN) python --out sdk/python/
 	cd sdk/python/ && \
 		echo "module fake_python_module // Exclude this directory from Go tools\n\ngo 1.17" > go.mod && \
@@ -77,6 +77,11 @@ clean:
 cleanup:
 	rm -r $(WORKING_DIR)/bin
 	rm -f provider/cmd/$(PROVIDER)/schema.go
+
+finish-patch:
+	@if [ ! -z "$$(cd upstream && git status --porcelain)" ]; then echo "Please commit your changes before finishing the patch"; exit 1; fi
+	@cd upstream && \
+		git format-patch HEAD~ -o ../patches --start-number $$(($$(ls ../patches | wc -l | xargs)+1))
 
 help:
 	@grep '^[^.#]\+:\s\+.*#' Makefile | \
@@ -99,15 +104,52 @@ lint_provider: provider
 provider: tfgen install_plugins
 	(cd provider && go build -p 1 -o $(WORKING_DIR)/bin/$(PROVIDER) -ldflags "-X $(PROJECT)/$(VERSION_PATH)=$(VERSION)" $(PROJECT)/$(PROVIDER_PATH)/cmd/$(PROVIDER))
 
+start-patch: upstream
+ifeq ("$(wildcard upstream)","")
+	@echo "No upstream found, so upstream can't be patched"
+	@exit 1
+else
+	# To add an additional patch:
+	#
+	#	1. Run this command (`make start-patch`).
+	#
+	#	2. Edit the `upstream` repo, making whatever changes you want to appear in the new
+	#	patch. It's fine to edit multiple files.
+	#
+	#	3. Commit your changes. The slugified first line of your commit description will
+	#	be used to generate the patch file name. Only the diff from the latest commit will
+	#	end up in the final patch.
+	#
+	#	4. Run `make finish-patch`.
+	#
+	# It is safe to run `make start-patch` as many times as you want, but any changes
+	# might be reverted until `make finish-patch` is run.
+	@cd upstream && git commit --quiet -m "existing patches"
+endif
+
 test:
 	cd examples && go test -v -tags=all -parallel $(TESTPARALLELISM) -timeout 2h
 
-tfgen: install_plugins
+tfgen: install_plugins upstream
 	(cd provider && go build -p 1 -o $(WORKING_DIR)/bin/$(TFGEN) -ldflags "-X $(PROJECT)/$(VERSION_PATH)=$(VERSION)" $(PROJECT)/$(PROVIDER_PATH)/cmd/$(TFGEN))
 	$(WORKING_DIR)/bin/$(TFGEN) schema --out provider/cmd/$(PROVIDER)
 	(cd provider && VERSION=$(VERSION) go generate cmd/$(PROVIDER)/main.go)
 
+upstream:
+ifeq ("$(wildcard upstream)","")
+	# upstream doesn't exist, so skip
+else ifeq ("$(wildcard patches/*.patch)","")
+	# upstream exists, but patches don't exist. This is probably an error.
+	@echo "No patches found within the patch operation"
+	@echo "patches were expected because upstream exists"
+	@exit 1
+else
+	git submodule update --force --init
+	cd upstream && \
+		for patch in $(sort $(wildcard patches/*.patch)); do git apply --3way ../$$patch || exit 1; done
+endif
+
 bin/pulumi-java-gen:
 	$(shell pulumictl download-binary -n pulumi-language-java -v $(JAVA_GEN_VERSION) -r pulumi/pulumi-java)
 
-.PHONY: development build build_sdks install_go_sdk install_java_sdk install_python_sdk install_sdks only_build build_dotnet build_go build_java build_nodejs build_python clean cleanup help install_dotnet_sdk install_nodejs_sdk install_plugins lint_provider provider test tfgen
+.PHONY: development build build_sdks install_go_sdk install_java_sdk install_python_sdk install_sdks only_build build_dotnet build_go build_java build_nodejs build_python clean cleanup finish-patch help install_dotnet_sdk install_nodejs_sdk install_plugins lint_provider provider start-patch test tfgen upstream

--- a/provider-ci/providers/oci/repo/Makefile
+++ b/provider-ci/providers/oci/repo/Makefile
@@ -148,7 +148,12 @@ else ifeq ("$(wildcard patches/*.patch)","")
 	@echo "patches were expected because upstream exists"
 	@exit 1
 else
+	# Checkout the submodule at the pinned commit.
+	# `--force`: If the submodule is at a different commit, move it to the pinned commit.
+	# `--init`: If the submodule is not initialized, initialize it.
 	git submodule update --force --init
+	# Iterating over the patches folder in sorted order,
+	# apply the patch using a 3-way merge strategy. This mirrors the default behavior of `git merge`
 	cd upstream && \
 		for patch in $(sort $(wildcard patches/*.patch)); do git apply --3way ../$$patch || exit 1; done
 endif

--- a/provider-ci/providers/oci/repo/Makefile
+++ b/provider-ci/providers/oci/repo/Makefile
@@ -30,7 +30,7 @@ install_sdks: install_dotnet_sdk install_python_sdk install_nodejs_sdk install_j
 only_build: build
 
 build_dotnet: DOTNET_VERSION := $(shell pulumictl get version --language dotnet)
-build_dotnet:
+build_dotnet: upstream
 	pulumictl get version --language dotnet
 	$(WORKING_DIR)/bin/$(TFGEN) dotnet --out sdk/dotnet/
 	cd sdk/dotnet/ && \
@@ -38,19 +38,19 @@ build_dotnet:
 		echo "$(DOTNET_VERSION)" >version.txt && \
 		dotnet build /p:Version=$(DOTNET_VERSION)
 
-build_go:
+build_go: upstream
 	$(WORKING_DIR)/bin/$(TFGEN) go --out sdk/go/
 	cd sdk && go list `grep -e "^module" go.mod | cut -d ' ' -f 2`/go/... | xargs go build
 
 build_java: PACKAGE_VERSION := $(shell pulumictl get version --language generic)
-build_java: bin/pulumi-java-gen
+build_java: bin/pulumi-java-gen upstream
 	$(WORKING_DIR)/bin/$(JAVA_GEN) generate --schema provider/cmd/$(PROVIDER)/schema.json --out sdk/java  --build gradle-nexus
 	cd sdk/java/ && \
 		echo "module fake_java_module // Exclude this directory from Go tools\n\ngo 1.17" > go.mod && \
 		gradle --console=plain build
 
 build_nodejs: VERSION := $(shell pulumictl get version --language javascript)
-build_nodejs:
+build_nodejs: upstream
 	$(WORKING_DIR)/bin/$(TFGEN) nodejs --out sdk/nodejs/
 	cd sdk/nodejs/ && \
 		echo "module fake_nodejs_module // Exclude this directory from Go tools\n\ngo 1.17" > go.mod && \
@@ -60,7 +60,7 @@ build_nodejs:
 		sed -i.bak -e "s/\$${VERSION}/$(VERSION)/g" ./bin/package.json
 
 build_python: PYPI_VERSION := $(shell pulumictl get version --language python)
-build_python:
+build_python: upstream
 	$(WORKING_DIR)/bin/$(TFGEN) python --out sdk/python/
 	cd sdk/python/ && \
 		echo "module fake_python_module // Exclude this directory from Go tools\n\ngo 1.17" > go.mod && \
@@ -77,6 +77,11 @@ clean:
 cleanup:
 	rm -r $(WORKING_DIR)/bin
 	rm -f provider/cmd/$(PROVIDER)/schema.go
+
+finish-patch:
+	@if [ ! -z "$$(cd upstream && git status --porcelain)" ]; then echo "Please commit your changes before finishing the patch"; exit 1; fi
+	@cd upstream && \
+		git format-patch HEAD~ -o ../patches --start-number $$(($$(ls ../patches | wc -l | xargs)+1))
 
 help:
 	@grep '^[^.#]\+:\s\+.*#' Makefile | \
@@ -103,15 +108,52 @@ lint_provider: provider
 provider: tfgen install_plugins
 	(cd provider && go build -p 1 -o $(WORKING_DIR)/bin/$(PROVIDER) -ldflags "-X $(PROJECT)/$(VERSION_PATH)=$(VERSION)" $(PROJECT)/$(PROVIDER_PATH)/cmd/$(PROVIDER))
 
+start-patch: upstream
+ifeq ("$(wildcard upstream)","")
+	@echo "No upstream found, so upstream can't be patched"
+	@exit 1
+else
+	# To add an additional patch:
+	#
+	#	1. Run this command (`make start-patch`).
+	#
+	#	2. Edit the `upstream` repo, making whatever changes you want to appear in the new
+	#	patch. It's fine to edit multiple files.
+	#
+	#	3. Commit your changes. The slugified first line of your commit description will
+	#	be used to generate the patch file name. Only the diff from the latest commit will
+	#	end up in the final patch.
+	#
+	#	4. Run `make finish-patch`.
+	#
+	# It is safe to run `make start-patch` as many times as you want, but any changes
+	# might be reverted until `make finish-patch` is run.
+	@cd upstream && git commit --quiet -m "existing patches"
+endif
+
 test:
 	cd examples && go test -v -tags=all -parallel $(TESTPARALLELISM) -timeout 2h
 
-tfgen: install_plugins
+tfgen: install_plugins upstream
 	(cd provider && go build -p 1 -o $(WORKING_DIR)/bin/$(TFGEN) -ldflags "-X $(PROJECT)/$(VERSION_PATH)=$(VERSION)" $(PROJECT)/$(PROVIDER_PATH)/cmd/$(TFGEN))
 	$(WORKING_DIR)/bin/$(TFGEN) schema --out provider/cmd/$(PROVIDER)
 	(cd provider && VERSION=$(VERSION) go generate cmd/$(PROVIDER)/main.go)
 
+upstream:
+ifeq ("$(wildcard upstream)","")
+	# upstream doesn't exist, so skip
+else ifeq ("$(wildcard patches/*.patch)","")
+	# upstream exists, but patches don't exist. This is probably an error.
+	@echo "No patches found within the patch operation"
+	@echo "patches were expected because upstream exists"
+	@exit 1
+else
+	git submodule update --force --init
+	cd upstream && \
+		for patch in $(sort $(wildcard patches/*.patch)); do git apply --3way ../$$patch || exit 1; done
+endif
+
 bin/pulumi-java-gen:
 	$(shell pulumictl download-binary -n pulumi-language-java -v $(JAVA_GEN_VERSION) -r pulumi/pulumi-java)
 
-.PHONY: development build build_sdks install_go_sdk install_java_sdk install_python_sdk install_sdks only_build build_dotnet build_go build_java build_nodejs build_python clean cleanup help install_dotnet_sdk install_nodejs_sdk install_plugins lint_provider provider test tfgen
+.PHONY: development build build_sdks install_go_sdk install_java_sdk install_python_sdk install_sdks only_build build_dotnet build_go build_java build_nodejs build_python clean cleanup finish-patch help install_dotnet_sdk install_nodejs_sdk install_plugins lint_provider provider start-patch test tfgen upstream

--- a/provider-ci/providers/okta/repo/Makefile
+++ b/provider-ci/providers/okta/repo/Makefile
@@ -30,7 +30,7 @@ install_sdks: install_dotnet_sdk install_python_sdk install_nodejs_sdk install_j
 only_build: build
 
 build_dotnet: DOTNET_VERSION := $(shell pulumictl get version --language dotnet)
-build_dotnet:
+build_dotnet: upstream
 	pulumictl get version --language dotnet
 	$(WORKING_DIR)/bin/$(TFGEN) dotnet --out sdk/dotnet/
 	cd sdk/dotnet/ && \
@@ -38,19 +38,19 @@ build_dotnet:
 		echo "$(DOTNET_VERSION)" >version.txt && \
 		dotnet build /p:Version=$(DOTNET_VERSION)
 
-build_go:
+build_go: upstream
 	$(WORKING_DIR)/bin/$(TFGEN) go --out sdk/go/
 	cd sdk && go list `grep -e "^module" go.mod | cut -d ' ' -f 2`/go/... | xargs go build
 
 build_java: PACKAGE_VERSION := $(shell pulumictl get version --language generic)
-build_java: bin/pulumi-java-gen
+build_java: bin/pulumi-java-gen upstream
 	$(WORKING_DIR)/bin/$(JAVA_GEN) generate --schema provider/cmd/$(PROVIDER)/schema.json --out sdk/java  --build gradle-nexus
 	cd sdk/java/ && \
 		echo "module fake_java_module // Exclude this directory from Go tools\n\ngo 1.17" > go.mod && \
 		gradle --console=plain build
 
 build_nodejs: VERSION := $(shell pulumictl get version --language javascript)
-build_nodejs:
+build_nodejs: upstream
 	$(WORKING_DIR)/bin/$(TFGEN) nodejs --out sdk/nodejs/
 	cd sdk/nodejs/ && \
 		echo "module fake_nodejs_module // Exclude this directory from Go tools\n\ngo 1.17" > go.mod && \
@@ -60,7 +60,7 @@ build_nodejs:
 		sed -i.bak -e "s/\$${VERSION}/$(VERSION)/g" ./bin/package.json
 
 build_python: PYPI_VERSION := $(shell pulumictl get version --language python)
-build_python:
+build_python: upstream
 	$(WORKING_DIR)/bin/$(TFGEN) python --out sdk/python/
 	cd sdk/python/ && \
 		echo "module fake_python_module // Exclude this directory from Go tools\n\ngo 1.17" > go.mod && \
@@ -77,6 +77,11 @@ clean:
 cleanup:
 	rm -r $(WORKING_DIR)/bin
 	rm -f provider/cmd/$(PROVIDER)/schema.go
+
+finish-patch:
+	@if [ ! -z "$$(cd upstream && git status --porcelain)" ]; then echo "Please commit your changes before finishing the patch"; exit 1; fi
+	@cd upstream && \
+		git format-patch HEAD~ -o ../patches --start-number $$(($$(ls ../patches | wc -l | xargs)+1))
 
 help:
 	@grep '^[^.#]\+:\s\+.*#' Makefile | \
@@ -100,15 +105,52 @@ lint_provider: provider
 provider: tfgen install_plugins
 	(cd provider && go build -p 1 -o $(WORKING_DIR)/bin/$(PROVIDER) -ldflags "-X $(PROJECT)/$(VERSION_PATH)=$(VERSION)" $(PROJECT)/$(PROVIDER_PATH)/cmd/$(PROVIDER))
 
+start-patch: upstream
+ifeq ("$(wildcard upstream)","")
+	@echo "No upstream found, so upstream can't be patched"
+	@exit 1
+else
+	# To add an additional patch:
+	#
+	#	1. Run this command (`make start-patch`).
+	#
+	#	2. Edit the `upstream` repo, making whatever changes you want to appear in the new
+	#	patch. It's fine to edit multiple files.
+	#
+	#	3. Commit your changes. The slugified first line of your commit description will
+	#	be used to generate the patch file name. Only the diff from the latest commit will
+	#	end up in the final patch.
+	#
+	#	4. Run `make finish-patch`.
+	#
+	# It is safe to run `make start-patch` as many times as you want, but any changes
+	# might be reverted until `make finish-patch` is run.
+	@cd upstream && git commit --quiet -m "existing patches"
+endif
+
 test:
 	cd examples && go test -v -tags=all -parallel $(TESTPARALLELISM) -timeout 2h
 
-tfgen: install_plugins
+tfgen: install_plugins upstream
 	(cd provider && go build -p 1 -o $(WORKING_DIR)/bin/$(TFGEN) -ldflags "-X $(PROJECT)/$(VERSION_PATH)=$(VERSION)" $(PROJECT)/$(PROVIDER_PATH)/cmd/$(TFGEN))
 	$(WORKING_DIR)/bin/$(TFGEN) schema --out provider/cmd/$(PROVIDER)
 	(cd provider && VERSION=$(VERSION) go generate cmd/$(PROVIDER)/main.go)
 
+upstream:
+ifeq ("$(wildcard upstream)","")
+	# upstream doesn't exist, so skip
+else ifeq ("$(wildcard patches/*.patch)","")
+	# upstream exists, but patches don't exist. This is probably an error.
+	@echo "No patches found within the patch operation"
+	@echo "patches were expected because upstream exists"
+	@exit 1
+else
+	git submodule update --force --init
+	cd upstream && \
+		for patch in $(sort $(wildcard patches/*.patch)); do git apply --3way ../$$patch || exit 1; done
+endif
+
 bin/pulumi-java-gen:
 	$(shell pulumictl download-binary -n pulumi-language-java -v $(JAVA_GEN_VERSION) -r pulumi/pulumi-java)
 
-.PHONY: development build build_sdks install_go_sdk install_java_sdk install_python_sdk install_sdks only_build build_dotnet build_go build_java build_nodejs build_python clean cleanup help install_dotnet_sdk install_nodejs_sdk install_plugins lint_provider provider test tfgen
+.PHONY: development build build_sdks install_go_sdk install_java_sdk install_python_sdk install_sdks only_build build_dotnet build_go build_java build_nodejs build_python clean cleanup finish-patch help install_dotnet_sdk install_nodejs_sdk install_plugins lint_provider provider start-patch test tfgen upstream

--- a/provider-ci/providers/okta/repo/Makefile
+++ b/provider-ci/providers/okta/repo/Makefile
@@ -145,7 +145,12 @@ else ifeq ("$(wildcard patches/*.patch)","")
 	@echo "patches were expected because upstream exists"
 	@exit 1
 else
+	# Checkout the submodule at the pinned commit.
+	# `--force`: If the submodule is at a different commit, move it to the pinned commit.
+	# `--init`: If the submodule is not initialized, initialize it.
 	git submodule update --force --init
+	# Iterating over the patches folder in sorted order,
+	# apply the patch using a 3-way merge strategy. This mirrors the default behavior of `git merge`
 	cd upstream && \
 		for patch in $(sort $(wildcard patches/*.patch)); do git apply --3way ../$$patch || exit 1; done
 endif

--- a/provider-ci/providers/onelogin/repo/Makefile
+++ b/provider-ci/providers/onelogin/repo/Makefile
@@ -30,7 +30,7 @@ install_sdks: install_dotnet_sdk install_python_sdk install_nodejs_sdk install_j
 only_build: build
 
 build_dotnet: DOTNET_VERSION := $(shell pulumictl get version --language dotnet)
-build_dotnet:
+build_dotnet: upstream
 	pulumictl get version --language dotnet
 	$(WORKING_DIR)/bin/$(TFGEN) dotnet --out sdk/dotnet/
 	cd sdk/dotnet/ && \
@@ -38,19 +38,19 @@ build_dotnet:
 		echo "$(DOTNET_VERSION)" >version.txt && \
 		dotnet build /p:Version=$(DOTNET_VERSION)
 
-build_go:
+build_go: upstream
 	$(WORKING_DIR)/bin/$(TFGEN) go --out sdk/go/
 	cd sdk && go list `grep -e "^module" go.mod | cut -d ' ' -f 2`/go/... | xargs go build
 
 build_java: PACKAGE_VERSION := $(shell pulumictl get version --language generic)
-build_java: bin/pulumi-java-gen
+build_java: bin/pulumi-java-gen upstream
 	$(WORKING_DIR)/bin/$(JAVA_GEN) generate --schema provider/cmd/$(PROVIDER)/schema.json --out sdk/java  --build gradle-nexus
 	cd sdk/java/ && \
 		echo "module fake_java_module // Exclude this directory from Go tools\n\ngo 1.17" > go.mod && \
 		gradle --console=plain build
 
 build_nodejs: VERSION := $(shell pulumictl get version --language javascript)
-build_nodejs:
+build_nodejs: upstream
 	$(WORKING_DIR)/bin/$(TFGEN) nodejs --out sdk/nodejs/
 	cd sdk/nodejs/ && \
 		echo "module fake_nodejs_module // Exclude this directory from Go tools\n\ngo 1.17" > go.mod && \
@@ -60,7 +60,7 @@ build_nodejs:
 		sed -i.bak -e "s/\$${VERSION}/$(VERSION)/g" ./bin/package.json
 
 build_python: PYPI_VERSION := $(shell pulumictl get version --language python)
-build_python:
+build_python: upstream
 	$(WORKING_DIR)/bin/$(TFGEN) python --out sdk/python/
 	cd sdk/python/ && \
 		echo "module fake_python_module // Exclude this directory from Go tools\n\ngo 1.17" > go.mod && \
@@ -77,6 +77,11 @@ clean:
 cleanup:
 	rm -r $(WORKING_DIR)/bin
 	rm -f provider/cmd/$(PROVIDER)/schema.go
+
+finish-patch:
+	@if [ ! -z "$$(cd upstream && git status --porcelain)" ]; then echo "Please commit your changes before finishing the patch"; exit 1; fi
+	@cd upstream && \
+		git format-patch HEAD~ -o ../patches --start-number $$(($$(ls ../patches | wc -l | xargs)+1))
 
 help:
 	@grep '^[^.#]\+:\s\+.*#' Makefile | \
@@ -100,15 +105,52 @@ lint_provider: provider
 provider: tfgen install_plugins
 	(cd provider && go build -p 1 -o $(WORKING_DIR)/bin/$(PROVIDER) -ldflags "-X $(PROJECT)/$(VERSION_PATH)=$(VERSION)" $(PROJECT)/$(PROVIDER_PATH)/cmd/$(PROVIDER))
 
+start-patch: upstream
+ifeq ("$(wildcard upstream)","")
+	@echo "No upstream found, so upstream can't be patched"
+	@exit 1
+else
+	# To add an additional patch:
+	#
+	#	1. Run this command (`make start-patch`).
+	#
+	#	2. Edit the `upstream` repo, making whatever changes you want to appear in the new
+	#	patch. It's fine to edit multiple files.
+	#
+	#	3. Commit your changes. The slugified first line of your commit description will
+	#	be used to generate the patch file name. Only the diff from the latest commit will
+	#	end up in the final patch.
+	#
+	#	4. Run `make finish-patch`.
+	#
+	# It is safe to run `make start-patch` as many times as you want, but any changes
+	# might be reverted until `make finish-patch` is run.
+	@cd upstream && git commit --quiet -m "existing patches"
+endif
+
 test:
 	cd examples && go test -v -tags=all -parallel $(TESTPARALLELISM) -timeout 2h
 
-tfgen: install_plugins
+tfgen: install_plugins upstream
 	(cd provider && go build -p 1 -o $(WORKING_DIR)/bin/$(TFGEN) -ldflags "-X $(PROJECT)/$(VERSION_PATH)=$(VERSION)" $(PROJECT)/$(PROVIDER_PATH)/cmd/$(TFGEN))
 	$(WORKING_DIR)/bin/$(TFGEN) schema --out provider/cmd/$(PROVIDER)
 	(cd provider && VERSION=$(VERSION) go generate cmd/$(PROVIDER)/main.go)
 
+upstream:
+ifeq ("$(wildcard upstream)","")
+	# upstream doesn't exist, so skip
+else ifeq ("$(wildcard patches/*.patch)","")
+	# upstream exists, but patches don't exist. This is probably an error.
+	@echo "No patches found within the patch operation"
+	@echo "patches were expected because upstream exists"
+	@exit 1
+else
+	git submodule update --force --init
+	cd upstream && \
+		for patch in $(sort $(wildcard patches/*.patch)); do git apply --3way ../$$patch || exit 1; done
+endif
+
 bin/pulumi-java-gen:
 	$(shell pulumictl download-binary -n pulumi-language-java -v $(JAVA_GEN_VERSION) -r pulumi/pulumi-java)
 
-.PHONY: development build build_sdks install_go_sdk install_java_sdk install_python_sdk install_sdks only_build build_dotnet build_go build_java build_nodejs build_python clean cleanup help install_dotnet_sdk install_nodejs_sdk install_plugins lint_provider provider test tfgen
+.PHONY: development build build_sdks install_go_sdk install_java_sdk install_python_sdk install_sdks only_build build_dotnet build_go build_java build_nodejs build_python clean cleanup finish-patch help install_dotnet_sdk install_nodejs_sdk install_plugins lint_provider provider start-patch test tfgen upstream

--- a/provider-ci/providers/onelogin/repo/Makefile
+++ b/provider-ci/providers/onelogin/repo/Makefile
@@ -145,7 +145,12 @@ else ifeq ("$(wildcard patches/*.patch)","")
 	@echo "patches were expected because upstream exists"
 	@exit 1
 else
+	# Checkout the submodule at the pinned commit.
+	# `--force`: If the submodule is at a different commit, move it to the pinned commit.
+	# `--init`: If the submodule is not initialized, initialize it.
 	git submodule update --force --init
+	# Iterating over the patches folder in sorted order,
+	# apply the patch using a 3-way merge strategy. This mirrors the default behavior of `git merge`
 	cd upstream && \
 		for patch in $(sort $(wildcard patches/*.patch)); do git apply --3way ../$$patch || exit 1; done
 endif

--- a/provider-ci/providers/openstack/repo/Makefile
+++ b/provider-ci/providers/openstack/repo/Makefile
@@ -144,7 +144,12 @@ else ifeq ("$(wildcard patches/*.patch)","")
 	@echo "patches were expected because upstream exists"
 	@exit 1
 else
+	# Checkout the submodule at the pinned commit.
+	# `--force`: If the submodule is at a different commit, move it to the pinned commit.
+	# `--init`: If the submodule is not initialized, initialize it.
 	git submodule update --force --init
+	# Iterating over the patches folder in sorted order,
+	# apply the patch using a 3-way merge strategy. This mirrors the default behavior of `git merge`
 	cd upstream && \
 		for patch in $(sort $(wildcard patches/*.patch)); do git apply --3way ../$$patch || exit 1; done
 endif

--- a/provider-ci/providers/openstack/repo/Makefile
+++ b/provider-ci/providers/openstack/repo/Makefile
@@ -30,7 +30,7 @@ install_sdks: install_dotnet_sdk install_python_sdk install_nodejs_sdk install_j
 only_build: build
 
 build_dotnet: DOTNET_VERSION := $(shell pulumictl get version --language dotnet)
-build_dotnet:
+build_dotnet: upstream
 	pulumictl get version --language dotnet
 	$(WORKING_DIR)/bin/$(TFGEN) dotnet --out sdk/dotnet/
 	cd sdk/dotnet/ && \
@@ -38,19 +38,19 @@ build_dotnet:
 		echo "$(DOTNET_VERSION)" >version.txt && \
 		dotnet build /p:Version=$(DOTNET_VERSION)
 
-build_go:
+build_go: upstream
 	$(WORKING_DIR)/bin/$(TFGEN) go --out sdk/go/
 	cd sdk && go list `grep -e "^module" go.mod | cut -d ' ' -f 2`/go/... | xargs go build
 
 build_java: PACKAGE_VERSION := $(shell pulumictl get version --language generic)
-build_java: bin/pulumi-java-gen
+build_java: bin/pulumi-java-gen upstream
 	$(WORKING_DIR)/bin/$(JAVA_GEN) generate --schema provider/cmd/$(PROVIDER)/schema.json --out sdk/java  --build gradle-nexus
 	cd sdk/java/ && \
 		echo "module fake_java_module // Exclude this directory from Go tools\n\ngo 1.17" > go.mod && \
 		gradle --console=plain build
 
 build_nodejs: VERSION := $(shell pulumictl get version --language javascript)
-build_nodejs:
+build_nodejs: upstream
 	$(WORKING_DIR)/bin/$(TFGEN) nodejs --out sdk/nodejs/
 	cd sdk/nodejs/ && \
 		echo "module fake_nodejs_module // Exclude this directory from Go tools\n\ngo 1.17" > go.mod && \
@@ -60,7 +60,7 @@ build_nodejs:
 		sed -i.bak -e "s/\$${VERSION}/$(VERSION)/g" ./bin/package.json
 
 build_python: PYPI_VERSION := $(shell pulumictl get version --language python)
-build_python:
+build_python: upstream
 	$(WORKING_DIR)/bin/$(TFGEN) python --out sdk/python/
 	cd sdk/python/ && \
 		echo "module fake_python_module // Exclude this directory from Go tools\n\ngo 1.17" > go.mod && \
@@ -77,6 +77,11 @@ clean:
 cleanup:
 	rm -r $(WORKING_DIR)/bin
 	rm -f provider/cmd/$(PROVIDER)/schema.go
+
+finish-patch:
+	@if [ ! -z "$$(cd upstream && git status --porcelain)" ]; then echo "Please commit your changes before finishing the patch"; exit 1; fi
+	@cd upstream && \
+		git format-patch HEAD~ -o ../patches --start-number $$(($$(ls ../patches | wc -l | xargs)+1))
 
 help:
 	@grep '^[^.#]\+:\s\+.*#' Makefile | \
@@ -99,15 +104,52 @@ lint_provider: provider
 provider: tfgen install_plugins
 	(cd provider && go build -p 1 -o $(WORKING_DIR)/bin/$(PROVIDER) -ldflags "-X $(PROJECT)/$(VERSION_PATH)=$(VERSION)" $(PROJECT)/$(PROVIDER_PATH)/cmd/$(PROVIDER))
 
+start-patch: upstream
+ifeq ("$(wildcard upstream)","")
+	@echo "No upstream found, so upstream can't be patched"
+	@exit 1
+else
+	# To add an additional patch:
+	#
+	#	1. Run this command (`make start-patch`).
+	#
+	#	2. Edit the `upstream` repo, making whatever changes you want to appear in the new
+	#	patch. It's fine to edit multiple files.
+	#
+	#	3. Commit your changes. The slugified first line of your commit description will
+	#	be used to generate the patch file name. Only the diff from the latest commit will
+	#	end up in the final patch.
+	#
+	#	4. Run `make finish-patch`.
+	#
+	# It is safe to run `make start-patch` as many times as you want, but any changes
+	# might be reverted until `make finish-patch` is run.
+	@cd upstream && git commit --quiet -m "existing patches"
+endif
+
 test:
 	cd examples && go test -v -tags=all -parallel $(TESTPARALLELISM) -timeout 2h
 
-tfgen: install_plugins
+tfgen: install_plugins upstream
 	(cd provider && go build -p 1 -o $(WORKING_DIR)/bin/$(TFGEN) -ldflags "-X $(PROJECT)/$(VERSION_PATH)=$(VERSION)" $(PROJECT)/$(PROVIDER_PATH)/cmd/$(TFGEN))
 	$(WORKING_DIR)/bin/$(TFGEN) schema --out provider/cmd/$(PROVIDER)
 	(cd provider && VERSION=$(VERSION) go generate cmd/$(PROVIDER)/main.go)
 
+upstream:
+ifeq ("$(wildcard upstream)","")
+	# upstream doesn't exist, so skip
+else ifeq ("$(wildcard patches/*.patch)","")
+	# upstream exists, but patches don't exist. This is probably an error.
+	@echo "No patches found within the patch operation"
+	@echo "patches were expected because upstream exists"
+	@exit 1
+else
+	git submodule update --force --init
+	cd upstream && \
+		for patch in $(sort $(wildcard patches/*.patch)); do git apply --3way ../$$patch || exit 1; done
+endif
+
 bin/pulumi-java-gen:
 	$(shell pulumictl download-binary -n pulumi-language-java -v $(JAVA_GEN_VERSION) -r pulumi/pulumi-java)
 
-.PHONY: development build build_sdks install_go_sdk install_java_sdk install_python_sdk install_sdks only_build build_dotnet build_go build_java build_nodejs build_python clean cleanup help install_dotnet_sdk install_nodejs_sdk install_plugins lint_provider provider test tfgen
+.PHONY: development build build_sdks install_go_sdk install_java_sdk install_python_sdk install_sdks only_build build_dotnet build_go build_java build_nodejs build_python clean cleanup finish-patch help install_dotnet_sdk install_nodejs_sdk install_plugins lint_provider provider start-patch test tfgen upstream

--- a/provider-ci/providers/opsgenie/repo/Makefile
+++ b/provider-ci/providers/opsgenie/repo/Makefile
@@ -144,7 +144,12 @@ else ifeq ("$(wildcard patches/*.patch)","")
 	@echo "patches were expected because upstream exists"
 	@exit 1
 else
+	# Checkout the submodule at the pinned commit.
+	# `--force`: If the submodule is at a different commit, move it to the pinned commit.
+	# `--init`: If the submodule is not initialized, initialize it.
 	git submodule update --force --init
+	# Iterating over the patches folder in sorted order,
+	# apply the patch using a 3-way merge strategy. This mirrors the default behavior of `git merge`
 	cd upstream && \
 		for patch in $(sort $(wildcard patches/*.patch)); do git apply --3way ../$$patch || exit 1; done
 endif

--- a/provider-ci/providers/opsgenie/repo/Makefile
+++ b/provider-ci/providers/opsgenie/repo/Makefile
@@ -30,7 +30,7 @@ install_sdks: install_dotnet_sdk install_python_sdk install_nodejs_sdk install_j
 only_build: build
 
 build_dotnet: DOTNET_VERSION := $(shell pulumictl get version --language dotnet)
-build_dotnet:
+build_dotnet: upstream
 	pulumictl get version --language dotnet
 	$(WORKING_DIR)/bin/$(TFGEN) dotnet --out sdk/dotnet/
 	cd sdk/dotnet/ && \
@@ -38,19 +38,19 @@ build_dotnet:
 		echo "$(DOTNET_VERSION)" >version.txt && \
 		dotnet build /p:Version=$(DOTNET_VERSION)
 
-build_go:
+build_go: upstream
 	$(WORKING_DIR)/bin/$(TFGEN) go --out sdk/go/
 	cd sdk && go list `grep -e "^module" go.mod | cut -d ' ' -f 2`/go/... | xargs go build
 
 build_java: PACKAGE_VERSION := $(shell pulumictl get version --language generic)
-build_java: bin/pulumi-java-gen
+build_java: bin/pulumi-java-gen upstream
 	$(WORKING_DIR)/bin/$(JAVA_GEN) generate --schema provider/cmd/$(PROVIDER)/schema.json --out sdk/java  --build gradle-nexus
 	cd sdk/java/ && \
 		echo "module fake_java_module // Exclude this directory from Go tools\n\ngo 1.17" > go.mod && \
 		gradle --console=plain build
 
 build_nodejs: VERSION := $(shell pulumictl get version --language javascript)
-build_nodejs:
+build_nodejs: upstream
 	$(WORKING_DIR)/bin/$(TFGEN) nodejs --out sdk/nodejs/
 	cd sdk/nodejs/ && \
 		echo "module fake_nodejs_module // Exclude this directory from Go tools\n\ngo 1.17" > go.mod && \
@@ -60,7 +60,7 @@ build_nodejs:
 		sed -i.bak -e "s/\$${VERSION}/$(VERSION)/g" ./bin/package.json
 
 build_python: PYPI_VERSION := $(shell pulumictl get version --language python)
-build_python:
+build_python: upstream
 	$(WORKING_DIR)/bin/$(TFGEN) python --out sdk/python/
 	cd sdk/python/ && \
 		echo "module fake_python_module // Exclude this directory from Go tools\n\ngo 1.17" > go.mod && \
@@ -77,6 +77,11 @@ clean:
 cleanup:
 	rm -r $(WORKING_DIR)/bin
 	rm -f provider/cmd/$(PROVIDER)/schema.go
+
+finish-patch:
+	@if [ ! -z "$$(cd upstream && git status --porcelain)" ]; then echo "Please commit your changes before finishing the patch"; exit 1; fi
+	@cd upstream && \
+		git format-patch HEAD~ -o ../patches --start-number $$(($$(ls ../patches | wc -l | xargs)+1))
 
 help:
 	@grep '^[^.#]\+:\s\+.*#' Makefile | \
@@ -99,15 +104,52 @@ lint_provider: provider
 provider: tfgen install_plugins
 	(cd provider && go build -p 1 -o $(WORKING_DIR)/bin/$(PROVIDER) -ldflags "-X $(PROJECT)/$(VERSION_PATH)=$(VERSION)" $(PROJECT)/$(PROVIDER_PATH)/cmd/$(PROVIDER))
 
+start-patch: upstream
+ifeq ("$(wildcard upstream)","")
+	@echo "No upstream found, so upstream can't be patched"
+	@exit 1
+else
+	# To add an additional patch:
+	#
+	#	1. Run this command (`make start-patch`).
+	#
+	#	2. Edit the `upstream` repo, making whatever changes you want to appear in the new
+	#	patch. It's fine to edit multiple files.
+	#
+	#	3. Commit your changes. The slugified first line of your commit description will
+	#	be used to generate the patch file name. Only the diff from the latest commit will
+	#	end up in the final patch.
+	#
+	#	4. Run `make finish-patch`.
+	#
+	# It is safe to run `make start-patch` as many times as you want, but any changes
+	# might be reverted until `make finish-patch` is run.
+	@cd upstream && git commit --quiet -m "existing patches"
+endif
+
 test:
 	cd examples && go test -v -tags=all -parallel $(TESTPARALLELISM) -timeout 2h
 
-tfgen: install_plugins
+tfgen: install_plugins upstream
 	(cd provider && go build -p 1 -o $(WORKING_DIR)/bin/$(TFGEN) -ldflags "-X $(PROJECT)/$(VERSION_PATH)=$(VERSION)" $(PROJECT)/$(PROVIDER_PATH)/cmd/$(TFGEN))
 	$(WORKING_DIR)/bin/$(TFGEN) schema --out provider/cmd/$(PROVIDER)
 	(cd provider && VERSION=$(VERSION) go generate cmd/$(PROVIDER)/main.go)
 
+upstream:
+ifeq ("$(wildcard upstream)","")
+	# upstream doesn't exist, so skip
+else ifeq ("$(wildcard patches/*.patch)","")
+	# upstream exists, but patches don't exist. This is probably an error.
+	@echo "No patches found within the patch operation"
+	@echo "patches were expected because upstream exists"
+	@exit 1
+else
+	git submodule update --force --init
+	cd upstream && \
+		for patch in $(sort $(wildcard patches/*.patch)); do git apply --3way ../$$patch || exit 1; done
+endif
+
 bin/pulumi-java-gen:
 	$(shell pulumictl download-binary -n pulumi-language-java -v $(JAVA_GEN_VERSION) -r pulumi/pulumi-java)
 
-.PHONY: development build build_sdks install_go_sdk install_java_sdk install_python_sdk install_sdks only_build build_dotnet build_go build_java build_nodejs build_python clean cleanup help install_dotnet_sdk install_nodejs_sdk install_plugins lint_provider provider test tfgen
+.PHONY: development build build_sdks install_go_sdk install_java_sdk install_python_sdk install_sdks only_build build_dotnet build_go build_java build_nodejs build_python clean cleanup finish-patch help install_dotnet_sdk install_nodejs_sdk install_plugins lint_provider provider start-patch test tfgen upstream

--- a/provider-ci/providers/pagerduty/repo/Makefile
+++ b/provider-ci/providers/pagerduty/repo/Makefile
@@ -144,7 +144,12 @@ else ifeq ("$(wildcard patches/*.patch)","")
 	@echo "patches were expected because upstream exists"
 	@exit 1
 else
+	# Checkout the submodule at the pinned commit.
+	# `--force`: If the submodule is at a different commit, move it to the pinned commit.
+	# `--init`: If the submodule is not initialized, initialize it.
 	git submodule update --force --init
+	# Iterating over the patches folder in sorted order,
+	# apply the patch using a 3-way merge strategy. This mirrors the default behavior of `git merge`
 	cd upstream && \
 		for patch in $(sort $(wildcard patches/*.patch)); do git apply --3way ../$$patch || exit 1; done
 endif

--- a/provider-ci/providers/pagerduty/repo/Makefile
+++ b/provider-ci/providers/pagerduty/repo/Makefile
@@ -30,7 +30,7 @@ install_sdks: install_dotnet_sdk install_python_sdk install_nodejs_sdk install_j
 only_build: build
 
 build_dotnet: DOTNET_VERSION := $(shell pulumictl get version --language dotnet)
-build_dotnet:
+build_dotnet: upstream
 	pulumictl get version --language dotnet
 	$(WORKING_DIR)/bin/$(TFGEN) dotnet --out sdk/dotnet/
 	cd sdk/dotnet/ && \
@@ -38,19 +38,19 @@ build_dotnet:
 		echo "$(DOTNET_VERSION)" >version.txt && \
 		dotnet build /p:Version=$(DOTNET_VERSION)
 
-build_go:
+build_go: upstream
 	$(WORKING_DIR)/bin/$(TFGEN) go --out sdk/go/
 	cd sdk && go list `grep -e "^module" go.mod | cut -d ' ' -f 2`/go/... | xargs go build
 
 build_java: PACKAGE_VERSION := $(shell pulumictl get version --language generic)
-build_java: bin/pulumi-java-gen
+build_java: bin/pulumi-java-gen upstream
 	$(WORKING_DIR)/bin/$(JAVA_GEN) generate --schema provider/cmd/$(PROVIDER)/schema.json --out sdk/java  --build gradle-nexus
 	cd sdk/java/ && \
 		echo "module fake_java_module // Exclude this directory from Go tools\n\ngo 1.17" > go.mod && \
 		gradle --console=plain build
 
 build_nodejs: VERSION := $(shell pulumictl get version --language javascript)
-build_nodejs:
+build_nodejs: upstream
 	$(WORKING_DIR)/bin/$(TFGEN) nodejs --out sdk/nodejs/
 	cd sdk/nodejs/ && \
 		echo "module fake_nodejs_module // Exclude this directory from Go tools\n\ngo 1.17" > go.mod && \
@@ -60,7 +60,7 @@ build_nodejs:
 		sed -i.bak -e "s/\$${VERSION}/$(VERSION)/g" ./bin/package.json
 
 build_python: PYPI_VERSION := $(shell pulumictl get version --language python)
-build_python:
+build_python: upstream
 	$(WORKING_DIR)/bin/$(TFGEN) python --out sdk/python/
 	cd sdk/python/ && \
 		echo "module fake_python_module // Exclude this directory from Go tools\n\ngo 1.17" > go.mod && \
@@ -77,6 +77,11 @@ clean:
 cleanup:
 	rm -r $(WORKING_DIR)/bin
 	rm -f provider/cmd/$(PROVIDER)/schema.go
+
+finish-patch:
+	@if [ ! -z "$$(cd upstream && git status --porcelain)" ]; then echo "Please commit your changes before finishing the patch"; exit 1; fi
+	@cd upstream && \
+		git format-patch HEAD~ -o ../patches --start-number $$(($$(ls ../patches | wc -l | xargs)+1))
 
 help:
 	@grep '^[^.#]\+:\s\+.*#' Makefile | \
@@ -99,15 +104,52 @@ lint_provider: provider
 provider: tfgen install_plugins
 	(cd provider && go build -p 1 -o $(WORKING_DIR)/bin/$(PROVIDER) -ldflags "-X $(PROJECT)/$(VERSION_PATH)=$(VERSION)" $(PROJECT)/$(PROVIDER_PATH)/cmd/$(PROVIDER))
 
+start-patch: upstream
+ifeq ("$(wildcard upstream)","")
+	@echo "No upstream found, so upstream can't be patched"
+	@exit 1
+else
+	# To add an additional patch:
+	#
+	#	1. Run this command (`make start-patch`).
+	#
+	#	2. Edit the `upstream` repo, making whatever changes you want to appear in the new
+	#	patch. It's fine to edit multiple files.
+	#
+	#	3. Commit your changes. The slugified first line of your commit description will
+	#	be used to generate the patch file name. Only the diff from the latest commit will
+	#	end up in the final patch.
+	#
+	#	4. Run `make finish-patch`.
+	#
+	# It is safe to run `make start-patch` as many times as you want, but any changes
+	# might be reverted until `make finish-patch` is run.
+	@cd upstream && git commit --quiet -m "existing patches"
+endif
+
 test:
 	cd examples && go test -v -tags=all -parallel $(TESTPARALLELISM) -timeout 2h
 
-tfgen: install_plugins
+tfgen: install_plugins upstream
 	(cd provider && go build -p 1 -o $(WORKING_DIR)/bin/$(TFGEN) -ldflags "-X $(PROJECT)/$(VERSION_PATH)=$(VERSION)" $(PROJECT)/$(PROVIDER_PATH)/cmd/$(TFGEN))
 	$(WORKING_DIR)/bin/$(TFGEN) schema --out provider/cmd/$(PROVIDER)
 	(cd provider && VERSION=$(VERSION) go generate cmd/$(PROVIDER)/main.go)
 
+upstream:
+ifeq ("$(wildcard upstream)","")
+	# upstream doesn't exist, so skip
+else ifeq ("$(wildcard patches/*.patch)","")
+	# upstream exists, but patches don't exist. This is probably an error.
+	@echo "No patches found within the patch operation"
+	@echo "patches were expected because upstream exists"
+	@exit 1
+else
+	git submodule update --force --init
+	cd upstream && \
+		for patch in $(sort $(wildcard patches/*.patch)); do git apply --3way ../$$patch || exit 1; done
+endif
+
 bin/pulumi-java-gen:
 	$(shell pulumictl download-binary -n pulumi-language-java -v $(JAVA_GEN_VERSION) -r pulumi/pulumi-java)
 
-.PHONY: development build build_sdks install_go_sdk install_java_sdk install_python_sdk install_sdks only_build build_dotnet build_go build_java build_nodejs build_python clean cleanup help install_dotnet_sdk install_nodejs_sdk install_plugins lint_provider provider test tfgen
+.PHONY: development build build_sdks install_go_sdk install_java_sdk install_python_sdk install_sdks only_build build_dotnet build_go build_java build_nodejs build_python clean cleanup finish-patch help install_dotnet_sdk install_nodejs_sdk install_plugins lint_provider provider start-patch test tfgen upstream

--- a/provider-ci/providers/postgresql/repo/Makefile
+++ b/provider-ci/providers/postgresql/repo/Makefile
@@ -144,7 +144,12 @@ else ifeq ("$(wildcard patches/*.patch)","")
 	@echo "patches were expected because upstream exists"
 	@exit 1
 else
+	# Checkout the submodule at the pinned commit.
+	# `--force`: If the submodule is at a different commit, move it to the pinned commit.
+	# `--init`: If the submodule is not initialized, initialize it.
 	git submodule update --force --init
+	# Iterating over the patches folder in sorted order,
+	# apply the patch using a 3-way merge strategy. This mirrors the default behavior of `git merge`
 	cd upstream && \
 		for patch in $(sort $(wildcard patches/*.patch)); do git apply --3way ../$$patch || exit 1; done
 endif

--- a/provider-ci/providers/postgresql/repo/Makefile
+++ b/provider-ci/providers/postgresql/repo/Makefile
@@ -30,7 +30,7 @@ install_sdks: install_dotnet_sdk install_python_sdk install_nodejs_sdk install_j
 only_build: build
 
 build_dotnet: DOTNET_VERSION := $(shell pulumictl get version --language dotnet)
-build_dotnet:
+build_dotnet: upstream
 	pulumictl get version --language dotnet
 	$(WORKING_DIR)/bin/$(TFGEN) dotnet --out sdk/dotnet/
 	cd sdk/dotnet/ && \
@@ -38,19 +38,19 @@ build_dotnet:
 		echo "$(DOTNET_VERSION)" >version.txt && \
 		dotnet build /p:Version=$(DOTNET_VERSION)
 
-build_go:
+build_go: upstream
 	$(WORKING_DIR)/bin/$(TFGEN) go --out sdk/go/
 	cd sdk && go list `grep -e "^module" go.mod | cut -d ' ' -f 2`/go/... | xargs go build
 
 build_java: PACKAGE_VERSION := $(shell pulumictl get version --language generic)
-build_java: bin/pulumi-java-gen
+build_java: bin/pulumi-java-gen upstream
 	$(WORKING_DIR)/bin/$(JAVA_GEN) generate --schema provider/cmd/$(PROVIDER)/schema.json --out sdk/java  --build gradle-nexus
 	cd sdk/java/ && \
 		echo "module fake_java_module // Exclude this directory from Go tools\n\ngo 1.17" > go.mod && \
 		gradle --console=plain build
 
 build_nodejs: VERSION := $(shell pulumictl get version --language javascript)
-build_nodejs:
+build_nodejs: upstream
 	$(WORKING_DIR)/bin/$(TFGEN) nodejs --out sdk/nodejs/
 	cd sdk/nodejs/ && \
 		echo "module fake_nodejs_module // Exclude this directory from Go tools\n\ngo 1.17" > go.mod && \
@@ -60,7 +60,7 @@ build_nodejs:
 		sed -i.bak -e "s/\$${VERSION}/$(VERSION)/g" ./bin/package.json
 
 build_python: PYPI_VERSION := $(shell pulumictl get version --language python)
-build_python:
+build_python: upstream
 	$(WORKING_DIR)/bin/$(TFGEN) python --out sdk/python/
 	cd sdk/python/ && \
 		echo "module fake_python_module // Exclude this directory from Go tools\n\ngo 1.17" > go.mod && \
@@ -77,6 +77,11 @@ clean:
 cleanup:
 	rm -r $(WORKING_DIR)/bin
 	rm -f provider/cmd/$(PROVIDER)/schema.go
+
+finish-patch:
+	@if [ ! -z "$$(cd upstream && git status --porcelain)" ]; then echo "Please commit your changes before finishing the patch"; exit 1; fi
+	@cd upstream && \
+		git format-patch HEAD~ -o ../patches --start-number $$(($$(ls ../patches | wc -l | xargs)+1))
 
 help:
 	@grep '^[^.#]\+:\s\+.*#' Makefile | \
@@ -99,15 +104,52 @@ lint_provider: provider
 provider: tfgen install_plugins
 	(cd provider && go build -p 1 -o $(WORKING_DIR)/bin/$(PROVIDER) -ldflags "-X $(PROJECT)/$(VERSION_PATH)=$(VERSION)" $(PROJECT)/$(PROVIDER_PATH)/cmd/$(PROVIDER))
 
+start-patch: upstream
+ifeq ("$(wildcard upstream)","")
+	@echo "No upstream found, so upstream can't be patched"
+	@exit 1
+else
+	# To add an additional patch:
+	#
+	#	1. Run this command (`make start-patch`).
+	#
+	#	2. Edit the `upstream` repo, making whatever changes you want to appear in the new
+	#	patch. It's fine to edit multiple files.
+	#
+	#	3. Commit your changes. The slugified first line of your commit description will
+	#	be used to generate the patch file name. Only the diff from the latest commit will
+	#	end up in the final patch.
+	#
+	#	4. Run `make finish-patch`.
+	#
+	# It is safe to run `make start-patch` as many times as you want, but any changes
+	# might be reverted until `make finish-patch` is run.
+	@cd upstream && git commit --quiet -m "existing patches"
+endif
+
 test:
 	cd examples && go test -v -tags=all -parallel $(TESTPARALLELISM) -timeout 2h
 
-tfgen: install_plugins
+tfgen: install_plugins upstream
 	(cd provider && go build -p 1 -o $(WORKING_DIR)/bin/$(TFGEN) -ldflags "-X $(PROJECT)/$(VERSION_PATH)=$(VERSION)" $(PROJECT)/$(PROVIDER_PATH)/cmd/$(TFGEN))
 	$(WORKING_DIR)/bin/$(TFGEN) schema --out provider/cmd/$(PROVIDER)
 	(cd provider && VERSION=$(VERSION) go generate cmd/$(PROVIDER)/main.go)
 
+upstream:
+ifeq ("$(wildcard upstream)","")
+	# upstream doesn't exist, so skip
+else ifeq ("$(wildcard patches/*.patch)","")
+	# upstream exists, but patches don't exist. This is probably an error.
+	@echo "No patches found within the patch operation"
+	@echo "patches were expected because upstream exists"
+	@exit 1
+else
+	git submodule update --force --init
+	cd upstream && \
+		for patch in $(sort $(wildcard patches/*.patch)); do git apply --3way ../$$patch || exit 1; done
+endif
+
 bin/pulumi-java-gen:
 	$(shell pulumictl download-binary -n pulumi-language-java -v $(JAVA_GEN_VERSION) -r pulumi/pulumi-java)
 
-.PHONY: development build build_sdks install_go_sdk install_java_sdk install_python_sdk install_sdks only_build build_dotnet build_go build_java build_nodejs build_python clean cleanup help install_dotnet_sdk install_nodejs_sdk install_plugins lint_provider provider test tfgen
+.PHONY: development build build_sdks install_go_sdk install_java_sdk install_python_sdk install_sdks only_build build_dotnet build_go build_java build_nodejs build_python clean cleanup finish-patch help install_dotnet_sdk install_nodejs_sdk install_plugins lint_provider provider start-patch test tfgen upstream

--- a/provider-ci/providers/rabbitmq/repo/Makefile
+++ b/provider-ci/providers/rabbitmq/repo/Makefile
@@ -144,7 +144,12 @@ else ifeq ("$(wildcard patches/*.patch)","")
 	@echo "patches were expected because upstream exists"
 	@exit 1
 else
+	# Checkout the submodule at the pinned commit.
+	# `--force`: If the submodule is at a different commit, move it to the pinned commit.
+	# `--init`: If the submodule is not initialized, initialize it.
 	git submodule update --force --init
+	# Iterating over the patches folder in sorted order,
+	# apply the patch using a 3-way merge strategy. This mirrors the default behavior of `git merge`
 	cd upstream && \
 		for patch in $(sort $(wildcard patches/*.patch)); do git apply --3way ../$$patch || exit 1; done
 endif

--- a/provider-ci/providers/rabbitmq/repo/Makefile
+++ b/provider-ci/providers/rabbitmq/repo/Makefile
@@ -30,7 +30,7 @@ install_sdks: install_dotnet_sdk install_python_sdk install_nodejs_sdk install_j
 only_build: build
 
 build_dotnet: DOTNET_VERSION := $(shell pulumictl get version --language dotnet)
-build_dotnet:
+build_dotnet: upstream
 	pulumictl get version --language dotnet
 	$(WORKING_DIR)/bin/$(TFGEN) dotnet --out sdk/dotnet/
 	cd sdk/dotnet/ && \
@@ -38,19 +38,19 @@ build_dotnet:
 		echo "$(DOTNET_VERSION)" >version.txt && \
 		dotnet build /p:Version=$(DOTNET_VERSION)
 
-build_go:
+build_go: upstream
 	$(WORKING_DIR)/bin/$(TFGEN) go --out sdk/go/
 	cd sdk && go list `grep -e "^module" go.mod | cut -d ' ' -f 2`/go/... | xargs go build
 
 build_java: PACKAGE_VERSION := $(shell pulumictl get version --language generic)
-build_java: bin/pulumi-java-gen
+build_java: bin/pulumi-java-gen upstream
 	$(WORKING_DIR)/bin/$(JAVA_GEN) generate --schema provider/cmd/$(PROVIDER)/schema.json --out sdk/java  --build gradle-nexus
 	cd sdk/java/ && \
 		echo "module fake_java_module // Exclude this directory from Go tools\n\ngo 1.17" > go.mod && \
 		gradle --console=plain build
 
 build_nodejs: VERSION := $(shell pulumictl get version --language javascript)
-build_nodejs:
+build_nodejs: upstream
 	$(WORKING_DIR)/bin/$(TFGEN) nodejs --out sdk/nodejs/
 	cd sdk/nodejs/ && \
 		echo "module fake_nodejs_module // Exclude this directory from Go tools\n\ngo 1.17" > go.mod && \
@@ -60,7 +60,7 @@ build_nodejs:
 		sed -i.bak -e "s/\$${VERSION}/$(VERSION)/g" ./bin/package.json
 
 build_python: PYPI_VERSION := $(shell pulumictl get version --language python)
-build_python:
+build_python: upstream
 	$(WORKING_DIR)/bin/$(TFGEN) python --out sdk/python/
 	cd sdk/python/ && \
 		echo "module fake_python_module // Exclude this directory from Go tools\n\ngo 1.17" > go.mod && \
@@ -77,6 +77,11 @@ clean:
 cleanup:
 	rm -r $(WORKING_DIR)/bin
 	rm -f provider/cmd/$(PROVIDER)/schema.go
+
+finish-patch:
+	@if [ ! -z "$$(cd upstream && git status --porcelain)" ]; then echo "Please commit your changes before finishing the patch"; exit 1; fi
+	@cd upstream && \
+		git format-patch HEAD~ -o ../patches --start-number $$(($$(ls ../patches | wc -l | xargs)+1))
 
 help:
 	@grep '^[^.#]\+:\s\+.*#' Makefile | \
@@ -99,15 +104,52 @@ lint_provider: provider
 provider: tfgen install_plugins
 	(cd provider && go build -p 1 -o $(WORKING_DIR)/bin/$(PROVIDER) -ldflags "-X $(PROJECT)/$(VERSION_PATH)=$(VERSION)" $(PROJECT)/$(PROVIDER_PATH)/cmd/$(PROVIDER))
 
+start-patch: upstream
+ifeq ("$(wildcard upstream)","")
+	@echo "No upstream found, so upstream can't be patched"
+	@exit 1
+else
+	# To add an additional patch:
+	#
+	#	1. Run this command (`make start-patch`).
+	#
+	#	2. Edit the `upstream` repo, making whatever changes you want to appear in the new
+	#	patch. It's fine to edit multiple files.
+	#
+	#	3. Commit your changes. The slugified first line of your commit description will
+	#	be used to generate the patch file name. Only the diff from the latest commit will
+	#	end up in the final patch.
+	#
+	#	4. Run `make finish-patch`.
+	#
+	# It is safe to run `make start-patch` as many times as you want, but any changes
+	# might be reverted until `make finish-patch` is run.
+	@cd upstream && git commit --quiet -m "existing patches"
+endif
+
 test:
 	cd examples && go test -v -tags=all -parallel $(TESTPARALLELISM) -timeout 2h
 
-tfgen: install_plugins
+tfgen: install_plugins upstream
 	(cd provider && go build -p 1 -o $(WORKING_DIR)/bin/$(TFGEN) -ldflags "-X $(PROJECT)/$(VERSION_PATH)=$(VERSION)" $(PROJECT)/$(PROVIDER_PATH)/cmd/$(TFGEN))
 	$(WORKING_DIR)/bin/$(TFGEN) schema --out provider/cmd/$(PROVIDER)
 	(cd provider && VERSION=$(VERSION) go generate cmd/$(PROVIDER)/main.go)
 
+upstream:
+ifeq ("$(wildcard upstream)","")
+	# upstream doesn't exist, so skip
+else ifeq ("$(wildcard patches/*.patch)","")
+	# upstream exists, but patches don't exist. This is probably an error.
+	@echo "No patches found within the patch operation"
+	@echo "patches were expected because upstream exists"
+	@exit 1
+else
+	git submodule update --force --init
+	cd upstream && \
+		for patch in $(sort $(wildcard patches/*.patch)); do git apply --3way ../$$patch || exit 1; done
+endif
+
 bin/pulumi-java-gen:
 	$(shell pulumictl download-binary -n pulumi-language-java -v $(JAVA_GEN_VERSION) -r pulumi/pulumi-java)
 
-.PHONY: development build build_sdks install_go_sdk install_java_sdk install_python_sdk install_sdks only_build build_dotnet build_go build_java build_nodejs build_python clean cleanup help install_dotnet_sdk install_nodejs_sdk install_plugins lint_provider provider test tfgen
+.PHONY: development build build_sdks install_go_sdk install_java_sdk install_python_sdk install_sdks only_build build_dotnet build_go build_java build_nodejs build_python clean cleanup finish-patch help install_dotnet_sdk install_nodejs_sdk install_plugins lint_provider provider start-patch test tfgen upstream

--- a/provider-ci/providers/rancher2/repo/Makefile
+++ b/provider-ci/providers/rancher2/repo/Makefile
@@ -144,7 +144,12 @@ else ifeq ("$(wildcard patches/*.patch)","")
 	@echo "patches were expected because upstream exists"
 	@exit 1
 else
+	# Checkout the submodule at the pinned commit.
+	# `--force`: If the submodule is at a different commit, move it to the pinned commit.
+	# `--init`: If the submodule is not initialized, initialize it.
 	git submodule update --force --init
+	# Iterating over the patches folder in sorted order,
+	# apply the patch using a 3-way merge strategy. This mirrors the default behavior of `git merge`
 	cd upstream && \
 		for patch in $(sort $(wildcard patches/*.patch)); do git apply --3way ../$$patch || exit 1; done
 endif

--- a/provider-ci/providers/rancher2/repo/Makefile
+++ b/provider-ci/providers/rancher2/repo/Makefile
@@ -30,7 +30,7 @@ install_sdks: install_dotnet_sdk install_python_sdk install_nodejs_sdk install_j
 only_build: build
 
 build_dotnet: DOTNET_VERSION := $(shell pulumictl get version --language dotnet)
-build_dotnet:
+build_dotnet: upstream
 	pulumictl get version --language dotnet
 	$(WORKING_DIR)/bin/$(TFGEN) dotnet --out sdk/dotnet/
 	cd sdk/dotnet/ && \
@@ -38,19 +38,19 @@ build_dotnet:
 		echo "$(DOTNET_VERSION)" >version.txt && \
 		dotnet build /p:Version=$(DOTNET_VERSION)
 
-build_go:
+build_go: upstream
 	$(WORKING_DIR)/bin/$(TFGEN) go --out sdk/go/
 	cd sdk && go list `grep -e "^module" go.mod | cut -d ' ' -f 2`/go/... | xargs go build
 
 build_java: PACKAGE_VERSION := $(shell pulumictl get version --language generic)
-build_java: bin/pulumi-java-gen
+build_java: bin/pulumi-java-gen upstream
 	$(WORKING_DIR)/bin/$(JAVA_GEN) generate --schema provider/cmd/$(PROVIDER)/schema.json --out sdk/java  --build gradle-nexus
 	cd sdk/java/ && \
 		echo "module fake_java_module // Exclude this directory from Go tools\n\ngo 1.17" > go.mod && \
 		gradle --console=plain build
 
 build_nodejs: VERSION := $(shell pulumictl get version --language javascript)
-build_nodejs:
+build_nodejs: upstream
 	$(WORKING_DIR)/bin/$(TFGEN) nodejs --out sdk/nodejs/
 	cd sdk/nodejs/ && \
 		echo "module fake_nodejs_module // Exclude this directory from Go tools\n\ngo 1.17" > go.mod && \
@@ -60,7 +60,7 @@ build_nodejs:
 		sed -i.bak -e "s/\$${VERSION}/$(VERSION)/g" ./bin/package.json
 
 build_python: PYPI_VERSION := $(shell pulumictl get version --language python)
-build_python:
+build_python: upstream
 	$(WORKING_DIR)/bin/$(TFGEN) python --out sdk/python/
 	cd sdk/python/ && \
 		echo "module fake_python_module // Exclude this directory from Go tools\n\ngo 1.17" > go.mod && \
@@ -77,6 +77,11 @@ clean:
 cleanup:
 	rm -r $(WORKING_DIR)/bin
 	rm -f provider/cmd/$(PROVIDER)/schema.go
+
+finish-patch:
+	@if [ ! -z "$$(cd upstream && git status --porcelain)" ]; then echo "Please commit your changes before finishing the patch"; exit 1; fi
+	@cd upstream && \
+		git format-patch HEAD~ -o ../patches --start-number $$(($$(ls ../patches | wc -l | xargs)+1))
 
 help:
 	@grep '^[^.#]\+:\s\+.*#' Makefile | \
@@ -99,15 +104,52 @@ lint_provider: provider
 provider: tfgen install_plugins
 	(cd provider && go build -p 1 -o $(WORKING_DIR)/bin/$(PROVIDER) -ldflags "-X $(PROJECT)/$(VERSION_PATH)=$(VERSION)" $(PROJECT)/$(PROVIDER_PATH)/cmd/$(PROVIDER))
 
+start-patch: upstream
+ifeq ("$(wildcard upstream)","")
+	@echo "No upstream found, so upstream can't be patched"
+	@exit 1
+else
+	# To add an additional patch:
+	#
+	#	1. Run this command (`make start-patch`).
+	#
+	#	2. Edit the `upstream` repo, making whatever changes you want to appear in the new
+	#	patch. It's fine to edit multiple files.
+	#
+	#	3. Commit your changes. The slugified first line of your commit description will
+	#	be used to generate the patch file name. Only the diff from the latest commit will
+	#	end up in the final patch.
+	#
+	#	4. Run `make finish-patch`.
+	#
+	# It is safe to run `make start-patch` as many times as you want, but any changes
+	# might be reverted until `make finish-patch` is run.
+	@cd upstream && git commit --quiet -m "existing patches"
+endif
+
 test:
 	cd examples && go test -v -tags=all -parallel $(TESTPARALLELISM) -timeout 2h
 
-tfgen: install_plugins
+tfgen: install_plugins upstream
 	(cd provider && go build -p 1 -o $(WORKING_DIR)/bin/$(TFGEN) -ldflags "-X $(PROJECT)/$(VERSION_PATH)=$(VERSION)" $(PROJECT)/$(PROVIDER_PATH)/cmd/$(TFGEN))
 	$(WORKING_DIR)/bin/$(TFGEN) schema --out provider/cmd/$(PROVIDER)
 	(cd provider && VERSION=$(VERSION) go generate cmd/$(PROVIDER)/main.go)
 
+upstream:
+ifeq ("$(wildcard upstream)","")
+	# upstream doesn't exist, so skip
+else ifeq ("$(wildcard patches/*.patch)","")
+	# upstream exists, but patches don't exist. This is probably an error.
+	@echo "No patches found within the patch operation"
+	@echo "patches were expected because upstream exists"
+	@exit 1
+else
+	git submodule update --force --init
+	cd upstream && \
+		for patch in $(sort $(wildcard patches/*.patch)); do git apply --3way ../$$patch || exit 1; done
+endif
+
 bin/pulumi-java-gen:
 	$(shell pulumictl download-binary -n pulumi-language-java -v $(JAVA_GEN_VERSION) -r pulumi/pulumi-java)
 
-.PHONY: development build build_sdks install_go_sdk install_java_sdk install_python_sdk install_sdks only_build build_dotnet build_go build_java build_nodejs build_python clean cleanup help install_dotnet_sdk install_nodejs_sdk install_plugins lint_provider provider test tfgen
+.PHONY: development build build_sdks install_go_sdk install_java_sdk install_python_sdk install_sdks only_build build_dotnet build_go build_java build_nodejs build_python clean cleanup finish-patch help install_dotnet_sdk install_nodejs_sdk install_plugins lint_provider provider start-patch test tfgen upstream

--- a/provider-ci/providers/random/repo/Makefile
+++ b/provider-ci/providers/random/repo/Makefile
@@ -146,7 +146,12 @@ else ifeq ("$(wildcard patches/*.patch)","")
 	@echo "patches were expected because upstream exists"
 	@exit 1
 else
+	# Checkout the submodule at the pinned commit.
+	# `--force`: If the submodule is at a different commit, move it to the pinned commit.
+	# `--init`: If the submodule is not initialized, initialize it.
 	git submodule update --force --init
+	# Iterating over the patches folder in sorted order,
+	# apply the patch using a 3-way merge strategy. This mirrors the default behavior of `git merge`
 	cd upstream && \
 		for patch in $(sort $(wildcard patches/*.patch)); do git apply --3way ../$$patch || exit 1; done
 endif

--- a/provider-ci/providers/random/repo/Makefile
+++ b/provider-ci/providers/random/repo/Makefile
@@ -30,7 +30,7 @@ install_sdks: install_dotnet_sdk install_python_sdk install_nodejs_sdk install_j
 only_build: build
 
 build_dotnet: DOTNET_VERSION := $(shell pulumictl get version --language dotnet)
-build_dotnet:
+build_dotnet: upstream
 	pulumictl get version --language dotnet
 	$(WORKING_DIR)/bin/$(TFGEN) dotnet --out sdk/dotnet/
 	cd sdk/dotnet/ && \
@@ -38,19 +38,19 @@ build_dotnet:
 		echo "$(DOTNET_VERSION)" >version.txt && \
 		dotnet build /p:Version=$(DOTNET_VERSION)
 
-build_go:
+build_go: upstream
 	$(WORKING_DIR)/bin/$(TFGEN) go --out sdk/go/
 	cd sdk && go list `grep -e "^module" go.mod | cut -d ' ' -f 2`/go/... | xargs go build
 
 build_java: PACKAGE_VERSION := $(shell pulumictl get version --language generic)
-build_java: bin/pulumi-java-gen
+build_java: bin/pulumi-java-gen upstream
 	$(WORKING_DIR)/bin/$(JAVA_GEN) generate --schema provider/cmd/$(PROVIDER)/schema.json --out sdk/java  --build gradle-nexus
 	cd sdk/java/ && \
 		echo "module fake_java_module // Exclude this directory from Go tools\n\ngo 1.17" > go.mod && \
 		gradle --console=plain build
 
 build_nodejs: VERSION := $(shell pulumictl get version --language javascript)
-build_nodejs:
+build_nodejs: upstream
 	$(WORKING_DIR)/bin/$(TFGEN) nodejs --out sdk/nodejs/
 	cd sdk/nodejs/ && \
 		echo "module fake_nodejs_module // Exclude this directory from Go tools\n\ngo 1.17" > go.mod && \
@@ -60,7 +60,7 @@ build_nodejs:
 		sed -i.bak -e "s/\$${VERSION}/$(VERSION)/g" ./bin/package.json
 
 build_python: PYPI_VERSION := $(shell pulumictl get version --language python)
-build_python:
+build_python: upstream
 	$(WORKING_DIR)/bin/$(TFGEN) python --out sdk/python/
 	cd sdk/python/ && \
 		echo "module fake_python_module // Exclude this directory from Go tools\n\ngo 1.17" > go.mod && \
@@ -77,6 +77,11 @@ clean:
 cleanup:
 	rm -r $(WORKING_DIR)/bin
 	rm -f provider/cmd/$(PROVIDER)/schema.go
+
+finish-patch:
+	@if [ ! -z "$$(cd upstream && git status --porcelain)" ]; then echo "Please commit your changes before finishing the patch"; exit 1; fi
+	@cd upstream && \
+		git format-patch HEAD~ -o ../patches --start-number $$(($$(ls ../patches | wc -l | xargs)+1))
 
 help:
 	@grep '^[^.#]\+:\s\+.*#' Makefile | \
@@ -101,15 +106,52 @@ lint_provider: provider
 provider: tfgen install_plugins
 	(cd provider && go build -p 1 -o $(WORKING_DIR)/bin/$(PROVIDER) -ldflags "-X $(PROJECT)/$(VERSION_PATH)=$(VERSION)" $(PROJECT)/$(PROVIDER_PATH)/cmd/$(PROVIDER))
 
+start-patch: upstream
+ifeq ("$(wildcard upstream)","")
+	@echo "No upstream found, so upstream can't be patched"
+	@exit 1
+else
+	# To add an additional patch:
+	#
+	#	1. Run this command (`make start-patch`).
+	#
+	#	2. Edit the `upstream` repo, making whatever changes you want to appear in the new
+	#	patch. It's fine to edit multiple files.
+	#
+	#	3. Commit your changes. The slugified first line of your commit description will
+	#	be used to generate the patch file name. Only the diff from the latest commit will
+	#	end up in the final patch.
+	#
+	#	4. Run `make finish-patch`.
+	#
+	# It is safe to run `make start-patch` as many times as you want, but any changes
+	# might be reverted until `make finish-patch` is run.
+	@cd upstream && git commit --quiet -m "existing patches"
+endif
+
 test:
 	cd examples && go test -v -tags=all -parallel $(TESTPARALLELISM) -timeout 2h
 
-tfgen: install_plugins
+tfgen: install_plugins upstream
 	(cd provider && go build -p 1 -o $(WORKING_DIR)/bin/$(TFGEN) -ldflags "-X $(PROJECT)/$(VERSION_PATH)=$(VERSION)" $(PROJECT)/$(PROVIDER_PATH)/cmd/$(TFGEN))
 	$(WORKING_DIR)/bin/$(TFGEN) schema --out provider/cmd/$(PROVIDER)
 	(cd provider && VERSION=$(VERSION) go generate cmd/$(PROVIDER)/main.go)
 
+upstream:
+ifeq ("$(wildcard upstream)","")
+	# upstream doesn't exist, so skip
+else ifeq ("$(wildcard patches/*.patch)","")
+	# upstream exists, but patches don't exist. This is probably an error.
+	@echo "No patches found within the patch operation"
+	@echo "patches were expected because upstream exists"
+	@exit 1
+else
+	git submodule update --force --init
+	cd upstream && \
+		for patch in $(sort $(wildcard patches/*.patch)); do git apply --3way ../$$patch || exit 1; done
+endif
+
 bin/pulumi-java-gen:
 	$(shell pulumictl download-binary -n pulumi-language-java -v $(JAVA_GEN_VERSION) -r pulumi/pulumi-java)
 
-.PHONY: development build build_sdks install_go_sdk install_java_sdk install_python_sdk install_sdks only_build build_dotnet build_go build_java build_nodejs build_python clean cleanup help install_dotnet_sdk install_nodejs_sdk install_plugins lint_provider provider test tfgen
+.PHONY: development build build_sdks install_go_sdk install_java_sdk install_python_sdk install_sdks only_build build_dotnet build_go build_java build_nodejs build_python clean cleanup finish-patch help install_dotnet_sdk install_nodejs_sdk install_plugins lint_provider provider start-patch test tfgen upstream

--- a/provider-ci/providers/rke/repo/Makefile
+++ b/provider-ci/providers/rke/repo/Makefile
@@ -144,7 +144,12 @@ else ifeq ("$(wildcard patches/*.patch)","")
 	@echo "patches were expected because upstream exists"
 	@exit 1
 else
+	# Checkout the submodule at the pinned commit.
+	# `--force`: If the submodule is at a different commit, move it to the pinned commit.
+	# `--init`: If the submodule is not initialized, initialize it.
 	git submodule update --force --init
+	# Iterating over the patches folder in sorted order,
+	# apply the patch using a 3-way merge strategy. This mirrors the default behavior of `git merge`
 	cd upstream && \
 		for patch in $(sort $(wildcard patches/*.patch)); do git apply --3way ../$$patch || exit 1; done
 endif

--- a/provider-ci/providers/rke/repo/Makefile
+++ b/provider-ci/providers/rke/repo/Makefile
@@ -30,7 +30,7 @@ install_sdks: install_dotnet_sdk install_python_sdk install_nodejs_sdk install_j
 only_build: build
 
 build_dotnet: DOTNET_VERSION := $(shell pulumictl get version --language dotnet)
-build_dotnet:
+build_dotnet: upstream
 	pulumictl get version --language dotnet
 	$(WORKING_DIR)/bin/$(TFGEN) dotnet --out sdk/dotnet/
 	cd sdk/dotnet/ && \
@@ -38,19 +38,19 @@ build_dotnet:
 		echo "$(DOTNET_VERSION)" >version.txt && \
 		dotnet build /p:Version=$(DOTNET_VERSION)
 
-build_go:
+build_go: upstream
 	$(WORKING_DIR)/bin/$(TFGEN) go --out sdk/go/
 	cd sdk && go list `grep -e "^module" go.mod | cut -d ' ' -f 2`/go/... | xargs go build
 
 build_java: PACKAGE_VERSION := $(shell pulumictl get version --language generic)
-build_java: bin/pulumi-java-gen
+build_java: bin/pulumi-java-gen upstream
 	$(WORKING_DIR)/bin/$(JAVA_GEN) generate --schema provider/cmd/$(PROVIDER)/schema.json --out sdk/java  --build gradle-nexus
 	cd sdk/java/ && \
 		echo "module fake_java_module // Exclude this directory from Go tools\n\ngo 1.17" > go.mod && \
 		gradle --console=plain build
 
 build_nodejs: VERSION := $(shell pulumictl get version --language javascript)
-build_nodejs:
+build_nodejs: upstream
 	$(WORKING_DIR)/bin/$(TFGEN) nodejs --out sdk/nodejs/
 	cd sdk/nodejs/ && \
 		echo "module fake_nodejs_module // Exclude this directory from Go tools\n\ngo 1.17" > go.mod && \
@@ -60,7 +60,7 @@ build_nodejs:
 		sed -i.bak -e "s/\$${VERSION}/$(VERSION)/g" ./bin/package.json
 
 build_python: PYPI_VERSION := $(shell pulumictl get version --language python)
-build_python:
+build_python: upstream
 	$(WORKING_DIR)/bin/$(TFGEN) python --out sdk/python/
 	cd sdk/python/ && \
 		echo "module fake_python_module // Exclude this directory from Go tools\n\ngo 1.17" > go.mod && \
@@ -77,6 +77,11 @@ clean:
 cleanup:
 	rm -r $(WORKING_DIR)/bin
 	rm -f provider/cmd/$(PROVIDER)/schema.go
+
+finish-patch:
+	@if [ ! -z "$$(cd upstream && git status --porcelain)" ]; then echo "Please commit your changes before finishing the patch"; exit 1; fi
+	@cd upstream && \
+		git format-patch HEAD~ -o ../patches --start-number $$(($$(ls ../patches | wc -l | xargs)+1))
 
 help:
 	@grep '^[^.#]\+:\s\+.*#' Makefile | \
@@ -99,15 +104,52 @@ lint_provider: provider
 provider: tfgen install_plugins
 	(cd provider && go build -p 1 -o $(WORKING_DIR)/bin/$(PROVIDER) -ldflags "-X $(PROJECT)/$(VERSION_PATH)=$(VERSION)" $(PROJECT)/$(PROVIDER_PATH)/cmd/$(PROVIDER))
 
+start-patch: upstream
+ifeq ("$(wildcard upstream)","")
+	@echo "No upstream found, so upstream can't be patched"
+	@exit 1
+else
+	# To add an additional patch:
+	#
+	#	1. Run this command (`make start-patch`).
+	#
+	#	2. Edit the `upstream` repo, making whatever changes you want to appear in the new
+	#	patch. It's fine to edit multiple files.
+	#
+	#	3. Commit your changes. The slugified first line of your commit description will
+	#	be used to generate the patch file name. Only the diff from the latest commit will
+	#	end up in the final patch.
+	#
+	#	4. Run `make finish-patch`.
+	#
+	# It is safe to run `make start-patch` as many times as you want, but any changes
+	# might be reverted until `make finish-patch` is run.
+	@cd upstream && git commit --quiet -m "existing patches"
+endif
+
 test:
 	cd examples && go test -v -tags=all -parallel $(TESTPARALLELISM) -timeout 2h
 
-tfgen: install_plugins
+tfgen: install_plugins upstream
 	(cd provider && go build -p 1 -o $(WORKING_DIR)/bin/$(TFGEN) -ldflags "-X $(PROJECT)/$(VERSION_PATH)=$(VERSION)" $(PROJECT)/$(PROVIDER_PATH)/cmd/$(TFGEN))
 	$(WORKING_DIR)/bin/$(TFGEN) schema --out provider/cmd/$(PROVIDER)
 	(cd provider && VERSION=$(VERSION) go generate cmd/$(PROVIDER)/main.go)
 
+upstream:
+ifeq ("$(wildcard upstream)","")
+	# upstream doesn't exist, so skip
+else ifeq ("$(wildcard patches/*.patch)","")
+	# upstream exists, but patches don't exist. This is probably an error.
+	@echo "No patches found within the patch operation"
+	@echo "patches were expected because upstream exists"
+	@exit 1
+else
+	git submodule update --force --init
+	cd upstream && \
+		for patch in $(sort $(wildcard patches/*.patch)); do git apply --3way ../$$patch || exit 1; done
+endif
+
 bin/pulumi-java-gen:
 	$(shell pulumictl download-binary -n pulumi-language-java -v $(JAVA_GEN_VERSION) -r pulumi/pulumi-java)
 
-.PHONY: development build build_sdks install_go_sdk install_java_sdk install_python_sdk install_sdks only_build build_dotnet build_go build_java build_nodejs build_python clean cleanup help install_dotnet_sdk install_nodejs_sdk install_plugins lint_provider provider test tfgen
+.PHONY: development build build_sdks install_go_sdk install_java_sdk install_python_sdk install_sdks only_build build_dotnet build_go build_java build_nodejs build_python clean cleanup finish-patch help install_dotnet_sdk install_nodejs_sdk install_plugins lint_provider provider start-patch test tfgen upstream

--- a/provider-ci/providers/signalfx/repo/Makefile
+++ b/provider-ci/providers/signalfx/repo/Makefile
@@ -30,7 +30,7 @@ install_sdks: install_dotnet_sdk install_python_sdk install_nodejs_sdk install_j
 only_build: build
 
 build_dotnet: DOTNET_VERSION := $(shell pulumictl get version --language dotnet)
-build_dotnet:
+build_dotnet: upstream
 	pulumictl get version --language dotnet
 	$(WORKING_DIR)/bin/$(TFGEN) dotnet --out sdk/dotnet/
 	cd sdk/dotnet/ && \
@@ -38,19 +38,19 @@ build_dotnet:
 		echo "$(DOTNET_VERSION)" >version.txt && \
 		dotnet build /p:Version=$(DOTNET_VERSION)
 
-build_go:
+build_go: upstream
 	$(WORKING_DIR)/bin/$(TFGEN) go --out sdk/go/
 	cd sdk && go list `grep -e "^module" go.mod | cut -d ' ' -f 2`/go/... | xargs go build
 
 build_java: PACKAGE_VERSION := $(shell pulumictl get version --language generic)
-build_java: bin/pulumi-java-gen
+build_java: bin/pulumi-java-gen upstream
 	$(WORKING_DIR)/bin/$(JAVA_GEN) generate --schema provider/cmd/$(PROVIDER)/schema.json --out sdk/java  --build gradle-nexus
 	cd sdk/java/ && \
 		echo "module fake_java_module // Exclude this directory from Go tools\n\ngo 1.17" > go.mod && \
 		gradle --console=plain build
 
 build_nodejs: VERSION := $(shell pulumictl get version --language javascript)
-build_nodejs:
+build_nodejs: upstream
 	$(WORKING_DIR)/bin/$(TFGEN) nodejs --out sdk/nodejs/
 	cd sdk/nodejs/ && \
 		echo "module fake_nodejs_module // Exclude this directory from Go tools\n\ngo 1.17" > go.mod && \
@@ -60,7 +60,7 @@ build_nodejs:
 		sed -i.bak -e "s/\$${VERSION}/$(VERSION)/g" ./bin/package.json
 
 build_python: PYPI_VERSION := $(shell pulumictl get version --language python)
-build_python:
+build_python: upstream
 	$(WORKING_DIR)/bin/$(TFGEN) python --out sdk/python/
 	cd sdk/python/ && \
 		echo "module fake_python_module // Exclude this directory from Go tools\n\ngo 1.17" > go.mod && \
@@ -77,6 +77,11 @@ clean:
 cleanup:
 	rm -r $(WORKING_DIR)/bin
 	rm -f provider/cmd/$(PROVIDER)/schema.go
+
+finish-patch:
+	@if [ ! -z "$$(cd upstream && git status --porcelain)" ]; then echo "Please commit your changes before finishing the patch"; exit 1; fi
+	@cd upstream && \
+		git format-patch HEAD~ -o ../patches --start-number $$(($$(ls ../patches | wc -l | xargs)+1))
 
 help:
 	@grep '^[^.#]\+:\s\+.*#' Makefile | \
@@ -100,15 +105,52 @@ lint_provider: provider
 provider: tfgen install_plugins
 	(cd provider && go build -p 1 -o $(WORKING_DIR)/bin/$(PROVIDER) -ldflags "-X $(PROJECT)/$(VERSION_PATH)=$(VERSION)" $(PROJECT)/$(PROVIDER_PATH)/cmd/$(PROVIDER))
 
+start-patch: upstream
+ifeq ("$(wildcard upstream)","")
+	@echo "No upstream found, so upstream can't be patched"
+	@exit 1
+else
+	# To add an additional patch:
+	#
+	#	1. Run this command (`make start-patch`).
+	#
+	#	2. Edit the `upstream` repo, making whatever changes you want to appear in the new
+	#	patch. It's fine to edit multiple files.
+	#
+	#	3. Commit your changes. The slugified first line of your commit description will
+	#	be used to generate the patch file name. Only the diff from the latest commit will
+	#	end up in the final patch.
+	#
+	#	4. Run `make finish-patch`.
+	#
+	# It is safe to run `make start-patch` as many times as you want, but any changes
+	# might be reverted until `make finish-patch` is run.
+	@cd upstream && git commit --quiet -m "existing patches"
+endif
+
 test:
 	cd examples && go test -v -tags=all -parallel $(TESTPARALLELISM) -timeout 2h
 
-tfgen: install_plugins
+tfgen: install_plugins upstream
 	(cd provider && go build -p 1 -o $(WORKING_DIR)/bin/$(TFGEN) -ldflags "-X $(PROJECT)/$(VERSION_PATH)=$(VERSION)" $(PROJECT)/$(PROVIDER_PATH)/cmd/$(TFGEN))
 	$(WORKING_DIR)/bin/$(TFGEN) schema --out provider/cmd/$(PROVIDER)
 	(cd provider && VERSION=$(VERSION) go generate cmd/$(PROVIDER)/main.go)
 
+upstream:
+ifeq ("$(wildcard upstream)","")
+	# upstream doesn't exist, so skip
+else ifeq ("$(wildcard patches/*.patch)","")
+	# upstream exists, but patches don't exist. This is probably an error.
+	@echo "No patches found within the patch operation"
+	@echo "patches were expected because upstream exists"
+	@exit 1
+else
+	git submodule update --force --init
+	cd upstream && \
+		for patch in $(sort $(wildcard patches/*.patch)); do git apply --3way ../$$patch || exit 1; done
+endif
+
 bin/pulumi-java-gen:
 	$(shell pulumictl download-binary -n pulumi-language-java -v $(JAVA_GEN_VERSION) -r pulumi/pulumi-java)
 
-.PHONY: development build build_sdks install_go_sdk install_java_sdk install_python_sdk install_sdks only_build build_dotnet build_go build_java build_nodejs build_python clean cleanup help install_dotnet_sdk install_nodejs_sdk install_plugins lint_provider provider test tfgen
+.PHONY: development build build_sdks install_go_sdk install_java_sdk install_python_sdk install_sdks only_build build_dotnet build_go build_java build_nodejs build_python clean cleanup finish-patch help install_dotnet_sdk install_nodejs_sdk install_plugins lint_provider provider start-patch test tfgen upstream

--- a/provider-ci/providers/signalfx/repo/Makefile
+++ b/provider-ci/providers/signalfx/repo/Makefile
@@ -145,7 +145,12 @@ else ifeq ("$(wildcard patches/*.patch)","")
 	@echo "patches were expected because upstream exists"
 	@exit 1
 else
+	# Checkout the submodule at the pinned commit.
+	# `--force`: If the submodule is at a different commit, move it to the pinned commit.
+	# `--init`: If the submodule is not initialized, initialize it.
 	git submodule update --force --init
+	# Iterating over the patches folder in sorted order,
+	# apply the patch using a 3-way merge strategy. This mirrors the default behavior of `git merge`
 	cd upstream && \
 		for patch in $(sort $(wildcard patches/*.patch)); do git apply --3way ../$$patch || exit 1; done
 endif

--- a/provider-ci/providers/slack/repo/Makefile
+++ b/provider-ci/providers/slack/repo/Makefile
@@ -30,7 +30,7 @@ install_sdks: install_dotnet_sdk install_python_sdk install_nodejs_sdk install_j
 only_build: build
 
 build_dotnet: DOTNET_VERSION := $(shell pulumictl get version --language dotnet)
-build_dotnet:
+build_dotnet: upstream
 	pulumictl get version --language dotnet
 	$(WORKING_DIR)/bin/$(TFGEN) dotnet --out sdk/dotnet/
 	cd sdk/dotnet/ && \
@@ -38,19 +38,19 @@ build_dotnet:
 		echo "$(DOTNET_VERSION)" >version.txt && \
 		dotnet build /p:Version=$(DOTNET_VERSION)
 
-build_go:
+build_go: upstream
 	$(WORKING_DIR)/bin/$(TFGEN) go --out sdk/go/
 	cd sdk && go list `grep -e "^module" go.mod | cut -d ' ' -f 2`/go/... | xargs go build
 
 build_java: PACKAGE_VERSION := $(shell pulumictl get version --language generic)
-build_java: bin/pulumi-java-gen
+build_java: bin/pulumi-java-gen upstream
 	$(WORKING_DIR)/bin/$(JAVA_GEN) generate --schema provider/cmd/$(PROVIDER)/schema.json --out sdk/java  --build gradle-nexus
 	cd sdk/java/ && \
 		echo "module fake_java_module // Exclude this directory from Go tools\n\ngo 1.17" > go.mod && \
 		gradle --console=plain build
 
 build_nodejs: VERSION := $(shell pulumictl get version --language javascript)
-build_nodejs:
+build_nodejs: upstream
 	$(WORKING_DIR)/bin/$(TFGEN) nodejs --out sdk/nodejs/
 	cd sdk/nodejs/ && \
 		echo "module fake_nodejs_module // Exclude this directory from Go tools\n\ngo 1.17" > go.mod && \
@@ -60,7 +60,7 @@ build_nodejs:
 		sed -i.bak -e "s/\$${VERSION}/$(VERSION)/g" ./bin/package.json
 
 build_python: PYPI_VERSION := $(shell pulumictl get version --language python)
-build_python:
+build_python: upstream
 	$(WORKING_DIR)/bin/$(TFGEN) python --out sdk/python/
 	cd sdk/python/ && \
 		echo "module fake_python_module // Exclude this directory from Go tools\n\ngo 1.17" > go.mod && \
@@ -77,6 +77,11 @@ clean:
 cleanup:
 	rm -r $(WORKING_DIR)/bin
 	rm -f provider/cmd/$(PROVIDER)/schema.go
+
+finish-patch:
+	@if [ ! -z "$$(cd upstream && git status --porcelain)" ]; then echo "Please commit your changes before finishing the patch"; exit 1; fi
+	@cd upstream && \
+		git format-patch HEAD~ -o ../patches --start-number $$(($$(ls ../patches | wc -l | xargs)+1))
 
 help:
 	@grep '^[^.#]\+:\s\+.*#' Makefile | \
@@ -100,15 +105,52 @@ lint_provider: provider
 provider: tfgen install_plugins
 	(cd provider && go build -p 1 -o $(WORKING_DIR)/bin/$(PROVIDER) -ldflags "-X $(PROJECT)/$(VERSION_PATH)=$(VERSION)" $(PROJECT)/$(PROVIDER_PATH)/cmd/$(PROVIDER))
 
+start-patch: upstream
+ifeq ("$(wildcard upstream)","")
+	@echo "No upstream found, so upstream can't be patched"
+	@exit 1
+else
+	# To add an additional patch:
+	#
+	#	1. Run this command (`make start-patch`).
+	#
+	#	2. Edit the `upstream` repo, making whatever changes you want to appear in the new
+	#	patch. It's fine to edit multiple files.
+	#
+	#	3. Commit your changes. The slugified first line of your commit description will
+	#	be used to generate the patch file name. Only the diff from the latest commit will
+	#	end up in the final patch.
+	#
+	#	4. Run `make finish-patch`.
+	#
+	# It is safe to run `make start-patch` as many times as you want, but any changes
+	# might be reverted until `make finish-patch` is run.
+	@cd upstream && git commit --quiet -m "existing patches"
+endif
+
 test:
 	cd examples && go test -v -tags=all -parallel $(TESTPARALLELISM) -timeout 2h
 
-tfgen: install_plugins
+tfgen: install_plugins upstream
 	(cd provider && go build -p 1 -o $(WORKING_DIR)/bin/$(TFGEN) -ldflags "-X $(PROJECT)/$(VERSION_PATH)=$(VERSION)" $(PROJECT)/$(PROVIDER_PATH)/cmd/$(TFGEN))
 	$(WORKING_DIR)/bin/$(TFGEN) schema --out provider/cmd/$(PROVIDER)
 	(cd provider && VERSION=$(VERSION) go generate cmd/$(PROVIDER)/main.go)
 
+upstream:
+ifeq ("$(wildcard upstream)","")
+	# upstream doesn't exist, so skip
+else ifeq ("$(wildcard patches/*.patch)","")
+	# upstream exists, but patches don't exist. This is probably an error.
+	@echo "No patches found within the patch operation"
+	@echo "patches were expected because upstream exists"
+	@exit 1
+else
+	git submodule update --force --init
+	cd upstream && \
+		for patch in $(sort $(wildcard patches/*.patch)); do git apply --3way ../$$patch || exit 1; done
+endif
+
 bin/pulumi-java-gen:
 	$(shell pulumictl download-binary -n pulumi-language-java -v $(JAVA_GEN_VERSION) -r pulumi/pulumi-java)
 
-.PHONY: development build build_sdks install_go_sdk install_java_sdk install_python_sdk install_sdks only_build build_dotnet build_go build_java build_nodejs build_python clean cleanup help install_dotnet_sdk install_nodejs_sdk install_plugins lint_provider provider test tfgen
+.PHONY: development build build_sdks install_go_sdk install_java_sdk install_python_sdk install_sdks only_build build_dotnet build_go build_java build_nodejs build_python clean cleanup finish-patch help install_dotnet_sdk install_nodejs_sdk install_plugins lint_provider provider start-patch test tfgen upstream

--- a/provider-ci/providers/slack/repo/Makefile
+++ b/provider-ci/providers/slack/repo/Makefile
@@ -145,7 +145,12 @@ else ifeq ("$(wildcard patches/*.patch)","")
 	@echo "patches were expected because upstream exists"
 	@exit 1
 else
+	# Checkout the submodule at the pinned commit.
+	# `--force`: If the submodule is at a different commit, move it to the pinned commit.
+	# `--init`: If the submodule is not initialized, initialize it.
 	git submodule update --force --init
+	# Iterating over the patches folder in sorted order,
+	# apply the patch using a 3-way merge strategy. This mirrors the default behavior of `git merge`
 	cd upstream && \
 		for patch in $(sort $(wildcard patches/*.patch)); do git apply --3way ../$$patch || exit 1; done
 endif

--- a/provider-ci/providers/snowflake/repo/Makefile
+++ b/provider-ci/providers/snowflake/repo/Makefile
@@ -148,7 +148,12 @@ else ifeq ("$(wildcard patches/*.patch)","")
 	@echo "patches were expected because upstream exists"
 	@exit 1
 else
+	# Checkout the submodule at the pinned commit.
+	# `--force`: If the submodule is at a different commit, move it to the pinned commit.
+	# `--init`: If the submodule is not initialized, initialize it.
 	git submodule update --force --init
+	# Iterating over the patches folder in sorted order,
+	# apply the patch using a 3-way merge strategy. This mirrors the default behavior of `git merge`
 	cd upstream && \
 		for patch in $(sort $(wildcard patches/*.patch)); do git apply --3way ../$$patch || exit 1; done
 endif

--- a/provider-ci/providers/snowflake/repo/Makefile
+++ b/provider-ci/providers/snowflake/repo/Makefile
@@ -30,7 +30,7 @@ install_sdks: install_dotnet_sdk install_python_sdk install_nodejs_sdk install_j
 only_build: build
 
 build_dotnet: DOTNET_VERSION := $(shell pulumictl get version --language dotnet)
-build_dotnet:
+build_dotnet: upstream
 	pulumictl get version --language dotnet
 	$(WORKING_DIR)/bin/$(TFGEN) dotnet --out sdk/dotnet/
 	cd sdk/dotnet/ && \
@@ -38,19 +38,19 @@ build_dotnet:
 		echo "$(DOTNET_VERSION)" >version.txt && \
 		dotnet build /p:Version=$(DOTNET_VERSION)
 
-build_go:
+build_go: upstream
 	$(WORKING_DIR)/bin/$(TFGEN) go --out sdk/go/
 	cd sdk && go list `grep -e "^module" go.mod | cut -d ' ' -f 2`/go/... | xargs go build
 
 build_java: PACKAGE_VERSION := $(shell pulumictl get version --language generic)
-build_java: bin/pulumi-java-gen
+build_java: bin/pulumi-java-gen upstream
 	$(WORKING_DIR)/bin/$(JAVA_GEN) generate --schema provider/cmd/$(PROVIDER)/schema.json --out sdk/java  --build gradle-nexus
 	cd sdk/java/ && \
 		echo "module fake_java_module // Exclude this directory from Go tools\n\ngo 1.17" > go.mod && \
 		gradle --console=plain build
 
 build_nodejs: VERSION := $(shell pulumictl get version --language javascript)
-build_nodejs:
+build_nodejs: upstream
 	$(WORKING_DIR)/bin/$(TFGEN) nodejs --out sdk/nodejs/
 	cd sdk/nodejs/ && \
 		echo "module fake_nodejs_module // Exclude this directory from Go tools\n\ngo 1.17" > go.mod && \
@@ -60,7 +60,7 @@ build_nodejs:
 		sed -i.bak -e "s/\$${VERSION}/$(VERSION)/g" ./bin/package.json
 
 build_python: PYPI_VERSION := $(shell pulumictl get version --language python)
-build_python:
+build_python: upstream
 	$(WORKING_DIR)/bin/$(TFGEN) python --out sdk/python/
 	cd sdk/python/ && \
 		echo "module fake_python_module // Exclude this directory from Go tools\n\ngo 1.17" > go.mod && \
@@ -77,6 +77,11 @@ clean:
 cleanup:
 	rm -r $(WORKING_DIR)/bin
 	rm -f provider/cmd/$(PROVIDER)/schema.go
+
+finish-patch:
+	@if [ ! -z "$$(cd upstream && git status --porcelain)" ]; then echo "Please commit your changes before finishing the patch"; exit 1; fi
+	@cd upstream && \
+		git format-patch HEAD~ -o ../patches --start-number $$(($$(ls ../patches | wc -l | xargs)+1))
 
 help:
 	@grep '^[^.#]\+:\s\+.*#' Makefile | \
@@ -103,15 +108,52 @@ lint_provider: provider
 provider: tfgen install_plugins
 	(cd provider && go build -p 1 -o $(WORKING_DIR)/bin/$(PROVIDER) -ldflags "-X $(PROJECT)/$(VERSION_PATH)=$(VERSION)" $(PROJECT)/$(PROVIDER_PATH)/cmd/$(PROVIDER))
 
+start-patch: upstream
+ifeq ("$(wildcard upstream)","")
+	@echo "No upstream found, so upstream can't be patched"
+	@exit 1
+else
+	# To add an additional patch:
+	#
+	#	1. Run this command (`make start-patch`).
+	#
+	#	2. Edit the `upstream` repo, making whatever changes you want to appear in the new
+	#	patch. It's fine to edit multiple files.
+	#
+	#	3. Commit your changes. The slugified first line of your commit description will
+	#	be used to generate the patch file name. Only the diff from the latest commit will
+	#	end up in the final patch.
+	#
+	#	4. Run `make finish-patch`.
+	#
+	# It is safe to run `make start-patch` as many times as you want, but any changes
+	# might be reverted until `make finish-patch` is run.
+	@cd upstream && git commit --quiet -m "existing patches"
+endif
+
 test:
 	cd examples && go test -v -tags=all -parallel $(TESTPARALLELISM) -timeout 2h
 
-tfgen: install_plugins
+tfgen: install_plugins upstream
 	(cd provider && go build -p 1 -o $(WORKING_DIR)/bin/$(TFGEN) -ldflags "-X $(PROJECT)/$(VERSION_PATH)=$(VERSION)" $(PROJECT)/$(PROVIDER_PATH)/cmd/$(TFGEN))
 	$(WORKING_DIR)/bin/$(TFGEN) schema --out provider/cmd/$(PROVIDER)
 	(cd provider && VERSION=$(VERSION) go generate cmd/$(PROVIDER)/main.go)
 
+upstream:
+ifeq ("$(wildcard upstream)","")
+	# upstream doesn't exist, so skip
+else ifeq ("$(wildcard patches/*.patch)","")
+	# upstream exists, but patches don't exist. This is probably an error.
+	@echo "No patches found within the patch operation"
+	@echo "patches were expected because upstream exists"
+	@exit 1
+else
+	git submodule update --force --init
+	cd upstream && \
+		for patch in $(sort $(wildcard patches/*.patch)); do git apply --3way ../$$patch || exit 1; done
+endif
+
 bin/pulumi-java-gen:
 	$(shell pulumictl download-binary -n pulumi-language-java -v $(JAVA_GEN_VERSION) -r pulumi/pulumi-java)
 
-.PHONY: development build build_sdks install_go_sdk install_java_sdk install_python_sdk install_sdks only_build build_dotnet build_go build_java build_nodejs build_python clean cleanup help install_dotnet_sdk install_nodejs_sdk install_plugins lint_provider provider test tfgen
+.PHONY: development build build_sdks install_go_sdk install_java_sdk install_python_sdk install_sdks only_build build_dotnet build_go build_java build_nodejs build_python clean cleanup finish-patch help install_dotnet_sdk install_nodejs_sdk install_plugins lint_provider provider start-patch test tfgen upstream

--- a/provider-ci/providers/splunk/repo/Makefile
+++ b/provider-ci/providers/splunk/repo/Makefile
@@ -144,7 +144,12 @@ else ifeq ("$(wildcard patches/*.patch)","")
 	@echo "patches were expected because upstream exists"
 	@exit 1
 else
+	# Checkout the submodule at the pinned commit.
+	# `--force`: If the submodule is at a different commit, move it to the pinned commit.
+	# `--init`: If the submodule is not initialized, initialize it.
 	git submodule update --force --init
+	# Iterating over the patches folder in sorted order,
+	# apply the patch using a 3-way merge strategy. This mirrors the default behavior of `git merge`
 	cd upstream && \
 		for patch in $(sort $(wildcard patches/*.patch)); do git apply --3way ../$$patch || exit 1; done
 endif

--- a/provider-ci/providers/splunk/repo/Makefile
+++ b/provider-ci/providers/splunk/repo/Makefile
@@ -30,7 +30,7 @@ install_sdks: install_dotnet_sdk install_python_sdk install_nodejs_sdk install_j
 only_build: build
 
 build_dotnet: DOTNET_VERSION := $(shell pulumictl get version --language dotnet)
-build_dotnet:
+build_dotnet: upstream
 	pulumictl get version --language dotnet
 	$(WORKING_DIR)/bin/$(TFGEN) dotnet --out sdk/dotnet/
 	cd sdk/dotnet/ && \
@@ -38,19 +38,19 @@ build_dotnet:
 		echo "$(DOTNET_VERSION)" >version.txt && \
 		dotnet build /p:Version=$(DOTNET_VERSION)
 
-build_go:
+build_go: upstream
 	$(WORKING_DIR)/bin/$(TFGEN) go --out sdk/go/
 	cd sdk && go list `grep -e "^module" go.mod | cut -d ' ' -f 2`/go/... | xargs go build
 
 build_java: PACKAGE_VERSION := $(shell pulumictl get version --language generic)
-build_java: bin/pulumi-java-gen
+build_java: bin/pulumi-java-gen upstream
 	$(WORKING_DIR)/bin/$(JAVA_GEN) generate --schema provider/cmd/$(PROVIDER)/schema.json --out sdk/java  --build gradle-nexus
 	cd sdk/java/ && \
 		echo "module fake_java_module // Exclude this directory from Go tools\n\ngo 1.17" > go.mod && \
 		gradle --console=plain build
 
 build_nodejs: VERSION := $(shell pulumictl get version --language javascript)
-build_nodejs:
+build_nodejs: upstream
 	$(WORKING_DIR)/bin/$(TFGEN) nodejs --out sdk/nodejs/
 	cd sdk/nodejs/ && \
 		echo "module fake_nodejs_module // Exclude this directory from Go tools\n\ngo 1.17" > go.mod && \
@@ -60,7 +60,7 @@ build_nodejs:
 		sed -i.bak -e "s/\$${VERSION}/$(VERSION)/g" ./bin/package.json
 
 build_python: PYPI_VERSION := $(shell pulumictl get version --language python)
-build_python:
+build_python: upstream
 	$(WORKING_DIR)/bin/$(TFGEN) python --out sdk/python/
 	cd sdk/python/ && \
 		echo "module fake_python_module // Exclude this directory from Go tools\n\ngo 1.17" > go.mod && \
@@ -77,6 +77,11 @@ clean:
 cleanup:
 	rm -r $(WORKING_DIR)/bin
 	rm -f provider/cmd/$(PROVIDER)/schema.go
+
+finish-patch:
+	@if [ ! -z "$$(cd upstream && git status --porcelain)" ]; then echo "Please commit your changes before finishing the patch"; exit 1; fi
+	@cd upstream && \
+		git format-patch HEAD~ -o ../patches --start-number $$(($$(ls ../patches | wc -l | xargs)+1))
 
 help:
 	@grep '^[^.#]\+:\s\+.*#' Makefile | \
@@ -99,15 +104,52 @@ lint_provider: provider
 provider: tfgen install_plugins
 	(cd provider && go build -p 1 -o $(WORKING_DIR)/bin/$(PROVIDER) -ldflags "-X $(PROJECT)/$(VERSION_PATH)=$(VERSION)" $(PROJECT)/$(PROVIDER_PATH)/cmd/$(PROVIDER))
 
+start-patch: upstream
+ifeq ("$(wildcard upstream)","")
+	@echo "No upstream found, so upstream can't be patched"
+	@exit 1
+else
+	# To add an additional patch:
+	#
+	#	1. Run this command (`make start-patch`).
+	#
+	#	2. Edit the `upstream` repo, making whatever changes you want to appear in the new
+	#	patch. It's fine to edit multiple files.
+	#
+	#	3. Commit your changes. The slugified first line of your commit description will
+	#	be used to generate the patch file name. Only the diff from the latest commit will
+	#	end up in the final patch.
+	#
+	#	4. Run `make finish-patch`.
+	#
+	# It is safe to run `make start-patch` as many times as you want, but any changes
+	# might be reverted until `make finish-patch` is run.
+	@cd upstream && git commit --quiet -m "existing patches"
+endif
+
 test:
 	cd examples && go test -v -tags=all -parallel $(TESTPARALLELISM) -timeout 2h
 
-tfgen: install_plugins
+tfgen: install_plugins upstream
 	(cd provider && go build -p 1 -o $(WORKING_DIR)/bin/$(TFGEN) -ldflags "-X $(PROJECT)/$(VERSION_PATH)=$(VERSION)" $(PROJECT)/$(PROVIDER_PATH)/cmd/$(TFGEN))
 	$(WORKING_DIR)/bin/$(TFGEN) schema --out provider/cmd/$(PROVIDER)
 	(cd provider && VERSION=$(VERSION) go generate cmd/$(PROVIDER)/main.go)
 
+upstream:
+ifeq ("$(wildcard upstream)","")
+	# upstream doesn't exist, so skip
+else ifeq ("$(wildcard patches/*.patch)","")
+	# upstream exists, but patches don't exist. This is probably an error.
+	@echo "No patches found within the patch operation"
+	@echo "patches were expected because upstream exists"
+	@exit 1
+else
+	git submodule update --force --init
+	cd upstream && \
+		for patch in $(sort $(wildcard patches/*.patch)); do git apply --3way ../$$patch || exit 1; done
+endif
+
 bin/pulumi-java-gen:
 	$(shell pulumictl download-binary -n pulumi-language-java -v $(JAVA_GEN_VERSION) -r pulumi/pulumi-java)
 
-.PHONY: development build build_sdks install_go_sdk install_java_sdk install_python_sdk install_sdks only_build build_dotnet build_go build_java build_nodejs build_python clean cleanup help install_dotnet_sdk install_nodejs_sdk install_plugins lint_provider provider test tfgen
+.PHONY: development build build_sdks install_go_sdk install_java_sdk install_python_sdk install_sdks only_build build_dotnet build_go build_java build_nodejs build_python clean cleanup finish-patch help install_dotnet_sdk install_nodejs_sdk install_plugins lint_provider provider start-patch test tfgen upstream

--- a/provider-ci/providers/spotinst/repo/Makefile
+++ b/provider-ci/providers/spotinst/repo/Makefile
@@ -30,7 +30,7 @@ install_sdks: install_dotnet_sdk install_python_sdk install_nodejs_sdk install_j
 only_build: build
 
 build_dotnet: DOTNET_VERSION := $(shell pulumictl get version --language dotnet)
-build_dotnet:
+build_dotnet: upstream
 	pulumictl get version --language dotnet
 	$(WORKING_DIR)/bin/$(TFGEN) dotnet --out sdk/dotnet/
 	cd sdk/dotnet/ && \
@@ -38,19 +38,19 @@ build_dotnet:
 		echo "$(DOTNET_VERSION)" >version.txt && \
 		dotnet build /p:Version=$(DOTNET_VERSION)
 
-build_go:
+build_go: upstream
 	$(WORKING_DIR)/bin/$(TFGEN) go --out sdk/go/
 	cd sdk && go list `grep -e "^module" go.mod | cut -d ' ' -f 2`/go/... | xargs go build
 
 build_java: PACKAGE_VERSION := $(shell pulumictl get version --language generic)
-build_java: bin/pulumi-java-gen
+build_java: bin/pulumi-java-gen upstream
 	$(WORKING_DIR)/bin/$(JAVA_GEN) generate --schema provider/cmd/$(PROVIDER)/schema.json --out sdk/java  --build gradle-nexus
 	cd sdk/java/ && \
 		echo "module fake_java_module // Exclude this directory from Go tools\n\ngo 1.17" > go.mod && \
 		gradle --console=plain build
 
 build_nodejs: VERSION := $(shell pulumictl get version --language javascript)
-build_nodejs:
+build_nodejs: upstream
 	$(WORKING_DIR)/bin/$(TFGEN) nodejs --out sdk/nodejs/
 	cd sdk/nodejs/ && \
 		echo "module fake_nodejs_module // Exclude this directory from Go tools\n\ngo 1.17" > go.mod && \
@@ -60,7 +60,7 @@ build_nodejs:
 		sed -i.bak -e "s/\$${VERSION}/$(VERSION)/g" ./bin/package.json
 
 build_python: PYPI_VERSION := $(shell pulumictl get version --language python)
-build_python:
+build_python: upstream
 	$(WORKING_DIR)/bin/$(TFGEN) python --out sdk/python/
 	cd sdk/python/ && \
 		echo "module fake_python_module // Exclude this directory from Go tools\n\ngo 1.17" > go.mod && \
@@ -77,6 +77,11 @@ clean:
 cleanup:
 	rm -r $(WORKING_DIR)/bin
 	rm -f provider/cmd/$(PROVIDER)/schema.go
+
+finish-patch:
+	@if [ ! -z "$$(cd upstream && git status --porcelain)" ]; then echo "Please commit your changes before finishing the patch"; exit 1; fi
+	@cd upstream && \
+		git format-patch HEAD~ -o ../patches --start-number $$(($$(ls ../patches | wc -l | xargs)+1))
 
 help:
 	@grep '^[^.#]\+:\s\+.*#' Makefile | \
@@ -102,15 +107,52 @@ lint_provider: provider
 provider: tfgen install_plugins
 	(cd provider && go build -p 1 -o $(WORKING_DIR)/bin/$(PROVIDER) -ldflags "-X $(PROJECT)/$(VERSION_PATH)=$(VERSION)" $(PROJECT)/$(PROVIDER_PATH)/cmd/$(PROVIDER))
 
+start-patch: upstream
+ifeq ("$(wildcard upstream)","")
+	@echo "No upstream found, so upstream can't be patched"
+	@exit 1
+else
+	# To add an additional patch:
+	#
+	#	1. Run this command (`make start-patch`).
+	#
+	#	2. Edit the `upstream` repo, making whatever changes you want to appear in the new
+	#	patch. It's fine to edit multiple files.
+	#
+	#	3. Commit your changes. The slugified first line of your commit description will
+	#	be used to generate the patch file name. Only the diff from the latest commit will
+	#	end up in the final patch.
+	#
+	#	4. Run `make finish-patch`.
+	#
+	# It is safe to run `make start-patch` as many times as you want, but any changes
+	# might be reverted until `make finish-patch` is run.
+	@cd upstream && git commit --quiet -m "existing patches"
+endif
+
 test:
 	cd examples && go test -v -tags=all -parallel $(TESTPARALLELISM) -timeout 2h
 
-tfgen: install_plugins
+tfgen: install_plugins upstream
 	(cd provider && go build -p 1 -o $(WORKING_DIR)/bin/$(TFGEN) -ldflags "-X $(PROJECT)/$(VERSION_PATH)=$(VERSION)" $(PROJECT)/$(PROVIDER_PATH)/cmd/$(TFGEN))
 	$(WORKING_DIR)/bin/$(TFGEN) schema --out provider/cmd/$(PROVIDER)
 	(cd provider && VERSION=$(VERSION) go generate cmd/$(PROVIDER)/main.go)
 
+upstream:
+ifeq ("$(wildcard upstream)","")
+	# upstream doesn't exist, so skip
+else ifeq ("$(wildcard patches/*.patch)","")
+	# upstream exists, but patches don't exist. This is probably an error.
+	@echo "No patches found within the patch operation"
+	@echo "patches were expected because upstream exists"
+	@exit 1
+else
+	git submodule update --force --init
+	cd upstream && \
+		for patch in $(sort $(wildcard patches/*.patch)); do git apply --3way ../$$patch || exit 1; done
+endif
+
 bin/pulumi-java-gen:
 	$(shell pulumictl download-binary -n pulumi-language-java -v $(JAVA_GEN_VERSION) -r pulumi/pulumi-java)
 
-.PHONY: development build build_sdks install_go_sdk install_java_sdk install_python_sdk install_sdks only_build build_dotnet build_go build_java build_nodejs build_python clean cleanup help install_dotnet_sdk install_nodejs_sdk install_plugins lint_provider provider test tfgen
+.PHONY: development build build_sdks install_go_sdk install_java_sdk install_python_sdk install_sdks only_build build_dotnet build_go build_java build_nodejs build_python clean cleanup finish-patch help install_dotnet_sdk install_nodejs_sdk install_plugins lint_provider provider start-patch test tfgen upstream

--- a/provider-ci/providers/spotinst/repo/Makefile
+++ b/provider-ci/providers/spotinst/repo/Makefile
@@ -147,7 +147,12 @@ else ifeq ("$(wildcard patches/*.patch)","")
 	@echo "patches were expected because upstream exists"
 	@exit 1
 else
+	# Checkout the submodule at the pinned commit.
+	# `--force`: If the submodule is at a different commit, move it to the pinned commit.
+	# `--init`: If the submodule is not initialized, initialize it.
 	git submodule update --force --init
+	# Iterating over the patches folder in sorted order,
+	# apply the patch using a 3-way merge strategy. This mirrors the default behavior of `git merge`
 	cd upstream && \
 		for patch in $(sort $(wildcard patches/*.patch)); do git apply --3way ../$$patch || exit 1; done
 endif

--- a/provider-ci/providers/sumologic/repo/Makefile
+++ b/provider-ci/providers/sumologic/repo/Makefile
@@ -146,7 +146,12 @@ else ifeq ("$(wildcard patches/*.patch)","")
 	@echo "patches were expected because upstream exists"
 	@exit 1
 else
+	# Checkout the submodule at the pinned commit.
+	# `--force`: If the submodule is at a different commit, move it to the pinned commit.
+	# `--init`: If the submodule is not initialized, initialize it.
 	git submodule update --force --init
+	# Iterating over the patches folder in sorted order,
+	# apply the patch using a 3-way merge strategy. This mirrors the default behavior of `git merge`
 	cd upstream && \
 		for patch in $(sort $(wildcard patches/*.patch)); do git apply --3way ../$$patch || exit 1; done
 endif

--- a/provider-ci/providers/sumologic/repo/Makefile
+++ b/provider-ci/providers/sumologic/repo/Makefile
@@ -30,7 +30,7 @@ install_sdks: install_dotnet_sdk install_python_sdk install_nodejs_sdk install_j
 only_build: build
 
 build_dotnet: DOTNET_VERSION := $(shell pulumictl get version --language dotnet)
-build_dotnet:
+build_dotnet: upstream
 	pulumictl get version --language dotnet
 	$(WORKING_DIR)/bin/$(TFGEN) dotnet --out sdk/dotnet/
 	cd sdk/dotnet/ && \
@@ -38,19 +38,19 @@ build_dotnet:
 		echo "$(DOTNET_VERSION)" >version.txt && \
 		dotnet build /p:Version=$(DOTNET_VERSION)
 
-build_go:
+build_go: upstream
 	$(WORKING_DIR)/bin/$(TFGEN) go --out sdk/go/
 	cd sdk && go list `grep -e "^module" go.mod | cut -d ' ' -f 2`/go/... | xargs go build
 
 build_java: PACKAGE_VERSION := $(shell pulumictl get version --language generic)
-build_java: bin/pulumi-java-gen
+build_java: bin/pulumi-java-gen upstream
 	$(WORKING_DIR)/bin/$(JAVA_GEN) generate --schema provider/cmd/$(PROVIDER)/schema.json --out sdk/java  --build gradle-nexus
 	cd sdk/java/ && \
 		echo "module fake_java_module // Exclude this directory from Go tools\n\ngo 1.17" > go.mod && \
 		gradle --console=plain build
 
 build_nodejs: VERSION := $(shell pulumictl get version --language javascript)
-build_nodejs:
+build_nodejs: upstream
 	$(WORKING_DIR)/bin/$(TFGEN) nodejs --out sdk/nodejs/
 	cd sdk/nodejs/ && \
 		echo "module fake_nodejs_module // Exclude this directory from Go tools\n\ngo 1.17" > go.mod && \
@@ -60,7 +60,7 @@ build_nodejs:
 		sed -i.bak -e "s/\$${VERSION}/$(VERSION)/g" ./bin/package.json
 
 build_python: PYPI_VERSION := $(shell pulumictl get version --language python)
-build_python:
+build_python: upstream
 	$(WORKING_DIR)/bin/$(TFGEN) python --out sdk/python/
 	cd sdk/python/ && \
 		echo "module fake_python_module // Exclude this directory from Go tools\n\ngo 1.17" > go.mod && \
@@ -77,6 +77,11 @@ clean:
 cleanup:
 	rm -r $(WORKING_DIR)/bin
 	rm -f provider/cmd/$(PROVIDER)/schema.go
+
+finish-patch:
+	@if [ ! -z "$$(cd upstream && git status --porcelain)" ]; then echo "Please commit your changes before finishing the patch"; exit 1; fi
+	@cd upstream && \
+		git format-patch HEAD~ -o ../patches --start-number $$(($$(ls ../patches | wc -l | xargs)+1))
 
 help:
 	@grep '^[^.#]\+:\s\+.*#' Makefile | \
@@ -101,15 +106,52 @@ lint_provider: provider
 provider: tfgen install_plugins
 	(cd provider && go build -p 1 -o $(WORKING_DIR)/bin/$(PROVIDER) -ldflags "-X $(PROJECT)/$(VERSION_PATH)=$(VERSION)" $(PROJECT)/$(PROVIDER_PATH)/cmd/$(PROVIDER))
 
+start-patch: upstream
+ifeq ("$(wildcard upstream)","")
+	@echo "No upstream found, so upstream can't be patched"
+	@exit 1
+else
+	# To add an additional patch:
+	#
+	#	1. Run this command (`make start-patch`).
+	#
+	#	2. Edit the `upstream` repo, making whatever changes you want to appear in the new
+	#	patch. It's fine to edit multiple files.
+	#
+	#	3. Commit your changes. The slugified first line of your commit description will
+	#	be used to generate the patch file name. Only the diff from the latest commit will
+	#	end up in the final patch.
+	#
+	#	4. Run `make finish-patch`.
+	#
+	# It is safe to run `make start-patch` as many times as you want, but any changes
+	# might be reverted until `make finish-patch` is run.
+	@cd upstream && git commit --quiet -m "existing patches"
+endif
+
 test:
 	cd examples && go test -v -tags=all -parallel $(TESTPARALLELISM) -timeout 2h
 
-tfgen: install_plugins
+tfgen: install_plugins upstream
 	(cd provider && go build -p 1 -o $(WORKING_DIR)/bin/$(TFGEN) -ldflags "-X $(PROJECT)/$(VERSION_PATH)=$(VERSION)" $(PROJECT)/$(PROVIDER_PATH)/cmd/$(TFGEN))
 	$(WORKING_DIR)/bin/$(TFGEN) schema --out provider/cmd/$(PROVIDER)
 	(cd provider && VERSION=$(VERSION) go generate cmd/$(PROVIDER)/main.go)
 
+upstream:
+ifeq ("$(wildcard upstream)","")
+	# upstream doesn't exist, so skip
+else ifeq ("$(wildcard patches/*.patch)","")
+	# upstream exists, but patches don't exist. This is probably an error.
+	@echo "No patches found within the patch operation"
+	@echo "patches were expected because upstream exists"
+	@exit 1
+else
+	git submodule update --force --init
+	cd upstream && \
+		for patch in $(sort $(wildcard patches/*.patch)); do git apply --3way ../$$patch || exit 1; done
+endif
+
 bin/pulumi-java-gen:
 	$(shell pulumictl download-binary -n pulumi-language-java -v $(JAVA_GEN_VERSION) -r pulumi/pulumi-java)
 
-.PHONY: development build build_sdks install_go_sdk install_java_sdk install_python_sdk install_sdks only_build build_dotnet build_go build_java build_nodejs build_python clean cleanup help install_dotnet_sdk install_nodejs_sdk install_plugins lint_provider provider test tfgen
+.PHONY: development build build_sdks install_go_sdk install_java_sdk install_python_sdk install_sdks only_build build_dotnet build_go build_java build_nodejs build_python clean cleanup finish-patch help install_dotnet_sdk install_nodejs_sdk install_plugins lint_provider provider start-patch test tfgen upstream

--- a/provider-ci/providers/tailscale/repo/Makefile
+++ b/provider-ci/providers/tailscale/repo/Makefile
@@ -30,7 +30,7 @@ install_sdks: install_dotnet_sdk install_python_sdk install_nodejs_sdk install_j
 only_build: build
 
 build_dotnet: DOTNET_VERSION := $(shell pulumictl get version --language dotnet)
-build_dotnet:
+build_dotnet: upstream
 	pulumictl get version --language dotnet
 	$(WORKING_DIR)/bin/$(TFGEN) dotnet --out sdk/dotnet/
 	cd sdk/dotnet/ && \
@@ -38,19 +38,19 @@ build_dotnet:
 		echo "$(DOTNET_VERSION)" >version.txt && \
 		dotnet build /p:Version=$(DOTNET_VERSION)
 
-build_go:
+build_go: upstream
 	$(WORKING_DIR)/bin/$(TFGEN) go --out sdk/go/
 	cd sdk && go list `grep -e "^module" go.mod | cut -d ' ' -f 2`/go/... | xargs go build
 
 build_java: PACKAGE_VERSION := $(shell pulumictl get version --language generic)
-build_java: bin/pulumi-java-gen
+build_java: bin/pulumi-java-gen upstream
 	$(WORKING_DIR)/bin/$(JAVA_GEN) generate --schema provider/cmd/$(PROVIDER)/schema.json --out sdk/java  --build gradle-nexus
 	cd sdk/java/ && \
 		echo "module fake_java_module // Exclude this directory from Go tools\n\ngo 1.17" > go.mod && \
 		gradle --console=plain build
 
 build_nodejs: VERSION := $(shell pulumictl get version --language javascript)
-build_nodejs:
+build_nodejs: upstream
 	$(WORKING_DIR)/bin/$(TFGEN) nodejs --out sdk/nodejs/
 	cd sdk/nodejs/ && \
 		echo "module fake_nodejs_module // Exclude this directory from Go tools\n\ngo 1.17" > go.mod && \
@@ -60,7 +60,7 @@ build_nodejs:
 		sed -i.bak -e "s/\$${VERSION}/$(VERSION)/g" ./bin/package.json
 
 build_python: PYPI_VERSION := $(shell pulumictl get version --language python)
-build_python:
+build_python: upstream
 	$(WORKING_DIR)/bin/$(TFGEN) python --out sdk/python/
 	cd sdk/python/ && \
 		echo "module fake_python_module // Exclude this directory from Go tools\n\ngo 1.17" > go.mod && \
@@ -77,6 +77,11 @@ clean:
 cleanup:
 	rm -r $(WORKING_DIR)/bin
 	rm -f provider/cmd/$(PROVIDER)/schema.go
+
+finish-patch:
+	@if [ ! -z "$$(cd upstream && git status --porcelain)" ]; then echo "Please commit your changes before finishing the patch"; exit 1; fi
+	@cd upstream && \
+		git format-patch HEAD~ -o ../patches --start-number $$(($$(ls ../patches | wc -l | xargs)+1))
 
 help:
 	@grep '^[^.#]\+:\s\+.*#' Makefile | \
@@ -100,15 +105,52 @@ lint_provider: provider
 provider: tfgen install_plugins
 	(cd provider && go build -p 1 -o $(WORKING_DIR)/bin/$(PROVIDER) -ldflags "-X $(PROJECT)/$(VERSION_PATH)=$(VERSION)" $(PROJECT)/$(PROVIDER_PATH)/cmd/$(PROVIDER))
 
+start-patch: upstream
+ifeq ("$(wildcard upstream)","")
+	@echo "No upstream found, so upstream can't be patched"
+	@exit 1
+else
+	# To add an additional patch:
+	#
+	#	1. Run this command (`make start-patch`).
+	#
+	#	2. Edit the `upstream` repo, making whatever changes you want to appear in the new
+	#	patch. It's fine to edit multiple files.
+	#
+	#	3. Commit your changes. The slugified first line of your commit description will
+	#	be used to generate the patch file name. Only the diff from the latest commit will
+	#	end up in the final patch.
+	#
+	#	4. Run `make finish-patch`.
+	#
+	# It is safe to run `make start-patch` as many times as you want, but any changes
+	# might be reverted until `make finish-patch` is run.
+	@cd upstream && git commit --quiet -m "existing patches"
+endif
+
 test:
 	cd examples && go test -v -tags=all -parallel $(TESTPARALLELISM) -timeout 2h
 
-tfgen: install_plugins
+tfgen: install_plugins upstream
 	(cd provider && go build -p 1 -o $(WORKING_DIR)/bin/$(TFGEN) -ldflags "-X $(PROJECT)/$(VERSION_PATH)=$(VERSION)" $(PROJECT)/$(PROVIDER_PATH)/cmd/$(TFGEN))
 	$(WORKING_DIR)/bin/$(TFGEN) schema --out provider/cmd/$(PROVIDER)
 	(cd provider && VERSION=$(VERSION) go generate cmd/$(PROVIDER)/main.go)
 
+upstream:
+ifeq ("$(wildcard upstream)","")
+	# upstream doesn't exist, so skip
+else ifeq ("$(wildcard patches/*.patch)","")
+	# upstream exists, but patches don't exist. This is probably an error.
+	@echo "No patches found within the patch operation"
+	@echo "patches were expected because upstream exists"
+	@exit 1
+else
+	git submodule update --force --init
+	cd upstream && \
+		for patch in $(sort $(wildcard patches/*.patch)); do git apply --3way ../$$patch || exit 1; done
+endif
+
 bin/pulumi-java-gen:
 	$(shell pulumictl download-binary -n pulumi-language-java -v $(JAVA_GEN_VERSION) -r pulumi/pulumi-java)
 
-.PHONY: development build build_sdks install_go_sdk install_java_sdk install_python_sdk install_sdks only_build build_dotnet build_go build_java build_nodejs build_python clean cleanup help install_dotnet_sdk install_nodejs_sdk install_plugins lint_provider provider test tfgen
+.PHONY: development build build_sdks install_go_sdk install_java_sdk install_python_sdk install_sdks only_build build_dotnet build_go build_java build_nodejs build_python clean cleanup finish-patch help install_dotnet_sdk install_nodejs_sdk install_plugins lint_provider provider start-patch test tfgen upstream

--- a/provider-ci/providers/tailscale/repo/Makefile
+++ b/provider-ci/providers/tailscale/repo/Makefile
@@ -145,7 +145,12 @@ else ifeq ("$(wildcard patches/*.patch)","")
 	@echo "patches were expected because upstream exists"
 	@exit 1
 else
+	# Checkout the submodule at the pinned commit.
+	# `--force`: If the submodule is at a different commit, move it to the pinned commit.
+	# `--init`: If the submodule is not initialized, initialize it.
 	git submodule update --force --init
+	# Iterating over the patches folder in sorted order,
+	# apply the patch using a 3-way merge strategy. This mirrors the default behavior of `git merge`
 	cd upstream && \
 		for patch in $(sort $(wildcard patches/*.patch)); do git apply --3way ../$$patch || exit 1; done
 endif

--- a/provider-ci/providers/tls/repo/Makefile
+++ b/provider-ci/providers/tls/repo/Makefile
@@ -30,7 +30,7 @@ install_sdks: install_dotnet_sdk install_python_sdk install_nodejs_sdk install_j
 only_build: build
 
 build_dotnet: DOTNET_VERSION := $(shell pulumictl get version --language dotnet)
-build_dotnet:
+build_dotnet: upstream
 	pulumictl get version --language dotnet
 	$(WORKING_DIR)/bin/$(TFGEN) dotnet --out sdk/dotnet/
 	cd sdk/dotnet/ && \
@@ -38,19 +38,19 @@ build_dotnet:
 		echo "$(DOTNET_VERSION)" >version.txt && \
 		dotnet build /p:Version=$(DOTNET_VERSION)
 
-build_go:
+build_go: upstream
 	$(WORKING_DIR)/bin/$(TFGEN) go --out sdk/go/
 	cd sdk && go list `grep -e "^module" go.mod | cut -d ' ' -f 2`/go/... | xargs go build
 
 build_java: PACKAGE_VERSION := $(shell pulumictl get version --language generic)
-build_java: bin/pulumi-java-gen
+build_java: bin/pulumi-java-gen upstream
 	$(WORKING_DIR)/bin/$(JAVA_GEN) generate --schema provider/cmd/$(PROVIDER)/schema.json --out sdk/java  --build gradle-nexus
 	cd sdk/java/ && \
 		echo "module fake_java_module // Exclude this directory from Go tools\n\ngo 1.17" > go.mod && \
 		gradle --console=plain build
 
 build_nodejs: VERSION := $(shell pulumictl get version --language javascript)
-build_nodejs:
+build_nodejs: upstream
 	$(WORKING_DIR)/bin/$(TFGEN) nodejs --out sdk/nodejs/
 	cd sdk/nodejs/ && \
 		echo "module fake_nodejs_module // Exclude this directory from Go tools\n\ngo 1.17" > go.mod && \
@@ -60,7 +60,7 @@ build_nodejs:
 		sed -i.bak -e "s/\$${VERSION}/$(VERSION)/g" ./bin/package.json
 
 build_python: PYPI_VERSION := $(shell pulumictl get version --language python)
-build_python:
+build_python: upstream
 	$(WORKING_DIR)/bin/$(TFGEN) python --out sdk/python/
 	cd sdk/python/ && \
 		echo "module fake_python_module // Exclude this directory from Go tools\n\ngo 1.17" > go.mod && \
@@ -77,6 +77,11 @@ clean:
 cleanup:
 	rm -r $(WORKING_DIR)/bin
 	rm -f provider/cmd/$(PROVIDER)/schema.go
+
+finish-patch:
+	@if [ ! -z "$$(cd upstream && git status --porcelain)" ]; then echo "Please commit your changes before finishing the patch"; exit 1; fi
+	@cd upstream && \
+		git format-patch HEAD~ -o ../patches --start-number $$(($$(ls ../patches | wc -l | xargs)+1))
 
 help:
 	@grep '^[^.#]\+:\s\+.*#' Makefile | \
@@ -100,15 +105,52 @@ lint_provider: provider
 provider: tfgen install_plugins
 	(cd provider && go build -p 1 -o $(WORKING_DIR)/bin/$(PROVIDER) -ldflags "-X $(PROJECT)/$(VERSION_PATH)=$(VERSION)" $(PROJECT)/$(PROVIDER_PATH)/cmd/$(PROVIDER))
 
+start-patch: upstream
+ifeq ("$(wildcard upstream)","")
+	@echo "No upstream found, so upstream can't be patched"
+	@exit 1
+else
+	# To add an additional patch:
+	#
+	#	1. Run this command (`make start-patch`).
+	#
+	#	2. Edit the `upstream` repo, making whatever changes you want to appear in the new
+	#	patch. It's fine to edit multiple files.
+	#
+	#	3. Commit your changes. The slugified first line of your commit description will
+	#	be used to generate the patch file name. Only the diff from the latest commit will
+	#	end up in the final patch.
+	#
+	#	4. Run `make finish-patch`.
+	#
+	# It is safe to run `make start-patch` as many times as you want, but any changes
+	# might be reverted until `make finish-patch` is run.
+	@cd upstream && git commit --quiet -m "existing patches"
+endif
+
 test:
 	cd examples && go test -v -tags=all -parallel $(TESTPARALLELISM) -timeout 2h
 
-tfgen: install_plugins
+tfgen: install_plugins upstream
 	(cd provider && go build -p 1 -o $(WORKING_DIR)/bin/$(TFGEN) -ldflags "-X $(PROJECT)/$(VERSION_PATH)=$(VERSION)" $(PROJECT)/$(PROVIDER_PATH)/cmd/$(TFGEN))
 	$(WORKING_DIR)/bin/$(TFGEN) schema --out provider/cmd/$(PROVIDER)
 	(cd provider && VERSION=$(VERSION) go generate cmd/$(PROVIDER)/main.go)
 
+upstream:
+ifeq ("$(wildcard upstream)","")
+	# upstream doesn't exist, so skip
+else ifeq ("$(wildcard patches/*.patch)","")
+	# upstream exists, but patches don't exist. This is probably an error.
+	@echo "No patches found within the patch operation"
+	@echo "patches were expected because upstream exists"
+	@exit 1
+else
+	git submodule update --force --init
+	cd upstream && \
+		for patch in $(sort $(wildcard patches/*.patch)); do git apply --3way ../$$patch || exit 1; done
+endif
+
 bin/pulumi-java-gen:
 	$(shell pulumictl download-binary -n pulumi-language-java -v $(JAVA_GEN_VERSION) -r pulumi/pulumi-java)
 
-.PHONY: development build build_sdks install_go_sdk install_java_sdk install_python_sdk install_sdks only_build build_dotnet build_go build_java build_nodejs build_python clean cleanup help install_dotnet_sdk install_nodejs_sdk install_plugins lint_provider provider test tfgen
+.PHONY: development build build_sdks install_go_sdk install_java_sdk install_python_sdk install_sdks only_build build_dotnet build_go build_java build_nodejs build_python clean cleanup finish-patch help install_dotnet_sdk install_nodejs_sdk install_plugins lint_provider provider start-patch test tfgen upstream

--- a/provider-ci/providers/tls/repo/Makefile
+++ b/provider-ci/providers/tls/repo/Makefile
@@ -145,7 +145,12 @@ else ifeq ("$(wildcard patches/*.patch)","")
 	@echo "patches were expected because upstream exists"
 	@exit 1
 else
+	# Checkout the submodule at the pinned commit.
+	# `--force`: If the submodule is at a different commit, move it to the pinned commit.
+	# `--init`: If the submodule is not initialized, initialize it.
 	git submodule update --force --init
+	# Iterating over the patches folder in sorted order,
+	# apply the patch using a 3-way merge strategy. This mirrors the default behavior of `git merge`
 	cd upstream && \
 		for patch in $(sort $(wildcard patches/*.patch)); do git apply --3way ../$$patch || exit 1; done
 endif

--- a/provider-ci/providers/vault/repo/Makefile
+++ b/provider-ci/providers/vault/repo/Makefile
@@ -30,7 +30,7 @@ install_sdks: install_dotnet_sdk install_python_sdk install_nodejs_sdk install_j
 only_build: build
 
 build_dotnet: DOTNET_VERSION := $(shell pulumictl get version --language dotnet)
-build_dotnet:
+build_dotnet: upstream
 	pulumictl get version --language dotnet
 	$(WORKING_DIR)/bin/$(TFGEN) dotnet --out sdk/dotnet/
 	cd sdk/dotnet/ && \
@@ -38,19 +38,19 @@ build_dotnet:
 		echo "$(DOTNET_VERSION)" >version.txt && \
 		dotnet build /p:Version=$(DOTNET_VERSION)
 
-build_go:
+build_go: upstream
 	$(WORKING_DIR)/bin/$(TFGEN) go --out sdk/go/
 	cd sdk && go list `grep -e "^module" go.mod | cut -d ' ' -f 2`/go/... | xargs go build
 
 build_java: PACKAGE_VERSION := $(shell pulumictl get version --language generic)
-build_java: bin/pulumi-java-gen
+build_java: bin/pulumi-java-gen upstream
 	$(WORKING_DIR)/bin/$(JAVA_GEN) generate --schema provider/cmd/$(PROVIDER)/schema.json --out sdk/java  --build gradle-nexus
 	cd sdk/java/ && \
 		echo "module fake_java_module // Exclude this directory from Go tools\n\ngo 1.17" > go.mod && \
 		gradle --console=plain build
 
 build_nodejs: VERSION := $(shell pulumictl get version --language javascript)
-build_nodejs:
+build_nodejs: upstream
 	$(WORKING_DIR)/bin/$(TFGEN) nodejs --out sdk/nodejs/
 	cd sdk/nodejs/ && \
 		echo "module fake_nodejs_module // Exclude this directory from Go tools\n\ngo 1.17" > go.mod && \
@@ -60,7 +60,7 @@ build_nodejs:
 		sed -i.bak -e "s/\$${VERSION}/$(VERSION)/g" ./bin/package.json
 
 build_python: PYPI_VERSION := $(shell pulumictl get version --language python)
-build_python:
+build_python: upstream
 	$(WORKING_DIR)/bin/$(TFGEN) python --out sdk/python/
 	cd sdk/python/ && \
 		echo "module fake_python_module // Exclude this directory from Go tools\n\ngo 1.17" > go.mod && \
@@ -77,6 +77,11 @@ clean:
 cleanup:
 	rm -r $(WORKING_DIR)/bin
 	rm -f provider/cmd/$(PROVIDER)/schema.go
+
+finish-patch:
+	@if [ ! -z "$$(cd upstream && git status --porcelain)" ]; then echo "Please commit your changes before finishing the patch"; exit 1; fi
+	@cd upstream && \
+		git format-patch HEAD~ -o ../patches --start-number $$(($$(ls ../patches | wc -l | xargs)+1))
 
 help:
 	@grep '^[^.#]\+:\s\+.*#' Makefile | \
@@ -100,15 +105,52 @@ lint_provider: provider
 provider: tfgen install_plugins
 	(cd provider && go build -p 1 -o $(WORKING_DIR)/bin/$(PROVIDER) -ldflags "-X $(PROJECT)/$(VERSION_PATH)=$(VERSION)" $(PROJECT)/$(PROVIDER_PATH)/cmd/$(PROVIDER))
 
+start-patch: upstream
+ifeq ("$(wildcard upstream)","")
+	@echo "No upstream found, so upstream can't be patched"
+	@exit 1
+else
+	# To add an additional patch:
+	#
+	#	1. Run this command (`make start-patch`).
+	#
+	#	2. Edit the `upstream` repo, making whatever changes you want to appear in the new
+	#	patch. It's fine to edit multiple files.
+	#
+	#	3. Commit your changes. The slugified first line of your commit description will
+	#	be used to generate the patch file name. Only the diff from the latest commit will
+	#	end up in the final patch.
+	#
+	#	4. Run `make finish-patch`.
+	#
+	# It is safe to run `make start-patch` as many times as you want, but any changes
+	# might be reverted until `make finish-patch` is run.
+	@cd upstream && git commit --quiet -m "existing patches"
+endif
+
 test:
 	cd examples && go test -v -tags=all -parallel $(TESTPARALLELISM) -timeout 2h
 
-tfgen: install_plugins
+tfgen: install_plugins upstream
 	(cd provider && go build -p 1 -o $(WORKING_DIR)/bin/$(TFGEN) -ldflags "-X $(PROJECT)/$(VERSION_PATH)=$(VERSION)" $(PROJECT)/$(PROVIDER_PATH)/cmd/$(TFGEN))
 	$(WORKING_DIR)/bin/$(TFGEN) schema --out provider/cmd/$(PROVIDER)
 	(cd provider && VERSION=$(VERSION) go generate cmd/$(PROVIDER)/main.go)
 
+upstream:
+ifeq ("$(wildcard upstream)","")
+	# upstream doesn't exist, so skip
+else ifeq ("$(wildcard patches/*.patch)","")
+	# upstream exists, but patches don't exist. This is probably an error.
+	@echo "No patches found within the patch operation"
+	@echo "patches were expected because upstream exists"
+	@exit 1
+else
+	git submodule update --force --init
+	cd upstream && \
+		for patch in $(sort $(wildcard patches/*.patch)); do git apply --3way ../$$patch || exit 1; done
+endif
+
 bin/pulumi-java-gen:
 	$(shell pulumictl download-binary -n pulumi-language-java -v $(JAVA_GEN_VERSION) -r pulumi/pulumi-java)
 
-.PHONY: development build build_sdks install_go_sdk install_java_sdk install_python_sdk install_sdks only_build build_dotnet build_go build_java build_nodejs build_python clean cleanup help install_dotnet_sdk install_nodejs_sdk install_plugins lint_provider provider test tfgen
+.PHONY: development build build_sdks install_go_sdk install_java_sdk install_python_sdk install_sdks only_build build_dotnet build_go build_java build_nodejs build_python clean cleanup finish-patch help install_dotnet_sdk install_nodejs_sdk install_plugins lint_provider provider start-patch test tfgen upstream

--- a/provider-ci/providers/vault/repo/Makefile
+++ b/provider-ci/providers/vault/repo/Makefile
@@ -145,7 +145,12 @@ else ifeq ("$(wildcard patches/*.patch)","")
 	@echo "patches were expected because upstream exists"
 	@exit 1
 else
+	# Checkout the submodule at the pinned commit.
+	# `--force`: If the submodule is at a different commit, move it to the pinned commit.
+	# `--init`: If the submodule is not initialized, initialize it.
 	git submodule update --force --init
+	# Iterating over the patches folder in sorted order,
+	# apply the patch using a 3-way merge strategy. This mirrors the default behavior of `git merge`
 	cd upstream && \
 		for patch in $(sort $(wildcard patches/*.patch)); do git apply --3way ../$$patch || exit 1; done
 endif

--- a/provider-ci/providers/venafi/repo/Makefile
+++ b/provider-ci/providers/venafi/repo/Makefile
@@ -144,7 +144,12 @@ else ifeq ("$(wildcard patches/*.patch)","")
 	@echo "patches were expected because upstream exists"
 	@exit 1
 else
+	# Checkout the submodule at the pinned commit.
+	# `--force`: If the submodule is at a different commit, move it to the pinned commit.
+	# `--init`: If the submodule is not initialized, initialize it.
 	git submodule update --force --init
+	# Iterating over the patches folder in sorted order,
+	# apply the patch using a 3-way merge strategy. This mirrors the default behavior of `git merge`
 	cd upstream && \
 		for patch in $(sort $(wildcard patches/*.patch)); do git apply --3way ../$$patch || exit 1; done
 endif

--- a/provider-ci/providers/venafi/repo/Makefile
+++ b/provider-ci/providers/venafi/repo/Makefile
@@ -30,7 +30,7 @@ install_sdks: install_dotnet_sdk install_python_sdk install_nodejs_sdk install_j
 only_build: build
 
 build_dotnet: DOTNET_VERSION := $(shell pulumictl get version --language dotnet)
-build_dotnet:
+build_dotnet: upstream
 	pulumictl get version --language dotnet
 	$(WORKING_DIR)/bin/$(TFGEN) dotnet --out sdk/dotnet/
 	cd sdk/dotnet/ && \
@@ -38,19 +38,19 @@ build_dotnet:
 		echo "$(DOTNET_VERSION)" >version.txt && \
 		dotnet build /p:Version=$(DOTNET_VERSION)
 
-build_go:
+build_go: upstream
 	$(WORKING_DIR)/bin/$(TFGEN) go --out sdk/go/
 	cd sdk && go list `grep -e "^module" go.mod | cut -d ' ' -f 2`/go/... | xargs go build
 
 build_java: PACKAGE_VERSION := $(shell pulumictl get version --language generic)
-build_java: bin/pulumi-java-gen
+build_java: bin/pulumi-java-gen upstream
 	$(WORKING_DIR)/bin/$(JAVA_GEN) generate --schema provider/cmd/$(PROVIDER)/schema.json --out sdk/java  --build gradle-nexus
 	cd sdk/java/ && \
 		echo "module fake_java_module // Exclude this directory from Go tools\n\ngo 1.17" > go.mod && \
 		gradle --console=plain build
 
 build_nodejs: VERSION := $(shell pulumictl get version --language javascript)
-build_nodejs:
+build_nodejs: upstream
 	$(WORKING_DIR)/bin/$(TFGEN) nodejs --out sdk/nodejs/
 	cd sdk/nodejs/ && \
 		echo "module fake_nodejs_module // Exclude this directory from Go tools\n\ngo 1.17" > go.mod && \
@@ -60,7 +60,7 @@ build_nodejs:
 		sed -i.bak -e "s/\$${VERSION}/$(VERSION)/g" ./bin/package.json
 
 build_python: PYPI_VERSION := $(shell pulumictl get version --language python)
-build_python:
+build_python: upstream
 	$(WORKING_DIR)/bin/$(TFGEN) python --out sdk/python/
 	cd sdk/python/ && \
 		echo "module fake_python_module // Exclude this directory from Go tools\n\ngo 1.17" > go.mod && \
@@ -77,6 +77,11 @@ clean:
 cleanup:
 	rm -r $(WORKING_DIR)/bin
 	rm -f provider/cmd/$(PROVIDER)/schema.go
+
+finish-patch:
+	@if [ ! -z "$$(cd upstream && git status --porcelain)" ]; then echo "Please commit your changes before finishing the patch"; exit 1; fi
+	@cd upstream && \
+		git format-patch HEAD~ -o ../patches --start-number $$(($$(ls ../patches | wc -l | xargs)+1))
 
 help:
 	@grep '^[^.#]\+:\s\+.*#' Makefile | \
@@ -99,15 +104,52 @@ lint_provider: provider
 provider: tfgen install_plugins
 	(cd provider && go build -p 1 -o $(WORKING_DIR)/bin/$(PROVIDER) -ldflags "-X $(PROJECT)/$(VERSION_PATH)=$(VERSION)" $(PROJECT)/$(PROVIDER_PATH)/cmd/$(PROVIDER))
 
+start-patch: upstream
+ifeq ("$(wildcard upstream)","")
+	@echo "No upstream found, so upstream can't be patched"
+	@exit 1
+else
+	# To add an additional patch:
+	#
+	#	1. Run this command (`make start-patch`).
+	#
+	#	2. Edit the `upstream` repo, making whatever changes you want to appear in the new
+	#	patch. It's fine to edit multiple files.
+	#
+	#	3. Commit your changes. The slugified first line of your commit description will
+	#	be used to generate the patch file name. Only the diff from the latest commit will
+	#	end up in the final patch.
+	#
+	#	4. Run `make finish-patch`.
+	#
+	# It is safe to run `make start-patch` as many times as you want, but any changes
+	# might be reverted until `make finish-patch` is run.
+	@cd upstream && git commit --quiet -m "existing patches"
+endif
+
 test:
 	cd examples && go test -v -tags=all -parallel $(TESTPARALLELISM) -timeout 2h
 
-tfgen: install_plugins
+tfgen: install_plugins upstream
 	(cd provider && go build -p 1 -o $(WORKING_DIR)/bin/$(TFGEN) -ldflags "-X $(PROJECT)/$(VERSION_PATH)=$(VERSION)" $(PROJECT)/$(PROVIDER_PATH)/cmd/$(TFGEN))
 	$(WORKING_DIR)/bin/$(TFGEN) schema --out provider/cmd/$(PROVIDER)
 	(cd provider && VERSION=$(VERSION) go generate cmd/$(PROVIDER)/main.go)
 
+upstream:
+ifeq ("$(wildcard upstream)","")
+	# upstream doesn't exist, so skip
+else ifeq ("$(wildcard patches/*.patch)","")
+	# upstream exists, but patches don't exist. This is probably an error.
+	@echo "No patches found within the patch operation"
+	@echo "patches were expected because upstream exists"
+	@exit 1
+else
+	git submodule update --force --init
+	cd upstream && \
+		for patch in $(sort $(wildcard patches/*.patch)); do git apply --3way ../$$patch || exit 1; done
+endif
+
 bin/pulumi-java-gen:
 	$(shell pulumictl download-binary -n pulumi-language-java -v $(JAVA_GEN_VERSION) -r pulumi/pulumi-java)
 
-.PHONY: development build build_sdks install_go_sdk install_java_sdk install_python_sdk install_sdks only_build build_dotnet build_go build_java build_nodejs build_python clean cleanup help install_dotnet_sdk install_nodejs_sdk install_plugins lint_provider provider test tfgen
+.PHONY: development build build_sdks install_go_sdk install_java_sdk install_python_sdk install_sdks only_build build_dotnet build_go build_java build_nodejs build_python clean cleanup finish-patch help install_dotnet_sdk install_nodejs_sdk install_plugins lint_provider provider start-patch test tfgen upstream

--- a/provider-ci/providers/vsphere/repo/Makefile
+++ b/provider-ci/providers/vsphere/repo/Makefile
@@ -144,7 +144,12 @@ else ifeq ("$(wildcard patches/*.patch)","")
 	@echo "patches were expected because upstream exists"
 	@exit 1
 else
+	# Checkout the submodule at the pinned commit.
+	# `--force`: If the submodule is at a different commit, move it to the pinned commit.
+	# `--init`: If the submodule is not initialized, initialize it.
 	git submodule update --force --init
+	# Iterating over the patches folder in sorted order,
+	# apply the patch using a 3-way merge strategy. This mirrors the default behavior of `git merge`
 	cd upstream && \
 		for patch in $(sort $(wildcard patches/*.patch)); do git apply --3way ../$$patch || exit 1; done
 endif

--- a/provider-ci/providers/vsphere/repo/Makefile
+++ b/provider-ci/providers/vsphere/repo/Makefile
@@ -30,7 +30,7 @@ install_sdks: install_dotnet_sdk install_python_sdk install_nodejs_sdk install_j
 only_build: build
 
 build_dotnet: DOTNET_VERSION := $(shell pulumictl get version --language dotnet)
-build_dotnet:
+build_dotnet: upstream
 	pulumictl get version --language dotnet
 	$(WORKING_DIR)/bin/$(TFGEN) dotnet --out sdk/dotnet/
 	cd sdk/dotnet/ && \
@@ -38,19 +38,19 @@ build_dotnet:
 		echo "$(DOTNET_VERSION)" >version.txt && \
 		dotnet build /p:Version=$(DOTNET_VERSION)
 
-build_go:
+build_go: upstream
 	$(WORKING_DIR)/bin/$(TFGEN) go --out sdk/go/
 	cd sdk && go list `grep -e "^module" go.mod | cut -d ' ' -f 2`/go/... | xargs go build
 
 build_java: PACKAGE_VERSION := $(shell pulumictl get version --language generic)
-build_java: bin/pulumi-java-gen
+build_java: bin/pulumi-java-gen upstream
 	$(WORKING_DIR)/bin/$(JAVA_GEN) generate --schema provider/cmd/$(PROVIDER)/schema.json --out sdk/java  --build gradle-nexus
 	cd sdk/java/ && \
 		echo "module fake_java_module // Exclude this directory from Go tools\n\ngo 1.17" > go.mod && \
 		gradle --console=plain build
 
 build_nodejs: VERSION := $(shell pulumictl get version --language javascript)
-build_nodejs:
+build_nodejs: upstream
 	$(WORKING_DIR)/bin/$(TFGEN) nodejs --out sdk/nodejs/
 	cd sdk/nodejs/ && \
 		echo "module fake_nodejs_module // Exclude this directory from Go tools\n\ngo 1.17" > go.mod && \
@@ -60,7 +60,7 @@ build_nodejs:
 		sed -i.bak -e "s/\$${VERSION}/$(VERSION)/g" ./bin/package.json
 
 build_python: PYPI_VERSION := $(shell pulumictl get version --language python)
-build_python:
+build_python: upstream
 	$(WORKING_DIR)/bin/$(TFGEN) python --out sdk/python/
 	cd sdk/python/ && \
 		echo "module fake_python_module // Exclude this directory from Go tools\n\ngo 1.17" > go.mod && \
@@ -77,6 +77,11 @@ clean:
 cleanup:
 	rm -r $(WORKING_DIR)/bin
 	rm -f provider/cmd/$(PROVIDER)/schema.go
+
+finish-patch:
+	@if [ ! -z "$$(cd upstream && git status --porcelain)" ]; then echo "Please commit your changes before finishing the patch"; exit 1; fi
+	@cd upstream && \
+		git format-patch HEAD~ -o ../patches --start-number $$(($$(ls ../patches | wc -l | xargs)+1))
 
 help:
 	@grep '^[^.#]\+:\s\+.*#' Makefile | \
@@ -99,15 +104,52 @@ lint_provider: provider
 provider: tfgen install_plugins
 	(cd provider && go build -p 1 -o $(WORKING_DIR)/bin/$(PROVIDER) -ldflags "-X $(PROJECT)/$(VERSION_PATH)=$(VERSION)" $(PROJECT)/$(PROVIDER_PATH)/cmd/$(PROVIDER))
 
+start-patch: upstream
+ifeq ("$(wildcard upstream)","")
+	@echo "No upstream found, so upstream can't be patched"
+	@exit 1
+else
+	# To add an additional patch:
+	#
+	#	1. Run this command (`make start-patch`).
+	#
+	#	2. Edit the `upstream` repo, making whatever changes you want to appear in the new
+	#	patch. It's fine to edit multiple files.
+	#
+	#	3. Commit your changes. The slugified first line of your commit description will
+	#	be used to generate the patch file name. Only the diff from the latest commit will
+	#	end up in the final patch.
+	#
+	#	4. Run `make finish-patch`.
+	#
+	# It is safe to run `make start-patch` as many times as you want, but any changes
+	# might be reverted until `make finish-patch` is run.
+	@cd upstream && git commit --quiet -m "existing patches"
+endif
+
 test:
 	cd examples && go test -v -tags=all -parallel $(TESTPARALLELISM) -timeout 2h
 
-tfgen: install_plugins
+tfgen: install_plugins upstream
 	(cd provider && go build -p 1 -o $(WORKING_DIR)/bin/$(TFGEN) -ldflags "-X $(PROJECT)/$(VERSION_PATH)=$(VERSION)" $(PROJECT)/$(PROVIDER_PATH)/cmd/$(TFGEN))
 	$(WORKING_DIR)/bin/$(TFGEN) schema --out provider/cmd/$(PROVIDER)
 	(cd provider && VERSION=$(VERSION) go generate cmd/$(PROVIDER)/main.go)
 
+upstream:
+ifeq ("$(wildcard upstream)","")
+	# upstream doesn't exist, so skip
+else ifeq ("$(wildcard patches/*.patch)","")
+	# upstream exists, but patches don't exist. This is probably an error.
+	@echo "No patches found within the patch operation"
+	@echo "patches were expected because upstream exists"
+	@exit 1
+else
+	git submodule update --force --init
+	cd upstream && \
+		for patch in $(sort $(wildcard patches/*.patch)); do git apply --3way ../$$patch || exit 1; done
+endif
+
 bin/pulumi-java-gen:
 	$(shell pulumictl download-binary -n pulumi-language-java -v $(JAVA_GEN_VERSION) -r pulumi/pulumi-java)
 
-.PHONY: development build build_sdks install_go_sdk install_java_sdk install_python_sdk install_sdks only_build build_dotnet build_go build_java build_nodejs build_python clean cleanup help install_dotnet_sdk install_nodejs_sdk install_plugins lint_provider provider test tfgen
+.PHONY: development build build_sdks install_go_sdk install_java_sdk install_python_sdk install_sdks only_build build_dotnet build_go build_java build_nodejs build_python clean cleanup finish-patch help install_dotnet_sdk install_nodejs_sdk install_plugins lint_provider provider start-patch test tfgen upstream

--- a/provider-ci/providers/wavefront/repo/Makefile
+++ b/provider-ci/providers/wavefront/repo/Makefile
@@ -144,7 +144,12 @@ else ifeq ("$(wildcard patches/*.patch)","")
 	@echo "patches were expected because upstream exists"
 	@exit 1
 else
+	# Checkout the submodule at the pinned commit.
+	# `--force`: If the submodule is at a different commit, move it to the pinned commit.
+	# `--init`: If the submodule is not initialized, initialize it.
 	git submodule update --force --init
+	# Iterating over the patches folder in sorted order,
+	# apply the patch using a 3-way merge strategy. This mirrors the default behavior of `git merge`
 	cd upstream && \
 		for patch in $(sort $(wildcard patches/*.patch)); do git apply --3way ../$$patch || exit 1; done
 endif

--- a/provider-ci/providers/wavefront/repo/Makefile
+++ b/provider-ci/providers/wavefront/repo/Makefile
@@ -30,7 +30,7 @@ install_sdks: install_dotnet_sdk install_python_sdk install_nodejs_sdk install_j
 only_build: build
 
 build_dotnet: DOTNET_VERSION := $(shell pulumictl get version --language dotnet)
-build_dotnet:
+build_dotnet: upstream
 	pulumictl get version --language dotnet
 	$(WORKING_DIR)/bin/$(TFGEN) dotnet --out sdk/dotnet/
 	cd sdk/dotnet/ && \
@@ -38,19 +38,19 @@ build_dotnet:
 		echo "$(DOTNET_VERSION)" >version.txt && \
 		dotnet build /p:Version=$(DOTNET_VERSION)
 
-build_go:
+build_go: upstream
 	$(WORKING_DIR)/bin/$(TFGEN) go --out sdk/go/
 	cd sdk && go list `grep -e "^module" go.mod | cut -d ' ' -f 2`/go/... | xargs go build
 
 build_java: PACKAGE_VERSION := $(shell pulumictl get version --language generic)
-build_java: bin/pulumi-java-gen
+build_java: bin/pulumi-java-gen upstream
 	$(WORKING_DIR)/bin/$(JAVA_GEN) generate --schema provider/cmd/$(PROVIDER)/schema.json --out sdk/java  --build gradle-nexus
 	cd sdk/java/ && \
 		echo "module fake_java_module // Exclude this directory from Go tools\n\ngo 1.17" > go.mod && \
 		gradle --console=plain build
 
 build_nodejs: VERSION := $(shell pulumictl get version --language javascript)
-build_nodejs:
+build_nodejs: upstream
 	$(WORKING_DIR)/bin/$(TFGEN) nodejs --out sdk/nodejs/
 	cd sdk/nodejs/ && \
 		echo "module fake_nodejs_module // Exclude this directory from Go tools\n\ngo 1.17" > go.mod && \
@@ -60,7 +60,7 @@ build_nodejs:
 		sed -i.bak -e "s/\$${VERSION}/$(VERSION)/g" ./bin/package.json
 
 build_python: PYPI_VERSION := $(shell pulumictl get version --language python)
-build_python:
+build_python: upstream
 	$(WORKING_DIR)/bin/$(TFGEN) python --out sdk/python/
 	cd sdk/python/ && \
 		echo "module fake_python_module // Exclude this directory from Go tools\n\ngo 1.17" > go.mod && \
@@ -77,6 +77,11 @@ clean:
 cleanup:
 	rm -r $(WORKING_DIR)/bin
 	rm -f provider/cmd/$(PROVIDER)/schema.go
+
+finish-patch:
+	@if [ ! -z "$$(cd upstream && git status --porcelain)" ]; then echo "Please commit your changes before finishing the patch"; exit 1; fi
+	@cd upstream && \
+		git format-patch HEAD~ -o ../patches --start-number $$(($$(ls ../patches | wc -l | xargs)+1))
 
 help:
 	@grep '^[^.#]\+:\s\+.*#' Makefile | \
@@ -99,15 +104,52 @@ lint_provider: provider
 provider: tfgen install_plugins
 	(cd provider && go build -p 1 -o $(WORKING_DIR)/bin/$(PROVIDER) -ldflags "-X $(PROJECT)/$(VERSION_PATH)=$(VERSION)" $(PROJECT)/$(PROVIDER_PATH)/cmd/$(PROVIDER))
 
+start-patch: upstream
+ifeq ("$(wildcard upstream)","")
+	@echo "No upstream found, so upstream can't be patched"
+	@exit 1
+else
+	# To add an additional patch:
+	#
+	#	1. Run this command (`make start-patch`).
+	#
+	#	2. Edit the `upstream` repo, making whatever changes you want to appear in the new
+	#	patch. It's fine to edit multiple files.
+	#
+	#	3. Commit your changes. The slugified first line of your commit description will
+	#	be used to generate the patch file name. Only the diff from the latest commit will
+	#	end up in the final patch.
+	#
+	#	4. Run `make finish-patch`.
+	#
+	# It is safe to run `make start-patch` as many times as you want, but any changes
+	# might be reverted until `make finish-patch` is run.
+	@cd upstream && git commit --quiet -m "existing patches"
+endif
+
 test:
 	cd examples && go test -v -tags=all -parallel $(TESTPARALLELISM) -timeout 2h
 
-tfgen: install_plugins
+tfgen: install_plugins upstream
 	(cd provider && go build -p 1 -o $(WORKING_DIR)/bin/$(TFGEN) -ldflags "-X $(PROJECT)/$(VERSION_PATH)=$(VERSION)" $(PROJECT)/$(PROVIDER_PATH)/cmd/$(TFGEN))
 	$(WORKING_DIR)/bin/$(TFGEN) schema --out provider/cmd/$(PROVIDER)
 	(cd provider && VERSION=$(VERSION) go generate cmd/$(PROVIDER)/main.go)
 
+upstream:
+ifeq ("$(wildcard upstream)","")
+	# upstream doesn't exist, so skip
+else ifeq ("$(wildcard patches/*.patch)","")
+	# upstream exists, but patches don't exist. This is probably an error.
+	@echo "No patches found within the patch operation"
+	@echo "patches were expected because upstream exists"
+	@exit 1
+else
+	git submodule update --force --init
+	cd upstream && \
+		for patch in $(sort $(wildcard patches/*.patch)); do git apply --3way ../$$patch || exit 1; done
+endif
+
 bin/pulumi-java-gen:
 	$(shell pulumictl download-binary -n pulumi-language-java -v $(JAVA_GEN_VERSION) -r pulumi/pulumi-java)
 
-.PHONY: development build build_sdks install_go_sdk install_java_sdk install_python_sdk install_sdks only_build build_dotnet build_go build_java build_nodejs build_python clean cleanup help install_dotnet_sdk install_nodejs_sdk install_plugins lint_provider provider test tfgen
+.PHONY: development build build_sdks install_go_sdk install_java_sdk install_python_sdk install_sdks only_build build_dotnet build_go build_java build_nodejs build_python clean cleanup finish-patch help install_dotnet_sdk install_nodejs_sdk install_plugins lint_provider provider start-patch test tfgen upstream

--- a/provider-ci/src/config.ts
+++ b/provider-ci/src/config.ts
@@ -43,6 +43,7 @@ const BridgedConfig = z
       .optional(),
     docsCmd: z.string().default(""),
     hybrid: z.boolean().default(false),
+    team: z.enum(["ecosystem", "providers"]).default("ecosystem"),
   })
   .transform((input) => {
     if (input["upstream-provider-repo"] !== "") {

--- a/provider-ci/src/make-bridged-provider.ts
+++ b/provider-ci/src/make-bridged-provider.ts
@@ -50,10 +50,91 @@ export function bridgedProvider(config: BridgedConfig): Makefile {
     ],
   };
 
+  const upstream: Target = {
+    name: "upstream",
+    phony: true,
+    commands: [{
+      parts: [
+        {
+          test: `ifeq ("$(wildcard upstream)","")`,
+          then: [`# upstream doesn't exist, so skip`],
+        },
+        {
+          test: `else ifeq ("$(wildcard patches/*.patch)","")`,
+          then: [
+            `# upstream exists, but patches don't exist. This is probably an error.`,
+            `@echo "No patches found within the patch operation"`,
+            `@echo "patches were expected because upstream exists"`,
+            `@exit 1`,
+          ]
+        },
+        {
+          test: `else`,
+          then: [
+            `git submodule update --force --init`,
+            [
+              `cd upstream`,
+              `for patch in $(sort $(wildcard patches/*.patch)); do git apply --3way ../$$patch || exit 1; done`
+            ],
+          ]
+        },
+      ],
+      end: "endif",
+    }]
+  };
+
+  const startPatch: Target = {
+    name: "start-patch",
+    phony: true,
+    dependencies: [upstream],
+    commands: [{
+      parts: [
+        {
+          test: `ifeq ("$(wildcard upstream)","")`,
+          then: [`@echo "No upstream found, so upstream can't be patched"`, `@exit 1`],
+        },
+        {
+          test: `else`,
+          then: [
+            `# To add an additional patch:`,
+            `#`,
+            "#	1. Run this command (`make start-patch`).",
+            `#`,
+            "#	2. Edit the `upstream` repo, making whatever changes you want to appear in the new",
+            `#	patch. It's fine to edit multiple files.`,
+            `#`,
+            `#	3. Commit your changes. The slugified first line of your commit description will`,
+            `#	be used to generate the patch file name. Only the diff from the latest commit will`,
+            `#	end up in the final patch.`,
+            `#`,
+            "#	4. Run `make finish-patch`.",
+            `#`,
+            "# It is safe to run `make start-patch` as many times as you want, but any changes",
+            "# might be reverted until `make finish-patch` is run.",
+            `@cd upstream && git commit --quiet -m "existing patches"`,
+          ],
+        },
+      ],
+      end: "endif",
+    }]
+  }
+
+  const finishPatch: Target = {
+    name: "finish-patch",
+    phony: true,
+    commands: [
+      `@if [ ! -z "$$(cd upstream && git status --porcelain)" ]; then echo "Please commit your changes before finishing the patch"; exit 1; fi`,
+      [
+        "@cd upstream",
+        `git format-patch HEAD~ -o ../patches --start-number $$(($$(ls ../patches | wc -l | xargs)+1))`,
+      ],
+    ],
+  }
+
   const tfgen: Target = {
     name: "tfgen",
     phony: true,
-    dependencies: [install_plugins],
+    dependencies: [install_plugins, upstream],
     commands: [
       '(cd provider && go build -p 1 -o $(WORKING_DIR)/bin/$(TFGEN) -ldflags "-X $(PROJECT)/$(VERSION_PATH)=$(VERSION)" $(PROJECT)/$(PROVIDER_PATH)/cmd/$(TFGEN))',
       "$(WORKING_DIR)/bin/$(TFGEN) schema --out provider/cmd/$(PROVIDER)",
@@ -81,6 +162,7 @@ export function bridgedProvider(config: BridgedConfig): Makefile {
   const build_nodejs: Target = {
     name: "build_nodejs",
     phony: true,
+    dependencies: [upstream],
     variables: {
       VERSION: "$(shell pulumictl get version --language javascript)",
     },
@@ -99,6 +181,7 @@ export function bridgedProvider(config: BridgedConfig): Makefile {
   const build_python: Target = {
     name: "build_python",
     phony: true,
+    dependencies: [upstream],
     variables: {
       PYPI_VERSION: "$(shell pulumictl get version --language python)",
     },
@@ -119,6 +202,7 @@ export function bridgedProvider(config: BridgedConfig): Makefile {
   const build_go: Target = {
     name: "build_go",
     phony: true,
+    dependencies: [upstream],
     commands: [
       "$(WORKING_DIR)/bin/$(TFGEN) go --out sdk/go/",
       // The following pulls out the `module` line from go.mod to determine the right
@@ -134,6 +218,7 @@ export function bridgedProvider(config: BridgedConfig): Makefile {
     variables: {
       DOTNET_VERSION: "$(shell pulumictl get version --language dotnet)",
     },
+    dependencies: [upstream],
     commands: [
       "pulumictl get version --language dotnet",
       "$(WORKING_DIR)/bin/$(TFGEN) dotnet --out sdk/dotnet/",
@@ -154,7 +239,7 @@ export function bridgedProvider(config: BridgedConfig): Makefile {
   const build_java: Target = {
     name: "build_java",
     phony: true,
-    dependencies: [bin_pulumi_java_gen],
+    dependencies: [bin_pulumi_java_gen, upstream],
     variables: {
       PACKAGE_VERSION: "$(shell pulumictl get version --language generic)",
     },
@@ -238,7 +323,7 @@ export function bridgedProvider(config: BridgedConfig): Makefile {
       install_java_sdk,
     ],
   };
-  const development: Target = {
+  const defaultTarget: Target = {
     name: "development",
     phony: true,
     dependencies: [install_plugins, provider, build_sdks, install_sdks],
@@ -261,7 +346,10 @@ export function bridgedProvider(config: BridgedConfig): Makefile {
     ],
   };
 
-  const returnTargets = [
+  const targets = [
+    upstream,
+    startPatch,
+    finishPatch,
     build,
     only_build,
     tfgen,
@@ -287,13 +375,14 @@ export function bridgedProvider(config: BridgedConfig): Makefile {
     test,
   ];
 
+
   if (config.hybrid) {
-    returnTargets.push(docs);
+    targets.push(docs);
   }
 
   return {
     variables,
-    defaultTarget: development,
-    targets: returnTargets,
+    defaultTarget,
+    targets,
   };
 }

--- a/provider-ci/src/make-bridged-provider.ts
+++ b/provider-ci/src/make-bridged-provider.ts
@@ -75,11 +75,16 @@ export function bridgedProvider(config: BridgedConfig): Makefile {
           {
             test: `else`,
             then: [
+              "# Checkout the submodule at the pinned commit.",
+              "# `--force`: If the submodule is at a different commit, move it to the pinned commit.",
+              "# `--init`: If the submodule is not initialized, initialize it.",
               `git submodule update --force --init`,
+              "# Iterating over the patches folder in sorted order,",
+              "# apply the patch using a 3-way merge strategy. This mirrors the default behavior of `git merge`",
               [
                 `cd upstream`,
                 `for patch in $(sort $(wildcard patches/*.patch)); do git apply --3way ../$$patch || exit 1; done`
-              ],
+              ]
             ]
           },
         ],

--- a/provider-ci/src/make.ts
+++ b/provider-ci/src/make.ts
@@ -18,7 +18,7 @@ export type Target = {
   /** Name of the target */
   name: string;
   /** Names or references of dependencies */
-  dependencies?: (string | Target)[];
+  dependencies?: (string | Target | null)[];
   /** Target-specific variable assignments */
   variables?: Variables;
   /** List of commands to execute
@@ -92,7 +92,9 @@ function renderCommands(
 
 function renderTarget(target: Target): string {
   const dependencies = target.dependencies ?? [];
-  const dependencyNames = dependencies.map(
+  const dependencyNames = dependencies.filter(
+    (x): x is (string | Target) => x !== null,
+  ).map(
     (d) => " " + (typeof d === "string" ? d : d.name)
   );
   const declaration = `${target.name}:${dependencyNames.join("")}`;
@@ -133,9 +135,12 @@ function descendentTargets(target: Target): Target[] {
   if (target.dependencies === undefined) {
     return [target];
   }
+  const dependencies: (string | Target)[] = target.dependencies.filter(
+    (x): x is (string | Target) => x !== null,
+  );
   return deduplicateTargets([
     target,
-    ...target.dependencies.flatMap((t) =>
+    ...dependencies.flatMap((t) =>
       typeof t !== "string" ? descendentTargets(t) : []
     ),
   ]);


### PR DESCRIPTION
Support is directly modeled after the digital ocean repo demoed in the design doc.

This PR adds 3 targets:

1. `upstream`: Ensure that the upstream folder (if it exists) reflects the patch set applied to the upstream commit.
2. `start-patch`: Prepare to create a new patch.
3. `finish-patch`: Set the current committed changes as a new patch.