### PR TITLE
Nightly trigger for update-workflows-ecosystem-providers

### DIFF
--- a/.github/workflows/update-workflows-ecosystem-providers.yml
+++ b/.github/workflows/update-workflows-ecosystem-providers.yml
@@ -6,6 +6,9 @@
 # when this workflow is run.
 name: Update GH workflows, ecosystem providers
 on:
+  schedule:
+  # 5 AM UTC ~ 10 PM PDT - specifically selected to avoid putting load on the CI system during working hours.
+  - cron: 0 5 * * *
   workflow_dispatch:
     inputs:
       automerge:


### PR DESCRIPTION
I've noticed that running this workflow can be very expensive and take resources away from other CI jobs folks are running during the day. Suggest preferring a nightly run to manual triggers.