### PR TITLE
Exclude providers team repos from automerge

### DIFF
--- a/.github/workflows/update-workflows-bridged-providers.yml
+++ b/.github/workflows/update-workflows-bridged-providers.yml
@@ -73,8 +73,11 @@ jobs:
           title: "Update GitHub Actions workflows."
           path: pulumi-${{ matrix.provider }}
           token: ${{ secrets.PULUMI_BOT_TOKEN }}
+      - id: team-responsible
+        run: |
+          echo "team=$(sed -nr 's/team: (.*)/\1/p' ci-mgmt/provider-ci/providers/${{ matrix.provider }}/config.yaml)" >> $GITHUB_OUTPUT
       - name: Set PR to auto-merge
-        if: steps.create-pr.outputs.pull-request-operation == 'created' && github.event.inputs.automerge == 'true'
+        if: steps.create-pr.outputs.pull-request-operation == 'created' && github.event.inputs.automerge == 'true' && steps.team-responsible.output.team != 'providers'
         run: "gh pr merge --auto --squash ${{ steps.create-pr.outputs.pull-request-url }}"
       # See: https://docs.github.com/en/rest/guides/best-practices-for-integrators#dealing-with-secondary-rate-limits
       - name: Sleep to prevent hitting secondary rate limits


### PR DESCRIPTION
Idea: Don't automerge for the providers team. We'll always review changes coming down which reduces the need for us to review ongoing work.

This is just to demonstrate the intended output ... might be better ways to implement! Also, need to check all other workflows.