### PR TITLE
configure git safe directory

### DIFF
--- a/provider-ci/config-schema.json
+++ b/provider-ci/config-schema.json
@@ -124,6 +124,14 @@
                 ],
                 "additionalProperties": false
               }
+            },
+            "docsCmd": {
+              "type": "string",
+              "default": ""
+            },
+            "hybrid": {
+              "type": "boolean",
+              "default": false
             }
           },
           "required": [

--- a/provider-ci/providers/artifactory/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/artifactory/repo/.github/workflows/main.yml
@@ -181,6 +181,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -214,6 +217,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/provider-ci/providers/artifactory/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/artifactory/repo/.github/workflows/master.yml
@@ -181,6 +181,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -214,6 +217,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/provider-ci/providers/artifactory/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/artifactory/repo/.github/workflows/prerelease.yml
@@ -131,6 +131,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -164,6 +167,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/provider-ci/providers/artifactory/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/artifactory/repo/.github/workflows/release.yml
@@ -144,6 +144,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -177,6 +180,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/provider-ci/providers/artifactory/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/artifactory/repo/.github/workflows/run-acceptance-tests.yml
@@ -155,6 +155,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -192,6 +195,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/provider-ci/providers/auth0/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/auth0/repo/.github/workflows/main.yml
@@ -181,6 +181,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -214,6 +217,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/provider-ci/providers/auth0/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/auth0/repo/.github/workflows/master.yml
@@ -181,6 +181,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -214,6 +217,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/provider-ci/providers/auth0/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/auth0/repo/.github/workflows/prerelease.yml
@@ -131,6 +131,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -164,6 +167,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/provider-ci/providers/auth0/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/auth0/repo/.github/workflows/release.yml
@@ -144,6 +144,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -177,6 +180,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/provider-ci/providers/auth0/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/auth0/repo/.github/workflows/run-acceptance-tests.yml
@@ -155,6 +155,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -192,6 +195,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/provider-ci/providers/azuread/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/azuread/repo/.github/workflows/main.yml
@@ -183,6 +183,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -216,6 +219,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/provider-ci/providers/azuread/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/azuread/repo/.github/workflows/master.yml
@@ -183,6 +183,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -216,6 +219,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/provider-ci/providers/azuread/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/azuread/repo/.github/workflows/prerelease.yml
@@ -133,6 +133,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -166,6 +169,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/provider-ci/providers/azuread/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/azuread/repo/.github/workflows/release.yml
@@ -146,6 +146,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -179,6 +182,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/provider-ci/providers/azuread/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/azuread/repo/.github/workflows/run-acceptance-tests.yml
@@ -157,6 +157,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -194,6 +197,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/provider-ci/providers/civo/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/civo/repo/.github/workflows/main.yml
@@ -179,6 +179,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -212,6 +215,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/provider-ci/providers/civo/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/civo/repo/.github/workflows/master.yml
@@ -179,6 +179,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -212,6 +215,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/provider-ci/providers/civo/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/civo/repo/.github/workflows/prerelease.yml
@@ -129,6 +129,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -162,6 +165,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/provider-ci/providers/civo/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/civo/repo/.github/workflows/release.yml
@@ -142,6 +142,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -175,6 +178,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/provider-ci/providers/civo/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/civo/repo/.github/workflows/run-acceptance-tests.yml
@@ -153,6 +153,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -190,6 +193,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/provider-ci/providers/cloudamqp/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/cloudamqp/repo/.github/workflows/main.yml
@@ -178,6 +178,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -211,6 +214,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/provider-ci/providers/cloudamqp/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/cloudamqp/repo/.github/workflows/master.yml
@@ -178,6 +178,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -211,6 +214,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/provider-ci/providers/cloudamqp/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/cloudamqp/repo/.github/workflows/prerelease.yml
@@ -128,6 +128,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -161,6 +164,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/provider-ci/providers/cloudamqp/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/cloudamqp/repo/.github/workflows/release.yml
@@ -141,6 +141,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -174,6 +177,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/provider-ci/providers/cloudamqp/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/cloudamqp/repo/.github/workflows/run-acceptance-tests.yml
@@ -152,6 +152,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -189,6 +192,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/provider-ci/providers/cloudflare/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/cloudflare/repo/.github/workflows/main.yml
@@ -178,6 +178,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -211,6 +214,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/provider-ci/providers/cloudflare/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/cloudflare/repo/.github/workflows/master.yml
@@ -178,6 +178,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -211,6 +214,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/provider-ci/providers/cloudflare/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/cloudflare/repo/.github/workflows/prerelease.yml
@@ -128,6 +128,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -161,6 +164,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/provider-ci/providers/cloudflare/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/cloudflare/repo/.github/workflows/release.yml
@@ -141,6 +141,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -174,6 +177,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/provider-ci/providers/cloudflare/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/cloudflare/repo/.github/workflows/run-acceptance-tests.yml
@@ -152,6 +152,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -189,6 +192,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/provider-ci/providers/confluent/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/confluent/repo/.github/workflows/main.yml
@@ -180,6 +180,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -213,6 +216,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/provider-ci/providers/confluent/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/confluent/repo/.github/workflows/master.yml
@@ -180,6 +180,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -213,6 +216,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/provider-ci/providers/confluent/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/confluent/repo/.github/workflows/prerelease.yml
@@ -130,6 +130,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -163,6 +166,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/provider-ci/providers/confluent/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/confluent/repo/.github/workflows/release.yml
@@ -143,6 +143,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -176,6 +179,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/provider-ci/providers/confluent/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/confluent/repo/.github/workflows/run-acceptance-tests.yml
@@ -154,6 +154,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -191,6 +194,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/provider-ci/providers/consul/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/consul/repo/.github/workflows/main.yml
@@ -178,6 +178,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -211,6 +214,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/provider-ci/providers/consul/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/consul/repo/.github/workflows/master.yml
@@ -178,6 +178,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -211,6 +214,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/provider-ci/providers/consul/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/consul/repo/.github/workflows/prerelease.yml
@@ -128,6 +128,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -161,6 +164,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/provider-ci/providers/consul/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/consul/repo/.github/workflows/release.yml
@@ -141,6 +141,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -174,6 +177,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/provider-ci/providers/consul/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/consul/repo/.github/workflows/run-acceptance-tests.yml
@@ -152,6 +152,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -189,6 +192,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/provider-ci/providers/databricks/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/databricks/repo/.github/workflows/main.yml
@@ -182,6 +182,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -215,6 +218,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/provider-ci/providers/databricks/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/databricks/repo/.github/workflows/master.yml
@@ -182,6 +182,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -215,6 +218,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/provider-ci/providers/databricks/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/databricks/repo/.github/workflows/prerelease.yml
@@ -132,6 +132,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -165,6 +168,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/provider-ci/providers/databricks/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/databricks/repo/.github/workflows/release.yml
@@ -145,6 +145,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -178,6 +181,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/provider-ci/providers/databricks/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/databricks/repo/.github/workflows/run-acceptance-tests.yml
@@ -156,6 +156,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -193,6 +196,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/provider-ci/providers/digitalocean/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/digitalocean/repo/.github/workflows/main.yml
@@ -179,6 +179,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -212,6 +215,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/provider-ci/providers/digitalocean/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/digitalocean/repo/.github/workflows/master.yml
@@ -179,6 +179,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -212,6 +215,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/provider-ci/providers/digitalocean/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/digitalocean/repo/.github/workflows/prerelease.yml
@@ -129,6 +129,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -162,6 +165,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/provider-ci/providers/digitalocean/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/digitalocean/repo/.github/workflows/release.yml
@@ -142,6 +142,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -175,6 +178,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/provider-ci/providers/digitalocean/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/digitalocean/repo/.github/workflows/run-acceptance-tests.yml
@@ -153,6 +153,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -190,6 +193,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/provider-ci/providers/dnsimple/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/dnsimple/repo/.github/workflows/main.yml
@@ -180,6 +180,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -213,6 +216,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/provider-ci/providers/dnsimple/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/dnsimple/repo/.github/workflows/master.yml
@@ -180,6 +180,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -213,6 +216,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/provider-ci/providers/dnsimple/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/dnsimple/repo/.github/workflows/prerelease.yml
@@ -130,6 +130,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -163,6 +166,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/provider-ci/providers/dnsimple/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/dnsimple/repo/.github/workflows/release.yml
@@ -143,6 +143,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -176,6 +179,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/provider-ci/providers/dnsimple/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/dnsimple/repo/.github/workflows/run-acceptance-tests.yml
@@ -154,6 +154,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -191,6 +194,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/provider-ci/providers/docker/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/docker/repo/.github/workflows/main.yml
@@ -184,6 +184,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -217,6 +220,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/provider-ci/providers/docker/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/docker/repo/.github/workflows/master.yml
@@ -184,6 +184,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -217,6 +220,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/provider-ci/providers/docker/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/docker/repo/.github/workflows/prerelease.yml
@@ -134,6 +134,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -167,6 +170,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/provider-ci/providers/docker/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/docker/repo/.github/workflows/release.yml
@@ -147,6 +147,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -180,6 +183,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/provider-ci/providers/docker/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/docker/repo/.github/workflows/run-acceptance-tests.yml
@@ -158,6 +158,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -195,6 +198,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/provider-ci/providers/ec/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/ec/repo/.github/workflows/main.yml
@@ -179,6 +179,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -212,6 +215,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/provider-ci/providers/ec/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/ec/repo/.github/workflows/master.yml
@@ -179,6 +179,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -212,6 +215,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/provider-ci/providers/ec/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/ec/repo/.github/workflows/prerelease.yml
@@ -129,6 +129,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -162,6 +165,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/provider-ci/providers/ec/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/ec/repo/.github/workflows/release.yml
@@ -142,6 +142,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -175,6 +178,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/provider-ci/providers/ec/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/ec/repo/.github/workflows/run-acceptance-tests.yml
@@ -153,6 +153,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -190,6 +193,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/provider-ci/providers/f5bigip/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/f5bigip/repo/.github/workflows/main.yml
@@ -182,6 +182,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -215,6 +218,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/provider-ci/providers/f5bigip/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/f5bigip/repo/.github/workflows/master.yml
@@ -182,6 +182,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -215,6 +218,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/provider-ci/providers/f5bigip/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/f5bigip/repo/.github/workflows/prerelease.yml
@@ -132,6 +132,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -165,6 +168,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/provider-ci/providers/f5bigip/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/f5bigip/repo/.github/workflows/release.yml
@@ -145,6 +145,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -178,6 +181,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/provider-ci/providers/f5bigip/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/f5bigip/repo/.github/workflows/run-acceptance-tests.yml
@@ -156,6 +156,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -193,6 +196,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/provider-ci/providers/fastly/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/fastly/repo/.github/workflows/main.yml
@@ -179,6 +179,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -212,6 +215,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/provider-ci/providers/fastly/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/fastly/repo/.github/workflows/master.yml
@@ -179,6 +179,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -212,6 +215,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/provider-ci/providers/fastly/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/fastly/repo/.github/workflows/prerelease.yml
@@ -129,6 +129,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -162,6 +165,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/provider-ci/providers/fastly/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/fastly/repo/.github/workflows/release.yml
@@ -142,6 +142,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -175,6 +178,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/provider-ci/providers/fastly/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/fastly/repo/.github/workflows/run-acceptance-tests.yml
@@ -153,6 +153,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -190,6 +193,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/provider-ci/providers/github/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/github/repo/.github/workflows/main.yml
@@ -180,6 +180,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -213,6 +216,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/provider-ci/providers/github/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/github/repo/.github/workflows/master.yml
@@ -180,6 +180,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -213,6 +216,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/provider-ci/providers/github/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/github/repo/.github/workflows/prerelease.yml
@@ -130,6 +130,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -163,6 +166,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/provider-ci/providers/github/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/github/repo/.github/workflows/release.yml
@@ -143,6 +143,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -176,6 +179,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/provider-ci/providers/github/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/github/repo/.github/workflows/run-acceptance-tests.yml
@@ -154,6 +154,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -191,6 +194,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/provider-ci/providers/gitlab/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/gitlab/repo/.github/workflows/main.yml
@@ -179,6 +179,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -212,6 +215,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/provider-ci/providers/gitlab/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/gitlab/repo/.github/workflows/master.yml
@@ -179,6 +179,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -212,6 +215,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/provider-ci/providers/gitlab/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/gitlab/repo/.github/workflows/prerelease.yml
@@ -129,6 +129,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -162,6 +165,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/provider-ci/providers/gitlab/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/gitlab/repo/.github/workflows/release.yml
@@ -142,6 +142,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -175,6 +178,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/provider-ci/providers/gitlab/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/gitlab/repo/.github/workflows/run-acceptance-tests.yml
@@ -153,6 +153,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -190,6 +193,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/provider-ci/providers/hcloud/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/hcloud/repo/.github/workflows/main.yml
@@ -179,6 +179,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -212,6 +215,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/provider-ci/providers/hcloud/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/hcloud/repo/.github/workflows/master.yml
@@ -179,6 +179,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -212,6 +215,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/provider-ci/providers/hcloud/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/hcloud/repo/.github/workflows/prerelease.yml
@@ -129,6 +129,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -162,6 +165,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/provider-ci/providers/hcloud/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/hcloud/repo/.github/workflows/release.yml
@@ -142,6 +142,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -175,6 +178,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/provider-ci/providers/hcloud/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/hcloud/repo/.github/workflows/run-acceptance-tests.yml
@@ -153,6 +153,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -190,6 +193,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/provider-ci/providers/kafka/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/kafka/repo/.github/workflows/main.yml
@@ -178,6 +178,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -211,6 +214,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/provider-ci/providers/kafka/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/kafka/repo/.github/workflows/master.yml
@@ -178,6 +178,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -211,6 +214,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/provider-ci/providers/kafka/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/kafka/repo/.github/workflows/prerelease.yml
@@ -128,6 +128,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -161,6 +164,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/provider-ci/providers/kafka/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/kafka/repo/.github/workflows/release.yml
@@ -141,6 +141,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -174,6 +177,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/provider-ci/providers/kafka/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/kafka/repo/.github/workflows/run-acceptance-tests.yml
@@ -152,6 +152,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -189,6 +192,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/provider-ci/providers/keycloak/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/keycloak/repo/.github/workflows/main.yml
@@ -183,6 +183,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -216,6 +219,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/provider-ci/providers/keycloak/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/keycloak/repo/.github/workflows/master.yml
@@ -183,6 +183,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -216,6 +219,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/provider-ci/providers/keycloak/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/keycloak/repo/.github/workflows/prerelease.yml
@@ -133,6 +133,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -166,6 +169,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/provider-ci/providers/keycloak/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/keycloak/repo/.github/workflows/release.yml
@@ -146,6 +146,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -179,6 +182,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/provider-ci/providers/keycloak/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/keycloak/repo/.github/workflows/run-acceptance-tests.yml
@@ -157,6 +157,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -194,6 +197,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/provider-ci/providers/kong/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/kong/repo/.github/workflows/main.yml
@@ -178,6 +178,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -211,6 +214,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/provider-ci/providers/kong/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/kong/repo/.github/workflows/master.yml
@@ -178,6 +178,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -211,6 +214,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/provider-ci/providers/kong/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/kong/repo/.github/workflows/prerelease.yml
@@ -128,6 +128,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -161,6 +164,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/provider-ci/providers/kong/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/kong/repo/.github/workflows/release.yml
@@ -141,6 +141,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -174,6 +177,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/provider-ci/providers/kong/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/kong/repo/.github/workflows/run-acceptance-tests.yml
@@ -152,6 +152,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -189,6 +192,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/provider-ci/providers/libvirt/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/libvirt/repo/.github/workflows/main.yml
@@ -179,6 +179,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -212,6 +215,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/provider-ci/providers/libvirt/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/libvirt/repo/.github/workflows/master.yml
@@ -179,6 +179,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -212,6 +215,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/provider-ci/providers/libvirt/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/libvirt/repo/.github/workflows/prerelease.yml
@@ -129,6 +129,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -162,6 +165,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/provider-ci/providers/libvirt/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/libvirt/repo/.github/workflows/release.yml
@@ -142,6 +142,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -175,6 +178,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/provider-ci/providers/libvirt/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/libvirt/repo/.github/workflows/run-acceptance-tests.yml
@@ -153,6 +153,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -190,6 +193,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/provider-ci/providers/linode/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/linode/repo/.github/workflows/main.yml
@@ -179,6 +179,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -212,6 +215,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/provider-ci/providers/linode/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/linode/repo/.github/workflows/master.yml
@@ -179,6 +179,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -212,6 +215,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/provider-ci/providers/linode/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/linode/repo/.github/workflows/prerelease.yml
@@ -129,6 +129,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -162,6 +165,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/provider-ci/providers/linode/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/linode/repo/.github/workflows/release.yml
@@ -142,6 +142,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -175,6 +178,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/provider-ci/providers/linode/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/linode/repo/.github/workflows/run-acceptance-tests.yml
@@ -153,6 +153,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -190,6 +193,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/provider-ci/providers/mailgun/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/mailgun/repo/.github/workflows/main.yml
@@ -179,6 +179,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -212,6 +215,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/provider-ci/providers/mailgun/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/mailgun/repo/.github/workflows/master.yml
@@ -179,6 +179,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -212,6 +215,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/provider-ci/providers/mailgun/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/mailgun/repo/.github/workflows/prerelease.yml
@@ -129,6 +129,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -162,6 +165,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/provider-ci/providers/mailgun/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/mailgun/repo/.github/workflows/release.yml
@@ -142,6 +142,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -175,6 +178,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/provider-ci/providers/mailgun/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/mailgun/repo/.github/workflows/run-acceptance-tests.yml
@@ -153,6 +153,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -190,6 +193,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/provider-ci/providers/minio/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/minio/repo/.github/workflows/main.yml
@@ -182,6 +182,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -215,6 +218,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/provider-ci/providers/minio/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/minio/repo/.github/workflows/master.yml
@@ -182,6 +182,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -215,6 +218,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/provider-ci/providers/minio/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/minio/repo/.github/workflows/prerelease.yml
@@ -132,6 +132,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -165,6 +168,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/provider-ci/providers/minio/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/minio/repo/.github/workflows/release.yml
@@ -145,6 +145,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -178,6 +181,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/provider-ci/providers/minio/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/minio/repo/.github/workflows/run-acceptance-tests.yml
@@ -156,6 +156,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -193,6 +196,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/provider-ci/providers/mongodbatlas/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/mongodbatlas/repo/.github/workflows/main.yml
@@ -181,6 +181,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -214,6 +217,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/provider-ci/providers/mongodbatlas/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/mongodbatlas/repo/.github/workflows/master.yml
@@ -181,6 +181,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -214,6 +217,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/provider-ci/providers/mongodbatlas/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/mongodbatlas/repo/.github/workflows/prerelease.yml
@@ -131,6 +131,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -164,6 +167,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/provider-ci/providers/mongodbatlas/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/mongodbatlas/repo/.github/workflows/release.yml
@@ -144,6 +144,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -177,6 +180,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/provider-ci/providers/mongodbatlas/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/mongodbatlas/repo/.github/workflows/run-acceptance-tests.yml
@@ -155,6 +155,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -192,6 +195,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/provider-ci/providers/mysql/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/mysql/repo/.github/workflows/main.yml
@@ -178,6 +178,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -211,6 +214,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/provider-ci/providers/mysql/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/mysql/repo/.github/workflows/master.yml
@@ -178,6 +178,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -211,6 +214,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/provider-ci/providers/mysql/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/mysql/repo/.github/workflows/prerelease.yml
@@ -128,6 +128,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -161,6 +164,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/provider-ci/providers/mysql/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/mysql/repo/.github/workflows/release.yml
@@ -141,6 +141,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -174,6 +177,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/provider-ci/providers/mysql/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/mysql/repo/.github/workflows/run-acceptance-tests.yml
@@ -152,6 +152,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -189,6 +192,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/provider-ci/providers/newrelic/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/newrelic/repo/.github/workflows/main.yml
@@ -180,6 +180,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -213,6 +216,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/provider-ci/providers/newrelic/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/newrelic/repo/.github/workflows/master.yml
@@ -180,6 +180,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -213,6 +216,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/provider-ci/providers/newrelic/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/newrelic/repo/.github/workflows/prerelease.yml
@@ -130,6 +130,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -163,6 +166,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/provider-ci/providers/newrelic/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/newrelic/repo/.github/workflows/release.yml
@@ -143,6 +143,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -176,6 +179,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/provider-ci/providers/newrelic/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/newrelic/repo/.github/workflows/run-acceptance-tests.yml
@@ -154,6 +154,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -191,6 +194,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/provider-ci/providers/nomad/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/nomad/repo/.github/workflows/main.yml
@@ -179,6 +179,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -212,6 +215,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/provider-ci/providers/nomad/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/nomad/repo/.github/workflows/master.yml
@@ -179,6 +179,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -212,6 +215,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/provider-ci/providers/nomad/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/nomad/repo/.github/workflows/prerelease.yml
@@ -129,6 +129,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -162,6 +165,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/provider-ci/providers/nomad/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/nomad/repo/.github/workflows/release.yml
@@ -142,6 +142,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -175,6 +178,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/provider-ci/providers/nomad/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/nomad/repo/.github/workflows/run-acceptance-tests.yml
@@ -153,6 +153,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -190,6 +193,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/provider-ci/providers/ns1/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/ns1/repo/.github/workflows/main.yml
@@ -179,6 +179,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -212,6 +215,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/provider-ci/providers/ns1/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/ns1/repo/.github/workflows/master.yml
@@ -179,6 +179,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -212,6 +215,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/provider-ci/providers/ns1/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/ns1/repo/.github/workflows/prerelease.yml
@@ -129,6 +129,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -162,6 +165,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/provider-ci/providers/ns1/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/ns1/repo/.github/workflows/release.yml
@@ -142,6 +142,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -175,6 +178,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/provider-ci/providers/ns1/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/ns1/repo/.github/workflows/run-acceptance-tests.yml
@@ -153,6 +153,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -190,6 +193,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/provider-ci/providers/okta/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/okta/repo/.github/workflows/main.yml
@@ -181,6 +181,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -214,6 +217,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/provider-ci/providers/okta/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/okta/repo/.github/workflows/master.yml
@@ -181,6 +181,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -214,6 +217,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/provider-ci/providers/okta/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/okta/repo/.github/workflows/prerelease.yml
@@ -131,6 +131,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -164,6 +167,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/provider-ci/providers/okta/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/okta/repo/.github/workflows/release.yml
@@ -144,6 +144,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -177,6 +180,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/provider-ci/providers/okta/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/okta/repo/.github/workflows/run-acceptance-tests.yml
@@ -155,6 +155,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -192,6 +195,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/provider-ci/providers/onelogin/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/onelogin/repo/.github/workflows/main.yml
@@ -178,6 +178,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -211,6 +214,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/provider-ci/providers/onelogin/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/onelogin/repo/.github/workflows/master.yml
@@ -178,6 +178,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -211,6 +214,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/provider-ci/providers/onelogin/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/onelogin/repo/.github/workflows/prerelease.yml
@@ -128,6 +128,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -161,6 +164,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/provider-ci/providers/onelogin/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/onelogin/repo/.github/workflows/release.yml
@@ -141,6 +141,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -174,6 +177,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/provider-ci/providers/onelogin/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/onelogin/repo/.github/workflows/run-acceptance-tests.yml
@@ -152,6 +152,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -189,6 +192,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/provider-ci/providers/openstack/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/openstack/repo/.github/workflows/main.yml
@@ -187,6 +187,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -220,6 +223,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/provider-ci/providers/openstack/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/openstack/repo/.github/workflows/master.yml
@@ -187,6 +187,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -220,6 +223,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/provider-ci/providers/openstack/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/openstack/repo/.github/workflows/prerelease.yml
@@ -137,6 +137,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -170,6 +173,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/provider-ci/providers/openstack/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/openstack/repo/.github/workflows/release.yml
@@ -150,6 +150,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -183,6 +186,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/provider-ci/providers/openstack/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/openstack/repo/.github/workflows/run-acceptance-tests.yml
@@ -161,6 +161,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -198,6 +201,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/provider-ci/providers/opsgenie/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/opsgenie/repo/.github/workflows/main.yml
@@ -179,6 +179,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -212,6 +215,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/provider-ci/providers/opsgenie/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/opsgenie/repo/.github/workflows/master.yml
@@ -179,6 +179,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -212,6 +215,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/provider-ci/providers/opsgenie/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/opsgenie/repo/.github/workflows/prerelease.yml
@@ -129,6 +129,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -162,6 +165,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/provider-ci/providers/opsgenie/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/opsgenie/repo/.github/workflows/release.yml
@@ -142,6 +142,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -175,6 +178,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/provider-ci/providers/opsgenie/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/opsgenie/repo/.github/workflows/run-acceptance-tests.yml
@@ -153,6 +153,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -190,6 +193,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/provider-ci/providers/pagerduty/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/pagerduty/repo/.github/workflows/main.yml
@@ -179,6 +179,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -212,6 +215,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/provider-ci/providers/pagerduty/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/pagerduty/repo/.github/workflows/master.yml
@@ -179,6 +179,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -212,6 +215,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/provider-ci/providers/pagerduty/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/pagerduty/repo/.github/workflows/prerelease.yml
@@ -129,6 +129,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -162,6 +165,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/provider-ci/providers/pagerduty/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/pagerduty/repo/.github/workflows/release.yml
@@ -142,6 +142,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -175,6 +178,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/provider-ci/providers/pagerduty/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/pagerduty/repo/.github/workflows/run-acceptance-tests.yml
@@ -153,6 +153,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -190,6 +193,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/provider-ci/providers/postgresql/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/postgresql/repo/.github/workflows/main.yml
@@ -178,6 +178,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -211,6 +214,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/provider-ci/providers/postgresql/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/postgresql/repo/.github/workflows/master.yml
@@ -178,6 +178,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -211,6 +214,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/provider-ci/providers/postgresql/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/postgresql/repo/.github/workflows/prerelease.yml
@@ -128,6 +128,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -161,6 +164,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/provider-ci/providers/postgresql/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/postgresql/repo/.github/workflows/release.yml
@@ -141,6 +141,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -174,6 +177,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/provider-ci/providers/postgresql/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/postgresql/repo/.github/workflows/run-acceptance-tests.yml
@@ -152,6 +152,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -189,6 +192,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/provider-ci/providers/rabbitmq/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/rabbitmq/repo/.github/workflows/main.yml
@@ -178,6 +178,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -211,6 +214,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/provider-ci/providers/rabbitmq/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/rabbitmq/repo/.github/workflows/master.yml
@@ -178,6 +178,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -211,6 +214,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/provider-ci/providers/rabbitmq/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/rabbitmq/repo/.github/workflows/prerelease.yml
@@ -128,6 +128,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -161,6 +164,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/provider-ci/providers/rabbitmq/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/rabbitmq/repo/.github/workflows/release.yml
@@ -141,6 +141,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -174,6 +177,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/provider-ci/providers/rabbitmq/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/rabbitmq/repo/.github/workflows/run-acceptance-tests.yml
@@ -152,6 +152,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -189,6 +192,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/provider-ci/providers/random/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/random/repo/.github/workflows/main.yml
@@ -178,6 +178,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -211,6 +214,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/provider-ci/providers/random/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/random/repo/.github/workflows/master.yml
@@ -178,6 +178,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -211,6 +214,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/provider-ci/providers/random/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/random/repo/.github/workflows/prerelease.yml
@@ -128,6 +128,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -161,6 +164,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/provider-ci/providers/random/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/random/repo/.github/workflows/release.yml
@@ -141,6 +141,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -174,6 +177,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/provider-ci/providers/random/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/random/repo/.github/workflows/run-acceptance-tests.yml
@@ -152,6 +152,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -189,6 +192,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/provider-ci/providers/rke/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/rke/repo/.github/workflows/main.yml
@@ -179,6 +179,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -212,6 +215,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/provider-ci/providers/rke/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/rke/repo/.github/workflows/master.yml
@@ -179,6 +179,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -212,6 +215,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/provider-ci/providers/rke/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/rke/repo/.github/workflows/prerelease.yml
@@ -129,6 +129,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -162,6 +165,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/provider-ci/providers/rke/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/rke/repo/.github/workflows/release.yml
@@ -142,6 +142,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -175,6 +178,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/provider-ci/providers/rke/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/rke/repo/.github/workflows/run-acceptance-tests.yml
@@ -153,6 +153,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -190,6 +193,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/provider-ci/providers/signalfx/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/signalfx/repo/.github/workflows/main.yml
@@ -178,6 +178,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -211,6 +214,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/provider-ci/providers/signalfx/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/signalfx/repo/.github/workflows/master.yml
@@ -178,6 +178,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -211,6 +214,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/provider-ci/providers/signalfx/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/signalfx/repo/.github/workflows/prerelease.yml
@@ -128,6 +128,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -161,6 +164,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/provider-ci/providers/signalfx/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/signalfx/repo/.github/workflows/release.yml
@@ -141,6 +141,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -174,6 +177,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/provider-ci/providers/signalfx/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/signalfx/repo/.github/workflows/run-acceptance-tests.yml
@@ -152,6 +152,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -189,6 +192,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/provider-ci/providers/slack/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/slack/repo/.github/workflows/main.yml
@@ -179,6 +179,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -212,6 +215,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/provider-ci/providers/slack/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/slack/repo/.github/workflows/master.yml
@@ -179,6 +179,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -212,6 +215,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/provider-ci/providers/slack/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/slack/repo/.github/workflows/prerelease.yml
@@ -129,6 +129,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -162,6 +165,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/provider-ci/providers/slack/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/slack/repo/.github/workflows/release.yml
@@ -142,6 +142,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -175,6 +178,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/provider-ci/providers/slack/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/slack/repo/.github/workflows/run-acceptance-tests.yml
@@ -153,6 +153,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -190,6 +193,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/provider-ci/providers/snowflake/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/snowflake/repo/.github/workflows/main.yml
@@ -183,6 +183,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -216,6 +219,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/provider-ci/providers/snowflake/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/snowflake/repo/.github/workflows/master.yml
@@ -183,6 +183,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -216,6 +219,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/provider-ci/providers/snowflake/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/snowflake/repo/.github/workflows/prerelease.yml
@@ -133,6 +133,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -166,6 +169,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/provider-ci/providers/snowflake/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/snowflake/repo/.github/workflows/release.yml
@@ -146,6 +146,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -179,6 +182,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/provider-ci/providers/snowflake/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/snowflake/repo/.github/workflows/run-acceptance-tests.yml
@@ -157,6 +157,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -194,6 +197,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/provider-ci/providers/splunk/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/splunk/repo/.github/workflows/main.yml
@@ -181,6 +181,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -214,6 +217,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/provider-ci/providers/splunk/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/splunk/repo/.github/workflows/master.yml
@@ -181,6 +181,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -214,6 +217,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/provider-ci/providers/splunk/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/splunk/repo/.github/workflows/prerelease.yml
@@ -131,6 +131,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -164,6 +167,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/provider-ci/providers/splunk/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/splunk/repo/.github/workflows/release.yml
@@ -144,6 +144,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -177,6 +180,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/provider-ci/providers/splunk/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/splunk/repo/.github/workflows/run-acceptance-tests.yml
@@ -155,6 +155,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -192,6 +195,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/provider-ci/providers/spotinst/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/spotinst/repo/.github/workflows/main.yml
@@ -181,6 +181,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -214,6 +217,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/provider-ci/providers/spotinst/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/spotinst/repo/.github/workflows/master.yml
@@ -181,6 +181,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -214,6 +217,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/provider-ci/providers/spotinst/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/spotinst/repo/.github/workflows/prerelease.yml
@@ -131,6 +131,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -164,6 +167,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/provider-ci/providers/spotinst/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/spotinst/repo/.github/workflows/release.yml
@@ -144,6 +144,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -177,6 +180,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/provider-ci/providers/spotinst/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/spotinst/repo/.github/workflows/run-acceptance-tests.yml
@@ -155,6 +155,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -192,6 +195,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/provider-ci/providers/sumologic/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/sumologic/repo/.github/workflows/main.yml
@@ -181,6 +181,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -214,6 +217,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/provider-ci/providers/sumologic/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/sumologic/repo/.github/workflows/master.yml
@@ -181,6 +181,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -214,6 +217,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/provider-ci/providers/sumologic/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/sumologic/repo/.github/workflows/prerelease.yml
@@ -131,6 +131,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -164,6 +167,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/provider-ci/providers/sumologic/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/sumologic/repo/.github/workflows/release.yml
@@ -144,6 +144,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -177,6 +180,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/provider-ci/providers/sumologic/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/sumologic/repo/.github/workflows/run-acceptance-tests.yml
@@ -155,6 +155,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -192,6 +195,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/provider-ci/providers/tailscale/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/tailscale/repo/.github/workflows/main.yml
@@ -180,6 +180,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -213,6 +216,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/provider-ci/providers/tailscale/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/tailscale/repo/.github/workflows/master.yml
@@ -180,6 +180,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -213,6 +216,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/provider-ci/providers/tailscale/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/tailscale/repo/.github/workflows/prerelease.yml
@@ -130,6 +130,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -163,6 +166,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/provider-ci/providers/tailscale/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/tailscale/repo/.github/workflows/release.yml
@@ -143,6 +143,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -176,6 +179,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/provider-ci/providers/tailscale/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/tailscale/repo/.github/workflows/run-acceptance-tests.yml
@@ -154,6 +154,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -191,6 +194,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/provider-ci/providers/tls/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/tls/repo/.github/workflows/main.yml
@@ -178,6 +178,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -211,6 +214,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/provider-ci/providers/tls/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/tls/repo/.github/workflows/master.yml
@@ -178,6 +178,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -211,6 +214,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/provider-ci/providers/tls/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/tls/repo/.github/workflows/prerelease.yml
@@ -128,6 +128,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -161,6 +164,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/provider-ci/providers/tls/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/tls/repo/.github/workflows/release.yml
@@ -141,6 +141,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -174,6 +177,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/provider-ci/providers/tls/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/tls/repo/.github/workflows/run-acceptance-tests.yml
@@ -152,6 +152,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -189,6 +192,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/provider-ci/providers/vault/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/vault/repo/.github/workflows/main.yml
@@ -178,6 +178,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -211,6 +214,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/provider-ci/providers/vault/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/vault/repo/.github/workflows/master.yml
@@ -178,6 +178,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -211,6 +214,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/provider-ci/providers/vault/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/vault/repo/.github/workflows/prerelease.yml
@@ -128,6 +128,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -161,6 +164,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/provider-ci/providers/vault/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/vault/repo/.github/workflows/release.yml
@@ -141,6 +141,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -174,6 +177,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/provider-ci/providers/vault/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/vault/repo/.github/workflows/run-acceptance-tests.yml
@@ -152,6 +152,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -189,6 +192,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/provider-ci/providers/venafi/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/venafi/repo/.github/workflows/main.yml
@@ -182,6 +182,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -215,6 +218,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/provider-ci/providers/venafi/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/venafi/repo/.github/workflows/master.yml
@@ -182,6 +182,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -215,6 +218,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/provider-ci/providers/venafi/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/venafi/repo/.github/workflows/prerelease.yml
@@ -132,6 +132,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -165,6 +168,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/provider-ci/providers/venafi/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/venafi/repo/.github/workflows/release.yml
@@ -145,6 +145,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -178,6 +181,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/provider-ci/providers/venafi/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/venafi/repo/.github/workflows/run-acceptance-tests.yml
@@ -156,6 +156,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -193,6 +196,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/provider-ci/providers/vsphere/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/vsphere/repo/.github/workflows/main.yml
@@ -178,6 +178,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -211,6 +214,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/provider-ci/providers/vsphere/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/vsphere/repo/.github/workflows/master.yml
@@ -178,6 +178,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -211,6 +214,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/provider-ci/providers/vsphere/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/vsphere/repo/.github/workflows/prerelease.yml
@@ -128,6 +128,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -161,6 +164,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/provider-ci/providers/vsphere/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/vsphere/repo/.github/workflows/release.yml
@@ -141,6 +141,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -174,6 +177,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/provider-ci/providers/vsphere/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/vsphere/repo/.github/workflows/run-acceptance-tests.yml
@@ -152,6 +152,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -189,6 +192,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/provider-ci/providers/wavefront/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/wavefront/repo/.github/workflows/main.yml
@@ -180,6 +180,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -213,6 +216,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/provider-ci/providers/wavefront/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/wavefront/repo/.github/workflows/master.yml
@@ -180,6 +180,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -213,6 +216,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/provider-ci/providers/wavefront/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/wavefront/repo/.github/workflows/prerelease.yml
@@ -130,6 +130,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -163,6 +166,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/provider-ci/providers/wavefront/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/wavefront/repo/.github/workflows/release.yml
@@ -143,6 +143,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -176,6 +179,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/provider-ci/providers/wavefront/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/wavefront/repo/.github/workflows/run-acceptance-tests.yml
@@ -154,6 +154,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -191,6 +194,9 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
+    - name: Mark repo as safe directory
+      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER
+        }}/pulumi-${{ env.PROVIDER }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/provider-ci/src/config.ts
+++ b/provider-ci/src/config.ts
@@ -42,7 +42,7 @@ const BridgedConfig = z
       .array(z.object({ name: z.string(), version: z.string() }))
       .optional(),
     docsCmd: z.string().default(""),
-    hybrid: z.boolean().default(false)
+    hybrid: z.boolean().default(false),
   })
   .transform((input) => {
     if (input["upstream-provider-repo"] !== "") {

--- a/provider-ci/src/make-bridged-provider.ts
+++ b/provider-ci/src/make-bridged-provider.ts
@@ -33,12 +33,11 @@ export function bridgedProvider(config: BridgedConfig): Makefile {
     WORKING_DIR,
   } as const;
 
-
   const docs: Target = {
     name: "docs",
     phony: true,
-    commands: [config.docsCmd]
-  }
+    commands: [config.docsCmd],
+  };
 
   const install_plugins: Target = {
     name: "install_plugins",
@@ -62,8 +61,8 @@ export function bridgedProvider(config: BridgedConfig): Makefile {
     ],
   };
 
-  if (config.provider == "docker" ) {
-    tfgen.dependencies = [install_plugins, docs]
+  if (config.provider == "docker") {
+    tfgen.dependencies = [install_plugins, docs];
   }
 
   const ldFlagStatements = ["-X $(PROJECT)/$(VERSION_PATH)=$(VERSION)"];
@@ -263,34 +262,33 @@ export function bridgedProvider(config: BridgedConfig): Makefile {
   };
 
   const returnTargets = [
-        build,
-        only_build,
-        tfgen,
-        provider,
-        build_sdks,
-        build_nodejs,
-        build_python,
-        build_go,
-        build_dotnet,
-        build_java,
-        bin_pulumi_java_gen,
-        lint_provider,
-        cleanup,
-        help,
-        clean,
-        install_plugins,
-        install_dotnet_sdk,
-        install_python_sdk,
-        install_go_sdk,
-        install_java_sdk,
-        install_nodejs_sdk,
-        install_sdks,
-        test,
-      ]
-
+    build,
+    only_build,
+    tfgen,
+    provider,
+    build_sdks,
+    build_nodejs,
+    build_python,
+    build_go,
+    build_dotnet,
+    build_java,
+    bin_pulumi_java_gen,
+    lint_provider,
+    cleanup,
+    help,
+    clean,
+    install_plugins,
+    install_dotnet_sdk,
+    install_python_sdk,
+    install_go_sdk,
+    install_java_sdk,
+    install_nodejs_sdk,
+    install_sdks,
+    test,
+  ];
 
   if (config.hybrid) {
-    returnTargets.push(docs)
+    returnTargets.push(docs);
   }
 
   return {

--- a/provider-ci/src/make.ts
+++ b/provider-ci/src/make.ts
@@ -65,8 +65,8 @@ function renderCommands(
 
 function renderTarget(target: Target): string {
   const dependencies = target.dependencies ?? [];
-  const dependencyNames = dependencies.map((d) =>
-    " " + (typeof d === "string" ? d : d.name)
+  const dependencyNames = dependencies.map(
+    (d) => " " + (typeof d === "string" ? d : d.name)
   );
   const declaration = `${target.name}:${dependencyNames.join("")}`;
   const commands = renderCommands(target.commands);

--- a/provider-ci/src/steps.ts
+++ b/provider-ci/src/steps.ts
@@ -51,6 +51,13 @@ export function CheckoutScriptsRepoStep(): Step {
   };
 }
 
+export function CheckoutSafeDirectoryStep(): Step {
+  return {
+    name: "Mark repo as safe directory",
+    run: "git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER }}/pulumi-${{ env.PROVIDER }}",
+  };
+}
+
 export function CheckoutTagsStep(): Step {
   return {
     name: "Unshallow clone for tags",

--- a/provider-ci/src/workflows.ts
+++ b/provider-ci/src/workflows.ts
@@ -901,6 +901,7 @@ export class LintProviderJob implements NormalJob {
   steps = [
     steps.CheckoutRepoStep(),
     steps.CheckoutScriptsRepoStep(),
+    steps.CheckoutSafeDirectoryStep(),
     steps.CheckoutTagsStep(),
     steps.InstallGo(),
     steps.InstallPulumiCtl(),
@@ -944,6 +945,7 @@ export class LintSDKJob implements NormalJob {
     this.steps = [
       steps.CheckoutRepoStep(),
       steps.CheckoutScriptsRepoStep(),
+      steps.CheckoutSafeDirectoryStep(),
       steps.CheckoutTagsStep(),
       steps.InstallGo(),
       steps.InstallPulumiCtl(),


### PR DESCRIPTION
Fixes #324 

Marks the working directory of the github action runner as a safe directory in git, which passes the recently added security check discussed in https://github.com/actions/runner-images/issues/6775.