### PR TITLE
Need auth on the GH BranchProtection managing stack

### DIFF
--- a/.github/workflows/update-gh-branch-protection.yml
+++ b/.github/workflows/update-gh-branch-protection.yml
@@ -46,4 +46,5 @@ jobs:
           work-dir: infra/providers
           github-token: ${{ secrets.PULUMI_BOT_TOKEN }}
         env:
+          GITHUB_TOKEN: ${{ secrets.PULUMI_BOT_TOKEN }}
           PULUMI_ACCESS_TOKEN: ${{ secrets.PULUMI_ACCESS_TOKEN_PRODUCTION }}


### PR DESCRIPTION
The workflow has been failing, presumably because it cannot auth to GH when executing BranchProtection changes.