### PR TITLE
Use Provider Publisher composite action for publish_sdks job

### DIFF
--- a/provider-ci/providers/aiven/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/aiven/repo/.github/workflows/main.yml
@@ -280,131 +280,13 @@ jobs:
         author_name: Failure in publishing binaries
         fields: repo,commit,author,action
         status: ${{ job.status }}
-  publish_java_sdk:
-    continue-on-error: true
-    name: publish_java_sdk
-    needs: publish
-    runs-on: ubuntu-latest
-    steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{ env.JAVAVERSION }}
-    - name: Setup Gradle
-      uses: gradle/gradle-build-action@v2
-      with:
-        gradle-version: "7.6"
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
   publish_sdk:
     name: publish_sdk
     needs: publish
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Node
-      uses: actions/setup-node@v2
-      with:
-        node-version: ${{ env.NODEVERSION }}
-        registry-url: https://registry.npmjs.org
-    - name: Setup DotNet
-      uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: ${{ env.DOTNETVERSION }}
-    - name: Setup Python
-      uses: actions/setup-python@v2
-      with:
-        python-version: ${{ env.PYTHONVERSION }}
-    - name: Download python SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: python-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress python SDK
-      run: tar -zxf ${{github.workspace}}/sdk/python.tar.gz -C
-        ${{github.workspace}}/sdk/python
-    - name: Download dotnet SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: dotnet-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress dotnet SDK
-      run: tar -zxf ${{github.workspace}}/sdk/dotnet.tar.gz -C
-        ${{github.workspace}}/sdk/dotnet
-    - name: Download nodejs SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: nodejs-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress nodejs SDK
-      run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
-        ${{github.workspace}}/sdk/nodejs
-    - run: python -m pip install pip twine
-    - env:
-        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-      name: Publish SDKs
-      run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - if: failure() && github.event_name == 'push'
-      name: Notify Slack
-      uses: 8398a7/action-slack@v3
-      with:
-        author_name: Failure in publishing SDK
-        fields: repo,commit,author,action
-        status: ${{ job.status }}
+    - name: Publish SDKs
+      uses: pulumi/pulumi-package-publisher@v0.0.5
   test:
     name: test
     needs: build_sdk

--- a/provider-ci/providers/aiven/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/aiven/repo/.github/workflows/master.yml
@@ -280,131 +280,13 @@ jobs:
         author_name: Failure in publishing binaries
         fields: repo,commit,author,action
         status: ${{ job.status }}
-  publish_java_sdk:
-    continue-on-error: true
-    name: publish_java_sdk
-    needs: publish
-    runs-on: ubuntu-latest
-    steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{ env.JAVAVERSION }}
-    - name: Setup Gradle
-      uses: gradle/gradle-build-action@v2
-      with:
-        gradle-version: "7.6"
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
   publish_sdk:
     name: publish_sdk
     needs: publish
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Node
-      uses: actions/setup-node@v2
-      with:
-        node-version: ${{ env.NODEVERSION }}
-        registry-url: https://registry.npmjs.org
-    - name: Setup DotNet
-      uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: ${{ env.DOTNETVERSION }}
-    - name: Setup Python
-      uses: actions/setup-python@v2
-      with:
-        python-version: ${{ env.PYTHONVERSION }}
-    - name: Download python SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: python-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress python SDK
-      run: tar -zxf ${{github.workspace}}/sdk/python.tar.gz -C
-        ${{github.workspace}}/sdk/python
-    - name: Download dotnet SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: dotnet-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress dotnet SDK
-      run: tar -zxf ${{github.workspace}}/sdk/dotnet.tar.gz -C
-        ${{github.workspace}}/sdk/dotnet
-    - name: Download nodejs SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: nodejs-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress nodejs SDK
-      run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
-        ${{github.workspace}}/sdk/nodejs
-    - run: python -m pip install pip twine
-    - env:
-        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-      name: Publish SDKs
-      run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - if: failure() && github.event_name == 'push'
-      name: Notify Slack
-      uses: 8398a7/action-slack@v3
-      with:
-        author_name: Failure in publishing SDK
-        fields: repo,commit,author,action
-        status: ${{ job.status }}
+    - name: Publish SDKs
+      uses: pulumi/pulumi-package-publisher@v0.0.5
   test:
     name: test
     needs: build_sdk

--- a/provider-ci/providers/aiven/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/aiven/repo/.github/workflows/prerelease.yml
@@ -230,131 +230,13 @@ jobs:
         author_name: Failure in publishing binaries
         fields: repo,commit,author,action
         status: ${{ job.status }}
-  publish_java_sdk:
-    continue-on-error: true
-    name: publish_java_sdk
-    needs: publish
-    runs-on: ubuntu-latest
-    steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{ env.JAVAVERSION }}
-    - name: Setup Gradle
-      uses: gradle/gradle-build-action@v2
-      with:
-        gradle-version: "7.6"
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
   publish_sdk:
     name: publish_sdk
     needs: publish
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Node
-      uses: actions/setup-node@v2
-      with:
-        node-version: ${{ env.NODEVERSION }}
-        registry-url: https://registry.npmjs.org
-    - name: Setup DotNet
-      uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: ${{ env.DOTNETVERSION }}
-    - name: Setup Python
-      uses: actions/setup-python@v2
-      with:
-        python-version: ${{ env.PYTHONVERSION }}
-    - name: Download python SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: python-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress python SDK
-      run: tar -zxf ${{github.workspace}}/sdk/python.tar.gz -C
-        ${{github.workspace}}/sdk/python
-    - name: Download dotnet SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: dotnet-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress dotnet SDK
-      run: tar -zxf ${{github.workspace}}/sdk/dotnet.tar.gz -C
-        ${{github.workspace}}/sdk/dotnet
-    - name: Download nodejs SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: nodejs-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress nodejs SDK
-      run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
-        ${{github.workspace}}/sdk/nodejs
-    - run: python -m pip install pip twine
-    - env:
-        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-      name: Publish SDKs
-      run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - if: failure() && github.event_name == 'push'
-      name: Notify Slack
-      uses: 8398a7/action-slack@v3
-      with:
-        author_name: Failure in publishing SDK
-        fields: repo,commit,author,action
-        status: ${{ job.status }}
+    - name: Publish SDKs
+      uses: pulumi/pulumi-package-publisher@v0.0.5
   test:
     name: test
     needs: build_sdk

--- a/provider-ci/providers/aiven/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/aiven/repo/.github/workflows/release.yml
@@ -242,131 +242,13 @@ jobs:
         author_name: Failure in publishing binaries
         fields: repo,commit,author,action
         status: ${{ job.status }}
-  publish_java_sdk:
-    continue-on-error: true
-    name: publish_java_sdk
-    needs: publish
-    runs-on: ubuntu-latest
-    steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{ env.JAVAVERSION }}
-    - name: Setup Gradle
-      uses: gradle/gradle-build-action@v2
-      with:
-        gradle-version: "7.6"
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
   publish_sdk:
     name: publish_sdk
     needs: publish
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Node
-      uses: actions/setup-node@v2
-      with:
-        node-version: ${{ env.NODEVERSION }}
-        registry-url: https://registry.npmjs.org
-    - name: Setup DotNet
-      uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: ${{ env.DOTNETVERSION }}
-    - name: Setup Python
-      uses: actions/setup-python@v2
-      with:
-        python-version: ${{ env.PYTHONVERSION }}
-    - name: Download python SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: python-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress python SDK
-      run: tar -zxf ${{github.workspace}}/sdk/python.tar.gz -C
-        ${{github.workspace}}/sdk/python
-    - name: Download dotnet SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: dotnet-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress dotnet SDK
-      run: tar -zxf ${{github.workspace}}/sdk/dotnet.tar.gz -C
-        ${{github.workspace}}/sdk/dotnet
-    - name: Download nodejs SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: nodejs-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress nodejs SDK
-      run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
-        ${{github.workspace}}/sdk/nodejs
-    - run: python -m pip install pip twine
-    - env:
-        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-      name: Publish SDKs
-      run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - if: failure() && github.event_name == 'push'
-      name: Notify Slack
-      uses: 8398a7/action-slack@v3
-      with:
-        author_name: Failure in publishing SDK
-        fields: repo,commit,author,action
-        status: ${{ job.status }}
+    - name: Publish SDKs
+      uses: pulumi/pulumi-package-publisher@v0.0.5
   tag_sdk:
     name: tag_sdk
     needs: publish_sdk

--- a/provider-ci/providers/akamai/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/akamai/repo/.github/workflows/main.yml
@@ -282,131 +282,13 @@ jobs:
         author_name: Failure in publishing binaries
         fields: repo,commit,author,action
         status: ${{ job.status }}
-  publish_java_sdk:
-    continue-on-error: true
-    name: publish_java_sdk
-    needs: publish
-    runs-on: ubuntu-latest
-    steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{ env.JAVAVERSION }}
-    - name: Setup Gradle
-      uses: gradle/gradle-build-action@v2
-      with:
-        gradle-version: "7.6"
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
   publish_sdk:
     name: publish_sdk
     needs: publish
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Node
-      uses: actions/setup-node@v2
-      with:
-        node-version: ${{ env.NODEVERSION }}
-        registry-url: https://registry.npmjs.org
-    - name: Setup DotNet
-      uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: ${{ env.DOTNETVERSION }}
-    - name: Setup Python
-      uses: actions/setup-python@v2
-      with:
-        python-version: ${{ env.PYTHONVERSION }}
-    - name: Download python SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: python-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress python SDK
-      run: tar -zxf ${{github.workspace}}/sdk/python.tar.gz -C
-        ${{github.workspace}}/sdk/python
-    - name: Download dotnet SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: dotnet-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress dotnet SDK
-      run: tar -zxf ${{github.workspace}}/sdk/dotnet.tar.gz -C
-        ${{github.workspace}}/sdk/dotnet
-    - name: Download nodejs SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: nodejs-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress nodejs SDK
-      run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
-        ${{github.workspace}}/sdk/nodejs
-    - run: python -m pip install pip twine
-    - env:
-        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-      name: Publish SDKs
-      run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - if: failure() && github.event_name == 'push'
-      name: Notify Slack
-      uses: 8398a7/action-slack@v3
-      with:
-        author_name: Failure in publishing SDK
-        fields: repo,commit,author,action
-        status: ${{ job.status }}
+    - name: Publish SDKs
+      uses: pulumi/pulumi-package-publisher@v0.0.5
   test:
     name: test
     needs: build_sdk

--- a/provider-ci/providers/akamai/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/akamai/repo/.github/workflows/master.yml
@@ -282,131 +282,13 @@ jobs:
         author_name: Failure in publishing binaries
         fields: repo,commit,author,action
         status: ${{ job.status }}
-  publish_java_sdk:
-    continue-on-error: true
-    name: publish_java_sdk
-    needs: publish
-    runs-on: ubuntu-latest
-    steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{ env.JAVAVERSION }}
-    - name: Setup Gradle
-      uses: gradle/gradle-build-action@v2
-      with:
-        gradle-version: "7.6"
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
   publish_sdk:
     name: publish_sdk
     needs: publish
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Node
-      uses: actions/setup-node@v2
-      with:
-        node-version: ${{ env.NODEVERSION }}
-        registry-url: https://registry.npmjs.org
-    - name: Setup DotNet
-      uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: ${{ env.DOTNETVERSION }}
-    - name: Setup Python
-      uses: actions/setup-python@v2
-      with:
-        python-version: ${{ env.PYTHONVERSION }}
-    - name: Download python SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: python-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress python SDK
-      run: tar -zxf ${{github.workspace}}/sdk/python.tar.gz -C
-        ${{github.workspace}}/sdk/python
-    - name: Download dotnet SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: dotnet-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress dotnet SDK
-      run: tar -zxf ${{github.workspace}}/sdk/dotnet.tar.gz -C
-        ${{github.workspace}}/sdk/dotnet
-    - name: Download nodejs SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: nodejs-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress nodejs SDK
-      run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
-        ${{github.workspace}}/sdk/nodejs
-    - run: python -m pip install pip twine
-    - env:
-        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-      name: Publish SDKs
-      run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - if: failure() && github.event_name == 'push'
-      name: Notify Slack
-      uses: 8398a7/action-slack@v3
-      with:
-        author_name: Failure in publishing SDK
-        fields: repo,commit,author,action
-        status: ${{ job.status }}
+    - name: Publish SDKs
+      uses: pulumi/pulumi-package-publisher@v0.0.5
   test:
     name: test
     needs: build_sdk

--- a/provider-ci/providers/akamai/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/akamai/repo/.github/workflows/prerelease.yml
@@ -232,131 +232,13 @@ jobs:
         author_name: Failure in publishing binaries
         fields: repo,commit,author,action
         status: ${{ job.status }}
-  publish_java_sdk:
-    continue-on-error: true
-    name: publish_java_sdk
-    needs: publish
-    runs-on: ubuntu-latest
-    steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{ env.JAVAVERSION }}
-    - name: Setup Gradle
-      uses: gradle/gradle-build-action@v2
-      with:
-        gradle-version: "7.6"
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
   publish_sdk:
     name: publish_sdk
     needs: publish
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Node
-      uses: actions/setup-node@v2
-      with:
-        node-version: ${{ env.NODEVERSION }}
-        registry-url: https://registry.npmjs.org
-    - name: Setup DotNet
-      uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: ${{ env.DOTNETVERSION }}
-    - name: Setup Python
-      uses: actions/setup-python@v2
-      with:
-        python-version: ${{ env.PYTHONVERSION }}
-    - name: Download python SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: python-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress python SDK
-      run: tar -zxf ${{github.workspace}}/sdk/python.tar.gz -C
-        ${{github.workspace}}/sdk/python
-    - name: Download dotnet SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: dotnet-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress dotnet SDK
-      run: tar -zxf ${{github.workspace}}/sdk/dotnet.tar.gz -C
-        ${{github.workspace}}/sdk/dotnet
-    - name: Download nodejs SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: nodejs-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress nodejs SDK
-      run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
-        ${{github.workspace}}/sdk/nodejs
-    - run: python -m pip install pip twine
-    - env:
-        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-      name: Publish SDKs
-      run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - if: failure() && github.event_name == 'push'
-      name: Notify Slack
-      uses: 8398a7/action-slack@v3
-      with:
-        author_name: Failure in publishing SDK
-        fields: repo,commit,author,action
-        status: ${{ job.status }}
+    - name: Publish SDKs
+      uses: pulumi/pulumi-package-publisher@v0.0.5
   test:
     name: test
     needs: build_sdk

--- a/provider-ci/providers/akamai/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/akamai/repo/.github/workflows/release.yml
@@ -244,131 +244,13 @@ jobs:
         author_name: Failure in publishing binaries
         fields: repo,commit,author,action
         status: ${{ job.status }}
-  publish_java_sdk:
-    continue-on-error: true
-    name: publish_java_sdk
-    needs: publish
-    runs-on: ubuntu-latest
-    steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{ env.JAVAVERSION }}
-    - name: Setup Gradle
-      uses: gradle/gradle-build-action@v2
-      with:
-        gradle-version: "7.6"
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
   publish_sdk:
     name: publish_sdk
     needs: publish
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Node
-      uses: actions/setup-node@v2
-      with:
-        node-version: ${{ env.NODEVERSION }}
-        registry-url: https://registry.npmjs.org
-    - name: Setup DotNet
-      uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: ${{ env.DOTNETVERSION }}
-    - name: Setup Python
-      uses: actions/setup-python@v2
-      with:
-        python-version: ${{ env.PYTHONVERSION }}
-    - name: Download python SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: python-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress python SDK
-      run: tar -zxf ${{github.workspace}}/sdk/python.tar.gz -C
-        ${{github.workspace}}/sdk/python
-    - name: Download dotnet SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: dotnet-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress dotnet SDK
-      run: tar -zxf ${{github.workspace}}/sdk/dotnet.tar.gz -C
-        ${{github.workspace}}/sdk/dotnet
-    - name: Download nodejs SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: nodejs-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress nodejs SDK
-      run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
-        ${{github.workspace}}/sdk/nodejs
-    - run: python -m pip install pip twine
-    - env:
-        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-      name: Publish SDKs
-      run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - if: failure() && github.event_name == 'push'
-      name: Notify Slack
-      uses: 8398a7/action-slack@v3
-      with:
-        author_name: Failure in publishing SDK
-        fields: repo,commit,author,action
-        status: ${{ job.status }}
+    - name: Publish SDKs
+      uses: pulumi/pulumi-package-publisher@v0.0.5
   tag_sdk:
     name: tag_sdk
     needs: publish_sdk

--- a/provider-ci/providers/alicloud/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/alicloud/repo/.github/workflows/main.yml
@@ -281,131 +281,13 @@ jobs:
         author_name: Failure in publishing binaries
         fields: repo,commit,author,action
         status: ${{ job.status }}
-  publish_java_sdk:
-    continue-on-error: true
-    name: publish_java_sdk
-    needs: publish
-    runs-on: ubuntu-latest
-    steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{ env.JAVAVERSION }}
-    - name: Setup Gradle
-      uses: gradle/gradle-build-action@v2
-      with:
-        gradle-version: "7.6"
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
   publish_sdk:
     name: publish_sdk
     needs: publish
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Node
-      uses: actions/setup-node@v2
-      with:
-        node-version: ${{ env.NODEVERSION }}
-        registry-url: https://registry.npmjs.org
-    - name: Setup DotNet
-      uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: ${{ env.DOTNETVERSION }}
-    - name: Setup Python
-      uses: actions/setup-python@v2
-      with:
-        python-version: ${{ env.PYTHONVERSION }}
-    - name: Download python SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: python-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress python SDK
-      run: tar -zxf ${{github.workspace}}/sdk/python.tar.gz -C
-        ${{github.workspace}}/sdk/python
-    - name: Download dotnet SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: dotnet-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress dotnet SDK
-      run: tar -zxf ${{github.workspace}}/sdk/dotnet.tar.gz -C
-        ${{github.workspace}}/sdk/dotnet
-    - name: Download nodejs SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: nodejs-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress nodejs SDK
-      run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
-        ${{github.workspace}}/sdk/nodejs
-    - run: python -m pip install pip twine
-    - env:
-        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-      name: Publish SDKs
-      run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - if: failure() && github.event_name == 'push'
-      name: Notify Slack
-      uses: 8398a7/action-slack@v3
-      with:
-        author_name: Failure in publishing SDK
-        fields: repo,commit,author,action
-        status: ${{ job.status }}
+    - name: Publish SDKs
+      uses: pulumi/pulumi-package-publisher@v0.0.5
   test:
     name: test
     needs: build_sdk

--- a/provider-ci/providers/alicloud/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/alicloud/repo/.github/workflows/master.yml
@@ -281,131 +281,13 @@ jobs:
         author_name: Failure in publishing binaries
         fields: repo,commit,author,action
         status: ${{ job.status }}
-  publish_java_sdk:
-    continue-on-error: true
-    name: publish_java_sdk
-    needs: publish
-    runs-on: ubuntu-latest
-    steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{ env.JAVAVERSION }}
-    - name: Setup Gradle
-      uses: gradle/gradle-build-action@v2
-      with:
-        gradle-version: "7.6"
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
   publish_sdk:
     name: publish_sdk
     needs: publish
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Node
-      uses: actions/setup-node@v2
-      with:
-        node-version: ${{ env.NODEVERSION }}
-        registry-url: https://registry.npmjs.org
-    - name: Setup DotNet
-      uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: ${{ env.DOTNETVERSION }}
-    - name: Setup Python
-      uses: actions/setup-python@v2
-      with:
-        python-version: ${{ env.PYTHONVERSION }}
-    - name: Download python SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: python-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress python SDK
-      run: tar -zxf ${{github.workspace}}/sdk/python.tar.gz -C
-        ${{github.workspace}}/sdk/python
-    - name: Download dotnet SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: dotnet-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress dotnet SDK
-      run: tar -zxf ${{github.workspace}}/sdk/dotnet.tar.gz -C
-        ${{github.workspace}}/sdk/dotnet
-    - name: Download nodejs SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: nodejs-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress nodejs SDK
-      run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
-        ${{github.workspace}}/sdk/nodejs
-    - run: python -m pip install pip twine
-    - env:
-        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-      name: Publish SDKs
-      run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - if: failure() && github.event_name == 'push'
-      name: Notify Slack
-      uses: 8398a7/action-slack@v3
-      with:
-        author_name: Failure in publishing SDK
-        fields: repo,commit,author,action
-        status: ${{ job.status }}
+    - name: Publish SDKs
+      uses: pulumi/pulumi-package-publisher@v0.0.5
   test:
     name: test
     needs: build_sdk

--- a/provider-ci/providers/alicloud/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/alicloud/repo/.github/workflows/prerelease.yml
@@ -231,131 +231,13 @@ jobs:
         author_name: Failure in publishing binaries
         fields: repo,commit,author,action
         status: ${{ job.status }}
-  publish_java_sdk:
-    continue-on-error: true
-    name: publish_java_sdk
-    needs: publish
-    runs-on: ubuntu-latest
-    steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{ env.JAVAVERSION }}
-    - name: Setup Gradle
-      uses: gradle/gradle-build-action@v2
-      with:
-        gradle-version: "7.6"
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
   publish_sdk:
     name: publish_sdk
     needs: publish
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Node
-      uses: actions/setup-node@v2
-      with:
-        node-version: ${{ env.NODEVERSION }}
-        registry-url: https://registry.npmjs.org
-    - name: Setup DotNet
-      uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: ${{ env.DOTNETVERSION }}
-    - name: Setup Python
-      uses: actions/setup-python@v2
-      with:
-        python-version: ${{ env.PYTHONVERSION }}
-    - name: Download python SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: python-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress python SDK
-      run: tar -zxf ${{github.workspace}}/sdk/python.tar.gz -C
-        ${{github.workspace}}/sdk/python
-    - name: Download dotnet SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: dotnet-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress dotnet SDK
-      run: tar -zxf ${{github.workspace}}/sdk/dotnet.tar.gz -C
-        ${{github.workspace}}/sdk/dotnet
-    - name: Download nodejs SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: nodejs-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress nodejs SDK
-      run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
-        ${{github.workspace}}/sdk/nodejs
-    - run: python -m pip install pip twine
-    - env:
-        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-      name: Publish SDKs
-      run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - if: failure() && github.event_name == 'push'
-      name: Notify Slack
-      uses: 8398a7/action-slack@v3
-      with:
-        author_name: Failure in publishing SDK
-        fields: repo,commit,author,action
-        status: ${{ job.status }}
+    - name: Publish SDKs
+      uses: pulumi/pulumi-package-publisher@v0.0.5
   test:
     name: test
     needs: build_sdk

--- a/provider-ci/providers/alicloud/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/alicloud/repo/.github/workflows/release.yml
@@ -243,131 +243,13 @@ jobs:
         author_name: Failure in publishing binaries
         fields: repo,commit,author,action
         status: ${{ job.status }}
-  publish_java_sdk:
-    continue-on-error: true
-    name: publish_java_sdk
-    needs: publish
-    runs-on: ubuntu-latest
-    steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{ env.JAVAVERSION }}
-    - name: Setup Gradle
-      uses: gradle/gradle-build-action@v2
-      with:
-        gradle-version: "7.6"
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
   publish_sdk:
     name: publish_sdk
     needs: publish
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Node
-      uses: actions/setup-node@v2
-      with:
-        node-version: ${{ env.NODEVERSION }}
-        registry-url: https://registry.npmjs.org
-    - name: Setup DotNet
-      uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: ${{ env.DOTNETVERSION }}
-    - name: Setup Python
-      uses: actions/setup-python@v2
-      with:
-        python-version: ${{ env.PYTHONVERSION }}
-    - name: Download python SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: python-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress python SDK
-      run: tar -zxf ${{github.workspace}}/sdk/python.tar.gz -C
-        ${{github.workspace}}/sdk/python
-    - name: Download dotnet SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: dotnet-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress dotnet SDK
-      run: tar -zxf ${{github.workspace}}/sdk/dotnet.tar.gz -C
-        ${{github.workspace}}/sdk/dotnet
-    - name: Download nodejs SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: nodejs-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress nodejs SDK
-      run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
-        ${{github.workspace}}/sdk/nodejs
-    - run: python -m pip install pip twine
-    - env:
-        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-      name: Publish SDKs
-      run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - if: failure() && github.event_name == 'push'
-      name: Notify Slack
-      uses: 8398a7/action-slack@v3
-      with:
-        author_name: Failure in publishing SDK
-        fields: repo,commit,author,action
-        status: ${{ job.status }}
+    - name: Publish SDKs
+      uses: pulumi/pulumi-package-publisher@v0.0.5
   tag_sdk:
     name: tag_sdk
     needs: publish_sdk

--- a/provider-ci/providers/artifactory/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/artifactory/repo/.github/workflows/main.yml
@@ -352,131 +352,13 @@ jobs:
         author_name: Failure in publishing binaries
         fields: repo,commit,author,action
         status: ${{ job.status }}
-  publish_java_sdk:
-    continue-on-error: true
-    name: publish_java_sdk
-    needs: publish
-    runs-on: ubuntu-latest
-    steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{ env.JAVAVERSION }}
-    - name: Setup Gradle
-      uses: gradle/gradle-build-action@v2
-      with:
-        gradle-version: "7.6"
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
   publish_sdk:
     name: publish_sdk
     needs: publish
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Node
-      uses: actions/setup-node@v2
-      with:
-        node-version: ${{ env.NODEVERSION }}
-        registry-url: https://registry.npmjs.org
-    - name: Setup DotNet
-      uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: ${{ env.DOTNETVERSION }}
-    - name: Setup Python
-      uses: actions/setup-python@v2
-      with:
-        python-version: ${{ env.PYTHONVERSION }}
-    - name: Download python SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: python-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress python SDK
-      run: tar -zxf ${{github.workspace}}/sdk/python.tar.gz -C
-        ${{github.workspace}}/sdk/python
-    - name: Download dotnet SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: dotnet-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress dotnet SDK
-      run: tar -zxf ${{github.workspace}}/sdk/dotnet.tar.gz -C
-        ${{github.workspace}}/sdk/dotnet
-    - name: Download nodejs SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: nodejs-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress nodejs SDK
-      run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
-        ${{github.workspace}}/sdk/nodejs
-    - run: python -m pip install pip twine
-    - env:
-        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-      name: Publish SDKs
-      run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - if: failure() && github.event_name == 'push'
-      name: Notify Slack
-      uses: 8398a7/action-slack@v3
-      with:
-        author_name: Failure in publishing SDK
-        fields: repo,commit,author,action
-        status: ${{ job.status }}
+    - name: Publish SDKs
+      uses: pulumi/pulumi-package-publisher@v0.0.5
   test:
     name: test
     needs: build_sdk

--- a/provider-ci/providers/artifactory/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/artifactory/repo/.github/workflows/master.yml
@@ -352,131 +352,13 @@ jobs:
         author_name: Failure in publishing binaries
         fields: repo,commit,author,action
         status: ${{ job.status }}
-  publish_java_sdk:
-    continue-on-error: true
-    name: publish_java_sdk
-    needs: publish
-    runs-on: ubuntu-latest
-    steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{ env.JAVAVERSION }}
-    - name: Setup Gradle
-      uses: gradle/gradle-build-action@v2
-      with:
-        gradle-version: "7.6"
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
   publish_sdk:
     name: publish_sdk
     needs: publish
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Node
-      uses: actions/setup-node@v2
-      with:
-        node-version: ${{ env.NODEVERSION }}
-        registry-url: https://registry.npmjs.org
-    - name: Setup DotNet
-      uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: ${{ env.DOTNETVERSION }}
-    - name: Setup Python
-      uses: actions/setup-python@v2
-      with:
-        python-version: ${{ env.PYTHONVERSION }}
-    - name: Download python SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: python-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress python SDK
-      run: tar -zxf ${{github.workspace}}/sdk/python.tar.gz -C
-        ${{github.workspace}}/sdk/python
-    - name: Download dotnet SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: dotnet-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress dotnet SDK
-      run: tar -zxf ${{github.workspace}}/sdk/dotnet.tar.gz -C
-        ${{github.workspace}}/sdk/dotnet
-    - name: Download nodejs SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: nodejs-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress nodejs SDK
-      run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
-        ${{github.workspace}}/sdk/nodejs
-    - run: python -m pip install pip twine
-    - env:
-        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-      name: Publish SDKs
-      run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - if: failure() && github.event_name == 'push'
-      name: Notify Slack
-      uses: 8398a7/action-slack@v3
-      with:
-        author_name: Failure in publishing SDK
-        fields: repo,commit,author,action
-        status: ${{ job.status }}
+    - name: Publish SDKs
+      uses: pulumi/pulumi-package-publisher@v0.0.5
   test:
     name: test
     needs: build_sdk

--- a/provider-ci/providers/artifactory/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/artifactory/repo/.github/workflows/prerelease.yml
@@ -302,131 +302,13 @@ jobs:
         author_name: Failure in publishing binaries
         fields: repo,commit,author,action
         status: ${{ job.status }}
-  publish_java_sdk:
-    continue-on-error: true
-    name: publish_java_sdk
-    needs: publish
-    runs-on: ubuntu-latest
-    steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{ env.JAVAVERSION }}
-    - name: Setup Gradle
-      uses: gradle/gradle-build-action@v2
-      with:
-        gradle-version: "7.6"
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
   publish_sdk:
     name: publish_sdk
     needs: publish
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Node
-      uses: actions/setup-node@v2
-      with:
-        node-version: ${{ env.NODEVERSION }}
-        registry-url: https://registry.npmjs.org
-    - name: Setup DotNet
-      uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: ${{ env.DOTNETVERSION }}
-    - name: Setup Python
-      uses: actions/setup-python@v2
-      with:
-        python-version: ${{ env.PYTHONVERSION }}
-    - name: Download python SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: python-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress python SDK
-      run: tar -zxf ${{github.workspace}}/sdk/python.tar.gz -C
-        ${{github.workspace}}/sdk/python
-    - name: Download dotnet SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: dotnet-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress dotnet SDK
-      run: tar -zxf ${{github.workspace}}/sdk/dotnet.tar.gz -C
-        ${{github.workspace}}/sdk/dotnet
-    - name: Download nodejs SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: nodejs-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress nodejs SDK
-      run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
-        ${{github.workspace}}/sdk/nodejs
-    - run: python -m pip install pip twine
-    - env:
-        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-      name: Publish SDKs
-      run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - if: failure() && github.event_name == 'push'
-      name: Notify Slack
-      uses: 8398a7/action-slack@v3
-      with:
-        author_name: Failure in publishing SDK
-        fields: repo,commit,author,action
-        status: ${{ job.status }}
+    - name: Publish SDKs
+      uses: pulumi/pulumi-package-publisher@v0.0.5
   test:
     name: test
     needs: build_sdk

--- a/provider-ci/providers/artifactory/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/artifactory/repo/.github/workflows/release.yml
@@ -314,131 +314,13 @@ jobs:
         author_name: Failure in publishing binaries
         fields: repo,commit,author,action
         status: ${{ job.status }}
-  publish_java_sdk:
-    continue-on-error: true
-    name: publish_java_sdk
-    needs: publish
-    runs-on: ubuntu-latest
-    steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{ env.JAVAVERSION }}
-    - name: Setup Gradle
-      uses: gradle/gradle-build-action@v2
-      with:
-        gradle-version: "7.6"
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
   publish_sdk:
     name: publish_sdk
     needs: publish
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Node
-      uses: actions/setup-node@v2
-      with:
-        node-version: ${{ env.NODEVERSION }}
-        registry-url: https://registry.npmjs.org
-    - name: Setup DotNet
-      uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: ${{ env.DOTNETVERSION }}
-    - name: Setup Python
-      uses: actions/setup-python@v2
-      with:
-        python-version: ${{ env.PYTHONVERSION }}
-    - name: Download python SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: python-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress python SDK
-      run: tar -zxf ${{github.workspace}}/sdk/python.tar.gz -C
-        ${{github.workspace}}/sdk/python
-    - name: Download dotnet SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: dotnet-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress dotnet SDK
-      run: tar -zxf ${{github.workspace}}/sdk/dotnet.tar.gz -C
-        ${{github.workspace}}/sdk/dotnet
-    - name: Download nodejs SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: nodejs-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress nodejs SDK
-      run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
-        ${{github.workspace}}/sdk/nodejs
-    - run: python -m pip install pip twine
-    - env:
-        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-      name: Publish SDKs
-      run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - if: failure() && github.event_name == 'push'
-      name: Notify Slack
-      uses: 8398a7/action-slack@v3
-      with:
-        author_name: Failure in publishing SDK
-        fields: repo,commit,author,action
-        status: ${{ job.status }}
+    - name: Publish SDKs
+      uses: pulumi/pulumi-package-publisher@v0.0.5
   tag_sdk:
     name: tag_sdk
     needs: publish_sdk

--- a/provider-ci/providers/auth0/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/auth0/repo/.github/workflows/main.yml
@@ -352,131 +352,13 @@ jobs:
         author_name: Failure in publishing binaries
         fields: repo,commit,author,action
         status: ${{ job.status }}
-  publish_java_sdk:
-    continue-on-error: true
-    name: publish_java_sdk
-    needs: publish
-    runs-on: ubuntu-latest
-    steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{ env.JAVAVERSION }}
-    - name: Setup Gradle
-      uses: gradle/gradle-build-action@v2
-      with:
-        gradle-version: "7.6"
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
   publish_sdk:
     name: publish_sdk
     needs: publish
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Node
-      uses: actions/setup-node@v2
-      with:
-        node-version: ${{ env.NODEVERSION }}
-        registry-url: https://registry.npmjs.org
-    - name: Setup DotNet
-      uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: ${{ env.DOTNETVERSION }}
-    - name: Setup Python
-      uses: actions/setup-python@v2
-      with:
-        python-version: ${{ env.PYTHONVERSION }}
-    - name: Download python SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: python-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress python SDK
-      run: tar -zxf ${{github.workspace}}/sdk/python.tar.gz -C
-        ${{github.workspace}}/sdk/python
-    - name: Download dotnet SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: dotnet-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress dotnet SDK
-      run: tar -zxf ${{github.workspace}}/sdk/dotnet.tar.gz -C
-        ${{github.workspace}}/sdk/dotnet
-    - name: Download nodejs SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: nodejs-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress nodejs SDK
-      run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
-        ${{github.workspace}}/sdk/nodejs
-    - run: python -m pip install pip twine
-    - env:
-        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-      name: Publish SDKs
-      run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - if: failure() && github.event_name == 'push'
-      name: Notify Slack
-      uses: 8398a7/action-slack@v3
-      with:
-        author_name: Failure in publishing SDK
-        fields: repo,commit,author,action
-        status: ${{ job.status }}
+    - name: Publish SDKs
+      uses: pulumi/pulumi-package-publisher@v0.0.5
   test:
     name: test
     needs: build_sdk

--- a/provider-ci/providers/auth0/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/auth0/repo/.github/workflows/master.yml
@@ -352,131 +352,13 @@ jobs:
         author_name: Failure in publishing binaries
         fields: repo,commit,author,action
         status: ${{ job.status }}
-  publish_java_sdk:
-    continue-on-error: true
-    name: publish_java_sdk
-    needs: publish
-    runs-on: ubuntu-latest
-    steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{ env.JAVAVERSION }}
-    - name: Setup Gradle
-      uses: gradle/gradle-build-action@v2
-      with:
-        gradle-version: "7.6"
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
   publish_sdk:
     name: publish_sdk
     needs: publish
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Node
-      uses: actions/setup-node@v2
-      with:
-        node-version: ${{ env.NODEVERSION }}
-        registry-url: https://registry.npmjs.org
-    - name: Setup DotNet
-      uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: ${{ env.DOTNETVERSION }}
-    - name: Setup Python
-      uses: actions/setup-python@v2
-      with:
-        python-version: ${{ env.PYTHONVERSION }}
-    - name: Download python SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: python-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress python SDK
-      run: tar -zxf ${{github.workspace}}/sdk/python.tar.gz -C
-        ${{github.workspace}}/sdk/python
-    - name: Download dotnet SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: dotnet-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress dotnet SDK
-      run: tar -zxf ${{github.workspace}}/sdk/dotnet.tar.gz -C
-        ${{github.workspace}}/sdk/dotnet
-    - name: Download nodejs SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: nodejs-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress nodejs SDK
-      run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
-        ${{github.workspace}}/sdk/nodejs
-    - run: python -m pip install pip twine
-    - env:
-        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-      name: Publish SDKs
-      run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - if: failure() && github.event_name == 'push'
-      name: Notify Slack
-      uses: 8398a7/action-slack@v3
-      with:
-        author_name: Failure in publishing SDK
-        fields: repo,commit,author,action
-        status: ${{ job.status }}
+    - name: Publish SDKs
+      uses: pulumi/pulumi-package-publisher@v0.0.5
   test:
     name: test
     needs: build_sdk

--- a/provider-ci/providers/auth0/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/auth0/repo/.github/workflows/prerelease.yml
@@ -302,131 +302,13 @@ jobs:
         author_name: Failure in publishing binaries
         fields: repo,commit,author,action
         status: ${{ job.status }}
-  publish_java_sdk:
-    continue-on-error: true
-    name: publish_java_sdk
-    needs: publish
-    runs-on: ubuntu-latest
-    steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{ env.JAVAVERSION }}
-    - name: Setup Gradle
-      uses: gradle/gradle-build-action@v2
-      with:
-        gradle-version: "7.6"
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
   publish_sdk:
     name: publish_sdk
     needs: publish
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Node
-      uses: actions/setup-node@v2
-      with:
-        node-version: ${{ env.NODEVERSION }}
-        registry-url: https://registry.npmjs.org
-    - name: Setup DotNet
-      uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: ${{ env.DOTNETVERSION }}
-    - name: Setup Python
-      uses: actions/setup-python@v2
-      with:
-        python-version: ${{ env.PYTHONVERSION }}
-    - name: Download python SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: python-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress python SDK
-      run: tar -zxf ${{github.workspace}}/sdk/python.tar.gz -C
-        ${{github.workspace}}/sdk/python
-    - name: Download dotnet SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: dotnet-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress dotnet SDK
-      run: tar -zxf ${{github.workspace}}/sdk/dotnet.tar.gz -C
-        ${{github.workspace}}/sdk/dotnet
-    - name: Download nodejs SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: nodejs-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress nodejs SDK
-      run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
-        ${{github.workspace}}/sdk/nodejs
-    - run: python -m pip install pip twine
-    - env:
-        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-      name: Publish SDKs
-      run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - if: failure() && github.event_name == 'push'
-      name: Notify Slack
-      uses: 8398a7/action-slack@v3
-      with:
-        author_name: Failure in publishing SDK
-        fields: repo,commit,author,action
-        status: ${{ job.status }}
+    - name: Publish SDKs
+      uses: pulumi/pulumi-package-publisher@v0.0.5
   test:
     name: test
     needs: build_sdk

--- a/provider-ci/providers/auth0/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/auth0/repo/.github/workflows/release.yml
@@ -314,131 +314,13 @@ jobs:
         author_name: Failure in publishing binaries
         fields: repo,commit,author,action
         status: ${{ job.status }}
-  publish_java_sdk:
-    continue-on-error: true
-    name: publish_java_sdk
-    needs: publish
-    runs-on: ubuntu-latest
-    steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{ env.JAVAVERSION }}
-    - name: Setup Gradle
-      uses: gradle/gradle-build-action@v2
-      with:
-        gradle-version: "7.6"
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
   publish_sdk:
     name: publish_sdk
     needs: publish
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Node
-      uses: actions/setup-node@v2
-      with:
-        node-version: ${{ env.NODEVERSION }}
-        registry-url: https://registry.npmjs.org
-    - name: Setup DotNet
-      uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: ${{ env.DOTNETVERSION }}
-    - name: Setup Python
-      uses: actions/setup-python@v2
-      with:
-        python-version: ${{ env.PYTHONVERSION }}
-    - name: Download python SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: python-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress python SDK
-      run: tar -zxf ${{github.workspace}}/sdk/python.tar.gz -C
-        ${{github.workspace}}/sdk/python
-    - name: Download dotnet SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: dotnet-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress dotnet SDK
-      run: tar -zxf ${{github.workspace}}/sdk/dotnet.tar.gz -C
-        ${{github.workspace}}/sdk/dotnet
-    - name: Download nodejs SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: nodejs-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress nodejs SDK
-      run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
-        ${{github.workspace}}/sdk/nodejs
-    - run: python -m pip install pip twine
-    - env:
-        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-      name: Publish SDKs
-      run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - if: failure() && github.event_name == 'push'
-      name: Notify Slack
-      uses: 8398a7/action-slack@v3
-      with:
-        author_name: Failure in publishing SDK
-        fields: repo,commit,author,action
-        status: ${{ job.status }}
+    - name: Publish SDKs
+      uses: pulumi/pulumi-package-publisher@v0.0.5
   tag_sdk:
     name: tag_sdk
     needs: publish_sdk

--- a/provider-ci/providers/aws/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/aws/repo/.github/workflows/main.yml
@@ -280,131 +280,13 @@ jobs:
         author_name: Failure in publishing binaries
         fields: repo,commit,author,action
         status: ${{ job.status }}
-  publish_java_sdk:
-    continue-on-error: true
-    name: publish_java_sdk
-    needs: publish
-    runs-on: ubuntu-latest
-    steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{ env.JAVAVERSION }}
-    - name: Setup Gradle
-      uses: gradle/gradle-build-action@v2
-      with:
-        gradle-version: "7.6"
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
   publish_sdk:
     name: publish_sdk
     needs: publish
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Node
-      uses: actions/setup-node@v2
-      with:
-        node-version: ${{ env.NODEVERSION }}
-        registry-url: https://registry.npmjs.org
-    - name: Setup DotNet
-      uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: ${{ env.DOTNETVERSION }}
-    - name: Setup Python
-      uses: actions/setup-python@v2
-      with:
-        python-version: ${{ env.PYTHONVERSION }}
-    - name: Download python SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: python-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress python SDK
-      run: tar -zxf ${{github.workspace}}/sdk/python.tar.gz -C
-        ${{github.workspace}}/sdk/python
-    - name: Download dotnet SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: dotnet-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress dotnet SDK
-      run: tar -zxf ${{github.workspace}}/sdk/dotnet.tar.gz -C
-        ${{github.workspace}}/sdk/dotnet
-    - name: Download nodejs SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: nodejs-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress nodejs SDK
-      run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
-        ${{github.workspace}}/sdk/nodejs
-    - run: python -m pip install pip twine
-    - env:
-        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-      name: Publish SDKs
-      run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - if: failure() && github.event_name == 'push'
-      name: Notify Slack
-      uses: 8398a7/action-slack@v3
-      with:
-        author_name: Failure in publishing SDK
-        fields: repo,commit,author,action
-        status: ${{ job.status }}
+    - name: Publish SDKs
+      uses: pulumi/pulumi-package-publisher@v0.0.5
   test:
     name: test
     needs: build_sdk

--- a/provider-ci/providers/aws/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/aws/repo/.github/workflows/master.yml
@@ -280,131 +280,13 @@ jobs:
         author_name: Failure in publishing binaries
         fields: repo,commit,author,action
         status: ${{ job.status }}
-  publish_java_sdk:
-    continue-on-error: true
-    name: publish_java_sdk
-    needs: publish
-    runs-on: ubuntu-latest
-    steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{ env.JAVAVERSION }}
-    - name: Setup Gradle
-      uses: gradle/gradle-build-action@v2
-      with:
-        gradle-version: "7.6"
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
   publish_sdk:
     name: publish_sdk
     needs: publish
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Node
-      uses: actions/setup-node@v2
-      with:
-        node-version: ${{ env.NODEVERSION }}
-        registry-url: https://registry.npmjs.org
-    - name: Setup DotNet
-      uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: ${{ env.DOTNETVERSION }}
-    - name: Setup Python
-      uses: actions/setup-python@v2
-      with:
-        python-version: ${{ env.PYTHONVERSION }}
-    - name: Download python SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: python-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress python SDK
-      run: tar -zxf ${{github.workspace}}/sdk/python.tar.gz -C
-        ${{github.workspace}}/sdk/python
-    - name: Download dotnet SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: dotnet-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress dotnet SDK
-      run: tar -zxf ${{github.workspace}}/sdk/dotnet.tar.gz -C
-        ${{github.workspace}}/sdk/dotnet
-    - name: Download nodejs SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: nodejs-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress nodejs SDK
-      run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
-        ${{github.workspace}}/sdk/nodejs
-    - run: python -m pip install pip twine
-    - env:
-        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-      name: Publish SDKs
-      run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - if: failure() && github.event_name == 'push'
-      name: Notify Slack
-      uses: 8398a7/action-slack@v3
-      with:
-        author_name: Failure in publishing SDK
-        fields: repo,commit,author,action
-        status: ${{ job.status }}
+    - name: Publish SDKs
+      uses: pulumi/pulumi-package-publisher@v0.0.5
   test:
     name: test
     needs: build_sdk

--- a/provider-ci/providers/aws/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/aws/repo/.github/workflows/prerelease.yml
@@ -230,131 +230,13 @@ jobs:
         author_name: Failure in publishing binaries
         fields: repo,commit,author,action
         status: ${{ job.status }}
-  publish_java_sdk:
-    continue-on-error: true
-    name: publish_java_sdk
-    needs: publish
-    runs-on: ubuntu-latest
-    steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{ env.JAVAVERSION }}
-    - name: Setup Gradle
-      uses: gradle/gradle-build-action@v2
-      with:
-        gradle-version: "7.6"
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
   publish_sdk:
     name: publish_sdk
     needs: publish
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Node
-      uses: actions/setup-node@v2
-      with:
-        node-version: ${{ env.NODEVERSION }}
-        registry-url: https://registry.npmjs.org
-    - name: Setup DotNet
-      uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: ${{ env.DOTNETVERSION }}
-    - name: Setup Python
-      uses: actions/setup-python@v2
-      with:
-        python-version: ${{ env.PYTHONVERSION }}
-    - name: Download python SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: python-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress python SDK
-      run: tar -zxf ${{github.workspace}}/sdk/python.tar.gz -C
-        ${{github.workspace}}/sdk/python
-    - name: Download dotnet SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: dotnet-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress dotnet SDK
-      run: tar -zxf ${{github.workspace}}/sdk/dotnet.tar.gz -C
-        ${{github.workspace}}/sdk/dotnet
-    - name: Download nodejs SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: nodejs-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress nodejs SDK
-      run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
-        ${{github.workspace}}/sdk/nodejs
-    - run: python -m pip install pip twine
-    - env:
-        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-      name: Publish SDKs
-      run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - if: failure() && github.event_name == 'push'
-      name: Notify Slack
-      uses: 8398a7/action-slack@v3
-      with:
-        author_name: Failure in publishing SDK
-        fields: repo,commit,author,action
-        status: ${{ job.status }}
+    - name: Publish SDKs
+      uses: pulumi/pulumi-package-publisher@v0.0.5
   test:
     name: test
     needs: build_sdk

--- a/provider-ci/providers/aws/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/aws/repo/.github/workflows/release.yml
@@ -242,131 +242,13 @@ jobs:
         author_name: Failure in publishing binaries
         fields: repo,commit,author,action
         status: ${{ job.status }}
-  publish_java_sdk:
-    continue-on-error: true
-    name: publish_java_sdk
-    needs: publish
-    runs-on: ubuntu-latest
-    steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{ env.JAVAVERSION }}
-    - name: Setup Gradle
-      uses: gradle/gradle-build-action@v2
-      with:
-        gradle-version: "7.6"
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
   publish_sdk:
     name: publish_sdk
     needs: publish
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Node
-      uses: actions/setup-node@v2
-      with:
-        node-version: ${{ env.NODEVERSION }}
-        registry-url: https://registry.npmjs.org
-    - name: Setup DotNet
-      uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: ${{ env.DOTNETVERSION }}
-    - name: Setup Python
-      uses: actions/setup-python@v2
-      with:
-        python-version: ${{ env.PYTHONVERSION }}
-    - name: Download python SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: python-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress python SDK
-      run: tar -zxf ${{github.workspace}}/sdk/python.tar.gz -C
-        ${{github.workspace}}/sdk/python
-    - name: Download dotnet SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: dotnet-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress dotnet SDK
-      run: tar -zxf ${{github.workspace}}/sdk/dotnet.tar.gz -C
-        ${{github.workspace}}/sdk/dotnet
-    - name: Download nodejs SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: nodejs-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress nodejs SDK
-      run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
-        ${{github.workspace}}/sdk/nodejs
-    - run: python -m pip install pip twine
-    - env:
-        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-      name: Publish SDKs
-      run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - if: failure() && github.event_name == 'push'
-      name: Notify Slack
-      uses: 8398a7/action-slack@v3
-      with:
-        author_name: Failure in publishing SDK
-        fields: repo,commit,author,action
-        status: ${{ job.status }}
+    - name: Publish SDKs
+      uses: pulumi/pulumi-package-publisher@v0.0.5
   tag_sdk:
     name: tag_sdk
     needs: publish_sdk

--- a/provider-ci/providers/azure/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/azure/repo/.github/workflows/main.yml
@@ -285,131 +285,13 @@ jobs:
         author_name: Failure in publishing binaries
         fields: repo,commit,author,action
         status: ${{ job.status }}
-  publish_java_sdk:
-    continue-on-error: true
-    name: publish_java_sdk
-    needs: publish
-    runs-on: ubuntu-latest
-    steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{ env.JAVAVERSION }}
-    - name: Setup Gradle
-      uses: gradle/gradle-build-action@v2
-      with:
-        gradle-version: "7.6"
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
   publish_sdk:
     name: publish_sdk
     needs: publish
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Node
-      uses: actions/setup-node@v2
-      with:
-        node-version: ${{ env.NODEVERSION }}
-        registry-url: https://registry.npmjs.org
-    - name: Setup DotNet
-      uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: ${{ env.DOTNETVERSION }}
-    - name: Setup Python
-      uses: actions/setup-python@v2
-      with:
-        python-version: ${{ env.PYTHONVERSION }}
-    - name: Download python SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: python-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress python SDK
-      run: tar -zxf ${{github.workspace}}/sdk/python.tar.gz -C
-        ${{github.workspace}}/sdk/python
-    - name: Download dotnet SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: dotnet-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress dotnet SDK
-      run: tar -zxf ${{github.workspace}}/sdk/dotnet.tar.gz -C
-        ${{github.workspace}}/sdk/dotnet
-    - name: Download nodejs SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: nodejs-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress nodejs SDK
-      run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
-        ${{github.workspace}}/sdk/nodejs
-    - run: python -m pip install pip twine
-    - env:
-        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-      name: Publish SDKs
-      run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - if: failure() && github.event_name == 'push'
-      name: Notify Slack
-      uses: 8398a7/action-slack@v3
-      with:
-        author_name: Failure in publishing SDK
-        fields: repo,commit,author,action
-        status: ${{ job.status }}
+    - name: Publish SDKs
+      uses: pulumi/pulumi-package-publisher@v0.0.5
   test:
     name: test
     needs: build_sdk

--- a/provider-ci/providers/azure/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/azure/repo/.github/workflows/master.yml
@@ -285,131 +285,13 @@ jobs:
         author_name: Failure in publishing binaries
         fields: repo,commit,author,action
         status: ${{ job.status }}
-  publish_java_sdk:
-    continue-on-error: true
-    name: publish_java_sdk
-    needs: publish
-    runs-on: ubuntu-latest
-    steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{ env.JAVAVERSION }}
-    - name: Setup Gradle
-      uses: gradle/gradle-build-action@v2
-      with:
-        gradle-version: "7.6"
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
   publish_sdk:
     name: publish_sdk
     needs: publish
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Node
-      uses: actions/setup-node@v2
-      with:
-        node-version: ${{ env.NODEVERSION }}
-        registry-url: https://registry.npmjs.org
-    - name: Setup DotNet
-      uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: ${{ env.DOTNETVERSION }}
-    - name: Setup Python
-      uses: actions/setup-python@v2
-      with:
-        python-version: ${{ env.PYTHONVERSION }}
-    - name: Download python SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: python-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress python SDK
-      run: tar -zxf ${{github.workspace}}/sdk/python.tar.gz -C
-        ${{github.workspace}}/sdk/python
-    - name: Download dotnet SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: dotnet-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress dotnet SDK
-      run: tar -zxf ${{github.workspace}}/sdk/dotnet.tar.gz -C
-        ${{github.workspace}}/sdk/dotnet
-    - name: Download nodejs SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: nodejs-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress nodejs SDK
-      run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
-        ${{github.workspace}}/sdk/nodejs
-    - run: python -m pip install pip twine
-    - env:
-        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-      name: Publish SDKs
-      run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - if: failure() && github.event_name == 'push'
-      name: Notify Slack
-      uses: 8398a7/action-slack@v3
-      with:
-        author_name: Failure in publishing SDK
-        fields: repo,commit,author,action
-        status: ${{ job.status }}
+    - name: Publish SDKs
+      uses: pulumi/pulumi-package-publisher@v0.0.5
   test:
     name: test
     needs: build_sdk

--- a/provider-ci/providers/azure/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/azure/repo/.github/workflows/prerelease.yml
@@ -235,131 +235,13 @@ jobs:
         author_name: Failure in publishing binaries
         fields: repo,commit,author,action
         status: ${{ job.status }}
-  publish_java_sdk:
-    continue-on-error: true
-    name: publish_java_sdk
-    needs: publish
-    runs-on: ubuntu-latest
-    steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{ env.JAVAVERSION }}
-    - name: Setup Gradle
-      uses: gradle/gradle-build-action@v2
-      with:
-        gradle-version: "7.6"
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
   publish_sdk:
     name: publish_sdk
     needs: publish
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Node
-      uses: actions/setup-node@v2
-      with:
-        node-version: ${{ env.NODEVERSION }}
-        registry-url: https://registry.npmjs.org
-    - name: Setup DotNet
-      uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: ${{ env.DOTNETVERSION }}
-    - name: Setup Python
-      uses: actions/setup-python@v2
-      with:
-        python-version: ${{ env.PYTHONVERSION }}
-    - name: Download python SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: python-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress python SDK
-      run: tar -zxf ${{github.workspace}}/sdk/python.tar.gz -C
-        ${{github.workspace}}/sdk/python
-    - name: Download dotnet SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: dotnet-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress dotnet SDK
-      run: tar -zxf ${{github.workspace}}/sdk/dotnet.tar.gz -C
-        ${{github.workspace}}/sdk/dotnet
-    - name: Download nodejs SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: nodejs-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress nodejs SDK
-      run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
-        ${{github.workspace}}/sdk/nodejs
-    - run: python -m pip install pip twine
-    - env:
-        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-      name: Publish SDKs
-      run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - if: failure() && github.event_name == 'push'
-      name: Notify Slack
-      uses: 8398a7/action-slack@v3
-      with:
-        author_name: Failure in publishing SDK
-        fields: repo,commit,author,action
-        status: ${{ job.status }}
+    - name: Publish SDKs
+      uses: pulumi/pulumi-package-publisher@v0.0.5
   test:
     name: test
     needs: build_sdk

--- a/provider-ci/providers/azure/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/azure/repo/.github/workflows/release.yml
@@ -247,131 +247,13 @@ jobs:
         author_name: Failure in publishing binaries
         fields: repo,commit,author,action
         status: ${{ job.status }}
-  publish_java_sdk:
-    continue-on-error: true
-    name: publish_java_sdk
-    needs: publish
-    runs-on: ubuntu-latest
-    steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{ env.JAVAVERSION }}
-    - name: Setup Gradle
-      uses: gradle/gradle-build-action@v2
-      with:
-        gradle-version: "7.6"
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
   publish_sdk:
     name: publish_sdk
     needs: publish
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Node
-      uses: actions/setup-node@v2
-      with:
-        node-version: ${{ env.NODEVERSION }}
-        registry-url: https://registry.npmjs.org
-    - name: Setup DotNet
-      uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: ${{ env.DOTNETVERSION }}
-    - name: Setup Python
-      uses: actions/setup-python@v2
-      with:
-        python-version: ${{ env.PYTHONVERSION }}
-    - name: Download python SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: python-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress python SDK
-      run: tar -zxf ${{github.workspace}}/sdk/python.tar.gz -C
-        ${{github.workspace}}/sdk/python
-    - name: Download dotnet SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: dotnet-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress dotnet SDK
-      run: tar -zxf ${{github.workspace}}/sdk/dotnet.tar.gz -C
-        ${{github.workspace}}/sdk/dotnet
-    - name: Download nodejs SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: nodejs-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress nodejs SDK
-      run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
-        ${{github.workspace}}/sdk/nodejs
-    - run: python -m pip install pip twine
-    - env:
-        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-      name: Publish SDKs
-      run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - if: failure() && github.event_name == 'push'
-      name: Notify Slack
-      uses: 8398a7/action-slack@v3
-      with:
-        author_name: Failure in publishing SDK
-        fields: repo,commit,author,action
-        status: ${{ job.status }}
+    - name: Publish SDKs
+      uses: pulumi/pulumi-package-publisher@v0.0.5
   tag_sdk:
     name: tag_sdk
     needs: publish_sdk

--- a/provider-ci/providers/azuread/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/azuread/repo/.github/workflows/main.yml
@@ -354,131 +354,13 @@ jobs:
         author_name: Failure in publishing binaries
         fields: repo,commit,author,action
         status: ${{ job.status }}
-  publish_java_sdk:
-    continue-on-error: true
-    name: publish_java_sdk
-    needs: publish
-    runs-on: ubuntu-latest
-    steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{ env.JAVAVERSION }}
-    - name: Setup Gradle
-      uses: gradle/gradle-build-action@v2
-      with:
-        gradle-version: "7.6"
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
   publish_sdk:
     name: publish_sdk
     needs: publish
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Node
-      uses: actions/setup-node@v2
-      with:
-        node-version: ${{ env.NODEVERSION }}
-        registry-url: https://registry.npmjs.org
-    - name: Setup DotNet
-      uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: ${{ env.DOTNETVERSION }}
-    - name: Setup Python
-      uses: actions/setup-python@v2
-      with:
-        python-version: ${{ env.PYTHONVERSION }}
-    - name: Download python SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: python-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress python SDK
-      run: tar -zxf ${{github.workspace}}/sdk/python.tar.gz -C
-        ${{github.workspace}}/sdk/python
-    - name: Download dotnet SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: dotnet-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress dotnet SDK
-      run: tar -zxf ${{github.workspace}}/sdk/dotnet.tar.gz -C
-        ${{github.workspace}}/sdk/dotnet
-    - name: Download nodejs SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: nodejs-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress nodejs SDK
-      run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
-        ${{github.workspace}}/sdk/nodejs
-    - run: python -m pip install pip twine
-    - env:
-        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-      name: Publish SDKs
-      run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - if: failure() && github.event_name == 'push'
-      name: Notify Slack
-      uses: 8398a7/action-slack@v3
-      with:
-        author_name: Failure in publishing SDK
-        fields: repo,commit,author,action
-        status: ${{ job.status }}
+    - name: Publish SDKs
+      uses: pulumi/pulumi-package-publisher@v0.0.5
   test:
     name: test
     needs: build_sdk

--- a/provider-ci/providers/azuread/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/azuread/repo/.github/workflows/master.yml
@@ -354,131 +354,13 @@ jobs:
         author_name: Failure in publishing binaries
         fields: repo,commit,author,action
         status: ${{ job.status }}
-  publish_java_sdk:
-    continue-on-error: true
-    name: publish_java_sdk
-    needs: publish
-    runs-on: ubuntu-latest
-    steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{ env.JAVAVERSION }}
-    - name: Setup Gradle
-      uses: gradle/gradle-build-action@v2
-      with:
-        gradle-version: "7.6"
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
   publish_sdk:
     name: publish_sdk
     needs: publish
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Node
-      uses: actions/setup-node@v2
-      with:
-        node-version: ${{ env.NODEVERSION }}
-        registry-url: https://registry.npmjs.org
-    - name: Setup DotNet
-      uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: ${{ env.DOTNETVERSION }}
-    - name: Setup Python
-      uses: actions/setup-python@v2
-      with:
-        python-version: ${{ env.PYTHONVERSION }}
-    - name: Download python SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: python-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress python SDK
-      run: tar -zxf ${{github.workspace}}/sdk/python.tar.gz -C
-        ${{github.workspace}}/sdk/python
-    - name: Download dotnet SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: dotnet-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress dotnet SDK
-      run: tar -zxf ${{github.workspace}}/sdk/dotnet.tar.gz -C
-        ${{github.workspace}}/sdk/dotnet
-    - name: Download nodejs SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: nodejs-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress nodejs SDK
-      run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
-        ${{github.workspace}}/sdk/nodejs
-    - run: python -m pip install pip twine
-    - env:
-        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-      name: Publish SDKs
-      run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - if: failure() && github.event_name == 'push'
-      name: Notify Slack
-      uses: 8398a7/action-slack@v3
-      with:
-        author_name: Failure in publishing SDK
-        fields: repo,commit,author,action
-        status: ${{ job.status }}
+    - name: Publish SDKs
+      uses: pulumi/pulumi-package-publisher@v0.0.5
   test:
     name: test
     needs: build_sdk

--- a/provider-ci/providers/azuread/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/azuread/repo/.github/workflows/prerelease.yml
@@ -304,131 +304,13 @@ jobs:
         author_name: Failure in publishing binaries
         fields: repo,commit,author,action
         status: ${{ job.status }}
-  publish_java_sdk:
-    continue-on-error: true
-    name: publish_java_sdk
-    needs: publish
-    runs-on: ubuntu-latest
-    steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{ env.JAVAVERSION }}
-    - name: Setup Gradle
-      uses: gradle/gradle-build-action@v2
-      with:
-        gradle-version: "7.6"
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
   publish_sdk:
     name: publish_sdk
     needs: publish
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Node
-      uses: actions/setup-node@v2
-      with:
-        node-version: ${{ env.NODEVERSION }}
-        registry-url: https://registry.npmjs.org
-    - name: Setup DotNet
-      uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: ${{ env.DOTNETVERSION }}
-    - name: Setup Python
-      uses: actions/setup-python@v2
-      with:
-        python-version: ${{ env.PYTHONVERSION }}
-    - name: Download python SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: python-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress python SDK
-      run: tar -zxf ${{github.workspace}}/sdk/python.tar.gz -C
-        ${{github.workspace}}/sdk/python
-    - name: Download dotnet SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: dotnet-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress dotnet SDK
-      run: tar -zxf ${{github.workspace}}/sdk/dotnet.tar.gz -C
-        ${{github.workspace}}/sdk/dotnet
-    - name: Download nodejs SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: nodejs-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress nodejs SDK
-      run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
-        ${{github.workspace}}/sdk/nodejs
-    - run: python -m pip install pip twine
-    - env:
-        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-      name: Publish SDKs
-      run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - if: failure() && github.event_name == 'push'
-      name: Notify Slack
-      uses: 8398a7/action-slack@v3
-      with:
-        author_name: Failure in publishing SDK
-        fields: repo,commit,author,action
-        status: ${{ job.status }}
+    - name: Publish SDKs
+      uses: pulumi/pulumi-package-publisher@v0.0.5
   test:
     name: test
     needs: build_sdk

--- a/provider-ci/providers/azuread/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/azuread/repo/.github/workflows/release.yml
@@ -316,131 +316,13 @@ jobs:
         author_name: Failure in publishing binaries
         fields: repo,commit,author,action
         status: ${{ job.status }}
-  publish_java_sdk:
-    continue-on-error: true
-    name: publish_java_sdk
-    needs: publish
-    runs-on: ubuntu-latest
-    steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{ env.JAVAVERSION }}
-    - name: Setup Gradle
-      uses: gradle/gradle-build-action@v2
-      with:
-        gradle-version: "7.6"
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
   publish_sdk:
     name: publish_sdk
     needs: publish
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Node
-      uses: actions/setup-node@v2
-      with:
-        node-version: ${{ env.NODEVERSION }}
-        registry-url: https://registry.npmjs.org
-    - name: Setup DotNet
-      uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: ${{ env.DOTNETVERSION }}
-    - name: Setup Python
-      uses: actions/setup-python@v2
-      with:
-        python-version: ${{ env.PYTHONVERSION }}
-    - name: Download python SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: python-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress python SDK
-      run: tar -zxf ${{github.workspace}}/sdk/python.tar.gz -C
-        ${{github.workspace}}/sdk/python
-    - name: Download dotnet SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: dotnet-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress dotnet SDK
-      run: tar -zxf ${{github.workspace}}/sdk/dotnet.tar.gz -C
-        ${{github.workspace}}/sdk/dotnet
-    - name: Download nodejs SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: nodejs-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress nodejs SDK
-      run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
-        ${{github.workspace}}/sdk/nodejs
-    - run: python -m pip install pip twine
-    - env:
-        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-      name: Publish SDKs
-      run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - if: failure() && github.event_name == 'push'
-      name: Notify Slack
-      uses: 8398a7/action-slack@v3
-      with:
-        author_name: Failure in publishing SDK
-        fields: repo,commit,author,action
-        status: ${{ job.status }}
+    - name: Publish SDKs
+      uses: pulumi/pulumi-package-publisher@v0.0.5
   tag_sdk:
     name: tag_sdk
     needs: publish_sdk

--- a/provider-ci/providers/azuredevops/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/azuredevops/repo/.github/workflows/main.yml
@@ -280,131 +280,13 @@ jobs:
         author_name: Failure in publishing binaries
         fields: repo,commit,author,action
         status: ${{ job.status }}
-  publish_java_sdk:
-    continue-on-error: true
-    name: publish_java_sdk
-    needs: publish
-    runs-on: ubuntu-latest
-    steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{ env.JAVAVERSION }}
-    - name: Setup Gradle
-      uses: gradle/gradle-build-action@v2
-      with:
-        gradle-version: "7.6"
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
   publish_sdk:
     name: publish_sdk
     needs: publish
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Node
-      uses: actions/setup-node@v2
-      with:
-        node-version: ${{ env.NODEVERSION }}
-        registry-url: https://registry.npmjs.org
-    - name: Setup DotNet
-      uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: ${{ env.DOTNETVERSION }}
-    - name: Setup Python
-      uses: actions/setup-python@v2
-      with:
-        python-version: ${{ env.PYTHONVERSION }}
-    - name: Download python SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: python-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress python SDK
-      run: tar -zxf ${{github.workspace}}/sdk/python.tar.gz -C
-        ${{github.workspace}}/sdk/python
-    - name: Download dotnet SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: dotnet-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress dotnet SDK
-      run: tar -zxf ${{github.workspace}}/sdk/dotnet.tar.gz -C
-        ${{github.workspace}}/sdk/dotnet
-    - name: Download nodejs SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: nodejs-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress nodejs SDK
-      run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
-        ${{github.workspace}}/sdk/nodejs
-    - run: python -m pip install pip twine
-    - env:
-        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-      name: Publish SDKs
-      run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - if: failure() && github.event_name == 'push'
-      name: Notify Slack
-      uses: 8398a7/action-slack@v3
-      with:
-        author_name: Failure in publishing SDK
-        fields: repo,commit,author,action
-        status: ${{ job.status }}
+    - name: Publish SDKs
+      uses: pulumi/pulumi-package-publisher@v0.0.5
   test:
     name: test
     needs: build_sdk

--- a/provider-ci/providers/azuredevops/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/azuredevops/repo/.github/workflows/master.yml
@@ -280,131 +280,13 @@ jobs:
         author_name: Failure in publishing binaries
         fields: repo,commit,author,action
         status: ${{ job.status }}
-  publish_java_sdk:
-    continue-on-error: true
-    name: publish_java_sdk
-    needs: publish
-    runs-on: ubuntu-latest
-    steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{ env.JAVAVERSION }}
-    - name: Setup Gradle
-      uses: gradle/gradle-build-action@v2
-      with:
-        gradle-version: "7.6"
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
   publish_sdk:
     name: publish_sdk
     needs: publish
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Node
-      uses: actions/setup-node@v2
-      with:
-        node-version: ${{ env.NODEVERSION }}
-        registry-url: https://registry.npmjs.org
-    - name: Setup DotNet
-      uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: ${{ env.DOTNETVERSION }}
-    - name: Setup Python
-      uses: actions/setup-python@v2
-      with:
-        python-version: ${{ env.PYTHONVERSION }}
-    - name: Download python SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: python-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress python SDK
-      run: tar -zxf ${{github.workspace}}/sdk/python.tar.gz -C
-        ${{github.workspace}}/sdk/python
-    - name: Download dotnet SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: dotnet-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress dotnet SDK
-      run: tar -zxf ${{github.workspace}}/sdk/dotnet.tar.gz -C
-        ${{github.workspace}}/sdk/dotnet
-    - name: Download nodejs SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: nodejs-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress nodejs SDK
-      run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
-        ${{github.workspace}}/sdk/nodejs
-    - run: python -m pip install pip twine
-    - env:
-        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-      name: Publish SDKs
-      run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - if: failure() && github.event_name == 'push'
-      name: Notify Slack
-      uses: 8398a7/action-slack@v3
-      with:
-        author_name: Failure in publishing SDK
-        fields: repo,commit,author,action
-        status: ${{ job.status }}
+    - name: Publish SDKs
+      uses: pulumi/pulumi-package-publisher@v0.0.5
   test:
     name: test
     needs: build_sdk

--- a/provider-ci/providers/azuredevops/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/azuredevops/repo/.github/workflows/prerelease.yml
@@ -230,131 +230,13 @@ jobs:
         author_name: Failure in publishing binaries
         fields: repo,commit,author,action
         status: ${{ job.status }}
-  publish_java_sdk:
-    continue-on-error: true
-    name: publish_java_sdk
-    needs: publish
-    runs-on: ubuntu-latest
-    steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{ env.JAVAVERSION }}
-    - name: Setup Gradle
-      uses: gradle/gradle-build-action@v2
-      with:
-        gradle-version: "7.6"
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
   publish_sdk:
     name: publish_sdk
     needs: publish
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Node
-      uses: actions/setup-node@v2
-      with:
-        node-version: ${{ env.NODEVERSION }}
-        registry-url: https://registry.npmjs.org
-    - name: Setup DotNet
-      uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: ${{ env.DOTNETVERSION }}
-    - name: Setup Python
-      uses: actions/setup-python@v2
-      with:
-        python-version: ${{ env.PYTHONVERSION }}
-    - name: Download python SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: python-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress python SDK
-      run: tar -zxf ${{github.workspace}}/sdk/python.tar.gz -C
-        ${{github.workspace}}/sdk/python
-    - name: Download dotnet SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: dotnet-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress dotnet SDK
-      run: tar -zxf ${{github.workspace}}/sdk/dotnet.tar.gz -C
-        ${{github.workspace}}/sdk/dotnet
-    - name: Download nodejs SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: nodejs-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress nodejs SDK
-      run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
-        ${{github.workspace}}/sdk/nodejs
-    - run: python -m pip install pip twine
-    - env:
-        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-      name: Publish SDKs
-      run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - if: failure() && github.event_name == 'push'
-      name: Notify Slack
-      uses: 8398a7/action-slack@v3
-      with:
-        author_name: Failure in publishing SDK
-        fields: repo,commit,author,action
-        status: ${{ job.status }}
+    - name: Publish SDKs
+      uses: pulumi/pulumi-package-publisher@v0.0.5
   test:
     name: test
     needs: build_sdk

--- a/provider-ci/providers/azuredevops/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/azuredevops/repo/.github/workflows/release.yml
@@ -242,131 +242,13 @@ jobs:
         author_name: Failure in publishing binaries
         fields: repo,commit,author,action
         status: ${{ job.status }}
-  publish_java_sdk:
-    continue-on-error: true
-    name: publish_java_sdk
-    needs: publish
-    runs-on: ubuntu-latest
-    steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{ env.JAVAVERSION }}
-    - name: Setup Gradle
-      uses: gradle/gradle-build-action@v2
-      with:
-        gradle-version: "7.6"
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
   publish_sdk:
     name: publish_sdk
     needs: publish
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Node
-      uses: actions/setup-node@v2
-      with:
-        node-version: ${{ env.NODEVERSION }}
-        registry-url: https://registry.npmjs.org
-    - name: Setup DotNet
-      uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: ${{ env.DOTNETVERSION }}
-    - name: Setup Python
-      uses: actions/setup-python@v2
-      with:
-        python-version: ${{ env.PYTHONVERSION }}
-    - name: Download python SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: python-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress python SDK
-      run: tar -zxf ${{github.workspace}}/sdk/python.tar.gz -C
-        ${{github.workspace}}/sdk/python
-    - name: Download dotnet SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: dotnet-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress dotnet SDK
-      run: tar -zxf ${{github.workspace}}/sdk/dotnet.tar.gz -C
-        ${{github.workspace}}/sdk/dotnet
-    - name: Download nodejs SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: nodejs-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress nodejs SDK
-      run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
-        ${{github.workspace}}/sdk/nodejs
-    - run: python -m pip install pip twine
-    - env:
-        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-      name: Publish SDKs
-      run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - if: failure() && github.event_name == 'push'
-      name: Notify Slack
-      uses: 8398a7/action-slack@v3
-      with:
-        author_name: Failure in publishing SDK
-        fields: repo,commit,author,action
-        status: ${{ job.status }}
+    - name: Publish SDKs
+      uses: pulumi/pulumi-package-publisher@v0.0.5
   tag_sdk:
     name: tag_sdk
     needs: publish_sdk

--- a/provider-ci/providers/civo/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/civo/repo/.github/workflows/main.yml
@@ -350,131 +350,13 @@ jobs:
         author_name: Failure in publishing binaries
         fields: repo,commit,author,action
         status: ${{ job.status }}
-  publish_java_sdk:
-    continue-on-error: true
-    name: publish_java_sdk
-    needs: publish
-    runs-on: ubuntu-latest
-    steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{ env.JAVAVERSION }}
-    - name: Setup Gradle
-      uses: gradle/gradle-build-action@v2
-      with:
-        gradle-version: "7.6"
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
   publish_sdk:
     name: publish_sdk
     needs: publish
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Node
-      uses: actions/setup-node@v2
-      with:
-        node-version: ${{ env.NODEVERSION }}
-        registry-url: https://registry.npmjs.org
-    - name: Setup DotNet
-      uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: ${{ env.DOTNETVERSION }}
-    - name: Setup Python
-      uses: actions/setup-python@v2
-      with:
-        python-version: ${{ env.PYTHONVERSION }}
-    - name: Download python SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: python-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress python SDK
-      run: tar -zxf ${{github.workspace}}/sdk/python.tar.gz -C
-        ${{github.workspace}}/sdk/python
-    - name: Download dotnet SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: dotnet-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress dotnet SDK
-      run: tar -zxf ${{github.workspace}}/sdk/dotnet.tar.gz -C
-        ${{github.workspace}}/sdk/dotnet
-    - name: Download nodejs SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: nodejs-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress nodejs SDK
-      run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
-        ${{github.workspace}}/sdk/nodejs
-    - run: python -m pip install pip twine
-    - env:
-        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-      name: Publish SDKs
-      run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - if: failure() && github.event_name == 'push'
-      name: Notify Slack
-      uses: 8398a7/action-slack@v3
-      with:
-        author_name: Failure in publishing SDK
-        fields: repo,commit,author,action
-        status: ${{ job.status }}
+    - name: Publish SDKs
+      uses: pulumi/pulumi-package-publisher@v0.0.5
   test:
     name: test
     needs: build_sdk

--- a/provider-ci/providers/civo/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/civo/repo/.github/workflows/master.yml
@@ -350,131 +350,13 @@ jobs:
         author_name: Failure in publishing binaries
         fields: repo,commit,author,action
         status: ${{ job.status }}
-  publish_java_sdk:
-    continue-on-error: true
-    name: publish_java_sdk
-    needs: publish
-    runs-on: ubuntu-latest
-    steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{ env.JAVAVERSION }}
-    - name: Setup Gradle
-      uses: gradle/gradle-build-action@v2
-      with:
-        gradle-version: "7.6"
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
   publish_sdk:
     name: publish_sdk
     needs: publish
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Node
-      uses: actions/setup-node@v2
-      with:
-        node-version: ${{ env.NODEVERSION }}
-        registry-url: https://registry.npmjs.org
-    - name: Setup DotNet
-      uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: ${{ env.DOTNETVERSION }}
-    - name: Setup Python
-      uses: actions/setup-python@v2
-      with:
-        python-version: ${{ env.PYTHONVERSION }}
-    - name: Download python SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: python-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress python SDK
-      run: tar -zxf ${{github.workspace}}/sdk/python.tar.gz -C
-        ${{github.workspace}}/sdk/python
-    - name: Download dotnet SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: dotnet-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress dotnet SDK
-      run: tar -zxf ${{github.workspace}}/sdk/dotnet.tar.gz -C
-        ${{github.workspace}}/sdk/dotnet
-    - name: Download nodejs SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: nodejs-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress nodejs SDK
-      run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
-        ${{github.workspace}}/sdk/nodejs
-    - run: python -m pip install pip twine
-    - env:
-        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-      name: Publish SDKs
-      run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - if: failure() && github.event_name == 'push'
-      name: Notify Slack
-      uses: 8398a7/action-slack@v3
-      with:
-        author_name: Failure in publishing SDK
-        fields: repo,commit,author,action
-        status: ${{ job.status }}
+    - name: Publish SDKs
+      uses: pulumi/pulumi-package-publisher@v0.0.5
   test:
     name: test
     needs: build_sdk

--- a/provider-ci/providers/civo/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/civo/repo/.github/workflows/prerelease.yml
@@ -300,131 +300,13 @@ jobs:
         author_name: Failure in publishing binaries
         fields: repo,commit,author,action
         status: ${{ job.status }}
-  publish_java_sdk:
-    continue-on-error: true
-    name: publish_java_sdk
-    needs: publish
-    runs-on: ubuntu-latest
-    steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{ env.JAVAVERSION }}
-    - name: Setup Gradle
-      uses: gradle/gradle-build-action@v2
-      with:
-        gradle-version: "7.6"
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
   publish_sdk:
     name: publish_sdk
     needs: publish
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Node
-      uses: actions/setup-node@v2
-      with:
-        node-version: ${{ env.NODEVERSION }}
-        registry-url: https://registry.npmjs.org
-    - name: Setup DotNet
-      uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: ${{ env.DOTNETVERSION }}
-    - name: Setup Python
-      uses: actions/setup-python@v2
-      with:
-        python-version: ${{ env.PYTHONVERSION }}
-    - name: Download python SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: python-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress python SDK
-      run: tar -zxf ${{github.workspace}}/sdk/python.tar.gz -C
-        ${{github.workspace}}/sdk/python
-    - name: Download dotnet SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: dotnet-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress dotnet SDK
-      run: tar -zxf ${{github.workspace}}/sdk/dotnet.tar.gz -C
-        ${{github.workspace}}/sdk/dotnet
-    - name: Download nodejs SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: nodejs-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress nodejs SDK
-      run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
-        ${{github.workspace}}/sdk/nodejs
-    - run: python -m pip install pip twine
-    - env:
-        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-      name: Publish SDKs
-      run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - if: failure() && github.event_name == 'push'
-      name: Notify Slack
-      uses: 8398a7/action-slack@v3
-      with:
-        author_name: Failure in publishing SDK
-        fields: repo,commit,author,action
-        status: ${{ job.status }}
+    - name: Publish SDKs
+      uses: pulumi/pulumi-package-publisher@v0.0.5
   test:
     name: test
     needs: build_sdk

--- a/provider-ci/providers/civo/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/civo/repo/.github/workflows/release.yml
@@ -312,131 +312,13 @@ jobs:
         author_name: Failure in publishing binaries
         fields: repo,commit,author,action
         status: ${{ job.status }}
-  publish_java_sdk:
-    continue-on-error: true
-    name: publish_java_sdk
-    needs: publish
-    runs-on: ubuntu-latest
-    steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{ env.JAVAVERSION }}
-    - name: Setup Gradle
-      uses: gradle/gradle-build-action@v2
-      with:
-        gradle-version: "7.6"
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
   publish_sdk:
     name: publish_sdk
     needs: publish
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Node
-      uses: actions/setup-node@v2
-      with:
-        node-version: ${{ env.NODEVERSION }}
-        registry-url: https://registry.npmjs.org
-    - name: Setup DotNet
-      uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: ${{ env.DOTNETVERSION }}
-    - name: Setup Python
-      uses: actions/setup-python@v2
-      with:
-        python-version: ${{ env.PYTHONVERSION }}
-    - name: Download python SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: python-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress python SDK
-      run: tar -zxf ${{github.workspace}}/sdk/python.tar.gz -C
-        ${{github.workspace}}/sdk/python
-    - name: Download dotnet SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: dotnet-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress dotnet SDK
-      run: tar -zxf ${{github.workspace}}/sdk/dotnet.tar.gz -C
-        ${{github.workspace}}/sdk/dotnet
-    - name: Download nodejs SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: nodejs-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress nodejs SDK
-      run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
-        ${{github.workspace}}/sdk/nodejs
-    - run: python -m pip install pip twine
-    - env:
-        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-      name: Publish SDKs
-      run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - if: failure() && github.event_name == 'push'
-      name: Notify Slack
-      uses: 8398a7/action-slack@v3
-      with:
-        author_name: Failure in publishing SDK
-        fields: repo,commit,author,action
-        status: ${{ job.status }}
+    - name: Publish SDKs
+      uses: pulumi/pulumi-package-publisher@v0.0.5
   tag_sdk:
     name: tag_sdk
     needs: publish_sdk

--- a/provider-ci/providers/cloudamqp/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/cloudamqp/repo/.github/workflows/main.yml
@@ -349,131 +349,13 @@ jobs:
         author_name: Failure in publishing binaries
         fields: repo,commit,author,action
         status: ${{ job.status }}
-  publish_java_sdk:
-    continue-on-error: true
-    name: publish_java_sdk
-    needs: publish
-    runs-on: ubuntu-latest
-    steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{ env.JAVAVERSION }}
-    - name: Setup Gradle
-      uses: gradle/gradle-build-action@v2
-      with:
-        gradle-version: "7.6"
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
   publish_sdk:
     name: publish_sdk
     needs: publish
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Node
-      uses: actions/setup-node@v2
-      with:
-        node-version: ${{ env.NODEVERSION }}
-        registry-url: https://registry.npmjs.org
-    - name: Setup DotNet
-      uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: ${{ env.DOTNETVERSION }}
-    - name: Setup Python
-      uses: actions/setup-python@v2
-      with:
-        python-version: ${{ env.PYTHONVERSION }}
-    - name: Download python SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: python-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress python SDK
-      run: tar -zxf ${{github.workspace}}/sdk/python.tar.gz -C
-        ${{github.workspace}}/sdk/python
-    - name: Download dotnet SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: dotnet-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress dotnet SDK
-      run: tar -zxf ${{github.workspace}}/sdk/dotnet.tar.gz -C
-        ${{github.workspace}}/sdk/dotnet
-    - name: Download nodejs SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: nodejs-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress nodejs SDK
-      run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
-        ${{github.workspace}}/sdk/nodejs
-    - run: python -m pip install pip twine
-    - env:
-        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-      name: Publish SDKs
-      run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - if: failure() && github.event_name == 'push'
-      name: Notify Slack
-      uses: 8398a7/action-slack@v3
-      with:
-        author_name: Failure in publishing SDK
-        fields: repo,commit,author,action
-        status: ${{ job.status }}
+    - name: Publish SDKs
+      uses: pulumi/pulumi-package-publisher@v0.0.5
   test:
     name: test
     needs: build_sdk

--- a/provider-ci/providers/cloudamqp/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/cloudamqp/repo/.github/workflows/master.yml
@@ -349,131 +349,13 @@ jobs:
         author_name: Failure in publishing binaries
         fields: repo,commit,author,action
         status: ${{ job.status }}
-  publish_java_sdk:
-    continue-on-error: true
-    name: publish_java_sdk
-    needs: publish
-    runs-on: ubuntu-latest
-    steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{ env.JAVAVERSION }}
-    - name: Setup Gradle
-      uses: gradle/gradle-build-action@v2
-      with:
-        gradle-version: "7.6"
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
   publish_sdk:
     name: publish_sdk
     needs: publish
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Node
-      uses: actions/setup-node@v2
-      with:
-        node-version: ${{ env.NODEVERSION }}
-        registry-url: https://registry.npmjs.org
-    - name: Setup DotNet
-      uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: ${{ env.DOTNETVERSION }}
-    - name: Setup Python
-      uses: actions/setup-python@v2
-      with:
-        python-version: ${{ env.PYTHONVERSION }}
-    - name: Download python SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: python-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress python SDK
-      run: tar -zxf ${{github.workspace}}/sdk/python.tar.gz -C
-        ${{github.workspace}}/sdk/python
-    - name: Download dotnet SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: dotnet-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress dotnet SDK
-      run: tar -zxf ${{github.workspace}}/sdk/dotnet.tar.gz -C
-        ${{github.workspace}}/sdk/dotnet
-    - name: Download nodejs SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: nodejs-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress nodejs SDK
-      run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
-        ${{github.workspace}}/sdk/nodejs
-    - run: python -m pip install pip twine
-    - env:
-        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-      name: Publish SDKs
-      run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - if: failure() && github.event_name == 'push'
-      name: Notify Slack
-      uses: 8398a7/action-slack@v3
-      with:
-        author_name: Failure in publishing SDK
-        fields: repo,commit,author,action
-        status: ${{ job.status }}
+    - name: Publish SDKs
+      uses: pulumi/pulumi-package-publisher@v0.0.5
   test:
     name: test
     needs: build_sdk

--- a/provider-ci/providers/cloudamqp/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/cloudamqp/repo/.github/workflows/prerelease.yml
@@ -299,131 +299,13 @@ jobs:
         author_name: Failure in publishing binaries
         fields: repo,commit,author,action
         status: ${{ job.status }}
-  publish_java_sdk:
-    continue-on-error: true
-    name: publish_java_sdk
-    needs: publish
-    runs-on: ubuntu-latest
-    steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{ env.JAVAVERSION }}
-    - name: Setup Gradle
-      uses: gradle/gradle-build-action@v2
-      with:
-        gradle-version: "7.6"
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
   publish_sdk:
     name: publish_sdk
     needs: publish
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Node
-      uses: actions/setup-node@v2
-      with:
-        node-version: ${{ env.NODEVERSION }}
-        registry-url: https://registry.npmjs.org
-    - name: Setup DotNet
-      uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: ${{ env.DOTNETVERSION }}
-    - name: Setup Python
-      uses: actions/setup-python@v2
-      with:
-        python-version: ${{ env.PYTHONVERSION }}
-    - name: Download python SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: python-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress python SDK
-      run: tar -zxf ${{github.workspace}}/sdk/python.tar.gz -C
-        ${{github.workspace}}/sdk/python
-    - name: Download dotnet SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: dotnet-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress dotnet SDK
-      run: tar -zxf ${{github.workspace}}/sdk/dotnet.tar.gz -C
-        ${{github.workspace}}/sdk/dotnet
-    - name: Download nodejs SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: nodejs-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress nodejs SDK
-      run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
-        ${{github.workspace}}/sdk/nodejs
-    - run: python -m pip install pip twine
-    - env:
-        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-      name: Publish SDKs
-      run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - if: failure() && github.event_name == 'push'
-      name: Notify Slack
-      uses: 8398a7/action-slack@v3
-      with:
-        author_name: Failure in publishing SDK
-        fields: repo,commit,author,action
-        status: ${{ job.status }}
+    - name: Publish SDKs
+      uses: pulumi/pulumi-package-publisher@v0.0.5
   test:
     name: test
     needs: build_sdk

--- a/provider-ci/providers/cloudamqp/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/cloudamqp/repo/.github/workflows/release.yml
@@ -311,131 +311,13 @@ jobs:
         author_name: Failure in publishing binaries
         fields: repo,commit,author,action
         status: ${{ job.status }}
-  publish_java_sdk:
-    continue-on-error: true
-    name: publish_java_sdk
-    needs: publish
-    runs-on: ubuntu-latest
-    steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{ env.JAVAVERSION }}
-    - name: Setup Gradle
-      uses: gradle/gradle-build-action@v2
-      with:
-        gradle-version: "7.6"
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
   publish_sdk:
     name: publish_sdk
     needs: publish
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Node
-      uses: actions/setup-node@v2
-      with:
-        node-version: ${{ env.NODEVERSION }}
-        registry-url: https://registry.npmjs.org
-    - name: Setup DotNet
-      uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: ${{ env.DOTNETVERSION }}
-    - name: Setup Python
-      uses: actions/setup-python@v2
-      with:
-        python-version: ${{ env.PYTHONVERSION }}
-    - name: Download python SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: python-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress python SDK
-      run: tar -zxf ${{github.workspace}}/sdk/python.tar.gz -C
-        ${{github.workspace}}/sdk/python
-    - name: Download dotnet SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: dotnet-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress dotnet SDK
-      run: tar -zxf ${{github.workspace}}/sdk/dotnet.tar.gz -C
-        ${{github.workspace}}/sdk/dotnet
-    - name: Download nodejs SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: nodejs-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress nodejs SDK
-      run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
-        ${{github.workspace}}/sdk/nodejs
-    - run: python -m pip install pip twine
-    - env:
-        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-      name: Publish SDKs
-      run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - if: failure() && github.event_name == 'push'
-      name: Notify Slack
-      uses: 8398a7/action-slack@v3
-      with:
-        author_name: Failure in publishing SDK
-        fields: repo,commit,author,action
-        status: ${{ job.status }}
+    - name: Publish SDKs
+      uses: pulumi/pulumi-package-publisher@v0.0.5
   tag_sdk:
     name: tag_sdk
     needs: publish_sdk

--- a/provider-ci/providers/cloudflare/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/cloudflare/repo/.github/workflows/main.yml
@@ -349,131 +349,13 @@ jobs:
         author_name: Failure in publishing binaries
         fields: repo,commit,author,action
         status: ${{ job.status }}
-  publish_java_sdk:
-    continue-on-error: true
-    name: publish_java_sdk
-    needs: publish
-    runs-on: ubuntu-latest
-    steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{ env.JAVAVERSION }}
-    - name: Setup Gradle
-      uses: gradle/gradle-build-action@v2
-      with:
-        gradle-version: "7.6"
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
   publish_sdk:
     name: publish_sdk
     needs: publish
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Node
-      uses: actions/setup-node@v2
-      with:
-        node-version: ${{ env.NODEVERSION }}
-        registry-url: https://registry.npmjs.org
-    - name: Setup DotNet
-      uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: ${{ env.DOTNETVERSION }}
-    - name: Setup Python
-      uses: actions/setup-python@v2
-      with:
-        python-version: ${{ env.PYTHONVERSION }}
-    - name: Download python SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: python-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress python SDK
-      run: tar -zxf ${{github.workspace}}/sdk/python.tar.gz -C
-        ${{github.workspace}}/sdk/python
-    - name: Download dotnet SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: dotnet-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress dotnet SDK
-      run: tar -zxf ${{github.workspace}}/sdk/dotnet.tar.gz -C
-        ${{github.workspace}}/sdk/dotnet
-    - name: Download nodejs SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: nodejs-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress nodejs SDK
-      run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
-        ${{github.workspace}}/sdk/nodejs
-    - run: python -m pip install pip twine
-    - env:
-        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-      name: Publish SDKs
-      run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - if: failure() && github.event_name == 'push'
-      name: Notify Slack
-      uses: 8398a7/action-slack@v3
-      with:
-        author_name: Failure in publishing SDK
-        fields: repo,commit,author,action
-        status: ${{ job.status }}
+    - name: Publish SDKs
+      uses: pulumi/pulumi-package-publisher@v0.0.5
   test:
     name: test
     needs: build_sdk

--- a/provider-ci/providers/cloudflare/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/cloudflare/repo/.github/workflows/master.yml
@@ -349,131 +349,13 @@ jobs:
         author_name: Failure in publishing binaries
         fields: repo,commit,author,action
         status: ${{ job.status }}
-  publish_java_sdk:
-    continue-on-error: true
-    name: publish_java_sdk
-    needs: publish
-    runs-on: ubuntu-latest
-    steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{ env.JAVAVERSION }}
-    - name: Setup Gradle
-      uses: gradle/gradle-build-action@v2
-      with:
-        gradle-version: "7.6"
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
   publish_sdk:
     name: publish_sdk
     needs: publish
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Node
-      uses: actions/setup-node@v2
-      with:
-        node-version: ${{ env.NODEVERSION }}
-        registry-url: https://registry.npmjs.org
-    - name: Setup DotNet
-      uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: ${{ env.DOTNETVERSION }}
-    - name: Setup Python
-      uses: actions/setup-python@v2
-      with:
-        python-version: ${{ env.PYTHONVERSION }}
-    - name: Download python SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: python-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress python SDK
-      run: tar -zxf ${{github.workspace}}/sdk/python.tar.gz -C
-        ${{github.workspace}}/sdk/python
-    - name: Download dotnet SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: dotnet-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress dotnet SDK
-      run: tar -zxf ${{github.workspace}}/sdk/dotnet.tar.gz -C
-        ${{github.workspace}}/sdk/dotnet
-    - name: Download nodejs SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: nodejs-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress nodejs SDK
-      run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
-        ${{github.workspace}}/sdk/nodejs
-    - run: python -m pip install pip twine
-    - env:
-        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-      name: Publish SDKs
-      run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - if: failure() && github.event_name == 'push'
-      name: Notify Slack
-      uses: 8398a7/action-slack@v3
-      with:
-        author_name: Failure in publishing SDK
-        fields: repo,commit,author,action
-        status: ${{ job.status }}
+    - name: Publish SDKs
+      uses: pulumi/pulumi-package-publisher@v0.0.5
   test:
     name: test
     needs: build_sdk

--- a/provider-ci/providers/cloudflare/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/cloudflare/repo/.github/workflows/prerelease.yml
@@ -299,131 +299,13 @@ jobs:
         author_name: Failure in publishing binaries
         fields: repo,commit,author,action
         status: ${{ job.status }}
-  publish_java_sdk:
-    continue-on-error: true
-    name: publish_java_sdk
-    needs: publish
-    runs-on: ubuntu-latest
-    steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{ env.JAVAVERSION }}
-    - name: Setup Gradle
-      uses: gradle/gradle-build-action@v2
-      with:
-        gradle-version: "7.6"
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
   publish_sdk:
     name: publish_sdk
     needs: publish
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Node
-      uses: actions/setup-node@v2
-      with:
-        node-version: ${{ env.NODEVERSION }}
-        registry-url: https://registry.npmjs.org
-    - name: Setup DotNet
-      uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: ${{ env.DOTNETVERSION }}
-    - name: Setup Python
-      uses: actions/setup-python@v2
-      with:
-        python-version: ${{ env.PYTHONVERSION }}
-    - name: Download python SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: python-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress python SDK
-      run: tar -zxf ${{github.workspace}}/sdk/python.tar.gz -C
-        ${{github.workspace}}/sdk/python
-    - name: Download dotnet SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: dotnet-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress dotnet SDK
-      run: tar -zxf ${{github.workspace}}/sdk/dotnet.tar.gz -C
-        ${{github.workspace}}/sdk/dotnet
-    - name: Download nodejs SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: nodejs-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress nodejs SDK
-      run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
-        ${{github.workspace}}/sdk/nodejs
-    - run: python -m pip install pip twine
-    - env:
-        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-      name: Publish SDKs
-      run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - if: failure() && github.event_name == 'push'
-      name: Notify Slack
-      uses: 8398a7/action-slack@v3
-      with:
-        author_name: Failure in publishing SDK
-        fields: repo,commit,author,action
-        status: ${{ job.status }}
+    - name: Publish SDKs
+      uses: pulumi/pulumi-package-publisher@v0.0.5
   test:
     name: test
     needs: build_sdk

--- a/provider-ci/providers/cloudflare/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/cloudflare/repo/.github/workflows/release.yml
@@ -311,131 +311,13 @@ jobs:
         author_name: Failure in publishing binaries
         fields: repo,commit,author,action
         status: ${{ job.status }}
-  publish_java_sdk:
-    continue-on-error: true
-    name: publish_java_sdk
-    needs: publish
-    runs-on: ubuntu-latest
-    steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{ env.JAVAVERSION }}
-    - name: Setup Gradle
-      uses: gradle/gradle-build-action@v2
-      with:
-        gradle-version: "7.6"
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
   publish_sdk:
     name: publish_sdk
     needs: publish
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Node
-      uses: actions/setup-node@v2
-      with:
-        node-version: ${{ env.NODEVERSION }}
-        registry-url: https://registry.npmjs.org
-    - name: Setup DotNet
-      uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: ${{ env.DOTNETVERSION }}
-    - name: Setup Python
-      uses: actions/setup-python@v2
-      with:
-        python-version: ${{ env.PYTHONVERSION }}
-    - name: Download python SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: python-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress python SDK
-      run: tar -zxf ${{github.workspace}}/sdk/python.tar.gz -C
-        ${{github.workspace}}/sdk/python
-    - name: Download dotnet SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: dotnet-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress dotnet SDK
-      run: tar -zxf ${{github.workspace}}/sdk/dotnet.tar.gz -C
-        ${{github.workspace}}/sdk/dotnet
-    - name: Download nodejs SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: nodejs-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress nodejs SDK
-      run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
-        ${{github.workspace}}/sdk/nodejs
-    - run: python -m pip install pip twine
-    - env:
-        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-      name: Publish SDKs
-      run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - if: failure() && github.event_name == 'push'
-      name: Notify Slack
-      uses: 8398a7/action-slack@v3
-      with:
-        author_name: Failure in publishing SDK
-        fields: repo,commit,author,action
-        status: ${{ job.status }}
+    - name: Publish SDKs
+      uses: pulumi/pulumi-package-publisher@v0.0.5
   tag_sdk:
     name: tag_sdk
     needs: publish_sdk

--- a/provider-ci/providers/cloudinit/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/cloudinit/repo/.github/workflows/main.yml
@@ -278,131 +278,13 @@ jobs:
         author_name: Failure in publishing binaries
         fields: repo,commit,author,action
         status: ${{ job.status }}
-  publish_java_sdk:
-    continue-on-error: true
-    name: publish_java_sdk
-    needs: publish
-    runs-on: ubuntu-latest
-    steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{ env.JAVAVERSION }}
-    - name: Setup Gradle
-      uses: gradle/gradle-build-action@v2
-      with:
-        gradle-version: "7.6"
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
   publish_sdk:
     name: publish_sdk
     needs: publish
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Node
-      uses: actions/setup-node@v2
-      with:
-        node-version: ${{ env.NODEVERSION }}
-        registry-url: https://registry.npmjs.org
-    - name: Setup DotNet
-      uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: ${{ env.DOTNETVERSION }}
-    - name: Setup Python
-      uses: actions/setup-python@v2
-      with:
-        python-version: ${{ env.PYTHONVERSION }}
-    - name: Download python SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: python-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress python SDK
-      run: tar -zxf ${{github.workspace}}/sdk/python.tar.gz -C
-        ${{github.workspace}}/sdk/python
-    - name: Download dotnet SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: dotnet-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress dotnet SDK
-      run: tar -zxf ${{github.workspace}}/sdk/dotnet.tar.gz -C
-        ${{github.workspace}}/sdk/dotnet
-    - name: Download nodejs SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: nodejs-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress nodejs SDK
-      run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
-        ${{github.workspace}}/sdk/nodejs
-    - run: python -m pip install pip twine
-    - env:
-        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-      name: Publish SDKs
-      run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - if: failure() && github.event_name == 'push'
-      name: Notify Slack
-      uses: 8398a7/action-slack@v3
-      with:
-        author_name: Failure in publishing SDK
-        fields: repo,commit,author,action
-        status: ${{ job.status }}
+    - name: Publish SDKs
+      uses: pulumi/pulumi-package-publisher@v0.0.5
   test:
     name: test
     needs: build_sdk

--- a/provider-ci/providers/cloudinit/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/cloudinit/repo/.github/workflows/master.yml
@@ -278,131 +278,13 @@ jobs:
         author_name: Failure in publishing binaries
         fields: repo,commit,author,action
         status: ${{ job.status }}
-  publish_java_sdk:
-    continue-on-error: true
-    name: publish_java_sdk
-    needs: publish
-    runs-on: ubuntu-latest
-    steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{ env.JAVAVERSION }}
-    - name: Setup Gradle
-      uses: gradle/gradle-build-action@v2
-      with:
-        gradle-version: "7.6"
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
   publish_sdk:
     name: publish_sdk
     needs: publish
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Node
-      uses: actions/setup-node@v2
-      with:
-        node-version: ${{ env.NODEVERSION }}
-        registry-url: https://registry.npmjs.org
-    - name: Setup DotNet
-      uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: ${{ env.DOTNETVERSION }}
-    - name: Setup Python
-      uses: actions/setup-python@v2
-      with:
-        python-version: ${{ env.PYTHONVERSION }}
-    - name: Download python SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: python-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress python SDK
-      run: tar -zxf ${{github.workspace}}/sdk/python.tar.gz -C
-        ${{github.workspace}}/sdk/python
-    - name: Download dotnet SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: dotnet-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress dotnet SDK
-      run: tar -zxf ${{github.workspace}}/sdk/dotnet.tar.gz -C
-        ${{github.workspace}}/sdk/dotnet
-    - name: Download nodejs SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: nodejs-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress nodejs SDK
-      run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
-        ${{github.workspace}}/sdk/nodejs
-    - run: python -m pip install pip twine
-    - env:
-        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-      name: Publish SDKs
-      run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - if: failure() && github.event_name == 'push'
-      name: Notify Slack
-      uses: 8398a7/action-slack@v3
-      with:
-        author_name: Failure in publishing SDK
-        fields: repo,commit,author,action
-        status: ${{ job.status }}
+    - name: Publish SDKs
+      uses: pulumi/pulumi-package-publisher@v0.0.5
   test:
     name: test
     needs: build_sdk

--- a/provider-ci/providers/cloudinit/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/cloudinit/repo/.github/workflows/prerelease.yml
@@ -228,131 +228,13 @@ jobs:
         author_name: Failure in publishing binaries
         fields: repo,commit,author,action
         status: ${{ job.status }}
-  publish_java_sdk:
-    continue-on-error: true
-    name: publish_java_sdk
-    needs: publish
-    runs-on: ubuntu-latest
-    steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{ env.JAVAVERSION }}
-    - name: Setup Gradle
-      uses: gradle/gradle-build-action@v2
-      with:
-        gradle-version: "7.6"
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
   publish_sdk:
     name: publish_sdk
     needs: publish
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Node
-      uses: actions/setup-node@v2
-      with:
-        node-version: ${{ env.NODEVERSION }}
-        registry-url: https://registry.npmjs.org
-    - name: Setup DotNet
-      uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: ${{ env.DOTNETVERSION }}
-    - name: Setup Python
-      uses: actions/setup-python@v2
-      with:
-        python-version: ${{ env.PYTHONVERSION }}
-    - name: Download python SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: python-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress python SDK
-      run: tar -zxf ${{github.workspace}}/sdk/python.tar.gz -C
-        ${{github.workspace}}/sdk/python
-    - name: Download dotnet SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: dotnet-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress dotnet SDK
-      run: tar -zxf ${{github.workspace}}/sdk/dotnet.tar.gz -C
-        ${{github.workspace}}/sdk/dotnet
-    - name: Download nodejs SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: nodejs-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress nodejs SDK
-      run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
-        ${{github.workspace}}/sdk/nodejs
-    - run: python -m pip install pip twine
-    - env:
-        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-      name: Publish SDKs
-      run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - if: failure() && github.event_name == 'push'
-      name: Notify Slack
-      uses: 8398a7/action-slack@v3
-      with:
-        author_name: Failure in publishing SDK
-        fields: repo,commit,author,action
-        status: ${{ job.status }}
+    - name: Publish SDKs
+      uses: pulumi/pulumi-package-publisher@v0.0.5
   test:
     name: test
     needs: build_sdk

--- a/provider-ci/providers/cloudinit/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/cloudinit/repo/.github/workflows/release.yml
@@ -240,131 +240,13 @@ jobs:
         author_name: Failure in publishing binaries
         fields: repo,commit,author,action
         status: ${{ job.status }}
-  publish_java_sdk:
-    continue-on-error: true
-    name: publish_java_sdk
-    needs: publish
-    runs-on: ubuntu-latest
-    steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{ env.JAVAVERSION }}
-    - name: Setup Gradle
-      uses: gradle/gradle-build-action@v2
-      with:
-        gradle-version: "7.6"
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
   publish_sdk:
     name: publish_sdk
     needs: publish
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Node
-      uses: actions/setup-node@v2
-      with:
-        node-version: ${{ env.NODEVERSION }}
-        registry-url: https://registry.npmjs.org
-    - name: Setup DotNet
-      uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: ${{ env.DOTNETVERSION }}
-    - name: Setup Python
-      uses: actions/setup-python@v2
-      with:
-        python-version: ${{ env.PYTHONVERSION }}
-    - name: Download python SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: python-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress python SDK
-      run: tar -zxf ${{github.workspace}}/sdk/python.tar.gz -C
-        ${{github.workspace}}/sdk/python
-    - name: Download dotnet SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: dotnet-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress dotnet SDK
-      run: tar -zxf ${{github.workspace}}/sdk/dotnet.tar.gz -C
-        ${{github.workspace}}/sdk/dotnet
-    - name: Download nodejs SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: nodejs-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress nodejs SDK
-      run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
-        ${{github.workspace}}/sdk/nodejs
-    - run: python -m pip install pip twine
-    - env:
-        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-      name: Publish SDKs
-      run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - if: failure() && github.event_name == 'push'
-      name: Notify Slack
-      uses: 8398a7/action-slack@v3
-      with:
-        author_name: Failure in publishing SDK
-        fields: repo,commit,author,action
-        status: ${{ job.status }}
+    - name: Publish SDKs
+      uses: pulumi/pulumi-package-publisher@v0.0.5
   tag_sdk:
     name: tag_sdk
     needs: publish_sdk

--- a/provider-ci/providers/confluentcloud/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/confluentcloud/repo/.github/workflows/main.yml
@@ -280,131 +280,13 @@ jobs:
         author_name: Failure in publishing binaries
         fields: repo,commit,author,action
         status: ${{ job.status }}
-  publish_java_sdk:
-    continue-on-error: true
-    name: publish_java_sdk
-    needs: publish
-    runs-on: ubuntu-latest
-    steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{ env.JAVAVERSION }}
-    - name: Setup Gradle
-      uses: gradle/gradle-build-action@v2
-      with:
-        gradle-version: "7.6"
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
   publish_sdk:
     name: publish_sdk
     needs: publish
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Node
-      uses: actions/setup-node@v2
-      with:
-        node-version: ${{ env.NODEVERSION }}
-        registry-url: https://registry.npmjs.org
-    - name: Setup DotNet
-      uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: ${{ env.DOTNETVERSION }}
-    - name: Setup Python
-      uses: actions/setup-python@v2
-      with:
-        python-version: ${{ env.PYTHONVERSION }}
-    - name: Download python SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: python-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress python SDK
-      run: tar -zxf ${{github.workspace}}/sdk/python.tar.gz -C
-        ${{github.workspace}}/sdk/python
-    - name: Download dotnet SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: dotnet-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress dotnet SDK
-      run: tar -zxf ${{github.workspace}}/sdk/dotnet.tar.gz -C
-        ${{github.workspace}}/sdk/dotnet
-    - name: Download nodejs SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: nodejs-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress nodejs SDK
-      run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
-        ${{github.workspace}}/sdk/nodejs
-    - run: python -m pip install pip twine
-    - env:
-        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-      name: Publish SDKs
-      run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - if: failure() && github.event_name == 'push'
-      name: Notify Slack
-      uses: 8398a7/action-slack@v3
-      with:
-        author_name: Failure in publishing SDK
-        fields: repo,commit,author,action
-        status: ${{ job.status }}
+    - name: Publish SDKs
+      uses: pulumi/pulumi-package-publisher@v0.0.5
   test:
     name: test
     needs: build_sdk

--- a/provider-ci/providers/confluentcloud/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/confluentcloud/repo/.github/workflows/master.yml
@@ -280,131 +280,13 @@ jobs:
         author_name: Failure in publishing binaries
         fields: repo,commit,author,action
         status: ${{ job.status }}
-  publish_java_sdk:
-    continue-on-error: true
-    name: publish_java_sdk
-    needs: publish
-    runs-on: ubuntu-latest
-    steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{ env.JAVAVERSION }}
-    - name: Setup Gradle
-      uses: gradle/gradle-build-action@v2
-      with:
-        gradle-version: "7.6"
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
   publish_sdk:
     name: publish_sdk
     needs: publish
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Node
-      uses: actions/setup-node@v2
-      with:
-        node-version: ${{ env.NODEVERSION }}
-        registry-url: https://registry.npmjs.org
-    - name: Setup DotNet
-      uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: ${{ env.DOTNETVERSION }}
-    - name: Setup Python
-      uses: actions/setup-python@v2
-      with:
-        python-version: ${{ env.PYTHONVERSION }}
-    - name: Download python SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: python-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress python SDK
-      run: tar -zxf ${{github.workspace}}/sdk/python.tar.gz -C
-        ${{github.workspace}}/sdk/python
-    - name: Download dotnet SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: dotnet-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress dotnet SDK
-      run: tar -zxf ${{github.workspace}}/sdk/dotnet.tar.gz -C
-        ${{github.workspace}}/sdk/dotnet
-    - name: Download nodejs SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: nodejs-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress nodejs SDK
-      run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
-        ${{github.workspace}}/sdk/nodejs
-    - run: python -m pip install pip twine
-    - env:
-        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-      name: Publish SDKs
-      run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - if: failure() && github.event_name == 'push'
-      name: Notify Slack
-      uses: 8398a7/action-slack@v3
-      with:
-        author_name: Failure in publishing SDK
-        fields: repo,commit,author,action
-        status: ${{ job.status }}
+    - name: Publish SDKs
+      uses: pulumi/pulumi-package-publisher@v0.0.5
   test:
     name: test
     needs: build_sdk

--- a/provider-ci/providers/confluentcloud/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/confluentcloud/repo/.github/workflows/prerelease.yml
@@ -230,131 +230,13 @@ jobs:
         author_name: Failure in publishing binaries
         fields: repo,commit,author,action
         status: ${{ job.status }}
-  publish_java_sdk:
-    continue-on-error: true
-    name: publish_java_sdk
-    needs: publish
-    runs-on: ubuntu-latest
-    steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{ env.JAVAVERSION }}
-    - name: Setup Gradle
-      uses: gradle/gradle-build-action@v2
-      with:
-        gradle-version: "7.6"
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
   publish_sdk:
     name: publish_sdk
     needs: publish
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Node
-      uses: actions/setup-node@v2
-      with:
-        node-version: ${{ env.NODEVERSION }}
-        registry-url: https://registry.npmjs.org
-    - name: Setup DotNet
-      uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: ${{ env.DOTNETVERSION }}
-    - name: Setup Python
-      uses: actions/setup-python@v2
-      with:
-        python-version: ${{ env.PYTHONVERSION }}
-    - name: Download python SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: python-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress python SDK
-      run: tar -zxf ${{github.workspace}}/sdk/python.tar.gz -C
-        ${{github.workspace}}/sdk/python
-    - name: Download dotnet SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: dotnet-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress dotnet SDK
-      run: tar -zxf ${{github.workspace}}/sdk/dotnet.tar.gz -C
-        ${{github.workspace}}/sdk/dotnet
-    - name: Download nodejs SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: nodejs-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress nodejs SDK
-      run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
-        ${{github.workspace}}/sdk/nodejs
-    - run: python -m pip install pip twine
-    - env:
-        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-      name: Publish SDKs
-      run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - if: failure() && github.event_name == 'push'
-      name: Notify Slack
-      uses: 8398a7/action-slack@v3
-      with:
-        author_name: Failure in publishing SDK
-        fields: repo,commit,author,action
-        status: ${{ job.status }}
+    - name: Publish SDKs
+      uses: pulumi/pulumi-package-publisher@v0.0.5
   test:
     name: test
     needs: build_sdk

--- a/provider-ci/providers/confluentcloud/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/confluentcloud/repo/.github/workflows/release.yml
@@ -242,131 +242,13 @@ jobs:
         author_name: Failure in publishing binaries
         fields: repo,commit,author,action
         status: ${{ job.status }}
-  publish_java_sdk:
-    continue-on-error: true
-    name: publish_java_sdk
-    needs: publish
-    runs-on: ubuntu-latest
-    steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{ env.JAVAVERSION }}
-    - name: Setup Gradle
-      uses: gradle/gradle-build-action@v2
-      with:
-        gradle-version: "7.6"
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
   publish_sdk:
     name: publish_sdk
     needs: publish
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Node
-      uses: actions/setup-node@v2
-      with:
-        node-version: ${{ env.NODEVERSION }}
-        registry-url: https://registry.npmjs.org
-    - name: Setup DotNet
-      uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: ${{ env.DOTNETVERSION }}
-    - name: Setup Python
-      uses: actions/setup-python@v2
-      with:
-        python-version: ${{ env.PYTHONVERSION }}
-    - name: Download python SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: python-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress python SDK
-      run: tar -zxf ${{github.workspace}}/sdk/python.tar.gz -C
-        ${{github.workspace}}/sdk/python
-    - name: Download dotnet SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: dotnet-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress dotnet SDK
-      run: tar -zxf ${{github.workspace}}/sdk/dotnet.tar.gz -C
-        ${{github.workspace}}/sdk/dotnet
-    - name: Download nodejs SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: nodejs-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress nodejs SDK
-      run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
-        ${{github.workspace}}/sdk/nodejs
-    - run: python -m pip install pip twine
-    - env:
-        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-      name: Publish SDKs
-      run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - if: failure() && github.event_name == 'push'
-      name: Notify Slack
-      uses: 8398a7/action-slack@v3
-      with:
-        author_name: Failure in publishing SDK
-        fields: repo,commit,author,action
-        status: ${{ job.status }}
+    - name: Publish SDKs
+      uses: pulumi/pulumi-package-publisher@v0.0.5
   tag_sdk:
     name: tag_sdk
     needs: publish_sdk

--- a/provider-ci/providers/consul/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/consul/repo/.github/workflows/main.yml
@@ -349,131 +349,13 @@ jobs:
         author_name: Failure in publishing binaries
         fields: repo,commit,author,action
         status: ${{ job.status }}
-  publish_java_sdk:
-    continue-on-error: true
-    name: publish_java_sdk
-    needs: publish
-    runs-on: ubuntu-latest
-    steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{ env.JAVAVERSION }}
-    - name: Setup Gradle
-      uses: gradle/gradle-build-action@v2
-      with:
-        gradle-version: "7.6"
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
   publish_sdk:
     name: publish_sdk
     needs: publish
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Node
-      uses: actions/setup-node@v2
-      with:
-        node-version: ${{ env.NODEVERSION }}
-        registry-url: https://registry.npmjs.org
-    - name: Setup DotNet
-      uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: ${{ env.DOTNETVERSION }}
-    - name: Setup Python
-      uses: actions/setup-python@v2
-      with:
-        python-version: ${{ env.PYTHONVERSION }}
-    - name: Download python SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: python-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress python SDK
-      run: tar -zxf ${{github.workspace}}/sdk/python.tar.gz -C
-        ${{github.workspace}}/sdk/python
-    - name: Download dotnet SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: dotnet-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress dotnet SDK
-      run: tar -zxf ${{github.workspace}}/sdk/dotnet.tar.gz -C
-        ${{github.workspace}}/sdk/dotnet
-    - name: Download nodejs SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: nodejs-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress nodejs SDK
-      run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
-        ${{github.workspace}}/sdk/nodejs
-    - run: python -m pip install pip twine
-    - env:
-        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-      name: Publish SDKs
-      run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - if: failure() && github.event_name == 'push'
-      name: Notify Slack
-      uses: 8398a7/action-slack@v3
-      with:
-        author_name: Failure in publishing SDK
-        fields: repo,commit,author,action
-        status: ${{ job.status }}
+    - name: Publish SDKs
+      uses: pulumi/pulumi-package-publisher@v0.0.5
   test:
     name: test
     needs: build_sdk

--- a/provider-ci/providers/consul/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/consul/repo/.github/workflows/master.yml
@@ -349,131 +349,13 @@ jobs:
         author_name: Failure in publishing binaries
         fields: repo,commit,author,action
         status: ${{ job.status }}
-  publish_java_sdk:
-    continue-on-error: true
-    name: publish_java_sdk
-    needs: publish
-    runs-on: ubuntu-latest
-    steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{ env.JAVAVERSION }}
-    - name: Setup Gradle
-      uses: gradle/gradle-build-action@v2
-      with:
-        gradle-version: "7.6"
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
   publish_sdk:
     name: publish_sdk
     needs: publish
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Node
-      uses: actions/setup-node@v2
-      with:
-        node-version: ${{ env.NODEVERSION }}
-        registry-url: https://registry.npmjs.org
-    - name: Setup DotNet
-      uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: ${{ env.DOTNETVERSION }}
-    - name: Setup Python
-      uses: actions/setup-python@v2
-      with:
-        python-version: ${{ env.PYTHONVERSION }}
-    - name: Download python SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: python-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress python SDK
-      run: tar -zxf ${{github.workspace}}/sdk/python.tar.gz -C
-        ${{github.workspace}}/sdk/python
-    - name: Download dotnet SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: dotnet-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress dotnet SDK
-      run: tar -zxf ${{github.workspace}}/sdk/dotnet.tar.gz -C
-        ${{github.workspace}}/sdk/dotnet
-    - name: Download nodejs SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: nodejs-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress nodejs SDK
-      run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
-        ${{github.workspace}}/sdk/nodejs
-    - run: python -m pip install pip twine
-    - env:
-        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-      name: Publish SDKs
-      run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - if: failure() && github.event_name == 'push'
-      name: Notify Slack
-      uses: 8398a7/action-slack@v3
-      with:
-        author_name: Failure in publishing SDK
-        fields: repo,commit,author,action
-        status: ${{ job.status }}
+    - name: Publish SDKs
+      uses: pulumi/pulumi-package-publisher@v0.0.5
   test:
     name: test
     needs: build_sdk

--- a/provider-ci/providers/consul/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/consul/repo/.github/workflows/prerelease.yml
@@ -299,131 +299,13 @@ jobs:
         author_name: Failure in publishing binaries
         fields: repo,commit,author,action
         status: ${{ job.status }}
-  publish_java_sdk:
-    continue-on-error: true
-    name: publish_java_sdk
-    needs: publish
-    runs-on: ubuntu-latest
-    steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{ env.JAVAVERSION }}
-    - name: Setup Gradle
-      uses: gradle/gradle-build-action@v2
-      with:
-        gradle-version: "7.6"
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
   publish_sdk:
     name: publish_sdk
     needs: publish
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Node
-      uses: actions/setup-node@v2
-      with:
-        node-version: ${{ env.NODEVERSION }}
-        registry-url: https://registry.npmjs.org
-    - name: Setup DotNet
-      uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: ${{ env.DOTNETVERSION }}
-    - name: Setup Python
-      uses: actions/setup-python@v2
-      with:
-        python-version: ${{ env.PYTHONVERSION }}
-    - name: Download python SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: python-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress python SDK
-      run: tar -zxf ${{github.workspace}}/sdk/python.tar.gz -C
-        ${{github.workspace}}/sdk/python
-    - name: Download dotnet SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: dotnet-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress dotnet SDK
-      run: tar -zxf ${{github.workspace}}/sdk/dotnet.tar.gz -C
-        ${{github.workspace}}/sdk/dotnet
-    - name: Download nodejs SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: nodejs-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress nodejs SDK
-      run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
-        ${{github.workspace}}/sdk/nodejs
-    - run: python -m pip install pip twine
-    - env:
-        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-      name: Publish SDKs
-      run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - if: failure() && github.event_name == 'push'
-      name: Notify Slack
-      uses: 8398a7/action-slack@v3
-      with:
-        author_name: Failure in publishing SDK
-        fields: repo,commit,author,action
-        status: ${{ job.status }}
+    - name: Publish SDKs
+      uses: pulumi/pulumi-package-publisher@v0.0.5
   test:
     name: test
     needs: build_sdk

--- a/provider-ci/providers/consul/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/consul/repo/.github/workflows/release.yml
@@ -311,131 +311,13 @@ jobs:
         author_name: Failure in publishing binaries
         fields: repo,commit,author,action
         status: ${{ job.status }}
-  publish_java_sdk:
-    continue-on-error: true
-    name: publish_java_sdk
-    needs: publish
-    runs-on: ubuntu-latest
-    steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{ env.JAVAVERSION }}
-    - name: Setup Gradle
-      uses: gradle/gradle-build-action@v2
-      with:
-        gradle-version: "7.6"
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
   publish_sdk:
     name: publish_sdk
     needs: publish
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Node
-      uses: actions/setup-node@v2
-      with:
-        node-version: ${{ env.NODEVERSION }}
-        registry-url: https://registry.npmjs.org
-    - name: Setup DotNet
-      uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: ${{ env.DOTNETVERSION }}
-    - name: Setup Python
-      uses: actions/setup-python@v2
-      with:
-        python-version: ${{ env.PYTHONVERSION }}
-    - name: Download python SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: python-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress python SDK
-      run: tar -zxf ${{github.workspace}}/sdk/python.tar.gz -C
-        ${{github.workspace}}/sdk/python
-    - name: Download dotnet SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: dotnet-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress dotnet SDK
-      run: tar -zxf ${{github.workspace}}/sdk/dotnet.tar.gz -C
-        ${{github.workspace}}/sdk/dotnet
-    - name: Download nodejs SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: nodejs-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress nodejs SDK
-      run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
-        ${{github.workspace}}/sdk/nodejs
-    - run: python -m pip install pip twine
-    - env:
-        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-      name: Publish SDKs
-      run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - if: failure() && github.event_name == 'push'
-      name: Notify Slack
-      uses: 8398a7/action-slack@v3
-      with:
-        author_name: Failure in publishing SDK
-        fields: repo,commit,author,action
-        status: ${{ job.status }}
+    - name: Publish SDKs
+      uses: pulumi/pulumi-package-publisher@v0.0.5
   tag_sdk:
     name: tag_sdk
     needs: publish_sdk

--- a/provider-ci/providers/databricks/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/databricks/repo/.github/workflows/main.yml
@@ -353,131 +353,13 @@ jobs:
         author_name: Failure in publishing binaries
         fields: repo,commit,author,action
         status: ${{ job.status }}
-  publish_java_sdk:
-    continue-on-error: true
-    name: publish_java_sdk
-    needs: publish
-    runs-on: ubuntu-latest
-    steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{ env.JAVAVERSION }}
-    - name: Setup Gradle
-      uses: gradle/gradle-build-action@v2
-      with:
-        gradle-version: "7.6"
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
   publish_sdk:
     name: publish_sdk
     needs: publish
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Node
-      uses: actions/setup-node@v2
-      with:
-        node-version: ${{ env.NODEVERSION }}
-        registry-url: https://registry.npmjs.org
-    - name: Setup DotNet
-      uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: ${{ env.DOTNETVERSION }}
-    - name: Setup Python
-      uses: actions/setup-python@v2
-      with:
-        python-version: ${{ env.PYTHONVERSION }}
-    - name: Download python SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: python-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress python SDK
-      run: tar -zxf ${{github.workspace}}/sdk/python.tar.gz -C
-        ${{github.workspace}}/sdk/python
-    - name: Download dotnet SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: dotnet-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress dotnet SDK
-      run: tar -zxf ${{github.workspace}}/sdk/dotnet.tar.gz -C
-        ${{github.workspace}}/sdk/dotnet
-    - name: Download nodejs SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: nodejs-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress nodejs SDK
-      run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
-        ${{github.workspace}}/sdk/nodejs
-    - run: python -m pip install pip twine
-    - env:
-        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-      name: Publish SDKs
-      run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - if: failure() && github.event_name == 'push'
-      name: Notify Slack
-      uses: 8398a7/action-slack@v3
-      with:
-        author_name: Failure in publishing SDK
-        fields: repo,commit,author,action
-        status: ${{ job.status }}
+    - name: Publish SDKs
+      uses: pulumi/pulumi-package-publisher@v0.0.5
   test:
     name: test
     needs: build_sdk

--- a/provider-ci/providers/databricks/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/databricks/repo/.github/workflows/master.yml
@@ -353,131 +353,13 @@ jobs:
         author_name: Failure in publishing binaries
         fields: repo,commit,author,action
         status: ${{ job.status }}
-  publish_java_sdk:
-    continue-on-error: true
-    name: publish_java_sdk
-    needs: publish
-    runs-on: ubuntu-latest
-    steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{ env.JAVAVERSION }}
-    - name: Setup Gradle
-      uses: gradle/gradle-build-action@v2
-      with:
-        gradle-version: "7.6"
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
   publish_sdk:
     name: publish_sdk
     needs: publish
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Node
-      uses: actions/setup-node@v2
-      with:
-        node-version: ${{ env.NODEVERSION }}
-        registry-url: https://registry.npmjs.org
-    - name: Setup DotNet
-      uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: ${{ env.DOTNETVERSION }}
-    - name: Setup Python
-      uses: actions/setup-python@v2
-      with:
-        python-version: ${{ env.PYTHONVERSION }}
-    - name: Download python SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: python-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress python SDK
-      run: tar -zxf ${{github.workspace}}/sdk/python.tar.gz -C
-        ${{github.workspace}}/sdk/python
-    - name: Download dotnet SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: dotnet-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress dotnet SDK
-      run: tar -zxf ${{github.workspace}}/sdk/dotnet.tar.gz -C
-        ${{github.workspace}}/sdk/dotnet
-    - name: Download nodejs SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: nodejs-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress nodejs SDK
-      run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
-        ${{github.workspace}}/sdk/nodejs
-    - run: python -m pip install pip twine
-    - env:
-        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-      name: Publish SDKs
-      run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - if: failure() && github.event_name == 'push'
-      name: Notify Slack
-      uses: 8398a7/action-slack@v3
-      with:
-        author_name: Failure in publishing SDK
-        fields: repo,commit,author,action
-        status: ${{ job.status }}
+    - name: Publish SDKs
+      uses: pulumi/pulumi-package-publisher@v0.0.5
   test:
     name: test
     needs: build_sdk

--- a/provider-ci/providers/databricks/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/databricks/repo/.github/workflows/prerelease.yml
@@ -303,131 +303,13 @@ jobs:
         author_name: Failure in publishing binaries
         fields: repo,commit,author,action
         status: ${{ job.status }}
-  publish_java_sdk:
-    continue-on-error: true
-    name: publish_java_sdk
-    needs: publish
-    runs-on: ubuntu-latest
-    steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{ env.JAVAVERSION }}
-    - name: Setup Gradle
-      uses: gradle/gradle-build-action@v2
-      with:
-        gradle-version: "7.6"
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
   publish_sdk:
     name: publish_sdk
     needs: publish
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Node
-      uses: actions/setup-node@v2
-      with:
-        node-version: ${{ env.NODEVERSION }}
-        registry-url: https://registry.npmjs.org
-    - name: Setup DotNet
-      uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: ${{ env.DOTNETVERSION }}
-    - name: Setup Python
-      uses: actions/setup-python@v2
-      with:
-        python-version: ${{ env.PYTHONVERSION }}
-    - name: Download python SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: python-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress python SDK
-      run: tar -zxf ${{github.workspace}}/sdk/python.tar.gz -C
-        ${{github.workspace}}/sdk/python
-    - name: Download dotnet SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: dotnet-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress dotnet SDK
-      run: tar -zxf ${{github.workspace}}/sdk/dotnet.tar.gz -C
-        ${{github.workspace}}/sdk/dotnet
-    - name: Download nodejs SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: nodejs-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress nodejs SDK
-      run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
-        ${{github.workspace}}/sdk/nodejs
-    - run: python -m pip install pip twine
-    - env:
-        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-      name: Publish SDKs
-      run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - if: failure() && github.event_name == 'push'
-      name: Notify Slack
-      uses: 8398a7/action-slack@v3
-      with:
-        author_name: Failure in publishing SDK
-        fields: repo,commit,author,action
-        status: ${{ job.status }}
+    - name: Publish SDKs
+      uses: pulumi/pulumi-package-publisher@v0.0.5
   test:
     name: test
     needs: build_sdk

--- a/provider-ci/providers/databricks/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/databricks/repo/.github/workflows/release.yml
@@ -315,131 +315,13 @@ jobs:
         author_name: Failure in publishing binaries
         fields: repo,commit,author,action
         status: ${{ job.status }}
-  publish_java_sdk:
-    continue-on-error: true
-    name: publish_java_sdk
-    needs: publish
-    runs-on: ubuntu-latest
-    steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{ env.JAVAVERSION }}
-    - name: Setup Gradle
-      uses: gradle/gradle-build-action@v2
-      with:
-        gradle-version: "7.6"
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
   publish_sdk:
     name: publish_sdk
     needs: publish
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Node
-      uses: actions/setup-node@v2
-      with:
-        node-version: ${{ env.NODEVERSION }}
-        registry-url: https://registry.npmjs.org
-    - name: Setup DotNet
-      uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: ${{ env.DOTNETVERSION }}
-    - name: Setup Python
-      uses: actions/setup-python@v2
-      with:
-        python-version: ${{ env.PYTHONVERSION }}
-    - name: Download python SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: python-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress python SDK
-      run: tar -zxf ${{github.workspace}}/sdk/python.tar.gz -C
-        ${{github.workspace}}/sdk/python
-    - name: Download dotnet SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: dotnet-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress dotnet SDK
-      run: tar -zxf ${{github.workspace}}/sdk/dotnet.tar.gz -C
-        ${{github.workspace}}/sdk/dotnet
-    - name: Download nodejs SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: nodejs-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress nodejs SDK
-      run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
-        ${{github.workspace}}/sdk/nodejs
-    - run: python -m pip install pip twine
-    - env:
-        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-      name: Publish SDKs
-      run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - if: failure() && github.event_name == 'push'
-      name: Notify Slack
-      uses: 8398a7/action-slack@v3
-      with:
-        author_name: Failure in publishing SDK
-        fields: repo,commit,author,action
-        status: ${{ job.status }}
+    - name: Publish SDKs
+      uses: pulumi/pulumi-package-publisher@v0.0.5
   tag_sdk:
     name: tag_sdk
     needs: publish_sdk

--- a/provider-ci/providers/datadog/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/datadog/repo/.github/workflows/main.yml
@@ -278,131 +278,13 @@ jobs:
         author_name: Failure in publishing binaries
         fields: repo,commit,author,action
         status: ${{ job.status }}
-  publish_java_sdk:
-    continue-on-error: true
-    name: publish_java_sdk
-    needs: publish
-    runs-on: ubuntu-latest
-    steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{ env.JAVAVERSION }}
-    - name: Setup Gradle
-      uses: gradle/gradle-build-action@v2
-      with:
-        gradle-version: "7.6"
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
   publish_sdk:
     name: publish_sdk
     needs: publish
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Node
-      uses: actions/setup-node@v2
-      with:
-        node-version: ${{ env.NODEVERSION }}
-        registry-url: https://registry.npmjs.org
-    - name: Setup DotNet
-      uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: ${{ env.DOTNETVERSION }}
-    - name: Setup Python
-      uses: actions/setup-python@v2
-      with:
-        python-version: ${{ env.PYTHONVERSION }}
-    - name: Download python SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: python-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress python SDK
-      run: tar -zxf ${{github.workspace}}/sdk/python.tar.gz -C
-        ${{github.workspace}}/sdk/python
-    - name: Download dotnet SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: dotnet-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress dotnet SDK
-      run: tar -zxf ${{github.workspace}}/sdk/dotnet.tar.gz -C
-        ${{github.workspace}}/sdk/dotnet
-    - name: Download nodejs SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: nodejs-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress nodejs SDK
-      run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
-        ${{github.workspace}}/sdk/nodejs
-    - run: python -m pip install pip twine
-    - env:
-        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-      name: Publish SDKs
-      run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - if: failure() && github.event_name == 'push'
-      name: Notify Slack
-      uses: 8398a7/action-slack@v3
-      with:
-        author_name: Failure in publishing SDK
-        fields: repo,commit,author,action
-        status: ${{ job.status }}
+    - name: Publish SDKs
+      uses: pulumi/pulumi-package-publisher@v0.0.5
   test:
     name: test
     needs: build_sdk

--- a/provider-ci/providers/datadog/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/datadog/repo/.github/workflows/master.yml
@@ -278,131 +278,13 @@ jobs:
         author_name: Failure in publishing binaries
         fields: repo,commit,author,action
         status: ${{ job.status }}
-  publish_java_sdk:
-    continue-on-error: true
-    name: publish_java_sdk
-    needs: publish
-    runs-on: ubuntu-latest
-    steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{ env.JAVAVERSION }}
-    - name: Setup Gradle
-      uses: gradle/gradle-build-action@v2
-      with:
-        gradle-version: "7.6"
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
   publish_sdk:
     name: publish_sdk
     needs: publish
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Node
-      uses: actions/setup-node@v2
-      with:
-        node-version: ${{ env.NODEVERSION }}
-        registry-url: https://registry.npmjs.org
-    - name: Setup DotNet
-      uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: ${{ env.DOTNETVERSION }}
-    - name: Setup Python
-      uses: actions/setup-python@v2
-      with:
-        python-version: ${{ env.PYTHONVERSION }}
-    - name: Download python SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: python-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress python SDK
-      run: tar -zxf ${{github.workspace}}/sdk/python.tar.gz -C
-        ${{github.workspace}}/sdk/python
-    - name: Download dotnet SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: dotnet-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress dotnet SDK
-      run: tar -zxf ${{github.workspace}}/sdk/dotnet.tar.gz -C
-        ${{github.workspace}}/sdk/dotnet
-    - name: Download nodejs SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: nodejs-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress nodejs SDK
-      run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
-        ${{github.workspace}}/sdk/nodejs
-    - run: python -m pip install pip twine
-    - env:
-        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-      name: Publish SDKs
-      run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - if: failure() && github.event_name == 'push'
-      name: Notify Slack
-      uses: 8398a7/action-slack@v3
-      with:
-        author_name: Failure in publishing SDK
-        fields: repo,commit,author,action
-        status: ${{ job.status }}
+    - name: Publish SDKs
+      uses: pulumi/pulumi-package-publisher@v0.0.5
   test:
     name: test
     needs: build_sdk

--- a/provider-ci/providers/datadog/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/datadog/repo/.github/workflows/prerelease.yml
@@ -228,131 +228,13 @@ jobs:
         author_name: Failure in publishing binaries
         fields: repo,commit,author,action
         status: ${{ job.status }}
-  publish_java_sdk:
-    continue-on-error: true
-    name: publish_java_sdk
-    needs: publish
-    runs-on: ubuntu-latest
-    steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{ env.JAVAVERSION }}
-    - name: Setup Gradle
-      uses: gradle/gradle-build-action@v2
-      with:
-        gradle-version: "7.6"
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
   publish_sdk:
     name: publish_sdk
     needs: publish
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Node
-      uses: actions/setup-node@v2
-      with:
-        node-version: ${{ env.NODEVERSION }}
-        registry-url: https://registry.npmjs.org
-    - name: Setup DotNet
-      uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: ${{ env.DOTNETVERSION }}
-    - name: Setup Python
-      uses: actions/setup-python@v2
-      with:
-        python-version: ${{ env.PYTHONVERSION }}
-    - name: Download python SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: python-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress python SDK
-      run: tar -zxf ${{github.workspace}}/sdk/python.tar.gz -C
-        ${{github.workspace}}/sdk/python
-    - name: Download dotnet SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: dotnet-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress dotnet SDK
-      run: tar -zxf ${{github.workspace}}/sdk/dotnet.tar.gz -C
-        ${{github.workspace}}/sdk/dotnet
-    - name: Download nodejs SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: nodejs-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress nodejs SDK
-      run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
-        ${{github.workspace}}/sdk/nodejs
-    - run: python -m pip install pip twine
-    - env:
-        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-      name: Publish SDKs
-      run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - if: failure() && github.event_name == 'push'
-      name: Notify Slack
-      uses: 8398a7/action-slack@v3
-      with:
-        author_name: Failure in publishing SDK
-        fields: repo,commit,author,action
-        status: ${{ job.status }}
+    - name: Publish SDKs
+      uses: pulumi/pulumi-package-publisher@v0.0.5
   test:
     name: test
     needs: build_sdk

--- a/provider-ci/providers/datadog/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/datadog/repo/.github/workflows/release.yml
@@ -240,131 +240,13 @@ jobs:
         author_name: Failure in publishing binaries
         fields: repo,commit,author,action
         status: ${{ job.status }}
-  publish_java_sdk:
-    continue-on-error: true
-    name: publish_java_sdk
-    needs: publish
-    runs-on: ubuntu-latest
-    steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{ env.JAVAVERSION }}
-    - name: Setup Gradle
-      uses: gradle/gradle-build-action@v2
-      with:
-        gradle-version: "7.6"
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
   publish_sdk:
     name: publish_sdk
     needs: publish
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Node
-      uses: actions/setup-node@v2
-      with:
-        node-version: ${{ env.NODEVERSION }}
-        registry-url: https://registry.npmjs.org
-    - name: Setup DotNet
-      uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: ${{ env.DOTNETVERSION }}
-    - name: Setup Python
-      uses: actions/setup-python@v2
-      with:
-        python-version: ${{ env.PYTHONVERSION }}
-    - name: Download python SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: python-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress python SDK
-      run: tar -zxf ${{github.workspace}}/sdk/python.tar.gz -C
-        ${{github.workspace}}/sdk/python
-    - name: Download dotnet SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: dotnet-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress dotnet SDK
-      run: tar -zxf ${{github.workspace}}/sdk/dotnet.tar.gz -C
-        ${{github.workspace}}/sdk/dotnet
-    - name: Download nodejs SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: nodejs-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress nodejs SDK
-      run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
-        ${{github.workspace}}/sdk/nodejs
-    - run: python -m pip install pip twine
-    - env:
-        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-      name: Publish SDKs
-      run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - if: failure() && github.event_name == 'push'
-      name: Notify Slack
-      uses: 8398a7/action-slack@v3
-      with:
-        author_name: Failure in publishing SDK
-        fields: repo,commit,author,action
-        status: ${{ job.status }}
+    - name: Publish SDKs
+      uses: pulumi/pulumi-package-publisher@v0.0.5
   tag_sdk:
     name: tag_sdk
     needs: publish_sdk

--- a/provider-ci/providers/digitalocean/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/digitalocean/repo/.github/workflows/main.yml
@@ -350,131 +350,13 @@ jobs:
         author_name: Failure in publishing binaries
         fields: repo,commit,author,action
         status: ${{ job.status }}
-  publish_java_sdk:
-    continue-on-error: true
-    name: publish_java_sdk
-    needs: publish
-    runs-on: ubuntu-latest
-    steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{ env.JAVAVERSION }}
-    - name: Setup Gradle
-      uses: gradle/gradle-build-action@v2
-      with:
-        gradle-version: "7.6"
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
   publish_sdk:
     name: publish_sdk
     needs: publish
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Node
-      uses: actions/setup-node@v2
-      with:
-        node-version: ${{ env.NODEVERSION }}
-        registry-url: https://registry.npmjs.org
-    - name: Setup DotNet
-      uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: ${{ env.DOTNETVERSION }}
-    - name: Setup Python
-      uses: actions/setup-python@v2
-      with:
-        python-version: ${{ env.PYTHONVERSION }}
-    - name: Download python SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: python-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress python SDK
-      run: tar -zxf ${{github.workspace}}/sdk/python.tar.gz -C
-        ${{github.workspace}}/sdk/python
-    - name: Download dotnet SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: dotnet-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress dotnet SDK
-      run: tar -zxf ${{github.workspace}}/sdk/dotnet.tar.gz -C
-        ${{github.workspace}}/sdk/dotnet
-    - name: Download nodejs SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: nodejs-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress nodejs SDK
-      run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
-        ${{github.workspace}}/sdk/nodejs
-    - run: python -m pip install pip twine
-    - env:
-        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-      name: Publish SDKs
-      run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - if: failure() && github.event_name == 'push'
-      name: Notify Slack
-      uses: 8398a7/action-slack@v3
-      with:
-        author_name: Failure in publishing SDK
-        fields: repo,commit,author,action
-        status: ${{ job.status }}
+    - name: Publish SDKs
+      uses: pulumi/pulumi-package-publisher@v0.0.5
   test:
     name: test
     needs: build_sdk

--- a/provider-ci/providers/digitalocean/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/digitalocean/repo/.github/workflows/master.yml
@@ -350,131 +350,13 @@ jobs:
         author_name: Failure in publishing binaries
         fields: repo,commit,author,action
         status: ${{ job.status }}
-  publish_java_sdk:
-    continue-on-error: true
-    name: publish_java_sdk
-    needs: publish
-    runs-on: ubuntu-latest
-    steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{ env.JAVAVERSION }}
-    - name: Setup Gradle
-      uses: gradle/gradle-build-action@v2
-      with:
-        gradle-version: "7.6"
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
   publish_sdk:
     name: publish_sdk
     needs: publish
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Node
-      uses: actions/setup-node@v2
-      with:
-        node-version: ${{ env.NODEVERSION }}
-        registry-url: https://registry.npmjs.org
-    - name: Setup DotNet
-      uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: ${{ env.DOTNETVERSION }}
-    - name: Setup Python
-      uses: actions/setup-python@v2
-      with:
-        python-version: ${{ env.PYTHONVERSION }}
-    - name: Download python SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: python-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress python SDK
-      run: tar -zxf ${{github.workspace}}/sdk/python.tar.gz -C
-        ${{github.workspace}}/sdk/python
-    - name: Download dotnet SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: dotnet-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress dotnet SDK
-      run: tar -zxf ${{github.workspace}}/sdk/dotnet.tar.gz -C
-        ${{github.workspace}}/sdk/dotnet
-    - name: Download nodejs SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: nodejs-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress nodejs SDK
-      run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
-        ${{github.workspace}}/sdk/nodejs
-    - run: python -m pip install pip twine
-    - env:
-        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-      name: Publish SDKs
-      run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - if: failure() && github.event_name == 'push'
-      name: Notify Slack
-      uses: 8398a7/action-slack@v3
-      with:
-        author_name: Failure in publishing SDK
-        fields: repo,commit,author,action
-        status: ${{ job.status }}
+    - name: Publish SDKs
+      uses: pulumi/pulumi-package-publisher@v0.0.5
   test:
     name: test
     needs: build_sdk

--- a/provider-ci/providers/digitalocean/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/digitalocean/repo/.github/workflows/prerelease.yml
@@ -300,131 +300,13 @@ jobs:
         author_name: Failure in publishing binaries
         fields: repo,commit,author,action
         status: ${{ job.status }}
-  publish_java_sdk:
-    continue-on-error: true
-    name: publish_java_sdk
-    needs: publish
-    runs-on: ubuntu-latest
-    steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{ env.JAVAVERSION }}
-    - name: Setup Gradle
-      uses: gradle/gradle-build-action@v2
-      with:
-        gradle-version: "7.6"
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
   publish_sdk:
     name: publish_sdk
     needs: publish
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Node
-      uses: actions/setup-node@v2
-      with:
-        node-version: ${{ env.NODEVERSION }}
-        registry-url: https://registry.npmjs.org
-    - name: Setup DotNet
-      uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: ${{ env.DOTNETVERSION }}
-    - name: Setup Python
-      uses: actions/setup-python@v2
-      with:
-        python-version: ${{ env.PYTHONVERSION }}
-    - name: Download python SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: python-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress python SDK
-      run: tar -zxf ${{github.workspace}}/sdk/python.tar.gz -C
-        ${{github.workspace}}/sdk/python
-    - name: Download dotnet SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: dotnet-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress dotnet SDK
-      run: tar -zxf ${{github.workspace}}/sdk/dotnet.tar.gz -C
-        ${{github.workspace}}/sdk/dotnet
-    - name: Download nodejs SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: nodejs-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress nodejs SDK
-      run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
-        ${{github.workspace}}/sdk/nodejs
-    - run: python -m pip install pip twine
-    - env:
-        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-      name: Publish SDKs
-      run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - if: failure() && github.event_name == 'push'
-      name: Notify Slack
-      uses: 8398a7/action-slack@v3
-      with:
-        author_name: Failure in publishing SDK
-        fields: repo,commit,author,action
-        status: ${{ job.status }}
+    - name: Publish SDKs
+      uses: pulumi/pulumi-package-publisher@v0.0.5
   test:
     name: test
     needs: build_sdk

--- a/provider-ci/providers/digitalocean/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/digitalocean/repo/.github/workflows/release.yml
@@ -312,131 +312,13 @@ jobs:
         author_name: Failure in publishing binaries
         fields: repo,commit,author,action
         status: ${{ job.status }}
-  publish_java_sdk:
-    continue-on-error: true
-    name: publish_java_sdk
-    needs: publish
-    runs-on: ubuntu-latest
-    steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{ env.JAVAVERSION }}
-    - name: Setup Gradle
-      uses: gradle/gradle-build-action@v2
-      with:
-        gradle-version: "7.6"
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
   publish_sdk:
     name: publish_sdk
     needs: publish
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Node
-      uses: actions/setup-node@v2
-      with:
-        node-version: ${{ env.NODEVERSION }}
-        registry-url: https://registry.npmjs.org
-    - name: Setup DotNet
-      uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: ${{ env.DOTNETVERSION }}
-    - name: Setup Python
-      uses: actions/setup-python@v2
-      with:
-        python-version: ${{ env.PYTHONVERSION }}
-    - name: Download python SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: python-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress python SDK
-      run: tar -zxf ${{github.workspace}}/sdk/python.tar.gz -C
-        ${{github.workspace}}/sdk/python
-    - name: Download dotnet SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: dotnet-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress dotnet SDK
-      run: tar -zxf ${{github.workspace}}/sdk/dotnet.tar.gz -C
-        ${{github.workspace}}/sdk/dotnet
-    - name: Download nodejs SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: nodejs-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress nodejs SDK
-      run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
-        ${{github.workspace}}/sdk/nodejs
-    - run: python -m pip install pip twine
-    - env:
-        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-      name: Publish SDKs
-      run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - if: failure() && github.event_name == 'push'
-      name: Notify Slack
-      uses: 8398a7/action-slack@v3
-      with:
-        author_name: Failure in publishing SDK
-        fields: repo,commit,author,action
-        status: ${{ job.status }}
+    - name: Publish SDKs
+      uses: pulumi/pulumi-package-publisher@v0.0.5
   tag_sdk:
     name: tag_sdk
     needs: publish_sdk

--- a/provider-ci/providers/dnsimple/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/dnsimple/repo/.github/workflows/main.yml
@@ -351,131 +351,13 @@ jobs:
         author_name: Failure in publishing binaries
         fields: repo,commit,author,action
         status: ${{ job.status }}
-  publish_java_sdk:
-    continue-on-error: true
-    name: publish_java_sdk
-    needs: publish
-    runs-on: ubuntu-latest
-    steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{ env.JAVAVERSION }}
-    - name: Setup Gradle
-      uses: gradle/gradle-build-action@v2
-      with:
-        gradle-version: "7.6"
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
   publish_sdk:
     name: publish_sdk
     needs: publish
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Node
-      uses: actions/setup-node@v2
-      with:
-        node-version: ${{ env.NODEVERSION }}
-        registry-url: https://registry.npmjs.org
-    - name: Setup DotNet
-      uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: ${{ env.DOTNETVERSION }}
-    - name: Setup Python
-      uses: actions/setup-python@v2
-      with:
-        python-version: ${{ env.PYTHONVERSION }}
-    - name: Download python SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: python-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress python SDK
-      run: tar -zxf ${{github.workspace}}/sdk/python.tar.gz -C
-        ${{github.workspace}}/sdk/python
-    - name: Download dotnet SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: dotnet-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress dotnet SDK
-      run: tar -zxf ${{github.workspace}}/sdk/dotnet.tar.gz -C
-        ${{github.workspace}}/sdk/dotnet
-    - name: Download nodejs SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: nodejs-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress nodejs SDK
-      run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
-        ${{github.workspace}}/sdk/nodejs
-    - run: python -m pip install pip twine
-    - env:
-        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-      name: Publish SDKs
-      run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - if: failure() && github.event_name == 'push'
-      name: Notify Slack
-      uses: 8398a7/action-slack@v3
-      with:
-        author_name: Failure in publishing SDK
-        fields: repo,commit,author,action
-        status: ${{ job.status }}
+    - name: Publish SDKs
+      uses: pulumi/pulumi-package-publisher@v0.0.5
   test:
     name: test
     needs: build_sdk

--- a/provider-ci/providers/dnsimple/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/dnsimple/repo/.github/workflows/master.yml
@@ -351,131 +351,13 @@ jobs:
         author_name: Failure in publishing binaries
         fields: repo,commit,author,action
         status: ${{ job.status }}
-  publish_java_sdk:
-    continue-on-error: true
-    name: publish_java_sdk
-    needs: publish
-    runs-on: ubuntu-latest
-    steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{ env.JAVAVERSION }}
-    - name: Setup Gradle
-      uses: gradle/gradle-build-action@v2
-      with:
-        gradle-version: "7.6"
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
   publish_sdk:
     name: publish_sdk
     needs: publish
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Node
-      uses: actions/setup-node@v2
-      with:
-        node-version: ${{ env.NODEVERSION }}
-        registry-url: https://registry.npmjs.org
-    - name: Setup DotNet
-      uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: ${{ env.DOTNETVERSION }}
-    - name: Setup Python
-      uses: actions/setup-python@v2
-      with:
-        python-version: ${{ env.PYTHONVERSION }}
-    - name: Download python SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: python-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress python SDK
-      run: tar -zxf ${{github.workspace}}/sdk/python.tar.gz -C
-        ${{github.workspace}}/sdk/python
-    - name: Download dotnet SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: dotnet-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress dotnet SDK
-      run: tar -zxf ${{github.workspace}}/sdk/dotnet.tar.gz -C
-        ${{github.workspace}}/sdk/dotnet
-    - name: Download nodejs SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: nodejs-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress nodejs SDK
-      run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
-        ${{github.workspace}}/sdk/nodejs
-    - run: python -m pip install pip twine
-    - env:
-        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-      name: Publish SDKs
-      run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - if: failure() && github.event_name == 'push'
-      name: Notify Slack
-      uses: 8398a7/action-slack@v3
-      with:
-        author_name: Failure in publishing SDK
-        fields: repo,commit,author,action
-        status: ${{ job.status }}
+    - name: Publish SDKs
+      uses: pulumi/pulumi-package-publisher@v0.0.5
   test:
     name: test
     needs: build_sdk

--- a/provider-ci/providers/dnsimple/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/dnsimple/repo/.github/workflows/prerelease.yml
@@ -301,131 +301,13 @@ jobs:
         author_name: Failure in publishing binaries
         fields: repo,commit,author,action
         status: ${{ job.status }}
-  publish_java_sdk:
-    continue-on-error: true
-    name: publish_java_sdk
-    needs: publish
-    runs-on: ubuntu-latest
-    steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{ env.JAVAVERSION }}
-    - name: Setup Gradle
-      uses: gradle/gradle-build-action@v2
-      with:
-        gradle-version: "7.6"
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
   publish_sdk:
     name: publish_sdk
     needs: publish
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Node
-      uses: actions/setup-node@v2
-      with:
-        node-version: ${{ env.NODEVERSION }}
-        registry-url: https://registry.npmjs.org
-    - name: Setup DotNet
-      uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: ${{ env.DOTNETVERSION }}
-    - name: Setup Python
-      uses: actions/setup-python@v2
-      with:
-        python-version: ${{ env.PYTHONVERSION }}
-    - name: Download python SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: python-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress python SDK
-      run: tar -zxf ${{github.workspace}}/sdk/python.tar.gz -C
-        ${{github.workspace}}/sdk/python
-    - name: Download dotnet SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: dotnet-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress dotnet SDK
-      run: tar -zxf ${{github.workspace}}/sdk/dotnet.tar.gz -C
-        ${{github.workspace}}/sdk/dotnet
-    - name: Download nodejs SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: nodejs-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress nodejs SDK
-      run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
-        ${{github.workspace}}/sdk/nodejs
-    - run: python -m pip install pip twine
-    - env:
-        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-      name: Publish SDKs
-      run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - if: failure() && github.event_name == 'push'
-      name: Notify Slack
-      uses: 8398a7/action-slack@v3
-      with:
-        author_name: Failure in publishing SDK
-        fields: repo,commit,author,action
-        status: ${{ job.status }}
+    - name: Publish SDKs
+      uses: pulumi/pulumi-package-publisher@v0.0.5
   test:
     name: test
     needs: build_sdk

--- a/provider-ci/providers/dnsimple/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/dnsimple/repo/.github/workflows/release.yml
@@ -313,131 +313,13 @@ jobs:
         author_name: Failure in publishing binaries
         fields: repo,commit,author,action
         status: ${{ job.status }}
-  publish_java_sdk:
-    continue-on-error: true
-    name: publish_java_sdk
-    needs: publish
-    runs-on: ubuntu-latest
-    steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{ env.JAVAVERSION }}
-    - name: Setup Gradle
-      uses: gradle/gradle-build-action@v2
-      with:
-        gradle-version: "7.6"
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
   publish_sdk:
     name: publish_sdk
     needs: publish
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Node
-      uses: actions/setup-node@v2
-      with:
-        node-version: ${{ env.NODEVERSION }}
-        registry-url: https://registry.npmjs.org
-    - name: Setup DotNet
-      uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: ${{ env.DOTNETVERSION }}
-    - name: Setup Python
-      uses: actions/setup-python@v2
-      with:
-        python-version: ${{ env.PYTHONVERSION }}
-    - name: Download python SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: python-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress python SDK
-      run: tar -zxf ${{github.workspace}}/sdk/python.tar.gz -C
-        ${{github.workspace}}/sdk/python
-    - name: Download dotnet SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: dotnet-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress dotnet SDK
-      run: tar -zxf ${{github.workspace}}/sdk/dotnet.tar.gz -C
-        ${{github.workspace}}/sdk/dotnet
-    - name: Download nodejs SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: nodejs-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress nodejs SDK
-      run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
-        ${{github.workspace}}/sdk/nodejs
-    - run: python -m pip install pip twine
-    - env:
-        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-      name: Publish SDKs
-      run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - if: failure() && github.event_name == 'push'
-      name: Notify Slack
-      uses: 8398a7/action-slack@v3
-      with:
-        author_name: Failure in publishing SDK
-        fields: repo,commit,author,action
-        status: ${{ job.status }}
+    - name: Publish SDKs
+      uses: pulumi/pulumi-package-publisher@v0.0.5
   tag_sdk:
     name: tag_sdk
     needs: publish_sdk

--- a/provider-ci/providers/docker/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/docker/repo/.github/workflows/main.yml
@@ -363,131 +363,13 @@ jobs:
         author_name: Failure in publishing binaries
         fields: repo,commit,author,action
         status: ${{ job.status }}
-  publish_java_sdk:
-    continue-on-error: true
-    name: publish_java_sdk
-    needs: publish
-    runs-on: ubuntu-latest
-    steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{ env.JAVAVERSION }}
-    - name: Setup Gradle
-      uses: gradle/gradle-build-action@v2
-      with:
-        gradle-version: "7.6"
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
   publish_sdk:
     name: publish_sdk
     needs: publish
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Node
-      uses: actions/setup-node@v2
-      with:
-        node-version: ${{ env.NODEVERSION }}
-        registry-url: https://registry.npmjs.org
-    - name: Setup DotNet
-      uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: ${{ env.DOTNETVERSION }}
-    - name: Setup Python
-      uses: actions/setup-python@v2
-      with:
-        python-version: ${{ env.PYTHONVERSION }}
-    - name: Download python SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: python-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress python SDK
-      run: tar -zxf ${{github.workspace}}/sdk/python.tar.gz -C
-        ${{github.workspace}}/sdk/python
-    - name: Download dotnet SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: dotnet-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress dotnet SDK
-      run: tar -zxf ${{github.workspace}}/sdk/dotnet.tar.gz -C
-        ${{github.workspace}}/sdk/dotnet
-    - name: Download nodejs SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: nodejs-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress nodejs SDK
-      run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
-        ${{github.workspace}}/sdk/nodejs
-    - run: python -m pip install pip twine
-    - env:
-        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-      name: Publish SDKs
-      run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - if: failure() && github.event_name == 'push'
-      name: Notify Slack
-      uses: 8398a7/action-slack@v3
-      with:
-        author_name: Failure in publishing SDK
-        fields: repo,commit,author,action
-        status: ${{ job.status }}
+    - name: Publish SDKs
+      uses: pulumi/pulumi-package-publisher@v0.0.5
   test:
     name: test
     needs: build_sdk

--- a/provider-ci/providers/docker/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/docker/repo/.github/workflows/master.yml
@@ -363,131 +363,13 @@ jobs:
         author_name: Failure in publishing binaries
         fields: repo,commit,author,action
         status: ${{ job.status }}
-  publish_java_sdk:
-    continue-on-error: true
-    name: publish_java_sdk
-    needs: publish
-    runs-on: ubuntu-latest
-    steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{ env.JAVAVERSION }}
-    - name: Setup Gradle
-      uses: gradle/gradle-build-action@v2
-      with:
-        gradle-version: "7.6"
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
   publish_sdk:
     name: publish_sdk
     needs: publish
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Node
-      uses: actions/setup-node@v2
-      with:
-        node-version: ${{ env.NODEVERSION }}
-        registry-url: https://registry.npmjs.org
-    - name: Setup DotNet
-      uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: ${{ env.DOTNETVERSION }}
-    - name: Setup Python
-      uses: actions/setup-python@v2
-      with:
-        python-version: ${{ env.PYTHONVERSION }}
-    - name: Download python SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: python-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress python SDK
-      run: tar -zxf ${{github.workspace}}/sdk/python.tar.gz -C
-        ${{github.workspace}}/sdk/python
-    - name: Download dotnet SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: dotnet-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress dotnet SDK
-      run: tar -zxf ${{github.workspace}}/sdk/dotnet.tar.gz -C
-        ${{github.workspace}}/sdk/dotnet
-    - name: Download nodejs SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: nodejs-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress nodejs SDK
-      run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
-        ${{github.workspace}}/sdk/nodejs
-    - run: python -m pip install pip twine
-    - env:
-        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-      name: Publish SDKs
-      run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - if: failure() && github.event_name == 'push'
-      name: Notify Slack
-      uses: 8398a7/action-slack@v3
-      with:
-        author_name: Failure in publishing SDK
-        fields: repo,commit,author,action
-        status: ${{ job.status }}
+    - name: Publish SDKs
+      uses: pulumi/pulumi-package-publisher@v0.0.5
   test:
     name: test
     needs: build_sdk

--- a/provider-ci/providers/docker/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/docker/repo/.github/workflows/prerelease.yml
@@ -313,131 +313,13 @@ jobs:
         author_name: Failure in publishing binaries
         fields: repo,commit,author,action
         status: ${{ job.status }}
-  publish_java_sdk:
-    continue-on-error: true
-    name: publish_java_sdk
-    needs: publish
-    runs-on: ubuntu-latest
-    steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{ env.JAVAVERSION }}
-    - name: Setup Gradle
-      uses: gradle/gradle-build-action@v2
-      with:
-        gradle-version: "7.6"
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
   publish_sdk:
     name: publish_sdk
     needs: publish
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Node
-      uses: actions/setup-node@v2
-      with:
-        node-version: ${{ env.NODEVERSION }}
-        registry-url: https://registry.npmjs.org
-    - name: Setup DotNet
-      uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: ${{ env.DOTNETVERSION }}
-    - name: Setup Python
-      uses: actions/setup-python@v2
-      with:
-        python-version: ${{ env.PYTHONVERSION }}
-    - name: Download python SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: python-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress python SDK
-      run: tar -zxf ${{github.workspace}}/sdk/python.tar.gz -C
-        ${{github.workspace}}/sdk/python
-    - name: Download dotnet SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: dotnet-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress dotnet SDK
-      run: tar -zxf ${{github.workspace}}/sdk/dotnet.tar.gz -C
-        ${{github.workspace}}/sdk/dotnet
-    - name: Download nodejs SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: nodejs-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress nodejs SDK
-      run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
-        ${{github.workspace}}/sdk/nodejs
-    - run: python -m pip install pip twine
-    - env:
-        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-      name: Publish SDKs
-      run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - if: failure() && github.event_name == 'push'
-      name: Notify Slack
-      uses: 8398a7/action-slack@v3
-      with:
-        author_name: Failure in publishing SDK
-        fields: repo,commit,author,action
-        status: ${{ job.status }}
+    - name: Publish SDKs
+      uses: pulumi/pulumi-package-publisher@v0.0.5
   test:
     name: test
     needs: build_sdk

--- a/provider-ci/providers/docker/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/docker/repo/.github/workflows/release.yml
@@ -325,131 +325,13 @@ jobs:
         author_name: Failure in publishing binaries
         fields: repo,commit,author,action
         status: ${{ job.status }}
-  publish_java_sdk:
-    continue-on-error: true
-    name: publish_java_sdk
-    needs: publish
-    runs-on: ubuntu-latest
-    steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{ env.JAVAVERSION }}
-    - name: Setup Gradle
-      uses: gradle/gradle-build-action@v2
-      with:
-        gradle-version: "7.6"
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
   publish_sdk:
     name: publish_sdk
     needs: publish
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Node
-      uses: actions/setup-node@v2
-      with:
-        node-version: ${{ env.NODEVERSION }}
-        registry-url: https://registry.npmjs.org
-    - name: Setup DotNet
-      uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: ${{ env.DOTNETVERSION }}
-    - name: Setup Python
-      uses: actions/setup-python@v2
-      with:
-        python-version: ${{ env.PYTHONVERSION }}
-    - name: Download python SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: python-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress python SDK
-      run: tar -zxf ${{github.workspace}}/sdk/python.tar.gz -C
-        ${{github.workspace}}/sdk/python
-    - name: Download dotnet SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: dotnet-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress dotnet SDK
-      run: tar -zxf ${{github.workspace}}/sdk/dotnet.tar.gz -C
-        ${{github.workspace}}/sdk/dotnet
-    - name: Download nodejs SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: nodejs-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress nodejs SDK
-      run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
-        ${{github.workspace}}/sdk/nodejs
-    - run: python -m pip install pip twine
-    - env:
-        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-      name: Publish SDKs
-      run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - if: failure() && github.event_name == 'push'
-      name: Notify Slack
-      uses: 8398a7/action-slack@v3
-      with:
-        author_name: Failure in publishing SDK
-        fields: repo,commit,author,action
-        status: ${{ job.status }}
+    - name: Publish SDKs
+      uses: pulumi/pulumi-package-publisher@v0.0.5
   tag_sdk:
     name: tag_sdk
     needs: publish_sdk

--- a/provider-ci/providers/ec/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/ec/repo/.github/workflows/main.yml
@@ -350,131 +350,13 @@ jobs:
         author_name: Failure in publishing binaries
         fields: repo,commit,author,action
         status: ${{ job.status }}
-  publish_java_sdk:
-    continue-on-error: true
-    name: publish_java_sdk
-    needs: publish
-    runs-on: ubuntu-latest
-    steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{ env.JAVAVERSION }}
-    - name: Setup Gradle
-      uses: gradle/gradle-build-action@v2
-      with:
-        gradle-version: "7.6"
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
   publish_sdk:
     name: publish_sdk
     needs: publish
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Node
-      uses: actions/setup-node@v2
-      with:
-        node-version: ${{ env.NODEVERSION }}
-        registry-url: https://registry.npmjs.org
-    - name: Setup DotNet
-      uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: ${{ env.DOTNETVERSION }}
-    - name: Setup Python
-      uses: actions/setup-python@v2
-      with:
-        python-version: ${{ env.PYTHONVERSION }}
-    - name: Download python SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: python-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress python SDK
-      run: tar -zxf ${{github.workspace}}/sdk/python.tar.gz -C
-        ${{github.workspace}}/sdk/python
-    - name: Download dotnet SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: dotnet-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress dotnet SDK
-      run: tar -zxf ${{github.workspace}}/sdk/dotnet.tar.gz -C
-        ${{github.workspace}}/sdk/dotnet
-    - name: Download nodejs SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: nodejs-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress nodejs SDK
-      run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
-        ${{github.workspace}}/sdk/nodejs
-    - run: python -m pip install pip twine
-    - env:
-        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-      name: Publish SDKs
-      run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - if: failure() && github.event_name == 'push'
-      name: Notify Slack
-      uses: 8398a7/action-slack@v3
-      with:
-        author_name: Failure in publishing SDK
-        fields: repo,commit,author,action
-        status: ${{ job.status }}
+    - name: Publish SDKs
+      uses: pulumi/pulumi-package-publisher@v0.0.5
   test:
     name: test
     needs: build_sdk

--- a/provider-ci/providers/ec/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/ec/repo/.github/workflows/master.yml
@@ -350,131 +350,13 @@ jobs:
         author_name: Failure in publishing binaries
         fields: repo,commit,author,action
         status: ${{ job.status }}
-  publish_java_sdk:
-    continue-on-error: true
-    name: publish_java_sdk
-    needs: publish
-    runs-on: ubuntu-latest
-    steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{ env.JAVAVERSION }}
-    - name: Setup Gradle
-      uses: gradle/gradle-build-action@v2
-      with:
-        gradle-version: "7.6"
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
   publish_sdk:
     name: publish_sdk
     needs: publish
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Node
-      uses: actions/setup-node@v2
-      with:
-        node-version: ${{ env.NODEVERSION }}
-        registry-url: https://registry.npmjs.org
-    - name: Setup DotNet
-      uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: ${{ env.DOTNETVERSION }}
-    - name: Setup Python
-      uses: actions/setup-python@v2
-      with:
-        python-version: ${{ env.PYTHONVERSION }}
-    - name: Download python SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: python-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress python SDK
-      run: tar -zxf ${{github.workspace}}/sdk/python.tar.gz -C
-        ${{github.workspace}}/sdk/python
-    - name: Download dotnet SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: dotnet-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress dotnet SDK
-      run: tar -zxf ${{github.workspace}}/sdk/dotnet.tar.gz -C
-        ${{github.workspace}}/sdk/dotnet
-    - name: Download nodejs SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: nodejs-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress nodejs SDK
-      run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
-        ${{github.workspace}}/sdk/nodejs
-    - run: python -m pip install pip twine
-    - env:
-        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-      name: Publish SDKs
-      run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - if: failure() && github.event_name == 'push'
-      name: Notify Slack
-      uses: 8398a7/action-slack@v3
-      with:
-        author_name: Failure in publishing SDK
-        fields: repo,commit,author,action
-        status: ${{ job.status }}
+    - name: Publish SDKs
+      uses: pulumi/pulumi-package-publisher@v0.0.5
   test:
     name: test
     needs: build_sdk

--- a/provider-ci/providers/ec/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/ec/repo/.github/workflows/prerelease.yml
@@ -300,131 +300,13 @@ jobs:
         author_name: Failure in publishing binaries
         fields: repo,commit,author,action
         status: ${{ job.status }}
-  publish_java_sdk:
-    continue-on-error: true
-    name: publish_java_sdk
-    needs: publish
-    runs-on: ubuntu-latest
-    steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{ env.JAVAVERSION }}
-    - name: Setup Gradle
-      uses: gradle/gradle-build-action@v2
-      with:
-        gradle-version: "7.6"
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
   publish_sdk:
     name: publish_sdk
     needs: publish
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Node
-      uses: actions/setup-node@v2
-      with:
-        node-version: ${{ env.NODEVERSION }}
-        registry-url: https://registry.npmjs.org
-    - name: Setup DotNet
-      uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: ${{ env.DOTNETVERSION }}
-    - name: Setup Python
-      uses: actions/setup-python@v2
-      with:
-        python-version: ${{ env.PYTHONVERSION }}
-    - name: Download python SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: python-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress python SDK
-      run: tar -zxf ${{github.workspace}}/sdk/python.tar.gz -C
-        ${{github.workspace}}/sdk/python
-    - name: Download dotnet SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: dotnet-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress dotnet SDK
-      run: tar -zxf ${{github.workspace}}/sdk/dotnet.tar.gz -C
-        ${{github.workspace}}/sdk/dotnet
-    - name: Download nodejs SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: nodejs-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress nodejs SDK
-      run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
-        ${{github.workspace}}/sdk/nodejs
-    - run: python -m pip install pip twine
-    - env:
-        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-      name: Publish SDKs
-      run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - if: failure() && github.event_name == 'push'
-      name: Notify Slack
-      uses: 8398a7/action-slack@v3
-      with:
-        author_name: Failure in publishing SDK
-        fields: repo,commit,author,action
-        status: ${{ job.status }}
+    - name: Publish SDKs
+      uses: pulumi/pulumi-package-publisher@v0.0.5
   test:
     name: test
     needs: build_sdk

--- a/provider-ci/providers/ec/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/ec/repo/.github/workflows/release.yml
@@ -312,131 +312,13 @@ jobs:
         author_name: Failure in publishing binaries
         fields: repo,commit,author,action
         status: ${{ job.status }}
-  publish_java_sdk:
-    continue-on-error: true
-    name: publish_java_sdk
-    needs: publish
-    runs-on: ubuntu-latest
-    steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{ env.JAVAVERSION }}
-    - name: Setup Gradle
-      uses: gradle/gradle-build-action@v2
-      with:
-        gradle-version: "7.6"
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
   publish_sdk:
     name: publish_sdk
     needs: publish
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Node
-      uses: actions/setup-node@v2
-      with:
-        node-version: ${{ env.NODEVERSION }}
-        registry-url: https://registry.npmjs.org
-    - name: Setup DotNet
-      uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: ${{ env.DOTNETVERSION }}
-    - name: Setup Python
-      uses: actions/setup-python@v2
-      with:
-        python-version: ${{ env.PYTHONVERSION }}
-    - name: Download python SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: python-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress python SDK
-      run: tar -zxf ${{github.workspace}}/sdk/python.tar.gz -C
-        ${{github.workspace}}/sdk/python
-    - name: Download dotnet SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: dotnet-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress dotnet SDK
-      run: tar -zxf ${{github.workspace}}/sdk/dotnet.tar.gz -C
-        ${{github.workspace}}/sdk/dotnet
-    - name: Download nodejs SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: nodejs-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress nodejs SDK
-      run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
-        ${{github.workspace}}/sdk/nodejs
-    - run: python -m pip install pip twine
-    - env:
-        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-      name: Publish SDKs
-      run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - if: failure() && github.event_name == 'push'
-      name: Notify Slack
-      uses: 8398a7/action-slack@v3
-      with:
-        author_name: Failure in publishing SDK
-        fields: repo,commit,author,action
-        status: ${{ job.status }}
+    - name: Publish SDKs
+      uses: pulumi/pulumi-package-publisher@v0.0.5
   tag_sdk:
     name: tag_sdk
     needs: publish_sdk

--- a/provider-ci/providers/equinix-metal/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/equinix-metal/repo/.github/workflows/main.yml
@@ -279,131 +279,13 @@ jobs:
         author_name: Failure in publishing binaries
         fields: repo,commit,author,action
         status: ${{ job.status }}
-  publish_java_sdk:
-    continue-on-error: true
-    name: publish_java_sdk
-    needs: publish
-    runs-on: ubuntu-latest
-    steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{ env.JAVAVERSION }}
-    - name: Setup Gradle
-      uses: gradle/gradle-build-action@v2
-      with:
-        gradle-version: "7.6"
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
   publish_sdk:
     name: publish_sdk
     needs: publish
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Node
-      uses: actions/setup-node@v2
-      with:
-        node-version: ${{ env.NODEVERSION }}
-        registry-url: https://registry.npmjs.org
-    - name: Setup DotNet
-      uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: ${{ env.DOTNETVERSION }}
-    - name: Setup Python
-      uses: actions/setup-python@v2
-      with:
-        python-version: ${{ env.PYTHONVERSION }}
-    - name: Download python SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: python-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress python SDK
-      run: tar -zxf ${{github.workspace}}/sdk/python.tar.gz -C
-        ${{github.workspace}}/sdk/python
-    - name: Download dotnet SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: dotnet-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress dotnet SDK
-      run: tar -zxf ${{github.workspace}}/sdk/dotnet.tar.gz -C
-        ${{github.workspace}}/sdk/dotnet
-    - name: Download nodejs SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: nodejs-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress nodejs SDK
-      run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
-        ${{github.workspace}}/sdk/nodejs
-    - run: python -m pip install pip twine
-    - env:
-        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-      name: Publish SDKs
-      run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - if: failure() && github.event_name == 'push'
-      name: Notify Slack
-      uses: 8398a7/action-slack@v3
-      with:
-        author_name: Failure in publishing SDK
-        fields: repo,commit,author,action
-        status: ${{ job.status }}
+    - name: Publish SDKs
+      uses: pulumi/pulumi-package-publisher@v0.0.5
   test:
     name: test
     needs: build_sdk

--- a/provider-ci/providers/equinix-metal/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/equinix-metal/repo/.github/workflows/master.yml
@@ -279,131 +279,13 @@ jobs:
         author_name: Failure in publishing binaries
         fields: repo,commit,author,action
         status: ${{ job.status }}
-  publish_java_sdk:
-    continue-on-error: true
-    name: publish_java_sdk
-    needs: publish
-    runs-on: ubuntu-latest
-    steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{ env.JAVAVERSION }}
-    - name: Setup Gradle
-      uses: gradle/gradle-build-action@v2
-      with:
-        gradle-version: "7.6"
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
   publish_sdk:
     name: publish_sdk
     needs: publish
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Node
-      uses: actions/setup-node@v2
-      with:
-        node-version: ${{ env.NODEVERSION }}
-        registry-url: https://registry.npmjs.org
-    - name: Setup DotNet
-      uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: ${{ env.DOTNETVERSION }}
-    - name: Setup Python
-      uses: actions/setup-python@v2
-      with:
-        python-version: ${{ env.PYTHONVERSION }}
-    - name: Download python SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: python-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress python SDK
-      run: tar -zxf ${{github.workspace}}/sdk/python.tar.gz -C
-        ${{github.workspace}}/sdk/python
-    - name: Download dotnet SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: dotnet-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress dotnet SDK
-      run: tar -zxf ${{github.workspace}}/sdk/dotnet.tar.gz -C
-        ${{github.workspace}}/sdk/dotnet
-    - name: Download nodejs SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: nodejs-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress nodejs SDK
-      run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
-        ${{github.workspace}}/sdk/nodejs
-    - run: python -m pip install pip twine
-    - env:
-        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-      name: Publish SDKs
-      run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - if: failure() && github.event_name == 'push'
-      name: Notify Slack
-      uses: 8398a7/action-slack@v3
-      with:
-        author_name: Failure in publishing SDK
-        fields: repo,commit,author,action
-        status: ${{ job.status }}
+    - name: Publish SDKs
+      uses: pulumi/pulumi-package-publisher@v0.0.5
   test:
     name: test
     needs: build_sdk

--- a/provider-ci/providers/equinix-metal/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/equinix-metal/repo/.github/workflows/prerelease.yml
@@ -229,131 +229,13 @@ jobs:
         author_name: Failure in publishing binaries
         fields: repo,commit,author,action
         status: ${{ job.status }}
-  publish_java_sdk:
-    continue-on-error: true
-    name: publish_java_sdk
-    needs: publish
-    runs-on: ubuntu-latest
-    steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{ env.JAVAVERSION }}
-    - name: Setup Gradle
-      uses: gradle/gradle-build-action@v2
-      with:
-        gradle-version: "7.6"
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
   publish_sdk:
     name: publish_sdk
     needs: publish
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Node
-      uses: actions/setup-node@v2
-      with:
-        node-version: ${{ env.NODEVERSION }}
-        registry-url: https://registry.npmjs.org
-    - name: Setup DotNet
-      uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: ${{ env.DOTNETVERSION }}
-    - name: Setup Python
-      uses: actions/setup-python@v2
-      with:
-        python-version: ${{ env.PYTHONVERSION }}
-    - name: Download python SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: python-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress python SDK
-      run: tar -zxf ${{github.workspace}}/sdk/python.tar.gz -C
-        ${{github.workspace}}/sdk/python
-    - name: Download dotnet SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: dotnet-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress dotnet SDK
-      run: tar -zxf ${{github.workspace}}/sdk/dotnet.tar.gz -C
-        ${{github.workspace}}/sdk/dotnet
-    - name: Download nodejs SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: nodejs-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress nodejs SDK
-      run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
-        ${{github.workspace}}/sdk/nodejs
-    - run: python -m pip install pip twine
-    - env:
-        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-      name: Publish SDKs
-      run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - if: failure() && github.event_name == 'push'
-      name: Notify Slack
-      uses: 8398a7/action-slack@v3
-      with:
-        author_name: Failure in publishing SDK
-        fields: repo,commit,author,action
-        status: ${{ job.status }}
+    - name: Publish SDKs
+      uses: pulumi/pulumi-package-publisher@v0.0.5
   test:
     name: test
     needs: build_sdk

--- a/provider-ci/providers/equinix-metal/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/equinix-metal/repo/.github/workflows/release.yml
@@ -241,131 +241,13 @@ jobs:
         author_name: Failure in publishing binaries
         fields: repo,commit,author,action
         status: ${{ job.status }}
-  publish_java_sdk:
-    continue-on-error: true
-    name: publish_java_sdk
-    needs: publish
-    runs-on: ubuntu-latest
-    steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{ env.JAVAVERSION }}
-    - name: Setup Gradle
-      uses: gradle/gradle-build-action@v2
-      with:
-        gradle-version: "7.6"
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
   publish_sdk:
     name: publish_sdk
     needs: publish
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Node
-      uses: actions/setup-node@v2
-      with:
-        node-version: ${{ env.NODEVERSION }}
-        registry-url: https://registry.npmjs.org
-    - name: Setup DotNet
-      uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: ${{ env.DOTNETVERSION }}
-    - name: Setup Python
-      uses: actions/setup-python@v2
-      with:
-        python-version: ${{ env.PYTHONVERSION }}
-    - name: Download python SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: python-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress python SDK
-      run: tar -zxf ${{github.workspace}}/sdk/python.tar.gz -C
-        ${{github.workspace}}/sdk/python
-    - name: Download dotnet SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: dotnet-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress dotnet SDK
-      run: tar -zxf ${{github.workspace}}/sdk/dotnet.tar.gz -C
-        ${{github.workspace}}/sdk/dotnet
-    - name: Download nodejs SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: nodejs-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress nodejs SDK
-      run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
-        ${{github.workspace}}/sdk/nodejs
-    - run: python -m pip install pip twine
-    - env:
-        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-      name: Publish SDKs
-      run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - if: failure() && github.event_name == 'push'
-      name: Notify Slack
-      uses: 8398a7/action-slack@v3
-      with:
-        author_name: Failure in publishing SDK
-        fields: repo,commit,author,action
-        status: ${{ job.status }}
+    - name: Publish SDKs
+      uses: pulumi/pulumi-package-publisher@v0.0.5
   tag_sdk:
     name: tag_sdk
     needs: publish_sdk

--- a/provider-ci/providers/f5bigip/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/f5bigip/repo/.github/workflows/main.yml
@@ -353,131 +353,13 @@ jobs:
         author_name: Failure in publishing binaries
         fields: repo,commit,author,action
         status: ${{ job.status }}
-  publish_java_sdk:
-    continue-on-error: true
-    name: publish_java_sdk
-    needs: publish
-    runs-on: ubuntu-latest
-    steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{ env.JAVAVERSION }}
-    - name: Setup Gradle
-      uses: gradle/gradle-build-action@v2
-      with:
-        gradle-version: "7.6"
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
   publish_sdk:
     name: publish_sdk
     needs: publish
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Node
-      uses: actions/setup-node@v2
-      with:
-        node-version: ${{ env.NODEVERSION }}
-        registry-url: https://registry.npmjs.org
-    - name: Setup DotNet
-      uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: ${{ env.DOTNETVERSION }}
-    - name: Setup Python
-      uses: actions/setup-python@v2
-      with:
-        python-version: ${{ env.PYTHONVERSION }}
-    - name: Download python SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: python-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress python SDK
-      run: tar -zxf ${{github.workspace}}/sdk/python.tar.gz -C
-        ${{github.workspace}}/sdk/python
-    - name: Download dotnet SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: dotnet-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress dotnet SDK
-      run: tar -zxf ${{github.workspace}}/sdk/dotnet.tar.gz -C
-        ${{github.workspace}}/sdk/dotnet
-    - name: Download nodejs SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: nodejs-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress nodejs SDK
-      run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
-        ${{github.workspace}}/sdk/nodejs
-    - run: python -m pip install pip twine
-    - env:
-        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-      name: Publish SDKs
-      run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - if: failure() && github.event_name == 'push'
-      name: Notify Slack
-      uses: 8398a7/action-slack@v3
-      with:
-        author_name: Failure in publishing SDK
-        fields: repo,commit,author,action
-        status: ${{ job.status }}
+    - name: Publish SDKs
+      uses: pulumi/pulumi-package-publisher@v0.0.5
   test:
     name: test
     needs: build_sdk

--- a/provider-ci/providers/f5bigip/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/f5bigip/repo/.github/workflows/master.yml
@@ -353,131 +353,13 @@ jobs:
         author_name: Failure in publishing binaries
         fields: repo,commit,author,action
         status: ${{ job.status }}
-  publish_java_sdk:
-    continue-on-error: true
-    name: publish_java_sdk
-    needs: publish
-    runs-on: ubuntu-latest
-    steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{ env.JAVAVERSION }}
-    - name: Setup Gradle
-      uses: gradle/gradle-build-action@v2
-      with:
-        gradle-version: "7.6"
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
   publish_sdk:
     name: publish_sdk
     needs: publish
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Node
-      uses: actions/setup-node@v2
-      with:
-        node-version: ${{ env.NODEVERSION }}
-        registry-url: https://registry.npmjs.org
-    - name: Setup DotNet
-      uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: ${{ env.DOTNETVERSION }}
-    - name: Setup Python
-      uses: actions/setup-python@v2
-      with:
-        python-version: ${{ env.PYTHONVERSION }}
-    - name: Download python SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: python-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress python SDK
-      run: tar -zxf ${{github.workspace}}/sdk/python.tar.gz -C
-        ${{github.workspace}}/sdk/python
-    - name: Download dotnet SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: dotnet-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress dotnet SDK
-      run: tar -zxf ${{github.workspace}}/sdk/dotnet.tar.gz -C
-        ${{github.workspace}}/sdk/dotnet
-    - name: Download nodejs SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: nodejs-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress nodejs SDK
-      run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
-        ${{github.workspace}}/sdk/nodejs
-    - run: python -m pip install pip twine
-    - env:
-        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-      name: Publish SDKs
-      run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - if: failure() && github.event_name == 'push'
-      name: Notify Slack
-      uses: 8398a7/action-slack@v3
-      with:
-        author_name: Failure in publishing SDK
-        fields: repo,commit,author,action
-        status: ${{ job.status }}
+    - name: Publish SDKs
+      uses: pulumi/pulumi-package-publisher@v0.0.5
   test:
     name: test
     needs: build_sdk

--- a/provider-ci/providers/f5bigip/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/f5bigip/repo/.github/workflows/prerelease.yml
@@ -303,131 +303,13 @@ jobs:
         author_name: Failure in publishing binaries
         fields: repo,commit,author,action
         status: ${{ job.status }}
-  publish_java_sdk:
-    continue-on-error: true
-    name: publish_java_sdk
-    needs: publish
-    runs-on: ubuntu-latest
-    steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{ env.JAVAVERSION }}
-    - name: Setup Gradle
-      uses: gradle/gradle-build-action@v2
-      with:
-        gradle-version: "7.6"
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
   publish_sdk:
     name: publish_sdk
     needs: publish
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Node
-      uses: actions/setup-node@v2
-      with:
-        node-version: ${{ env.NODEVERSION }}
-        registry-url: https://registry.npmjs.org
-    - name: Setup DotNet
-      uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: ${{ env.DOTNETVERSION }}
-    - name: Setup Python
-      uses: actions/setup-python@v2
-      with:
-        python-version: ${{ env.PYTHONVERSION }}
-    - name: Download python SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: python-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress python SDK
-      run: tar -zxf ${{github.workspace}}/sdk/python.tar.gz -C
-        ${{github.workspace}}/sdk/python
-    - name: Download dotnet SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: dotnet-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress dotnet SDK
-      run: tar -zxf ${{github.workspace}}/sdk/dotnet.tar.gz -C
-        ${{github.workspace}}/sdk/dotnet
-    - name: Download nodejs SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: nodejs-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress nodejs SDK
-      run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
-        ${{github.workspace}}/sdk/nodejs
-    - run: python -m pip install pip twine
-    - env:
-        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-      name: Publish SDKs
-      run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - if: failure() && github.event_name == 'push'
-      name: Notify Slack
-      uses: 8398a7/action-slack@v3
-      with:
-        author_name: Failure in publishing SDK
-        fields: repo,commit,author,action
-        status: ${{ job.status }}
+    - name: Publish SDKs
+      uses: pulumi/pulumi-package-publisher@v0.0.5
   test:
     name: test
     needs: build_sdk

--- a/provider-ci/providers/f5bigip/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/f5bigip/repo/.github/workflows/release.yml
@@ -315,131 +315,13 @@ jobs:
         author_name: Failure in publishing binaries
         fields: repo,commit,author,action
         status: ${{ job.status }}
-  publish_java_sdk:
-    continue-on-error: true
-    name: publish_java_sdk
-    needs: publish
-    runs-on: ubuntu-latest
-    steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{ env.JAVAVERSION }}
-    - name: Setup Gradle
-      uses: gradle/gradle-build-action@v2
-      with:
-        gradle-version: "7.6"
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
   publish_sdk:
     name: publish_sdk
     needs: publish
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Node
-      uses: actions/setup-node@v2
-      with:
-        node-version: ${{ env.NODEVERSION }}
-        registry-url: https://registry.npmjs.org
-    - name: Setup DotNet
-      uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: ${{ env.DOTNETVERSION }}
-    - name: Setup Python
-      uses: actions/setup-python@v2
-      with:
-        python-version: ${{ env.PYTHONVERSION }}
-    - name: Download python SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: python-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress python SDK
-      run: tar -zxf ${{github.workspace}}/sdk/python.tar.gz -C
-        ${{github.workspace}}/sdk/python
-    - name: Download dotnet SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: dotnet-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress dotnet SDK
-      run: tar -zxf ${{github.workspace}}/sdk/dotnet.tar.gz -C
-        ${{github.workspace}}/sdk/dotnet
-    - name: Download nodejs SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: nodejs-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress nodejs SDK
-      run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
-        ${{github.workspace}}/sdk/nodejs
-    - run: python -m pip install pip twine
-    - env:
-        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-      name: Publish SDKs
-      run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - if: failure() && github.event_name == 'push'
-      name: Notify Slack
-      uses: 8398a7/action-slack@v3
-      with:
-        author_name: Failure in publishing SDK
-        fields: repo,commit,author,action
-        status: ${{ job.status }}
+    - name: Publish SDKs
+      uses: pulumi/pulumi-package-publisher@v0.0.5
   tag_sdk:
     name: tag_sdk
     needs: publish_sdk

--- a/provider-ci/providers/fastly/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/fastly/repo/.github/workflows/main.yml
@@ -350,131 +350,13 @@ jobs:
         author_name: Failure in publishing binaries
         fields: repo,commit,author,action
         status: ${{ job.status }}
-  publish_java_sdk:
-    continue-on-error: true
-    name: publish_java_sdk
-    needs: publish
-    runs-on: ubuntu-latest
-    steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{ env.JAVAVERSION }}
-    - name: Setup Gradle
-      uses: gradle/gradle-build-action@v2
-      with:
-        gradle-version: "7.6"
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
   publish_sdk:
     name: publish_sdk
     needs: publish
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Node
-      uses: actions/setup-node@v2
-      with:
-        node-version: ${{ env.NODEVERSION }}
-        registry-url: https://registry.npmjs.org
-    - name: Setup DotNet
-      uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: ${{ env.DOTNETVERSION }}
-    - name: Setup Python
-      uses: actions/setup-python@v2
-      with:
-        python-version: ${{ env.PYTHONVERSION }}
-    - name: Download python SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: python-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress python SDK
-      run: tar -zxf ${{github.workspace}}/sdk/python.tar.gz -C
-        ${{github.workspace}}/sdk/python
-    - name: Download dotnet SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: dotnet-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress dotnet SDK
-      run: tar -zxf ${{github.workspace}}/sdk/dotnet.tar.gz -C
-        ${{github.workspace}}/sdk/dotnet
-    - name: Download nodejs SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: nodejs-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress nodejs SDK
-      run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
-        ${{github.workspace}}/sdk/nodejs
-    - run: python -m pip install pip twine
-    - env:
-        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-      name: Publish SDKs
-      run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - if: failure() && github.event_name == 'push'
-      name: Notify Slack
-      uses: 8398a7/action-slack@v3
-      with:
-        author_name: Failure in publishing SDK
-        fields: repo,commit,author,action
-        status: ${{ job.status }}
+    - name: Publish SDKs
+      uses: pulumi/pulumi-package-publisher@v0.0.5
   test:
     name: test
     needs: build_sdk

--- a/provider-ci/providers/fastly/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/fastly/repo/.github/workflows/master.yml
@@ -350,131 +350,13 @@ jobs:
         author_name: Failure in publishing binaries
         fields: repo,commit,author,action
         status: ${{ job.status }}
-  publish_java_sdk:
-    continue-on-error: true
-    name: publish_java_sdk
-    needs: publish
-    runs-on: ubuntu-latest
-    steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{ env.JAVAVERSION }}
-    - name: Setup Gradle
-      uses: gradle/gradle-build-action@v2
-      with:
-        gradle-version: "7.6"
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
   publish_sdk:
     name: publish_sdk
     needs: publish
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Node
-      uses: actions/setup-node@v2
-      with:
-        node-version: ${{ env.NODEVERSION }}
-        registry-url: https://registry.npmjs.org
-    - name: Setup DotNet
-      uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: ${{ env.DOTNETVERSION }}
-    - name: Setup Python
-      uses: actions/setup-python@v2
-      with:
-        python-version: ${{ env.PYTHONVERSION }}
-    - name: Download python SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: python-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress python SDK
-      run: tar -zxf ${{github.workspace}}/sdk/python.tar.gz -C
-        ${{github.workspace}}/sdk/python
-    - name: Download dotnet SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: dotnet-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress dotnet SDK
-      run: tar -zxf ${{github.workspace}}/sdk/dotnet.tar.gz -C
-        ${{github.workspace}}/sdk/dotnet
-    - name: Download nodejs SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: nodejs-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress nodejs SDK
-      run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
-        ${{github.workspace}}/sdk/nodejs
-    - run: python -m pip install pip twine
-    - env:
-        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-      name: Publish SDKs
-      run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - if: failure() && github.event_name == 'push'
-      name: Notify Slack
-      uses: 8398a7/action-slack@v3
-      with:
-        author_name: Failure in publishing SDK
-        fields: repo,commit,author,action
-        status: ${{ job.status }}
+    - name: Publish SDKs
+      uses: pulumi/pulumi-package-publisher@v0.0.5
   test:
     name: test
     needs: build_sdk

--- a/provider-ci/providers/fastly/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/fastly/repo/.github/workflows/prerelease.yml
@@ -300,131 +300,13 @@ jobs:
         author_name: Failure in publishing binaries
         fields: repo,commit,author,action
         status: ${{ job.status }}
-  publish_java_sdk:
-    continue-on-error: true
-    name: publish_java_sdk
-    needs: publish
-    runs-on: ubuntu-latest
-    steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{ env.JAVAVERSION }}
-    - name: Setup Gradle
-      uses: gradle/gradle-build-action@v2
-      with:
-        gradle-version: "7.6"
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
   publish_sdk:
     name: publish_sdk
     needs: publish
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Node
-      uses: actions/setup-node@v2
-      with:
-        node-version: ${{ env.NODEVERSION }}
-        registry-url: https://registry.npmjs.org
-    - name: Setup DotNet
-      uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: ${{ env.DOTNETVERSION }}
-    - name: Setup Python
-      uses: actions/setup-python@v2
-      with:
-        python-version: ${{ env.PYTHONVERSION }}
-    - name: Download python SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: python-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress python SDK
-      run: tar -zxf ${{github.workspace}}/sdk/python.tar.gz -C
-        ${{github.workspace}}/sdk/python
-    - name: Download dotnet SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: dotnet-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress dotnet SDK
-      run: tar -zxf ${{github.workspace}}/sdk/dotnet.tar.gz -C
-        ${{github.workspace}}/sdk/dotnet
-    - name: Download nodejs SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: nodejs-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress nodejs SDK
-      run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
-        ${{github.workspace}}/sdk/nodejs
-    - run: python -m pip install pip twine
-    - env:
-        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-      name: Publish SDKs
-      run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - if: failure() && github.event_name == 'push'
-      name: Notify Slack
-      uses: 8398a7/action-slack@v3
-      with:
-        author_name: Failure in publishing SDK
-        fields: repo,commit,author,action
-        status: ${{ job.status }}
+    - name: Publish SDKs
+      uses: pulumi/pulumi-package-publisher@v0.0.5
   test:
     name: test
     needs: build_sdk

--- a/provider-ci/providers/fastly/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/fastly/repo/.github/workflows/release.yml
@@ -312,131 +312,13 @@ jobs:
         author_name: Failure in publishing binaries
         fields: repo,commit,author,action
         status: ${{ job.status }}
-  publish_java_sdk:
-    continue-on-error: true
-    name: publish_java_sdk
-    needs: publish
-    runs-on: ubuntu-latest
-    steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{ env.JAVAVERSION }}
-    - name: Setup Gradle
-      uses: gradle/gradle-build-action@v2
-      with:
-        gradle-version: "7.6"
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
   publish_sdk:
     name: publish_sdk
     needs: publish
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Node
-      uses: actions/setup-node@v2
-      with:
-        node-version: ${{ env.NODEVERSION }}
-        registry-url: https://registry.npmjs.org
-    - name: Setup DotNet
-      uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: ${{ env.DOTNETVERSION }}
-    - name: Setup Python
-      uses: actions/setup-python@v2
-      with:
-        python-version: ${{ env.PYTHONVERSION }}
-    - name: Download python SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: python-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress python SDK
-      run: tar -zxf ${{github.workspace}}/sdk/python.tar.gz -C
-        ${{github.workspace}}/sdk/python
-    - name: Download dotnet SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: dotnet-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress dotnet SDK
-      run: tar -zxf ${{github.workspace}}/sdk/dotnet.tar.gz -C
-        ${{github.workspace}}/sdk/dotnet
-    - name: Download nodejs SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: nodejs-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress nodejs SDK
-      run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
-        ${{github.workspace}}/sdk/nodejs
-    - run: python -m pip install pip twine
-    - env:
-        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-      name: Publish SDKs
-      run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - if: failure() && github.event_name == 'push'
-      name: Notify Slack
-      uses: 8398a7/action-slack@v3
-      with:
-        author_name: Failure in publishing SDK
-        fields: repo,commit,author,action
-        status: ${{ job.status }}
+    - name: Publish SDKs
+      uses: pulumi/pulumi-package-publisher@v0.0.5
   tag_sdk:
     name: tag_sdk
     needs: publish_sdk

--- a/provider-ci/providers/gcp/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/gcp/repo/.github/workflows/main.yml
@@ -286,131 +286,13 @@ jobs:
         author_name: Failure in publishing binaries
         fields: repo,commit,author,action
         status: ${{ job.status }}
-  publish_java_sdk:
-    continue-on-error: true
-    name: publish_java_sdk
-    needs: publish
-    runs-on: ubuntu-latest
-    steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{ env.JAVAVERSION }}
-    - name: Setup Gradle
-      uses: gradle/gradle-build-action@v2
-      with:
-        gradle-version: "7.6"
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
   publish_sdk:
     name: publish_sdk
     needs: publish
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Node
-      uses: actions/setup-node@v2
-      with:
-        node-version: ${{ env.NODEVERSION }}
-        registry-url: https://registry.npmjs.org
-    - name: Setup DotNet
-      uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: ${{ env.DOTNETVERSION }}
-    - name: Setup Python
-      uses: actions/setup-python@v2
-      with:
-        python-version: ${{ env.PYTHONVERSION }}
-    - name: Download python SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: python-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress python SDK
-      run: tar -zxf ${{github.workspace}}/sdk/python.tar.gz -C
-        ${{github.workspace}}/sdk/python
-    - name: Download dotnet SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: dotnet-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress dotnet SDK
-      run: tar -zxf ${{github.workspace}}/sdk/dotnet.tar.gz -C
-        ${{github.workspace}}/sdk/dotnet
-    - name: Download nodejs SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: nodejs-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress nodejs SDK
-      run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
-        ${{github.workspace}}/sdk/nodejs
-    - run: python -m pip install pip twine
-    - env:
-        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-      name: Publish SDKs
-      run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - if: failure() && github.event_name == 'push'
-      name: Notify Slack
-      uses: 8398a7/action-slack@v3
-      with:
-        author_name: Failure in publishing SDK
-        fields: repo,commit,author,action
-        status: ${{ job.status }}
+    - name: Publish SDKs
+      uses: pulumi/pulumi-package-publisher@v0.0.5
   test:
     name: test
     needs: build_sdk

--- a/provider-ci/providers/gcp/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/gcp/repo/.github/workflows/master.yml
@@ -286,131 +286,13 @@ jobs:
         author_name: Failure in publishing binaries
         fields: repo,commit,author,action
         status: ${{ job.status }}
-  publish_java_sdk:
-    continue-on-error: true
-    name: publish_java_sdk
-    needs: publish
-    runs-on: ubuntu-latest
-    steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{ env.JAVAVERSION }}
-    - name: Setup Gradle
-      uses: gradle/gradle-build-action@v2
-      with:
-        gradle-version: "7.6"
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
   publish_sdk:
     name: publish_sdk
     needs: publish
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Node
-      uses: actions/setup-node@v2
-      with:
-        node-version: ${{ env.NODEVERSION }}
-        registry-url: https://registry.npmjs.org
-    - name: Setup DotNet
-      uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: ${{ env.DOTNETVERSION }}
-    - name: Setup Python
-      uses: actions/setup-python@v2
-      with:
-        python-version: ${{ env.PYTHONVERSION }}
-    - name: Download python SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: python-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress python SDK
-      run: tar -zxf ${{github.workspace}}/sdk/python.tar.gz -C
-        ${{github.workspace}}/sdk/python
-    - name: Download dotnet SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: dotnet-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress dotnet SDK
-      run: tar -zxf ${{github.workspace}}/sdk/dotnet.tar.gz -C
-        ${{github.workspace}}/sdk/dotnet
-    - name: Download nodejs SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: nodejs-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress nodejs SDK
-      run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
-        ${{github.workspace}}/sdk/nodejs
-    - run: python -m pip install pip twine
-    - env:
-        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-      name: Publish SDKs
-      run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - if: failure() && github.event_name == 'push'
-      name: Notify Slack
-      uses: 8398a7/action-slack@v3
-      with:
-        author_name: Failure in publishing SDK
-        fields: repo,commit,author,action
-        status: ${{ job.status }}
+    - name: Publish SDKs
+      uses: pulumi/pulumi-package-publisher@v0.0.5
   test:
     name: test
     needs: build_sdk

--- a/provider-ci/providers/gcp/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/gcp/repo/.github/workflows/prerelease.yml
@@ -236,131 +236,13 @@ jobs:
         author_name: Failure in publishing binaries
         fields: repo,commit,author,action
         status: ${{ job.status }}
-  publish_java_sdk:
-    continue-on-error: true
-    name: publish_java_sdk
-    needs: publish
-    runs-on: ubuntu-latest
-    steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{ env.JAVAVERSION }}
-    - name: Setup Gradle
-      uses: gradle/gradle-build-action@v2
-      with:
-        gradle-version: "7.6"
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
   publish_sdk:
     name: publish_sdk
     needs: publish
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Node
-      uses: actions/setup-node@v2
-      with:
-        node-version: ${{ env.NODEVERSION }}
-        registry-url: https://registry.npmjs.org
-    - name: Setup DotNet
-      uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: ${{ env.DOTNETVERSION }}
-    - name: Setup Python
-      uses: actions/setup-python@v2
-      with:
-        python-version: ${{ env.PYTHONVERSION }}
-    - name: Download python SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: python-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress python SDK
-      run: tar -zxf ${{github.workspace}}/sdk/python.tar.gz -C
-        ${{github.workspace}}/sdk/python
-    - name: Download dotnet SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: dotnet-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress dotnet SDK
-      run: tar -zxf ${{github.workspace}}/sdk/dotnet.tar.gz -C
-        ${{github.workspace}}/sdk/dotnet
-    - name: Download nodejs SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: nodejs-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress nodejs SDK
-      run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
-        ${{github.workspace}}/sdk/nodejs
-    - run: python -m pip install pip twine
-    - env:
-        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-      name: Publish SDKs
-      run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - if: failure() && github.event_name == 'push'
-      name: Notify Slack
-      uses: 8398a7/action-slack@v3
-      with:
-        author_name: Failure in publishing SDK
-        fields: repo,commit,author,action
-        status: ${{ job.status }}
+    - name: Publish SDKs
+      uses: pulumi/pulumi-package-publisher@v0.0.5
   test:
     name: test
     needs: build_sdk

--- a/provider-ci/providers/gcp/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/gcp/repo/.github/workflows/release.yml
@@ -248,131 +248,13 @@ jobs:
         author_name: Failure in publishing binaries
         fields: repo,commit,author,action
         status: ${{ job.status }}
-  publish_java_sdk:
-    continue-on-error: true
-    name: publish_java_sdk
-    needs: publish
-    runs-on: ubuntu-latest
-    steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{ env.JAVAVERSION }}
-    - name: Setup Gradle
-      uses: gradle/gradle-build-action@v2
-      with:
-        gradle-version: "7.6"
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
   publish_sdk:
     name: publish_sdk
     needs: publish
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Node
-      uses: actions/setup-node@v2
-      with:
-        node-version: ${{ env.NODEVERSION }}
-        registry-url: https://registry.npmjs.org
-    - name: Setup DotNet
-      uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: ${{ env.DOTNETVERSION }}
-    - name: Setup Python
-      uses: actions/setup-python@v2
-      with:
-        python-version: ${{ env.PYTHONVERSION }}
-    - name: Download python SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: python-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress python SDK
-      run: tar -zxf ${{github.workspace}}/sdk/python.tar.gz -C
-        ${{github.workspace}}/sdk/python
-    - name: Download dotnet SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: dotnet-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress dotnet SDK
-      run: tar -zxf ${{github.workspace}}/sdk/dotnet.tar.gz -C
-        ${{github.workspace}}/sdk/dotnet
-    - name: Download nodejs SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: nodejs-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress nodejs SDK
-      run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
-        ${{github.workspace}}/sdk/nodejs
-    - run: python -m pip install pip twine
-    - env:
-        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-      name: Publish SDKs
-      run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - if: failure() && github.event_name == 'push'
-      name: Notify Slack
-      uses: 8398a7/action-slack@v3
-      with:
-        author_name: Failure in publishing SDK
-        fields: repo,commit,author,action
-        status: ${{ job.status }}
+    - name: Publish SDKs
+      uses: pulumi/pulumi-package-publisher@v0.0.5
   tag_sdk:
     name: tag_sdk
     needs: publish_sdk

--- a/provider-ci/providers/github/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/github/repo/.github/workflows/main.yml
@@ -351,131 +351,13 @@ jobs:
         author_name: Failure in publishing binaries
         fields: repo,commit,author,action
         status: ${{ job.status }}
-  publish_java_sdk:
-    continue-on-error: true
-    name: publish_java_sdk
-    needs: publish
-    runs-on: ubuntu-latest
-    steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{ env.JAVAVERSION }}
-    - name: Setup Gradle
-      uses: gradle/gradle-build-action@v2
-      with:
-        gradle-version: "7.6"
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
   publish_sdk:
     name: publish_sdk
     needs: publish
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Node
-      uses: actions/setup-node@v2
-      with:
-        node-version: ${{ env.NODEVERSION }}
-        registry-url: https://registry.npmjs.org
-    - name: Setup DotNet
-      uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: ${{ env.DOTNETVERSION }}
-    - name: Setup Python
-      uses: actions/setup-python@v2
-      with:
-        python-version: ${{ env.PYTHONVERSION }}
-    - name: Download python SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: python-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress python SDK
-      run: tar -zxf ${{github.workspace}}/sdk/python.tar.gz -C
-        ${{github.workspace}}/sdk/python
-    - name: Download dotnet SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: dotnet-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress dotnet SDK
-      run: tar -zxf ${{github.workspace}}/sdk/dotnet.tar.gz -C
-        ${{github.workspace}}/sdk/dotnet
-    - name: Download nodejs SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: nodejs-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress nodejs SDK
-      run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
-        ${{github.workspace}}/sdk/nodejs
-    - run: python -m pip install pip twine
-    - env:
-        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-      name: Publish SDKs
-      run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - if: failure() && github.event_name == 'push'
-      name: Notify Slack
-      uses: 8398a7/action-slack@v3
-      with:
-        author_name: Failure in publishing SDK
-        fields: repo,commit,author,action
-        status: ${{ job.status }}
+    - name: Publish SDKs
+      uses: pulumi/pulumi-package-publisher@v0.0.5
   test:
     name: test
     needs: build_sdk

--- a/provider-ci/providers/github/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/github/repo/.github/workflows/master.yml
@@ -351,131 +351,13 @@ jobs:
         author_name: Failure in publishing binaries
         fields: repo,commit,author,action
         status: ${{ job.status }}
-  publish_java_sdk:
-    continue-on-error: true
-    name: publish_java_sdk
-    needs: publish
-    runs-on: ubuntu-latest
-    steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{ env.JAVAVERSION }}
-    - name: Setup Gradle
-      uses: gradle/gradle-build-action@v2
-      with:
-        gradle-version: "7.6"
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
   publish_sdk:
     name: publish_sdk
     needs: publish
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Node
-      uses: actions/setup-node@v2
-      with:
-        node-version: ${{ env.NODEVERSION }}
-        registry-url: https://registry.npmjs.org
-    - name: Setup DotNet
-      uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: ${{ env.DOTNETVERSION }}
-    - name: Setup Python
-      uses: actions/setup-python@v2
-      with:
-        python-version: ${{ env.PYTHONVERSION }}
-    - name: Download python SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: python-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress python SDK
-      run: tar -zxf ${{github.workspace}}/sdk/python.tar.gz -C
-        ${{github.workspace}}/sdk/python
-    - name: Download dotnet SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: dotnet-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress dotnet SDK
-      run: tar -zxf ${{github.workspace}}/sdk/dotnet.tar.gz -C
-        ${{github.workspace}}/sdk/dotnet
-    - name: Download nodejs SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: nodejs-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress nodejs SDK
-      run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
-        ${{github.workspace}}/sdk/nodejs
-    - run: python -m pip install pip twine
-    - env:
-        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-      name: Publish SDKs
-      run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - if: failure() && github.event_name == 'push'
-      name: Notify Slack
-      uses: 8398a7/action-slack@v3
-      with:
-        author_name: Failure in publishing SDK
-        fields: repo,commit,author,action
-        status: ${{ job.status }}
+    - name: Publish SDKs
+      uses: pulumi/pulumi-package-publisher@v0.0.5
   test:
     name: test
     needs: build_sdk

--- a/provider-ci/providers/github/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/github/repo/.github/workflows/prerelease.yml
@@ -301,131 +301,13 @@ jobs:
         author_name: Failure in publishing binaries
         fields: repo,commit,author,action
         status: ${{ job.status }}
-  publish_java_sdk:
-    continue-on-error: true
-    name: publish_java_sdk
-    needs: publish
-    runs-on: ubuntu-latest
-    steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{ env.JAVAVERSION }}
-    - name: Setup Gradle
-      uses: gradle/gradle-build-action@v2
-      with:
-        gradle-version: "7.6"
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
   publish_sdk:
     name: publish_sdk
     needs: publish
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Node
-      uses: actions/setup-node@v2
-      with:
-        node-version: ${{ env.NODEVERSION }}
-        registry-url: https://registry.npmjs.org
-    - name: Setup DotNet
-      uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: ${{ env.DOTNETVERSION }}
-    - name: Setup Python
-      uses: actions/setup-python@v2
-      with:
-        python-version: ${{ env.PYTHONVERSION }}
-    - name: Download python SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: python-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress python SDK
-      run: tar -zxf ${{github.workspace}}/sdk/python.tar.gz -C
-        ${{github.workspace}}/sdk/python
-    - name: Download dotnet SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: dotnet-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress dotnet SDK
-      run: tar -zxf ${{github.workspace}}/sdk/dotnet.tar.gz -C
-        ${{github.workspace}}/sdk/dotnet
-    - name: Download nodejs SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: nodejs-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress nodejs SDK
-      run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
-        ${{github.workspace}}/sdk/nodejs
-    - run: python -m pip install pip twine
-    - env:
-        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-      name: Publish SDKs
-      run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - if: failure() && github.event_name == 'push'
-      name: Notify Slack
-      uses: 8398a7/action-slack@v3
-      with:
-        author_name: Failure in publishing SDK
-        fields: repo,commit,author,action
-        status: ${{ job.status }}
+    - name: Publish SDKs
+      uses: pulumi/pulumi-package-publisher@v0.0.5
   test:
     name: test
     needs: build_sdk

--- a/provider-ci/providers/github/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/github/repo/.github/workflows/release.yml
@@ -313,131 +313,13 @@ jobs:
         author_name: Failure in publishing binaries
         fields: repo,commit,author,action
         status: ${{ job.status }}
-  publish_java_sdk:
-    continue-on-error: true
-    name: publish_java_sdk
-    needs: publish
-    runs-on: ubuntu-latest
-    steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{ env.JAVAVERSION }}
-    - name: Setup Gradle
-      uses: gradle/gradle-build-action@v2
-      with:
-        gradle-version: "7.6"
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
   publish_sdk:
     name: publish_sdk
     needs: publish
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Node
-      uses: actions/setup-node@v2
-      with:
-        node-version: ${{ env.NODEVERSION }}
-        registry-url: https://registry.npmjs.org
-    - name: Setup DotNet
-      uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: ${{ env.DOTNETVERSION }}
-    - name: Setup Python
-      uses: actions/setup-python@v2
-      with:
-        python-version: ${{ env.PYTHONVERSION }}
-    - name: Download python SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: python-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress python SDK
-      run: tar -zxf ${{github.workspace}}/sdk/python.tar.gz -C
-        ${{github.workspace}}/sdk/python
-    - name: Download dotnet SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: dotnet-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress dotnet SDK
-      run: tar -zxf ${{github.workspace}}/sdk/dotnet.tar.gz -C
-        ${{github.workspace}}/sdk/dotnet
-    - name: Download nodejs SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: nodejs-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress nodejs SDK
-      run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
-        ${{github.workspace}}/sdk/nodejs
-    - run: python -m pip install pip twine
-    - env:
-        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-      name: Publish SDKs
-      run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - if: failure() && github.event_name == 'push'
-      name: Notify Slack
-      uses: 8398a7/action-slack@v3
-      with:
-        author_name: Failure in publishing SDK
-        fields: repo,commit,author,action
-        status: ${{ job.status }}
+    - name: Publish SDKs
+      uses: pulumi/pulumi-package-publisher@v0.0.5
   tag_sdk:
     name: tag_sdk
     needs: publish_sdk

--- a/provider-ci/providers/gitlab/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/gitlab/repo/.github/workflows/main.yml
@@ -350,131 +350,13 @@ jobs:
         author_name: Failure in publishing binaries
         fields: repo,commit,author,action
         status: ${{ job.status }}
-  publish_java_sdk:
-    continue-on-error: true
-    name: publish_java_sdk
-    needs: publish
-    runs-on: ubuntu-latest
-    steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{ env.JAVAVERSION }}
-    - name: Setup Gradle
-      uses: gradle/gradle-build-action@v2
-      with:
-        gradle-version: "7.6"
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
   publish_sdk:
     name: publish_sdk
     needs: publish
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Node
-      uses: actions/setup-node@v2
-      with:
-        node-version: ${{ env.NODEVERSION }}
-        registry-url: https://registry.npmjs.org
-    - name: Setup DotNet
-      uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: ${{ env.DOTNETVERSION }}
-    - name: Setup Python
-      uses: actions/setup-python@v2
-      with:
-        python-version: ${{ env.PYTHONVERSION }}
-    - name: Download python SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: python-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress python SDK
-      run: tar -zxf ${{github.workspace}}/sdk/python.tar.gz -C
-        ${{github.workspace}}/sdk/python
-    - name: Download dotnet SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: dotnet-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress dotnet SDK
-      run: tar -zxf ${{github.workspace}}/sdk/dotnet.tar.gz -C
-        ${{github.workspace}}/sdk/dotnet
-    - name: Download nodejs SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: nodejs-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress nodejs SDK
-      run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
-        ${{github.workspace}}/sdk/nodejs
-    - run: python -m pip install pip twine
-    - env:
-        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-      name: Publish SDKs
-      run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - if: failure() && github.event_name == 'push'
-      name: Notify Slack
-      uses: 8398a7/action-slack@v3
-      with:
-        author_name: Failure in publishing SDK
-        fields: repo,commit,author,action
-        status: ${{ job.status }}
+    - name: Publish SDKs
+      uses: pulumi/pulumi-package-publisher@v0.0.5
   test:
     name: test
     needs: build_sdk

--- a/provider-ci/providers/gitlab/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/gitlab/repo/.github/workflows/master.yml
@@ -350,131 +350,13 @@ jobs:
         author_name: Failure in publishing binaries
         fields: repo,commit,author,action
         status: ${{ job.status }}
-  publish_java_sdk:
-    continue-on-error: true
-    name: publish_java_sdk
-    needs: publish
-    runs-on: ubuntu-latest
-    steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{ env.JAVAVERSION }}
-    - name: Setup Gradle
-      uses: gradle/gradle-build-action@v2
-      with:
-        gradle-version: "7.6"
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
   publish_sdk:
     name: publish_sdk
     needs: publish
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Node
-      uses: actions/setup-node@v2
-      with:
-        node-version: ${{ env.NODEVERSION }}
-        registry-url: https://registry.npmjs.org
-    - name: Setup DotNet
-      uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: ${{ env.DOTNETVERSION }}
-    - name: Setup Python
-      uses: actions/setup-python@v2
-      with:
-        python-version: ${{ env.PYTHONVERSION }}
-    - name: Download python SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: python-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress python SDK
-      run: tar -zxf ${{github.workspace}}/sdk/python.tar.gz -C
-        ${{github.workspace}}/sdk/python
-    - name: Download dotnet SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: dotnet-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress dotnet SDK
-      run: tar -zxf ${{github.workspace}}/sdk/dotnet.tar.gz -C
-        ${{github.workspace}}/sdk/dotnet
-    - name: Download nodejs SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: nodejs-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress nodejs SDK
-      run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
-        ${{github.workspace}}/sdk/nodejs
-    - run: python -m pip install pip twine
-    - env:
-        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-      name: Publish SDKs
-      run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - if: failure() && github.event_name == 'push'
-      name: Notify Slack
-      uses: 8398a7/action-slack@v3
-      with:
-        author_name: Failure in publishing SDK
-        fields: repo,commit,author,action
-        status: ${{ job.status }}
+    - name: Publish SDKs
+      uses: pulumi/pulumi-package-publisher@v0.0.5
   test:
     name: test
     needs: build_sdk

--- a/provider-ci/providers/gitlab/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/gitlab/repo/.github/workflows/prerelease.yml
@@ -300,131 +300,13 @@ jobs:
         author_name: Failure in publishing binaries
         fields: repo,commit,author,action
         status: ${{ job.status }}
-  publish_java_sdk:
-    continue-on-error: true
-    name: publish_java_sdk
-    needs: publish
-    runs-on: ubuntu-latest
-    steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{ env.JAVAVERSION }}
-    - name: Setup Gradle
-      uses: gradle/gradle-build-action@v2
-      with:
-        gradle-version: "7.6"
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
   publish_sdk:
     name: publish_sdk
     needs: publish
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Node
-      uses: actions/setup-node@v2
-      with:
-        node-version: ${{ env.NODEVERSION }}
-        registry-url: https://registry.npmjs.org
-    - name: Setup DotNet
-      uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: ${{ env.DOTNETVERSION }}
-    - name: Setup Python
-      uses: actions/setup-python@v2
-      with:
-        python-version: ${{ env.PYTHONVERSION }}
-    - name: Download python SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: python-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress python SDK
-      run: tar -zxf ${{github.workspace}}/sdk/python.tar.gz -C
-        ${{github.workspace}}/sdk/python
-    - name: Download dotnet SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: dotnet-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress dotnet SDK
-      run: tar -zxf ${{github.workspace}}/sdk/dotnet.tar.gz -C
-        ${{github.workspace}}/sdk/dotnet
-    - name: Download nodejs SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: nodejs-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress nodejs SDK
-      run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
-        ${{github.workspace}}/sdk/nodejs
-    - run: python -m pip install pip twine
-    - env:
-        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-      name: Publish SDKs
-      run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - if: failure() && github.event_name == 'push'
-      name: Notify Slack
-      uses: 8398a7/action-slack@v3
-      with:
-        author_name: Failure in publishing SDK
-        fields: repo,commit,author,action
-        status: ${{ job.status }}
+    - name: Publish SDKs
+      uses: pulumi/pulumi-package-publisher@v0.0.5
   test:
     name: test
     needs: build_sdk

--- a/provider-ci/providers/gitlab/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/gitlab/repo/.github/workflows/release.yml
@@ -312,131 +312,13 @@ jobs:
         author_name: Failure in publishing binaries
         fields: repo,commit,author,action
         status: ${{ job.status }}
-  publish_java_sdk:
-    continue-on-error: true
-    name: publish_java_sdk
-    needs: publish
-    runs-on: ubuntu-latest
-    steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{ env.JAVAVERSION }}
-    - name: Setup Gradle
-      uses: gradle/gradle-build-action@v2
-      with:
-        gradle-version: "7.6"
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
   publish_sdk:
     name: publish_sdk
     needs: publish
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Node
-      uses: actions/setup-node@v2
-      with:
-        node-version: ${{ env.NODEVERSION }}
-        registry-url: https://registry.npmjs.org
-    - name: Setup DotNet
-      uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: ${{ env.DOTNETVERSION }}
-    - name: Setup Python
-      uses: actions/setup-python@v2
-      with:
-        python-version: ${{ env.PYTHONVERSION }}
-    - name: Download python SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: python-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress python SDK
-      run: tar -zxf ${{github.workspace}}/sdk/python.tar.gz -C
-        ${{github.workspace}}/sdk/python
-    - name: Download dotnet SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: dotnet-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress dotnet SDK
-      run: tar -zxf ${{github.workspace}}/sdk/dotnet.tar.gz -C
-        ${{github.workspace}}/sdk/dotnet
-    - name: Download nodejs SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: nodejs-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress nodejs SDK
-      run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
-        ${{github.workspace}}/sdk/nodejs
-    - run: python -m pip install pip twine
-    - env:
-        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-      name: Publish SDKs
-      run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - if: failure() && github.event_name == 'push'
-      name: Notify Slack
-      uses: 8398a7/action-slack@v3
-      with:
-        author_name: Failure in publishing SDK
-        fields: repo,commit,author,action
-        status: ${{ job.status }}
+    - name: Publish SDKs
+      uses: pulumi/pulumi-package-publisher@v0.0.5
   tag_sdk:
     name: tag_sdk
     needs: publish_sdk

--- a/provider-ci/providers/hcloud/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/hcloud/repo/.github/workflows/main.yml
@@ -350,131 +350,13 @@ jobs:
         author_name: Failure in publishing binaries
         fields: repo,commit,author,action
         status: ${{ job.status }}
-  publish_java_sdk:
-    continue-on-error: true
-    name: publish_java_sdk
-    needs: publish
-    runs-on: ubuntu-latest
-    steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{ env.JAVAVERSION }}
-    - name: Setup Gradle
-      uses: gradle/gradle-build-action@v2
-      with:
-        gradle-version: "7.6"
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
   publish_sdk:
     name: publish_sdk
     needs: publish
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Node
-      uses: actions/setup-node@v2
-      with:
-        node-version: ${{ env.NODEVERSION }}
-        registry-url: https://registry.npmjs.org
-    - name: Setup DotNet
-      uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: ${{ env.DOTNETVERSION }}
-    - name: Setup Python
-      uses: actions/setup-python@v2
-      with:
-        python-version: ${{ env.PYTHONVERSION }}
-    - name: Download python SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: python-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress python SDK
-      run: tar -zxf ${{github.workspace}}/sdk/python.tar.gz -C
-        ${{github.workspace}}/sdk/python
-    - name: Download dotnet SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: dotnet-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress dotnet SDK
-      run: tar -zxf ${{github.workspace}}/sdk/dotnet.tar.gz -C
-        ${{github.workspace}}/sdk/dotnet
-    - name: Download nodejs SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: nodejs-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress nodejs SDK
-      run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
-        ${{github.workspace}}/sdk/nodejs
-    - run: python -m pip install pip twine
-    - env:
-        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-      name: Publish SDKs
-      run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - if: failure() && github.event_name == 'push'
-      name: Notify Slack
-      uses: 8398a7/action-slack@v3
-      with:
-        author_name: Failure in publishing SDK
-        fields: repo,commit,author,action
-        status: ${{ job.status }}
+    - name: Publish SDKs
+      uses: pulumi/pulumi-package-publisher@v0.0.5
   test:
     name: test
     needs: build_sdk

--- a/provider-ci/providers/hcloud/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/hcloud/repo/.github/workflows/master.yml
@@ -350,131 +350,13 @@ jobs:
         author_name: Failure in publishing binaries
         fields: repo,commit,author,action
         status: ${{ job.status }}
-  publish_java_sdk:
-    continue-on-error: true
-    name: publish_java_sdk
-    needs: publish
-    runs-on: ubuntu-latest
-    steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{ env.JAVAVERSION }}
-    - name: Setup Gradle
-      uses: gradle/gradle-build-action@v2
-      with:
-        gradle-version: "7.6"
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
   publish_sdk:
     name: publish_sdk
     needs: publish
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Node
-      uses: actions/setup-node@v2
-      with:
-        node-version: ${{ env.NODEVERSION }}
-        registry-url: https://registry.npmjs.org
-    - name: Setup DotNet
-      uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: ${{ env.DOTNETVERSION }}
-    - name: Setup Python
-      uses: actions/setup-python@v2
-      with:
-        python-version: ${{ env.PYTHONVERSION }}
-    - name: Download python SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: python-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress python SDK
-      run: tar -zxf ${{github.workspace}}/sdk/python.tar.gz -C
-        ${{github.workspace}}/sdk/python
-    - name: Download dotnet SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: dotnet-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress dotnet SDK
-      run: tar -zxf ${{github.workspace}}/sdk/dotnet.tar.gz -C
-        ${{github.workspace}}/sdk/dotnet
-    - name: Download nodejs SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: nodejs-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress nodejs SDK
-      run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
-        ${{github.workspace}}/sdk/nodejs
-    - run: python -m pip install pip twine
-    - env:
-        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-      name: Publish SDKs
-      run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - if: failure() && github.event_name == 'push'
-      name: Notify Slack
-      uses: 8398a7/action-slack@v3
-      with:
-        author_name: Failure in publishing SDK
-        fields: repo,commit,author,action
-        status: ${{ job.status }}
+    - name: Publish SDKs
+      uses: pulumi/pulumi-package-publisher@v0.0.5
   test:
     name: test
     needs: build_sdk

--- a/provider-ci/providers/hcloud/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/hcloud/repo/.github/workflows/prerelease.yml
@@ -300,131 +300,13 @@ jobs:
         author_name: Failure in publishing binaries
         fields: repo,commit,author,action
         status: ${{ job.status }}
-  publish_java_sdk:
-    continue-on-error: true
-    name: publish_java_sdk
-    needs: publish
-    runs-on: ubuntu-latest
-    steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{ env.JAVAVERSION }}
-    - name: Setup Gradle
-      uses: gradle/gradle-build-action@v2
-      with:
-        gradle-version: "7.6"
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
   publish_sdk:
     name: publish_sdk
     needs: publish
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Node
-      uses: actions/setup-node@v2
-      with:
-        node-version: ${{ env.NODEVERSION }}
-        registry-url: https://registry.npmjs.org
-    - name: Setup DotNet
-      uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: ${{ env.DOTNETVERSION }}
-    - name: Setup Python
-      uses: actions/setup-python@v2
-      with:
-        python-version: ${{ env.PYTHONVERSION }}
-    - name: Download python SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: python-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress python SDK
-      run: tar -zxf ${{github.workspace}}/sdk/python.tar.gz -C
-        ${{github.workspace}}/sdk/python
-    - name: Download dotnet SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: dotnet-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress dotnet SDK
-      run: tar -zxf ${{github.workspace}}/sdk/dotnet.tar.gz -C
-        ${{github.workspace}}/sdk/dotnet
-    - name: Download nodejs SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: nodejs-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress nodejs SDK
-      run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
-        ${{github.workspace}}/sdk/nodejs
-    - run: python -m pip install pip twine
-    - env:
-        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-      name: Publish SDKs
-      run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - if: failure() && github.event_name == 'push'
-      name: Notify Slack
-      uses: 8398a7/action-slack@v3
-      with:
-        author_name: Failure in publishing SDK
-        fields: repo,commit,author,action
-        status: ${{ job.status }}
+    - name: Publish SDKs
+      uses: pulumi/pulumi-package-publisher@v0.0.5
   test:
     name: test
     needs: build_sdk

--- a/provider-ci/providers/hcloud/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/hcloud/repo/.github/workflows/release.yml
@@ -312,131 +312,13 @@ jobs:
         author_name: Failure in publishing binaries
         fields: repo,commit,author,action
         status: ${{ job.status }}
-  publish_java_sdk:
-    continue-on-error: true
-    name: publish_java_sdk
-    needs: publish
-    runs-on: ubuntu-latest
-    steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{ env.JAVAVERSION }}
-    - name: Setup Gradle
-      uses: gradle/gradle-build-action@v2
-      with:
-        gradle-version: "7.6"
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
   publish_sdk:
     name: publish_sdk
     needs: publish
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Node
-      uses: actions/setup-node@v2
-      with:
-        node-version: ${{ env.NODEVERSION }}
-        registry-url: https://registry.npmjs.org
-    - name: Setup DotNet
-      uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: ${{ env.DOTNETVERSION }}
-    - name: Setup Python
-      uses: actions/setup-python@v2
-      with:
-        python-version: ${{ env.PYTHONVERSION }}
-    - name: Download python SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: python-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress python SDK
-      run: tar -zxf ${{github.workspace}}/sdk/python.tar.gz -C
-        ${{github.workspace}}/sdk/python
-    - name: Download dotnet SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: dotnet-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress dotnet SDK
-      run: tar -zxf ${{github.workspace}}/sdk/dotnet.tar.gz -C
-        ${{github.workspace}}/sdk/dotnet
-    - name: Download nodejs SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: nodejs-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress nodejs SDK
-      run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
-        ${{github.workspace}}/sdk/nodejs
-    - run: python -m pip install pip twine
-    - env:
-        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-      name: Publish SDKs
-      run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - if: failure() && github.event_name == 'push'
-      name: Notify Slack
-      uses: 8398a7/action-slack@v3
-      with:
-        author_name: Failure in publishing SDK
-        fields: repo,commit,author,action
-        status: ${{ job.status }}
+    - name: Publish SDKs
+      uses: pulumi/pulumi-package-publisher@v0.0.5
   tag_sdk:
     name: tag_sdk
     needs: publish_sdk

--- a/provider-ci/providers/kafka/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/kafka/repo/.github/workflows/main.yml
@@ -349,131 +349,13 @@ jobs:
         author_name: Failure in publishing binaries
         fields: repo,commit,author,action
         status: ${{ job.status }}
-  publish_java_sdk:
-    continue-on-error: true
-    name: publish_java_sdk
-    needs: publish
-    runs-on: ubuntu-latest
-    steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{ env.JAVAVERSION }}
-    - name: Setup Gradle
-      uses: gradle/gradle-build-action@v2
-      with:
-        gradle-version: "7.6"
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
   publish_sdk:
     name: publish_sdk
     needs: publish
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Node
-      uses: actions/setup-node@v2
-      with:
-        node-version: ${{ env.NODEVERSION }}
-        registry-url: https://registry.npmjs.org
-    - name: Setup DotNet
-      uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: ${{ env.DOTNETVERSION }}
-    - name: Setup Python
-      uses: actions/setup-python@v2
-      with:
-        python-version: ${{ env.PYTHONVERSION }}
-    - name: Download python SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: python-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress python SDK
-      run: tar -zxf ${{github.workspace}}/sdk/python.tar.gz -C
-        ${{github.workspace}}/sdk/python
-    - name: Download dotnet SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: dotnet-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress dotnet SDK
-      run: tar -zxf ${{github.workspace}}/sdk/dotnet.tar.gz -C
-        ${{github.workspace}}/sdk/dotnet
-    - name: Download nodejs SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: nodejs-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress nodejs SDK
-      run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
-        ${{github.workspace}}/sdk/nodejs
-    - run: python -m pip install pip twine
-    - env:
-        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-      name: Publish SDKs
-      run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - if: failure() && github.event_name == 'push'
-      name: Notify Slack
-      uses: 8398a7/action-slack@v3
-      with:
-        author_name: Failure in publishing SDK
-        fields: repo,commit,author,action
-        status: ${{ job.status }}
+    - name: Publish SDKs
+      uses: pulumi/pulumi-package-publisher@v0.0.5
   test:
     name: test
     needs: build_sdk

--- a/provider-ci/providers/kafka/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/kafka/repo/.github/workflows/master.yml
@@ -354,72 +354,8 @@ jobs:
     needs: publish
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Node
-      uses: actions/setup-node@v2
-      with:
-        node-version: ${{ env.NODEVERSION }}
-        registry-url: https://registry.npmjs.org
-    - name: Setup DotNet
-      uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: ${{ env.DOTNETVERSION }}
-    - name: Setup Python
-      uses: actions/setup-python@v2
-      with:
-        python-version: ${{ env.PYTHONVERSION }}
-    - name: Download python SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: python-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress python SDK
-      run: tar -zxf ${{github.workspace}}/sdk/python.tar.gz -C
-        ${{github.workspace}}/sdk/python
-    - name: Download dotnet SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: dotnet-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress dotnet SDK
-      run: tar -zxf ${{github.workspace}}/sdk/dotnet.tar.gz -C
-        ${{github.workspace}}/sdk/dotnet
-    - name: Download nodejs SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: nodejs-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress nodejs SDK
-      run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
-        ${{github.workspace}}/sdk/nodejs
-    - run: python -m pip install pip twine
     - name: Publish SDKs
       uses: pulumi/pulumi-package-publisher@v0.0.5
-    - if: failure() && github.event_name == 'push'
-      name: Notify Slack
-      uses: 8398a7/action-slack@v3
-      with:
-        author_name: Failure in publishing SDK
-        fields: repo,commit,author,action
-        status: ${{ job.status }}
   test:
     name: test
     needs: build_sdk

--- a/provider-ci/providers/kafka/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/kafka/repo/.github/workflows/master.yml
@@ -349,58 +349,6 @@ jobs:
         author_name: Failure in publishing binaries
         fields: repo,commit,author,action
         status: ${{ job.status }}
-  publish_java_sdk:
-    continue-on-error: true
-    name: publish_java_sdk
-    needs: publish
-    runs-on: ubuntu-latest
-    steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{ env.JAVAVERSION }}
-    - name: Setup Gradle
-      uses: gradle/gradle-build-action@v2
-      with:
-        gradle-version: "7.6"
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
   publish_sdk:
     name: publish_sdk
     needs: publish
@@ -463,10 +411,8 @@ jobs:
       run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
         ${{github.workspace}}/sdk/nodejs
     - run: python -m pip install pip twine
-    - env:
-        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-      name: Publish SDKs
-      run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
+    - name: Publish SDKs
+      uses: pulumi/pulumi-package-publisher@v0.0.5
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3

--- a/provider-ci/providers/kafka/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/kafka/repo/.github/workflows/prerelease.yml
@@ -299,131 +299,13 @@ jobs:
         author_name: Failure in publishing binaries
         fields: repo,commit,author,action
         status: ${{ job.status }}
-  publish_java_sdk:
-    continue-on-error: true
-    name: publish_java_sdk
-    needs: publish
-    runs-on: ubuntu-latest
-    steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{ env.JAVAVERSION }}
-    - name: Setup Gradle
-      uses: gradle/gradle-build-action@v2
-      with:
-        gradle-version: "7.6"
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
   publish_sdk:
     name: publish_sdk
     needs: publish
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Node
-      uses: actions/setup-node@v2
-      with:
-        node-version: ${{ env.NODEVERSION }}
-        registry-url: https://registry.npmjs.org
-    - name: Setup DotNet
-      uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: ${{ env.DOTNETVERSION }}
-    - name: Setup Python
-      uses: actions/setup-python@v2
-      with:
-        python-version: ${{ env.PYTHONVERSION }}
-    - name: Download python SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: python-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress python SDK
-      run: tar -zxf ${{github.workspace}}/sdk/python.tar.gz -C
-        ${{github.workspace}}/sdk/python
-    - name: Download dotnet SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: dotnet-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress dotnet SDK
-      run: tar -zxf ${{github.workspace}}/sdk/dotnet.tar.gz -C
-        ${{github.workspace}}/sdk/dotnet
-    - name: Download nodejs SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: nodejs-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress nodejs SDK
-      run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
-        ${{github.workspace}}/sdk/nodejs
-    - run: python -m pip install pip twine
-    - env:
-        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-      name: Publish SDKs
-      run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - if: failure() && github.event_name == 'push'
-      name: Notify Slack
-      uses: 8398a7/action-slack@v3
-      with:
-        author_name: Failure in publishing SDK
-        fields: repo,commit,author,action
-        status: ${{ job.status }}
+    - name: Publish SDKs
+      uses: pulumi/pulumi-package-publisher@v0.0.5
   test:
     name: test
     needs: build_sdk

--- a/provider-ci/providers/kafka/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/kafka/repo/.github/workflows/release.yml
@@ -311,131 +311,13 @@ jobs:
         author_name: Failure in publishing binaries
         fields: repo,commit,author,action
         status: ${{ job.status }}
-  publish_java_sdk:
-    continue-on-error: true
-    name: publish_java_sdk
-    needs: publish
-    runs-on: ubuntu-latest
-    steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{ env.JAVAVERSION }}
-    - name: Setup Gradle
-      uses: gradle/gradle-build-action@v2
-      with:
-        gradle-version: "7.6"
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
   publish_sdk:
     name: publish_sdk
     needs: publish
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Node
-      uses: actions/setup-node@v2
-      with:
-        node-version: ${{ env.NODEVERSION }}
-        registry-url: https://registry.npmjs.org
-    - name: Setup DotNet
-      uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: ${{ env.DOTNETVERSION }}
-    - name: Setup Python
-      uses: actions/setup-python@v2
-      with:
-        python-version: ${{ env.PYTHONVERSION }}
-    - name: Download python SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: python-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress python SDK
-      run: tar -zxf ${{github.workspace}}/sdk/python.tar.gz -C
-        ${{github.workspace}}/sdk/python
-    - name: Download dotnet SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: dotnet-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress dotnet SDK
-      run: tar -zxf ${{github.workspace}}/sdk/dotnet.tar.gz -C
-        ${{github.workspace}}/sdk/dotnet
-    - name: Download nodejs SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: nodejs-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress nodejs SDK
-      run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
-        ${{github.workspace}}/sdk/nodejs
-    - run: python -m pip install pip twine
-    - env:
-        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-      name: Publish SDKs
-      run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - if: failure() && github.event_name == 'push'
-      name: Notify Slack
-      uses: 8398a7/action-slack@v3
-      with:
-        author_name: Failure in publishing SDK
-        fields: repo,commit,author,action
-        status: ${{ job.status }}
+    - name: Publish SDKs
+      uses: pulumi/pulumi-package-publisher@v0.0.5
   tag_sdk:
     name: tag_sdk
     needs: publish_sdk

--- a/provider-ci/providers/keycloak/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/keycloak/repo/.github/workflows/main.yml
@@ -354,131 +354,13 @@ jobs:
         author_name: Failure in publishing binaries
         fields: repo,commit,author,action
         status: ${{ job.status }}
-  publish_java_sdk:
-    continue-on-error: true
-    name: publish_java_sdk
-    needs: publish
-    runs-on: ubuntu-latest
-    steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{ env.JAVAVERSION }}
-    - name: Setup Gradle
-      uses: gradle/gradle-build-action@v2
-      with:
-        gradle-version: "7.6"
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
   publish_sdk:
     name: publish_sdk
     needs: publish
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Node
-      uses: actions/setup-node@v2
-      with:
-        node-version: ${{ env.NODEVERSION }}
-        registry-url: https://registry.npmjs.org
-    - name: Setup DotNet
-      uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: ${{ env.DOTNETVERSION }}
-    - name: Setup Python
-      uses: actions/setup-python@v2
-      with:
-        python-version: ${{ env.PYTHONVERSION }}
-    - name: Download python SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: python-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress python SDK
-      run: tar -zxf ${{github.workspace}}/sdk/python.tar.gz -C
-        ${{github.workspace}}/sdk/python
-    - name: Download dotnet SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: dotnet-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress dotnet SDK
-      run: tar -zxf ${{github.workspace}}/sdk/dotnet.tar.gz -C
-        ${{github.workspace}}/sdk/dotnet
-    - name: Download nodejs SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: nodejs-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress nodejs SDK
-      run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
-        ${{github.workspace}}/sdk/nodejs
-    - run: python -m pip install pip twine
-    - env:
-        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-      name: Publish SDKs
-      run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - if: failure() && github.event_name == 'push'
-      name: Notify Slack
-      uses: 8398a7/action-slack@v3
-      with:
-        author_name: Failure in publishing SDK
-        fields: repo,commit,author,action
-        status: ${{ job.status }}
+    - name: Publish SDKs
+      uses: pulumi/pulumi-package-publisher@v0.0.5
   test:
     name: test
     needs: build_sdk

--- a/provider-ci/providers/keycloak/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/keycloak/repo/.github/workflows/master.yml
@@ -354,131 +354,13 @@ jobs:
         author_name: Failure in publishing binaries
         fields: repo,commit,author,action
         status: ${{ job.status }}
-  publish_java_sdk:
-    continue-on-error: true
-    name: publish_java_sdk
-    needs: publish
-    runs-on: ubuntu-latest
-    steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{ env.JAVAVERSION }}
-    - name: Setup Gradle
-      uses: gradle/gradle-build-action@v2
-      with:
-        gradle-version: "7.6"
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
   publish_sdk:
     name: publish_sdk
     needs: publish
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Node
-      uses: actions/setup-node@v2
-      with:
-        node-version: ${{ env.NODEVERSION }}
-        registry-url: https://registry.npmjs.org
-    - name: Setup DotNet
-      uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: ${{ env.DOTNETVERSION }}
-    - name: Setup Python
-      uses: actions/setup-python@v2
-      with:
-        python-version: ${{ env.PYTHONVERSION }}
-    - name: Download python SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: python-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress python SDK
-      run: tar -zxf ${{github.workspace}}/sdk/python.tar.gz -C
-        ${{github.workspace}}/sdk/python
-    - name: Download dotnet SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: dotnet-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress dotnet SDK
-      run: tar -zxf ${{github.workspace}}/sdk/dotnet.tar.gz -C
-        ${{github.workspace}}/sdk/dotnet
-    - name: Download nodejs SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: nodejs-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress nodejs SDK
-      run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
-        ${{github.workspace}}/sdk/nodejs
-    - run: python -m pip install pip twine
-    - env:
-        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-      name: Publish SDKs
-      run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - if: failure() && github.event_name == 'push'
-      name: Notify Slack
-      uses: 8398a7/action-slack@v3
-      with:
-        author_name: Failure in publishing SDK
-        fields: repo,commit,author,action
-        status: ${{ job.status }}
+    - name: Publish SDKs
+      uses: pulumi/pulumi-package-publisher@v0.0.5
   test:
     name: test
     needs: build_sdk

--- a/provider-ci/providers/keycloak/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/keycloak/repo/.github/workflows/prerelease.yml
@@ -304,131 +304,13 @@ jobs:
         author_name: Failure in publishing binaries
         fields: repo,commit,author,action
         status: ${{ job.status }}
-  publish_java_sdk:
-    continue-on-error: true
-    name: publish_java_sdk
-    needs: publish
-    runs-on: ubuntu-latest
-    steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{ env.JAVAVERSION }}
-    - name: Setup Gradle
-      uses: gradle/gradle-build-action@v2
-      with:
-        gradle-version: "7.6"
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
   publish_sdk:
     name: publish_sdk
     needs: publish
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Node
-      uses: actions/setup-node@v2
-      with:
-        node-version: ${{ env.NODEVERSION }}
-        registry-url: https://registry.npmjs.org
-    - name: Setup DotNet
-      uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: ${{ env.DOTNETVERSION }}
-    - name: Setup Python
-      uses: actions/setup-python@v2
-      with:
-        python-version: ${{ env.PYTHONVERSION }}
-    - name: Download python SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: python-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress python SDK
-      run: tar -zxf ${{github.workspace}}/sdk/python.tar.gz -C
-        ${{github.workspace}}/sdk/python
-    - name: Download dotnet SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: dotnet-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress dotnet SDK
-      run: tar -zxf ${{github.workspace}}/sdk/dotnet.tar.gz -C
-        ${{github.workspace}}/sdk/dotnet
-    - name: Download nodejs SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: nodejs-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress nodejs SDK
-      run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
-        ${{github.workspace}}/sdk/nodejs
-    - run: python -m pip install pip twine
-    - env:
-        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-      name: Publish SDKs
-      run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - if: failure() && github.event_name == 'push'
-      name: Notify Slack
-      uses: 8398a7/action-slack@v3
-      with:
-        author_name: Failure in publishing SDK
-        fields: repo,commit,author,action
-        status: ${{ job.status }}
+    - name: Publish SDKs
+      uses: pulumi/pulumi-package-publisher@v0.0.5
   test:
     name: test
     needs: build_sdk

--- a/provider-ci/providers/keycloak/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/keycloak/repo/.github/workflows/release.yml
@@ -316,131 +316,13 @@ jobs:
         author_name: Failure in publishing binaries
         fields: repo,commit,author,action
         status: ${{ job.status }}
-  publish_java_sdk:
-    continue-on-error: true
-    name: publish_java_sdk
-    needs: publish
-    runs-on: ubuntu-latest
-    steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{ env.JAVAVERSION }}
-    - name: Setup Gradle
-      uses: gradle/gradle-build-action@v2
-      with:
-        gradle-version: "7.6"
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
   publish_sdk:
     name: publish_sdk
     needs: publish
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Node
-      uses: actions/setup-node@v2
-      with:
-        node-version: ${{ env.NODEVERSION }}
-        registry-url: https://registry.npmjs.org
-    - name: Setup DotNet
-      uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: ${{ env.DOTNETVERSION }}
-    - name: Setup Python
-      uses: actions/setup-python@v2
-      with:
-        python-version: ${{ env.PYTHONVERSION }}
-    - name: Download python SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: python-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress python SDK
-      run: tar -zxf ${{github.workspace}}/sdk/python.tar.gz -C
-        ${{github.workspace}}/sdk/python
-    - name: Download dotnet SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: dotnet-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress dotnet SDK
-      run: tar -zxf ${{github.workspace}}/sdk/dotnet.tar.gz -C
-        ${{github.workspace}}/sdk/dotnet
-    - name: Download nodejs SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: nodejs-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress nodejs SDK
-      run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
-        ${{github.workspace}}/sdk/nodejs
-    - run: python -m pip install pip twine
-    - env:
-        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-      name: Publish SDKs
-      run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - if: failure() && github.event_name == 'push'
-      name: Notify Slack
-      uses: 8398a7/action-slack@v3
-      with:
-        author_name: Failure in publishing SDK
-        fields: repo,commit,author,action
-        status: ${{ job.status }}
+    - name: Publish SDKs
+      uses: pulumi/pulumi-package-publisher@v0.0.5
   tag_sdk:
     name: tag_sdk
     needs: publish_sdk

--- a/provider-ci/providers/kong/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/kong/repo/.github/workflows/main.yml
@@ -349,131 +349,13 @@ jobs:
         author_name: Failure in publishing binaries
         fields: repo,commit,author,action
         status: ${{ job.status }}
-  publish_java_sdk:
-    continue-on-error: true
-    name: publish_java_sdk
-    needs: publish
-    runs-on: ubuntu-latest
-    steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{ env.JAVAVERSION }}
-    - name: Setup Gradle
-      uses: gradle/gradle-build-action@v2
-      with:
-        gradle-version: "7.6"
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
   publish_sdk:
     name: publish_sdk
     needs: publish
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Node
-      uses: actions/setup-node@v2
-      with:
-        node-version: ${{ env.NODEVERSION }}
-        registry-url: https://registry.npmjs.org
-    - name: Setup DotNet
-      uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: ${{ env.DOTNETVERSION }}
-    - name: Setup Python
-      uses: actions/setup-python@v2
-      with:
-        python-version: ${{ env.PYTHONVERSION }}
-    - name: Download python SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: python-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress python SDK
-      run: tar -zxf ${{github.workspace}}/sdk/python.tar.gz -C
-        ${{github.workspace}}/sdk/python
-    - name: Download dotnet SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: dotnet-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress dotnet SDK
-      run: tar -zxf ${{github.workspace}}/sdk/dotnet.tar.gz -C
-        ${{github.workspace}}/sdk/dotnet
-    - name: Download nodejs SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: nodejs-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress nodejs SDK
-      run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
-        ${{github.workspace}}/sdk/nodejs
-    - run: python -m pip install pip twine
-    - env:
-        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-      name: Publish SDKs
-      run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - if: failure() && github.event_name == 'push'
-      name: Notify Slack
-      uses: 8398a7/action-slack@v3
-      with:
-        author_name: Failure in publishing SDK
-        fields: repo,commit,author,action
-        status: ${{ job.status }}
+    - name: Publish SDKs
+      uses: pulumi/pulumi-package-publisher@v0.0.5
   test:
     name: test
     needs: build_sdk

--- a/provider-ci/providers/kong/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/kong/repo/.github/workflows/master.yml
@@ -349,131 +349,13 @@ jobs:
         author_name: Failure in publishing binaries
         fields: repo,commit,author,action
         status: ${{ job.status }}
-  publish_java_sdk:
-    continue-on-error: true
-    name: publish_java_sdk
-    needs: publish
-    runs-on: ubuntu-latest
-    steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{ env.JAVAVERSION }}
-    - name: Setup Gradle
-      uses: gradle/gradle-build-action@v2
-      with:
-        gradle-version: "7.6"
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
   publish_sdk:
     name: publish_sdk
     needs: publish
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Node
-      uses: actions/setup-node@v2
-      with:
-        node-version: ${{ env.NODEVERSION }}
-        registry-url: https://registry.npmjs.org
-    - name: Setup DotNet
-      uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: ${{ env.DOTNETVERSION }}
-    - name: Setup Python
-      uses: actions/setup-python@v2
-      with:
-        python-version: ${{ env.PYTHONVERSION }}
-    - name: Download python SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: python-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress python SDK
-      run: tar -zxf ${{github.workspace}}/sdk/python.tar.gz -C
-        ${{github.workspace}}/sdk/python
-    - name: Download dotnet SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: dotnet-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress dotnet SDK
-      run: tar -zxf ${{github.workspace}}/sdk/dotnet.tar.gz -C
-        ${{github.workspace}}/sdk/dotnet
-    - name: Download nodejs SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: nodejs-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress nodejs SDK
-      run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
-        ${{github.workspace}}/sdk/nodejs
-    - run: python -m pip install pip twine
-    - env:
-        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-      name: Publish SDKs
-      run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - if: failure() && github.event_name == 'push'
-      name: Notify Slack
-      uses: 8398a7/action-slack@v3
-      with:
-        author_name: Failure in publishing SDK
-        fields: repo,commit,author,action
-        status: ${{ job.status }}
+    - name: Publish SDKs
+      uses: pulumi/pulumi-package-publisher@v0.0.5
   test:
     name: test
     needs: build_sdk

--- a/provider-ci/providers/kong/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/kong/repo/.github/workflows/prerelease.yml
@@ -299,131 +299,13 @@ jobs:
         author_name: Failure in publishing binaries
         fields: repo,commit,author,action
         status: ${{ job.status }}
-  publish_java_sdk:
-    continue-on-error: true
-    name: publish_java_sdk
-    needs: publish
-    runs-on: ubuntu-latest
-    steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{ env.JAVAVERSION }}
-    - name: Setup Gradle
-      uses: gradle/gradle-build-action@v2
-      with:
-        gradle-version: "7.6"
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
   publish_sdk:
     name: publish_sdk
     needs: publish
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Node
-      uses: actions/setup-node@v2
-      with:
-        node-version: ${{ env.NODEVERSION }}
-        registry-url: https://registry.npmjs.org
-    - name: Setup DotNet
-      uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: ${{ env.DOTNETVERSION }}
-    - name: Setup Python
-      uses: actions/setup-python@v2
-      with:
-        python-version: ${{ env.PYTHONVERSION }}
-    - name: Download python SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: python-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress python SDK
-      run: tar -zxf ${{github.workspace}}/sdk/python.tar.gz -C
-        ${{github.workspace}}/sdk/python
-    - name: Download dotnet SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: dotnet-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress dotnet SDK
-      run: tar -zxf ${{github.workspace}}/sdk/dotnet.tar.gz -C
-        ${{github.workspace}}/sdk/dotnet
-    - name: Download nodejs SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: nodejs-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress nodejs SDK
-      run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
-        ${{github.workspace}}/sdk/nodejs
-    - run: python -m pip install pip twine
-    - env:
-        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-      name: Publish SDKs
-      run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - if: failure() && github.event_name == 'push'
-      name: Notify Slack
-      uses: 8398a7/action-slack@v3
-      with:
-        author_name: Failure in publishing SDK
-        fields: repo,commit,author,action
-        status: ${{ job.status }}
+    - name: Publish SDKs
+      uses: pulumi/pulumi-package-publisher@v0.0.5
   test:
     name: test
     needs: build_sdk

--- a/provider-ci/providers/kong/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/kong/repo/.github/workflows/release.yml
@@ -311,131 +311,13 @@ jobs:
         author_name: Failure in publishing binaries
         fields: repo,commit,author,action
         status: ${{ job.status }}
-  publish_java_sdk:
-    continue-on-error: true
-    name: publish_java_sdk
-    needs: publish
-    runs-on: ubuntu-latest
-    steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{ env.JAVAVERSION }}
-    - name: Setup Gradle
-      uses: gradle/gradle-build-action@v2
-      with:
-        gradle-version: "7.6"
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
   publish_sdk:
     name: publish_sdk
     needs: publish
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Node
-      uses: actions/setup-node@v2
-      with:
-        node-version: ${{ env.NODEVERSION }}
-        registry-url: https://registry.npmjs.org
-    - name: Setup DotNet
-      uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: ${{ env.DOTNETVERSION }}
-    - name: Setup Python
-      uses: actions/setup-python@v2
-      with:
-        python-version: ${{ env.PYTHONVERSION }}
-    - name: Download python SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: python-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress python SDK
-      run: tar -zxf ${{github.workspace}}/sdk/python.tar.gz -C
-        ${{github.workspace}}/sdk/python
-    - name: Download dotnet SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: dotnet-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress dotnet SDK
-      run: tar -zxf ${{github.workspace}}/sdk/dotnet.tar.gz -C
-        ${{github.workspace}}/sdk/dotnet
-    - name: Download nodejs SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: nodejs-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress nodejs SDK
-      run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
-        ${{github.workspace}}/sdk/nodejs
-    - run: python -m pip install pip twine
-    - env:
-        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-      name: Publish SDKs
-      run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - if: failure() && github.event_name == 'push'
-      name: Notify Slack
-      uses: 8398a7/action-slack@v3
-      with:
-        author_name: Failure in publishing SDK
-        fields: repo,commit,author,action
-        status: ${{ job.status }}
+    - name: Publish SDKs
+      uses: pulumi/pulumi-package-publisher@v0.0.5
   tag_sdk:
     name: tag_sdk
     needs: publish_sdk

--- a/provider-ci/providers/libvirt/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/libvirt/repo/.github/workflows/main.yml
@@ -350,131 +350,13 @@ jobs:
         author_name: Failure in publishing binaries
         fields: repo,commit,author,action
         status: ${{ job.status }}
-  publish_java_sdk:
-    continue-on-error: true
-    name: publish_java_sdk
-    needs: publish
-    runs-on: ubuntu-latest
-    steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{ env.JAVAVERSION }}
-    - name: Setup Gradle
-      uses: gradle/gradle-build-action@v2
-      with:
-        gradle-version: "7.6"
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
   publish_sdk:
     name: publish_sdk
     needs: publish
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Node
-      uses: actions/setup-node@v2
-      with:
-        node-version: ${{ env.NODEVERSION }}
-        registry-url: https://registry.npmjs.org
-    - name: Setup DotNet
-      uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: ${{ env.DOTNETVERSION }}
-    - name: Setup Python
-      uses: actions/setup-python@v2
-      with:
-        python-version: ${{ env.PYTHONVERSION }}
-    - name: Download python SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: python-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress python SDK
-      run: tar -zxf ${{github.workspace}}/sdk/python.tar.gz -C
-        ${{github.workspace}}/sdk/python
-    - name: Download dotnet SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: dotnet-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress dotnet SDK
-      run: tar -zxf ${{github.workspace}}/sdk/dotnet.tar.gz -C
-        ${{github.workspace}}/sdk/dotnet
-    - name: Download nodejs SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: nodejs-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress nodejs SDK
-      run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
-        ${{github.workspace}}/sdk/nodejs
-    - run: python -m pip install pip twine
-    - env:
-        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-      name: Publish SDKs
-      run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - if: failure() && github.event_name == 'push'
-      name: Notify Slack
-      uses: 8398a7/action-slack@v3
-      with:
-        author_name: Failure in publishing SDK
-        fields: repo,commit,author,action
-        status: ${{ job.status }}
+    - name: Publish SDKs
+      uses: pulumi/pulumi-package-publisher@v0.0.5
   test:
     name: test
     needs: build_sdk

--- a/provider-ci/providers/libvirt/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/libvirt/repo/.github/workflows/master.yml
@@ -350,131 +350,13 @@ jobs:
         author_name: Failure in publishing binaries
         fields: repo,commit,author,action
         status: ${{ job.status }}
-  publish_java_sdk:
-    continue-on-error: true
-    name: publish_java_sdk
-    needs: publish
-    runs-on: ubuntu-latest
-    steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{ env.JAVAVERSION }}
-    - name: Setup Gradle
-      uses: gradle/gradle-build-action@v2
-      with:
-        gradle-version: "7.6"
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
   publish_sdk:
     name: publish_sdk
     needs: publish
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Node
-      uses: actions/setup-node@v2
-      with:
-        node-version: ${{ env.NODEVERSION }}
-        registry-url: https://registry.npmjs.org
-    - name: Setup DotNet
-      uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: ${{ env.DOTNETVERSION }}
-    - name: Setup Python
-      uses: actions/setup-python@v2
-      with:
-        python-version: ${{ env.PYTHONVERSION }}
-    - name: Download python SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: python-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress python SDK
-      run: tar -zxf ${{github.workspace}}/sdk/python.tar.gz -C
-        ${{github.workspace}}/sdk/python
-    - name: Download dotnet SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: dotnet-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress dotnet SDK
-      run: tar -zxf ${{github.workspace}}/sdk/dotnet.tar.gz -C
-        ${{github.workspace}}/sdk/dotnet
-    - name: Download nodejs SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: nodejs-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress nodejs SDK
-      run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
-        ${{github.workspace}}/sdk/nodejs
-    - run: python -m pip install pip twine
-    - env:
-        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-      name: Publish SDKs
-      run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - if: failure() && github.event_name == 'push'
-      name: Notify Slack
-      uses: 8398a7/action-slack@v3
-      with:
-        author_name: Failure in publishing SDK
-        fields: repo,commit,author,action
-        status: ${{ job.status }}
+    - name: Publish SDKs
+      uses: pulumi/pulumi-package-publisher@v0.0.5
   test:
     name: test
     needs: build_sdk

--- a/provider-ci/providers/libvirt/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/libvirt/repo/.github/workflows/prerelease.yml
@@ -300,131 +300,13 @@ jobs:
         author_name: Failure in publishing binaries
         fields: repo,commit,author,action
         status: ${{ job.status }}
-  publish_java_sdk:
-    continue-on-error: true
-    name: publish_java_sdk
-    needs: publish
-    runs-on: ubuntu-latest
-    steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{ env.JAVAVERSION }}
-    - name: Setup Gradle
-      uses: gradle/gradle-build-action@v2
-      with:
-        gradle-version: "7.6"
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
   publish_sdk:
     name: publish_sdk
     needs: publish
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Node
-      uses: actions/setup-node@v2
-      with:
-        node-version: ${{ env.NODEVERSION }}
-        registry-url: https://registry.npmjs.org
-    - name: Setup DotNet
-      uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: ${{ env.DOTNETVERSION }}
-    - name: Setup Python
-      uses: actions/setup-python@v2
-      with:
-        python-version: ${{ env.PYTHONVERSION }}
-    - name: Download python SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: python-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress python SDK
-      run: tar -zxf ${{github.workspace}}/sdk/python.tar.gz -C
-        ${{github.workspace}}/sdk/python
-    - name: Download dotnet SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: dotnet-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress dotnet SDK
-      run: tar -zxf ${{github.workspace}}/sdk/dotnet.tar.gz -C
-        ${{github.workspace}}/sdk/dotnet
-    - name: Download nodejs SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: nodejs-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress nodejs SDK
-      run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
-        ${{github.workspace}}/sdk/nodejs
-    - run: python -m pip install pip twine
-    - env:
-        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-      name: Publish SDKs
-      run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - if: failure() && github.event_name == 'push'
-      name: Notify Slack
-      uses: 8398a7/action-slack@v3
-      with:
-        author_name: Failure in publishing SDK
-        fields: repo,commit,author,action
-        status: ${{ job.status }}
+    - name: Publish SDKs
+      uses: pulumi/pulumi-package-publisher@v0.0.5
   test:
     name: test
     needs: build_sdk

--- a/provider-ci/providers/libvirt/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/libvirt/repo/.github/workflows/release.yml
@@ -312,131 +312,13 @@ jobs:
         author_name: Failure in publishing binaries
         fields: repo,commit,author,action
         status: ${{ job.status }}
-  publish_java_sdk:
-    continue-on-error: true
-    name: publish_java_sdk
-    needs: publish
-    runs-on: ubuntu-latest
-    steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{ env.JAVAVERSION }}
-    - name: Setup Gradle
-      uses: gradle/gradle-build-action@v2
-      with:
-        gradle-version: "7.6"
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
   publish_sdk:
     name: publish_sdk
     needs: publish
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Node
-      uses: actions/setup-node@v2
-      with:
-        node-version: ${{ env.NODEVERSION }}
-        registry-url: https://registry.npmjs.org
-    - name: Setup DotNet
-      uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: ${{ env.DOTNETVERSION }}
-    - name: Setup Python
-      uses: actions/setup-python@v2
-      with:
-        python-version: ${{ env.PYTHONVERSION }}
-    - name: Download python SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: python-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress python SDK
-      run: tar -zxf ${{github.workspace}}/sdk/python.tar.gz -C
-        ${{github.workspace}}/sdk/python
-    - name: Download dotnet SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: dotnet-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress dotnet SDK
-      run: tar -zxf ${{github.workspace}}/sdk/dotnet.tar.gz -C
-        ${{github.workspace}}/sdk/dotnet
-    - name: Download nodejs SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: nodejs-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress nodejs SDK
-      run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
-        ${{github.workspace}}/sdk/nodejs
-    - run: python -m pip install pip twine
-    - env:
-        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-      name: Publish SDKs
-      run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - if: failure() && github.event_name == 'push'
-      name: Notify Slack
-      uses: 8398a7/action-slack@v3
-      with:
-        author_name: Failure in publishing SDK
-        fields: repo,commit,author,action
-        status: ${{ job.status }}
+    - name: Publish SDKs
+      uses: pulumi/pulumi-package-publisher@v0.0.5
   tag_sdk:
     name: tag_sdk
     needs: publish_sdk

--- a/provider-ci/providers/linode/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/linode/repo/.github/workflows/main.yml
@@ -350,131 +350,13 @@ jobs:
         author_name: Failure in publishing binaries
         fields: repo,commit,author,action
         status: ${{ job.status }}
-  publish_java_sdk:
-    continue-on-error: true
-    name: publish_java_sdk
-    needs: publish
-    runs-on: ubuntu-latest
-    steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{ env.JAVAVERSION }}
-    - name: Setup Gradle
-      uses: gradle/gradle-build-action@v2
-      with:
-        gradle-version: "7.6"
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
   publish_sdk:
     name: publish_sdk
     needs: publish
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Node
-      uses: actions/setup-node@v2
-      with:
-        node-version: ${{ env.NODEVERSION }}
-        registry-url: https://registry.npmjs.org
-    - name: Setup DotNet
-      uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: ${{ env.DOTNETVERSION }}
-    - name: Setup Python
-      uses: actions/setup-python@v2
-      with:
-        python-version: ${{ env.PYTHONVERSION }}
-    - name: Download python SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: python-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress python SDK
-      run: tar -zxf ${{github.workspace}}/sdk/python.tar.gz -C
-        ${{github.workspace}}/sdk/python
-    - name: Download dotnet SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: dotnet-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress dotnet SDK
-      run: tar -zxf ${{github.workspace}}/sdk/dotnet.tar.gz -C
-        ${{github.workspace}}/sdk/dotnet
-    - name: Download nodejs SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: nodejs-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress nodejs SDK
-      run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
-        ${{github.workspace}}/sdk/nodejs
-    - run: python -m pip install pip twine
-    - env:
-        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-      name: Publish SDKs
-      run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - if: failure() && github.event_name == 'push'
-      name: Notify Slack
-      uses: 8398a7/action-slack@v3
-      with:
-        author_name: Failure in publishing SDK
-        fields: repo,commit,author,action
-        status: ${{ job.status }}
+    - name: Publish SDKs
+      uses: pulumi/pulumi-package-publisher@v0.0.5
   test:
     name: test
     needs: build_sdk

--- a/provider-ci/providers/linode/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/linode/repo/.github/workflows/master.yml
@@ -350,131 +350,13 @@ jobs:
         author_name: Failure in publishing binaries
         fields: repo,commit,author,action
         status: ${{ job.status }}
-  publish_java_sdk:
-    continue-on-error: true
-    name: publish_java_sdk
-    needs: publish
-    runs-on: ubuntu-latest
-    steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{ env.JAVAVERSION }}
-    - name: Setup Gradle
-      uses: gradle/gradle-build-action@v2
-      with:
-        gradle-version: "7.6"
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
   publish_sdk:
     name: publish_sdk
     needs: publish
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Node
-      uses: actions/setup-node@v2
-      with:
-        node-version: ${{ env.NODEVERSION }}
-        registry-url: https://registry.npmjs.org
-    - name: Setup DotNet
-      uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: ${{ env.DOTNETVERSION }}
-    - name: Setup Python
-      uses: actions/setup-python@v2
-      with:
-        python-version: ${{ env.PYTHONVERSION }}
-    - name: Download python SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: python-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress python SDK
-      run: tar -zxf ${{github.workspace}}/sdk/python.tar.gz -C
-        ${{github.workspace}}/sdk/python
-    - name: Download dotnet SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: dotnet-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress dotnet SDK
-      run: tar -zxf ${{github.workspace}}/sdk/dotnet.tar.gz -C
-        ${{github.workspace}}/sdk/dotnet
-    - name: Download nodejs SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: nodejs-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress nodejs SDK
-      run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
-        ${{github.workspace}}/sdk/nodejs
-    - run: python -m pip install pip twine
-    - env:
-        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-      name: Publish SDKs
-      run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - if: failure() && github.event_name == 'push'
-      name: Notify Slack
-      uses: 8398a7/action-slack@v3
-      with:
-        author_name: Failure in publishing SDK
-        fields: repo,commit,author,action
-        status: ${{ job.status }}
+    - name: Publish SDKs
+      uses: pulumi/pulumi-package-publisher@v0.0.5
   test:
     name: test
     needs: build_sdk

--- a/provider-ci/providers/linode/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/linode/repo/.github/workflows/prerelease.yml
@@ -300,131 +300,13 @@ jobs:
         author_name: Failure in publishing binaries
         fields: repo,commit,author,action
         status: ${{ job.status }}
-  publish_java_sdk:
-    continue-on-error: true
-    name: publish_java_sdk
-    needs: publish
-    runs-on: ubuntu-latest
-    steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{ env.JAVAVERSION }}
-    - name: Setup Gradle
-      uses: gradle/gradle-build-action@v2
-      with:
-        gradle-version: "7.6"
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
   publish_sdk:
     name: publish_sdk
     needs: publish
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Node
-      uses: actions/setup-node@v2
-      with:
-        node-version: ${{ env.NODEVERSION }}
-        registry-url: https://registry.npmjs.org
-    - name: Setup DotNet
-      uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: ${{ env.DOTNETVERSION }}
-    - name: Setup Python
-      uses: actions/setup-python@v2
-      with:
-        python-version: ${{ env.PYTHONVERSION }}
-    - name: Download python SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: python-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress python SDK
-      run: tar -zxf ${{github.workspace}}/sdk/python.tar.gz -C
-        ${{github.workspace}}/sdk/python
-    - name: Download dotnet SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: dotnet-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress dotnet SDK
-      run: tar -zxf ${{github.workspace}}/sdk/dotnet.tar.gz -C
-        ${{github.workspace}}/sdk/dotnet
-    - name: Download nodejs SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: nodejs-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress nodejs SDK
-      run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
-        ${{github.workspace}}/sdk/nodejs
-    - run: python -m pip install pip twine
-    - env:
-        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-      name: Publish SDKs
-      run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - if: failure() && github.event_name == 'push'
-      name: Notify Slack
-      uses: 8398a7/action-slack@v3
-      with:
-        author_name: Failure in publishing SDK
-        fields: repo,commit,author,action
-        status: ${{ job.status }}
+    - name: Publish SDKs
+      uses: pulumi/pulumi-package-publisher@v0.0.5
   test:
     name: test
     needs: build_sdk

--- a/provider-ci/providers/linode/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/linode/repo/.github/workflows/release.yml
@@ -312,131 +312,13 @@ jobs:
         author_name: Failure in publishing binaries
         fields: repo,commit,author,action
         status: ${{ job.status }}
-  publish_java_sdk:
-    continue-on-error: true
-    name: publish_java_sdk
-    needs: publish
-    runs-on: ubuntu-latest
-    steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{ env.JAVAVERSION }}
-    - name: Setup Gradle
-      uses: gradle/gradle-build-action@v2
-      with:
-        gradle-version: "7.6"
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
   publish_sdk:
     name: publish_sdk
     needs: publish
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Node
-      uses: actions/setup-node@v2
-      with:
-        node-version: ${{ env.NODEVERSION }}
-        registry-url: https://registry.npmjs.org
-    - name: Setup DotNet
-      uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: ${{ env.DOTNETVERSION }}
-    - name: Setup Python
-      uses: actions/setup-python@v2
-      with:
-        python-version: ${{ env.PYTHONVERSION }}
-    - name: Download python SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: python-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress python SDK
-      run: tar -zxf ${{github.workspace}}/sdk/python.tar.gz -C
-        ${{github.workspace}}/sdk/python
-    - name: Download dotnet SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: dotnet-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress dotnet SDK
-      run: tar -zxf ${{github.workspace}}/sdk/dotnet.tar.gz -C
-        ${{github.workspace}}/sdk/dotnet
-    - name: Download nodejs SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: nodejs-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress nodejs SDK
-      run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
-        ${{github.workspace}}/sdk/nodejs
-    - run: python -m pip install pip twine
-    - env:
-        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-      name: Publish SDKs
-      run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - if: failure() && github.event_name == 'push'
-      name: Notify Slack
-      uses: 8398a7/action-slack@v3
-      with:
-        author_name: Failure in publishing SDK
-        fields: repo,commit,author,action
-        status: ${{ job.status }}
+    - name: Publish SDKs
+      uses: pulumi/pulumi-package-publisher@v0.0.5
   tag_sdk:
     name: tag_sdk
     needs: publish_sdk

--- a/provider-ci/providers/mailgun/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/mailgun/repo/.github/workflows/main.yml
@@ -350,131 +350,13 @@ jobs:
         author_name: Failure in publishing binaries
         fields: repo,commit,author,action
         status: ${{ job.status }}
-  publish_java_sdk:
-    continue-on-error: true
-    name: publish_java_sdk
-    needs: publish
-    runs-on: ubuntu-latest
-    steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{ env.JAVAVERSION }}
-    - name: Setup Gradle
-      uses: gradle/gradle-build-action@v2
-      with:
-        gradle-version: "7.6"
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
   publish_sdk:
     name: publish_sdk
     needs: publish
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Node
-      uses: actions/setup-node@v2
-      with:
-        node-version: ${{ env.NODEVERSION }}
-        registry-url: https://registry.npmjs.org
-    - name: Setup DotNet
-      uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: ${{ env.DOTNETVERSION }}
-    - name: Setup Python
-      uses: actions/setup-python@v2
-      with:
-        python-version: ${{ env.PYTHONVERSION }}
-    - name: Download python SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: python-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress python SDK
-      run: tar -zxf ${{github.workspace}}/sdk/python.tar.gz -C
-        ${{github.workspace}}/sdk/python
-    - name: Download dotnet SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: dotnet-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress dotnet SDK
-      run: tar -zxf ${{github.workspace}}/sdk/dotnet.tar.gz -C
-        ${{github.workspace}}/sdk/dotnet
-    - name: Download nodejs SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: nodejs-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress nodejs SDK
-      run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
-        ${{github.workspace}}/sdk/nodejs
-    - run: python -m pip install pip twine
-    - env:
-        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-      name: Publish SDKs
-      run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - if: failure() && github.event_name == 'push'
-      name: Notify Slack
-      uses: 8398a7/action-slack@v3
-      with:
-        author_name: Failure in publishing SDK
-        fields: repo,commit,author,action
-        status: ${{ job.status }}
+    - name: Publish SDKs
+      uses: pulumi/pulumi-package-publisher@v0.0.5
   test:
     name: test
     needs: build_sdk

--- a/provider-ci/providers/mailgun/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/mailgun/repo/.github/workflows/master.yml
@@ -350,131 +350,13 @@ jobs:
         author_name: Failure in publishing binaries
         fields: repo,commit,author,action
         status: ${{ job.status }}
-  publish_java_sdk:
-    continue-on-error: true
-    name: publish_java_sdk
-    needs: publish
-    runs-on: ubuntu-latest
-    steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{ env.JAVAVERSION }}
-    - name: Setup Gradle
-      uses: gradle/gradle-build-action@v2
-      with:
-        gradle-version: "7.6"
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
   publish_sdk:
     name: publish_sdk
     needs: publish
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Node
-      uses: actions/setup-node@v2
-      with:
-        node-version: ${{ env.NODEVERSION }}
-        registry-url: https://registry.npmjs.org
-    - name: Setup DotNet
-      uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: ${{ env.DOTNETVERSION }}
-    - name: Setup Python
-      uses: actions/setup-python@v2
-      with:
-        python-version: ${{ env.PYTHONVERSION }}
-    - name: Download python SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: python-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress python SDK
-      run: tar -zxf ${{github.workspace}}/sdk/python.tar.gz -C
-        ${{github.workspace}}/sdk/python
-    - name: Download dotnet SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: dotnet-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress dotnet SDK
-      run: tar -zxf ${{github.workspace}}/sdk/dotnet.tar.gz -C
-        ${{github.workspace}}/sdk/dotnet
-    - name: Download nodejs SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: nodejs-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress nodejs SDK
-      run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
-        ${{github.workspace}}/sdk/nodejs
-    - run: python -m pip install pip twine
-    - env:
-        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-      name: Publish SDKs
-      run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - if: failure() && github.event_name == 'push'
-      name: Notify Slack
-      uses: 8398a7/action-slack@v3
-      with:
-        author_name: Failure in publishing SDK
-        fields: repo,commit,author,action
-        status: ${{ job.status }}
+    - name: Publish SDKs
+      uses: pulumi/pulumi-package-publisher@v0.0.5
   test:
     name: test
     needs: build_sdk

--- a/provider-ci/providers/mailgun/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/mailgun/repo/.github/workflows/prerelease.yml
@@ -300,131 +300,13 @@ jobs:
         author_name: Failure in publishing binaries
         fields: repo,commit,author,action
         status: ${{ job.status }}
-  publish_java_sdk:
-    continue-on-error: true
-    name: publish_java_sdk
-    needs: publish
-    runs-on: ubuntu-latest
-    steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{ env.JAVAVERSION }}
-    - name: Setup Gradle
-      uses: gradle/gradle-build-action@v2
-      with:
-        gradle-version: "7.6"
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
   publish_sdk:
     name: publish_sdk
     needs: publish
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Node
-      uses: actions/setup-node@v2
-      with:
-        node-version: ${{ env.NODEVERSION }}
-        registry-url: https://registry.npmjs.org
-    - name: Setup DotNet
-      uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: ${{ env.DOTNETVERSION }}
-    - name: Setup Python
-      uses: actions/setup-python@v2
-      with:
-        python-version: ${{ env.PYTHONVERSION }}
-    - name: Download python SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: python-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress python SDK
-      run: tar -zxf ${{github.workspace}}/sdk/python.tar.gz -C
-        ${{github.workspace}}/sdk/python
-    - name: Download dotnet SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: dotnet-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress dotnet SDK
-      run: tar -zxf ${{github.workspace}}/sdk/dotnet.tar.gz -C
-        ${{github.workspace}}/sdk/dotnet
-    - name: Download nodejs SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: nodejs-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress nodejs SDK
-      run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
-        ${{github.workspace}}/sdk/nodejs
-    - run: python -m pip install pip twine
-    - env:
-        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-      name: Publish SDKs
-      run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - if: failure() && github.event_name == 'push'
-      name: Notify Slack
-      uses: 8398a7/action-slack@v3
-      with:
-        author_name: Failure in publishing SDK
-        fields: repo,commit,author,action
-        status: ${{ job.status }}
+    - name: Publish SDKs
+      uses: pulumi/pulumi-package-publisher@v0.0.5
   test:
     name: test
     needs: build_sdk

--- a/provider-ci/providers/mailgun/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/mailgun/repo/.github/workflows/release.yml
@@ -312,131 +312,13 @@ jobs:
         author_name: Failure in publishing binaries
         fields: repo,commit,author,action
         status: ${{ job.status }}
-  publish_java_sdk:
-    continue-on-error: true
-    name: publish_java_sdk
-    needs: publish
-    runs-on: ubuntu-latest
-    steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{ env.JAVAVERSION }}
-    - name: Setup Gradle
-      uses: gradle/gradle-build-action@v2
-      with:
-        gradle-version: "7.6"
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
   publish_sdk:
     name: publish_sdk
     needs: publish
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Node
-      uses: actions/setup-node@v2
-      with:
-        node-version: ${{ env.NODEVERSION }}
-        registry-url: https://registry.npmjs.org
-    - name: Setup DotNet
-      uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: ${{ env.DOTNETVERSION }}
-    - name: Setup Python
-      uses: actions/setup-python@v2
-      with:
-        python-version: ${{ env.PYTHONVERSION }}
-    - name: Download python SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: python-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress python SDK
-      run: tar -zxf ${{github.workspace}}/sdk/python.tar.gz -C
-        ${{github.workspace}}/sdk/python
-    - name: Download dotnet SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: dotnet-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress dotnet SDK
-      run: tar -zxf ${{github.workspace}}/sdk/dotnet.tar.gz -C
-        ${{github.workspace}}/sdk/dotnet
-    - name: Download nodejs SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: nodejs-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress nodejs SDK
-      run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
-        ${{github.workspace}}/sdk/nodejs
-    - run: python -m pip install pip twine
-    - env:
-        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-      name: Publish SDKs
-      run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - if: failure() && github.event_name == 'push'
-      name: Notify Slack
-      uses: 8398a7/action-slack@v3
-      with:
-        author_name: Failure in publishing SDK
-        fields: repo,commit,author,action
-        status: ${{ job.status }}
+    - name: Publish SDKs
+      uses: pulumi/pulumi-package-publisher@v0.0.5
   tag_sdk:
     name: tag_sdk
     needs: publish_sdk

--- a/provider-ci/providers/minio/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/minio/repo/.github/workflows/main.yml
@@ -353,131 +353,13 @@ jobs:
         author_name: Failure in publishing binaries
         fields: repo,commit,author,action
         status: ${{ job.status }}
-  publish_java_sdk:
-    continue-on-error: true
-    name: publish_java_sdk
-    needs: publish
-    runs-on: ubuntu-latest
-    steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{ env.JAVAVERSION }}
-    - name: Setup Gradle
-      uses: gradle/gradle-build-action@v2
-      with:
-        gradle-version: "7.6"
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
   publish_sdk:
     name: publish_sdk
     needs: publish
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Node
-      uses: actions/setup-node@v2
-      with:
-        node-version: ${{ env.NODEVERSION }}
-        registry-url: https://registry.npmjs.org
-    - name: Setup DotNet
-      uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: ${{ env.DOTNETVERSION }}
-    - name: Setup Python
-      uses: actions/setup-python@v2
-      with:
-        python-version: ${{ env.PYTHONVERSION }}
-    - name: Download python SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: python-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress python SDK
-      run: tar -zxf ${{github.workspace}}/sdk/python.tar.gz -C
-        ${{github.workspace}}/sdk/python
-    - name: Download dotnet SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: dotnet-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress dotnet SDK
-      run: tar -zxf ${{github.workspace}}/sdk/dotnet.tar.gz -C
-        ${{github.workspace}}/sdk/dotnet
-    - name: Download nodejs SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: nodejs-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress nodejs SDK
-      run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
-        ${{github.workspace}}/sdk/nodejs
-    - run: python -m pip install pip twine
-    - env:
-        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-      name: Publish SDKs
-      run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - if: failure() && github.event_name == 'push'
-      name: Notify Slack
-      uses: 8398a7/action-slack@v3
-      with:
-        author_name: Failure in publishing SDK
-        fields: repo,commit,author,action
-        status: ${{ job.status }}
+    - name: Publish SDKs
+      uses: pulumi/pulumi-package-publisher@v0.0.5
   test:
     name: test
     needs: build_sdk

--- a/provider-ci/providers/minio/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/minio/repo/.github/workflows/master.yml
@@ -353,131 +353,13 @@ jobs:
         author_name: Failure in publishing binaries
         fields: repo,commit,author,action
         status: ${{ job.status }}
-  publish_java_sdk:
-    continue-on-error: true
-    name: publish_java_sdk
-    needs: publish
-    runs-on: ubuntu-latest
-    steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{ env.JAVAVERSION }}
-    - name: Setup Gradle
-      uses: gradle/gradle-build-action@v2
-      with:
-        gradle-version: "7.6"
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
   publish_sdk:
     name: publish_sdk
     needs: publish
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Node
-      uses: actions/setup-node@v2
-      with:
-        node-version: ${{ env.NODEVERSION }}
-        registry-url: https://registry.npmjs.org
-    - name: Setup DotNet
-      uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: ${{ env.DOTNETVERSION }}
-    - name: Setup Python
-      uses: actions/setup-python@v2
-      with:
-        python-version: ${{ env.PYTHONVERSION }}
-    - name: Download python SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: python-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress python SDK
-      run: tar -zxf ${{github.workspace}}/sdk/python.tar.gz -C
-        ${{github.workspace}}/sdk/python
-    - name: Download dotnet SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: dotnet-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress dotnet SDK
-      run: tar -zxf ${{github.workspace}}/sdk/dotnet.tar.gz -C
-        ${{github.workspace}}/sdk/dotnet
-    - name: Download nodejs SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: nodejs-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress nodejs SDK
-      run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
-        ${{github.workspace}}/sdk/nodejs
-    - run: python -m pip install pip twine
-    - env:
-        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-      name: Publish SDKs
-      run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - if: failure() && github.event_name == 'push'
-      name: Notify Slack
-      uses: 8398a7/action-slack@v3
-      with:
-        author_name: Failure in publishing SDK
-        fields: repo,commit,author,action
-        status: ${{ job.status }}
+    - name: Publish SDKs
+      uses: pulumi/pulumi-package-publisher@v0.0.5
   test:
     name: test
     needs: build_sdk

--- a/provider-ci/providers/minio/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/minio/repo/.github/workflows/prerelease.yml
@@ -303,131 +303,13 @@ jobs:
         author_name: Failure in publishing binaries
         fields: repo,commit,author,action
         status: ${{ job.status }}
-  publish_java_sdk:
-    continue-on-error: true
-    name: publish_java_sdk
-    needs: publish
-    runs-on: ubuntu-latest
-    steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{ env.JAVAVERSION }}
-    - name: Setup Gradle
-      uses: gradle/gradle-build-action@v2
-      with:
-        gradle-version: "7.6"
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
   publish_sdk:
     name: publish_sdk
     needs: publish
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Node
-      uses: actions/setup-node@v2
-      with:
-        node-version: ${{ env.NODEVERSION }}
-        registry-url: https://registry.npmjs.org
-    - name: Setup DotNet
-      uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: ${{ env.DOTNETVERSION }}
-    - name: Setup Python
-      uses: actions/setup-python@v2
-      with:
-        python-version: ${{ env.PYTHONVERSION }}
-    - name: Download python SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: python-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress python SDK
-      run: tar -zxf ${{github.workspace}}/sdk/python.tar.gz -C
-        ${{github.workspace}}/sdk/python
-    - name: Download dotnet SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: dotnet-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress dotnet SDK
-      run: tar -zxf ${{github.workspace}}/sdk/dotnet.tar.gz -C
-        ${{github.workspace}}/sdk/dotnet
-    - name: Download nodejs SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: nodejs-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress nodejs SDK
-      run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
-        ${{github.workspace}}/sdk/nodejs
-    - run: python -m pip install pip twine
-    - env:
-        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-      name: Publish SDKs
-      run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - if: failure() && github.event_name == 'push'
-      name: Notify Slack
-      uses: 8398a7/action-slack@v3
-      with:
-        author_name: Failure in publishing SDK
-        fields: repo,commit,author,action
-        status: ${{ job.status }}
+    - name: Publish SDKs
+      uses: pulumi/pulumi-package-publisher@v0.0.5
   test:
     name: test
     needs: build_sdk

--- a/provider-ci/providers/minio/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/minio/repo/.github/workflows/release.yml
@@ -315,131 +315,13 @@ jobs:
         author_name: Failure in publishing binaries
         fields: repo,commit,author,action
         status: ${{ job.status }}
-  publish_java_sdk:
-    continue-on-error: true
-    name: publish_java_sdk
-    needs: publish
-    runs-on: ubuntu-latest
-    steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{ env.JAVAVERSION }}
-    - name: Setup Gradle
-      uses: gradle/gradle-build-action@v2
-      with:
-        gradle-version: "7.6"
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
   publish_sdk:
     name: publish_sdk
     needs: publish
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Node
-      uses: actions/setup-node@v2
-      with:
-        node-version: ${{ env.NODEVERSION }}
-        registry-url: https://registry.npmjs.org
-    - name: Setup DotNet
-      uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: ${{ env.DOTNETVERSION }}
-    - name: Setup Python
-      uses: actions/setup-python@v2
-      with:
-        python-version: ${{ env.PYTHONVERSION }}
-    - name: Download python SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: python-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress python SDK
-      run: tar -zxf ${{github.workspace}}/sdk/python.tar.gz -C
-        ${{github.workspace}}/sdk/python
-    - name: Download dotnet SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: dotnet-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress dotnet SDK
-      run: tar -zxf ${{github.workspace}}/sdk/dotnet.tar.gz -C
-        ${{github.workspace}}/sdk/dotnet
-    - name: Download nodejs SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: nodejs-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress nodejs SDK
-      run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
-        ${{github.workspace}}/sdk/nodejs
-    - run: python -m pip install pip twine
-    - env:
-        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-      name: Publish SDKs
-      run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - if: failure() && github.event_name == 'push'
-      name: Notify Slack
-      uses: 8398a7/action-slack@v3
-      with:
-        author_name: Failure in publishing SDK
-        fields: repo,commit,author,action
-        status: ${{ job.status }}
+    - name: Publish SDKs
+      uses: pulumi/pulumi-package-publisher@v0.0.5
   tag_sdk:
     name: tag_sdk
     needs: publish_sdk

--- a/provider-ci/providers/mongodbatlas/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/mongodbatlas/repo/.github/workflows/main.yml
@@ -352,131 +352,13 @@ jobs:
         author_name: Failure in publishing binaries
         fields: repo,commit,author,action
         status: ${{ job.status }}
-  publish_java_sdk:
-    continue-on-error: true
-    name: publish_java_sdk
-    needs: publish
-    runs-on: ubuntu-latest
-    steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{ env.JAVAVERSION }}
-    - name: Setup Gradle
-      uses: gradle/gradle-build-action@v2
-      with:
-        gradle-version: "7.6"
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
   publish_sdk:
     name: publish_sdk
     needs: publish
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Node
-      uses: actions/setup-node@v2
-      with:
-        node-version: ${{ env.NODEVERSION }}
-        registry-url: https://registry.npmjs.org
-    - name: Setup DotNet
-      uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: ${{ env.DOTNETVERSION }}
-    - name: Setup Python
-      uses: actions/setup-python@v2
-      with:
-        python-version: ${{ env.PYTHONVERSION }}
-    - name: Download python SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: python-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress python SDK
-      run: tar -zxf ${{github.workspace}}/sdk/python.tar.gz -C
-        ${{github.workspace}}/sdk/python
-    - name: Download dotnet SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: dotnet-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress dotnet SDK
-      run: tar -zxf ${{github.workspace}}/sdk/dotnet.tar.gz -C
-        ${{github.workspace}}/sdk/dotnet
-    - name: Download nodejs SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: nodejs-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress nodejs SDK
-      run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
-        ${{github.workspace}}/sdk/nodejs
-    - run: python -m pip install pip twine
-    - env:
-        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-      name: Publish SDKs
-      run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - if: failure() && github.event_name == 'push'
-      name: Notify Slack
-      uses: 8398a7/action-slack@v3
-      with:
-        author_name: Failure in publishing SDK
-        fields: repo,commit,author,action
-        status: ${{ job.status }}
+    - name: Publish SDKs
+      uses: pulumi/pulumi-package-publisher@v0.0.5
   test:
     name: test
     needs: build_sdk

--- a/provider-ci/providers/mongodbatlas/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/mongodbatlas/repo/.github/workflows/master.yml
@@ -352,131 +352,13 @@ jobs:
         author_name: Failure in publishing binaries
         fields: repo,commit,author,action
         status: ${{ job.status }}
-  publish_java_sdk:
-    continue-on-error: true
-    name: publish_java_sdk
-    needs: publish
-    runs-on: ubuntu-latest
-    steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{ env.JAVAVERSION }}
-    - name: Setup Gradle
-      uses: gradle/gradle-build-action@v2
-      with:
-        gradle-version: "7.6"
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
   publish_sdk:
     name: publish_sdk
     needs: publish
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Node
-      uses: actions/setup-node@v2
-      with:
-        node-version: ${{ env.NODEVERSION }}
-        registry-url: https://registry.npmjs.org
-    - name: Setup DotNet
-      uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: ${{ env.DOTNETVERSION }}
-    - name: Setup Python
-      uses: actions/setup-python@v2
-      with:
-        python-version: ${{ env.PYTHONVERSION }}
-    - name: Download python SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: python-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress python SDK
-      run: tar -zxf ${{github.workspace}}/sdk/python.tar.gz -C
-        ${{github.workspace}}/sdk/python
-    - name: Download dotnet SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: dotnet-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress dotnet SDK
-      run: tar -zxf ${{github.workspace}}/sdk/dotnet.tar.gz -C
-        ${{github.workspace}}/sdk/dotnet
-    - name: Download nodejs SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: nodejs-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress nodejs SDK
-      run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
-        ${{github.workspace}}/sdk/nodejs
-    - run: python -m pip install pip twine
-    - env:
-        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-      name: Publish SDKs
-      run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - if: failure() && github.event_name == 'push'
-      name: Notify Slack
-      uses: 8398a7/action-slack@v3
-      with:
-        author_name: Failure in publishing SDK
-        fields: repo,commit,author,action
-        status: ${{ job.status }}
+    - name: Publish SDKs
+      uses: pulumi/pulumi-package-publisher@v0.0.5
   test:
     name: test
     needs: build_sdk

--- a/provider-ci/providers/mongodbatlas/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/mongodbatlas/repo/.github/workflows/prerelease.yml
@@ -302,131 +302,13 @@ jobs:
         author_name: Failure in publishing binaries
         fields: repo,commit,author,action
         status: ${{ job.status }}
-  publish_java_sdk:
-    continue-on-error: true
-    name: publish_java_sdk
-    needs: publish
-    runs-on: ubuntu-latest
-    steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{ env.JAVAVERSION }}
-    - name: Setup Gradle
-      uses: gradle/gradle-build-action@v2
-      with:
-        gradle-version: "7.6"
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
   publish_sdk:
     name: publish_sdk
     needs: publish
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Node
-      uses: actions/setup-node@v2
-      with:
-        node-version: ${{ env.NODEVERSION }}
-        registry-url: https://registry.npmjs.org
-    - name: Setup DotNet
-      uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: ${{ env.DOTNETVERSION }}
-    - name: Setup Python
-      uses: actions/setup-python@v2
-      with:
-        python-version: ${{ env.PYTHONVERSION }}
-    - name: Download python SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: python-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress python SDK
-      run: tar -zxf ${{github.workspace}}/sdk/python.tar.gz -C
-        ${{github.workspace}}/sdk/python
-    - name: Download dotnet SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: dotnet-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress dotnet SDK
-      run: tar -zxf ${{github.workspace}}/sdk/dotnet.tar.gz -C
-        ${{github.workspace}}/sdk/dotnet
-    - name: Download nodejs SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: nodejs-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress nodejs SDK
-      run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
-        ${{github.workspace}}/sdk/nodejs
-    - run: python -m pip install pip twine
-    - env:
-        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-      name: Publish SDKs
-      run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - if: failure() && github.event_name == 'push'
-      name: Notify Slack
-      uses: 8398a7/action-slack@v3
-      with:
-        author_name: Failure in publishing SDK
-        fields: repo,commit,author,action
-        status: ${{ job.status }}
+    - name: Publish SDKs
+      uses: pulumi/pulumi-package-publisher@v0.0.5
   test:
     name: test
     needs: build_sdk

--- a/provider-ci/providers/mongodbatlas/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/mongodbatlas/repo/.github/workflows/release.yml
@@ -314,131 +314,13 @@ jobs:
         author_name: Failure in publishing binaries
         fields: repo,commit,author,action
         status: ${{ job.status }}
-  publish_java_sdk:
-    continue-on-error: true
-    name: publish_java_sdk
-    needs: publish
-    runs-on: ubuntu-latest
-    steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{ env.JAVAVERSION }}
-    - name: Setup Gradle
-      uses: gradle/gradle-build-action@v2
-      with:
-        gradle-version: "7.6"
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
   publish_sdk:
     name: publish_sdk
     needs: publish
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Node
-      uses: actions/setup-node@v2
-      with:
-        node-version: ${{ env.NODEVERSION }}
-        registry-url: https://registry.npmjs.org
-    - name: Setup DotNet
-      uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: ${{ env.DOTNETVERSION }}
-    - name: Setup Python
-      uses: actions/setup-python@v2
-      with:
-        python-version: ${{ env.PYTHONVERSION }}
-    - name: Download python SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: python-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress python SDK
-      run: tar -zxf ${{github.workspace}}/sdk/python.tar.gz -C
-        ${{github.workspace}}/sdk/python
-    - name: Download dotnet SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: dotnet-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress dotnet SDK
-      run: tar -zxf ${{github.workspace}}/sdk/dotnet.tar.gz -C
-        ${{github.workspace}}/sdk/dotnet
-    - name: Download nodejs SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: nodejs-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress nodejs SDK
-      run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
-        ${{github.workspace}}/sdk/nodejs
-    - run: python -m pip install pip twine
-    - env:
-        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-      name: Publish SDKs
-      run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - if: failure() && github.event_name == 'push'
-      name: Notify Slack
-      uses: 8398a7/action-slack@v3
-      with:
-        author_name: Failure in publishing SDK
-        fields: repo,commit,author,action
-        status: ${{ job.status }}
+    - name: Publish SDKs
+      uses: pulumi/pulumi-package-publisher@v0.0.5
   tag_sdk:
     name: tag_sdk
     needs: publish_sdk

--- a/provider-ci/providers/mysql/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/mysql/repo/.github/workflows/main.yml
@@ -349,131 +349,13 @@ jobs:
         author_name: Failure in publishing binaries
         fields: repo,commit,author,action
         status: ${{ job.status }}
-  publish_java_sdk:
-    continue-on-error: true
-    name: publish_java_sdk
-    needs: publish
-    runs-on: ubuntu-latest
-    steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{ env.JAVAVERSION }}
-    - name: Setup Gradle
-      uses: gradle/gradle-build-action@v2
-      with:
-        gradle-version: "7.6"
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
   publish_sdk:
     name: publish_sdk
     needs: publish
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Node
-      uses: actions/setup-node@v2
-      with:
-        node-version: ${{ env.NODEVERSION }}
-        registry-url: https://registry.npmjs.org
-    - name: Setup DotNet
-      uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: ${{ env.DOTNETVERSION }}
-    - name: Setup Python
-      uses: actions/setup-python@v2
-      with:
-        python-version: ${{ env.PYTHONVERSION }}
-    - name: Download python SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: python-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress python SDK
-      run: tar -zxf ${{github.workspace}}/sdk/python.tar.gz -C
-        ${{github.workspace}}/sdk/python
-    - name: Download dotnet SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: dotnet-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress dotnet SDK
-      run: tar -zxf ${{github.workspace}}/sdk/dotnet.tar.gz -C
-        ${{github.workspace}}/sdk/dotnet
-    - name: Download nodejs SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: nodejs-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress nodejs SDK
-      run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
-        ${{github.workspace}}/sdk/nodejs
-    - run: python -m pip install pip twine
-    - env:
-        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-      name: Publish SDKs
-      run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - if: failure() && github.event_name == 'push'
-      name: Notify Slack
-      uses: 8398a7/action-slack@v3
-      with:
-        author_name: Failure in publishing SDK
-        fields: repo,commit,author,action
-        status: ${{ job.status }}
+    - name: Publish SDKs
+      uses: pulumi/pulumi-package-publisher@v0.0.5
   test:
     name: test
     needs: build_sdk

--- a/provider-ci/providers/mysql/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/mysql/repo/.github/workflows/master.yml
@@ -349,131 +349,13 @@ jobs:
         author_name: Failure in publishing binaries
         fields: repo,commit,author,action
         status: ${{ job.status }}
-  publish_java_sdk:
-    continue-on-error: true
-    name: publish_java_sdk
-    needs: publish
-    runs-on: ubuntu-latest
-    steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{ env.JAVAVERSION }}
-    - name: Setup Gradle
-      uses: gradle/gradle-build-action@v2
-      with:
-        gradle-version: "7.6"
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
   publish_sdk:
     name: publish_sdk
     needs: publish
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Node
-      uses: actions/setup-node@v2
-      with:
-        node-version: ${{ env.NODEVERSION }}
-        registry-url: https://registry.npmjs.org
-    - name: Setup DotNet
-      uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: ${{ env.DOTNETVERSION }}
-    - name: Setup Python
-      uses: actions/setup-python@v2
-      with:
-        python-version: ${{ env.PYTHONVERSION }}
-    - name: Download python SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: python-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress python SDK
-      run: tar -zxf ${{github.workspace}}/sdk/python.tar.gz -C
-        ${{github.workspace}}/sdk/python
-    - name: Download dotnet SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: dotnet-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress dotnet SDK
-      run: tar -zxf ${{github.workspace}}/sdk/dotnet.tar.gz -C
-        ${{github.workspace}}/sdk/dotnet
-    - name: Download nodejs SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: nodejs-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress nodejs SDK
-      run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
-        ${{github.workspace}}/sdk/nodejs
-    - run: python -m pip install pip twine
-    - env:
-        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-      name: Publish SDKs
-      run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - if: failure() && github.event_name == 'push'
-      name: Notify Slack
-      uses: 8398a7/action-slack@v3
-      with:
-        author_name: Failure in publishing SDK
-        fields: repo,commit,author,action
-        status: ${{ job.status }}
+    - name: Publish SDKs
+      uses: pulumi/pulumi-package-publisher@v0.0.5
   test:
     name: test
     needs: build_sdk

--- a/provider-ci/providers/mysql/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/mysql/repo/.github/workflows/prerelease.yml
@@ -299,131 +299,13 @@ jobs:
         author_name: Failure in publishing binaries
         fields: repo,commit,author,action
         status: ${{ job.status }}
-  publish_java_sdk:
-    continue-on-error: true
-    name: publish_java_sdk
-    needs: publish
-    runs-on: ubuntu-latest
-    steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{ env.JAVAVERSION }}
-    - name: Setup Gradle
-      uses: gradle/gradle-build-action@v2
-      with:
-        gradle-version: "7.6"
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
   publish_sdk:
     name: publish_sdk
     needs: publish
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Node
-      uses: actions/setup-node@v2
-      with:
-        node-version: ${{ env.NODEVERSION }}
-        registry-url: https://registry.npmjs.org
-    - name: Setup DotNet
-      uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: ${{ env.DOTNETVERSION }}
-    - name: Setup Python
-      uses: actions/setup-python@v2
-      with:
-        python-version: ${{ env.PYTHONVERSION }}
-    - name: Download python SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: python-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress python SDK
-      run: tar -zxf ${{github.workspace}}/sdk/python.tar.gz -C
-        ${{github.workspace}}/sdk/python
-    - name: Download dotnet SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: dotnet-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress dotnet SDK
-      run: tar -zxf ${{github.workspace}}/sdk/dotnet.tar.gz -C
-        ${{github.workspace}}/sdk/dotnet
-    - name: Download nodejs SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: nodejs-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress nodejs SDK
-      run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
-        ${{github.workspace}}/sdk/nodejs
-    - run: python -m pip install pip twine
-    - env:
-        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-      name: Publish SDKs
-      run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - if: failure() && github.event_name == 'push'
-      name: Notify Slack
-      uses: 8398a7/action-slack@v3
-      with:
-        author_name: Failure in publishing SDK
-        fields: repo,commit,author,action
-        status: ${{ job.status }}
+    - name: Publish SDKs
+      uses: pulumi/pulumi-package-publisher@v0.0.5
   test:
     name: test
     needs: build_sdk

--- a/provider-ci/providers/mysql/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/mysql/repo/.github/workflows/release.yml
@@ -311,131 +311,13 @@ jobs:
         author_name: Failure in publishing binaries
         fields: repo,commit,author,action
         status: ${{ job.status }}
-  publish_java_sdk:
-    continue-on-error: true
-    name: publish_java_sdk
-    needs: publish
-    runs-on: ubuntu-latest
-    steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{ env.JAVAVERSION }}
-    - name: Setup Gradle
-      uses: gradle/gradle-build-action@v2
-      with:
-        gradle-version: "7.6"
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
   publish_sdk:
     name: publish_sdk
     needs: publish
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Node
-      uses: actions/setup-node@v2
-      with:
-        node-version: ${{ env.NODEVERSION }}
-        registry-url: https://registry.npmjs.org
-    - name: Setup DotNet
-      uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: ${{ env.DOTNETVERSION }}
-    - name: Setup Python
-      uses: actions/setup-python@v2
-      with:
-        python-version: ${{ env.PYTHONVERSION }}
-    - name: Download python SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: python-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress python SDK
-      run: tar -zxf ${{github.workspace}}/sdk/python.tar.gz -C
-        ${{github.workspace}}/sdk/python
-    - name: Download dotnet SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: dotnet-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress dotnet SDK
-      run: tar -zxf ${{github.workspace}}/sdk/dotnet.tar.gz -C
-        ${{github.workspace}}/sdk/dotnet
-    - name: Download nodejs SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: nodejs-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress nodejs SDK
-      run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
-        ${{github.workspace}}/sdk/nodejs
-    - run: python -m pip install pip twine
-    - env:
-        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-      name: Publish SDKs
-      run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - if: failure() && github.event_name == 'push'
-      name: Notify Slack
-      uses: 8398a7/action-slack@v3
-      with:
-        author_name: Failure in publishing SDK
-        fields: repo,commit,author,action
-        status: ${{ job.status }}
+    - name: Publish SDKs
+      uses: pulumi/pulumi-package-publisher@v0.0.5
   tag_sdk:
     name: tag_sdk
     needs: publish_sdk

--- a/provider-ci/providers/newrelic/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/newrelic/repo/.github/workflows/main.yml
@@ -351,131 +351,13 @@ jobs:
         author_name: Failure in publishing binaries
         fields: repo,commit,author,action
         status: ${{ job.status }}
-  publish_java_sdk:
-    continue-on-error: true
-    name: publish_java_sdk
-    needs: publish
-    runs-on: ubuntu-latest
-    steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{ env.JAVAVERSION }}
-    - name: Setup Gradle
-      uses: gradle/gradle-build-action@v2
-      with:
-        gradle-version: "7.6"
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
   publish_sdk:
     name: publish_sdk
     needs: publish
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Node
-      uses: actions/setup-node@v2
-      with:
-        node-version: ${{ env.NODEVERSION }}
-        registry-url: https://registry.npmjs.org
-    - name: Setup DotNet
-      uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: ${{ env.DOTNETVERSION }}
-    - name: Setup Python
-      uses: actions/setup-python@v2
-      with:
-        python-version: ${{ env.PYTHONVERSION }}
-    - name: Download python SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: python-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress python SDK
-      run: tar -zxf ${{github.workspace}}/sdk/python.tar.gz -C
-        ${{github.workspace}}/sdk/python
-    - name: Download dotnet SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: dotnet-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress dotnet SDK
-      run: tar -zxf ${{github.workspace}}/sdk/dotnet.tar.gz -C
-        ${{github.workspace}}/sdk/dotnet
-    - name: Download nodejs SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: nodejs-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress nodejs SDK
-      run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
-        ${{github.workspace}}/sdk/nodejs
-    - run: python -m pip install pip twine
-    - env:
-        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-      name: Publish SDKs
-      run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - if: failure() && github.event_name == 'push'
-      name: Notify Slack
-      uses: 8398a7/action-slack@v3
-      with:
-        author_name: Failure in publishing SDK
-        fields: repo,commit,author,action
-        status: ${{ job.status }}
+    - name: Publish SDKs
+      uses: pulumi/pulumi-package-publisher@v0.0.5
   test:
     name: test
     needs: build_sdk

--- a/provider-ci/providers/newrelic/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/newrelic/repo/.github/workflows/master.yml
@@ -351,131 +351,13 @@ jobs:
         author_name: Failure in publishing binaries
         fields: repo,commit,author,action
         status: ${{ job.status }}
-  publish_java_sdk:
-    continue-on-error: true
-    name: publish_java_sdk
-    needs: publish
-    runs-on: ubuntu-latest
-    steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{ env.JAVAVERSION }}
-    - name: Setup Gradle
-      uses: gradle/gradle-build-action@v2
-      with:
-        gradle-version: "7.6"
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
   publish_sdk:
     name: publish_sdk
     needs: publish
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Node
-      uses: actions/setup-node@v2
-      with:
-        node-version: ${{ env.NODEVERSION }}
-        registry-url: https://registry.npmjs.org
-    - name: Setup DotNet
-      uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: ${{ env.DOTNETVERSION }}
-    - name: Setup Python
-      uses: actions/setup-python@v2
-      with:
-        python-version: ${{ env.PYTHONVERSION }}
-    - name: Download python SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: python-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress python SDK
-      run: tar -zxf ${{github.workspace}}/sdk/python.tar.gz -C
-        ${{github.workspace}}/sdk/python
-    - name: Download dotnet SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: dotnet-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress dotnet SDK
-      run: tar -zxf ${{github.workspace}}/sdk/dotnet.tar.gz -C
-        ${{github.workspace}}/sdk/dotnet
-    - name: Download nodejs SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: nodejs-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress nodejs SDK
-      run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
-        ${{github.workspace}}/sdk/nodejs
-    - run: python -m pip install pip twine
-    - env:
-        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-      name: Publish SDKs
-      run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - if: failure() && github.event_name == 'push'
-      name: Notify Slack
-      uses: 8398a7/action-slack@v3
-      with:
-        author_name: Failure in publishing SDK
-        fields: repo,commit,author,action
-        status: ${{ job.status }}
+    - name: Publish SDKs
+      uses: pulumi/pulumi-package-publisher@v0.0.5
   test:
     name: test
     needs: build_sdk

--- a/provider-ci/providers/newrelic/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/newrelic/repo/.github/workflows/prerelease.yml
@@ -301,131 +301,13 @@ jobs:
         author_name: Failure in publishing binaries
         fields: repo,commit,author,action
         status: ${{ job.status }}
-  publish_java_sdk:
-    continue-on-error: true
-    name: publish_java_sdk
-    needs: publish
-    runs-on: ubuntu-latest
-    steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{ env.JAVAVERSION }}
-    - name: Setup Gradle
-      uses: gradle/gradle-build-action@v2
-      with:
-        gradle-version: "7.6"
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
   publish_sdk:
     name: publish_sdk
     needs: publish
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Node
-      uses: actions/setup-node@v2
-      with:
-        node-version: ${{ env.NODEVERSION }}
-        registry-url: https://registry.npmjs.org
-    - name: Setup DotNet
-      uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: ${{ env.DOTNETVERSION }}
-    - name: Setup Python
-      uses: actions/setup-python@v2
-      with:
-        python-version: ${{ env.PYTHONVERSION }}
-    - name: Download python SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: python-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress python SDK
-      run: tar -zxf ${{github.workspace}}/sdk/python.tar.gz -C
-        ${{github.workspace}}/sdk/python
-    - name: Download dotnet SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: dotnet-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress dotnet SDK
-      run: tar -zxf ${{github.workspace}}/sdk/dotnet.tar.gz -C
-        ${{github.workspace}}/sdk/dotnet
-    - name: Download nodejs SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: nodejs-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress nodejs SDK
-      run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
-        ${{github.workspace}}/sdk/nodejs
-    - run: python -m pip install pip twine
-    - env:
-        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-      name: Publish SDKs
-      run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - if: failure() && github.event_name == 'push'
-      name: Notify Slack
-      uses: 8398a7/action-slack@v3
-      with:
-        author_name: Failure in publishing SDK
-        fields: repo,commit,author,action
-        status: ${{ job.status }}
+    - name: Publish SDKs
+      uses: pulumi/pulumi-package-publisher@v0.0.5
   test:
     name: test
     needs: build_sdk

--- a/provider-ci/providers/newrelic/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/newrelic/repo/.github/workflows/release.yml
@@ -313,131 +313,13 @@ jobs:
         author_name: Failure in publishing binaries
         fields: repo,commit,author,action
         status: ${{ job.status }}
-  publish_java_sdk:
-    continue-on-error: true
-    name: publish_java_sdk
-    needs: publish
-    runs-on: ubuntu-latest
-    steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{ env.JAVAVERSION }}
-    - name: Setup Gradle
-      uses: gradle/gradle-build-action@v2
-      with:
-        gradle-version: "7.6"
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
   publish_sdk:
     name: publish_sdk
     needs: publish
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Node
-      uses: actions/setup-node@v2
-      with:
-        node-version: ${{ env.NODEVERSION }}
-        registry-url: https://registry.npmjs.org
-    - name: Setup DotNet
-      uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: ${{ env.DOTNETVERSION }}
-    - name: Setup Python
-      uses: actions/setup-python@v2
-      with:
-        python-version: ${{ env.PYTHONVERSION }}
-    - name: Download python SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: python-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress python SDK
-      run: tar -zxf ${{github.workspace}}/sdk/python.tar.gz -C
-        ${{github.workspace}}/sdk/python
-    - name: Download dotnet SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: dotnet-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress dotnet SDK
-      run: tar -zxf ${{github.workspace}}/sdk/dotnet.tar.gz -C
-        ${{github.workspace}}/sdk/dotnet
-    - name: Download nodejs SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: nodejs-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress nodejs SDK
-      run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
-        ${{github.workspace}}/sdk/nodejs
-    - run: python -m pip install pip twine
-    - env:
-        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-      name: Publish SDKs
-      run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - if: failure() && github.event_name == 'push'
-      name: Notify Slack
-      uses: 8398a7/action-slack@v3
-      with:
-        author_name: Failure in publishing SDK
-        fields: repo,commit,author,action
-        status: ${{ job.status }}
+    - name: Publish SDKs
+      uses: pulumi/pulumi-package-publisher@v0.0.5
   tag_sdk:
     name: tag_sdk
     needs: publish_sdk

--- a/provider-ci/providers/nomad/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/nomad/repo/.github/workflows/main.yml
@@ -350,131 +350,13 @@ jobs:
         author_name: Failure in publishing binaries
         fields: repo,commit,author,action
         status: ${{ job.status }}
-  publish_java_sdk:
-    continue-on-error: true
-    name: publish_java_sdk
-    needs: publish
-    runs-on: ubuntu-latest
-    steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{ env.JAVAVERSION }}
-    - name: Setup Gradle
-      uses: gradle/gradle-build-action@v2
-      with:
-        gradle-version: "7.6"
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
   publish_sdk:
     name: publish_sdk
     needs: publish
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Node
-      uses: actions/setup-node@v2
-      with:
-        node-version: ${{ env.NODEVERSION }}
-        registry-url: https://registry.npmjs.org
-    - name: Setup DotNet
-      uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: ${{ env.DOTNETVERSION }}
-    - name: Setup Python
-      uses: actions/setup-python@v2
-      with:
-        python-version: ${{ env.PYTHONVERSION }}
-    - name: Download python SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: python-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress python SDK
-      run: tar -zxf ${{github.workspace}}/sdk/python.tar.gz -C
-        ${{github.workspace}}/sdk/python
-    - name: Download dotnet SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: dotnet-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress dotnet SDK
-      run: tar -zxf ${{github.workspace}}/sdk/dotnet.tar.gz -C
-        ${{github.workspace}}/sdk/dotnet
-    - name: Download nodejs SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: nodejs-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress nodejs SDK
-      run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
-        ${{github.workspace}}/sdk/nodejs
-    - run: python -m pip install pip twine
-    - env:
-        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-      name: Publish SDKs
-      run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - if: failure() && github.event_name == 'push'
-      name: Notify Slack
-      uses: 8398a7/action-slack@v3
-      with:
-        author_name: Failure in publishing SDK
-        fields: repo,commit,author,action
-        status: ${{ job.status }}
+    - name: Publish SDKs
+      uses: pulumi/pulumi-package-publisher@v0.0.5
   test:
     name: test
     needs: build_sdk

--- a/provider-ci/providers/nomad/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/nomad/repo/.github/workflows/master.yml
@@ -350,131 +350,13 @@ jobs:
         author_name: Failure in publishing binaries
         fields: repo,commit,author,action
         status: ${{ job.status }}
-  publish_java_sdk:
-    continue-on-error: true
-    name: publish_java_sdk
-    needs: publish
-    runs-on: ubuntu-latest
-    steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{ env.JAVAVERSION }}
-    - name: Setup Gradle
-      uses: gradle/gradle-build-action@v2
-      with:
-        gradle-version: "7.6"
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
   publish_sdk:
     name: publish_sdk
     needs: publish
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Node
-      uses: actions/setup-node@v2
-      with:
-        node-version: ${{ env.NODEVERSION }}
-        registry-url: https://registry.npmjs.org
-    - name: Setup DotNet
-      uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: ${{ env.DOTNETVERSION }}
-    - name: Setup Python
-      uses: actions/setup-python@v2
-      with:
-        python-version: ${{ env.PYTHONVERSION }}
-    - name: Download python SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: python-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress python SDK
-      run: tar -zxf ${{github.workspace}}/sdk/python.tar.gz -C
-        ${{github.workspace}}/sdk/python
-    - name: Download dotnet SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: dotnet-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress dotnet SDK
-      run: tar -zxf ${{github.workspace}}/sdk/dotnet.tar.gz -C
-        ${{github.workspace}}/sdk/dotnet
-    - name: Download nodejs SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: nodejs-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress nodejs SDK
-      run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
-        ${{github.workspace}}/sdk/nodejs
-    - run: python -m pip install pip twine
-    - env:
-        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-      name: Publish SDKs
-      run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - if: failure() && github.event_name == 'push'
-      name: Notify Slack
-      uses: 8398a7/action-slack@v3
-      with:
-        author_name: Failure in publishing SDK
-        fields: repo,commit,author,action
-        status: ${{ job.status }}
+    - name: Publish SDKs
+      uses: pulumi/pulumi-package-publisher@v0.0.5
   test:
     name: test
     needs: build_sdk

--- a/provider-ci/providers/nomad/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/nomad/repo/.github/workflows/prerelease.yml
@@ -300,131 +300,13 @@ jobs:
         author_name: Failure in publishing binaries
         fields: repo,commit,author,action
         status: ${{ job.status }}
-  publish_java_sdk:
-    continue-on-error: true
-    name: publish_java_sdk
-    needs: publish
-    runs-on: ubuntu-latest
-    steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{ env.JAVAVERSION }}
-    - name: Setup Gradle
-      uses: gradle/gradle-build-action@v2
-      with:
-        gradle-version: "7.6"
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
   publish_sdk:
     name: publish_sdk
     needs: publish
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Node
-      uses: actions/setup-node@v2
-      with:
-        node-version: ${{ env.NODEVERSION }}
-        registry-url: https://registry.npmjs.org
-    - name: Setup DotNet
-      uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: ${{ env.DOTNETVERSION }}
-    - name: Setup Python
-      uses: actions/setup-python@v2
-      with:
-        python-version: ${{ env.PYTHONVERSION }}
-    - name: Download python SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: python-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress python SDK
-      run: tar -zxf ${{github.workspace}}/sdk/python.tar.gz -C
-        ${{github.workspace}}/sdk/python
-    - name: Download dotnet SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: dotnet-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress dotnet SDK
-      run: tar -zxf ${{github.workspace}}/sdk/dotnet.tar.gz -C
-        ${{github.workspace}}/sdk/dotnet
-    - name: Download nodejs SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: nodejs-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress nodejs SDK
-      run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
-        ${{github.workspace}}/sdk/nodejs
-    - run: python -m pip install pip twine
-    - env:
-        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-      name: Publish SDKs
-      run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - if: failure() && github.event_name == 'push'
-      name: Notify Slack
-      uses: 8398a7/action-slack@v3
-      with:
-        author_name: Failure in publishing SDK
-        fields: repo,commit,author,action
-        status: ${{ job.status }}
+    - name: Publish SDKs
+      uses: pulumi/pulumi-package-publisher@v0.0.5
   test:
     name: test
     needs: build_sdk

--- a/provider-ci/providers/nomad/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/nomad/repo/.github/workflows/release.yml
@@ -312,131 +312,13 @@ jobs:
         author_name: Failure in publishing binaries
         fields: repo,commit,author,action
         status: ${{ job.status }}
-  publish_java_sdk:
-    continue-on-error: true
-    name: publish_java_sdk
-    needs: publish
-    runs-on: ubuntu-latest
-    steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{ env.JAVAVERSION }}
-    - name: Setup Gradle
-      uses: gradle/gradle-build-action@v2
-      with:
-        gradle-version: "7.6"
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
   publish_sdk:
     name: publish_sdk
     needs: publish
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Node
-      uses: actions/setup-node@v2
-      with:
-        node-version: ${{ env.NODEVERSION }}
-        registry-url: https://registry.npmjs.org
-    - name: Setup DotNet
-      uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: ${{ env.DOTNETVERSION }}
-    - name: Setup Python
-      uses: actions/setup-python@v2
-      with:
-        python-version: ${{ env.PYTHONVERSION }}
-    - name: Download python SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: python-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress python SDK
-      run: tar -zxf ${{github.workspace}}/sdk/python.tar.gz -C
-        ${{github.workspace}}/sdk/python
-    - name: Download dotnet SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: dotnet-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress dotnet SDK
-      run: tar -zxf ${{github.workspace}}/sdk/dotnet.tar.gz -C
-        ${{github.workspace}}/sdk/dotnet
-    - name: Download nodejs SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: nodejs-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress nodejs SDK
-      run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
-        ${{github.workspace}}/sdk/nodejs
-    - run: python -m pip install pip twine
-    - env:
-        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-      name: Publish SDKs
-      run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - if: failure() && github.event_name == 'push'
-      name: Notify Slack
-      uses: 8398a7/action-slack@v3
-      with:
-        author_name: Failure in publishing SDK
-        fields: repo,commit,author,action
-        status: ${{ job.status }}
+    - name: Publish SDKs
+      uses: pulumi/pulumi-package-publisher@v0.0.5
   tag_sdk:
     name: tag_sdk
     needs: publish_sdk

--- a/provider-ci/providers/ns1/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/ns1/repo/.github/workflows/main.yml
@@ -350,131 +350,13 @@ jobs:
         author_name: Failure in publishing binaries
         fields: repo,commit,author,action
         status: ${{ job.status }}
-  publish_java_sdk:
-    continue-on-error: true
-    name: publish_java_sdk
-    needs: publish
-    runs-on: ubuntu-latest
-    steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{ env.JAVAVERSION }}
-    - name: Setup Gradle
-      uses: gradle/gradle-build-action@v2
-      with:
-        gradle-version: "7.6"
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
   publish_sdk:
     name: publish_sdk
     needs: publish
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Node
-      uses: actions/setup-node@v2
-      with:
-        node-version: ${{ env.NODEVERSION }}
-        registry-url: https://registry.npmjs.org
-    - name: Setup DotNet
-      uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: ${{ env.DOTNETVERSION }}
-    - name: Setup Python
-      uses: actions/setup-python@v2
-      with:
-        python-version: ${{ env.PYTHONVERSION }}
-    - name: Download python SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: python-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress python SDK
-      run: tar -zxf ${{github.workspace}}/sdk/python.tar.gz -C
-        ${{github.workspace}}/sdk/python
-    - name: Download dotnet SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: dotnet-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress dotnet SDK
-      run: tar -zxf ${{github.workspace}}/sdk/dotnet.tar.gz -C
-        ${{github.workspace}}/sdk/dotnet
-    - name: Download nodejs SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: nodejs-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress nodejs SDK
-      run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
-        ${{github.workspace}}/sdk/nodejs
-    - run: python -m pip install pip twine
-    - env:
-        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-      name: Publish SDKs
-      run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - if: failure() && github.event_name == 'push'
-      name: Notify Slack
-      uses: 8398a7/action-slack@v3
-      with:
-        author_name: Failure in publishing SDK
-        fields: repo,commit,author,action
-        status: ${{ job.status }}
+    - name: Publish SDKs
+      uses: pulumi/pulumi-package-publisher@v0.0.5
   test:
     name: test
     needs: build_sdk

--- a/provider-ci/providers/ns1/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/ns1/repo/.github/workflows/master.yml
@@ -350,131 +350,13 @@ jobs:
         author_name: Failure in publishing binaries
         fields: repo,commit,author,action
         status: ${{ job.status }}
-  publish_java_sdk:
-    continue-on-error: true
-    name: publish_java_sdk
-    needs: publish
-    runs-on: ubuntu-latest
-    steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{ env.JAVAVERSION }}
-    - name: Setup Gradle
-      uses: gradle/gradle-build-action@v2
-      with:
-        gradle-version: "7.6"
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
   publish_sdk:
     name: publish_sdk
     needs: publish
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Node
-      uses: actions/setup-node@v2
-      with:
-        node-version: ${{ env.NODEVERSION }}
-        registry-url: https://registry.npmjs.org
-    - name: Setup DotNet
-      uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: ${{ env.DOTNETVERSION }}
-    - name: Setup Python
-      uses: actions/setup-python@v2
-      with:
-        python-version: ${{ env.PYTHONVERSION }}
-    - name: Download python SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: python-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress python SDK
-      run: tar -zxf ${{github.workspace}}/sdk/python.tar.gz -C
-        ${{github.workspace}}/sdk/python
-    - name: Download dotnet SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: dotnet-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress dotnet SDK
-      run: tar -zxf ${{github.workspace}}/sdk/dotnet.tar.gz -C
-        ${{github.workspace}}/sdk/dotnet
-    - name: Download nodejs SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: nodejs-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress nodejs SDK
-      run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
-        ${{github.workspace}}/sdk/nodejs
-    - run: python -m pip install pip twine
-    - env:
-        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-      name: Publish SDKs
-      run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - if: failure() && github.event_name == 'push'
-      name: Notify Slack
-      uses: 8398a7/action-slack@v3
-      with:
-        author_name: Failure in publishing SDK
-        fields: repo,commit,author,action
-        status: ${{ job.status }}
+    - name: Publish SDKs
+      uses: pulumi/pulumi-package-publisher@v0.0.5
   test:
     name: test
     needs: build_sdk

--- a/provider-ci/providers/ns1/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/ns1/repo/.github/workflows/prerelease.yml
@@ -300,131 +300,13 @@ jobs:
         author_name: Failure in publishing binaries
         fields: repo,commit,author,action
         status: ${{ job.status }}
-  publish_java_sdk:
-    continue-on-error: true
-    name: publish_java_sdk
-    needs: publish
-    runs-on: ubuntu-latest
-    steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{ env.JAVAVERSION }}
-    - name: Setup Gradle
-      uses: gradle/gradle-build-action@v2
-      with:
-        gradle-version: "7.6"
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
   publish_sdk:
     name: publish_sdk
     needs: publish
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Node
-      uses: actions/setup-node@v2
-      with:
-        node-version: ${{ env.NODEVERSION }}
-        registry-url: https://registry.npmjs.org
-    - name: Setup DotNet
-      uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: ${{ env.DOTNETVERSION }}
-    - name: Setup Python
-      uses: actions/setup-python@v2
-      with:
-        python-version: ${{ env.PYTHONVERSION }}
-    - name: Download python SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: python-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress python SDK
-      run: tar -zxf ${{github.workspace}}/sdk/python.tar.gz -C
-        ${{github.workspace}}/sdk/python
-    - name: Download dotnet SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: dotnet-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress dotnet SDK
-      run: tar -zxf ${{github.workspace}}/sdk/dotnet.tar.gz -C
-        ${{github.workspace}}/sdk/dotnet
-    - name: Download nodejs SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: nodejs-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress nodejs SDK
-      run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
-        ${{github.workspace}}/sdk/nodejs
-    - run: python -m pip install pip twine
-    - env:
-        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-      name: Publish SDKs
-      run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - if: failure() && github.event_name == 'push'
-      name: Notify Slack
-      uses: 8398a7/action-slack@v3
-      with:
-        author_name: Failure in publishing SDK
-        fields: repo,commit,author,action
-        status: ${{ job.status }}
+    - name: Publish SDKs
+      uses: pulumi/pulumi-package-publisher@v0.0.5
   test:
     name: test
     needs: build_sdk

--- a/provider-ci/providers/ns1/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/ns1/repo/.github/workflows/release.yml
@@ -312,131 +312,13 @@ jobs:
         author_name: Failure in publishing binaries
         fields: repo,commit,author,action
         status: ${{ job.status }}
-  publish_java_sdk:
-    continue-on-error: true
-    name: publish_java_sdk
-    needs: publish
-    runs-on: ubuntu-latest
-    steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{ env.JAVAVERSION }}
-    - name: Setup Gradle
-      uses: gradle/gradle-build-action@v2
-      with:
-        gradle-version: "7.6"
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
   publish_sdk:
     name: publish_sdk
     needs: publish
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Node
-      uses: actions/setup-node@v2
-      with:
-        node-version: ${{ env.NODEVERSION }}
-        registry-url: https://registry.npmjs.org
-    - name: Setup DotNet
-      uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: ${{ env.DOTNETVERSION }}
-    - name: Setup Python
-      uses: actions/setup-python@v2
-      with:
-        python-version: ${{ env.PYTHONVERSION }}
-    - name: Download python SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: python-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress python SDK
-      run: tar -zxf ${{github.workspace}}/sdk/python.tar.gz -C
-        ${{github.workspace}}/sdk/python
-    - name: Download dotnet SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: dotnet-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress dotnet SDK
-      run: tar -zxf ${{github.workspace}}/sdk/dotnet.tar.gz -C
-        ${{github.workspace}}/sdk/dotnet
-    - name: Download nodejs SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: nodejs-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress nodejs SDK
-      run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
-        ${{github.workspace}}/sdk/nodejs
-    - run: python -m pip install pip twine
-    - env:
-        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-      name: Publish SDKs
-      run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - if: failure() && github.event_name == 'push'
-      name: Notify Slack
-      uses: 8398a7/action-slack@v3
-      with:
-        author_name: Failure in publishing SDK
-        fields: repo,commit,author,action
-        status: ${{ job.status }}
+    - name: Publish SDKs
+      uses: pulumi/pulumi-package-publisher@v0.0.5
   tag_sdk:
     name: tag_sdk
     needs: publish_sdk

--- a/provider-ci/providers/oci/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/oci/repo/.github/workflows/main.yml
@@ -282,131 +282,13 @@ jobs:
         author_name: Failure in publishing binaries
         fields: repo,commit,author,action
         status: ${{ job.status }}
-  publish_java_sdk:
-    continue-on-error: true
-    name: publish_java_sdk
-    needs: publish
-    runs-on: ubuntu-latest
-    steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{ env.JAVAVERSION }}
-    - name: Setup Gradle
-      uses: gradle/gradle-build-action@v2
-      with:
-        gradle-version: "7.6"
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
   publish_sdk:
     name: publish_sdk
     needs: publish
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Node
-      uses: actions/setup-node@v2
-      with:
-        node-version: ${{ env.NODEVERSION }}
-        registry-url: https://registry.npmjs.org
-    - name: Setup DotNet
-      uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: ${{ env.DOTNETVERSION }}
-    - name: Setup Python
-      uses: actions/setup-python@v2
-      with:
-        python-version: ${{ env.PYTHONVERSION }}
-    - name: Download python SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: python-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress python SDK
-      run: tar -zxf ${{github.workspace}}/sdk/python.tar.gz -C
-        ${{github.workspace}}/sdk/python
-    - name: Download dotnet SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: dotnet-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress dotnet SDK
-      run: tar -zxf ${{github.workspace}}/sdk/dotnet.tar.gz -C
-        ${{github.workspace}}/sdk/dotnet
-    - name: Download nodejs SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: nodejs-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress nodejs SDK
-      run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
-        ${{github.workspace}}/sdk/nodejs
-    - run: python -m pip install pip twine
-    - env:
-        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-      name: Publish SDKs
-      run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - if: failure() && github.event_name == 'push'
-      name: Notify Slack
-      uses: 8398a7/action-slack@v3
-      with:
-        author_name: Failure in publishing SDK
-        fields: repo,commit,author,action
-        status: ${{ job.status }}
+    - name: Publish SDKs
+      uses: pulumi/pulumi-package-publisher@v0.0.5
   test:
     name: test
     needs: build_sdk

--- a/provider-ci/providers/oci/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/oci/repo/.github/workflows/master.yml
@@ -282,131 +282,13 @@ jobs:
         author_name: Failure in publishing binaries
         fields: repo,commit,author,action
         status: ${{ job.status }}
-  publish_java_sdk:
-    continue-on-error: true
-    name: publish_java_sdk
-    needs: publish
-    runs-on: ubuntu-latest
-    steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{ env.JAVAVERSION }}
-    - name: Setup Gradle
-      uses: gradle/gradle-build-action@v2
-      with:
-        gradle-version: "7.6"
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
   publish_sdk:
     name: publish_sdk
     needs: publish
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Node
-      uses: actions/setup-node@v2
-      with:
-        node-version: ${{ env.NODEVERSION }}
-        registry-url: https://registry.npmjs.org
-    - name: Setup DotNet
-      uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: ${{ env.DOTNETVERSION }}
-    - name: Setup Python
-      uses: actions/setup-python@v2
-      with:
-        python-version: ${{ env.PYTHONVERSION }}
-    - name: Download python SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: python-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress python SDK
-      run: tar -zxf ${{github.workspace}}/sdk/python.tar.gz -C
-        ${{github.workspace}}/sdk/python
-    - name: Download dotnet SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: dotnet-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress dotnet SDK
-      run: tar -zxf ${{github.workspace}}/sdk/dotnet.tar.gz -C
-        ${{github.workspace}}/sdk/dotnet
-    - name: Download nodejs SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: nodejs-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress nodejs SDK
-      run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
-        ${{github.workspace}}/sdk/nodejs
-    - run: python -m pip install pip twine
-    - env:
-        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-      name: Publish SDKs
-      run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - if: failure() && github.event_name == 'push'
-      name: Notify Slack
-      uses: 8398a7/action-slack@v3
-      with:
-        author_name: Failure in publishing SDK
-        fields: repo,commit,author,action
-        status: ${{ job.status }}
+    - name: Publish SDKs
+      uses: pulumi/pulumi-package-publisher@v0.0.5
   test:
     name: test
     needs: build_sdk

--- a/provider-ci/providers/oci/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/oci/repo/.github/workflows/prerelease.yml
@@ -232,131 +232,13 @@ jobs:
         author_name: Failure in publishing binaries
         fields: repo,commit,author,action
         status: ${{ job.status }}
-  publish_java_sdk:
-    continue-on-error: true
-    name: publish_java_sdk
-    needs: publish
-    runs-on: ubuntu-latest
-    steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{ env.JAVAVERSION }}
-    - name: Setup Gradle
-      uses: gradle/gradle-build-action@v2
-      with:
-        gradle-version: "7.6"
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
   publish_sdk:
     name: publish_sdk
     needs: publish
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Node
-      uses: actions/setup-node@v2
-      with:
-        node-version: ${{ env.NODEVERSION }}
-        registry-url: https://registry.npmjs.org
-    - name: Setup DotNet
-      uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: ${{ env.DOTNETVERSION }}
-    - name: Setup Python
-      uses: actions/setup-python@v2
-      with:
-        python-version: ${{ env.PYTHONVERSION }}
-    - name: Download python SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: python-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress python SDK
-      run: tar -zxf ${{github.workspace}}/sdk/python.tar.gz -C
-        ${{github.workspace}}/sdk/python
-    - name: Download dotnet SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: dotnet-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress dotnet SDK
-      run: tar -zxf ${{github.workspace}}/sdk/dotnet.tar.gz -C
-        ${{github.workspace}}/sdk/dotnet
-    - name: Download nodejs SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: nodejs-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress nodejs SDK
-      run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
-        ${{github.workspace}}/sdk/nodejs
-    - run: python -m pip install pip twine
-    - env:
-        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-      name: Publish SDKs
-      run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - if: failure() && github.event_name == 'push'
-      name: Notify Slack
-      uses: 8398a7/action-slack@v3
-      with:
-        author_name: Failure in publishing SDK
-        fields: repo,commit,author,action
-        status: ${{ job.status }}
+    - name: Publish SDKs
+      uses: pulumi/pulumi-package-publisher@v0.0.5
   test:
     name: test
     needs: build_sdk

--- a/provider-ci/providers/oci/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/oci/repo/.github/workflows/release.yml
@@ -244,131 +244,13 @@ jobs:
         author_name: Failure in publishing binaries
         fields: repo,commit,author,action
         status: ${{ job.status }}
-  publish_java_sdk:
-    continue-on-error: true
-    name: publish_java_sdk
-    needs: publish
-    runs-on: ubuntu-latest
-    steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{ env.JAVAVERSION }}
-    - name: Setup Gradle
-      uses: gradle/gradle-build-action@v2
-      with:
-        gradle-version: "7.6"
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
   publish_sdk:
     name: publish_sdk
     needs: publish
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Node
-      uses: actions/setup-node@v2
-      with:
-        node-version: ${{ env.NODEVERSION }}
-        registry-url: https://registry.npmjs.org
-    - name: Setup DotNet
-      uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: ${{ env.DOTNETVERSION }}
-    - name: Setup Python
-      uses: actions/setup-python@v2
-      with:
-        python-version: ${{ env.PYTHONVERSION }}
-    - name: Download python SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: python-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress python SDK
-      run: tar -zxf ${{github.workspace}}/sdk/python.tar.gz -C
-        ${{github.workspace}}/sdk/python
-    - name: Download dotnet SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: dotnet-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress dotnet SDK
-      run: tar -zxf ${{github.workspace}}/sdk/dotnet.tar.gz -C
-        ${{github.workspace}}/sdk/dotnet
-    - name: Download nodejs SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: nodejs-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress nodejs SDK
-      run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
-        ${{github.workspace}}/sdk/nodejs
-    - run: python -m pip install pip twine
-    - env:
-        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-      name: Publish SDKs
-      run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - if: failure() && github.event_name == 'push'
-      name: Notify Slack
-      uses: 8398a7/action-slack@v3
-      with:
-        author_name: Failure in publishing SDK
-        fields: repo,commit,author,action
-        status: ${{ job.status }}
+    - name: Publish SDKs
+      uses: pulumi/pulumi-package-publisher@v0.0.5
   tag_sdk:
     name: tag_sdk
     needs: publish_sdk

--- a/provider-ci/providers/okta/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/okta/repo/.github/workflows/main.yml
@@ -352,131 +352,13 @@ jobs:
         author_name: Failure in publishing binaries
         fields: repo,commit,author,action
         status: ${{ job.status }}
-  publish_java_sdk:
-    continue-on-error: true
-    name: publish_java_sdk
-    needs: publish
-    runs-on: ubuntu-latest
-    steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{ env.JAVAVERSION }}
-    - name: Setup Gradle
-      uses: gradle/gradle-build-action@v2
-      with:
-        gradle-version: "7.6"
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
   publish_sdk:
     name: publish_sdk
     needs: publish
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Node
-      uses: actions/setup-node@v2
-      with:
-        node-version: ${{ env.NODEVERSION }}
-        registry-url: https://registry.npmjs.org
-    - name: Setup DotNet
-      uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: ${{ env.DOTNETVERSION }}
-    - name: Setup Python
-      uses: actions/setup-python@v2
-      with:
-        python-version: ${{ env.PYTHONVERSION }}
-    - name: Download python SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: python-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress python SDK
-      run: tar -zxf ${{github.workspace}}/sdk/python.tar.gz -C
-        ${{github.workspace}}/sdk/python
-    - name: Download dotnet SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: dotnet-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress dotnet SDK
-      run: tar -zxf ${{github.workspace}}/sdk/dotnet.tar.gz -C
-        ${{github.workspace}}/sdk/dotnet
-    - name: Download nodejs SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: nodejs-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress nodejs SDK
-      run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
-        ${{github.workspace}}/sdk/nodejs
-    - run: python -m pip install pip twine
-    - env:
-        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-      name: Publish SDKs
-      run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - if: failure() && github.event_name == 'push'
-      name: Notify Slack
-      uses: 8398a7/action-slack@v3
-      with:
-        author_name: Failure in publishing SDK
-        fields: repo,commit,author,action
-        status: ${{ job.status }}
+    - name: Publish SDKs
+      uses: pulumi/pulumi-package-publisher@v0.0.5
   test:
     name: test
     needs: build_sdk

--- a/provider-ci/providers/okta/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/okta/repo/.github/workflows/master.yml
@@ -352,131 +352,13 @@ jobs:
         author_name: Failure in publishing binaries
         fields: repo,commit,author,action
         status: ${{ job.status }}
-  publish_java_sdk:
-    continue-on-error: true
-    name: publish_java_sdk
-    needs: publish
-    runs-on: ubuntu-latest
-    steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{ env.JAVAVERSION }}
-    - name: Setup Gradle
-      uses: gradle/gradle-build-action@v2
-      with:
-        gradle-version: "7.6"
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
   publish_sdk:
     name: publish_sdk
     needs: publish
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Node
-      uses: actions/setup-node@v2
-      with:
-        node-version: ${{ env.NODEVERSION }}
-        registry-url: https://registry.npmjs.org
-    - name: Setup DotNet
-      uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: ${{ env.DOTNETVERSION }}
-    - name: Setup Python
-      uses: actions/setup-python@v2
-      with:
-        python-version: ${{ env.PYTHONVERSION }}
-    - name: Download python SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: python-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress python SDK
-      run: tar -zxf ${{github.workspace}}/sdk/python.tar.gz -C
-        ${{github.workspace}}/sdk/python
-    - name: Download dotnet SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: dotnet-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress dotnet SDK
-      run: tar -zxf ${{github.workspace}}/sdk/dotnet.tar.gz -C
-        ${{github.workspace}}/sdk/dotnet
-    - name: Download nodejs SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: nodejs-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress nodejs SDK
-      run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
-        ${{github.workspace}}/sdk/nodejs
-    - run: python -m pip install pip twine
-    - env:
-        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-      name: Publish SDKs
-      run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - if: failure() && github.event_name == 'push'
-      name: Notify Slack
-      uses: 8398a7/action-slack@v3
-      with:
-        author_name: Failure in publishing SDK
-        fields: repo,commit,author,action
-        status: ${{ job.status }}
+    - name: Publish SDKs
+      uses: pulumi/pulumi-package-publisher@v0.0.5
   test:
     name: test
     needs: build_sdk

--- a/provider-ci/providers/okta/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/okta/repo/.github/workflows/prerelease.yml
@@ -302,131 +302,13 @@ jobs:
         author_name: Failure in publishing binaries
         fields: repo,commit,author,action
         status: ${{ job.status }}
-  publish_java_sdk:
-    continue-on-error: true
-    name: publish_java_sdk
-    needs: publish
-    runs-on: ubuntu-latest
-    steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{ env.JAVAVERSION }}
-    - name: Setup Gradle
-      uses: gradle/gradle-build-action@v2
-      with:
-        gradle-version: "7.6"
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
   publish_sdk:
     name: publish_sdk
     needs: publish
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Node
-      uses: actions/setup-node@v2
-      with:
-        node-version: ${{ env.NODEVERSION }}
-        registry-url: https://registry.npmjs.org
-    - name: Setup DotNet
-      uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: ${{ env.DOTNETVERSION }}
-    - name: Setup Python
-      uses: actions/setup-python@v2
-      with:
-        python-version: ${{ env.PYTHONVERSION }}
-    - name: Download python SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: python-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress python SDK
-      run: tar -zxf ${{github.workspace}}/sdk/python.tar.gz -C
-        ${{github.workspace}}/sdk/python
-    - name: Download dotnet SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: dotnet-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress dotnet SDK
-      run: tar -zxf ${{github.workspace}}/sdk/dotnet.tar.gz -C
-        ${{github.workspace}}/sdk/dotnet
-    - name: Download nodejs SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: nodejs-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress nodejs SDK
-      run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
-        ${{github.workspace}}/sdk/nodejs
-    - run: python -m pip install pip twine
-    - env:
-        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-      name: Publish SDKs
-      run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - if: failure() && github.event_name == 'push'
-      name: Notify Slack
-      uses: 8398a7/action-slack@v3
-      with:
-        author_name: Failure in publishing SDK
-        fields: repo,commit,author,action
-        status: ${{ job.status }}
+    - name: Publish SDKs
+      uses: pulumi/pulumi-package-publisher@v0.0.5
   test:
     name: test
     needs: build_sdk

--- a/provider-ci/providers/okta/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/okta/repo/.github/workflows/release.yml
@@ -314,131 +314,13 @@ jobs:
         author_name: Failure in publishing binaries
         fields: repo,commit,author,action
         status: ${{ job.status }}
-  publish_java_sdk:
-    continue-on-error: true
-    name: publish_java_sdk
-    needs: publish
-    runs-on: ubuntu-latest
-    steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{ env.JAVAVERSION }}
-    - name: Setup Gradle
-      uses: gradle/gradle-build-action@v2
-      with:
-        gradle-version: "7.6"
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
   publish_sdk:
     name: publish_sdk
     needs: publish
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Node
-      uses: actions/setup-node@v2
-      with:
-        node-version: ${{ env.NODEVERSION }}
-        registry-url: https://registry.npmjs.org
-    - name: Setup DotNet
-      uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: ${{ env.DOTNETVERSION }}
-    - name: Setup Python
-      uses: actions/setup-python@v2
-      with:
-        python-version: ${{ env.PYTHONVERSION }}
-    - name: Download python SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: python-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress python SDK
-      run: tar -zxf ${{github.workspace}}/sdk/python.tar.gz -C
-        ${{github.workspace}}/sdk/python
-    - name: Download dotnet SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: dotnet-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress dotnet SDK
-      run: tar -zxf ${{github.workspace}}/sdk/dotnet.tar.gz -C
-        ${{github.workspace}}/sdk/dotnet
-    - name: Download nodejs SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: nodejs-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress nodejs SDK
-      run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
-        ${{github.workspace}}/sdk/nodejs
-    - run: python -m pip install pip twine
-    - env:
-        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-      name: Publish SDKs
-      run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - if: failure() && github.event_name == 'push'
-      name: Notify Slack
-      uses: 8398a7/action-slack@v3
-      with:
-        author_name: Failure in publishing SDK
-        fields: repo,commit,author,action
-        status: ${{ job.status }}
+    - name: Publish SDKs
+      uses: pulumi/pulumi-package-publisher@v0.0.5
   tag_sdk:
     name: tag_sdk
     needs: publish_sdk

--- a/provider-ci/providers/onelogin/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/onelogin/repo/.github/workflows/main.yml
@@ -349,131 +349,13 @@ jobs:
         author_name: Failure in publishing binaries
         fields: repo,commit,author,action
         status: ${{ job.status }}
-  publish_java_sdk:
-    continue-on-error: true
-    name: publish_java_sdk
-    needs: publish
-    runs-on: ubuntu-latest
-    steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{ env.JAVAVERSION }}
-    - name: Setup Gradle
-      uses: gradle/gradle-build-action@v2
-      with:
-        gradle-version: "7.6"
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
   publish_sdk:
     name: publish_sdk
     needs: publish
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Node
-      uses: actions/setup-node@v2
-      with:
-        node-version: ${{ env.NODEVERSION }}
-        registry-url: https://registry.npmjs.org
-    - name: Setup DotNet
-      uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: ${{ env.DOTNETVERSION }}
-    - name: Setup Python
-      uses: actions/setup-python@v2
-      with:
-        python-version: ${{ env.PYTHONVERSION }}
-    - name: Download python SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: python-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress python SDK
-      run: tar -zxf ${{github.workspace}}/sdk/python.tar.gz -C
-        ${{github.workspace}}/sdk/python
-    - name: Download dotnet SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: dotnet-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress dotnet SDK
-      run: tar -zxf ${{github.workspace}}/sdk/dotnet.tar.gz -C
-        ${{github.workspace}}/sdk/dotnet
-    - name: Download nodejs SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: nodejs-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress nodejs SDK
-      run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
-        ${{github.workspace}}/sdk/nodejs
-    - run: python -m pip install pip twine
-    - env:
-        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-      name: Publish SDKs
-      run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - if: failure() && github.event_name == 'push'
-      name: Notify Slack
-      uses: 8398a7/action-slack@v3
-      with:
-        author_name: Failure in publishing SDK
-        fields: repo,commit,author,action
-        status: ${{ job.status }}
+    - name: Publish SDKs
+      uses: pulumi/pulumi-package-publisher@v0.0.5
   test:
     name: test
     needs: build_sdk

--- a/provider-ci/providers/onelogin/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/onelogin/repo/.github/workflows/master.yml
@@ -349,131 +349,13 @@ jobs:
         author_name: Failure in publishing binaries
         fields: repo,commit,author,action
         status: ${{ job.status }}
-  publish_java_sdk:
-    continue-on-error: true
-    name: publish_java_sdk
-    needs: publish
-    runs-on: ubuntu-latest
-    steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{ env.JAVAVERSION }}
-    - name: Setup Gradle
-      uses: gradle/gradle-build-action@v2
-      with:
-        gradle-version: "7.6"
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
   publish_sdk:
     name: publish_sdk
     needs: publish
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Node
-      uses: actions/setup-node@v2
-      with:
-        node-version: ${{ env.NODEVERSION }}
-        registry-url: https://registry.npmjs.org
-    - name: Setup DotNet
-      uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: ${{ env.DOTNETVERSION }}
-    - name: Setup Python
-      uses: actions/setup-python@v2
-      with:
-        python-version: ${{ env.PYTHONVERSION }}
-    - name: Download python SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: python-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress python SDK
-      run: tar -zxf ${{github.workspace}}/sdk/python.tar.gz -C
-        ${{github.workspace}}/sdk/python
-    - name: Download dotnet SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: dotnet-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress dotnet SDK
-      run: tar -zxf ${{github.workspace}}/sdk/dotnet.tar.gz -C
-        ${{github.workspace}}/sdk/dotnet
-    - name: Download nodejs SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: nodejs-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress nodejs SDK
-      run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
-        ${{github.workspace}}/sdk/nodejs
-    - run: python -m pip install pip twine
-    - env:
-        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-      name: Publish SDKs
-      run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - if: failure() && github.event_name == 'push'
-      name: Notify Slack
-      uses: 8398a7/action-slack@v3
-      with:
-        author_name: Failure in publishing SDK
-        fields: repo,commit,author,action
-        status: ${{ job.status }}
+    - name: Publish SDKs
+      uses: pulumi/pulumi-package-publisher@v0.0.5
   test:
     name: test
     needs: build_sdk

--- a/provider-ci/providers/onelogin/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/onelogin/repo/.github/workflows/prerelease.yml
@@ -299,131 +299,13 @@ jobs:
         author_name: Failure in publishing binaries
         fields: repo,commit,author,action
         status: ${{ job.status }}
-  publish_java_sdk:
-    continue-on-error: true
-    name: publish_java_sdk
-    needs: publish
-    runs-on: ubuntu-latest
-    steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{ env.JAVAVERSION }}
-    - name: Setup Gradle
-      uses: gradle/gradle-build-action@v2
-      with:
-        gradle-version: "7.6"
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
   publish_sdk:
     name: publish_sdk
     needs: publish
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Node
-      uses: actions/setup-node@v2
-      with:
-        node-version: ${{ env.NODEVERSION }}
-        registry-url: https://registry.npmjs.org
-    - name: Setup DotNet
-      uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: ${{ env.DOTNETVERSION }}
-    - name: Setup Python
-      uses: actions/setup-python@v2
-      with:
-        python-version: ${{ env.PYTHONVERSION }}
-    - name: Download python SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: python-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress python SDK
-      run: tar -zxf ${{github.workspace}}/sdk/python.tar.gz -C
-        ${{github.workspace}}/sdk/python
-    - name: Download dotnet SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: dotnet-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress dotnet SDK
-      run: tar -zxf ${{github.workspace}}/sdk/dotnet.tar.gz -C
-        ${{github.workspace}}/sdk/dotnet
-    - name: Download nodejs SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: nodejs-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress nodejs SDK
-      run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
-        ${{github.workspace}}/sdk/nodejs
-    - run: python -m pip install pip twine
-    - env:
-        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-      name: Publish SDKs
-      run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - if: failure() && github.event_name == 'push'
-      name: Notify Slack
-      uses: 8398a7/action-slack@v3
-      with:
-        author_name: Failure in publishing SDK
-        fields: repo,commit,author,action
-        status: ${{ job.status }}
+    - name: Publish SDKs
+      uses: pulumi/pulumi-package-publisher@v0.0.5
   test:
     name: test
     needs: build_sdk

--- a/provider-ci/providers/onelogin/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/onelogin/repo/.github/workflows/release.yml
@@ -311,131 +311,13 @@ jobs:
         author_name: Failure in publishing binaries
         fields: repo,commit,author,action
         status: ${{ job.status }}
-  publish_java_sdk:
-    continue-on-error: true
-    name: publish_java_sdk
-    needs: publish
-    runs-on: ubuntu-latest
-    steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{ env.JAVAVERSION }}
-    - name: Setup Gradle
-      uses: gradle/gradle-build-action@v2
-      with:
-        gradle-version: "7.6"
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
   publish_sdk:
     name: publish_sdk
     needs: publish
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Node
-      uses: actions/setup-node@v2
-      with:
-        node-version: ${{ env.NODEVERSION }}
-        registry-url: https://registry.npmjs.org
-    - name: Setup DotNet
-      uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: ${{ env.DOTNETVERSION }}
-    - name: Setup Python
-      uses: actions/setup-python@v2
-      with:
-        python-version: ${{ env.PYTHONVERSION }}
-    - name: Download python SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: python-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress python SDK
-      run: tar -zxf ${{github.workspace}}/sdk/python.tar.gz -C
-        ${{github.workspace}}/sdk/python
-    - name: Download dotnet SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: dotnet-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress dotnet SDK
-      run: tar -zxf ${{github.workspace}}/sdk/dotnet.tar.gz -C
-        ${{github.workspace}}/sdk/dotnet
-    - name: Download nodejs SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: nodejs-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress nodejs SDK
-      run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
-        ${{github.workspace}}/sdk/nodejs
-    - run: python -m pip install pip twine
-    - env:
-        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-      name: Publish SDKs
-      run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - if: failure() && github.event_name == 'push'
-      name: Notify Slack
-      uses: 8398a7/action-slack@v3
-      with:
-        author_name: Failure in publishing SDK
-        fields: repo,commit,author,action
-        status: ${{ job.status }}
+    - name: Publish SDKs
+      uses: pulumi/pulumi-package-publisher@v0.0.5
   tag_sdk:
     name: tag_sdk
     needs: publish_sdk

--- a/provider-ci/providers/openstack/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/openstack/repo/.github/workflows/main.yml
@@ -358,131 +358,13 @@ jobs:
         author_name: Failure in publishing binaries
         fields: repo,commit,author,action
         status: ${{ job.status }}
-  publish_java_sdk:
-    continue-on-error: true
-    name: publish_java_sdk
-    needs: publish
-    runs-on: ubuntu-latest
-    steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{ env.JAVAVERSION }}
-    - name: Setup Gradle
-      uses: gradle/gradle-build-action@v2
-      with:
-        gradle-version: "7.6"
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
   publish_sdk:
     name: publish_sdk
     needs: publish
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Node
-      uses: actions/setup-node@v2
-      with:
-        node-version: ${{ env.NODEVERSION }}
-        registry-url: https://registry.npmjs.org
-    - name: Setup DotNet
-      uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: ${{ env.DOTNETVERSION }}
-    - name: Setup Python
-      uses: actions/setup-python@v2
-      with:
-        python-version: ${{ env.PYTHONVERSION }}
-    - name: Download python SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: python-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress python SDK
-      run: tar -zxf ${{github.workspace}}/sdk/python.tar.gz -C
-        ${{github.workspace}}/sdk/python
-    - name: Download dotnet SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: dotnet-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress dotnet SDK
-      run: tar -zxf ${{github.workspace}}/sdk/dotnet.tar.gz -C
-        ${{github.workspace}}/sdk/dotnet
-    - name: Download nodejs SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: nodejs-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress nodejs SDK
-      run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
-        ${{github.workspace}}/sdk/nodejs
-    - run: python -m pip install pip twine
-    - env:
-        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-      name: Publish SDKs
-      run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - if: failure() && github.event_name == 'push'
-      name: Notify Slack
-      uses: 8398a7/action-slack@v3
-      with:
-        author_name: Failure in publishing SDK
-        fields: repo,commit,author,action
-        status: ${{ job.status }}
+    - name: Publish SDKs
+      uses: pulumi/pulumi-package-publisher@v0.0.5
   test:
     name: test
     needs: build_sdk

--- a/provider-ci/providers/openstack/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/openstack/repo/.github/workflows/master.yml
@@ -358,131 +358,13 @@ jobs:
         author_name: Failure in publishing binaries
         fields: repo,commit,author,action
         status: ${{ job.status }}
-  publish_java_sdk:
-    continue-on-error: true
-    name: publish_java_sdk
-    needs: publish
-    runs-on: ubuntu-latest
-    steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{ env.JAVAVERSION }}
-    - name: Setup Gradle
-      uses: gradle/gradle-build-action@v2
-      with:
-        gradle-version: "7.6"
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
   publish_sdk:
     name: publish_sdk
     needs: publish
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Node
-      uses: actions/setup-node@v2
-      with:
-        node-version: ${{ env.NODEVERSION }}
-        registry-url: https://registry.npmjs.org
-    - name: Setup DotNet
-      uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: ${{ env.DOTNETVERSION }}
-    - name: Setup Python
-      uses: actions/setup-python@v2
-      with:
-        python-version: ${{ env.PYTHONVERSION }}
-    - name: Download python SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: python-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress python SDK
-      run: tar -zxf ${{github.workspace}}/sdk/python.tar.gz -C
-        ${{github.workspace}}/sdk/python
-    - name: Download dotnet SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: dotnet-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress dotnet SDK
-      run: tar -zxf ${{github.workspace}}/sdk/dotnet.tar.gz -C
-        ${{github.workspace}}/sdk/dotnet
-    - name: Download nodejs SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: nodejs-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress nodejs SDK
-      run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
-        ${{github.workspace}}/sdk/nodejs
-    - run: python -m pip install pip twine
-    - env:
-        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-      name: Publish SDKs
-      run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - if: failure() && github.event_name == 'push'
-      name: Notify Slack
-      uses: 8398a7/action-slack@v3
-      with:
-        author_name: Failure in publishing SDK
-        fields: repo,commit,author,action
-        status: ${{ job.status }}
+    - name: Publish SDKs
+      uses: pulumi/pulumi-package-publisher@v0.0.5
   test:
     name: test
     needs: build_sdk

--- a/provider-ci/providers/openstack/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/openstack/repo/.github/workflows/prerelease.yml
@@ -308,131 +308,13 @@ jobs:
         author_name: Failure in publishing binaries
         fields: repo,commit,author,action
         status: ${{ job.status }}
-  publish_java_sdk:
-    continue-on-error: true
-    name: publish_java_sdk
-    needs: publish
-    runs-on: ubuntu-latest
-    steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{ env.JAVAVERSION }}
-    - name: Setup Gradle
-      uses: gradle/gradle-build-action@v2
-      with:
-        gradle-version: "7.6"
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
   publish_sdk:
     name: publish_sdk
     needs: publish
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Node
-      uses: actions/setup-node@v2
-      with:
-        node-version: ${{ env.NODEVERSION }}
-        registry-url: https://registry.npmjs.org
-    - name: Setup DotNet
-      uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: ${{ env.DOTNETVERSION }}
-    - name: Setup Python
-      uses: actions/setup-python@v2
-      with:
-        python-version: ${{ env.PYTHONVERSION }}
-    - name: Download python SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: python-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress python SDK
-      run: tar -zxf ${{github.workspace}}/sdk/python.tar.gz -C
-        ${{github.workspace}}/sdk/python
-    - name: Download dotnet SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: dotnet-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress dotnet SDK
-      run: tar -zxf ${{github.workspace}}/sdk/dotnet.tar.gz -C
-        ${{github.workspace}}/sdk/dotnet
-    - name: Download nodejs SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: nodejs-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress nodejs SDK
-      run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
-        ${{github.workspace}}/sdk/nodejs
-    - run: python -m pip install pip twine
-    - env:
-        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-      name: Publish SDKs
-      run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - if: failure() && github.event_name == 'push'
-      name: Notify Slack
-      uses: 8398a7/action-slack@v3
-      with:
-        author_name: Failure in publishing SDK
-        fields: repo,commit,author,action
-        status: ${{ job.status }}
+    - name: Publish SDKs
+      uses: pulumi/pulumi-package-publisher@v0.0.5
   test:
     name: test
     needs: build_sdk

--- a/provider-ci/providers/openstack/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/openstack/repo/.github/workflows/release.yml
@@ -320,131 +320,13 @@ jobs:
         author_name: Failure in publishing binaries
         fields: repo,commit,author,action
         status: ${{ job.status }}
-  publish_java_sdk:
-    continue-on-error: true
-    name: publish_java_sdk
-    needs: publish
-    runs-on: ubuntu-latest
-    steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{ env.JAVAVERSION }}
-    - name: Setup Gradle
-      uses: gradle/gradle-build-action@v2
-      with:
-        gradle-version: "7.6"
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
   publish_sdk:
     name: publish_sdk
     needs: publish
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Node
-      uses: actions/setup-node@v2
-      with:
-        node-version: ${{ env.NODEVERSION }}
-        registry-url: https://registry.npmjs.org
-    - name: Setup DotNet
-      uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: ${{ env.DOTNETVERSION }}
-    - name: Setup Python
-      uses: actions/setup-python@v2
-      with:
-        python-version: ${{ env.PYTHONVERSION }}
-    - name: Download python SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: python-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress python SDK
-      run: tar -zxf ${{github.workspace}}/sdk/python.tar.gz -C
-        ${{github.workspace}}/sdk/python
-    - name: Download dotnet SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: dotnet-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress dotnet SDK
-      run: tar -zxf ${{github.workspace}}/sdk/dotnet.tar.gz -C
-        ${{github.workspace}}/sdk/dotnet
-    - name: Download nodejs SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: nodejs-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress nodejs SDK
-      run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
-        ${{github.workspace}}/sdk/nodejs
-    - run: python -m pip install pip twine
-    - env:
-        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-      name: Publish SDKs
-      run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - if: failure() && github.event_name == 'push'
-      name: Notify Slack
-      uses: 8398a7/action-slack@v3
-      with:
-        author_name: Failure in publishing SDK
-        fields: repo,commit,author,action
-        status: ${{ job.status }}
+    - name: Publish SDKs
+      uses: pulumi/pulumi-package-publisher@v0.0.5
   tag_sdk:
     name: tag_sdk
     needs: publish_sdk

--- a/provider-ci/providers/opsgenie/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/opsgenie/repo/.github/workflows/main.yml
@@ -350,131 +350,13 @@ jobs:
         author_name: Failure in publishing binaries
         fields: repo,commit,author,action
         status: ${{ job.status }}
-  publish_java_sdk:
-    continue-on-error: true
-    name: publish_java_sdk
-    needs: publish
-    runs-on: ubuntu-latest
-    steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{ env.JAVAVERSION }}
-    - name: Setup Gradle
-      uses: gradle/gradle-build-action@v2
-      with:
-        gradle-version: "7.6"
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
   publish_sdk:
     name: publish_sdk
     needs: publish
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Node
-      uses: actions/setup-node@v2
-      with:
-        node-version: ${{ env.NODEVERSION }}
-        registry-url: https://registry.npmjs.org
-    - name: Setup DotNet
-      uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: ${{ env.DOTNETVERSION }}
-    - name: Setup Python
-      uses: actions/setup-python@v2
-      with:
-        python-version: ${{ env.PYTHONVERSION }}
-    - name: Download python SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: python-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress python SDK
-      run: tar -zxf ${{github.workspace}}/sdk/python.tar.gz -C
-        ${{github.workspace}}/sdk/python
-    - name: Download dotnet SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: dotnet-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress dotnet SDK
-      run: tar -zxf ${{github.workspace}}/sdk/dotnet.tar.gz -C
-        ${{github.workspace}}/sdk/dotnet
-    - name: Download nodejs SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: nodejs-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress nodejs SDK
-      run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
-        ${{github.workspace}}/sdk/nodejs
-    - run: python -m pip install pip twine
-    - env:
-        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-      name: Publish SDKs
-      run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - if: failure() && github.event_name == 'push'
-      name: Notify Slack
-      uses: 8398a7/action-slack@v3
-      with:
-        author_name: Failure in publishing SDK
-        fields: repo,commit,author,action
-        status: ${{ job.status }}
+    - name: Publish SDKs
+      uses: pulumi/pulumi-package-publisher@v0.0.5
   test:
     name: test
     needs: build_sdk

--- a/provider-ci/providers/opsgenie/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/opsgenie/repo/.github/workflows/master.yml
@@ -350,131 +350,13 @@ jobs:
         author_name: Failure in publishing binaries
         fields: repo,commit,author,action
         status: ${{ job.status }}
-  publish_java_sdk:
-    continue-on-error: true
-    name: publish_java_sdk
-    needs: publish
-    runs-on: ubuntu-latest
-    steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{ env.JAVAVERSION }}
-    - name: Setup Gradle
-      uses: gradle/gradle-build-action@v2
-      with:
-        gradle-version: "7.6"
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
   publish_sdk:
     name: publish_sdk
     needs: publish
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Node
-      uses: actions/setup-node@v2
-      with:
-        node-version: ${{ env.NODEVERSION }}
-        registry-url: https://registry.npmjs.org
-    - name: Setup DotNet
-      uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: ${{ env.DOTNETVERSION }}
-    - name: Setup Python
-      uses: actions/setup-python@v2
-      with:
-        python-version: ${{ env.PYTHONVERSION }}
-    - name: Download python SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: python-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress python SDK
-      run: tar -zxf ${{github.workspace}}/sdk/python.tar.gz -C
-        ${{github.workspace}}/sdk/python
-    - name: Download dotnet SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: dotnet-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress dotnet SDK
-      run: tar -zxf ${{github.workspace}}/sdk/dotnet.tar.gz -C
-        ${{github.workspace}}/sdk/dotnet
-    - name: Download nodejs SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: nodejs-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress nodejs SDK
-      run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
-        ${{github.workspace}}/sdk/nodejs
-    - run: python -m pip install pip twine
-    - env:
-        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-      name: Publish SDKs
-      run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - if: failure() && github.event_name == 'push'
-      name: Notify Slack
-      uses: 8398a7/action-slack@v3
-      with:
-        author_name: Failure in publishing SDK
-        fields: repo,commit,author,action
-        status: ${{ job.status }}
+    - name: Publish SDKs
+      uses: pulumi/pulumi-package-publisher@v0.0.5
   test:
     name: test
     needs: build_sdk

--- a/provider-ci/providers/opsgenie/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/opsgenie/repo/.github/workflows/prerelease.yml
@@ -300,131 +300,13 @@ jobs:
         author_name: Failure in publishing binaries
         fields: repo,commit,author,action
         status: ${{ job.status }}
-  publish_java_sdk:
-    continue-on-error: true
-    name: publish_java_sdk
-    needs: publish
-    runs-on: ubuntu-latest
-    steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{ env.JAVAVERSION }}
-    - name: Setup Gradle
-      uses: gradle/gradle-build-action@v2
-      with:
-        gradle-version: "7.6"
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
   publish_sdk:
     name: publish_sdk
     needs: publish
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Node
-      uses: actions/setup-node@v2
-      with:
-        node-version: ${{ env.NODEVERSION }}
-        registry-url: https://registry.npmjs.org
-    - name: Setup DotNet
-      uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: ${{ env.DOTNETVERSION }}
-    - name: Setup Python
-      uses: actions/setup-python@v2
-      with:
-        python-version: ${{ env.PYTHONVERSION }}
-    - name: Download python SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: python-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress python SDK
-      run: tar -zxf ${{github.workspace}}/sdk/python.tar.gz -C
-        ${{github.workspace}}/sdk/python
-    - name: Download dotnet SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: dotnet-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress dotnet SDK
-      run: tar -zxf ${{github.workspace}}/sdk/dotnet.tar.gz -C
-        ${{github.workspace}}/sdk/dotnet
-    - name: Download nodejs SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: nodejs-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress nodejs SDK
-      run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
-        ${{github.workspace}}/sdk/nodejs
-    - run: python -m pip install pip twine
-    - env:
-        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-      name: Publish SDKs
-      run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - if: failure() && github.event_name == 'push'
-      name: Notify Slack
-      uses: 8398a7/action-slack@v3
-      with:
-        author_name: Failure in publishing SDK
-        fields: repo,commit,author,action
-        status: ${{ job.status }}
+    - name: Publish SDKs
+      uses: pulumi/pulumi-package-publisher@v0.0.5
   test:
     name: test
     needs: build_sdk

--- a/provider-ci/providers/opsgenie/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/opsgenie/repo/.github/workflows/release.yml
@@ -312,131 +312,13 @@ jobs:
         author_name: Failure in publishing binaries
         fields: repo,commit,author,action
         status: ${{ job.status }}
-  publish_java_sdk:
-    continue-on-error: true
-    name: publish_java_sdk
-    needs: publish
-    runs-on: ubuntu-latest
-    steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{ env.JAVAVERSION }}
-    - name: Setup Gradle
-      uses: gradle/gradle-build-action@v2
-      with:
-        gradle-version: "7.6"
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
   publish_sdk:
     name: publish_sdk
     needs: publish
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Node
-      uses: actions/setup-node@v2
-      with:
-        node-version: ${{ env.NODEVERSION }}
-        registry-url: https://registry.npmjs.org
-    - name: Setup DotNet
-      uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: ${{ env.DOTNETVERSION }}
-    - name: Setup Python
-      uses: actions/setup-python@v2
-      with:
-        python-version: ${{ env.PYTHONVERSION }}
-    - name: Download python SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: python-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress python SDK
-      run: tar -zxf ${{github.workspace}}/sdk/python.tar.gz -C
-        ${{github.workspace}}/sdk/python
-    - name: Download dotnet SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: dotnet-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress dotnet SDK
-      run: tar -zxf ${{github.workspace}}/sdk/dotnet.tar.gz -C
-        ${{github.workspace}}/sdk/dotnet
-    - name: Download nodejs SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: nodejs-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress nodejs SDK
-      run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
-        ${{github.workspace}}/sdk/nodejs
-    - run: python -m pip install pip twine
-    - env:
-        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-      name: Publish SDKs
-      run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - if: failure() && github.event_name == 'push'
-      name: Notify Slack
-      uses: 8398a7/action-slack@v3
-      with:
-        author_name: Failure in publishing SDK
-        fields: repo,commit,author,action
-        status: ${{ job.status }}
+    - name: Publish SDKs
+      uses: pulumi/pulumi-package-publisher@v0.0.5
   tag_sdk:
     name: tag_sdk
     needs: publish_sdk

--- a/provider-ci/providers/pagerduty/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/pagerduty/repo/.github/workflows/main.yml
@@ -350,131 +350,13 @@ jobs:
         author_name: Failure in publishing binaries
         fields: repo,commit,author,action
         status: ${{ job.status }}
-  publish_java_sdk:
-    continue-on-error: true
-    name: publish_java_sdk
-    needs: publish
-    runs-on: ubuntu-latest
-    steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{ env.JAVAVERSION }}
-    - name: Setup Gradle
-      uses: gradle/gradle-build-action@v2
-      with:
-        gradle-version: "7.6"
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
   publish_sdk:
     name: publish_sdk
     needs: publish
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Node
-      uses: actions/setup-node@v2
-      with:
-        node-version: ${{ env.NODEVERSION }}
-        registry-url: https://registry.npmjs.org
-    - name: Setup DotNet
-      uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: ${{ env.DOTNETVERSION }}
-    - name: Setup Python
-      uses: actions/setup-python@v2
-      with:
-        python-version: ${{ env.PYTHONVERSION }}
-    - name: Download python SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: python-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress python SDK
-      run: tar -zxf ${{github.workspace}}/sdk/python.tar.gz -C
-        ${{github.workspace}}/sdk/python
-    - name: Download dotnet SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: dotnet-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress dotnet SDK
-      run: tar -zxf ${{github.workspace}}/sdk/dotnet.tar.gz -C
-        ${{github.workspace}}/sdk/dotnet
-    - name: Download nodejs SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: nodejs-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress nodejs SDK
-      run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
-        ${{github.workspace}}/sdk/nodejs
-    - run: python -m pip install pip twine
-    - env:
-        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-      name: Publish SDKs
-      run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - if: failure() && github.event_name == 'push'
-      name: Notify Slack
-      uses: 8398a7/action-slack@v3
-      with:
-        author_name: Failure in publishing SDK
-        fields: repo,commit,author,action
-        status: ${{ job.status }}
+    - name: Publish SDKs
+      uses: pulumi/pulumi-package-publisher@v0.0.5
   test:
     name: test
     needs: build_sdk

--- a/provider-ci/providers/pagerduty/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/pagerduty/repo/.github/workflows/master.yml
@@ -350,131 +350,13 @@ jobs:
         author_name: Failure in publishing binaries
         fields: repo,commit,author,action
         status: ${{ job.status }}
-  publish_java_sdk:
-    continue-on-error: true
-    name: publish_java_sdk
-    needs: publish
-    runs-on: ubuntu-latest
-    steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{ env.JAVAVERSION }}
-    - name: Setup Gradle
-      uses: gradle/gradle-build-action@v2
-      with:
-        gradle-version: "7.6"
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
   publish_sdk:
     name: publish_sdk
     needs: publish
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Node
-      uses: actions/setup-node@v2
-      with:
-        node-version: ${{ env.NODEVERSION }}
-        registry-url: https://registry.npmjs.org
-    - name: Setup DotNet
-      uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: ${{ env.DOTNETVERSION }}
-    - name: Setup Python
-      uses: actions/setup-python@v2
-      with:
-        python-version: ${{ env.PYTHONVERSION }}
-    - name: Download python SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: python-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress python SDK
-      run: tar -zxf ${{github.workspace}}/sdk/python.tar.gz -C
-        ${{github.workspace}}/sdk/python
-    - name: Download dotnet SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: dotnet-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress dotnet SDK
-      run: tar -zxf ${{github.workspace}}/sdk/dotnet.tar.gz -C
-        ${{github.workspace}}/sdk/dotnet
-    - name: Download nodejs SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: nodejs-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress nodejs SDK
-      run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
-        ${{github.workspace}}/sdk/nodejs
-    - run: python -m pip install pip twine
-    - env:
-        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-      name: Publish SDKs
-      run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - if: failure() && github.event_name == 'push'
-      name: Notify Slack
-      uses: 8398a7/action-slack@v3
-      with:
-        author_name: Failure in publishing SDK
-        fields: repo,commit,author,action
-        status: ${{ job.status }}
+    - name: Publish SDKs
+      uses: pulumi/pulumi-package-publisher@v0.0.5
   test:
     name: test
     needs: build_sdk

--- a/provider-ci/providers/pagerduty/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/pagerduty/repo/.github/workflows/prerelease.yml
@@ -300,131 +300,13 @@ jobs:
         author_name: Failure in publishing binaries
         fields: repo,commit,author,action
         status: ${{ job.status }}
-  publish_java_sdk:
-    continue-on-error: true
-    name: publish_java_sdk
-    needs: publish
-    runs-on: ubuntu-latest
-    steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{ env.JAVAVERSION }}
-    - name: Setup Gradle
-      uses: gradle/gradle-build-action@v2
-      with:
-        gradle-version: "7.6"
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
   publish_sdk:
     name: publish_sdk
     needs: publish
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Node
-      uses: actions/setup-node@v2
-      with:
-        node-version: ${{ env.NODEVERSION }}
-        registry-url: https://registry.npmjs.org
-    - name: Setup DotNet
-      uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: ${{ env.DOTNETVERSION }}
-    - name: Setup Python
-      uses: actions/setup-python@v2
-      with:
-        python-version: ${{ env.PYTHONVERSION }}
-    - name: Download python SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: python-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress python SDK
-      run: tar -zxf ${{github.workspace}}/sdk/python.tar.gz -C
-        ${{github.workspace}}/sdk/python
-    - name: Download dotnet SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: dotnet-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress dotnet SDK
-      run: tar -zxf ${{github.workspace}}/sdk/dotnet.tar.gz -C
-        ${{github.workspace}}/sdk/dotnet
-    - name: Download nodejs SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: nodejs-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress nodejs SDK
-      run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
-        ${{github.workspace}}/sdk/nodejs
-    - run: python -m pip install pip twine
-    - env:
-        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-      name: Publish SDKs
-      run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - if: failure() && github.event_name == 'push'
-      name: Notify Slack
-      uses: 8398a7/action-slack@v3
-      with:
-        author_name: Failure in publishing SDK
-        fields: repo,commit,author,action
-        status: ${{ job.status }}
+    - name: Publish SDKs
+      uses: pulumi/pulumi-package-publisher@v0.0.5
   test:
     name: test
     needs: build_sdk

--- a/provider-ci/providers/pagerduty/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/pagerduty/repo/.github/workflows/release.yml
@@ -312,131 +312,13 @@ jobs:
         author_name: Failure in publishing binaries
         fields: repo,commit,author,action
         status: ${{ job.status }}
-  publish_java_sdk:
-    continue-on-error: true
-    name: publish_java_sdk
-    needs: publish
-    runs-on: ubuntu-latest
-    steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{ env.JAVAVERSION }}
-    - name: Setup Gradle
-      uses: gradle/gradle-build-action@v2
-      with:
-        gradle-version: "7.6"
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
   publish_sdk:
     name: publish_sdk
     needs: publish
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Node
-      uses: actions/setup-node@v2
-      with:
-        node-version: ${{ env.NODEVERSION }}
-        registry-url: https://registry.npmjs.org
-    - name: Setup DotNet
-      uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: ${{ env.DOTNETVERSION }}
-    - name: Setup Python
-      uses: actions/setup-python@v2
-      with:
-        python-version: ${{ env.PYTHONVERSION }}
-    - name: Download python SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: python-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress python SDK
-      run: tar -zxf ${{github.workspace}}/sdk/python.tar.gz -C
-        ${{github.workspace}}/sdk/python
-    - name: Download dotnet SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: dotnet-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress dotnet SDK
-      run: tar -zxf ${{github.workspace}}/sdk/dotnet.tar.gz -C
-        ${{github.workspace}}/sdk/dotnet
-    - name: Download nodejs SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: nodejs-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress nodejs SDK
-      run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
-        ${{github.workspace}}/sdk/nodejs
-    - run: python -m pip install pip twine
-    - env:
-        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-      name: Publish SDKs
-      run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - if: failure() && github.event_name == 'push'
-      name: Notify Slack
-      uses: 8398a7/action-slack@v3
-      with:
-        author_name: Failure in publishing SDK
-        fields: repo,commit,author,action
-        status: ${{ job.status }}
+    - name: Publish SDKs
+      uses: pulumi/pulumi-package-publisher@v0.0.5
   tag_sdk:
     name: tag_sdk
     needs: publish_sdk

--- a/provider-ci/providers/postgresql/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/postgresql/repo/.github/workflows/main.yml
@@ -349,131 +349,13 @@ jobs:
         author_name: Failure in publishing binaries
         fields: repo,commit,author,action
         status: ${{ job.status }}
-  publish_java_sdk:
-    continue-on-error: true
-    name: publish_java_sdk
-    needs: publish
-    runs-on: ubuntu-latest
-    steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{ env.JAVAVERSION }}
-    - name: Setup Gradle
-      uses: gradle/gradle-build-action@v2
-      with:
-        gradle-version: "7.6"
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
   publish_sdk:
     name: publish_sdk
     needs: publish
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Node
-      uses: actions/setup-node@v2
-      with:
-        node-version: ${{ env.NODEVERSION }}
-        registry-url: https://registry.npmjs.org
-    - name: Setup DotNet
-      uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: ${{ env.DOTNETVERSION }}
-    - name: Setup Python
-      uses: actions/setup-python@v2
-      with:
-        python-version: ${{ env.PYTHONVERSION }}
-    - name: Download python SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: python-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress python SDK
-      run: tar -zxf ${{github.workspace}}/sdk/python.tar.gz -C
-        ${{github.workspace}}/sdk/python
-    - name: Download dotnet SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: dotnet-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress dotnet SDK
-      run: tar -zxf ${{github.workspace}}/sdk/dotnet.tar.gz -C
-        ${{github.workspace}}/sdk/dotnet
-    - name: Download nodejs SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: nodejs-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress nodejs SDK
-      run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
-        ${{github.workspace}}/sdk/nodejs
-    - run: python -m pip install pip twine
-    - env:
-        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-      name: Publish SDKs
-      run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - if: failure() && github.event_name == 'push'
-      name: Notify Slack
-      uses: 8398a7/action-slack@v3
-      with:
-        author_name: Failure in publishing SDK
-        fields: repo,commit,author,action
-        status: ${{ job.status }}
+    - name: Publish SDKs
+      uses: pulumi/pulumi-package-publisher@v0.0.5
   test:
     name: test
     needs: build_sdk

--- a/provider-ci/providers/postgresql/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/postgresql/repo/.github/workflows/master.yml
@@ -349,131 +349,13 @@ jobs:
         author_name: Failure in publishing binaries
         fields: repo,commit,author,action
         status: ${{ job.status }}
-  publish_java_sdk:
-    continue-on-error: true
-    name: publish_java_sdk
-    needs: publish
-    runs-on: ubuntu-latest
-    steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{ env.JAVAVERSION }}
-    - name: Setup Gradle
-      uses: gradle/gradle-build-action@v2
-      with:
-        gradle-version: "7.6"
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
   publish_sdk:
     name: publish_sdk
     needs: publish
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Node
-      uses: actions/setup-node@v2
-      with:
-        node-version: ${{ env.NODEVERSION }}
-        registry-url: https://registry.npmjs.org
-    - name: Setup DotNet
-      uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: ${{ env.DOTNETVERSION }}
-    - name: Setup Python
-      uses: actions/setup-python@v2
-      with:
-        python-version: ${{ env.PYTHONVERSION }}
-    - name: Download python SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: python-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress python SDK
-      run: tar -zxf ${{github.workspace}}/sdk/python.tar.gz -C
-        ${{github.workspace}}/sdk/python
-    - name: Download dotnet SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: dotnet-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress dotnet SDK
-      run: tar -zxf ${{github.workspace}}/sdk/dotnet.tar.gz -C
-        ${{github.workspace}}/sdk/dotnet
-    - name: Download nodejs SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: nodejs-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress nodejs SDK
-      run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
-        ${{github.workspace}}/sdk/nodejs
-    - run: python -m pip install pip twine
-    - env:
-        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-      name: Publish SDKs
-      run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - if: failure() && github.event_name == 'push'
-      name: Notify Slack
-      uses: 8398a7/action-slack@v3
-      with:
-        author_name: Failure in publishing SDK
-        fields: repo,commit,author,action
-        status: ${{ job.status }}
+    - name: Publish SDKs
+      uses: pulumi/pulumi-package-publisher@v0.0.5
   test:
     name: test
     needs: build_sdk

--- a/provider-ci/providers/postgresql/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/postgresql/repo/.github/workflows/prerelease.yml
@@ -299,131 +299,13 @@ jobs:
         author_name: Failure in publishing binaries
         fields: repo,commit,author,action
         status: ${{ job.status }}
-  publish_java_sdk:
-    continue-on-error: true
-    name: publish_java_sdk
-    needs: publish
-    runs-on: ubuntu-latest
-    steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{ env.JAVAVERSION }}
-    - name: Setup Gradle
-      uses: gradle/gradle-build-action@v2
-      with:
-        gradle-version: "7.6"
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
   publish_sdk:
     name: publish_sdk
     needs: publish
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Node
-      uses: actions/setup-node@v2
-      with:
-        node-version: ${{ env.NODEVERSION }}
-        registry-url: https://registry.npmjs.org
-    - name: Setup DotNet
-      uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: ${{ env.DOTNETVERSION }}
-    - name: Setup Python
-      uses: actions/setup-python@v2
-      with:
-        python-version: ${{ env.PYTHONVERSION }}
-    - name: Download python SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: python-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress python SDK
-      run: tar -zxf ${{github.workspace}}/sdk/python.tar.gz -C
-        ${{github.workspace}}/sdk/python
-    - name: Download dotnet SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: dotnet-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress dotnet SDK
-      run: tar -zxf ${{github.workspace}}/sdk/dotnet.tar.gz -C
-        ${{github.workspace}}/sdk/dotnet
-    - name: Download nodejs SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: nodejs-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress nodejs SDK
-      run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
-        ${{github.workspace}}/sdk/nodejs
-    - run: python -m pip install pip twine
-    - env:
-        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-      name: Publish SDKs
-      run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - if: failure() && github.event_name == 'push'
-      name: Notify Slack
-      uses: 8398a7/action-slack@v3
-      with:
-        author_name: Failure in publishing SDK
-        fields: repo,commit,author,action
-        status: ${{ job.status }}
+    - name: Publish SDKs
+      uses: pulumi/pulumi-package-publisher@v0.0.5
   test:
     name: test
     needs: build_sdk

--- a/provider-ci/providers/postgresql/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/postgresql/repo/.github/workflows/release.yml
@@ -311,131 +311,13 @@ jobs:
         author_name: Failure in publishing binaries
         fields: repo,commit,author,action
         status: ${{ job.status }}
-  publish_java_sdk:
-    continue-on-error: true
-    name: publish_java_sdk
-    needs: publish
-    runs-on: ubuntu-latest
-    steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{ env.JAVAVERSION }}
-    - name: Setup Gradle
-      uses: gradle/gradle-build-action@v2
-      with:
-        gradle-version: "7.6"
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
   publish_sdk:
     name: publish_sdk
     needs: publish
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Node
-      uses: actions/setup-node@v2
-      with:
-        node-version: ${{ env.NODEVERSION }}
-        registry-url: https://registry.npmjs.org
-    - name: Setup DotNet
-      uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: ${{ env.DOTNETVERSION }}
-    - name: Setup Python
-      uses: actions/setup-python@v2
-      with:
-        python-version: ${{ env.PYTHONVERSION }}
-    - name: Download python SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: python-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress python SDK
-      run: tar -zxf ${{github.workspace}}/sdk/python.tar.gz -C
-        ${{github.workspace}}/sdk/python
-    - name: Download dotnet SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: dotnet-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress dotnet SDK
-      run: tar -zxf ${{github.workspace}}/sdk/dotnet.tar.gz -C
-        ${{github.workspace}}/sdk/dotnet
-    - name: Download nodejs SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: nodejs-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress nodejs SDK
-      run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
-        ${{github.workspace}}/sdk/nodejs
-    - run: python -m pip install pip twine
-    - env:
-        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-      name: Publish SDKs
-      run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - if: failure() && github.event_name == 'push'
-      name: Notify Slack
-      uses: 8398a7/action-slack@v3
-      with:
-        author_name: Failure in publishing SDK
-        fields: repo,commit,author,action
-        status: ${{ job.status }}
+    - name: Publish SDKs
+      uses: pulumi/pulumi-package-publisher@v0.0.5
   tag_sdk:
     name: tag_sdk
     needs: publish_sdk

--- a/provider-ci/providers/rabbitmq/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/rabbitmq/repo/.github/workflows/main.yml
@@ -349,131 +349,13 @@ jobs:
         author_name: Failure in publishing binaries
         fields: repo,commit,author,action
         status: ${{ job.status }}
-  publish_java_sdk:
-    continue-on-error: true
-    name: publish_java_sdk
-    needs: publish
-    runs-on: ubuntu-latest
-    steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{ env.JAVAVERSION }}
-    - name: Setup Gradle
-      uses: gradle/gradle-build-action@v2
-      with:
-        gradle-version: "7.6"
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
   publish_sdk:
     name: publish_sdk
     needs: publish
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Node
-      uses: actions/setup-node@v2
-      with:
-        node-version: ${{ env.NODEVERSION }}
-        registry-url: https://registry.npmjs.org
-    - name: Setup DotNet
-      uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: ${{ env.DOTNETVERSION }}
-    - name: Setup Python
-      uses: actions/setup-python@v2
-      with:
-        python-version: ${{ env.PYTHONVERSION }}
-    - name: Download python SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: python-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress python SDK
-      run: tar -zxf ${{github.workspace}}/sdk/python.tar.gz -C
-        ${{github.workspace}}/sdk/python
-    - name: Download dotnet SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: dotnet-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress dotnet SDK
-      run: tar -zxf ${{github.workspace}}/sdk/dotnet.tar.gz -C
-        ${{github.workspace}}/sdk/dotnet
-    - name: Download nodejs SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: nodejs-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress nodejs SDK
-      run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
-        ${{github.workspace}}/sdk/nodejs
-    - run: python -m pip install pip twine
-    - env:
-        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-      name: Publish SDKs
-      run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - if: failure() && github.event_name == 'push'
-      name: Notify Slack
-      uses: 8398a7/action-slack@v3
-      with:
-        author_name: Failure in publishing SDK
-        fields: repo,commit,author,action
-        status: ${{ job.status }}
+    - name: Publish SDKs
+      uses: pulumi/pulumi-package-publisher@v0.0.5
   test:
     name: test
     needs: build_sdk

--- a/provider-ci/providers/rabbitmq/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/rabbitmq/repo/.github/workflows/master.yml
@@ -349,131 +349,13 @@ jobs:
         author_name: Failure in publishing binaries
         fields: repo,commit,author,action
         status: ${{ job.status }}
-  publish_java_sdk:
-    continue-on-error: true
-    name: publish_java_sdk
-    needs: publish
-    runs-on: ubuntu-latest
-    steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{ env.JAVAVERSION }}
-    - name: Setup Gradle
-      uses: gradle/gradle-build-action@v2
-      with:
-        gradle-version: "7.6"
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
   publish_sdk:
     name: publish_sdk
     needs: publish
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Node
-      uses: actions/setup-node@v2
-      with:
-        node-version: ${{ env.NODEVERSION }}
-        registry-url: https://registry.npmjs.org
-    - name: Setup DotNet
-      uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: ${{ env.DOTNETVERSION }}
-    - name: Setup Python
-      uses: actions/setup-python@v2
-      with:
-        python-version: ${{ env.PYTHONVERSION }}
-    - name: Download python SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: python-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress python SDK
-      run: tar -zxf ${{github.workspace}}/sdk/python.tar.gz -C
-        ${{github.workspace}}/sdk/python
-    - name: Download dotnet SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: dotnet-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress dotnet SDK
-      run: tar -zxf ${{github.workspace}}/sdk/dotnet.tar.gz -C
-        ${{github.workspace}}/sdk/dotnet
-    - name: Download nodejs SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: nodejs-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress nodejs SDK
-      run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
-        ${{github.workspace}}/sdk/nodejs
-    - run: python -m pip install pip twine
-    - env:
-        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-      name: Publish SDKs
-      run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - if: failure() && github.event_name == 'push'
-      name: Notify Slack
-      uses: 8398a7/action-slack@v3
-      with:
-        author_name: Failure in publishing SDK
-        fields: repo,commit,author,action
-        status: ${{ job.status }}
+    - name: Publish SDKs
+      uses: pulumi/pulumi-package-publisher@v0.0.5
   test:
     name: test
     needs: build_sdk

--- a/provider-ci/providers/rabbitmq/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/rabbitmq/repo/.github/workflows/prerelease.yml
@@ -299,131 +299,13 @@ jobs:
         author_name: Failure in publishing binaries
         fields: repo,commit,author,action
         status: ${{ job.status }}
-  publish_java_sdk:
-    continue-on-error: true
-    name: publish_java_sdk
-    needs: publish
-    runs-on: ubuntu-latest
-    steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{ env.JAVAVERSION }}
-    - name: Setup Gradle
-      uses: gradle/gradle-build-action@v2
-      with:
-        gradle-version: "7.6"
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
   publish_sdk:
     name: publish_sdk
     needs: publish
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Node
-      uses: actions/setup-node@v2
-      with:
-        node-version: ${{ env.NODEVERSION }}
-        registry-url: https://registry.npmjs.org
-    - name: Setup DotNet
-      uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: ${{ env.DOTNETVERSION }}
-    - name: Setup Python
-      uses: actions/setup-python@v2
-      with:
-        python-version: ${{ env.PYTHONVERSION }}
-    - name: Download python SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: python-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress python SDK
-      run: tar -zxf ${{github.workspace}}/sdk/python.tar.gz -C
-        ${{github.workspace}}/sdk/python
-    - name: Download dotnet SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: dotnet-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress dotnet SDK
-      run: tar -zxf ${{github.workspace}}/sdk/dotnet.tar.gz -C
-        ${{github.workspace}}/sdk/dotnet
-    - name: Download nodejs SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: nodejs-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress nodejs SDK
-      run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
-        ${{github.workspace}}/sdk/nodejs
-    - run: python -m pip install pip twine
-    - env:
-        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-      name: Publish SDKs
-      run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - if: failure() && github.event_name == 'push'
-      name: Notify Slack
-      uses: 8398a7/action-slack@v3
-      with:
-        author_name: Failure in publishing SDK
-        fields: repo,commit,author,action
-        status: ${{ job.status }}
+    - name: Publish SDKs
+      uses: pulumi/pulumi-package-publisher@v0.0.5
   test:
     name: test
     needs: build_sdk

--- a/provider-ci/providers/rabbitmq/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/rabbitmq/repo/.github/workflows/release.yml
@@ -311,131 +311,13 @@ jobs:
         author_name: Failure in publishing binaries
         fields: repo,commit,author,action
         status: ${{ job.status }}
-  publish_java_sdk:
-    continue-on-error: true
-    name: publish_java_sdk
-    needs: publish
-    runs-on: ubuntu-latest
-    steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{ env.JAVAVERSION }}
-    - name: Setup Gradle
-      uses: gradle/gradle-build-action@v2
-      with:
-        gradle-version: "7.6"
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
   publish_sdk:
     name: publish_sdk
     needs: publish
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Node
-      uses: actions/setup-node@v2
-      with:
-        node-version: ${{ env.NODEVERSION }}
-        registry-url: https://registry.npmjs.org
-    - name: Setup DotNet
-      uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: ${{ env.DOTNETVERSION }}
-    - name: Setup Python
-      uses: actions/setup-python@v2
-      with:
-        python-version: ${{ env.PYTHONVERSION }}
-    - name: Download python SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: python-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress python SDK
-      run: tar -zxf ${{github.workspace}}/sdk/python.tar.gz -C
-        ${{github.workspace}}/sdk/python
-    - name: Download dotnet SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: dotnet-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress dotnet SDK
-      run: tar -zxf ${{github.workspace}}/sdk/dotnet.tar.gz -C
-        ${{github.workspace}}/sdk/dotnet
-    - name: Download nodejs SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: nodejs-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress nodejs SDK
-      run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
-        ${{github.workspace}}/sdk/nodejs
-    - run: python -m pip install pip twine
-    - env:
-        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-      name: Publish SDKs
-      run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - if: failure() && github.event_name == 'push'
-      name: Notify Slack
-      uses: 8398a7/action-slack@v3
-      with:
-        author_name: Failure in publishing SDK
-        fields: repo,commit,author,action
-        status: ${{ job.status }}
+    - name: Publish SDKs
+      uses: pulumi/pulumi-package-publisher@v0.0.5
   tag_sdk:
     name: tag_sdk
     needs: publish_sdk

--- a/provider-ci/providers/rancher2/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/rancher2/repo/.github/workflows/main.yml
@@ -280,131 +280,13 @@ jobs:
         author_name: Failure in publishing binaries
         fields: repo,commit,author,action
         status: ${{ job.status }}
-  publish_java_sdk:
-    continue-on-error: true
-    name: publish_java_sdk
-    needs: publish
-    runs-on: ubuntu-latest
-    steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{ env.JAVAVERSION }}
-    - name: Setup Gradle
-      uses: gradle/gradle-build-action@v2
-      with:
-        gradle-version: "7.6"
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
   publish_sdk:
     name: publish_sdk
     needs: publish
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Node
-      uses: actions/setup-node@v2
-      with:
-        node-version: ${{ env.NODEVERSION }}
-        registry-url: https://registry.npmjs.org
-    - name: Setup DotNet
-      uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: ${{ env.DOTNETVERSION }}
-    - name: Setup Python
-      uses: actions/setup-python@v2
-      with:
-        python-version: ${{ env.PYTHONVERSION }}
-    - name: Download python SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: python-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress python SDK
-      run: tar -zxf ${{github.workspace}}/sdk/python.tar.gz -C
-        ${{github.workspace}}/sdk/python
-    - name: Download dotnet SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: dotnet-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress dotnet SDK
-      run: tar -zxf ${{github.workspace}}/sdk/dotnet.tar.gz -C
-        ${{github.workspace}}/sdk/dotnet
-    - name: Download nodejs SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: nodejs-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress nodejs SDK
-      run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
-        ${{github.workspace}}/sdk/nodejs
-    - run: python -m pip install pip twine
-    - env:
-        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-      name: Publish SDKs
-      run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - if: failure() && github.event_name == 'push'
-      name: Notify Slack
-      uses: 8398a7/action-slack@v3
-      with:
-        author_name: Failure in publishing SDK
-        fields: repo,commit,author,action
-        status: ${{ job.status }}
+    - name: Publish SDKs
+      uses: pulumi/pulumi-package-publisher@v0.0.5
   test:
     name: test
     needs: build_sdk

--- a/provider-ci/providers/rancher2/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/rancher2/repo/.github/workflows/master.yml
@@ -280,131 +280,13 @@ jobs:
         author_name: Failure in publishing binaries
         fields: repo,commit,author,action
         status: ${{ job.status }}
-  publish_java_sdk:
-    continue-on-error: true
-    name: publish_java_sdk
-    needs: publish
-    runs-on: ubuntu-latest
-    steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{ env.JAVAVERSION }}
-    - name: Setup Gradle
-      uses: gradle/gradle-build-action@v2
-      with:
-        gradle-version: "7.6"
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
   publish_sdk:
     name: publish_sdk
     needs: publish
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Node
-      uses: actions/setup-node@v2
-      with:
-        node-version: ${{ env.NODEVERSION }}
-        registry-url: https://registry.npmjs.org
-    - name: Setup DotNet
-      uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: ${{ env.DOTNETVERSION }}
-    - name: Setup Python
-      uses: actions/setup-python@v2
-      with:
-        python-version: ${{ env.PYTHONVERSION }}
-    - name: Download python SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: python-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress python SDK
-      run: tar -zxf ${{github.workspace}}/sdk/python.tar.gz -C
-        ${{github.workspace}}/sdk/python
-    - name: Download dotnet SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: dotnet-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress dotnet SDK
-      run: tar -zxf ${{github.workspace}}/sdk/dotnet.tar.gz -C
-        ${{github.workspace}}/sdk/dotnet
-    - name: Download nodejs SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: nodejs-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress nodejs SDK
-      run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
-        ${{github.workspace}}/sdk/nodejs
-    - run: python -m pip install pip twine
-    - env:
-        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-      name: Publish SDKs
-      run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - if: failure() && github.event_name == 'push'
-      name: Notify Slack
-      uses: 8398a7/action-slack@v3
-      with:
-        author_name: Failure in publishing SDK
-        fields: repo,commit,author,action
-        status: ${{ job.status }}
+    - name: Publish SDKs
+      uses: pulumi/pulumi-package-publisher@v0.0.5
   test:
     name: test
     needs: build_sdk

--- a/provider-ci/providers/rancher2/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/rancher2/repo/.github/workflows/prerelease.yml
@@ -230,131 +230,13 @@ jobs:
         author_name: Failure in publishing binaries
         fields: repo,commit,author,action
         status: ${{ job.status }}
-  publish_java_sdk:
-    continue-on-error: true
-    name: publish_java_sdk
-    needs: publish
-    runs-on: ubuntu-latest
-    steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{ env.JAVAVERSION }}
-    - name: Setup Gradle
-      uses: gradle/gradle-build-action@v2
-      with:
-        gradle-version: "7.6"
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
   publish_sdk:
     name: publish_sdk
     needs: publish
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Node
-      uses: actions/setup-node@v2
-      with:
-        node-version: ${{ env.NODEVERSION }}
-        registry-url: https://registry.npmjs.org
-    - name: Setup DotNet
-      uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: ${{ env.DOTNETVERSION }}
-    - name: Setup Python
-      uses: actions/setup-python@v2
-      with:
-        python-version: ${{ env.PYTHONVERSION }}
-    - name: Download python SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: python-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress python SDK
-      run: tar -zxf ${{github.workspace}}/sdk/python.tar.gz -C
-        ${{github.workspace}}/sdk/python
-    - name: Download dotnet SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: dotnet-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress dotnet SDK
-      run: tar -zxf ${{github.workspace}}/sdk/dotnet.tar.gz -C
-        ${{github.workspace}}/sdk/dotnet
-    - name: Download nodejs SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: nodejs-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress nodejs SDK
-      run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
-        ${{github.workspace}}/sdk/nodejs
-    - run: python -m pip install pip twine
-    - env:
-        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-      name: Publish SDKs
-      run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - if: failure() && github.event_name == 'push'
-      name: Notify Slack
-      uses: 8398a7/action-slack@v3
-      with:
-        author_name: Failure in publishing SDK
-        fields: repo,commit,author,action
-        status: ${{ job.status }}
+    - name: Publish SDKs
+      uses: pulumi/pulumi-package-publisher@v0.0.5
   test:
     name: test
     needs: build_sdk

--- a/provider-ci/providers/rancher2/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/rancher2/repo/.github/workflows/release.yml
@@ -242,131 +242,13 @@ jobs:
         author_name: Failure in publishing binaries
         fields: repo,commit,author,action
         status: ${{ job.status }}
-  publish_java_sdk:
-    continue-on-error: true
-    name: publish_java_sdk
-    needs: publish
-    runs-on: ubuntu-latest
-    steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{ env.JAVAVERSION }}
-    - name: Setup Gradle
-      uses: gradle/gradle-build-action@v2
-      with:
-        gradle-version: "7.6"
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
   publish_sdk:
     name: publish_sdk
     needs: publish
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Node
-      uses: actions/setup-node@v2
-      with:
-        node-version: ${{ env.NODEVERSION }}
-        registry-url: https://registry.npmjs.org
-    - name: Setup DotNet
-      uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: ${{ env.DOTNETVERSION }}
-    - name: Setup Python
-      uses: actions/setup-python@v2
-      with:
-        python-version: ${{ env.PYTHONVERSION }}
-    - name: Download python SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: python-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress python SDK
-      run: tar -zxf ${{github.workspace}}/sdk/python.tar.gz -C
-        ${{github.workspace}}/sdk/python
-    - name: Download dotnet SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: dotnet-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress dotnet SDK
-      run: tar -zxf ${{github.workspace}}/sdk/dotnet.tar.gz -C
-        ${{github.workspace}}/sdk/dotnet
-    - name: Download nodejs SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: nodejs-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress nodejs SDK
-      run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
-        ${{github.workspace}}/sdk/nodejs
-    - run: python -m pip install pip twine
-    - env:
-        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-      name: Publish SDKs
-      run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - if: failure() && github.event_name == 'push'
-      name: Notify Slack
-      uses: 8398a7/action-slack@v3
-      with:
-        author_name: Failure in publishing SDK
-        fields: repo,commit,author,action
-        status: ${{ job.status }}
+    - name: Publish SDKs
+      uses: pulumi/pulumi-package-publisher@v0.0.5
   tag_sdk:
     name: tag_sdk
     needs: publish_sdk

--- a/provider-ci/providers/random/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/random/repo/.github/workflows/main.yml
@@ -349,131 +349,13 @@ jobs:
         author_name: Failure in publishing binaries
         fields: repo,commit,author,action
         status: ${{ job.status }}
-  publish_java_sdk:
-    continue-on-error: true
-    name: publish_java_sdk
-    needs: publish
-    runs-on: ubuntu-latest
-    steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{ env.JAVAVERSION }}
-    - name: Setup Gradle
-      uses: gradle/gradle-build-action@v2
-      with:
-        gradle-version: "7.6"
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
   publish_sdk:
     name: publish_sdk
     needs: publish
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Node
-      uses: actions/setup-node@v2
-      with:
-        node-version: ${{ env.NODEVERSION }}
-        registry-url: https://registry.npmjs.org
-    - name: Setup DotNet
-      uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: ${{ env.DOTNETVERSION }}
-    - name: Setup Python
-      uses: actions/setup-python@v2
-      with:
-        python-version: ${{ env.PYTHONVERSION }}
-    - name: Download python SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: python-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress python SDK
-      run: tar -zxf ${{github.workspace}}/sdk/python.tar.gz -C
-        ${{github.workspace}}/sdk/python
-    - name: Download dotnet SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: dotnet-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress dotnet SDK
-      run: tar -zxf ${{github.workspace}}/sdk/dotnet.tar.gz -C
-        ${{github.workspace}}/sdk/dotnet
-    - name: Download nodejs SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: nodejs-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress nodejs SDK
-      run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
-        ${{github.workspace}}/sdk/nodejs
-    - run: python -m pip install pip twine
-    - env:
-        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-      name: Publish SDKs
-      run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - if: failure() && github.event_name == 'push'
-      name: Notify Slack
-      uses: 8398a7/action-slack@v3
-      with:
-        author_name: Failure in publishing SDK
-        fields: repo,commit,author,action
-        status: ${{ job.status }}
+    - name: Publish SDKs
+      uses: pulumi/pulumi-package-publisher@v0.0.5
   test:
     name: test
     needs: build_sdk

--- a/provider-ci/providers/random/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/random/repo/.github/workflows/master.yml
@@ -349,131 +349,13 @@ jobs:
         author_name: Failure in publishing binaries
         fields: repo,commit,author,action
         status: ${{ job.status }}
-  publish_java_sdk:
-    continue-on-error: true
-    name: publish_java_sdk
-    needs: publish
-    runs-on: ubuntu-latest
-    steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{ env.JAVAVERSION }}
-    - name: Setup Gradle
-      uses: gradle/gradle-build-action@v2
-      with:
-        gradle-version: "7.6"
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
   publish_sdk:
     name: publish_sdk
     needs: publish
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Node
-      uses: actions/setup-node@v2
-      with:
-        node-version: ${{ env.NODEVERSION }}
-        registry-url: https://registry.npmjs.org
-    - name: Setup DotNet
-      uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: ${{ env.DOTNETVERSION }}
-    - name: Setup Python
-      uses: actions/setup-python@v2
-      with:
-        python-version: ${{ env.PYTHONVERSION }}
-    - name: Download python SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: python-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress python SDK
-      run: tar -zxf ${{github.workspace}}/sdk/python.tar.gz -C
-        ${{github.workspace}}/sdk/python
-    - name: Download dotnet SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: dotnet-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress dotnet SDK
-      run: tar -zxf ${{github.workspace}}/sdk/dotnet.tar.gz -C
-        ${{github.workspace}}/sdk/dotnet
-    - name: Download nodejs SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: nodejs-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress nodejs SDK
-      run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
-        ${{github.workspace}}/sdk/nodejs
-    - run: python -m pip install pip twine
-    - env:
-        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-      name: Publish SDKs
-      run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - if: failure() && github.event_name == 'push'
-      name: Notify Slack
-      uses: 8398a7/action-slack@v3
-      with:
-        author_name: Failure in publishing SDK
-        fields: repo,commit,author,action
-        status: ${{ job.status }}
+    - name: Publish SDKs
+      uses: pulumi/pulumi-package-publisher@v0.0.5
   test:
     name: test
     needs: build_sdk

--- a/provider-ci/providers/random/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/random/repo/.github/workflows/prerelease.yml
@@ -299,131 +299,13 @@ jobs:
         author_name: Failure in publishing binaries
         fields: repo,commit,author,action
         status: ${{ job.status }}
-  publish_java_sdk:
-    continue-on-error: true
-    name: publish_java_sdk
-    needs: publish
-    runs-on: ubuntu-latest
-    steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{ env.JAVAVERSION }}
-    - name: Setup Gradle
-      uses: gradle/gradle-build-action@v2
-      with:
-        gradle-version: "7.6"
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
   publish_sdk:
     name: publish_sdk
     needs: publish
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Node
-      uses: actions/setup-node@v2
-      with:
-        node-version: ${{ env.NODEVERSION }}
-        registry-url: https://registry.npmjs.org
-    - name: Setup DotNet
-      uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: ${{ env.DOTNETVERSION }}
-    - name: Setup Python
-      uses: actions/setup-python@v2
-      with:
-        python-version: ${{ env.PYTHONVERSION }}
-    - name: Download python SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: python-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress python SDK
-      run: tar -zxf ${{github.workspace}}/sdk/python.tar.gz -C
-        ${{github.workspace}}/sdk/python
-    - name: Download dotnet SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: dotnet-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress dotnet SDK
-      run: tar -zxf ${{github.workspace}}/sdk/dotnet.tar.gz -C
-        ${{github.workspace}}/sdk/dotnet
-    - name: Download nodejs SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: nodejs-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress nodejs SDK
-      run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
-        ${{github.workspace}}/sdk/nodejs
-    - run: python -m pip install pip twine
-    - env:
-        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-      name: Publish SDKs
-      run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - if: failure() && github.event_name == 'push'
-      name: Notify Slack
-      uses: 8398a7/action-slack@v3
-      with:
-        author_name: Failure in publishing SDK
-        fields: repo,commit,author,action
-        status: ${{ job.status }}
+    - name: Publish SDKs
+      uses: pulumi/pulumi-package-publisher@v0.0.5
   test:
     name: test
     needs: build_sdk

--- a/provider-ci/providers/random/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/random/repo/.github/workflows/release.yml
@@ -311,131 +311,13 @@ jobs:
         author_name: Failure in publishing binaries
         fields: repo,commit,author,action
         status: ${{ job.status }}
-  publish_java_sdk:
-    continue-on-error: true
-    name: publish_java_sdk
-    needs: publish
-    runs-on: ubuntu-latest
-    steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{ env.JAVAVERSION }}
-    - name: Setup Gradle
-      uses: gradle/gradle-build-action@v2
-      with:
-        gradle-version: "7.6"
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
   publish_sdk:
     name: publish_sdk
     needs: publish
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Node
-      uses: actions/setup-node@v2
-      with:
-        node-version: ${{ env.NODEVERSION }}
-        registry-url: https://registry.npmjs.org
-    - name: Setup DotNet
-      uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: ${{ env.DOTNETVERSION }}
-    - name: Setup Python
-      uses: actions/setup-python@v2
-      with:
-        python-version: ${{ env.PYTHONVERSION }}
-    - name: Download python SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: python-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress python SDK
-      run: tar -zxf ${{github.workspace}}/sdk/python.tar.gz -C
-        ${{github.workspace}}/sdk/python
-    - name: Download dotnet SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: dotnet-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress dotnet SDK
-      run: tar -zxf ${{github.workspace}}/sdk/dotnet.tar.gz -C
-        ${{github.workspace}}/sdk/dotnet
-    - name: Download nodejs SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: nodejs-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress nodejs SDK
-      run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
-        ${{github.workspace}}/sdk/nodejs
-    - run: python -m pip install pip twine
-    - env:
-        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-      name: Publish SDKs
-      run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - if: failure() && github.event_name == 'push'
-      name: Notify Slack
-      uses: 8398a7/action-slack@v3
-      with:
-        author_name: Failure in publishing SDK
-        fields: repo,commit,author,action
-        status: ${{ job.status }}
+    - name: Publish SDKs
+      uses: pulumi/pulumi-package-publisher@v0.0.5
   tag_sdk:
     name: tag_sdk
     needs: publish_sdk

--- a/provider-ci/providers/rke/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/rke/repo/.github/workflows/main.yml
@@ -350,131 +350,13 @@ jobs:
         author_name: Failure in publishing binaries
         fields: repo,commit,author,action
         status: ${{ job.status }}
-  publish_java_sdk:
-    continue-on-error: true
-    name: publish_java_sdk
-    needs: publish
-    runs-on: ubuntu-latest
-    steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{ env.JAVAVERSION }}
-    - name: Setup Gradle
-      uses: gradle/gradle-build-action@v2
-      with:
-        gradle-version: "7.6"
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
   publish_sdk:
     name: publish_sdk
     needs: publish
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Node
-      uses: actions/setup-node@v2
-      with:
-        node-version: ${{ env.NODEVERSION }}
-        registry-url: https://registry.npmjs.org
-    - name: Setup DotNet
-      uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: ${{ env.DOTNETVERSION }}
-    - name: Setup Python
-      uses: actions/setup-python@v2
-      with:
-        python-version: ${{ env.PYTHONVERSION }}
-    - name: Download python SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: python-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress python SDK
-      run: tar -zxf ${{github.workspace}}/sdk/python.tar.gz -C
-        ${{github.workspace}}/sdk/python
-    - name: Download dotnet SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: dotnet-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress dotnet SDK
-      run: tar -zxf ${{github.workspace}}/sdk/dotnet.tar.gz -C
-        ${{github.workspace}}/sdk/dotnet
-    - name: Download nodejs SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: nodejs-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress nodejs SDK
-      run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
-        ${{github.workspace}}/sdk/nodejs
-    - run: python -m pip install pip twine
-    - env:
-        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-      name: Publish SDKs
-      run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - if: failure() && github.event_name == 'push'
-      name: Notify Slack
-      uses: 8398a7/action-slack@v3
-      with:
-        author_name: Failure in publishing SDK
-        fields: repo,commit,author,action
-        status: ${{ job.status }}
+    - name: Publish SDKs
+      uses: pulumi/pulumi-package-publisher@v0.0.5
   test:
     name: test
     needs: build_sdk

--- a/provider-ci/providers/rke/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/rke/repo/.github/workflows/master.yml
@@ -350,131 +350,13 @@ jobs:
         author_name: Failure in publishing binaries
         fields: repo,commit,author,action
         status: ${{ job.status }}
-  publish_java_sdk:
-    continue-on-error: true
-    name: publish_java_sdk
-    needs: publish
-    runs-on: ubuntu-latest
-    steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{ env.JAVAVERSION }}
-    - name: Setup Gradle
-      uses: gradle/gradle-build-action@v2
-      with:
-        gradle-version: "7.6"
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
   publish_sdk:
     name: publish_sdk
     needs: publish
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Node
-      uses: actions/setup-node@v2
-      with:
-        node-version: ${{ env.NODEVERSION }}
-        registry-url: https://registry.npmjs.org
-    - name: Setup DotNet
-      uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: ${{ env.DOTNETVERSION }}
-    - name: Setup Python
-      uses: actions/setup-python@v2
-      with:
-        python-version: ${{ env.PYTHONVERSION }}
-    - name: Download python SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: python-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress python SDK
-      run: tar -zxf ${{github.workspace}}/sdk/python.tar.gz -C
-        ${{github.workspace}}/sdk/python
-    - name: Download dotnet SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: dotnet-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress dotnet SDK
-      run: tar -zxf ${{github.workspace}}/sdk/dotnet.tar.gz -C
-        ${{github.workspace}}/sdk/dotnet
-    - name: Download nodejs SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: nodejs-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress nodejs SDK
-      run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
-        ${{github.workspace}}/sdk/nodejs
-    - run: python -m pip install pip twine
-    - env:
-        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-      name: Publish SDKs
-      run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - if: failure() && github.event_name == 'push'
-      name: Notify Slack
-      uses: 8398a7/action-slack@v3
-      with:
-        author_name: Failure in publishing SDK
-        fields: repo,commit,author,action
-        status: ${{ job.status }}
+    - name: Publish SDKs
+      uses: pulumi/pulumi-package-publisher@v0.0.5
   test:
     name: test
     needs: build_sdk

--- a/provider-ci/providers/rke/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/rke/repo/.github/workflows/prerelease.yml
@@ -300,131 +300,13 @@ jobs:
         author_name: Failure in publishing binaries
         fields: repo,commit,author,action
         status: ${{ job.status }}
-  publish_java_sdk:
-    continue-on-error: true
-    name: publish_java_sdk
-    needs: publish
-    runs-on: ubuntu-latest
-    steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{ env.JAVAVERSION }}
-    - name: Setup Gradle
-      uses: gradle/gradle-build-action@v2
-      with:
-        gradle-version: "7.6"
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
   publish_sdk:
     name: publish_sdk
     needs: publish
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Node
-      uses: actions/setup-node@v2
-      with:
-        node-version: ${{ env.NODEVERSION }}
-        registry-url: https://registry.npmjs.org
-    - name: Setup DotNet
-      uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: ${{ env.DOTNETVERSION }}
-    - name: Setup Python
-      uses: actions/setup-python@v2
-      with:
-        python-version: ${{ env.PYTHONVERSION }}
-    - name: Download python SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: python-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress python SDK
-      run: tar -zxf ${{github.workspace}}/sdk/python.tar.gz -C
-        ${{github.workspace}}/sdk/python
-    - name: Download dotnet SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: dotnet-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress dotnet SDK
-      run: tar -zxf ${{github.workspace}}/sdk/dotnet.tar.gz -C
-        ${{github.workspace}}/sdk/dotnet
-    - name: Download nodejs SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: nodejs-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress nodejs SDK
-      run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
-        ${{github.workspace}}/sdk/nodejs
-    - run: python -m pip install pip twine
-    - env:
-        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-      name: Publish SDKs
-      run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - if: failure() && github.event_name == 'push'
-      name: Notify Slack
-      uses: 8398a7/action-slack@v3
-      with:
-        author_name: Failure in publishing SDK
-        fields: repo,commit,author,action
-        status: ${{ job.status }}
+    - name: Publish SDKs
+      uses: pulumi/pulumi-package-publisher@v0.0.5
   test:
     name: test
     needs: build_sdk

--- a/provider-ci/providers/rke/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/rke/repo/.github/workflows/release.yml
@@ -312,131 +312,13 @@ jobs:
         author_name: Failure in publishing binaries
         fields: repo,commit,author,action
         status: ${{ job.status }}
-  publish_java_sdk:
-    continue-on-error: true
-    name: publish_java_sdk
-    needs: publish
-    runs-on: ubuntu-latest
-    steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{ env.JAVAVERSION }}
-    - name: Setup Gradle
-      uses: gradle/gradle-build-action@v2
-      with:
-        gradle-version: "7.6"
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
   publish_sdk:
     name: publish_sdk
     needs: publish
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Node
-      uses: actions/setup-node@v2
-      with:
-        node-version: ${{ env.NODEVERSION }}
-        registry-url: https://registry.npmjs.org
-    - name: Setup DotNet
-      uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: ${{ env.DOTNETVERSION }}
-    - name: Setup Python
-      uses: actions/setup-python@v2
-      with:
-        python-version: ${{ env.PYTHONVERSION }}
-    - name: Download python SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: python-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress python SDK
-      run: tar -zxf ${{github.workspace}}/sdk/python.tar.gz -C
-        ${{github.workspace}}/sdk/python
-    - name: Download dotnet SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: dotnet-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress dotnet SDK
-      run: tar -zxf ${{github.workspace}}/sdk/dotnet.tar.gz -C
-        ${{github.workspace}}/sdk/dotnet
-    - name: Download nodejs SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: nodejs-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress nodejs SDK
-      run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
-        ${{github.workspace}}/sdk/nodejs
-    - run: python -m pip install pip twine
-    - env:
-        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-      name: Publish SDKs
-      run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - if: failure() && github.event_name == 'push'
-      name: Notify Slack
-      uses: 8398a7/action-slack@v3
-      with:
-        author_name: Failure in publishing SDK
-        fields: repo,commit,author,action
-        status: ${{ job.status }}
+    - name: Publish SDKs
+      uses: pulumi/pulumi-package-publisher@v0.0.5
   tag_sdk:
     name: tag_sdk
     needs: publish_sdk

--- a/provider-ci/providers/signalfx/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/signalfx/repo/.github/workflows/main.yml
@@ -349,131 +349,13 @@ jobs:
         author_name: Failure in publishing binaries
         fields: repo,commit,author,action
         status: ${{ job.status }}
-  publish_java_sdk:
-    continue-on-error: true
-    name: publish_java_sdk
-    needs: publish
-    runs-on: ubuntu-latest
-    steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{ env.JAVAVERSION }}
-    - name: Setup Gradle
-      uses: gradle/gradle-build-action@v2
-      with:
-        gradle-version: "7.6"
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
   publish_sdk:
     name: publish_sdk
     needs: publish
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Node
-      uses: actions/setup-node@v2
-      with:
-        node-version: ${{ env.NODEVERSION }}
-        registry-url: https://registry.npmjs.org
-    - name: Setup DotNet
-      uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: ${{ env.DOTNETVERSION }}
-    - name: Setup Python
-      uses: actions/setup-python@v2
-      with:
-        python-version: ${{ env.PYTHONVERSION }}
-    - name: Download python SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: python-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress python SDK
-      run: tar -zxf ${{github.workspace}}/sdk/python.tar.gz -C
-        ${{github.workspace}}/sdk/python
-    - name: Download dotnet SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: dotnet-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress dotnet SDK
-      run: tar -zxf ${{github.workspace}}/sdk/dotnet.tar.gz -C
-        ${{github.workspace}}/sdk/dotnet
-    - name: Download nodejs SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: nodejs-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress nodejs SDK
-      run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
-        ${{github.workspace}}/sdk/nodejs
-    - run: python -m pip install pip twine
-    - env:
-        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-      name: Publish SDKs
-      run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - if: failure() && github.event_name == 'push'
-      name: Notify Slack
-      uses: 8398a7/action-slack@v3
-      with:
-        author_name: Failure in publishing SDK
-        fields: repo,commit,author,action
-        status: ${{ job.status }}
+    - name: Publish SDKs
+      uses: pulumi/pulumi-package-publisher@v0.0.5
   test:
     name: test
     needs: build_sdk

--- a/provider-ci/providers/signalfx/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/signalfx/repo/.github/workflows/master.yml
@@ -349,131 +349,13 @@ jobs:
         author_name: Failure in publishing binaries
         fields: repo,commit,author,action
         status: ${{ job.status }}
-  publish_java_sdk:
-    continue-on-error: true
-    name: publish_java_sdk
-    needs: publish
-    runs-on: ubuntu-latest
-    steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{ env.JAVAVERSION }}
-    - name: Setup Gradle
-      uses: gradle/gradle-build-action@v2
-      with:
-        gradle-version: "7.6"
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
   publish_sdk:
     name: publish_sdk
     needs: publish
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Node
-      uses: actions/setup-node@v2
-      with:
-        node-version: ${{ env.NODEVERSION }}
-        registry-url: https://registry.npmjs.org
-    - name: Setup DotNet
-      uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: ${{ env.DOTNETVERSION }}
-    - name: Setup Python
-      uses: actions/setup-python@v2
-      with:
-        python-version: ${{ env.PYTHONVERSION }}
-    - name: Download python SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: python-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress python SDK
-      run: tar -zxf ${{github.workspace}}/sdk/python.tar.gz -C
-        ${{github.workspace}}/sdk/python
-    - name: Download dotnet SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: dotnet-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress dotnet SDK
-      run: tar -zxf ${{github.workspace}}/sdk/dotnet.tar.gz -C
-        ${{github.workspace}}/sdk/dotnet
-    - name: Download nodejs SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: nodejs-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress nodejs SDK
-      run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
-        ${{github.workspace}}/sdk/nodejs
-    - run: python -m pip install pip twine
-    - env:
-        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-      name: Publish SDKs
-      run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - if: failure() && github.event_name == 'push'
-      name: Notify Slack
-      uses: 8398a7/action-slack@v3
-      with:
-        author_name: Failure in publishing SDK
-        fields: repo,commit,author,action
-        status: ${{ job.status }}
+    - name: Publish SDKs
+      uses: pulumi/pulumi-package-publisher@v0.0.5
   test:
     name: test
     needs: build_sdk

--- a/provider-ci/providers/signalfx/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/signalfx/repo/.github/workflows/prerelease.yml
@@ -299,131 +299,13 @@ jobs:
         author_name: Failure in publishing binaries
         fields: repo,commit,author,action
         status: ${{ job.status }}
-  publish_java_sdk:
-    continue-on-error: true
-    name: publish_java_sdk
-    needs: publish
-    runs-on: ubuntu-latest
-    steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{ env.JAVAVERSION }}
-    - name: Setup Gradle
-      uses: gradle/gradle-build-action@v2
-      with:
-        gradle-version: "7.6"
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
   publish_sdk:
     name: publish_sdk
     needs: publish
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Node
-      uses: actions/setup-node@v2
-      with:
-        node-version: ${{ env.NODEVERSION }}
-        registry-url: https://registry.npmjs.org
-    - name: Setup DotNet
-      uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: ${{ env.DOTNETVERSION }}
-    - name: Setup Python
-      uses: actions/setup-python@v2
-      with:
-        python-version: ${{ env.PYTHONVERSION }}
-    - name: Download python SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: python-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress python SDK
-      run: tar -zxf ${{github.workspace}}/sdk/python.tar.gz -C
-        ${{github.workspace}}/sdk/python
-    - name: Download dotnet SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: dotnet-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress dotnet SDK
-      run: tar -zxf ${{github.workspace}}/sdk/dotnet.tar.gz -C
-        ${{github.workspace}}/sdk/dotnet
-    - name: Download nodejs SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: nodejs-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress nodejs SDK
-      run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
-        ${{github.workspace}}/sdk/nodejs
-    - run: python -m pip install pip twine
-    - env:
-        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-      name: Publish SDKs
-      run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - if: failure() && github.event_name == 'push'
-      name: Notify Slack
-      uses: 8398a7/action-slack@v3
-      with:
-        author_name: Failure in publishing SDK
-        fields: repo,commit,author,action
-        status: ${{ job.status }}
+    - name: Publish SDKs
+      uses: pulumi/pulumi-package-publisher@v0.0.5
   test:
     name: test
     needs: build_sdk

--- a/provider-ci/providers/signalfx/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/signalfx/repo/.github/workflows/release.yml
@@ -311,131 +311,13 @@ jobs:
         author_name: Failure in publishing binaries
         fields: repo,commit,author,action
         status: ${{ job.status }}
-  publish_java_sdk:
-    continue-on-error: true
-    name: publish_java_sdk
-    needs: publish
-    runs-on: ubuntu-latest
-    steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{ env.JAVAVERSION }}
-    - name: Setup Gradle
-      uses: gradle/gradle-build-action@v2
-      with:
-        gradle-version: "7.6"
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
   publish_sdk:
     name: publish_sdk
     needs: publish
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Node
-      uses: actions/setup-node@v2
-      with:
-        node-version: ${{ env.NODEVERSION }}
-        registry-url: https://registry.npmjs.org
-    - name: Setup DotNet
-      uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: ${{ env.DOTNETVERSION }}
-    - name: Setup Python
-      uses: actions/setup-python@v2
-      with:
-        python-version: ${{ env.PYTHONVERSION }}
-    - name: Download python SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: python-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress python SDK
-      run: tar -zxf ${{github.workspace}}/sdk/python.tar.gz -C
-        ${{github.workspace}}/sdk/python
-    - name: Download dotnet SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: dotnet-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress dotnet SDK
-      run: tar -zxf ${{github.workspace}}/sdk/dotnet.tar.gz -C
-        ${{github.workspace}}/sdk/dotnet
-    - name: Download nodejs SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: nodejs-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress nodejs SDK
-      run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
-        ${{github.workspace}}/sdk/nodejs
-    - run: python -m pip install pip twine
-    - env:
-        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-      name: Publish SDKs
-      run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - if: failure() && github.event_name == 'push'
-      name: Notify Slack
-      uses: 8398a7/action-slack@v3
-      with:
-        author_name: Failure in publishing SDK
-        fields: repo,commit,author,action
-        status: ${{ job.status }}
+    - name: Publish SDKs
+      uses: pulumi/pulumi-package-publisher@v0.0.5
   tag_sdk:
     name: tag_sdk
     needs: publish_sdk

--- a/provider-ci/providers/slack/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/slack/repo/.github/workflows/main.yml
@@ -350,131 +350,13 @@ jobs:
         author_name: Failure in publishing binaries
         fields: repo,commit,author,action
         status: ${{ job.status }}
-  publish_java_sdk:
-    continue-on-error: true
-    name: publish_java_sdk
-    needs: publish
-    runs-on: ubuntu-latest
-    steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{ env.JAVAVERSION }}
-    - name: Setup Gradle
-      uses: gradle/gradle-build-action@v2
-      with:
-        gradle-version: "7.6"
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
   publish_sdk:
     name: publish_sdk
     needs: publish
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Node
-      uses: actions/setup-node@v2
-      with:
-        node-version: ${{ env.NODEVERSION }}
-        registry-url: https://registry.npmjs.org
-    - name: Setup DotNet
-      uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: ${{ env.DOTNETVERSION }}
-    - name: Setup Python
-      uses: actions/setup-python@v2
-      with:
-        python-version: ${{ env.PYTHONVERSION }}
-    - name: Download python SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: python-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress python SDK
-      run: tar -zxf ${{github.workspace}}/sdk/python.tar.gz -C
-        ${{github.workspace}}/sdk/python
-    - name: Download dotnet SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: dotnet-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress dotnet SDK
-      run: tar -zxf ${{github.workspace}}/sdk/dotnet.tar.gz -C
-        ${{github.workspace}}/sdk/dotnet
-    - name: Download nodejs SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: nodejs-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress nodejs SDK
-      run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
-        ${{github.workspace}}/sdk/nodejs
-    - run: python -m pip install pip twine
-    - env:
-        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-      name: Publish SDKs
-      run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - if: failure() && github.event_name == 'push'
-      name: Notify Slack
-      uses: 8398a7/action-slack@v3
-      with:
-        author_name: Failure in publishing SDK
-        fields: repo,commit,author,action
-        status: ${{ job.status }}
+    - name: Publish SDKs
+      uses: pulumi/pulumi-package-publisher@v0.0.5
   test:
     name: test
     needs: build_sdk

--- a/provider-ci/providers/slack/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/slack/repo/.github/workflows/master.yml
@@ -350,131 +350,13 @@ jobs:
         author_name: Failure in publishing binaries
         fields: repo,commit,author,action
         status: ${{ job.status }}
-  publish_java_sdk:
-    continue-on-error: true
-    name: publish_java_sdk
-    needs: publish
-    runs-on: ubuntu-latest
-    steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{ env.JAVAVERSION }}
-    - name: Setup Gradle
-      uses: gradle/gradle-build-action@v2
-      with:
-        gradle-version: "7.6"
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
   publish_sdk:
     name: publish_sdk
     needs: publish
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Node
-      uses: actions/setup-node@v2
-      with:
-        node-version: ${{ env.NODEVERSION }}
-        registry-url: https://registry.npmjs.org
-    - name: Setup DotNet
-      uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: ${{ env.DOTNETVERSION }}
-    - name: Setup Python
-      uses: actions/setup-python@v2
-      with:
-        python-version: ${{ env.PYTHONVERSION }}
-    - name: Download python SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: python-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress python SDK
-      run: tar -zxf ${{github.workspace}}/sdk/python.tar.gz -C
-        ${{github.workspace}}/sdk/python
-    - name: Download dotnet SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: dotnet-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress dotnet SDK
-      run: tar -zxf ${{github.workspace}}/sdk/dotnet.tar.gz -C
-        ${{github.workspace}}/sdk/dotnet
-    - name: Download nodejs SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: nodejs-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress nodejs SDK
-      run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
-        ${{github.workspace}}/sdk/nodejs
-    - run: python -m pip install pip twine
-    - env:
-        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-      name: Publish SDKs
-      run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - if: failure() && github.event_name == 'push'
-      name: Notify Slack
-      uses: 8398a7/action-slack@v3
-      with:
-        author_name: Failure in publishing SDK
-        fields: repo,commit,author,action
-        status: ${{ job.status }}
+    - name: Publish SDKs
+      uses: pulumi/pulumi-package-publisher@v0.0.5
   test:
     name: test
     needs: build_sdk

--- a/provider-ci/providers/slack/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/slack/repo/.github/workflows/prerelease.yml
@@ -300,131 +300,13 @@ jobs:
         author_name: Failure in publishing binaries
         fields: repo,commit,author,action
         status: ${{ job.status }}
-  publish_java_sdk:
-    continue-on-error: true
-    name: publish_java_sdk
-    needs: publish
-    runs-on: ubuntu-latest
-    steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{ env.JAVAVERSION }}
-    - name: Setup Gradle
-      uses: gradle/gradle-build-action@v2
-      with:
-        gradle-version: "7.6"
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
   publish_sdk:
     name: publish_sdk
     needs: publish
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Node
-      uses: actions/setup-node@v2
-      with:
-        node-version: ${{ env.NODEVERSION }}
-        registry-url: https://registry.npmjs.org
-    - name: Setup DotNet
-      uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: ${{ env.DOTNETVERSION }}
-    - name: Setup Python
-      uses: actions/setup-python@v2
-      with:
-        python-version: ${{ env.PYTHONVERSION }}
-    - name: Download python SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: python-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress python SDK
-      run: tar -zxf ${{github.workspace}}/sdk/python.tar.gz -C
-        ${{github.workspace}}/sdk/python
-    - name: Download dotnet SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: dotnet-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress dotnet SDK
-      run: tar -zxf ${{github.workspace}}/sdk/dotnet.tar.gz -C
-        ${{github.workspace}}/sdk/dotnet
-    - name: Download nodejs SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: nodejs-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress nodejs SDK
-      run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
-        ${{github.workspace}}/sdk/nodejs
-    - run: python -m pip install pip twine
-    - env:
-        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-      name: Publish SDKs
-      run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - if: failure() && github.event_name == 'push'
-      name: Notify Slack
-      uses: 8398a7/action-slack@v3
-      with:
-        author_name: Failure in publishing SDK
-        fields: repo,commit,author,action
-        status: ${{ job.status }}
+    - name: Publish SDKs
+      uses: pulumi/pulumi-package-publisher@v0.0.5
   test:
     name: test
     needs: build_sdk

--- a/provider-ci/providers/slack/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/slack/repo/.github/workflows/release.yml
@@ -312,131 +312,13 @@ jobs:
         author_name: Failure in publishing binaries
         fields: repo,commit,author,action
         status: ${{ job.status }}
-  publish_java_sdk:
-    continue-on-error: true
-    name: publish_java_sdk
-    needs: publish
-    runs-on: ubuntu-latest
-    steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{ env.JAVAVERSION }}
-    - name: Setup Gradle
-      uses: gradle/gradle-build-action@v2
-      with:
-        gradle-version: "7.6"
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
   publish_sdk:
     name: publish_sdk
     needs: publish
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Node
-      uses: actions/setup-node@v2
-      with:
-        node-version: ${{ env.NODEVERSION }}
-        registry-url: https://registry.npmjs.org
-    - name: Setup DotNet
-      uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: ${{ env.DOTNETVERSION }}
-    - name: Setup Python
-      uses: actions/setup-python@v2
-      with:
-        python-version: ${{ env.PYTHONVERSION }}
-    - name: Download python SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: python-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress python SDK
-      run: tar -zxf ${{github.workspace}}/sdk/python.tar.gz -C
-        ${{github.workspace}}/sdk/python
-    - name: Download dotnet SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: dotnet-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress dotnet SDK
-      run: tar -zxf ${{github.workspace}}/sdk/dotnet.tar.gz -C
-        ${{github.workspace}}/sdk/dotnet
-    - name: Download nodejs SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: nodejs-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress nodejs SDK
-      run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
-        ${{github.workspace}}/sdk/nodejs
-    - run: python -m pip install pip twine
-    - env:
-        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-      name: Publish SDKs
-      run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - if: failure() && github.event_name == 'push'
-      name: Notify Slack
-      uses: 8398a7/action-slack@v3
-      with:
-        author_name: Failure in publishing SDK
-        fields: repo,commit,author,action
-        status: ${{ job.status }}
+    - name: Publish SDKs
+      uses: pulumi/pulumi-package-publisher@v0.0.5
   tag_sdk:
     name: tag_sdk
     needs: publish_sdk

--- a/provider-ci/providers/snowflake/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/snowflake/repo/.github/workflows/main.yml
@@ -354,131 +354,13 @@ jobs:
         author_name: Failure in publishing binaries
         fields: repo,commit,author,action
         status: ${{ job.status }}
-  publish_java_sdk:
-    continue-on-error: true
-    name: publish_java_sdk
-    needs: publish
-    runs-on: ubuntu-latest
-    steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{ env.JAVAVERSION }}
-    - name: Setup Gradle
-      uses: gradle/gradle-build-action@v2
-      with:
-        gradle-version: "7.6"
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
   publish_sdk:
     name: publish_sdk
     needs: publish
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Node
-      uses: actions/setup-node@v2
-      with:
-        node-version: ${{ env.NODEVERSION }}
-        registry-url: https://registry.npmjs.org
-    - name: Setup DotNet
-      uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: ${{ env.DOTNETVERSION }}
-    - name: Setup Python
-      uses: actions/setup-python@v2
-      with:
-        python-version: ${{ env.PYTHONVERSION }}
-    - name: Download python SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: python-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress python SDK
-      run: tar -zxf ${{github.workspace}}/sdk/python.tar.gz -C
-        ${{github.workspace}}/sdk/python
-    - name: Download dotnet SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: dotnet-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress dotnet SDK
-      run: tar -zxf ${{github.workspace}}/sdk/dotnet.tar.gz -C
-        ${{github.workspace}}/sdk/dotnet
-    - name: Download nodejs SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: nodejs-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress nodejs SDK
-      run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
-        ${{github.workspace}}/sdk/nodejs
-    - run: python -m pip install pip twine
-    - env:
-        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-      name: Publish SDKs
-      run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - if: failure() && github.event_name == 'push'
-      name: Notify Slack
-      uses: 8398a7/action-slack@v3
-      with:
-        author_name: Failure in publishing SDK
-        fields: repo,commit,author,action
-        status: ${{ job.status }}
+    - name: Publish SDKs
+      uses: pulumi/pulumi-package-publisher@v0.0.5
   test:
     name: test
     needs: build_sdk

--- a/provider-ci/providers/snowflake/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/snowflake/repo/.github/workflows/master.yml
@@ -354,131 +354,13 @@ jobs:
         author_name: Failure in publishing binaries
         fields: repo,commit,author,action
         status: ${{ job.status }}
-  publish_java_sdk:
-    continue-on-error: true
-    name: publish_java_sdk
-    needs: publish
-    runs-on: ubuntu-latest
-    steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{ env.JAVAVERSION }}
-    - name: Setup Gradle
-      uses: gradle/gradle-build-action@v2
-      with:
-        gradle-version: "7.6"
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
   publish_sdk:
     name: publish_sdk
     needs: publish
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Node
-      uses: actions/setup-node@v2
-      with:
-        node-version: ${{ env.NODEVERSION }}
-        registry-url: https://registry.npmjs.org
-    - name: Setup DotNet
-      uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: ${{ env.DOTNETVERSION }}
-    - name: Setup Python
-      uses: actions/setup-python@v2
-      with:
-        python-version: ${{ env.PYTHONVERSION }}
-    - name: Download python SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: python-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress python SDK
-      run: tar -zxf ${{github.workspace}}/sdk/python.tar.gz -C
-        ${{github.workspace}}/sdk/python
-    - name: Download dotnet SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: dotnet-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress dotnet SDK
-      run: tar -zxf ${{github.workspace}}/sdk/dotnet.tar.gz -C
-        ${{github.workspace}}/sdk/dotnet
-    - name: Download nodejs SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: nodejs-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress nodejs SDK
-      run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
-        ${{github.workspace}}/sdk/nodejs
-    - run: python -m pip install pip twine
-    - env:
-        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-      name: Publish SDKs
-      run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - if: failure() && github.event_name == 'push'
-      name: Notify Slack
-      uses: 8398a7/action-slack@v3
-      with:
-        author_name: Failure in publishing SDK
-        fields: repo,commit,author,action
-        status: ${{ job.status }}
+    - name: Publish SDKs
+      uses: pulumi/pulumi-package-publisher@v0.0.5
   test:
     name: test
     needs: build_sdk

--- a/provider-ci/providers/snowflake/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/snowflake/repo/.github/workflows/prerelease.yml
@@ -304,131 +304,13 @@ jobs:
         author_name: Failure in publishing binaries
         fields: repo,commit,author,action
         status: ${{ job.status }}
-  publish_java_sdk:
-    continue-on-error: true
-    name: publish_java_sdk
-    needs: publish
-    runs-on: ubuntu-latest
-    steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{ env.JAVAVERSION }}
-    - name: Setup Gradle
-      uses: gradle/gradle-build-action@v2
-      with:
-        gradle-version: "7.6"
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
   publish_sdk:
     name: publish_sdk
     needs: publish
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Node
-      uses: actions/setup-node@v2
-      with:
-        node-version: ${{ env.NODEVERSION }}
-        registry-url: https://registry.npmjs.org
-    - name: Setup DotNet
-      uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: ${{ env.DOTNETVERSION }}
-    - name: Setup Python
-      uses: actions/setup-python@v2
-      with:
-        python-version: ${{ env.PYTHONVERSION }}
-    - name: Download python SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: python-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress python SDK
-      run: tar -zxf ${{github.workspace}}/sdk/python.tar.gz -C
-        ${{github.workspace}}/sdk/python
-    - name: Download dotnet SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: dotnet-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress dotnet SDK
-      run: tar -zxf ${{github.workspace}}/sdk/dotnet.tar.gz -C
-        ${{github.workspace}}/sdk/dotnet
-    - name: Download nodejs SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: nodejs-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress nodejs SDK
-      run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
-        ${{github.workspace}}/sdk/nodejs
-    - run: python -m pip install pip twine
-    - env:
-        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-      name: Publish SDKs
-      run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - if: failure() && github.event_name == 'push'
-      name: Notify Slack
-      uses: 8398a7/action-slack@v3
-      with:
-        author_name: Failure in publishing SDK
-        fields: repo,commit,author,action
-        status: ${{ job.status }}
+    - name: Publish SDKs
+      uses: pulumi/pulumi-package-publisher@v0.0.5
   test:
     name: test
     needs: build_sdk

--- a/provider-ci/providers/snowflake/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/snowflake/repo/.github/workflows/release.yml
@@ -316,131 +316,13 @@ jobs:
         author_name: Failure in publishing binaries
         fields: repo,commit,author,action
         status: ${{ job.status }}
-  publish_java_sdk:
-    continue-on-error: true
-    name: publish_java_sdk
-    needs: publish
-    runs-on: ubuntu-latest
-    steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{ env.JAVAVERSION }}
-    - name: Setup Gradle
-      uses: gradle/gradle-build-action@v2
-      with:
-        gradle-version: "7.6"
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
   publish_sdk:
     name: publish_sdk
     needs: publish
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Node
-      uses: actions/setup-node@v2
-      with:
-        node-version: ${{ env.NODEVERSION }}
-        registry-url: https://registry.npmjs.org
-    - name: Setup DotNet
-      uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: ${{ env.DOTNETVERSION }}
-    - name: Setup Python
-      uses: actions/setup-python@v2
-      with:
-        python-version: ${{ env.PYTHONVERSION }}
-    - name: Download python SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: python-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress python SDK
-      run: tar -zxf ${{github.workspace}}/sdk/python.tar.gz -C
-        ${{github.workspace}}/sdk/python
-    - name: Download dotnet SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: dotnet-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress dotnet SDK
-      run: tar -zxf ${{github.workspace}}/sdk/dotnet.tar.gz -C
-        ${{github.workspace}}/sdk/dotnet
-    - name: Download nodejs SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: nodejs-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress nodejs SDK
-      run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
-        ${{github.workspace}}/sdk/nodejs
-    - run: python -m pip install pip twine
-    - env:
-        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-      name: Publish SDKs
-      run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - if: failure() && github.event_name == 'push'
-      name: Notify Slack
-      uses: 8398a7/action-slack@v3
-      with:
-        author_name: Failure in publishing SDK
-        fields: repo,commit,author,action
-        status: ${{ job.status }}
+    - name: Publish SDKs
+      uses: pulumi/pulumi-package-publisher@v0.0.5
   tag_sdk:
     name: tag_sdk
     needs: publish_sdk

--- a/provider-ci/providers/splunk/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/splunk/repo/.github/workflows/main.yml
@@ -352,131 +352,13 @@ jobs:
         author_name: Failure in publishing binaries
         fields: repo,commit,author,action
         status: ${{ job.status }}
-  publish_java_sdk:
-    continue-on-error: true
-    name: publish_java_sdk
-    needs: publish
-    runs-on: ubuntu-latest
-    steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{ env.JAVAVERSION }}
-    - name: Setup Gradle
-      uses: gradle/gradle-build-action@v2
-      with:
-        gradle-version: "7.6"
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
   publish_sdk:
     name: publish_sdk
     needs: publish
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Node
-      uses: actions/setup-node@v2
-      with:
-        node-version: ${{ env.NODEVERSION }}
-        registry-url: https://registry.npmjs.org
-    - name: Setup DotNet
-      uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: ${{ env.DOTNETVERSION }}
-    - name: Setup Python
-      uses: actions/setup-python@v2
-      with:
-        python-version: ${{ env.PYTHONVERSION }}
-    - name: Download python SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: python-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress python SDK
-      run: tar -zxf ${{github.workspace}}/sdk/python.tar.gz -C
-        ${{github.workspace}}/sdk/python
-    - name: Download dotnet SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: dotnet-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress dotnet SDK
-      run: tar -zxf ${{github.workspace}}/sdk/dotnet.tar.gz -C
-        ${{github.workspace}}/sdk/dotnet
-    - name: Download nodejs SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: nodejs-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress nodejs SDK
-      run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
-        ${{github.workspace}}/sdk/nodejs
-    - run: python -m pip install pip twine
-    - env:
-        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-      name: Publish SDKs
-      run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - if: failure() && github.event_name == 'push'
-      name: Notify Slack
-      uses: 8398a7/action-slack@v3
-      with:
-        author_name: Failure in publishing SDK
-        fields: repo,commit,author,action
-        status: ${{ job.status }}
+    - name: Publish SDKs
+      uses: pulumi/pulumi-package-publisher@v0.0.5
   test:
     name: test
     needs: build_sdk

--- a/provider-ci/providers/splunk/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/splunk/repo/.github/workflows/master.yml
@@ -352,131 +352,13 @@ jobs:
         author_name: Failure in publishing binaries
         fields: repo,commit,author,action
         status: ${{ job.status }}
-  publish_java_sdk:
-    continue-on-error: true
-    name: publish_java_sdk
-    needs: publish
-    runs-on: ubuntu-latest
-    steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{ env.JAVAVERSION }}
-    - name: Setup Gradle
-      uses: gradle/gradle-build-action@v2
-      with:
-        gradle-version: "7.6"
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
   publish_sdk:
     name: publish_sdk
     needs: publish
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Node
-      uses: actions/setup-node@v2
-      with:
-        node-version: ${{ env.NODEVERSION }}
-        registry-url: https://registry.npmjs.org
-    - name: Setup DotNet
-      uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: ${{ env.DOTNETVERSION }}
-    - name: Setup Python
-      uses: actions/setup-python@v2
-      with:
-        python-version: ${{ env.PYTHONVERSION }}
-    - name: Download python SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: python-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress python SDK
-      run: tar -zxf ${{github.workspace}}/sdk/python.tar.gz -C
-        ${{github.workspace}}/sdk/python
-    - name: Download dotnet SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: dotnet-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress dotnet SDK
-      run: tar -zxf ${{github.workspace}}/sdk/dotnet.tar.gz -C
-        ${{github.workspace}}/sdk/dotnet
-    - name: Download nodejs SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: nodejs-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress nodejs SDK
-      run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
-        ${{github.workspace}}/sdk/nodejs
-    - run: python -m pip install pip twine
-    - env:
-        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-      name: Publish SDKs
-      run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - if: failure() && github.event_name == 'push'
-      name: Notify Slack
-      uses: 8398a7/action-slack@v3
-      with:
-        author_name: Failure in publishing SDK
-        fields: repo,commit,author,action
-        status: ${{ job.status }}
+    - name: Publish SDKs
+      uses: pulumi/pulumi-package-publisher@v0.0.5
   test:
     name: test
     needs: build_sdk

--- a/provider-ci/providers/splunk/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/splunk/repo/.github/workflows/prerelease.yml
@@ -302,131 +302,13 @@ jobs:
         author_name: Failure in publishing binaries
         fields: repo,commit,author,action
         status: ${{ job.status }}
-  publish_java_sdk:
-    continue-on-error: true
-    name: publish_java_sdk
-    needs: publish
-    runs-on: ubuntu-latest
-    steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{ env.JAVAVERSION }}
-    - name: Setup Gradle
-      uses: gradle/gradle-build-action@v2
-      with:
-        gradle-version: "7.6"
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
   publish_sdk:
     name: publish_sdk
     needs: publish
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Node
-      uses: actions/setup-node@v2
-      with:
-        node-version: ${{ env.NODEVERSION }}
-        registry-url: https://registry.npmjs.org
-    - name: Setup DotNet
-      uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: ${{ env.DOTNETVERSION }}
-    - name: Setup Python
-      uses: actions/setup-python@v2
-      with:
-        python-version: ${{ env.PYTHONVERSION }}
-    - name: Download python SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: python-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress python SDK
-      run: tar -zxf ${{github.workspace}}/sdk/python.tar.gz -C
-        ${{github.workspace}}/sdk/python
-    - name: Download dotnet SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: dotnet-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress dotnet SDK
-      run: tar -zxf ${{github.workspace}}/sdk/dotnet.tar.gz -C
-        ${{github.workspace}}/sdk/dotnet
-    - name: Download nodejs SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: nodejs-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress nodejs SDK
-      run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
-        ${{github.workspace}}/sdk/nodejs
-    - run: python -m pip install pip twine
-    - env:
-        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-      name: Publish SDKs
-      run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - if: failure() && github.event_name == 'push'
-      name: Notify Slack
-      uses: 8398a7/action-slack@v3
-      with:
-        author_name: Failure in publishing SDK
-        fields: repo,commit,author,action
-        status: ${{ job.status }}
+    - name: Publish SDKs
+      uses: pulumi/pulumi-package-publisher@v0.0.5
   test:
     name: test
     needs: build_sdk

--- a/provider-ci/providers/splunk/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/splunk/repo/.github/workflows/release.yml
@@ -314,131 +314,13 @@ jobs:
         author_name: Failure in publishing binaries
         fields: repo,commit,author,action
         status: ${{ job.status }}
-  publish_java_sdk:
-    continue-on-error: true
-    name: publish_java_sdk
-    needs: publish
-    runs-on: ubuntu-latest
-    steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{ env.JAVAVERSION }}
-    - name: Setup Gradle
-      uses: gradle/gradle-build-action@v2
-      with:
-        gradle-version: "7.6"
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
   publish_sdk:
     name: publish_sdk
     needs: publish
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Node
-      uses: actions/setup-node@v2
-      with:
-        node-version: ${{ env.NODEVERSION }}
-        registry-url: https://registry.npmjs.org
-    - name: Setup DotNet
-      uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: ${{ env.DOTNETVERSION }}
-    - name: Setup Python
-      uses: actions/setup-python@v2
-      with:
-        python-version: ${{ env.PYTHONVERSION }}
-    - name: Download python SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: python-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress python SDK
-      run: tar -zxf ${{github.workspace}}/sdk/python.tar.gz -C
-        ${{github.workspace}}/sdk/python
-    - name: Download dotnet SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: dotnet-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress dotnet SDK
-      run: tar -zxf ${{github.workspace}}/sdk/dotnet.tar.gz -C
-        ${{github.workspace}}/sdk/dotnet
-    - name: Download nodejs SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: nodejs-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress nodejs SDK
-      run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
-        ${{github.workspace}}/sdk/nodejs
-    - run: python -m pip install pip twine
-    - env:
-        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-      name: Publish SDKs
-      run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - if: failure() && github.event_name == 'push'
-      name: Notify Slack
-      uses: 8398a7/action-slack@v3
-      with:
-        author_name: Failure in publishing SDK
-        fields: repo,commit,author,action
-        status: ${{ job.status }}
+    - name: Publish SDKs
+      uses: pulumi/pulumi-package-publisher@v0.0.5
   tag_sdk:
     name: tag_sdk
     needs: publish_sdk

--- a/provider-ci/providers/spotinst/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/spotinst/repo/.github/workflows/main.yml
@@ -352,131 +352,13 @@ jobs:
         author_name: Failure in publishing binaries
         fields: repo,commit,author,action
         status: ${{ job.status }}
-  publish_java_sdk:
-    continue-on-error: true
-    name: publish_java_sdk
-    needs: publish
-    runs-on: ubuntu-latest
-    steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{ env.JAVAVERSION }}
-    - name: Setup Gradle
-      uses: gradle/gradle-build-action@v2
-      with:
-        gradle-version: "7.6"
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
   publish_sdk:
     name: publish_sdk
     needs: publish
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Node
-      uses: actions/setup-node@v2
-      with:
-        node-version: ${{ env.NODEVERSION }}
-        registry-url: https://registry.npmjs.org
-    - name: Setup DotNet
-      uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: ${{ env.DOTNETVERSION }}
-    - name: Setup Python
-      uses: actions/setup-python@v2
-      with:
-        python-version: ${{ env.PYTHONVERSION }}
-    - name: Download python SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: python-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress python SDK
-      run: tar -zxf ${{github.workspace}}/sdk/python.tar.gz -C
-        ${{github.workspace}}/sdk/python
-    - name: Download dotnet SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: dotnet-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress dotnet SDK
-      run: tar -zxf ${{github.workspace}}/sdk/dotnet.tar.gz -C
-        ${{github.workspace}}/sdk/dotnet
-    - name: Download nodejs SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: nodejs-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress nodejs SDK
-      run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
-        ${{github.workspace}}/sdk/nodejs
-    - run: python -m pip install pip twine
-    - env:
-        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-      name: Publish SDKs
-      run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - if: failure() && github.event_name == 'push'
-      name: Notify Slack
-      uses: 8398a7/action-slack@v3
-      with:
-        author_name: Failure in publishing SDK
-        fields: repo,commit,author,action
-        status: ${{ job.status }}
+    - name: Publish SDKs
+      uses: pulumi/pulumi-package-publisher@v0.0.5
   test:
     name: test
     needs: build_sdk

--- a/provider-ci/providers/spotinst/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/spotinst/repo/.github/workflows/master.yml
@@ -352,131 +352,13 @@ jobs:
         author_name: Failure in publishing binaries
         fields: repo,commit,author,action
         status: ${{ job.status }}
-  publish_java_sdk:
-    continue-on-error: true
-    name: publish_java_sdk
-    needs: publish
-    runs-on: ubuntu-latest
-    steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{ env.JAVAVERSION }}
-    - name: Setup Gradle
-      uses: gradle/gradle-build-action@v2
-      with:
-        gradle-version: "7.6"
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
   publish_sdk:
     name: publish_sdk
     needs: publish
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Node
-      uses: actions/setup-node@v2
-      with:
-        node-version: ${{ env.NODEVERSION }}
-        registry-url: https://registry.npmjs.org
-    - name: Setup DotNet
-      uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: ${{ env.DOTNETVERSION }}
-    - name: Setup Python
-      uses: actions/setup-python@v2
-      with:
-        python-version: ${{ env.PYTHONVERSION }}
-    - name: Download python SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: python-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress python SDK
-      run: tar -zxf ${{github.workspace}}/sdk/python.tar.gz -C
-        ${{github.workspace}}/sdk/python
-    - name: Download dotnet SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: dotnet-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress dotnet SDK
-      run: tar -zxf ${{github.workspace}}/sdk/dotnet.tar.gz -C
-        ${{github.workspace}}/sdk/dotnet
-    - name: Download nodejs SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: nodejs-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress nodejs SDK
-      run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
-        ${{github.workspace}}/sdk/nodejs
-    - run: python -m pip install pip twine
-    - env:
-        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-      name: Publish SDKs
-      run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - if: failure() && github.event_name == 'push'
-      name: Notify Slack
-      uses: 8398a7/action-slack@v3
-      with:
-        author_name: Failure in publishing SDK
-        fields: repo,commit,author,action
-        status: ${{ job.status }}
+    - name: Publish SDKs
+      uses: pulumi/pulumi-package-publisher@v0.0.5
   test:
     name: test
     needs: build_sdk

--- a/provider-ci/providers/spotinst/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/spotinst/repo/.github/workflows/prerelease.yml
@@ -302,131 +302,13 @@ jobs:
         author_name: Failure in publishing binaries
         fields: repo,commit,author,action
         status: ${{ job.status }}
-  publish_java_sdk:
-    continue-on-error: true
-    name: publish_java_sdk
-    needs: publish
-    runs-on: ubuntu-latest
-    steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{ env.JAVAVERSION }}
-    - name: Setup Gradle
-      uses: gradle/gradle-build-action@v2
-      with:
-        gradle-version: "7.6"
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
   publish_sdk:
     name: publish_sdk
     needs: publish
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Node
-      uses: actions/setup-node@v2
-      with:
-        node-version: ${{ env.NODEVERSION }}
-        registry-url: https://registry.npmjs.org
-    - name: Setup DotNet
-      uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: ${{ env.DOTNETVERSION }}
-    - name: Setup Python
-      uses: actions/setup-python@v2
-      with:
-        python-version: ${{ env.PYTHONVERSION }}
-    - name: Download python SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: python-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress python SDK
-      run: tar -zxf ${{github.workspace}}/sdk/python.tar.gz -C
-        ${{github.workspace}}/sdk/python
-    - name: Download dotnet SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: dotnet-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress dotnet SDK
-      run: tar -zxf ${{github.workspace}}/sdk/dotnet.tar.gz -C
-        ${{github.workspace}}/sdk/dotnet
-    - name: Download nodejs SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: nodejs-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress nodejs SDK
-      run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
-        ${{github.workspace}}/sdk/nodejs
-    - run: python -m pip install pip twine
-    - env:
-        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-      name: Publish SDKs
-      run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - if: failure() && github.event_name == 'push'
-      name: Notify Slack
-      uses: 8398a7/action-slack@v3
-      with:
-        author_name: Failure in publishing SDK
-        fields: repo,commit,author,action
-        status: ${{ job.status }}
+    - name: Publish SDKs
+      uses: pulumi/pulumi-package-publisher@v0.0.5
   test:
     name: test
     needs: build_sdk

--- a/provider-ci/providers/spotinst/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/spotinst/repo/.github/workflows/release.yml
@@ -314,131 +314,13 @@ jobs:
         author_name: Failure in publishing binaries
         fields: repo,commit,author,action
         status: ${{ job.status }}
-  publish_java_sdk:
-    continue-on-error: true
-    name: publish_java_sdk
-    needs: publish
-    runs-on: ubuntu-latest
-    steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{ env.JAVAVERSION }}
-    - name: Setup Gradle
-      uses: gradle/gradle-build-action@v2
-      with:
-        gradle-version: "7.6"
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
   publish_sdk:
     name: publish_sdk
     needs: publish
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Node
-      uses: actions/setup-node@v2
-      with:
-        node-version: ${{ env.NODEVERSION }}
-        registry-url: https://registry.npmjs.org
-    - name: Setup DotNet
-      uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: ${{ env.DOTNETVERSION }}
-    - name: Setup Python
-      uses: actions/setup-python@v2
-      with:
-        python-version: ${{ env.PYTHONVERSION }}
-    - name: Download python SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: python-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress python SDK
-      run: tar -zxf ${{github.workspace}}/sdk/python.tar.gz -C
-        ${{github.workspace}}/sdk/python
-    - name: Download dotnet SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: dotnet-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress dotnet SDK
-      run: tar -zxf ${{github.workspace}}/sdk/dotnet.tar.gz -C
-        ${{github.workspace}}/sdk/dotnet
-    - name: Download nodejs SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: nodejs-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress nodejs SDK
-      run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
-        ${{github.workspace}}/sdk/nodejs
-    - run: python -m pip install pip twine
-    - env:
-        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-      name: Publish SDKs
-      run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - if: failure() && github.event_name == 'push'
-      name: Notify Slack
-      uses: 8398a7/action-slack@v3
-      with:
-        author_name: Failure in publishing SDK
-        fields: repo,commit,author,action
-        status: ${{ job.status }}
+    - name: Publish SDKs
+      uses: pulumi/pulumi-package-publisher@v0.0.5
   tag_sdk:
     name: tag_sdk
     needs: publish_sdk

--- a/provider-ci/providers/sumologic/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/sumologic/repo/.github/workflows/main.yml
@@ -352,131 +352,13 @@ jobs:
         author_name: Failure in publishing binaries
         fields: repo,commit,author,action
         status: ${{ job.status }}
-  publish_java_sdk:
-    continue-on-error: true
-    name: publish_java_sdk
-    needs: publish
-    runs-on: ubuntu-latest
-    steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{ env.JAVAVERSION }}
-    - name: Setup Gradle
-      uses: gradle/gradle-build-action@v2
-      with:
-        gradle-version: "7.6"
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
   publish_sdk:
     name: publish_sdk
     needs: publish
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Node
-      uses: actions/setup-node@v2
-      with:
-        node-version: ${{ env.NODEVERSION }}
-        registry-url: https://registry.npmjs.org
-    - name: Setup DotNet
-      uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: ${{ env.DOTNETVERSION }}
-    - name: Setup Python
-      uses: actions/setup-python@v2
-      with:
-        python-version: ${{ env.PYTHONVERSION }}
-    - name: Download python SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: python-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress python SDK
-      run: tar -zxf ${{github.workspace}}/sdk/python.tar.gz -C
-        ${{github.workspace}}/sdk/python
-    - name: Download dotnet SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: dotnet-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress dotnet SDK
-      run: tar -zxf ${{github.workspace}}/sdk/dotnet.tar.gz -C
-        ${{github.workspace}}/sdk/dotnet
-    - name: Download nodejs SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: nodejs-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress nodejs SDK
-      run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
-        ${{github.workspace}}/sdk/nodejs
-    - run: python -m pip install pip twine
-    - env:
-        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-      name: Publish SDKs
-      run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - if: failure() && github.event_name == 'push'
-      name: Notify Slack
-      uses: 8398a7/action-slack@v3
-      with:
-        author_name: Failure in publishing SDK
-        fields: repo,commit,author,action
-        status: ${{ job.status }}
+    - name: Publish SDKs
+      uses: pulumi/pulumi-package-publisher@v0.0.5
   test:
     name: test
     needs: build_sdk

--- a/provider-ci/providers/sumologic/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/sumologic/repo/.github/workflows/master.yml
@@ -352,131 +352,13 @@ jobs:
         author_name: Failure in publishing binaries
         fields: repo,commit,author,action
         status: ${{ job.status }}
-  publish_java_sdk:
-    continue-on-error: true
-    name: publish_java_sdk
-    needs: publish
-    runs-on: ubuntu-latest
-    steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{ env.JAVAVERSION }}
-    - name: Setup Gradle
-      uses: gradle/gradle-build-action@v2
-      with:
-        gradle-version: "7.6"
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
   publish_sdk:
     name: publish_sdk
     needs: publish
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Node
-      uses: actions/setup-node@v2
-      with:
-        node-version: ${{ env.NODEVERSION }}
-        registry-url: https://registry.npmjs.org
-    - name: Setup DotNet
-      uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: ${{ env.DOTNETVERSION }}
-    - name: Setup Python
-      uses: actions/setup-python@v2
-      with:
-        python-version: ${{ env.PYTHONVERSION }}
-    - name: Download python SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: python-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress python SDK
-      run: tar -zxf ${{github.workspace}}/sdk/python.tar.gz -C
-        ${{github.workspace}}/sdk/python
-    - name: Download dotnet SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: dotnet-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress dotnet SDK
-      run: tar -zxf ${{github.workspace}}/sdk/dotnet.tar.gz -C
-        ${{github.workspace}}/sdk/dotnet
-    - name: Download nodejs SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: nodejs-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress nodejs SDK
-      run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
-        ${{github.workspace}}/sdk/nodejs
-    - run: python -m pip install pip twine
-    - env:
-        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-      name: Publish SDKs
-      run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - if: failure() && github.event_name == 'push'
-      name: Notify Slack
-      uses: 8398a7/action-slack@v3
-      with:
-        author_name: Failure in publishing SDK
-        fields: repo,commit,author,action
-        status: ${{ job.status }}
+    - name: Publish SDKs
+      uses: pulumi/pulumi-package-publisher@v0.0.5
   test:
     name: test
     needs: build_sdk

--- a/provider-ci/providers/sumologic/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/sumologic/repo/.github/workflows/prerelease.yml
@@ -302,131 +302,13 @@ jobs:
         author_name: Failure in publishing binaries
         fields: repo,commit,author,action
         status: ${{ job.status }}
-  publish_java_sdk:
-    continue-on-error: true
-    name: publish_java_sdk
-    needs: publish
-    runs-on: ubuntu-latest
-    steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{ env.JAVAVERSION }}
-    - name: Setup Gradle
-      uses: gradle/gradle-build-action@v2
-      with:
-        gradle-version: "7.6"
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
   publish_sdk:
     name: publish_sdk
     needs: publish
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Node
-      uses: actions/setup-node@v2
-      with:
-        node-version: ${{ env.NODEVERSION }}
-        registry-url: https://registry.npmjs.org
-    - name: Setup DotNet
-      uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: ${{ env.DOTNETVERSION }}
-    - name: Setup Python
-      uses: actions/setup-python@v2
-      with:
-        python-version: ${{ env.PYTHONVERSION }}
-    - name: Download python SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: python-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress python SDK
-      run: tar -zxf ${{github.workspace}}/sdk/python.tar.gz -C
-        ${{github.workspace}}/sdk/python
-    - name: Download dotnet SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: dotnet-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress dotnet SDK
-      run: tar -zxf ${{github.workspace}}/sdk/dotnet.tar.gz -C
-        ${{github.workspace}}/sdk/dotnet
-    - name: Download nodejs SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: nodejs-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress nodejs SDK
-      run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
-        ${{github.workspace}}/sdk/nodejs
-    - run: python -m pip install pip twine
-    - env:
-        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-      name: Publish SDKs
-      run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - if: failure() && github.event_name == 'push'
-      name: Notify Slack
-      uses: 8398a7/action-slack@v3
-      with:
-        author_name: Failure in publishing SDK
-        fields: repo,commit,author,action
-        status: ${{ job.status }}
+    - name: Publish SDKs
+      uses: pulumi/pulumi-package-publisher@v0.0.5
   test:
     name: test
     needs: build_sdk

--- a/provider-ci/providers/sumologic/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/sumologic/repo/.github/workflows/release.yml
@@ -314,131 +314,13 @@ jobs:
         author_name: Failure in publishing binaries
         fields: repo,commit,author,action
         status: ${{ job.status }}
-  publish_java_sdk:
-    continue-on-error: true
-    name: publish_java_sdk
-    needs: publish
-    runs-on: ubuntu-latest
-    steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{ env.JAVAVERSION }}
-    - name: Setup Gradle
-      uses: gradle/gradle-build-action@v2
-      with:
-        gradle-version: "7.6"
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
   publish_sdk:
     name: publish_sdk
     needs: publish
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Node
-      uses: actions/setup-node@v2
-      with:
-        node-version: ${{ env.NODEVERSION }}
-        registry-url: https://registry.npmjs.org
-    - name: Setup DotNet
-      uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: ${{ env.DOTNETVERSION }}
-    - name: Setup Python
-      uses: actions/setup-python@v2
-      with:
-        python-version: ${{ env.PYTHONVERSION }}
-    - name: Download python SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: python-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress python SDK
-      run: tar -zxf ${{github.workspace}}/sdk/python.tar.gz -C
-        ${{github.workspace}}/sdk/python
-    - name: Download dotnet SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: dotnet-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress dotnet SDK
-      run: tar -zxf ${{github.workspace}}/sdk/dotnet.tar.gz -C
-        ${{github.workspace}}/sdk/dotnet
-    - name: Download nodejs SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: nodejs-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress nodejs SDK
-      run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
-        ${{github.workspace}}/sdk/nodejs
-    - run: python -m pip install pip twine
-    - env:
-        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-      name: Publish SDKs
-      run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - if: failure() && github.event_name == 'push'
-      name: Notify Slack
-      uses: 8398a7/action-slack@v3
-      with:
-        author_name: Failure in publishing SDK
-        fields: repo,commit,author,action
-        status: ${{ job.status }}
+    - name: Publish SDKs
+      uses: pulumi/pulumi-package-publisher@v0.0.5
   tag_sdk:
     name: tag_sdk
     needs: publish_sdk

--- a/provider-ci/providers/tailscale/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/tailscale/repo/.github/workflows/main.yml
@@ -351,131 +351,13 @@ jobs:
         author_name: Failure in publishing binaries
         fields: repo,commit,author,action
         status: ${{ job.status }}
-  publish_java_sdk:
-    continue-on-error: true
-    name: publish_java_sdk
-    needs: publish
-    runs-on: ubuntu-latest
-    steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{ env.JAVAVERSION }}
-    - name: Setup Gradle
-      uses: gradle/gradle-build-action@v2
-      with:
-        gradle-version: "7.6"
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
   publish_sdk:
     name: publish_sdk
     needs: publish
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Node
-      uses: actions/setup-node@v2
-      with:
-        node-version: ${{ env.NODEVERSION }}
-        registry-url: https://registry.npmjs.org
-    - name: Setup DotNet
-      uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: ${{ env.DOTNETVERSION }}
-    - name: Setup Python
-      uses: actions/setup-python@v2
-      with:
-        python-version: ${{ env.PYTHONVERSION }}
-    - name: Download python SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: python-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress python SDK
-      run: tar -zxf ${{github.workspace}}/sdk/python.tar.gz -C
-        ${{github.workspace}}/sdk/python
-    - name: Download dotnet SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: dotnet-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress dotnet SDK
-      run: tar -zxf ${{github.workspace}}/sdk/dotnet.tar.gz -C
-        ${{github.workspace}}/sdk/dotnet
-    - name: Download nodejs SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: nodejs-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress nodejs SDK
-      run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
-        ${{github.workspace}}/sdk/nodejs
-    - run: python -m pip install pip twine
-    - env:
-        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-      name: Publish SDKs
-      run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - if: failure() && github.event_name == 'push'
-      name: Notify Slack
-      uses: 8398a7/action-slack@v3
-      with:
-        author_name: Failure in publishing SDK
-        fields: repo,commit,author,action
-        status: ${{ job.status }}
+    - name: Publish SDKs
+      uses: pulumi/pulumi-package-publisher@v0.0.5
   test:
     name: test
     needs: build_sdk

--- a/provider-ci/providers/tailscale/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/tailscale/repo/.github/workflows/master.yml
@@ -351,131 +351,13 @@ jobs:
         author_name: Failure in publishing binaries
         fields: repo,commit,author,action
         status: ${{ job.status }}
-  publish_java_sdk:
-    continue-on-error: true
-    name: publish_java_sdk
-    needs: publish
-    runs-on: ubuntu-latest
-    steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{ env.JAVAVERSION }}
-    - name: Setup Gradle
-      uses: gradle/gradle-build-action@v2
-      with:
-        gradle-version: "7.6"
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
   publish_sdk:
     name: publish_sdk
     needs: publish
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Node
-      uses: actions/setup-node@v2
-      with:
-        node-version: ${{ env.NODEVERSION }}
-        registry-url: https://registry.npmjs.org
-    - name: Setup DotNet
-      uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: ${{ env.DOTNETVERSION }}
-    - name: Setup Python
-      uses: actions/setup-python@v2
-      with:
-        python-version: ${{ env.PYTHONVERSION }}
-    - name: Download python SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: python-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress python SDK
-      run: tar -zxf ${{github.workspace}}/sdk/python.tar.gz -C
-        ${{github.workspace}}/sdk/python
-    - name: Download dotnet SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: dotnet-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress dotnet SDK
-      run: tar -zxf ${{github.workspace}}/sdk/dotnet.tar.gz -C
-        ${{github.workspace}}/sdk/dotnet
-    - name: Download nodejs SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: nodejs-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress nodejs SDK
-      run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
-        ${{github.workspace}}/sdk/nodejs
-    - run: python -m pip install pip twine
-    - env:
-        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-      name: Publish SDKs
-      run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - if: failure() && github.event_name == 'push'
-      name: Notify Slack
-      uses: 8398a7/action-slack@v3
-      with:
-        author_name: Failure in publishing SDK
-        fields: repo,commit,author,action
-        status: ${{ job.status }}
+    - name: Publish SDKs
+      uses: pulumi/pulumi-package-publisher@v0.0.5
   test:
     name: test
     needs: build_sdk

--- a/provider-ci/providers/tailscale/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/tailscale/repo/.github/workflows/prerelease.yml
@@ -301,131 +301,13 @@ jobs:
         author_name: Failure in publishing binaries
         fields: repo,commit,author,action
         status: ${{ job.status }}
-  publish_java_sdk:
-    continue-on-error: true
-    name: publish_java_sdk
-    needs: publish
-    runs-on: ubuntu-latest
-    steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{ env.JAVAVERSION }}
-    - name: Setup Gradle
-      uses: gradle/gradle-build-action@v2
-      with:
-        gradle-version: "7.6"
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
   publish_sdk:
     name: publish_sdk
     needs: publish
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Node
-      uses: actions/setup-node@v2
-      with:
-        node-version: ${{ env.NODEVERSION }}
-        registry-url: https://registry.npmjs.org
-    - name: Setup DotNet
-      uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: ${{ env.DOTNETVERSION }}
-    - name: Setup Python
-      uses: actions/setup-python@v2
-      with:
-        python-version: ${{ env.PYTHONVERSION }}
-    - name: Download python SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: python-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress python SDK
-      run: tar -zxf ${{github.workspace}}/sdk/python.tar.gz -C
-        ${{github.workspace}}/sdk/python
-    - name: Download dotnet SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: dotnet-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress dotnet SDK
-      run: tar -zxf ${{github.workspace}}/sdk/dotnet.tar.gz -C
-        ${{github.workspace}}/sdk/dotnet
-    - name: Download nodejs SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: nodejs-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress nodejs SDK
-      run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
-        ${{github.workspace}}/sdk/nodejs
-    - run: python -m pip install pip twine
-    - env:
-        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-      name: Publish SDKs
-      run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - if: failure() && github.event_name == 'push'
-      name: Notify Slack
-      uses: 8398a7/action-slack@v3
-      with:
-        author_name: Failure in publishing SDK
-        fields: repo,commit,author,action
-        status: ${{ job.status }}
+    - name: Publish SDKs
+      uses: pulumi/pulumi-package-publisher@v0.0.5
   test:
     name: test
     needs: build_sdk

--- a/provider-ci/providers/tailscale/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/tailscale/repo/.github/workflows/release.yml
@@ -313,131 +313,13 @@ jobs:
         author_name: Failure in publishing binaries
         fields: repo,commit,author,action
         status: ${{ job.status }}
-  publish_java_sdk:
-    continue-on-error: true
-    name: publish_java_sdk
-    needs: publish
-    runs-on: ubuntu-latest
-    steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{ env.JAVAVERSION }}
-    - name: Setup Gradle
-      uses: gradle/gradle-build-action@v2
-      with:
-        gradle-version: "7.6"
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
   publish_sdk:
     name: publish_sdk
     needs: publish
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Node
-      uses: actions/setup-node@v2
-      with:
-        node-version: ${{ env.NODEVERSION }}
-        registry-url: https://registry.npmjs.org
-    - name: Setup DotNet
-      uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: ${{ env.DOTNETVERSION }}
-    - name: Setup Python
-      uses: actions/setup-python@v2
-      with:
-        python-version: ${{ env.PYTHONVERSION }}
-    - name: Download python SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: python-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress python SDK
-      run: tar -zxf ${{github.workspace}}/sdk/python.tar.gz -C
-        ${{github.workspace}}/sdk/python
-    - name: Download dotnet SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: dotnet-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress dotnet SDK
-      run: tar -zxf ${{github.workspace}}/sdk/dotnet.tar.gz -C
-        ${{github.workspace}}/sdk/dotnet
-    - name: Download nodejs SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: nodejs-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress nodejs SDK
-      run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
-        ${{github.workspace}}/sdk/nodejs
-    - run: python -m pip install pip twine
-    - env:
-        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-      name: Publish SDKs
-      run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - if: failure() && github.event_name == 'push'
-      name: Notify Slack
-      uses: 8398a7/action-slack@v3
-      with:
-        author_name: Failure in publishing SDK
-        fields: repo,commit,author,action
-        status: ${{ job.status }}
+    - name: Publish SDKs
+      uses: pulumi/pulumi-package-publisher@v0.0.5
   tag_sdk:
     name: tag_sdk
     needs: publish_sdk

--- a/provider-ci/providers/tls/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/tls/repo/.github/workflows/main.yml
@@ -349,131 +349,13 @@ jobs:
         author_name: Failure in publishing binaries
         fields: repo,commit,author,action
         status: ${{ job.status }}
-  publish_java_sdk:
-    continue-on-error: true
-    name: publish_java_sdk
-    needs: publish
-    runs-on: ubuntu-latest
-    steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{ env.JAVAVERSION }}
-    - name: Setup Gradle
-      uses: gradle/gradle-build-action@v2
-      with:
-        gradle-version: "7.6"
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
   publish_sdk:
     name: publish_sdk
     needs: publish
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Node
-      uses: actions/setup-node@v2
-      with:
-        node-version: ${{ env.NODEVERSION }}
-        registry-url: https://registry.npmjs.org
-    - name: Setup DotNet
-      uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: ${{ env.DOTNETVERSION }}
-    - name: Setup Python
-      uses: actions/setup-python@v2
-      with:
-        python-version: ${{ env.PYTHONVERSION }}
-    - name: Download python SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: python-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress python SDK
-      run: tar -zxf ${{github.workspace}}/sdk/python.tar.gz -C
-        ${{github.workspace}}/sdk/python
-    - name: Download dotnet SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: dotnet-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress dotnet SDK
-      run: tar -zxf ${{github.workspace}}/sdk/dotnet.tar.gz -C
-        ${{github.workspace}}/sdk/dotnet
-    - name: Download nodejs SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: nodejs-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress nodejs SDK
-      run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
-        ${{github.workspace}}/sdk/nodejs
-    - run: python -m pip install pip twine
-    - env:
-        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-      name: Publish SDKs
-      run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - if: failure() && github.event_name == 'push'
-      name: Notify Slack
-      uses: 8398a7/action-slack@v3
-      with:
-        author_name: Failure in publishing SDK
-        fields: repo,commit,author,action
-        status: ${{ job.status }}
+    - name: Publish SDKs
+      uses: pulumi/pulumi-package-publisher@v0.0.5
   test:
     name: test
     needs: build_sdk

--- a/provider-ci/providers/tls/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/tls/repo/.github/workflows/master.yml
@@ -349,131 +349,13 @@ jobs:
         author_name: Failure in publishing binaries
         fields: repo,commit,author,action
         status: ${{ job.status }}
-  publish_java_sdk:
-    continue-on-error: true
-    name: publish_java_sdk
-    needs: publish
-    runs-on: ubuntu-latest
-    steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{ env.JAVAVERSION }}
-    - name: Setup Gradle
-      uses: gradle/gradle-build-action@v2
-      with:
-        gradle-version: "7.6"
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
   publish_sdk:
     name: publish_sdk
     needs: publish
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Node
-      uses: actions/setup-node@v2
-      with:
-        node-version: ${{ env.NODEVERSION }}
-        registry-url: https://registry.npmjs.org
-    - name: Setup DotNet
-      uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: ${{ env.DOTNETVERSION }}
-    - name: Setup Python
-      uses: actions/setup-python@v2
-      with:
-        python-version: ${{ env.PYTHONVERSION }}
-    - name: Download python SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: python-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress python SDK
-      run: tar -zxf ${{github.workspace}}/sdk/python.tar.gz -C
-        ${{github.workspace}}/sdk/python
-    - name: Download dotnet SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: dotnet-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress dotnet SDK
-      run: tar -zxf ${{github.workspace}}/sdk/dotnet.tar.gz -C
-        ${{github.workspace}}/sdk/dotnet
-    - name: Download nodejs SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: nodejs-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress nodejs SDK
-      run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
-        ${{github.workspace}}/sdk/nodejs
-    - run: python -m pip install pip twine
-    - env:
-        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-      name: Publish SDKs
-      run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - if: failure() && github.event_name == 'push'
-      name: Notify Slack
-      uses: 8398a7/action-slack@v3
-      with:
-        author_name: Failure in publishing SDK
-        fields: repo,commit,author,action
-        status: ${{ job.status }}
+    - name: Publish SDKs
+      uses: pulumi/pulumi-package-publisher@v0.0.5
   test:
     name: test
     needs: build_sdk

--- a/provider-ci/providers/tls/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/tls/repo/.github/workflows/prerelease.yml
@@ -299,131 +299,13 @@ jobs:
         author_name: Failure in publishing binaries
         fields: repo,commit,author,action
         status: ${{ job.status }}
-  publish_java_sdk:
-    continue-on-error: true
-    name: publish_java_sdk
-    needs: publish
-    runs-on: ubuntu-latest
-    steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{ env.JAVAVERSION }}
-    - name: Setup Gradle
-      uses: gradle/gradle-build-action@v2
-      with:
-        gradle-version: "7.6"
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
   publish_sdk:
     name: publish_sdk
     needs: publish
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Node
-      uses: actions/setup-node@v2
-      with:
-        node-version: ${{ env.NODEVERSION }}
-        registry-url: https://registry.npmjs.org
-    - name: Setup DotNet
-      uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: ${{ env.DOTNETVERSION }}
-    - name: Setup Python
-      uses: actions/setup-python@v2
-      with:
-        python-version: ${{ env.PYTHONVERSION }}
-    - name: Download python SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: python-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress python SDK
-      run: tar -zxf ${{github.workspace}}/sdk/python.tar.gz -C
-        ${{github.workspace}}/sdk/python
-    - name: Download dotnet SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: dotnet-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress dotnet SDK
-      run: tar -zxf ${{github.workspace}}/sdk/dotnet.tar.gz -C
-        ${{github.workspace}}/sdk/dotnet
-    - name: Download nodejs SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: nodejs-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress nodejs SDK
-      run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
-        ${{github.workspace}}/sdk/nodejs
-    - run: python -m pip install pip twine
-    - env:
-        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-      name: Publish SDKs
-      run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - if: failure() && github.event_name == 'push'
-      name: Notify Slack
-      uses: 8398a7/action-slack@v3
-      with:
-        author_name: Failure in publishing SDK
-        fields: repo,commit,author,action
-        status: ${{ job.status }}
+    - name: Publish SDKs
+      uses: pulumi/pulumi-package-publisher@v0.0.5
   test:
     name: test
     needs: build_sdk

--- a/provider-ci/providers/tls/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/tls/repo/.github/workflows/release.yml
@@ -311,131 +311,13 @@ jobs:
         author_name: Failure in publishing binaries
         fields: repo,commit,author,action
         status: ${{ job.status }}
-  publish_java_sdk:
-    continue-on-error: true
-    name: publish_java_sdk
-    needs: publish
-    runs-on: ubuntu-latest
-    steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{ env.JAVAVERSION }}
-    - name: Setup Gradle
-      uses: gradle/gradle-build-action@v2
-      with:
-        gradle-version: "7.6"
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
   publish_sdk:
     name: publish_sdk
     needs: publish
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Node
-      uses: actions/setup-node@v2
-      with:
-        node-version: ${{ env.NODEVERSION }}
-        registry-url: https://registry.npmjs.org
-    - name: Setup DotNet
-      uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: ${{ env.DOTNETVERSION }}
-    - name: Setup Python
-      uses: actions/setup-python@v2
-      with:
-        python-version: ${{ env.PYTHONVERSION }}
-    - name: Download python SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: python-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress python SDK
-      run: tar -zxf ${{github.workspace}}/sdk/python.tar.gz -C
-        ${{github.workspace}}/sdk/python
-    - name: Download dotnet SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: dotnet-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress dotnet SDK
-      run: tar -zxf ${{github.workspace}}/sdk/dotnet.tar.gz -C
-        ${{github.workspace}}/sdk/dotnet
-    - name: Download nodejs SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: nodejs-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress nodejs SDK
-      run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
-        ${{github.workspace}}/sdk/nodejs
-    - run: python -m pip install pip twine
-    - env:
-        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-      name: Publish SDKs
-      run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - if: failure() && github.event_name == 'push'
-      name: Notify Slack
-      uses: 8398a7/action-slack@v3
-      with:
-        author_name: Failure in publishing SDK
-        fields: repo,commit,author,action
-        status: ${{ job.status }}
+    - name: Publish SDKs
+      uses: pulumi/pulumi-package-publisher@v0.0.5
   tag_sdk:
     name: tag_sdk
     needs: publish_sdk

--- a/provider-ci/providers/vault/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/vault/repo/.github/workflows/main.yml
@@ -349,131 +349,13 @@ jobs:
         author_name: Failure in publishing binaries
         fields: repo,commit,author,action
         status: ${{ job.status }}
-  publish_java_sdk:
-    continue-on-error: true
-    name: publish_java_sdk
-    needs: publish
-    runs-on: ubuntu-latest
-    steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{ env.JAVAVERSION }}
-    - name: Setup Gradle
-      uses: gradle/gradle-build-action@v2
-      with:
-        gradle-version: "7.6"
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
   publish_sdk:
     name: publish_sdk
     needs: publish
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Node
-      uses: actions/setup-node@v2
-      with:
-        node-version: ${{ env.NODEVERSION }}
-        registry-url: https://registry.npmjs.org
-    - name: Setup DotNet
-      uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: ${{ env.DOTNETVERSION }}
-    - name: Setup Python
-      uses: actions/setup-python@v2
-      with:
-        python-version: ${{ env.PYTHONVERSION }}
-    - name: Download python SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: python-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress python SDK
-      run: tar -zxf ${{github.workspace}}/sdk/python.tar.gz -C
-        ${{github.workspace}}/sdk/python
-    - name: Download dotnet SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: dotnet-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress dotnet SDK
-      run: tar -zxf ${{github.workspace}}/sdk/dotnet.tar.gz -C
-        ${{github.workspace}}/sdk/dotnet
-    - name: Download nodejs SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: nodejs-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress nodejs SDK
-      run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
-        ${{github.workspace}}/sdk/nodejs
-    - run: python -m pip install pip twine
-    - env:
-        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-      name: Publish SDKs
-      run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - if: failure() && github.event_name == 'push'
-      name: Notify Slack
-      uses: 8398a7/action-slack@v3
-      with:
-        author_name: Failure in publishing SDK
-        fields: repo,commit,author,action
-        status: ${{ job.status }}
+    - name: Publish SDKs
+      uses: pulumi/pulumi-package-publisher@v0.0.5
   test:
     name: test
     needs: build_sdk

--- a/provider-ci/providers/vault/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/vault/repo/.github/workflows/master.yml
@@ -349,131 +349,13 @@ jobs:
         author_name: Failure in publishing binaries
         fields: repo,commit,author,action
         status: ${{ job.status }}
-  publish_java_sdk:
-    continue-on-error: true
-    name: publish_java_sdk
-    needs: publish
-    runs-on: ubuntu-latest
-    steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{ env.JAVAVERSION }}
-    - name: Setup Gradle
-      uses: gradle/gradle-build-action@v2
-      with:
-        gradle-version: "7.6"
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
   publish_sdk:
     name: publish_sdk
     needs: publish
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Node
-      uses: actions/setup-node@v2
-      with:
-        node-version: ${{ env.NODEVERSION }}
-        registry-url: https://registry.npmjs.org
-    - name: Setup DotNet
-      uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: ${{ env.DOTNETVERSION }}
-    - name: Setup Python
-      uses: actions/setup-python@v2
-      with:
-        python-version: ${{ env.PYTHONVERSION }}
-    - name: Download python SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: python-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress python SDK
-      run: tar -zxf ${{github.workspace}}/sdk/python.tar.gz -C
-        ${{github.workspace}}/sdk/python
-    - name: Download dotnet SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: dotnet-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress dotnet SDK
-      run: tar -zxf ${{github.workspace}}/sdk/dotnet.tar.gz -C
-        ${{github.workspace}}/sdk/dotnet
-    - name: Download nodejs SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: nodejs-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress nodejs SDK
-      run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
-        ${{github.workspace}}/sdk/nodejs
-    - run: python -m pip install pip twine
-    - env:
-        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-      name: Publish SDKs
-      run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - if: failure() && github.event_name == 'push'
-      name: Notify Slack
-      uses: 8398a7/action-slack@v3
-      with:
-        author_name: Failure in publishing SDK
-        fields: repo,commit,author,action
-        status: ${{ job.status }}
+    - name: Publish SDKs
+      uses: pulumi/pulumi-package-publisher@v0.0.5
   test:
     name: test
     needs: build_sdk

--- a/provider-ci/providers/vault/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/vault/repo/.github/workflows/prerelease.yml
@@ -299,131 +299,13 @@ jobs:
         author_name: Failure in publishing binaries
         fields: repo,commit,author,action
         status: ${{ job.status }}
-  publish_java_sdk:
-    continue-on-error: true
-    name: publish_java_sdk
-    needs: publish
-    runs-on: ubuntu-latest
-    steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{ env.JAVAVERSION }}
-    - name: Setup Gradle
-      uses: gradle/gradle-build-action@v2
-      with:
-        gradle-version: "7.6"
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
   publish_sdk:
     name: publish_sdk
     needs: publish
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Node
-      uses: actions/setup-node@v2
-      with:
-        node-version: ${{ env.NODEVERSION }}
-        registry-url: https://registry.npmjs.org
-    - name: Setup DotNet
-      uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: ${{ env.DOTNETVERSION }}
-    - name: Setup Python
-      uses: actions/setup-python@v2
-      with:
-        python-version: ${{ env.PYTHONVERSION }}
-    - name: Download python SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: python-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress python SDK
-      run: tar -zxf ${{github.workspace}}/sdk/python.tar.gz -C
-        ${{github.workspace}}/sdk/python
-    - name: Download dotnet SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: dotnet-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress dotnet SDK
-      run: tar -zxf ${{github.workspace}}/sdk/dotnet.tar.gz -C
-        ${{github.workspace}}/sdk/dotnet
-    - name: Download nodejs SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: nodejs-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress nodejs SDK
-      run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
-        ${{github.workspace}}/sdk/nodejs
-    - run: python -m pip install pip twine
-    - env:
-        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-      name: Publish SDKs
-      run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - if: failure() && github.event_name == 'push'
-      name: Notify Slack
-      uses: 8398a7/action-slack@v3
-      with:
-        author_name: Failure in publishing SDK
-        fields: repo,commit,author,action
-        status: ${{ job.status }}
+    - name: Publish SDKs
+      uses: pulumi/pulumi-package-publisher@v0.0.5
   test:
     name: test
     needs: build_sdk

--- a/provider-ci/providers/vault/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/vault/repo/.github/workflows/release.yml
@@ -311,131 +311,13 @@ jobs:
         author_name: Failure in publishing binaries
         fields: repo,commit,author,action
         status: ${{ job.status }}
-  publish_java_sdk:
-    continue-on-error: true
-    name: publish_java_sdk
-    needs: publish
-    runs-on: ubuntu-latest
-    steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{ env.JAVAVERSION }}
-    - name: Setup Gradle
-      uses: gradle/gradle-build-action@v2
-      with:
-        gradle-version: "7.6"
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
   publish_sdk:
     name: publish_sdk
     needs: publish
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Node
-      uses: actions/setup-node@v2
-      with:
-        node-version: ${{ env.NODEVERSION }}
-        registry-url: https://registry.npmjs.org
-    - name: Setup DotNet
-      uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: ${{ env.DOTNETVERSION }}
-    - name: Setup Python
-      uses: actions/setup-python@v2
-      with:
-        python-version: ${{ env.PYTHONVERSION }}
-    - name: Download python SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: python-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress python SDK
-      run: tar -zxf ${{github.workspace}}/sdk/python.tar.gz -C
-        ${{github.workspace}}/sdk/python
-    - name: Download dotnet SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: dotnet-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress dotnet SDK
-      run: tar -zxf ${{github.workspace}}/sdk/dotnet.tar.gz -C
-        ${{github.workspace}}/sdk/dotnet
-    - name: Download nodejs SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: nodejs-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress nodejs SDK
-      run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
-        ${{github.workspace}}/sdk/nodejs
-    - run: python -m pip install pip twine
-    - env:
-        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-      name: Publish SDKs
-      run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - if: failure() && github.event_name == 'push'
-      name: Notify Slack
-      uses: 8398a7/action-slack@v3
-      with:
-        author_name: Failure in publishing SDK
-        fields: repo,commit,author,action
-        status: ${{ job.status }}
+    - name: Publish SDKs
+      uses: pulumi/pulumi-package-publisher@v0.0.5
   tag_sdk:
     name: tag_sdk
     needs: publish_sdk

--- a/provider-ci/providers/venafi/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/venafi/repo/.github/workflows/main.yml
@@ -353,131 +353,13 @@ jobs:
         author_name: Failure in publishing binaries
         fields: repo,commit,author,action
         status: ${{ job.status }}
-  publish_java_sdk:
-    continue-on-error: true
-    name: publish_java_sdk
-    needs: publish
-    runs-on: ubuntu-latest
-    steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{ env.JAVAVERSION }}
-    - name: Setup Gradle
-      uses: gradle/gradle-build-action@v2
-      with:
-        gradle-version: "7.6"
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
   publish_sdk:
     name: publish_sdk
     needs: publish
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Node
-      uses: actions/setup-node@v2
-      with:
-        node-version: ${{ env.NODEVERSION }}
-        registry-url: https://registry.npmjs.org
-    - name: Setup DotNet
-      uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: ${{ env.DOTNETVERSION }}
-    - name: Setup Python
-      uses: actions/setup-python@v2
-      with:
-        python-version: ${{ env.PYTHONVERSION }}
-    - name: Download python SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: python-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress python SDK
-      run: tar -zxf ${{github.workspace}}/sdk/python.tar.gz -C
-        ${{github.workspace}}/sdk/python
-    - name: Download dotnet SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: dotnet-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress dotnet SDK
-      run: tar -zxf ${{github.workspace}}/sdk/dotnet.tar.gz -C
-        ${{github.workspace}}/sdk/dotnet
-    - name: Download nodejs SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: nodejs-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress nodejs SDK
-      run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
-        ${{github.workspace}}/sdk/nodejs
-    - run: python -m pip install pip twine
-    - env:
-        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-      name: Publish SDKs
-      run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - if: failure() && github.event_name == 'push'
-      name: Notify Slack
-      uses: 8398a7/action-slack@v3
-      with:
-        author_name: Failure in publishing SDK
-        fields: repo,commit,author,action
-        status: ${{ job.status }}
+    - name: Publish SDKs
+      uses: pulumi/pulumi-package-publisher@v0.0.5
   test:
     name: test
     needs: build_sdk

--- a/provider-ci/providers/venafi/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/venafi/repo/.github/workflows/master.yml
@@ -353,131 +353,13 @@ jobs:
         author_name: Failure in publishing binaries
         fields: repo,commit,author,action
         status: ${{ job.status }}
-  publish_java_sdk:
-    continue-on-error: true
-    name: publish_java_sdk
-    needs: publish
-    runs-on: ubuntu-latest
-    steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{ env.JAVAVERSION }}
-    - name: Setup Gradle
-      uses: gradle/gradle-build-action@v2
-      with:
-        gradle-version: "7.6"
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
   publish_sdk:
     name: publish_sdk
     needs: publish
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Node
-      uses: actions/setup-node@v2
-      with:
-        node-version: ${{ env.NODEVERSION }}
-        registry-url: https://registry.npmjs.org
-    - name: Setup DotNet
-      uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: ${{ env.DOTNETVERSION }}
-    - name: Setup Python
-      uses: actions/setup-python@v2
-      with:
-        python-version: ${{ env.PYTHONVERSION }}
-    - name: Download python SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: python-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress python SDK
-      run: tar -zxf ${{github.workspace}}/sdk/python.tar.gz -C
-        ${{github.workspace}}/sdk/python
-    - name: Download dotnet SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: dotnet-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress dotnet SDK
-      run: tar -zxf ${{github.workspace}}/sdk/dotnet.tar.gz -C
-        ${{github.workspace}}/sdk/dotnet
-    - name: Download nodejs SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: nodejs-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress nodejs SDK
-      run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
-        ${{github.workspace}}/sdk/nodejs
-    - run: python -m pip install pip twine
-    - env:
-        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-      name: Publish SDKs
-      run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - if: failure() && github.event_name == 'push'
-      name: Notify Slack
-      uses: 8398a7/action-slack@v3
-      with:
-        author_name: Failure in publishing SDK
-        fields: repo,commit,author,action
-        status: ${{ job.status }}
+    - name: Publish SDKs
+      uses: pulumi/pulumi-package-publisher@v0.0.5
   test:
     name: test
     needs: build_sdk

--- a/provider-ci/providers/venafi/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/venafi/repo/.github/workflows/prerelease.yml
@@ -303,131 +303,13 @@ jobs:
         author_name: Failure in publishing binaries
         fields: repo,commit,author,action
         status: ${{ job.status }}
-  publish_java_sdk:
-    continue-on-error: true
-    name: publish_java_sdk
-    needs: publish
-    runs-on: ubuntu-latest
-    steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{ env.JAVAVERSION }}
-    - name: Setup Gradle
-      uses: gradle/gradle-build-action@v2
-      with:
-        gradle-version: "7.6"
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
   publish_sdk:
     name: publish_sdk
     needs: publish
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Node
-      uses: actions/setup-node@v2
-      with:
-        node-version: ${{ env.NODEVERSION }}
-        registry-url: https://registry.npmjs.org
-    - name: Setup DotNet
-      uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: ${{ env.DOTNETVERSION }}
-    - name: Setup Python
-      uses: actions/setup-python@v2
-      with:
-        python-version: ${{ env.PYTHONVERSION }}
-    - name: Download python SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: python-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress python SDK
-      run: tar -zxf ${{github.workspace}}/sdk/python.tar.gz -C
-        ${{github.workspace}}/sdk/python
-    - name: Download dotnet SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: dotnet-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress dotnet SDK
-      run: tar -zxf ${{github.workspace}}/sdk/dotnet.tar.gz -C
-        ${{github.workspace}}/sdk/dotnet
-    - name: Download nodejs SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: nodejs-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress nodejs SDK
-      run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
-        ${{github.workspace}}/sdk/nodejs
-    - run: python -m pip install pip twine
-    - env:
-        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-      name: Publish SDKs
-      run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - if: failure() && github.event_name == 'push'
-      name: Notify Slack
-      uses: 8398a7/action-slack@v3
-      with:
-        author_name: Failure in publishing SDK
-        fields: repo,commit,author,action
-        status: ${{ job.status }}
+    - name: Publish SDKs
+      uses: pulumi/pulumi-package-publisher@v0.0.5
   test:
     name: test
     needs: build_sdk

--- a/provider-ci/providers/venafi/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/venafi/repo/.github/workflows/release.yml
@@ -315,131 +315,13 @@ jobs:
         author_name: Failure in publishing binaries
         fields: repo,commit,author,action
         status: ${{ job.status }}
-  publish_java_sdk:
-    continue-on-error: true
-    name: publish_java_sdk
-    needs: publish
-    runs-on: ubuntu-latest
-    steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{ env.JAVAVERSION }}
-    - name: Setup Gradle
-      uses: gradle/gradle-build-action@v2
-      with:
-        gradle-version: "7.6"
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
   publish_sdk:
     name: publish_sdk
     needs: publish
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Node
-      uses: actions/setup-node@v2
-      with:
-        node-version: ${{ env.NODEVERSION }}
-        registry-url: https://registry.npmjs.org
-    - name: Setup DotNet
-      uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: ${{ env.DOTNETVERSION }}
-    - name: Setup Python
-      uses: actions/setup-python@v2
-      with:
-        python-version: ${{ env.PYTHONVERSION }}
-    - name: Download python SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: python-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress python SDK
-      run: tar -zxf ${{github.workspace}}/sdk/python.tar.gz -C
-        ${{github.workspace}}/sdk/python
-    - name: Download dotnet SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: dotnet-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress dotnet SDK
-      run: tar -zxf ${{github.workspace}}/sdk/dotnet.tar.gz -C
-        ${{github.workspace}}/sdk/dotnet
-    - name: Download nodejs SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: nodejs-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress nodejs SDK
-      run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
-        ${{github.workspace}}/sdk/nodejs
-    - run: python -m pip install pip twine
-    - env:
-        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-      name: Publish SDKs
-      run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - if: failure() && github.event_name == 'push'
-      name: Notify Slack
-      uses: 8398a7/action-slack@v3
-      with:
-        author_name: Failure in publishing SDK
-        fields: repo,commit,author,action
-        status: ${{ job.status }}
+    - name: Publish SDKs
+      uses: pulumi/pulumi-package-publisher@v0.0.5
   tag_sdk:
     name: tag_sdk
     needs: publish_sdk

--- a/provider-ci/providers/vsphere/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/vsphere/repo/.github/workflows/main.yml
@@ -349,131 +349,13 @@ jobs:
         author_name: Failure in publishing binaries
         fields: repo,commit,author,action
         status: ${{ job.status }}
-  publish_java_sdk:
-    continue-on-error: true
-    name: publish_java_sdk
-    needs: publish
-    runs-on: ubuntu-latest
-    steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{ env.JAVAVERSION }}
-    - name: Setup Gradle
-      uses: gradle/gradle-build-action@v2
-      with:
-        gradle-version: "7.6"
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
   publish_sdk:
     name: publish_sdk
     needs: publish
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Node
-      uses: actions/setup-node@v2
-      with:
-        node-version: ${{ env.NODEVERSION }}
-        registry-url: https://registry.npmjs.org
-    - name: Setup DotNet
-      uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: ${{ env.DOTNETVERSION }}
-    - name: Setup Python
-      uses: actions/setup-python@v2
-      with:
-        python-version: ${{ env.PYTHONVERSION }}
-    - name: Download python SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: python-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress python SDK
-      run: tar -zxf ${{github.workspace}}/sdk/python.tar.gz -C
-        ${{github.workspace}}/sdk/python
-    - name: Download dotnet SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: dotnet-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress dotnet SDK
-      run: tar -zxf ${{github.workspace}}/sdk/dotnet.tar.gz -C
-        ${{github.workspace}}/sdk/dotnet
-    - name: Download nodejs SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: nodejs-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress nodejs SDK
-      run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
-        ${{github.workspace}}/sdk/nodejs
-    - run: python -m pip install pip twine
-    - env:
-        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-      name: Publish SDKs
-      run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - if: failure() && github.event_name == 'push'
-      name: Notify Slack
-      uses: 8398a7/action-slack@v3
-      with:
-        author_name: Failure in publishing SDK
-        fields: repo,commit,author,action
-        status: ${{ job.status }}
+    - name: Publish SDKs
+      uses: pulumi/pulumi-package-publisher@v0.0.5
   test:
     name: test
     needs: build_sdk

--- a/provider-ci/providers/vsphere/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/vsphere/repo/.github/workflows/master.yml
@@ -349,131 +349,13 @@ jobs:
         author_name: Failure in publishing binaries
         fields: repo,commit,author,action
         status: ${{ job.status }}
-  publish_java_sdk:
-    continue-on-error: true
-    name: publish_java_sdk
-    needs: publish
-    runs-on: ubuntu-latest
-    steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{ env.JAVAVERSION }}
-    - name: Setup Gradle
-      uses: gradle/gradle-build-action@v2
-      with:
-        gradle-version: "7.6"
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
   publish_sdk:
     name: publish_sdk
     needs: publish
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Node
-      uses: actions/setup-node@v2
-      with:
-        node-version: ${{ env.NODEVERSION }}
-        registry-url: https://registry.npmjs.org
-    - name: Setup DotNet
-      uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: ${{ env.DOTNETVERSION }}
-    - name: Setup Python
-      uses: actions/setup-python@v2
-      with:
-        python-version: ${{ env.PYTHONVERSION }}
-    - name: Download python SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: python-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress python SDK
-      run: tar -zxf ${{github.workspace}}/sdk/python.tar.gz -C
-        ${{github.workspace}}/sdk/python
-    - name: Download dotnet SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: dotnet-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress dotnet SDK
-      run: tar -zxf ${{github.workspace}}/sdk/dotnet.tar.gz -C
-        ${{github.workspace}}/sdk/dotnet
-    - name: Download nodejs SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: nodejs-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress nodejs SDK
-      run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
-        ${{github.workspace}}/sdk/nodejs
-    - run: python -m pip install pip twine
-    - env:
-        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-      name: Publish SDKs
-      run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - if: failure() && github.event_name == 'push'
-      name: Notify Slack
-      uses: 8398a7/action-slack@v3
-      with:
-        author_name: Failure in publishing SDK
-        fields: repo,commit,author,action
-        status: ${{ job.status }}
+    - name: Publish SDKs
+      uses: pulumi/pulumi-package-publisher@v0.0.5
   test:
     name: test
     needs: build_sdk

--- a/provider-ci/providers/vsphere/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/vsphere/repo/.github/workflows/prerelease.yml
@@ -299,131 +299,13 @@ jobs:
         author_name: Failure in publishing binaries
         fields: repo,commit,author,action
         status: ${{ job.status }}
-  publish_java_sdk:
-    continue-on-error: true
-    name: publish_java_sdk
-    needs: publish
-    runs-on: ubuntu-latest
-    steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{ env.JAVAVERSION }}
-    - name: Setup Gradle
-      uses: gradle/gradle-build-action@v2
-      with:
-        gradle-version: "7.6"
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
   publish_sdk:
     name: publish_sdk
     needs: publish
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Node
-      uses: actions/setup-node@v2
-      with:
-        node-version: ${{ env.NODEVERSION }}
-        registry-url: https://registry.npmjs.org
-    - name: Setup DotNet
-      uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: ${{ env.DOTNETVERSION }}
-    - name: Setup Python
-      uses: actions/setup-python@v2
-      with:
-        python-version: ${{ env.PYTHONVERSION }}
-    - name: Download python SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: python-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress python SDK
-      run: tar -zxf ${{github.workspace}}/sdk/python.tar.gz -C
-        ${{github.workspace}}/sdk/python
-    - name: Download dotnet SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: dotnet-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress dotnet SDK
-      run: tar -zxf ${{github.workspace}}/sdk/dotnet.tar.gz -C
-        ${{github.workspace}}/sdk/dotnet
-    - name: Download nodejs SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: nodejs-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress nodejs SDK
-      run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
-        ${{github.workspace}}/sdk/nodejs
-    - run: python -m pip install pip twine
-    - env:
-        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-      name: Publish SDKs
-      run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - if: failure() && github.event_name == 'push'
-      name: Notify Slack
-      uses: 8398a7/action-slack@v3
-      with:
-        author_name: Failure in publishing SDK
-        fields: repo,commit,author,action
-        status: ${{ job.status }}
+    - name: Publish SDKs
+      uses: pulumi/pulumi-package-publisher@v0.0.5
   test:
     name: test
     needs: build_sdk

--- a/provider-ci/providers/vsphere/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/vsphere/repo/.github/workflows/release.yml
@@ -311,131 +311,13 @@ jobs:
         author_name: Failure in publishing binaries
         fields: repo,commit,author,action
         status: ${{ job.status }}
-  publish_java_sdk:
-    continue-on-error: true
-    name: publish_java_sdk
-    needs: publish
-    runs-on: ubuntu-latest
-    steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{ env.JAVAVERSION }}
-    - name: Setup Gradle
-      uses: gradle/gradle-build-action@v2
-      with:
-        gradle-version: "7.6"
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
   publish_sdk:
     name: publish_sdk
     needs: publish
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Node
-      uses: actions/setup-node@v2
-      with:
-        node-version: ${{ env.NODEVERSION }}
-        registry-url: https://registry.npmjs.org
-    - name: Setup DotNet
-      uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: ${{ env.DOTNETVERSION }}
-    - name: Setup Python
-      uses: actions/setup-python@v2
-      with:
-        python-version: ${{ env.PYTHONVERSION }}
-    - name: Download python SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: python-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress python SDK
-      run: tar -zxf ${{github.workspace}}/sdk/python.tar.gz -C
-        ${{github.workspace}}/sdk/python
-    - name: Download dotnet SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: dotnet-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress dotnet SDK
-      run: tar -zxf ${{github.workspace}}/sdk/dotnet.tar.gz -C
-        ${{github.workspace}}/sdk/dotnet
-    - name: Download nodejs SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: nodejs-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress nodejs SDK
-      run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
-        ${{github.workspace}}/sdk/nodejs
-    - run: python -m pip install pip twine
-    - env:
-        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-      name: Publish SDKs
-      run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - if: failure() && github.event_name == 'push'
-      name: Notify Slack
-      uses: 8398a7/action-slack@v3
-      with:
-        author_name: Failure in publishing SDK
-        fields: repo,commit,author,action
-        status: ${{ job.status }}
+    - name: Publish SDKs
+      uses: pulumi/pulumi-package-publisher@v0.0.5
   tag_sdk:
     name: tag_sdk
     needs: publish_sdk

--- a/provider-ci/providers/wavefront/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/wavefront/repo/.github/workflows/main.yml
@@ -351,131 +351,13 @@ jobs:
         author_name: Failure in publishing binaries
         fields: repo,commit,author,action
         status: ${{ job.status }}
-  publish_java_sdk:
-    continue-on-error: true
-    name: publish_java_sdk
-    needs: publish
-    runs-on: ubuntu-latest
-    steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{ env.JAVAVERSION }}
-    - name: Setup Gradle
-      uses: gradle/gradle-build-action@v2
-      with:
-        gradle-version: "7.6"
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
   publish_sdk:
     name: publish_sdk
     needs: publish
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Node
-      uses: actions/setup-node@v2
-      with:
-        node-version: ${{ env.NODEVERSION }}
-        registry-url: https://registry.npmjs.org
-    - name: Setup DotNet
-      uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: ${{ env.DOTNETVERSION }}
-    - name: Setup Python
-      uses: actions/setup-python@v2
-      with:
-        python-version: ${{ env.PYTHONVERSION }}
-    - name: Download python SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: python-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress python SDK
-      run: tar -zxf ${{github.workspace}}/sdk/python.tar.gz -C
-        ${{github.workspace}}/sdk/python
-    - name: Download dotnet SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: dotnet-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress dotnet SDK
-      run: tar -zxf ${{github.workspace}}/sdk/dotnet.tar.gz -C
-        ${{github.workspace}}/sdk/dotnet
-    - name: Download nodejs SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: nodejs-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress nodejs SDK
-      run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
-        ${{github.workspace}}/sdk/nodejs
-    - run: python -m pip install pip twine
-    - env:
-        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-      name: Publish SDKs
-      run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - if: failure() && github.event_name == 'push'
-      name: Notify Slack
-      uses: 8398a7/action-slack@v3
-      with:
-        author_name: Failure in publishing SDK
-        fields: repo,commit,author,action
-        status: ${{ job.status }}
+    - name: Publish SDKs
+      uses: pulumi/pulumi-package-publisher@v0.0.5
   test:
     name: test
     needs: build_sdk

--- a/provider-ci/providers/wavefront/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/wavefront/repo/.github/workflows/master.yml
@@ -351,131 +351,13 @@ jobs:
         author_name: Failure in publishing binaries
         fields: repo,commit,author,action
         status: ${{ job.status }}
-  publish_java_sdk:
-    continue-on-error: true
-    name: publish_java_sdk
-    needs: publish
-    runs-on: ubuntu-latest
-    steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{ env.JAVAVERSION }}
-    - name: Setup Gradle
-      uses: gradle/gradle-build-action@v2
-      with:
-        gradle-version: "7.6"
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
   publish_sdk:
     name: publish_sdk
     needs: publish
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Node
-      uses: actions/setup-node@v2
-      with:
-        node-version: ${{ env.NODEVERSION }}
-        registry-url: https://registry.npmjs.org
-    - name: Setup DotNet
-      uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: ${{ env.DOTNETVERSION }}
-    - name: Setup Python
-      uses: actions/setup-python@v2
-      with:
-        python-version: ${{ env.PYTHONVERSION }}
-    - name: Download python SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: python-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress python SDK
-      run: tar -zxf ${{github.workspace}}/sdk/python.tar.gz -C
-        ${{github.workspace}}/sdk/python
-    - name: Download dotnet SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: dotnet-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress dotnet SDK
-      run: tar -zxf ${{github.workspace}}/sdk/dotnet.tar.gz -C
-        ${{github.workspace}}/sdk/dotnet
-    - name: Download nodejs SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: nodejs-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress nodejs SDK
-      run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
-        ${{github.workspace}}/sdk/nodejs
-    - run: python -m pip install pip twine
-    - env:
-        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-      name: Publish SDKs
-      run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - if: failure() && github.event_name == 'push'
-      name: Notify Slack
-      uses: 8398a7/action-slack@v3
-      with:
-        author_name: Failure in publishing SDK
-        fields: repo,commit,author,action
-        status: ${{ job.status }}
+    - name: Publish SDKs
+      uses: pulumi/pulumi-package-publisher@v0.0.5
   test:
     name: test
     needs: build_sdk

--- a/provider-ci/providers/wavefront/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/wavefront/repo/.github/workflows/prerelease.yml
@@ -301,131 +301,13 @@ jobs:
         author_name: Failure in publishing binaries
         fields: repo,commit,author,action
         status: ${{ job.status }}
-  publish_java_sdk:
-    continue-on-error: true
-    name: publish_java_sdk
-    needs: publish
-    runs-on: ubuntu-latest
-    steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{ env.JAVAVERSION }}
-    - name: Setup Gradle
-      uses: gradle/gradle-build-action@v2
-      with:
-        gradle-version: "7.6"
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
   publish_sdk:
     name: publish_sdk
     needs: publish
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Node
-      uses: actions/setup-node@v2
-      with:
-        node-version: ${{ env.NODEVERSION }}
-        registry-url: https://registry.npmjs.org
-    - name: Setup DotNet
-      uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: ${{ env.DOTNETVERSION }}
-    - name: Setup Python
-      uses: actions/setup-python@v2
-      with:
-        python-version: ${{ env.PYTHONVERSION }}
-    - name: Download python SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: python-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress python SDK
-      run: tar -zxf ${{github.workspace}}/sdk/python.tar.gz -C
-        ${{github.workspace}}/sdk/python
-    - name: Download dotnet SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: dotnet-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress dotnet SDK
-      run: tar -zxf ${{github.workspace}}/sdk/dotnet.tar.gz -C
-        ${{github.workspace}}/sdk/dotnet
-    - name: Download nodejs SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: nodejs-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress nodejs SDK
-      run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
-        ${{github.workspace}}/sdk/nodejs
-    - run: python -m pip install pip twine
-    - env:
-        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-      name: Publish SDKs
-      run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - if: failure() && github.event_name == 'push'
-      name: Notify Slack
-      uses: 8398a7/action-slack@v3
-      with:
-        author_name: Failure in publishing SDK
-        fields: repo,commit,author,action
-        status: ${{ job.status }}
+    - name: Publish SDKs
+      uses: pulumi/pulumi-package-publisher@v0.0.5
   test:
     name: test
     needs: build_sdk

--- a/provider-ci/providers/wavefront/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/wavefront/repo/.github/workflows/release.yml
@@ -313,131 +313,13 @@ jobs:
         author_name: Failure in publishing binaries
         fields: repo,commit,author,action
         status: ${{ job.status }}
-  publish_java_sdk:
-    continue-on-error: true
-    name: publish_java_sdk
-    needs: publish
-    runs-on: ubuntu-latest
-    steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{ env.JAVAVERSION }}
-    - name: Setup Gradle
-      uses: gradle/gradle-build-action@v2
-      with:
-        gradle-version: "7.6"
-    - name: Download java SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: java-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-    - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-      with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-        build-root-directory: ./sdk/java
-        gradle-version: 7.4.1
   publish_sdk:
     name: publish_sdk
     needs: publish
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.20.1
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - name: Setup Node
-      uses: actions/setup-node@v2
-      with:
-        node-version: ${{ env.NODEVERSION }}
-        registry-url: https://registry.npmjs.org
-    - name: Setup DotNet
-      uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: ${{ env.DOTNETVERSION }}
-    - name: Setup Python
-      uses: actions/setup-python@v2
-      with:
-        python-version: ${{ env.PYTHONVERSION }}
-    - name: Download python SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: python-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress python SDK
-      run: tar -zxf ${{github.workspace}}/sdk/python.tar.gz -C
-        ${{github.workspace}}/sdk/python
-    - name: Download dotnet SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: dotnet-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress dotnet SDK
-      run: tar -zxf ${{github.workspace}}/sdk/dotnet.tar.gz -C
-        ${{github.workspace}}/sdk/dotnet
-    - name: Download nodejs SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: nodejs-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress nodejs SDK
-      run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
-        ${{github.workspace}}/sdk/nodejs
-    - run: python -m pip install pip twine
-    - env:
-        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-      name: Publish SDKs
-      run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - if: failure() && github.event_name == 'push'
-      name: Notify Slack
-      uses: 8398a7/action-slack@v3
-      with:
-        author_name: Failure in publishing SDK
-        fields: repo,commit,author,action
-        status: ${{ job.status }}
+    - name: Publish SDKs
+      uses: pulumi/pulumi-package-publisher@v0.0.5
   tag_sdk:
     name: tag_sdk
     needs: publish_sdk

--- a/provider-ci/src/action-versions.ts
+++ b/provider-ci/src/action-versions.ts
@@ -38,3 +38,4 @@ export const slashCommand = "peter-evans/slash-command-dispatch@v2";
 export const uploadArtifact = "actions/upload-artifact@v2";
 export const githubScript = "actions/github-script@v6";
 export const upgradeProviderAction = "pulumi/pulumi-upgrade-provider-action@v0.0.4"
+export const publishProviderSDKs = "pulumi/pulumi-package-publisher@v0.0.5"

--- a/provider-ci/src/steps.ts
+++ b/provider-ci/src/steps.ts
@@ -494,22 +494,7 @@ export function RunCommand(command: string): Step {
 export function RunPublishSDK(): Step {
   return {
     name: "Publish SDKs",
-    run: "./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}",
-    env: {
-      NODE_AUTH_TOKEN: "${{ secrets.NPM_TOKEN }}",
-    },
-  };
-}
-
-export function RunPublishJavaSDK(): Step {
-  return {
-    name: "Publish Java SDK",
-    uses: action.gradleBuildAction,
-    with: {
-      arguments: "publishToSonatype closeAndReleaseSonatypeStagingRepository",
-      "build-root-directory": "./sdk/java",
-      "gradle-version": "7.4.1",
-    },
+    uses: action.publishProviderSDKs,
   };
 }
 
@@ -738,7 +723,14 @@ export function UpgradeProviderAction(providerName: string, defaultBranch: strin
 			"slack-webhook": "${{ secrets.SLACK_WEBHOOK_URL }}",
 			"slack-channel": "provider-upgrade-status",
 			"git-username": "Pulumi bot",
-       		"git-email": "bot@pulumi.com",
+            "git-email": "bot@pulumi.com",
 		}
 	}
+}
+
+export function PublishProviderSDKs(): Step {
+  return {
+    name: "Publish SDKs",
+    uses: action.publishProviderSDKs,
+  }
 }

--- a/provider-ci/src/workflows.ts
+++ b/provider-ci/src/workflows.ts
@@ -62,7 +62,6 @@ export function DefaultBranchWorkflow(
       test: new TestsJob("test", opts),
       publish: new PublishPrereleaseJob("publish", opts),
       publish_sdk: new PublishSDKJob("publish_sdk"),
-      publish_java_sdk: new PublishJavaSDKJob("publish_java_sdk"),
       generate_coverage_data: new GenerateCoverageDataJob(
         "generate_coverage_data"
       ),
@@ -118,7 +117,6 @@ export function ReleaseWorkflow(
       test: new TestsJob("test", opts),
       publish: new PublishJob("publish", opts),
       publish_sdk: new PublishSDKJob("publish_sdk"),
-      publish_java_sdk: new PublishJavaSDKJob("publish_java_sdk"),
       tag_sdk: new TagSDKJob("tag_sdk"),
       create_docs_build: new DocsBuildJob("create_docs_build"),
     },
@@ -154,7 +152,6 @@ export function PrereleaseWorkflow(
       test: new TestsJob("test", opts),
       publish: new PublishPrereleaseJob("publish", opts),
       publish_sdk: new PublishSDKJob("publish_sdk"),
-      publish_java_sdk: new PublishJavaSDKJob("publish_java_sdk"),
     },
   };
 
@@ -875,33 +872,6 @@ export class PublishSDKJob implements NormalJob {
     Object.assign(this, { name });
   }
 }
-
-export class PublishJavaSDKJob implements NormalJob {
-  "runs-on" = "ubuntu-latest";
-  "continue-on-error" = true;
-  needs = "publish";
-  steps = [
-    steps.CheckoutRepoStep(),
-    steps.CheckoutScriptsRepoStep(),
-    steps.CheckoutTagsStep(),
-    steps.InstallGo(),
-    steps.InstallPulumiCtl(),
-    steps.InstallPulumiCli(),
-    steps.InstallJava(),
-    steps.InstallGradle("7.6"),
-    steps.DownloadSpecificSDKStep("java"),
-    steps.UnzipSpecificSDKStep("java"),
-    steps.SetPackageVersionToEnv(),
-    steps.RunPublishJavaSDK(),
-  ];
-  name: string;
-
-  constructor(name: string) {
-    this.name = name;
-    Object.assign(this, { name });
-  }
-}
-
 export class LintProviderJob implements NormalJob {
   "runs-on" = "ubuntu-latest";
   container = `golangci/golangci-lint:${golangciLintContainerVersion}`;
@@ -1069,11 +1039,11 @@ export function UpgradeProvider(opts: BridgedConfig): GithubWorkflow {
       issues: {
         types: ["opened"],
       },
-	  workflow_dispatch: {},
+      workflow_dispatch: {},
     },
     env: {
       GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}",
-	  GH_TOKEN: "${{ secrets.PULUMI_BOT_TOKEN }}",
+      GH_TOKEN: "${{ secrets.PULUMI_BOT_TOKEN }}",
     },
     jobs: {
       upgrade_provider: new EmptyJob("upgrade-provider")

--- a/provider-ci/src/workflows.ts
+++ b/provider-ci/src/workflows.ts
@@ -846,24 +846,7 @@ export class PublishSDKJob implements NormalJob {
   "runs-on" = "ubuntu-latest";
   needs = "publish";
   steps = [
-    steps.CheckoutRepoStep(),
-    steps.CheckoutScriptsRepoStep(),
-    steps.CheckoutTagsStep(),
-    steps.InstallGo(),
-    steps.InstallPulumiCtl(),
-    steps.InstallPulumiCli(),
-    steps.InstallNodeJS(),
-    steps.InstallDotNet(),
-    steps.InstallPython(),
-    steps.DownloadSpecificSDKStep("python"),
-    steps.UnzipSpecificSDKStep("python"),
-    steps.DownloadSpecificSDKStep("dotnet"),
-    steps.UnzipSpecificSDKStep("dotnet"),
-    steps.DownloadSpecificSDKStep("nodejs"),
-    steps.UnzipSpecificSDKStep("nodejs"),
-    steps.RunCommand("python -m pip install pip twine"),
     steps.RunPublishSDK(),
-    steps.NotifySlack("Failure in publishing SDK"),
   ];
   name: string;
 


### PR DESCRIPTION
This PR removes the multi-step implementation for package publishing and replaces it with a single composite GitHub Action, which we [maintain as pulumi-package-publisher](https://github.com/pulumi/pulumi-package-publisher).

A successful run of the composite Action can be [found against master on pulumi-kafka](https://github.com/pulumi/pulumi-kafka/actions/runs/4800273904/jobs/8541833586).

My main question is - rather than pin to v0.0.5, there may be benefit to using latest, as we will be using the package publisher action to use the Pulumi CLI tool instead.

Note also we are not touching the Goreleaser step.
 
Fixes https://github.com/pulumi/home/issues/2773.


- First pass at action gen
- Refactor: Use Provider Publish Action for publishing SDKs
- Remove the individual checkout steps
- generate provider workflows
