### PR TITLE
Make automerge the default for update-workflows-ecosystem-providers

### DIFF
--- a/.github/workflows/update-workflows-ecosystem-providers.yml
+++ b/.github/workflows/update-workflows-ecosystem-providers.yml
@@ -15,7 +15,7 @@ on:
         description: Mark created PRs for auto-merging?
         required: true
         type: boolean
-        default: false
+        default: true
 env:
   GITHUB_TOKEN: ${{ secrets.PULUMI_BOT_TOKEN }}
 jobs:


### PR DESCRIPTION
Noticing a lot of unmerged PRs that pass tests. Stood up nightly. This should make them auto-merge hopefully.