### PR TITLE
Use v5 major version on cloudflare

### DIFF
--- a/provider-ci/providers/cloudflare/config.yaml
+++ b/provider-ci/providers/cloudflare/config.yaml
@@ -1,5 +1,5 @@
 provider: cloudflare
-major-version: 4
+major-version: 5
 upstream-provider-org: cloudflare
 makeTemplate: bridged
 plugins:

--- a/provider-ci/providers/cloudflare/repo/.goreleaser.prerelease.yml
+++ b/provider-ci/providers/cloudflare/repo/.goreleaser.prerelease.yml
@@ -29,7 +29,7 @@ builds:
   ignore: []
   ldflags:
   - -X
-    github.com/pulumi/pulumi-cloudflare/provider/v4/pkg/version.Version={{.Tag}}
+    github.com/pulumi/pulumi-cloudflare/provider/v5/pkg/version.Version={{.Tag}}
   main: ./cmd/pulumi-resource-cloudflare/
 changelog:
   skip: true

--- a/provider-ci/providers/cloudflare/repo/.goreleaser.yml
+++ b/provider-ci/providers/cloudflare/repo/.goreleaser.yml
@@ -29,7 +29,7 @@ builds:
   ignore: []
   ldflags:
   - -X
-    github.com/pulumi/pulumi-cloudflare/provider/v4/pkg/version.Version={{.Tag}}
+    github.com/pulumi/pulumi-cloudflare/provider/v5/pkg/version.Version={{.Tag}}
   main: ./cmd/pulumi-resource-cloudflare/
 changelog:
   filters:

--- a/provider-ci/providers/cloudflare/repo/Makefile
+++ b/provider-ci/providers/cloudflare/repo/Makefile
@@ -3,7 +3,7 @@
 PACK := cloudflare
 ORG := pulumi
 PROJECT := github.com/$(ORG)/pulumi-$(PACK)
-PROVIDER_PATH := provider/v4
+PROVIDER_PATH := provider/v5
 VERSION_PATH := $(PROVIDER_PATH)/pkg/version.Version
 TFGEN := pulumi-tfgen-$(PACK)
 PROVIDER := pulumi-resource-$(PACK)


### PR DESCRIPTION
Looks like pulumi-cloudflare is on v5 now but ci-mgmt conflicts with it and tries to auto-update to v4.