### PR TITLE
Fixes 332: do not fail fast in tests

### DIFF
--- a/provider-ci/providers/aiven/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/aiven/repo/.github/workflows/main.yml
@@ -499,7 +499,7 @@ jobs:
         fields: repo,commit,author,action
         status: ${{ job.status }}
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         language:
         - nodejs

--- a/provider-ci/providers/aiven/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/aiven/repo/.github/workflows/master.yml
@@ -499,7 +499,7 @@ jobs:
         fields: repo,commit,author,action
         status: ${{ job.status }}
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         language:
         - nodejs

--- a/provider-ci/providers/aiven/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/aiven/repo/.github/workflows/prerelease.yml
@@ -449,7 +449,7 @@ jobs:
         fields: repo,commit,author,action
         status: ${{ job.status }}
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         language:
         - nodejs

--- a/provider-ci/providers/aiven/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/aiven/repo/.github/workflows/release.yml
@@ -475,7 +475,7 @@ jobs:
         fields: repo,commit,author,action
         status: ${{ job.status }}
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         language:
         - nodejs

--- a/provider-ci/providers/aiven/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/aiven/repo/.github/workflows/run-acceptance-tests.yml
@@ -317,7 +317,7 @@ jobs:
         fields: repo,commit,author,action
         status: ${{ job.status }}
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         language:
         - nodejs

--- a/provider-ci/providers/akamai/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/akamai/repo/.github/workflows/main.yml
@@ -501,7 +501,7 @@ jobs:
         fields: repo,commit,author,action
         status: ${{ job.status }}
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         language:
         - nodejs

--- a/provider-ci/providers/akamai/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/akamai/repo/.github/workflows/master.yml
@@ -501,7 +501,7 @@ jobs:
         fields: repo,commit,author,action
         status: ${{ job.status }}
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         language:
         - nodejs

--- a/provider-ci/providers/akamai/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/akamai/repo/.github/workflows/prerelease.yml
@@ -451,7 +451,7 @@ jobs:
         fields: repo,commit,author,action
         status: ${{ job.status }}
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         language:
         - nodejs

--- a/provider-ci/providers/akamai/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/akamai/repo/.github/workflows/release.yml
@@ -477,7 +477,7 @@ jobs:
         fields: repo,commit,author,action
         status: ${{ job.status }}
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         language:
         - nodejs

--- a/provider-ci/providers/akamai/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/akamai/repo/.github/workflows/run-acceptance-tests.yml
@@ -319,7 +319,7 @@ jobs:
         fields: repo,commit,author,action
         status: ${{ job.status }}
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         language:
         - nodejs

--- a/provider-ci/providers/alicloud/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/alicloud/repo/.github/workflows/main.yml
@@ -500,7 +500,7 @@ jobs:
         fields: repo,commit,author,action
         status: ${{ job.status }}
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         language:
         - nodejs

--- a/provider-ci/providers/alicloud/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/alicloud/repo/.github/workflows/master.yml
@@ -500,7 +500,7 @@ jobs:
         fields: repo,commit,author,action
         status: ${{ job.status }}
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         language:
         - nodejs

--- a/provider-ci/providers/alicloud/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/alicloud/repo/.github/workflows/prerelease.yml
@@ -450,7 +450,7 @@ jobs:
         fields: repo,commit,author,action
         status: ${{ job.status }}
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         language:
         - nodejs

--- a/provider-ci/providers/alicloud/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/alicloud/repo/.github/workflows/release.yml
@@ -476,7 +476,7 @@ jobs:
         fields: repo,commit,author,action
         status: ${{ job.status }}
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         language:
         - nodejs

--- a/provider-ci/providers/alicloud/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/alicloud/repo/.github/workflows/run-acceptance-tests.yml
@@ -318,7 +318,7 @@ jobs:
         fields: repo,commit,author,action
         status: ${{ job.status }}
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         language:
         - nodejs

--- a/provider-ci/providers/artifactory/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/artifactory/repo/.github/workflows/main.yml
@@ -571,7 +571,7 @@ jobs:
         fields: repo,commit,author,action
         status: ${{ job.status }}
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         language:
         - nodejs

--- a/provider-ci/providers/artifactory/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/artifactory/repo/.github/workflows/master.yml
@@ -571,7 +571,7 @@ jobs:
         fields: repo,commit,author,action
         status: ${{ job.status }}
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         language:
         - nodejs

--- a/provider-ci/providers/artifactory/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/artifactory/repo/.github/workflows/prerelease.yml
@@ -521,7 +521,7 @@ jobs:
         fields: repo,commit,author,action
         status: ${{ job.status }}
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         language:
         - nodejs

--- a/provider-ci/providers/artifactory/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/artifactory/repo/.github/workflows/release.yml
@@ -547,7 +547,7 @@ jobs:
         fields: repo,commit,author,action
         status: ${{ job.status }}
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         language:
         - nodejs

--- a/provider-ci/providers/artifactory/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/artifactory/repo/.github/workflows/run-acceptance-tests.yml
@@ -399,7 +399,7 @@ jobs:
         fields: repo,commit,author,action
         status: ${{ job.status }}
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         language:
         - nodejs

--- a/provider-ci/providers/auth0/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/auth0/repo/.github/workflows/main.yml
@@ -571,7 +571,7 @@ jobs:
         fields: repo,commit,author,action
         status: ${{ job.status }}
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         language:
         - nodejs

--- a/provider-ci/providers/auth0/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/auth0/repo/.github/workflows/master.yml
@@ -571,7 +571,7 @@ jobs:
         fields: repo,commit,author,action
         status: ${{ job.status }}
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         language:
         - nodejs

--- a/provider-ci/providers/auth0/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/auth0/repo/.github/workflows/prerelease.yml
@@ -521,7 +521,7 @@ jobs:
         fields: repo,commit,author,action
         status: ${{ job.status }}
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         language:
         - nodejs

--- a/provider-ci/providers/auth0/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/auth0/repo/.github/workflows/release.yml
@@ -547,7 +547,7 @@ jobs:
         fields: repo,commit,author,action
         status: ${{ job.status }}
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         language:
         - nodejs

--- a/provider-ci/providers/auth0/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/auth0/repo/.github/workflows/run-acceptance-tests.yml
@@ -399,7 +399,7 @@ jobs:
         fields: repo,commit,author,action
         status: ${{ job.status }}
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         language:
         - nodejs

--- a/provider-ci/providers/aws/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/aws/repo/.github/workflows/main.yml
@@ -508,7 +508,7 @@ jobs:
         fields: repo,commit,author,action
         status: ${{ job.status }}
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         language:
         - nodejs

--- a/provider-ci/providers/aws/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/aws/repo/.github/workflows/master.yml
@@ -508,7 +508,7 @@ jobs:
         fields: repo,commit,author,action
         status: ${{ job.status }}
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         language:
         - nodejs

--- a/provider-ci/providers/aws/repo/.github/workflows/nightly-test.yml
+++ b/provider-ci/providers/aws/repo/.github/workflows/nightly-test.yml
@@ -287,7 +287,7 @@ jobs:
         fields: repo,commit,author,action
         status: ${{ job.status }}
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         language:
         - nodejs

--- a/provider-ci/providers/aws/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/aws/repo/.github/workflows/prerelease.yml
@@ -458,7 +458,7 @@ jobs:
         fields: repo,commit,author,action
         status: ${{ job.status }}
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         language:
         - nodejs

--- a/provider-ci/providers/aws/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/aws/repo/.github/workflows/release.yml
@@ -484,7 +484,7 @@ jobs:
         fields: repo,commit,author,action
         status: ${{ job.status }}
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         language:
         - nodejs

--- a/provider-ci/providers/aws/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/aws/repo/.github/workflows/run-acceptance-tests.yml
@@ -326,7 +326,7 @@ jobs:
         fields: repo,commit,author,action
         status: ${{ job.status }}
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         language:
         - nodejs

--- a/provider-ci/providers/azure/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/azure/repo/.github/workflows/main.yml
@@ -504,7 +504,7 @@ jobs:
         fields: repo,commit,author,action
         status: ${{ job.status }}
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         language:
         - nodejs

--- a/provider-ci/providers/azure/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/azure/repo/.github/workflows/master.yml
@@ -504,7 +504,7 @@ jobs:
         fields: repo,commit,author,action
         status: ${{ job.status }}
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         language:
         - nodejs

--- a/provider-ci/providers/azure/repo/.github/workflows/nightly-test.yml
+++ b/provider-ci/providers/azure/repo/.github/workflows/nightly-test.yml
@@ -283,7 +283,7 @@ jobs:
         fields: repo,commit,author,action
         status: ${{ job.status }}
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         language:
         - nodejs

--- a/provider-ci/providers/azure/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/azure/repo/.github/workflows/prerelease.yml
@@ -454,7 +454,7 @@ jobs:
         fields: repo,commit,author,action
         status: ${{ job.status }}
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         language:
         - nodejs

--- a/provider-ci/providers/azure/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/azure/repo/.github/workflows/release.yml
@@ -480,7 +480,7 @@ jobs:
         fields: repo,commit,author,action
         status: ${{ job.status }}
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         language:
         - nodejs

--- a/provider-ci/providers/azure/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/azure/repo/.github/workflows/run-acceptance-tests.yml
@@ -322,7 +322,7 @@ jobs:
         fields: repo,commit,author,action
         status: ${{ job.status }}
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         language:
         - nodejs

--- a/provider-ci/providers/azuread/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/azuread/repo/.github/workflows/main.yml
@@ -573,7 +573,7 @@ jobs:
         fields: repo,commit,author,action
         status: ${{ job.status }}
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         language:
         - nodejs

--- a/provider-ci/providers/azuread/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/azuread/repo/.github/workflows/master.yml
@@ -573,7 +573,7 @@ jobs:
         fields: repo,commit,author,action
         status: ${{ job.status }}
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         language:
         - nodejs

--- a/provider-ci/providers/azuread/repo/.github/workflows/nightly-test.yml
+++ b/provider-ci/providers/azuread/repo/.github/workflows/nightly-test.yml
@@ -281,7 +281,7 @@ jobs:
         fields: repo,commit,author,action
         status: ${{ job.status }}
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         language:
         - nodejs

--- a/provider-ci/providers/azuread/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/azuread/repo/.github/workflows/prerelease.yml
@@ -523,7 +523,7 @@ jobs:
         fields: repo,commit,author,action
         status: ${{ job.status }}
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         language:
         - nodejs

--- a/provider-ci/providers/azuread/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/azuread/repo/.github/workflows/release.yml
@@ -549,7 +549,7 @@ jobs:
         fields: repo,commit,author,action
         status: ${{ job.status }}
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         language:
         - nodejs

--- a/provider-ci/providers/azuread/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/azuread/repo/.github/workflows/run-acceptance-tests.yml
@@ -401,7 +401,7 @@ jobs:
         fields: repo,commit,author,action
         status: ${{ job.status }}
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         language:
         - nodejs

--- a/provider-ci/providers/azuredevops/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/azuredevops/repo/.github/workflows/main.yml
@@ -499,7 +499,7 @@ jobs:
         fields: repo,commit,author,action
         status: ${{ job.status }}
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         language:
         - nodejs

--- a/provider-ci/providers/azuredevops/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/azuredevops/repo/.github/workflows/master.yml
@@ -499,7 +499,7 @@ jobs:
         fields: repo,commit,author,action
         status: ${{ job.status }}
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         language:
         - nodejs

--- a/provider-ci/providers/azuredevops/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/azuredevops/repo/.github/workflows/prerelease.yml
@@ -449,7 +449,7 @@ jobs:
         fields: repo,commit,author,action
         status: ${{ job.status }}
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         language:
         - nodejs

--- a/provider-ci/providers/azuredevops/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/azuredevops/repo/.github/workflows/release.yml
@@ -475,7 +475,7 @@ jobs:
         fields: repo,commit,author,action
         status: ${{ job.status }}
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         language:
         - nodejs

--- a/provider-ci/providers/azuredevops/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/azuredevops/repo/.github/workflows/run-acceptance-tests.yml
@@ -317,7 +317,7 @@ jobs:
         fields: repo,commit,author,action
         status: ${{ job.status }}
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         language:
         - nodejs

--- a/provider-ci/providers/civo/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/civo/repo/.github/workflows/main.yml
@@ -569,7 +569,7 @@ jobs:
         fields: repo,commit,author,action
         status: ${{ job.status }}
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         language:
         - nodejs

--- a/provider-ci/providers/civo/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/civo/repo/.github/workflows/master.yml
@@ -569,7 +569,7 @@ jobs:
         fields: repo,commit,author,action
         status: ${{ job.status }}
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         language:
         - nodejs

--- a/provider-ci/providers/civo/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/civo/repo/.github/workflows/prerelease.yml
@@ -519,7 +519,7 @@ jobs:
         fields: repo,commit,author,action
         status: ${{ job.status }}
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         language:
         - nodejs

--- a/provider-ci/providers/civo/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/civo/repo/.github/workflows/release.yml
@@ -545,7 +545,7 @@ jobs:
         fields: repo,commit,author,action
         status: ${{ job.status }}
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         language:
         - nodejs

--- a/provider-ci/providers/civo/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/civo/repo/.github/workflows/run-acceptance-tests.yml
@@ -397,7 +397,7 @@ jobs:
         fields: repo,commit,author,action
         status: ${{ job.status }}
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         language:
         - nodejs

--- a/provider-ci/providers/cloudamqp/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/cloudamqp/repo/.github/workflows/main.yml
@@ -568,7 +568,7 @@ jobs:
         fields: repo,commit,author,action
         status: ${{ job.status }}
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         language:
         - nodejs

--- a/provider-ci/providers/cloudamqp/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/cloudamqp/repo/.github/workflows/master.yml
@@ -568,7 +568,7 @@ jobs:
         fields: repo,commit,author,action
         status: ${{ job.status }}
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         language:
         - nodejs

--- a/provider-ci/providers/cloudamqp/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/cloudamqp/repo/.github/workflows/prerelease.yml
@@ -518,7 +518,7 @@ jobs:
         fields: repo,commit,author,action
         status: ${{ job.status }}
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         language:
         - nodejs

--- a/provider-ci/providers/cloudamqp/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/cloudamqp/repo/.github/workflows/release.yml
@@ -544,7 +544,7 @@ jobs:
         fields: repo,commit,author,action
         status: ${{ job.status }}
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         language:
         - nodejs

--- a/provider-ci/providers/cloudamqp/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/cloudamqp/repo/.github/workflows/run-acceptance-tests.yml
@@ -396,7 +396,7 @@ jobs:
         fields: repo,commit,author,action
         status: ${{ job.status }}
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         language:
         - nodejs

--- a/provider-ci/providers/cloudflare/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/cloudflare/repo/.github/workflows/main.yml
@@ -568,7 +568,7 @@ jobs:
         fields: repo,commit,author,action
         status: ${{ job.status }}
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         language:
         - nodejs

--- a/provider-ci/providers/cloudflare/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/cloudflare/repo/.github/workflows/master.yml
@@ -568,7 +568,7 @@ jobs:
         fields: repo,commit,author,action
         status: ${{ job.status }}
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         language:
         - nodejs

--- a/provider-ci/providers/cloudflare/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/cloudflare/repo/.github/workflows/prerelease.yml
@@ -518,7 +518,7 @@ jobs:
         fields: repo,commit,author,action
         status: ${{ job.status }}
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         language:
         - nodejs

--- a/provider-ci/providers/cloudflare/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/cloudflare/repo/.github/workflows/release.yml
@@ -544,7 +544,7 @@ jobs:
         fields: repo,commit,author,action
         status: ${{ job.status }}
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         language:
         - nodejs

--- a/provider-ci/providers/cloudflare/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/cloudflare/repo/.github/workflows/run-acceptance-tests.yml
@@ -396,7 +396,7 @@ jobs:
         fields: repo,commit,author,action
         status: ${{ job.status }}
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         language:
         - nodejs

--- a/provider-ci/providers/cloudinit/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/cloudinit/repo/.github/workflows/main.yml
@@ -497,7 +497,7 @@ jobs:
         fields: repo,commit,author,action
         status: ${{ job.status }}
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         language:
         - nodejs

--- a/provider-ci/providers/cloudinit/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/cloudinit/repo/.github/workflows/master.yml
@@ -497,7 +497,7 @@ jobs:
         fields: repo,commit,author,action
         status: ${{ job.status }}
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         language:
         - nodejs

--- a/provider-ci/providers/cloudinit/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/cloudinit/repo/.github/workflows/prerelease.yml
@@ -447,7 +447,7 @@ jobs:
         fields: repo,commit,author,action
         status: ${{ job.status }}
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         language:
         - nodejs

--- a/provider-ci/providers/cloudinit/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/cloudinit/repo/.github/workflows/release.yml
@@ -473,7 +473,7 @@ jobs:
         fields: repo,commit,author,action
         status: ${{ job.status }}
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         language:
         - nodejs

--- a/provider-ci/providers/cloudinit/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/cloudinit/repo/.github/workflows/run-acceptance-tests.yml
@@ -315,7 +315,7 @@ jobs:
         fields: repo,commit,author,action
         status: ${{ job.status }}
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         language:
         - nodejs

--- a/provider-ci/providers/confluentcloud/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/confluentcloud/repo/.github/workflows/main.yml
@@ -499,7 +499,7 @@ jobs:
         fields: repo,commit,author,action
         status: ${{ job.status }}
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         language:
         - nodejs

--- a/provider-ci/providers/confluentcloud/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/confluentcloud/repo/.github/workflows/master.yml
@@ -499,7 +499,7 @@ jobs:
         fields: repo,commit,author,action
         status: ${{ job.status }}
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         language:
         - nodejs

--- a/provider-ci/providers/confluentcloud/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/confluentcloud/repo/.github/workflows/prerelease.yml
@@ -449,7 +449,7 @@ jobs:
         fields: repo,commit,author,action
         status: ${{ job.status }}
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         language:
         - nodejs

--- a/provider-ci/providers/confluentcloud/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/confluentcloud/repo/.github/workflows/release.yml
@@ -475,7 +475,7 @@ jobs:
         fields: repo,commit,author,action
         status: ${{ job.status }}
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         language:
         - nodejs

--- a/provider-ci/providers/confluentcloud/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/confluentcloud/repo/.github/workflows/run-acceptance-tests.yml
@@ -317,7 +317,7 @@ jobs:
         fields: repo,commit,author,action
         status: ${{ job.status }}
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         language:
         - nodejs

--- a/provider-ci/providers/consul/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/consul/repo/.github/workflows/main.yml
@@ -570,7 +570,7 @@ jobs:
         fields: repo,commit,author,action
         status: ${{ job.status }}
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         language:
         - nodejs

--- a/provider-ci/providers/consul/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/consul/repo/.github/workflows/master.yml
@@ -570,7 +570,7 @@ jobs:
         fields: repo,commit,author,action
         status: ${{ job.status }}
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         language:
         - nodejs

--- a/provider-ci/providers/consul/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/consul/repo/.github/workflows/prerelease.yml
@@ -520,7 +520,7 @@ jobs:
         fields: repo,commit,author,action
         status: ${{ job.status }}
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         language:
         - nodejs

--- a/provider-ci/providers/consul/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/consul/repo/.github/workflows/release.yml
@@ -546,7 +546,7 @@ jobs:
         fields: repo,commit,author,action
         status: ${{ job.status }}
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         language:
         - nodejs

--- a/provider-ci/providers/consul/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/consul/repo/.github/workflows/run-acceptance-tests.yml
@@ -398,7 +398,7 @@ jobs:
         fields: repo,commit,author,action
         status: ${{ job.status }}
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         language:
         - nodejs

--- a/provider-ci/providers/databricks/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/databricks/repo/.github/workflows/main.yml
@@ -572,7 +572,7 @@ jobs:
         fields: repo,commit,author,action
         status: ${{ job.status }}
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         language:
         - nodejs

--- a/provider-ci/providers/databricks/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/databricks/repo/.github/workflows/master.yml
@@ -572,7 +572,7 @@ jobs:
         fields: repo,commit,author,action
         status: ${{ job.status }}
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         language:
         - nodejs

--- a/provider-ci/providers/databricks/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/databricks/repo/.github/workflows/prerelease.yml
@@ -522,7 +522,7 @@ jobs:
         fields: repo,commit,author,action
         status: ${{ job.status }}
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         language:
         - nodejs

--- a/provider-ci/providers/databricks/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/databricks/repo/.github/workflows/release.yml
@@ -548,7 +548,7 @@ jobs:
         fields: repo,commit,author,action
         status: ${{ job.status }}
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         language:
         - nodejs

--- a/provider-ci/providers/databricks/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/databricks/repo/.github/workflows/run-acceptance-tests.yml
@@ -400,7 +400,7 @@ jobs:
         fields: repo,commit,author,action
         status: ${{ job.status }}
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         language:
         - nodejs

--- a/provider-ci/providers/datadog/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/datadog/repo/.github/workflows/main.yml
@@ -497,7 +497,7 @@ jobs:
         fields: repo,commit,author,action
         status: ${{ job.status }}
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         language:
         - nodejs

--- a/provider-ci/providers/datadog/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/datadog/repo/.github/workflows/master.yml
@@ -497,7 +497,7 @@ jobs:
         fields: repo,commit,author,action
         status: ${{ job.status }}
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         language:
         - nodejs

--- a/provider-ci/providers/datadog/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/datadog/repo/.github/workflows/prerelease.yml
@@ -447,7 +447,7 @@ jobs:
         fields: repo,commit,author,action
         status: ${{ job.status }}
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         language:
         - nodejs

--- a/provider-ci/providers/datadog/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/datadog/repo/.github/workflows/release.yml
@@ -473,7 +473,7 @@ jobs:
         fields: repo,commit,author,action
         status: ${{ job.status }}
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         language:
         - nodejs

--- a/provider-ci/providers/datadog/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/datadog/repo/.github/workflows/run-acceptance-tests.yml
@@ -315,7 +315,7 @@ jobs:
         fields: repo,commit,author,action
         status: ${{ job.status }}
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         language:
         - nodejs

--- a/provider-ci/providers/digitalocean/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/digitalocean/repo/.github/workflows/main.yml
@@ -569,7 +569,7 @@ jobs:
         fields: repo,commit,author,action
         status: ${{ job.status }}
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         language:
         - nodejs

--- a/provider-ci/providers/digitalocean/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/digitalocean/repo/.github/workflows/master.yml
@@ -569,7 +569,7 @@ jobs:
         fields: repo,commit,author,action
         status: ${{ job.status }}
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         language:
         - nodejs

--- a/provider-ci/providers/digitalocean/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/digitalocean/repo/.github/workflows/prerelease.yml
@@ -519,7 +519,7 @@ jobs:
         fields: repo,commit,author,action
         status: ${{ job.status }}
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         language:
         - nodejs

--- a/provider-ci/providers/digitalocean/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/digitalocean/repo/.github/workflows/release.yml
@@ -545,7 +545,7 @@ jobs:
         fields: repo,commit,author,action
         status: ${{ job.status }}
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         language:
         - nodejs

--- a/provider-ci/providers/digitalocean/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/digitalocean/repo/.github/workflows/run-acceptance-tests.yml
@@ -397,7 +397,7 @@ jobs:
         fields: repo,commit,author,action
         status: ${{ job.status }}
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         language:
         - nodejs

--- a/provider-ci/providers/dnsimple/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/dnsimple/repo/.github/workflows/main.yml
@@ -570,7 +570,7 @@ jobs:
         fields: repo,commit,author,action
         status: ${{ job.status }}
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         language:
         - nodejs

--- a/provider-ci/providers/dnsimple/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/dnsimple/repo/.github/workflows/master.yml
@@ -570,7 +570,7 @@ jobs:
         fields: repo,commit,author,action
         status: ${{ job.status }}
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         language:
         - nodejs

--- a/provider-ci/providers/dnsimple/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/dnsimple/repo/.github/workflows/prerelease.yml
@@ -520,7 +520,7 @@ jobs:
         fields: repo,commit,author,action
         status: ${{ job.status }}
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         language:
         - nodejs

--- a/provider-ci/providers/dnsimple/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/dnsimple/repo/.github/workflows/release.yml
@@ -546,7 +546,7 @@ jobs:
         fields: repo,commit,author,action
         status: ${{ job.status }}
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         language:
         - nodejs

--- a/provider-ci/providers/dnsimple/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/dnsimple/repo/.github/workflows/run-acceptance-tests.yml
@@ -398,7 +398,7 @@ jobs:
         fields: repo,commit,author,action
         status: ${{ job.status }}
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         language:
         - nodejs

--- a/provider-ci/providers/docker/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/docker/repo/.github/workflows/main.yml
@@ -605,7 +605,7 @@ jobs:
         fields: repo,commit,author,action
         status: ${{ job.status }}
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         language:
         - nodejs

--- a/provider-ci/providers/docker/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/docker/repo/.github/workflows/master.yml
@@ -605,7 +605,7 @@ jobs:
         fields: repo,commit,author,action
         status: ${{ job.status }}
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         language:
         - nodejs

--- a/provider-ci/providers/docker/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/docker/repo/.github/workflows/prerelease.yml
@@ -555,7 +555,7 @@ jobs:
         fields: repo,commit,author,action
         status: ${{ job.status }}
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         language:
         - nodejs

--- a/provider-ci/providers/docker/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/docker/repo/.github/workflows/release.yml
@@ -581,7 +581,7 @@ jobs:
         fields: repo,commit,author,action
         status: ${{ job.status }}
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         language:
         - nodejs

--- a/provider-ci/providers/docker/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/docker/repo/.github/workflows/run-acceptance-tests.yml
@@ -433,7 +433,7 @@ jobs:
         fields: repo,commit,author,action
         status: ${{ job.status }}
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         language:
         - nodejs

--- a/provider-ci/providers/ec/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/ec/repo/.github/workflows/main.yml
@@ -569,7 +569,7 @@ jobs:
         fields: repo,commit,author,action
         status: ${{ job.status }}
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         language:
         - nodejs

--- a/provider-ci/providers/ec/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/ec/repo/.github/workflows/master.yml
@@ -569,7 +569,7 @@ jobs:
         fields: repo,commit,author,action
         status: ${{ job.status }}
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         language:
         - nodejs

--- a/provider-ci/providers/ec/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/ec/repo/.github/workflows/prerelease.yml
@@ -519,7 +519,7 @@ jobs:
         fields: repo,commit,author,action
         status: ${{ job.status }}
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         language:
         - nodejs

--- a/provider-ci/providers/ec/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/ec/repo/.github/workflows/release.yml
@@ -545,7 +545,7 @@ jobs:
         fields: repo,commit,author,action
         status: ${{ job.status }}
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         language:
         - nodejs

--- a/provider-ci/providers/ec/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/ec/repo/.github/workflows/run-acceptance-tests.yml
@@ -397,7 +397,7 @@ jobs:
         fields: repo,commit,author,action
         status: ${{ job.status }}
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         language:
         - nodejs

--- a/provider-ci/providers/equinix-metal/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/equinix-metal/repo/.github/workflows/main.yml
@@ -498,7 +498,7 @@ jobs:
         fields: repo,commit,author,action
         status: ${{ job.status }}
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         language:
         - nodejs

--- a/provider-ci/providers/equinix-metal/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/equinix-metal/repo/.github/workflows/master.yml
@@ -498,7 +498,7 @@ jobs:
         fields: repo,commit,author,action
         status: ${{ job.status }}
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         language:
         - nodejs

--- a/provider-ci/providers/equinix-metal/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/equinix-metal/repo/.github/workflows/prerelease.yml
@@ -448,7 +448,7 @@ jobs:
         fields: repo,commit,author,action
         status: ${{ job.status }}
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         language:
         - nodejs

--- a/provider-ci/providers/equinix-metal/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/equinix-metal/repo/.github/workflows/release.yml
@@ -474,7 +474,7 @@ jobs:
         fields: repo,commit,author,action
         status: ${{ job.status }}
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         language:
         - nodejs

--- a/provider-ci/providers/equinix-metal/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/equinix-metal/repo/.github/workflows/run-acceptance-tests.yml
@@ -316,7 +316,7 @@ jobs:
         fields: repo,commit,author,action
         status: ${{ job.status }}
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         language:
         - nodejs

--- a/provider-ci/providers/f5bigip/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/f5bigip/repo/.github/workflows/main.yml
@@ -581,7 +581,7 @@ jobs:
         fields: repo,commit,author,action
         status: ${{ job.status }}
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         language:
         - nodejs

--- a/provider-ci/providers/f5bigip/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/f5bigip/repo/.github/workflows/master.yml
@@ -581,7 +581,7 @@ jobs:
         fields: repo,commit,author,action
         status: ${{ job.status }}
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         language:
         - nodejs

--- a/provider-ci/providers/f5bigip/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/f5bigip/repo/.github/workflows/prerelease.yml
@@ -531,7 +531,7 @@ jobs:
         fields: repo,commit,author,action
         status: ${{ job.status }}
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         language:
         - nodejs

--- a/provider-ci/providers/f5bigip/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/f5bigip/repo/.github/workflows/release.yml
@@ -557,7 +557,7 @@ jobs:
         fields: repo,commit,author,action
         status: ${{ job.status }}
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         language:
         - nodejs

--- a/provider-ci/providers/f5bigip/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/f5bigip/repo/.github/workflows/run-acceptance-tests.yml
@@ -409,7 +409,7 @@ jobs:
         fields: repo,commit,author,action
         status: ${{ job.status }}
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         language:
         - nodejs

--- a/provider-ci/providers/fastly/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/fastly/repo/.github/workflows/main.yml
@@ -569,7 +569,7 @@ jobs:
         fields: repo,commit,author,action
         status: ${{ job.status }}
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         language:
         - nodejs

--- a/provider-ci/providers/fastly/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/fastly/repo/.github/workflows/master.yml
@@ -569,7 +569,7 @@ jobs:
         fields: repo,commit,author,action
         status: ${{ job.status }}
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         language:
         - nodejs

--- a/provider-ci/providers/fastly/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/fastly/repo/.github/workflows/prerelease.yml
@@ -519,7 +519,7 @@ jobs:
         fields: repo,commit,author,action
         status: ${{ job.status }}
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         language:
         - nodejs

--- a/provider-ci/providers/fastly/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/fastly/repo/.github/workflows/release.yml
@@ -545,7 +545,7 @@ jobs:
         fields: repo,commit,author,action
         status: ${{ job.status }}
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         language:
         - nodejs

--- a/provider-ci/providers/fastly/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/fastly/repo/.github/workflows/run-acceptance-tests.yml
@@ -397,7 +397,7 @@ jobs:
         fields: repo,commit,author,action
         status: ${{ job.status }}
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         language:
         - nodejs

--- a/provider-ci/providers/gcp/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/gcp/repo/.github/workflows/main.yml
@@ -517,7 +517,7 @@ jobs:
         fields: repo,commit,author,action
         status: ${{ job.status }}
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         language:
         - nodejs

--- a/provider-ci/providers/gcp/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/gcp/repo/.github/workflows/master.yml
@@ -517,7 +517,7 @@ jobs:
         fields: repo,commit,author,action
         status: ${{ job.status }}
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         language:
         - nodejs

--- a/provider-ci/providers/gcp/repo/.github/workflows/nightly-test.yml
+++ b/provider-ci/providers/gcp/repo/.github/workflows/nightly-test.yml
@@ -296,7 +296,7 @@ jobs:
         fields: repo,commit,author,action
         status: ${{ job.status }}
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         language:
         - nodejs

--- a/provider-ci/providers/gcp/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/gcp/repo/.github/workflows/prerelease.yml
@@ -467,7 +467,7 @@ jobs:
         fields: repo,commit,author,action
         status: ${{ job.status }}
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         language:
         - nodejs

--- a/provider-ci/providers/gcp/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/gcp/repo/.github/workflows/release.yml
@@ -493,7 +493,7 @@ jobs:
         fields: repo,commit,author,action
         status: ${{ job.status }}
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         language:
         - nodejs

--- a/provider-ci/providers/gcp/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/gcp/repo/.github/workflows/run-acceptance-tests.yml
@@ -335,7 +335,7 @@ jobs:
         fields: repo,commit,author,action
         status: ${{ job.status }}
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         language:
         - nodejs

--- a/provider-ci/providers/github/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/github/repo/.github/workflows/main.yml
@@ -570,7 +570,7 @@ jobs:
         fields: repo,commit,author,action
         status: ${{ job.status }}
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         language:
         - nodejs

--- a/provider-ci/providers/github/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/github/repo/.github/workflows/master.yml
@@ -570,7 +570,7 @@ jobs:
         fields: repo,commit,author,action
         status: ${{ job.status }}
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         language:
         - nodejs

--- a/provider-ci/providers/github/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/github/repo/.github/workflows/prerelease.yml
@@ -520,7 +520,7 @@ jobs:
         fields: repo,commit,author,action
         status: ${{ job.status }}
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         language:
         - nodejs

--- a/provider-ci/providers/github/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/github/repo/.github/workflows/release.yml
@@ -546,7 +546,7 @@ jobs:
         fields: repo,commit,author,action
         status: ${{ job.status }}
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         language:
         - nodejs

--- a/provider-ci/providers/github/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/github/repo/.github/workflows/run-acceptance-tests.yml
@@ -398,7 +398,7 @@ jobs:
         fields: repo,commit,author,action
         status: ${{ job.status }}
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         language:
         - nodejs

--- a/provider-ci/providers/gitlab/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/gitlab/repo/.github/workflows/main.yml
@@ -569,7 +569,7 @@ jobs:
         fields: repo,commit,author,action
         status: ${{ job.status }}
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         language:
         - nodejs

--- a/provider-ci/providers/gitlab/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/gitlab/repo/.github/workflows/master.yml
@@ -569,7 +569,7 @@ jobs:
         fields: repo,commit,author,action
         status: ${{ job.status }}
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         language:
         - nodejs

--- a/provider-ci/providers/gitlab/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/gitlab/repo/.github/workflows/prerelease.yml
@@ -519,7 +519,7 @@ jobs:
         fields: repo,commit,author,action
         status: ${{ job.status }}
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         language:
         - nodejs

--- a/provider-ci/providers/gitlab/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/gitlab/repo/.github/workflows/release.yml
@@ -545,7 +545,7 @@ jobs:
         fields: repo,commit,author,action
         status: ${{ job.status }}
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         language:
         - nodejs

--- a/provider-ci/providers/gitlab/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/gitlab/repo/.github/workflows/run-acceptance-tests.yml
@@ -397,7 +397,7 @@ jobs:
         fields: repo,commit,author,action
         status: ${{ job.status }}
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         language:
         - nodejs

--- a/provider-ci/providers/hcloud/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/hcloud/repo/.github/workflows/main.yml
@@ -569,7 +569,7 @@ jobs:
         fields: repo,commit,author,action
         status: ${{ job.status }}
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         language:
         - nodejs

--- a/provider-ci/providers/hcloud/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/hcloud/repo/.github/workflows/master.yml
@@ -569,7 +569,7 @@ jobs:
         fields: repo,commit,author,action
         status: ${{ job.status }}
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         language:
         - nodejs

--- a/provider-ci/providers/hcloud/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/hcloud/repo/.github/workflows/prerelease.yml
@@ -519,7 +519,7 @@ jobs:
         fields: repo,commit,author,action
         status: ${{ job.status }}
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         language:
         - nodejs

--- a/provider-ci/providers/hcloud/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/hcloud/repo/.github/workflows/release.yml
@@ -545,7 +545,7 @@ jobs:
         fields: repo,commit,author,action
         status: ${{ job.status }}
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         language:
         - nodejs

--- a/provider-ci/providers/hcloud/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/hcloud/repo/.github/workflows/run-acceptance-tests.yml
@@ -397,7 +397,7 @@ jobs:
         fields: repo,commit,author,action
         status: ${{ job.status }}
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         language:
         - nodejs

--- a/provider-ci/providers/kafka/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/kafka/repo/.github/workflows/main.yml
@@ -570,7 +570,7 @@ jobs:
         fields: repo,commit,author,action
         status: ${{ job.status }}
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         language:
         - nodejs

--- a/provider-ci/providers/kafka/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/kafka/repo/.github/workflows/master.yml
@@ -570,7 +570,7 @@ jobs:
         fields: repo,commit,author,action
         status: ${{ job.status }}
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         language:
         - nodejs

--- a/provider-ci/providers/kafka/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/kafka/repo/.github/workflows/prerelease.yml
@@ -520,7 +520,7 @@ jobs:
         fields: repo,commit,author,action
         status: ${{ job.status }}
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         language:
         - nodejs

--- a/provider-ci/providers/kafka/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/kafka/repo/.github/workflows/release.yml
@@ -546,7 +546,7 @@ jobs:
         fields: repo,commit,author,action
         status: ${{ job.status }}
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         language:
         - nodejs

--- a/provider-ci/providers/kafka/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/kafka/repo/.github/workflows/run-acceptance-tests.yml
@@ -398,7 +398,7 @@ jobs:
         fields: repo,commit,author,action
         status: ${{ job.status }}
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         language:
         - nodejs

--- a/provider-ci/providers/keycloak/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/keycloak/repo/.github/workflows/main.yml
@@ -577,7 +577,7 @@ jobs:
         fields: repo,commit,author,action
         status: ${{ job.status }}
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         language:
         - nodejs

--- a/provider-ci/providers/keycloak/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/keycloak/repo/.github/workflows/master.yml
@@ -577,7 +577,7 @@ jobs:
         fields: repo,commit,author,action
         status: ${{ job.status }}
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         language:
         - nodejs

--- a/provider-ci/providers/keycloak/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/keycloak/repo/.github/workflows/prerelease.yml
@@ -527,7 +527,7 @@ jobs:
         fields: repo,commit,author,action
         status: ${{ job.status }}
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         language:
         - nodejs

--- a/provider-ci/providers/keycloak/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/keycloak/repo/.github/workflows/release.yml
@@ -553,7 +553,7 @@ jobs:
         fields: repo,commit,author,action
         status: ${{ job.status }}
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         language:
         - nodejs

--- a/provider-ci/providers/keycloak/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/keycloak/repo/.github/workflows/run-acceptance-tests.yml
@@ -405,7 +405,7 @@ jobs:
         fields: repo,commit,author,action
         status: ${{ job.status }}
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         language:
         - nodejs

--- a/provider-ci/providers/kong/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/kong/repo/.github/workflows/main.yml
@@ -570,7 +570,7 @@ jobs:
         fields: repo,commit,author,action
         status: ${{ job.status }}
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         language:
         - nodejs

--- a/provider-ci/providers/kong/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/kong/repo/.github/workflows/master.yml
@@ -570,7 +570,7 @@ jobs:
         fields: repo,commit,author,action
         status: ${{ job.status }}
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         language:
         - nodejs

--- a/provider-ci/providers/kong/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/kong/repo/.github/workflows/prerelease.yml
@@ -520,7 +520,7 @@ jobs:
         fields: repo,commit,author,action
         status: ${{ job.status }}
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         language:
         - nodejs

--- a/provider-ci/providers/kong/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/kong/repo/.github/workflows/release.yml
@@ -546,7 +546,7 @@ jobs:
         fields: repo,commit,author,action
         status: ${{ job.status }}
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         language:
         - nodejs

--- a/provider-ci/providers/kong/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/kong/repo/.github/workflows/run-acceptance-tests.yml
@@ -398,7 +398,7 @@ jobs:
         fields: repo,commit,author,action
         status: ${{ job.status }}
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         language:
         - nodejs

--- a/provider-ci/providers/libvirt/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/libvirt/repo/.github/workflows/main.yml
@@ -571,7 +571,7 @@ jobs:
         fields: repo,commit,author,action
         status: ${{ job.status }}
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         language:
         - nodejs

--- a/provider-ci/providers/libvirt/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/libvirt/repo/.github/workflows/master.yml
@@ -571,7 +571,7 @@ jobs:
         fields: repo,commit,author,action
         status: ${{ job.status }}
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         language:
         - nodejs

--- a/provider-ci/providers/libvirt/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/libvirt/repo/.github/workflows/prerelease.yml
@@ -521,7 +521,7 @@ jobs:
         fields: repo,commit,author,action
         status: ${{ job.status }}
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         language:
         - nodejs

--- a/provider-ci/providers/libvirt/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/libvirt/repo/.github/workflows/release.yml
@@ -547,7 +547,7 @@ jobs:
         fields: repo,commit,author,action
         status: ${{ job.status }}
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         language:
         - nodejs

--- a/provider-ci/providers/libvirt/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/libvirt/repo/.github/workflows/run-acceptance-tests.yml
@@ -399,7 +399,7 @@ jobs:
         fields: repo,commit,author,action
         status: ${{ job.status }}
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         language:
         - nodejs

--- a/provider-ci/providers/linode/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/linode/repo/.github/workflows/main.yml
@@ -569,7 +569,7 @@ jobs:
         fields: repo,commit,author,action
         status: ${{ job.status }}
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         language:
         - nodejs

--- a/provider-ci/providers/linode/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/linode/repo/.github/workflows/master.yml
@@ -569,7 +569,7 @@ jobs:
         fields: repo,commit,author,action
         status: ${{ job.status }}
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         language:
         - nodejs

--- a/provider-ci/providers/linode/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/linode/repo/.github/workflows/prerelease.yml
@@ -519,7 +519,7 @@ jobs:
         fields: repo,commit,author,action
         status: ${{ job.status }}
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         language:
         - nodejs

--- a/provider-ci/providers/linode/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/linode/repo/.github/workflows/release.yml
@@ -545,7 +545,7 @@ jobs:
         fields: repo,commit,author,action
         status: ${{ job.status }}
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         language:
         - nodejs

--- a/provider-ci/providers/linode/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/linode/repo/.github/workflows/run-acceptance-tests.yml
@@ -397,7 +397,7 @@ jobs:
         fields: repo,commit,author,action
         status: ${{ job.status }}
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         language:
         - nodejs

--- a/provider-ci/providers/mailgun/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/mailgun/repo/.github/workflows/main.yml
@@ -569,7 +569,7 @@ jobs:
         fields: repo,commit,author,action
         status: ${{ job.status }}
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         language:
         - nodejs

--- a/provider-ci/providers/mailgun/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/mailgun/repo/.github/workflows/master.yml
@@ -569,7 +569,7 @@ jobs:
         fields: repo,commit,author,action
         status: ${{ job.status }}
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         language:
         - nodejs

--- a/provider-ci/providers/mailgun/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/mailgun/repo/.github/workflows/prerelease.yml
@@ -519,7 +519,7 @@ jobs:
         fields: repo,commit,author,action
         status: ${{ job.status }}
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         language:
         - nodejs

--- a/provider-ci/providers/mailgun/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/mailgun/repo/.github/workflows/release.yml
@@ -545,7 +545,7 @@ jobs:
         fields: repo,commit,author,action
         status: ${{ job.status }}
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         language:
         - nodejs

--- a/provider-ci/providers/mailgun/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/mailgun/repo/.github/workflows/run-acceptance-tests.yml
@@ -397,7 +397,7 @@ jobs:
         fields: repo,commit,author,action
         status: ${{ job.status }}
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         language:
         - nodejs

--- a/provider-ci/providers/minio/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/minio/repo/.github/workflows/main.yml
@@ -574,7 +574,7 @@ jobs:
         fields: repo,commit,author,action
         status: ${{ job.status }}
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         language:
         - nodejs

--- a/provider-ci/providers/minio/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/minio/repo/.github/workflows/master.yml
@@ -574,7 +574,7 @@ jobs:
         fields: repo,commit,author,action
         status: ${{ job.status }}
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         language:
         - nodejs

--- a/provider-ci/providers/minio/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/minio/repo/.github/workflows/prerelease.yml
@@ -524,7 +524,7 @@ jobs:
         fields: repo,commit,author,action
         status: ${{ job.status }}
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         language:
         - nodejs

--- a/provider-ci/providers/minio/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/minio/repo/.github/workflows/release.yml
@@ -550,7 +550,7 @@ jobs:
         fields: repo,commit,author,action
         status: ${{ job.status }}
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         language:
         - nodejs

--- a/provider-ci/providers/minio/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/minio/repo/.github/workflows/run-acceptance-tests.yml
@@ -402,7 +402,7 @@ jobs:
         fields: repo,commit,author,action
         status: ${{ job.status }}
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         language:
         - nodejs

--- a/provider-ci/providers/mongodbatlas/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/mongodbatlas/repo/.github/workflows/main.yml
@@ -571,7 +571,7 @@ jobs:
         fields: repo,commit,author,action
         status: ${{ job.status }}
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         language:
         - nodejs

--- a/provider-ci/providers/mongodbatlas/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/mongodbatlas/repo/.github/workflows/master.yml
@@ -571,7 +571,7 @@ jobs:
         fields: repo,commit,author,action
         status: ${{ job.status }}
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         language:
         - nodejs

--- a/provider-ci/providers/mongodbatlas/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/mongodbatlas/repo/.github/workflows/prerelease.yml
@@ -521,7 +521,7 @@ jobs:
         fields: repo,commit,author,action
         status: ${{ job.status }}
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         language:
         - nodejs

--- a/provider-ci/providers/mongodbatlas/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/mongodbatlas/repo/.github/workflows/release.yml
@@ -547,7 +547,7 @@ jobs:
         fields: repo,commit,author,action
         status: ${{ job.status }}
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         language:
         - nodejs

--- a/provider-ci/providers/mongodbatlas/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/mongodbatlas/repo/.github/workflows/run-acceptance-tests.yml
@@ -399,7 +399,7 @@ jobs:
         fields: repo,commit,author,action
         status: ${{ job.status }}
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         language:
         - nodejs

--- a/provider-ci/providers/mysql/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/mysql/repo/.github/workflows/main.yml
@@ -570,7 +570,7 @@ jobs:
         fields: repo,commit,author,action
         status: ${{ job.status }}
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         language:
         - nodejs

--- a/provider-ci/providers/mysql/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/mysql/repo/.github/workflows/master.yml
@@ -570,7 +570,7 @@ jobs:
         fields: repo,commit,author,action
         status: ${{ job.status }}
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         language:
         - nodejs

--- a/provider-ci/providers/mysql/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/mysql/repo/.github/workflows/prerelease.yml
@@ -520,7 +520,7 @@ jobs:
         fields: repo,commit,author,action
         status: ${{ job.status }}
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         language:
         - nodejs

--- a/provider-ci/providers/mysql/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/mysql/repo/.github/workflows/release.yml
@@ -546,7 +546,7 @@ jobs:
         fields: repo,commit,author,action
         status: ${{ job.status }}
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         language:
         - nodejs

--- a/provider-ci/providers/mysql/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/mysql/repo/.github/workflows/run-acceptance-tests.yml
@@ -398,7 +398,7 @@ jobs:
         fields: repo,commit,author,action
         status: ${{ job.status }}
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         language:
         - nodejs

--- a/provider-ci/providers/newrelic/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/newrelic/repo/.github/workflows/main.yml
@@ -570,7 +570,7 @@ jobs:
         fields: repo,commit,author,action
         status: ${{ job.status }}
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         language:
         - nodejs

--- a/provider-ci/providers/newrelic/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/newrelic/repo/.github/workflows/master.yml
@@ -570,7 +570,7 @@ jobs:
         fields: repo,commit,author,action
         status: ${{ job.status }}
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         language:
         - nodejs

--- a/provider-ci/providers/newrelic/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/newrelic/repo/.github/workflows/prerelease.yml
@@ -520,7 +520,7 @@ jobs:
         fields: repo,commit,author,action
         status: ${{ job.status }}
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         language:
         - nodejs

--- a/provider-ci/providers/newrelic/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/newrelic/repo/.github/workflows/release.yml
@@ -546,7 +546,7 @@ jobs:
         fields: repo,commit,author,action
         status: ${{ job.status }}
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         language:
         - nodejs

--- a/provider-ci/providers/newrelic/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/newrelic/repo/.github/workflows/run-acceptance-tests.yml
@@ -398,7 +398,7 @@ jobs:
         fields: repo,commit,author,action
         status: ${{ job.status }}
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         language:
         - nodejs

--- a/provider-ci/providers/nomad/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/nomad/repo/.github/workflows/main.yml
@@ -571,7 +571,7 @@ jobs:
         fields: repo,commit,author,action
         status: ${{ job.status }}
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         language:
         - nodejs

--- a/provider-ci/providers/nomad/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/nomad/repo/.github/workflows/master.yml
@@ -571,7 +571,7 @@ jobs:
         fields: repo,commit,author,action
         status: ${{ job.status }}
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         language:
         - nodejs

--- a/provider-ci/providers/nomad/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/nomad/repo/.github/workflows/prerelease.yml
@@ -521,7 +521,7 @@ jobs:
         fields: repo,commit,author,action
         status: ${{ job.status }}
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         language:
         - nodejs

--- a/provider-ci/providers/nomad/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/nomad/repo/.github/workflows/release.yml
@@ -547,7 +547,7 @@ jobs:
         fields: repo,commit,author,action
         status: ${{ job.status }}
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         language:
         - nodejs

--- a/provider-ci/providers/nomad/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/nomad/repo/.github/workflows/run-acceptance-tests.yml
@@ -399,7 +399,7 @@ jobs:
         fields: repo,commit,author,action
         status: ${{ job.status }}
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         language:
         - nodejs

--- a/provider-ci/providers/ns1/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/ns1/repo/.github/workflows/main.yml
@@ -569,7 +569,7 @@ jobs:
         fields: repo,commit,author,action
         status: ${{ job.status }}
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         language:
         - nodejs

--- a/provider-ci/providers/ns1/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/ns1/repo/.github/workflows/master.yml
@@ -569,7 +569,7 @@ jobs:
         fields: repo,commit,author,action
         status: ${{ job.status }}
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         language:
         - nodejs

--- a/provider-ci/providers/ns1/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/ns1/repo/.github/workflows/prerelease.yml
@@ -519,7 +519,7 @@ jobs:
         fields: repo,commit,author,action
         status: ${{ job.status }}
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         language:
         - nodejs

--- a/provider-ci/providers/ns1/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/ns1/repo/.github/workflows/release.yml
@@ -545,7 +545,7 @@ jobs:
         fields: repo,commit,author,action
         status: ${{ job.status }}
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         language:
         - nodejs

--- a/provider-ci/providers/ns1/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/ns1/repo/.github/workflows/run-acceptance-tests.yml
@@ -397,7 +397,7 @@ jobs:
         fields: repo,commit,author,action
         status: ${{ job.status }}
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         language:
         - nodejs

--- a/provider-ci/providers/oci/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/oci/repo/.github/workflows/main.yml
@@ -501,7 +501,7 @@ jobs:
         fields: repo,commit,author,action
         status: ${{ job.status }}
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         language:
         - nodejs

--- a/provider-ci/providers/oci/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/oci/repo/.github/workflows/master.yml
@@ -501,7 +501,7 @@ jobs:
         fields: repo,commit,author,action
         status: ${{ job.status }}
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         language:
         - nodejs

--- a/provider-ci/providers/oci/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/oci/repo/.github/workflows/prerelease.yml
@@ -451,7 +451,7 @@ jobs:
         fields: repo,commit,author,action
         status: ${{ job.status }}
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         language:
         - nodejs

--- a/provider-ci/providers/oci/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/oci/repo/.github/workflows/release.yml
@@ -477,7 +477,7 @@ jobs:
         fields: repo,commit,author,action
         status: ${{ job.status }}
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         language:
         - nodejs

--- a/provider-ci/providers/oci/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/oci/repo/.github/workflows/run-acceptance-tests.yml
@@ -319,7 +319,7 @@ jobs:
         fields: repo,commit,author,action
         status: ${{ job.status }}
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         language:
         - nodejs

--- a/provider-ci/providers/okta/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/okta/repo/.github/workflows/main.yml
@@ -571,7 +571,7 @@ jobs:
         fields: repo,commit,author,action
         status: ${{ job.status }}
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         language:
         - nodejs

--- a/provider-ci/providers/okta/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/okta/repo/.github/workflows/master.yml
@@ -571,7 +571,7 @@ jobs:
         fields: repo,commit,author,action
         status: ${{ job.status }}
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         language:
         - nodejs

--- a/provider-ci/providers/okta/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/okta/repo/.github/workflows/prerelease.yml
@@ -521,7 +521,7 @@ jobs:
         fields: repo,commit,author,action
         status: ${{ job.status }}
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         language:
         - nodejs

--- a/provider-ci/providers/okta/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/okta/repo/.github/workflows/release.yml
@@ -547,7 +547,7 @@ jobs:
         fields: repo,commit,author,action
         status: ${{ job.status }}
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         language:
         - nodejs

--- a/provider-ci/providers/okta/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/okta/repo/.github/workflows/run-acceptance-tests.yml
@@ -399,7 +399,7 @@ jobs:
         fields: repo,commit,author,action
         status: ${{ job.status }}
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         language:
         - nodejs

--- a/provider-ci/providers/onelogin/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/onelogin/repo/.github/workflows/main.yml
@@ -568,7 +568,7 @@ jobs:
         fields: repo,commit,author,action
         status: ${{ job.status }}
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         language:
         - nodejs

--- a/provider-ci/providers/onelogin/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/onelogin/repo/.github/workflows/master.yml
@@ -568,7 +568,7 @@ jobs:
         fields: repo,commit,author,action
         status: ${{ job.status }}
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         language:
         - nodejs

--- a/provider-ci/providers/onelogin/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/onelogin/repo/.github/workflows/prerelease.yml
@@ -518,7 +518,7 @@ jobs:
         fields: repo,commit,author,action
         status: ${{ job.status }}
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         language:
         - nodejs

--- a/provider-ci/providers/onelogin/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/onelogin/repo/.github/workflows/release.yml
@@ -544,7 +544,7 @@ jobs:
         fields: repo,commit,author,action
         status: ${{ job.status }}
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         language:
         - nodejs

--- a/provider-ci/providers/onelogin/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/onelogin/repo/.github/workflows/run-acceptance-tests.yml
@@ -396,7 +396,7 @@ jobs:
         fields: repo,commit,author,action
         status: ${{ job.status }}
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         language:
         - nodejs

--- a/provider-ci/providers/openstack/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/openstack/repo/.github/workflows/main.yml
@@ -577,7 +577,7 @@ jobs:
         fields: repo,commit,author,action
         status: ${{ job.status }}
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         language:
         - nodejs

--- a/provider-ci/providers/openstack/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/openstack/repo/.github/workflows/master.yml
@@ -577,7 +577,7 @@ jobs:
         fields: repo,commit,author,action
         status: ${{ job.status }}
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         language:
         - nodejs

--- a/provider-ci/providers/openstack/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/openstack/repo/.github/workflows/prerelease.yml
@@ -527,7 +527,7 @@ jobs:
         fields: repo,commit,author,action
         status: ${{ job.status }}
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         language:
         - nodejs

--- a/provider-ci/providers/openstack/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/openstack/repo/.github/workflows/release.yml
@@ -553,7 +553,7 @@ jobs:
         fields: repo,commit,author,action
         status: ${{ job.status }}
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         language:
         - nodejs

--- a/provider-ci/providers/openstack/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/openstack/repo/.github/workflows/run-acceptance-tests.yml
@@ -405,7 +405,7 @@ jobs:
         fields: repo,commit,author,action
         status: ${{ job.status }}
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         language:
         - nodejs

--- a/provider-ci/providers/opsgenie/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/opsgenie/repo/.github/workflows/main.yml
@@ -569,7 +569,7 @@ jobs:
         fields: repo,commit,author,action
         status: ${{ job.status }}
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         language:
         - nodejs

--- a/provider-ci/providers/opsgenie/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/opsgenie/repo/.github/workflows/master.yml
@@ -569,7 +569,7 @@ jobs:
         fields: repo,commit,author,action
         status: ${{ job.status }}
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         language:
         - nodejs

--- a/provider-ci/providers/opsgenie/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/opsgenie/repo/.github/workflows/prerelease.yml
@@ -519,7 +519,7 @@ jobs:
         fields: repo,commit,author,action
         status: ${{ job.status }}
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         language:
         - nodejs

--- a/provider-ci/providers/opsgenie/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/opsgenie/repo/.github/workflows/release.yml
@@ -545,7 +545,7 @@ jobs:
         fields: repo,commit,author,action
         status: ${{ job.status }}
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         language:
         - nodejs

--- a/provider-ci/providers/opsgenie/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/opsgenie/repo/.github/workflows/run-acceptance-tests.yml
@@ -397,7 +397,7 @@ jobs:
         fields: repo,commit,author,action
         status: ${{ job.status }}
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         language:
         - nodejs

--- a/provider-ci/providers/pagerduty/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/pagerduty/repo/.github/workflows/main.yml
@@ -569,7 +569,7 @@ jobs:
         fields: repo,commit,author,action
         status: ${{ job.status }}
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         language:
         - nodejs

--- a/provider-ci/providers/pagerduty/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/pagerduty/repo/.github/workflows/master.yml
@@ -569,7 +569,7 @@ jobs:
         fields: repo,commit,author,action
         status: ${{ job.status }}
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         language:
         - nodejs

--- a/provider-ci/providers/pagerduty/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/pagerduty/repo/.github/workflows/prerelease.yml
@@ -519,7 +519,7 @@ jobs:
         fields: repo,commit,author,action
         status: ${{ job.status }}
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         language:
         - nodejs

--- a/provider-ci/providers/pagerduty/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/pagerduty/repo/.github/workflows/release.yml
@@ -545,7 +545,7 @@ jobs:
         fields: repo,commit,author,action
         status: ${{ job.status }}
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         language:
         - nodejs

--- a/provider-ci/providers/pagerduty/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/pagerduty/repo/.github/workflows/run-acceptance-tests.yml
@@ -397,7 +397,7 @@ jobs:
         fields: repo,commit,author,action
         status: ${{ job.status }}
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         language:
         - nodejs

--- a/provider-ci/providers/postgresql/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/postgresql/repo/.github/workflows/main.yml
@@ -570,7 +570,7 @@ jobs:
         fields: repo,commit,author,action
         status: ${{ job.status }}
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         language:
         - nodejs

--- a/provider-ci/providers/postgresql/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/postgresql/repo/.github/workflows/master.yml
@@ -570,7 +570,7 @@ jobs:
         fields: repo,commit,author,action
         status: ${{ job.status }}
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         language:
         - nodejs

--- a/provider-ci/providers/postgresql/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/postgresql/repo/.github/workflows/prerelease.yml
@@ -520,7 +520,7 @@ jobs:
         fields: repo,commit,author,action
         status: ${{ job.status }}
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         language:
         - nodejs

--- a/provider-ci/providers/postgresql/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/postgresql/repo/.github/workflows/release.yml
@@ -546,7 +546,7 @@ jobs:
         fields: repo,commit,author,action
         status: ${{ job.status }}
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         language:
         - nodejs

--- a/provider-ci/providers/postgresql/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/postgresql/repo/.github/workflows/run-acceptance-tests.yml
@@ -398,7 +398,7 @@ jobs:
         fields: repo,commit,author,action
         status: ${{ job.status }}
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         language:
         - nodejs

--- a/provider-ci/providers/rabbitmq/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/rabbitmq/repo/.github/workflows/main.yml
@@ -570,7 +570,7 @@ jobs:
         fields: repo,commit,author,action
         status: ${{ job.status }}
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         language:
         - nodejs

--- a/provider-ci/providers/rabbitmq/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/rabbitmq/repo/.github/workflows/master.yml
@@ -570,7 +570,7 @@ jobs:
         fields: repo,commit,author,action
         status: ${{ job.status }}
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         language:
         - nodejs

--- a/provider-ci/providers/rabbitmq/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/rabbitmq/repo/.github/workflows/prerelease.yml
@@ -520,7 +520,7 @@ jobs:
         fields: repo,commit,author,action
         status: ${{ job.status }}
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         language:
         - nodejs

--- a/provider-ci/providers/rabbitmq/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/rabbitmq/repo/.github/workflows/release.yml
@@ -546,7 +546,7 @@ jobs:
         fields: repo,commit,author,action
         status: ${{ job.status }}
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         language:
         - nodejs

--- a/provider-ci/providers/rabbitmq/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/rabbitmq/repo/.github/workflows/run-acceptance-tests.yml
@@ -398,7 +398,7 @@ jobs:
         fields: repo,commit,author,action
         status: ${{ job.status }}
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         language:
         - nodejs

--- a/provider-ci/providers/rancher2/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/rancher2/repo/.github/workflows/main.yml
@@ -501,7 +501,7 @@ jobs:
         fields: repo,commit,author,action
         status: ${{ job.status }}
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         language:
         - nodejs

--- a/provider-ci/providers/rancher2/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/rancher2/repo/.github/workflows/master.yml
@@ -501,7 +501,7 @@ jobs:
         fields: repo,commit,author,action
         status: ${{ job.status }}
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         language:
         - nodejs

--- a/provider-ci/providers/rancher2/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/rancher2/repo/.github/workflows/prerelease.yml
@@ -451,7 +451,7 @@ jobs:
         fields: repo,commit,author,action
         status: ${{ job.status }}
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         language:
         - nodejs

--- a/provider-ci/providers/rancher2/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/rancher2/repo/.github/workflows/release.yml
@@ -477,7 +477,7 @@ jobs:
         fields: repo,commit,author,action
         status: ${{ job.status }}
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         language:
         - nodejs

--- a/provider-ci/providers/rancher2/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/rancher2/repo/.github/workflows/run-acceptance-tests.yml
@@ -319,7 +319,7 @@ jobs:
         fields: repo,commit,author,action
         status: ${{ job.status }}
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         language:
         - nodejs

--- a/provider-ci/providers/random/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/random/repo/.github/workflows/main.yml
@@ -568,7 +568,7 @@ jobs:
         fields: repo,commit,author,action
         status: ${{ job.status }}
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         language:
         - nodejs

--- a/provider-ci/providers/random/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/random/repo/.github/workflows/master.yml
@@ -568,7 +568,7 @@ jobs:
         fields: repo,commit,author,action
         status: ${{ job.status }}
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         language:
         - nodejs

--- a/provider-ci/providers/random/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/random/repo/.github/workflows/prerelease.yml
@@ -518,7 +518,7 @@ jobs:
         fields: repo,commit,author,action
         status: ${{ job.status }}
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         language:
         - nodejs

--- a/provider-ci/providers/random/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/random/repo/.github/workflows/release.yml
@@ -544,7 +544,7 @@ jobs:
         fields: repo,commit,author,action
         status: ${{ job.status }}
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         language:
         - nodejs

--- a/provider-ci/providers/random/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/random/repo/.github/workflows/run-acceptance-tests.yml
@@ -396,7 +396,7 @@ jobs:
         fields: repo,commit,author,action
         status: ${{ job.status }}
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         language:
         - nodejs

--- a/provider-ci/providers/rke/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/rke/repo/.github/workflows/main.yml
@@ -578,7 +578,7 @@ jobs:
         fields: repo,commit,author,action
         status: ${{ job.status }}
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         language:
         - nodejs

--- a/provider-ci/providers/rke/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/rke/repo/.github/workflows/master.yml
@@ -578,7 +578,7 @@ jobs:
         fields: repo,commit,author,action
         status: ${{ job.status }}
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         language:
         - nodejs

--- a/provider-ci/providers/rke/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/rke/repo/.github/workflows/prerelease.yml
@@ -528,7 +528,7 @@ jobs:
         fields: repo,commit,author,action
         status: ${{ job.status }}
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         language:
         - nodejs

--- a/provider-ci/providers/rke/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/rke/repo/.github/workflows/release.yml
@@ -554,7 +554,7 @@ jobs:
         fields: repo,commit,author,action
         status: ${{ job.status }}
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         language:
         - nodejs

--- a/provider-ci/providers/rke/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/rke/repo/.github/workflows/run-acceptance-tests.yml
@@ -406,7 +406,7 @@ jobs:
         fields: repo,commit,author,action
         status: ${{ job.status }}
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         language:
         - nodejs

--- a/provider-ci/providers/signalfx/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/signalfx/repo/.github/workflows/main.yml
@@ -568,7 +568,7 @@ jobs:
         fields: repo,commit,author,action
         status: ${{ job.status }}
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         language:
         - nodejs

--- a/provider-ci/providers/signalfx/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/signalfx/repo/.github/workflows/master.yml
@@ -568,7 +568,7 @@ jobs:
         fields: repo,commit,author,action
         status: ${{ job.status }}
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         language:
         - nodejs

--- a/provider-ci/providers/signalfx/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/signalfx/repo/.github/workflows/prerelease.yml
@@ -518,7 +518,7 @@ jobs:
         fields: repo,commit,author,action
         status: ${{ job.status }}
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         language:
         - nodejs

--- a/provider-ci/providers/signalfx/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/signalfx/repo/.github/workflows/release.yml
@@ -544,7 +544,7 @@ jobs:
         fields: repo,commit,author,action
         status: ${{ job.status }}
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         language:
         - nodejs

--- a/provider-ci/providers/signalfx/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/signalfx/repo/.github/workflows/run-acceptance-tests.yml
@@ -396,7 +396,7 @@ jobs:
         fields: repo,commit,author,action
         status: ${{ job.status }}
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         language:
         - nodejs

--- a/provider-ci/providers/slack/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/slack/repo/.github/workflows/main.yml
@@ -569,7 +569,7 @@ jobs:
         fields: repo,commit,author,action
         status: ${{ job.status }}
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         language:
         - nodejs

--- a/provider-ci/providers/slack/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/slack/repo/.github/workflows/master.yml
@@ -569,7 +569,7 @@ jobs:
         fields: repo,commit,author,action
         status: ${{ job.status }}
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         language:
         - nodejs

--- a/provider-ci/providers/slack/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/slack/repo/.github/workflows/prerelease.yml
@@ -519,7 +519,7 @@ jobs:
         fields: repo,commit,author,action
         status: ${{ job.status }}
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         language:
         - nodejs

--- a/provider-ci/providers/slack/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/slack/repo/.github/workflows/release.yml
@@ -545,7 +545,7 @@ jobs:
         fields: repo,commit,author,action
         status: ${{ job.status }}
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         language:
         - nodejs

--- a/provider-ci/providers/slack/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/slack/repo/.github/workflows/run-acceptance-tests.yml
@@ -397,7 +397,7 @@ jobs:
         fields: repo,commit,author,action
         status: ${{ job.status }}
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         language:
         - nodejs

--- a/provider-ci/providers/snowflake/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/snowflake/repo/.github/workflows/main.yml
@@ -573,7 +573,7 @@ jobs:
         fields: repo,commit,author,action
         status: ${{ job.status }}
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         language:
         - nodejs

--- a/provider-ci/providers/snowflake/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/snowflake/repo/.github/workflows/master.yml
@@ -573,7 +573,7 @@ jobs:
         fields: repo,commit,author,action
         status: ${{ job.status }}
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         language:
         - nodejs

--- a/provider-ci/providers/snowflake/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/snowflake/repo/.github/workflows/prerelease.yml
@@ -523,7 +523,7 @@ jobs:
         fields: repo,commit,author,action
         status: ${{ job.status }}
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         language:
         - nodejs

--- a/provider-ci/providers/snowflake/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/snowflake/repo/.github/workflows/release.yml
@@ -549,7 +549,7 @@ jobs:
         fields: repo,commit,author,action
         status: ${{ job.status }}
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         language:
         - nodejs

--- a/provider-ci/providers/snowflake/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/snowflake/repo/.github/workflows/run-acceptance-tests.yml
@@ -401,7 +401,7 @@ jobs:
         fields: repo,commit,author,action
         status: ${{ job.status }}
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         language:
         - nodejs

--- a/provider-ci/providers/splunk/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/splunk/repo/.github/workflows/main.yml
@@ -573,7 +573,7 @@ jobs:
         fields: repo,commit,author,action
         status: ${{ job.status }}
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         language:
         - nodejs

--- a/provider-ci/providers/splunk/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/splunk/repo/.github/workflows/master.yml
@@ -573,7 +573,7 @@ jobs:
         fields: repo,commit,author,action
         status: ${{ job.status }}
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         language:
         - nodejs

--- a/provider-ci/providers/splunk/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/splunk/repo/.github/workflows/prerelease.yml
@@ -523,7 +523,7 @@ jobs:
         fields: repo,commit,author,action
         status: ${{ job.status }}
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         language:
         - nodejs

--- a/provider-ci/providers/splunk/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/splunk/repo/.github/workflows/release.yml
@@ -549,7 +549,7 @@ jobs:
         fields: repo,commit,author,action
         status: ${{ job.status }}
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         language:
         - nodejs

--- a/provider-ci/providers/splunk/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/splunk/repo/.github/workflows/run-acceptance-tests.yml
@@ -401,7 +401,7 @@ jobs:
         fields: repo,commit,author,action
         status: ${{ job.status }}
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         language:
         - nodejs

--- a/provider-ci/providers/spotinst/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/spotinst/repo/.github/workflows/main.yml
@@ -580,7 +580,7 @@ jobs:
         fields: repo,commit,author,action
         status: ${{ job.status }}
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         language:
         - nodejs

--- a/provider-ci/providers/spotinst/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/spotinst/repo/.github/workflows/master.yml
@@ -580,7 +580,7 @@ jobs:
         fields: repo,commit,author,action
         status: ${{ job.status }}
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         language:
         - nodejs

--- a/provider-ci/providers/spotinst/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/spotinst/repo/.github/workflows/prerelease.yml
@@ -530,7 +530,7 @@ jobs:
         fields: repo,commit,author,action
         status: ${{ job.status }}
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         language:
         - nodejs

--- a/provider-ci/providers/spotinst/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/spotinst/repo/.github/workflows/release.yml
@@ -556,7 +556,7 @@ jobs:
         fields: repo,commit,author,action
         status: ${{ job.status }}
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         language:
         - nodejs

--- a/provider-ci/providers/spotinst/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/spotinst/repo/.github/workflows/run-acceptance-tests.yml
@@ -408,7 +408,7 @@ jobs:
         fields: repo,commit,author,action
         status: ${{ job.status }}
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         language:
         - nodejs

--- a/provider-ci/providers/sumologic/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/sumologic/repo/.github/workflows/main.yml
@@ -571,7 +571,7 @@ jobs:
         fields: repo,commit,author,action
         status: ${{ job.status }}
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         language:
         - nodejs

--- a/provider-ci/providers/sumologic/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/sumologic/repo/.github/workflows/master.yml
@@ -571,7 +571,7 @@ jobs:
         fields: repo,commit,author,action
         status: ${{ job.status }}
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         language:
         - nodejs

--- a/provider-ci/providers/sumologic/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/sumologic/repo/.github/workflows/prerelease.yml
@@ -521,7 +521,7 @@ jobs:
         fields: repo,commit,author,action
         status: ${{ job.status }}
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         language:
         - nodejs

--- a/provider-ci/providers/sumologic/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/sumologic/repo/.github/workflows/release.yml
@@ -547,7 +547,7 @@ jobs:
         fields: repo,commit,author,action
         status: ${{ job.status }}
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         language:
         - nodejs

--- a/provider-ci/providers/sumologic/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/sumologic/repo/.github/workflows/run-acceptance-tests.yml
@@ -399,7 +399,7 @@ jobs:
         fields: repo,commit,author,action
         status: ${{ job.status }}
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         language:
         - nodejs

--- a/provider-ci/providers/tailscale/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/tailscale/repo/.github/workflows/main.yml
@@ -570,7 +570,7 @@ jobs:
         fields: repo,commit,author,action
         status: ${{ job.status }}
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         language:
         - nodejs

--- a/provider-ci/providers/tailscale/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/tailscale/repo/.github/workflows/master.yml
@@ -570,7 +570,7 @@ jobs:
         fields: repo,commit,author,action
         status: ${{ job.status }}
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         language:
         - nodejs

--- a/provider-ci/providers/tailscale/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/tailscale/repo/.github/workflows/prerelease.yml
@@ -520,7 +520,7 @@ jobs:
         fields: repo,commit,author,action
         status: ${{ job.status }}
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         language:
         - nodejs

--- a/provider-ci/providers/tailscale/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/tailscale/repo/.github/workflows/release.yml
@@ -546,7 +546,7 @@ jobs:
         fields: repo,commit,author,action
         status: ${{ job.status }}
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         language:
         - nodejs

--- a/provider-ci/providers/tailscale/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/tailscale/repo/.github/workflows/run-acceptance-tests.yml
@@ -398,7 +398,7 @@ jobs:
         fields: repo,commit,author,action
         status: ${{ job.status }}
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         language:
         - nodejs

--- a/provider-ci/providers/tls/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/tls/repo/.github/workflows/main.yml
@@ -568,7 +568,7 @@ jobs:
         fields: repo,commit,author,action
         status: ${{ job.status }}
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         language:
         - nodejs

--- a/provider-ci/providers/tls/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/tls/repo/.github/workflows/master.yml
@@ -568,7 +568,7 @@ jobs:
         fields: repo,commit,author,action
         status: ${{ job.status }}
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         language:
         - nodejs

--- a/provider-ci/providers/tls/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/tls/repo/.github/workflows/prerelease.yml
@@ -518,7 +518,7 @@ jobs:
         fields: repo,commit,author,action
         status: ${{ job.status }}
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         language:
         - nodejs

--- a/provider-ci/providers/tls/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/tls/repo/.github/workflows/release.yml
@@ -544,7 +544,7 @@ jobs:
         fields: repo,commit,author,action
         status: ${{ job.status }}
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         language:
         - nodejs

--- a/provider-ci/providers/tls/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/tls/repo/.github/workflows/run-acceptance-tests.yml
@@ -396,7 +396,7 @@ jobs:
         fields: repo,commit,author,action
         status: ${{ job.status }}
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         language:
         - nodejs

--- a/provider-ci/providers/vault/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/vault/repo/.github/workflows/main.yml
@@ -570,7 +570,7 @@ jobs:
         fields: repo,commit,author,action
         status: ${{ job.status }}
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         language:
         - nodejs

--- a/provider-ci/providers/vault/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/vault/repo/.github/workflows/master.yml
@@ -570,7 +570,7 @@ jobs:
         fields: repo,commit,author,action
         status: ${{ job.status }}
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         language:
         - nodejs

--- a/provider-ci/providers/vault/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/vault/repo/.github/workflows/prerelease.yml
@@ -520,7 +520,7 @@ jobs:
         fields: repo,commit,author,action
         status: ${{ job.status }}
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         language:
         - nodejs

--- a/provider-ci/providers/vault/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/vault/repo/.github/workflows/release.yml
@@ -546,7 +546,7 @@ jobs:
         fields: repo,commit,author,action
         status: ${{ job.status }}
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         language:
         - nodejs

--- a/provider-ci/providers/vault/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/vault/repo/.github/workflows/run-acceptance-tests.yml
@@ -398,7 +398,7 @@ jobs:
         fields: repo,commit,author,action
         status: ${{ job.status }}
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         language:
         - nodejs

--- a/provider-ci/providers/venafi/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/venafi/repo/.github/workflows/main.yml
@@ -572,7 +572,7 @@ jobs:
         fields: repo,commit,author,action
         status: ${{ job.status }}
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         language:
         - nodejs

--- a/provider-ci/providers/venafi/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/venafi/repo/.github/workflows/master.yml
@@ -572,7 +572,7 @@ jobs:
         fields: repo,commit,author,action
         status: ${{ job.status }}
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         language:
         - nodejs

--- a/provider-ci/providers/venafi/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/venafi/repo/.github/workflows/prerelease.yml
@@ -522,7 +522,7 @@ jobs:
         fields: repo,commit,author,action
         status: ${{ job.status }}
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         language:
         - nodejs

--- a/provider-ci/providers/venafi/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/venafi/repo/.github/workflows/release.yml
@@ -548,7 +548,7 @@ jobs:
         fields: repo,commit,author,action
         status: ${{ job.status }}
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         language:
         - nodejs

--- a/provider-ci/providers/venafi/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/venafi/repo/.github/workflows/run-acceptance-tests.yml
@@ -400,7 +400,7 @@ jobs:
         fields: repo,commit,author,action
         status: ${{ job.status }}
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         language:
         - nodejs

--- a/provider-ci/providers/vsphere/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/vsphere/repo/.github/workflows/main.yml
@@ -568,7 +568,7 @@ jobs:
         fields: repo,commit,author,action
         status: ${{ job.status }}
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         language:
         - nodejs

--- a/provider-ci/providers/vsphere/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/vsphere/repo/.github/workflows/master.yml
@@ -568,7 +568,7 @@ jobs:
         fields: repo,commit,author,action
         status: ${{ job.status }}
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         language:
         - nodejs

--- a/provider-ci/providers/vsphere/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/vsphere/repo/.github/workflows/prerelease.yml
@@ -518,7 +518,7 @@ jobs:
         fields: repo,commit,author,action
         status: ${{ job.status }}
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         language:
         - nodejs

--- a/provider-ci/providers/vsphere/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/vsphere/repo/.github/workflows/release.yml
@@ -544,7 +544,7 @@ jobs:
         fields: repo,commit,author,action
         status: ${{ job.status }}
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         language:
         - nodejs

--- a/provider-ci/providers/vsphere/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/vsphere/repo/.github/workflows/run-acceptance-tests.yml
@@ -396,7 +396,7 @@ jobs:
         fields: repo,commit,author,action
         status: ${{ job.status }}
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         language:
         - nodejs

--- a/provider-ci/providers/wavefront/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/wavefront/repo/.github/workflows/main.yml
@@ -570,7 +570,7 @@ jobs:
         fields: repo,commit,author,action
         status: ${{ job.status }}
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         language:
         - nodejs

--- a/provider-ci/providers/wavefront/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/wavefront/repo/.github/workflows/master.yml
@@ -570,7 +570,7 @@ jobs:
         fields: repo,commit,author,action
         status: ${{ job.status }}
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         language:
         - nodejs

--- a/provider-ci/providers/wavefront/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/wavefront/repo/.github/workflows/prerelease.yml
@@ -520,7 +520,7 @@ jobs:
         fields: repo,commit,author,action
         status: ${{ job.status }}
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         language:
         - nodejs

--- a/provider-ci/providers/wavefront/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/wavefront/repo/.github/workflows/release.yml
@@ -546,7 +546,7 @@ jobs:
         fields: repo,commit,author,action
         status: ${{ job.status }}
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         language:
         - nodejs

--- a/provider-ci/providers/wavefront/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/wavefront/repo/.github/workflows/run-acceptance-tests.yml
@@ -398,7 +398,7 @@ jobs:
         fields: repo,commit,author,action
         status: ${{ job.status }}
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         language:
         - nodejs

--- a/provider-ci/src/workflows.ts
+++ b/provider-ci/src/workflows.ts
@@ -707,7 +707,7 @@ export class TestsJob implements NormalJob {
   "runs-on" = "ubuntu-latest";
   needs = "build_sdk";
   strategy = {
-    "fail-fast": true,
+    "fail-fast": false,
     matrix: {
       language: ["nodejs", "python", "dotnet", "go", "java"],
     },


### PR DESCRIPTION
Fixes #332 

This will use more CI runner time but will make sure infra is cleaned up in test accounts, the later consideration weighs more heavily.