### PR TITLE
Auto-close stale Update GitHub Actions workflows PRs before opening a new one

### DIFF
--- a/.github/workflows/update-workflows-ecosystem-providers.yml
+++ b/.github/workflows/update-workflows-ecosystem-providers.yml
@@ -65,6 +65,26 @@ jobs:
           cd ci-mgmt/tools/sourcemigrator
           npm ci
           npx ts-node index.ts "$DIR"
+      - name: Find obsolete PRs started by this workflow
+        uses: octokit/request-action@v2.x
+        id: find-obsolete-prs
+        with:
+          route: GET /repos/:owner/:repo/pulls?state=open
+          owner: pulumi
+          repo: pulumi-${{ matrix.provider }}
+      - name: Close obsolete PRs started by this workflow
+        uses: octokit/request-action@v2.x
+        with:
+          route: PATCH /repos/:owner/:repo/pulls/:pull_number
+          owner: pulumi
+          repo: pulumi-${{ matrix.provider }}
+          pull_number: ${{ fromJson(steps.find-matching-prs.outputs.data).filter(pr => /Update GitHub Actions workflows/i.test(pr.title)).map(pr => pr.number).join(',') }}
+          body: |
+            This obsolete pull request has been automatically closed by update-workflows-ecosystem-providers.yml.
+          headers: |
+            { "Content-Type": "application/json" }
+            { "Authorization": "Bearer ${{ secrets.GITHUB_TOKEN }}" }
+          body-encoding: json
       - name: Create PR
         id: create-pr
         uses: peter-evans/create-pull-request@v3

--- a/.github/workflows/update-workflows-ecosystem-providers.yml
+++ b/.github/workflows/update-workflows-ecosystem-providers.yml
@@ -65,26 +65,31 @@ jobs:
           cd ci-mgmt/tools/sourcemigrator
           npm ci
           npx ts-node index.ts "$DIR"
-      - name: Find obsolete PRs started by this workflow
-        uses: octokit/request-action@v2.x
-        id: find-obsolete-prs
-        with:
-          route: GET /repos/:owner/:repo/pulls?state=open
-          owner: pulumi
-          repo: pulumi-${{ matrix.provider }}
       - name: Close obsolete PRs started by this workflow
-        uses: octokit/request-action@v2.x
+        uses: actions/github-script@v6
         with:
-          route: PATCH /repos/:owner/:repo/pulls/:pull_number
-          owner: pulumi
-          repo: pulumi-${{ matrix.provider }}
-          pull_number: ${{ fromJson(steps.find-matching-prs.outputs.data).filter(pr => /Update GitHub Actions workflows/i.test(pr.title)).map(pr => pr.number).join(',') }}
-          body: |
-            This obsolete pull request has been automatically closed by update-workflows-ecosystem-providers.yml.
-          headers: |
-            { "Content-Type": "application/json" }
-            { "Authorization": "Bearer ${{ secrets.GITHUB_TOKEN }}" }
-          body-encoding: json
+          github-token: ${{ secrets.PULUMI_BOT_TOKEN }}
+          script: |
+            const regex = /Update GitHub Actions workflows/i;
+            const octokit = github.rest;
+            const repo = 'pulumi-${{ matrix.provider }}'
+            console.log('Checking ' + repo);
+            const { data: pullRequests } = await octokit.pulls.list({
+              owner: 'pulumi',
+              repo: repo,
+              state: 'open',
+            });
+            for (const pullRequest of pullRequests) {
+              if (regex.test(pullRequest.title)) {
+                console.log('Closing obsolete PR ' + pullRequest.number);
+                await octokit.pulls.update({
+                  owner: 'pulumi',
+                  repo: repo,
+                  pull_number: pullRequest.number,
+                  state: 'closed',
+                });
+              }
+            }
       - name: Create PR
         id: create-pr
         uses: peter-evans/create-pull-request@v3

--- a/.github/workflows/update-workflows-single-bridged-provider.yml
+++ b/.github/workflows/update-workflows-single-bridged-provider.yml
@@ -48,7 +48,7 @@ jobs:
       - name: Close obsolete PRs started by this workflow
         uses: actions/github-script@v6
         with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+          github-token: ${{ secrets.PULUMI_BOT_TOKEN }}
           script: |
             const regex = /Update GitHub Actions workflows/i;
             const octokit = github.rest;

--- a/.github/workflows/update-workflows-single-bridged-provider.yml
+++ b/.github/workflows/update-workflows-single-bridged-provider.yml
@@ -45,6 +45,26 @@ jobs:
           cd ci-mgmt/tools/sourcemigrator
           npm ci
           npx ts-node index.ts "$DIR"
+      - name: Find obsolete PRs started by this workflow
+        uses: octokit/request-action@v2.x
+        id: find-obsolete-prs
+        with:
+          route: GET /repos/:owner/:repo/pulls?state=open
+          owner: pulumi
+          repo: pulumi-${{ github.event.inputs.provider_name }}
+      - name: Close obsolete PRs started by this workflow
+        uses: octokit/request-action@v2.x
+        with:
+          route: PATCH /repos/:owner/:repo/pulls/:pull_number
+          owner: pulumi
+          repo: pulumi-${{ github.event.inputs.provider_name }}
+          pull_number: ${{ fromJson(steps.find-matching-prs.outputs.data).filter(pr => /Update GitHub Actions workflows/i.test(pr.title)).map(pr => pr.number).join(',') }}
+          body: |
+            This obsolete pull request has been automatically closed by update-workflows-single-bridged-provider.yml.
+          headers: |
+            { "Content-Type": "application/json" }
+            { "Authorization": "Bearer ${{ secrets.GITHUB_TOKEN }}" }
+          body-encoding: json
       - name: Create PR
         id: create-pr
         uses: peter-evans/create-pull-request@v3

--- a/.github/workflows/update-workflows-single-bridged-provider.yml
+++ b/.github/workflows/update-workflows-single-bridged-provider.yml
@@ -51,8 +51,9 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
             const regex = /Update GitHub Actions workflows/i;
-            const octokit = await github.getOctokit();
+            const octokit = github.rest;
             const repo = 'pulumi-' + github.event.inputs.provider_name;
+            console.log('Checking ' + repo);
             const { data: pullRequests } = await octokit.pulls.list({
               owner: 'pulumi',
               repo: repo,

--- a/.github/workflows/update-workflows-single-bridged-provider.yml
+++ b/.github/workflows/update-workflows-single-bridged-provider.yml
@@ -52,7 +52,7 @@ jobs:
           script: |
             const regex = /Update GitHub Actions workflows/i;
             const octokit = github.rest;
-            const repo = 'pulumi-' + github.event.inputs.provider_name;
+            const repo = 'pulumi-${{ github.event.inputs.provider_name }}'
             console.log('Checking ' + repo);
             const { data: pullRequests } = await octokit.pulls.list({
               owner: 'pulumi',

--- a/.github/workflows/update-workflows-single-bridged-provider.yml
+++ b/.github/workflows/update-workflows-single-bridged-provider.yml
@@ -45,26 +45,30 @@ jobs:
           cd ci-mgmt/tools/sourcemigrator
           npm ci
           npx ts-node index.ts "$DIR"
-      - name: Find obsolete PRs started by this workflow
-        uses: octokit/request-action@v2.x
-        id: find-obsolete-prs
-        with:
-          route: GET /repos/:owner/:repo/pulls?state=open
-          owner: pulumi
-          repo: pulumi-${{ github.event.inputs.provider_name }}
       - name: Close obsolete PRs started by this workflow
-        uses: octokit/request-action@v2.x
+        uses: actions/github-script@v6
         with:
-          route: PATCH /repos/:owner/:repo/pulls/:pull_number
-          owner: pulumi
-          repo: pulumi-${{ github.event.inputs.provider_name }}
-          pull_number: ${{ fromJson(steps.find-matching-prs.outputs.data).filter(pr => /Update GitHub Actions workflows/i.test(pr.title)).map(pr => pr.number).join(',') }}
-          body: |
-            This obsolete pull request has been automatically closed by update-workflows-single-bridged-provider.yml.
-          headers: |
-            { "Content-Type": "application/json" }
-            { "Authorization": "Bearer ${{ secrets.GITHUB_TOKEN }}" }
-          body-encoding: json
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const regex = /Update GitHub Actions workflows/i;
+            const octokit = await github.getOctokit();
+            const repo = 'pulumi-' + github.event.inputs.provider_name;
+            const { data: pullRequests } = await octokit.pulls.list({
+              owner: 'pulumi',
+              repo: repo,
+              state: 'open',
+            });
+            for (const pullRequest of pullRequests) {
+              if (regex.test(pullRequest.title)) {
+                console.log('Closing obsolete PR ' + pullRequest.number);
+                await octokit.pulls.update({
+                  owner: 'pulumi',
+                  repo: repo,
+                  pull_number: pullRequest.number,
+                  state: 'closed',
+                });
+              }
+            }
       - name: Create PR
         id: create-pr
         uses: peter-evans/create-pull-request@v3


### PR DESCRIPTION
Jobs in this repo open 'Update GitHub Actions workflows' PRs, and we have a lot of them. Usually only the last one is relevant. Add some code to scan open PRs for this title and auto-close them before opening a new one.

Fixes https://github.com/pulumi/ci-mgmt/issues/398