### PR TITLE
Add notification step to provider upgrade

### DIFF
--- a/provider-ci/providers/aiven/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/aiven/repo/.github/workflows/main.yml
@@ -291,7 +291,7 @@ jobs:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
-        SLACK_MESSAGE: " Publish failed :x:"
+        SLACK_MESSAGE: "Publish failed :x:"
         SLACK_TITLE: ${{ github.event.repository.name }} upgrade result
         SLACK_USERNAME: provider-bot
         SLACK_WEBHOOK: ${{ env.SLACK_WEBHOOK_URL }}

--- a/provider-ci/providers/aiven/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/aiven/repo/.github/workflows/master.yml
@@ -291,7 +291,7 @@ jobs:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
-        SLACK_MESSAGE: " Publish failed :x:"
+        SLACK_MESSAGE: "Publish failed :x:"
         SLACK_TITLE: ${{ github.event.repository.name }} upgrade result
         SLACK_USERNAME: provider-bot
         SLACK_WEBHOOK: ${{ env.SLACK_WEBHOOK_URL }}

--- a/provider-ci/providers/aiven/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/aiven/repo/.github/workflows/prerelease.yml
@@ -241,7 +241,7 @@ jobs:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
-        SLACK_MESSAGE: " Publish failed :x:"
+        SLACK_MESSAGE: "Publish failed :x:"
         SLACK_TITLE: ${{ github.event.repository.name }} upgrade result
         SLACK_USERNAME: provider-bot
         SLACK_WEBHOOK: ${{ env.SLACK_WEBHOOK_URL }}

--- a/provider-ci/providers/aiven/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/aiven/repo/.github/workflows/release.yml
@@ -253,7 +253,7 @@ jobs:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
-        SLACK_MESSAGE: " Publish failed :x:"
+        SLACK_MESSAGE: "Publish failed :x:"
         SLACK_TITLE: ${{ github.event.repository.name }} upgrade result
         SLACK_USERNAME: provider-bot
         SLACK_WEBHOOK: ${{ env.SLACK_WEBHOOK_URL }}

--- a/provider-ci/providers/aiven/repo/.github/workflows/upgrade-provider.yml
+++ b/provider-ci/providers/aiven/repo/.github/workflows/upgrade-provider.yml
@@ -14,6 +14,30 @@ jobs:
       with:
         slack-channel: provider-upgrade-status
         slack-webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
+    - env:
+        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_COLOR: "#FF0000"
+        SLACK_ICON_EMOJI: ":taco:"
+        SLACK_MESSAGE: >-
+          Upgrade succeeded :heart_decoration:
+
+          PR opened at github.com/pulumi/${{ github.event.repository.name }}/pulls
+        SLACK_TITLE: ${{ github.event.repository.name }} upgrade result
+        SLACK_USERNAME: provider-bot
+        SLACK_WEBHOOK: ${{ env.SLACK_WEBHOOK_URL }}
+      name: Send Upgrade Success To Slack
+      uses: rtCamp/action-slack-notify@v2
+    - env:
+        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_COLOR: "#FF0000"
+        SLACK_ICON_EMOJI: ":taco:"
+        SLACK_MESSAGE: " Upgrade failed :x:"
+        SLACK_TITLE: ${{ github.event.repository.name }} upgrade result
+        SLACK_USERNAME: provider-bot
+        SLACK_WEBHOOK: ${{ env.SLACK_WEBHOOK_URL }}
+      if: failure()
+      name: Send Upgrade Failure To Slack
+      uses: rtCamp/action-slack-notify@v2
 name: Upgrade provider
 on:
   issues:

--- a/provider-ci/providers/aiven/repo/.github/workflows/upgrade-provider.yml
+++ b/provider-ci/providers/aiven/repo/.github/workflows/upgrade-provider.yml
@@ -5,7 +5,7 @@ env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 jobs:
   upgrade_provider:
-    if: contains(github.event.issue.title, 'Upgrade terraform-provider-')
+    if: contains(${{ github.event.issue.title }}, 'Upgrade terraform-provider-')
     name: upgrade-provider
     runs-on: ubuntu-latest
     steps:

--- a/provider-ci/providers/akamai/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/akamai/repo/.github/workflows/main.yml
@@ -293,7 +293,7 @@ jobs:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
-        SLACK_MESSAGE: " Publish failed :x:"
+        SLACK_MESSAGE: "Publish failed :x:"
         SLACK_TITLE: ${{ github.event.repository.name }} upgrade result
         SLACK_USERNAME: provider-bot
         SLACK_WEBHOOK: ${{ env.SLACK_WEBHOOK_URL }}

--- a/provider-ci/providers/akamai/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/akamai/repo/.github/workflows/master.yml
@@ -293,7 +293,7 @@ jobs:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
-        SLACK_MESSAGE: " Publish failed :x:"
+        SLACK_MESSAGE: "Publish failed :x:"
         SLACK_TITLE: ${{ github.event.repository.name }} upgrade result
         SLACK_USERNAME: provider-bot
         SLACK_WEBHOOK: ${{ env.SLACK_WEBHOOK_URL }}

--- a/provider-ci/providers/akamai/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/akamai/repo/.github/workflows/prerelease.yml
@@ -243,7 +243,7 @@ jobs:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
-        SLACK_MESSAGE: " Publish failed :x:"
+        SLACK_MESSAGE: "Publish failed :x:"
         SLACK_TITLE: ${{ github.event.repository.name }} upgrade result
         SLACK_USERNAME: provider-bot
         SLACK_WEBHOOK: ${{ env.SLACK_WEBHOOK_URL }}

--- a/provider-ci/providers/akamai/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/akamai/repo/.github/workflows/release.yml
@@ -255,7 +255,7 @@ jobs:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
-        SLACK_MESSAGE: " Publish failed :x:"
+        SLACK_MESSAGE: "Publish failed :x:"
         SLACK_TITLE: ${{ github.event.repository.name }} upgrade result
         SLACK_USERNAME: provider-bot
         SLACK_WEBHOOK: ${{ env.SLACK_WEBHOOK_URL }}

--- a/provider-ci/providers/akamai/repo/.github/workflows/upgrade-provider.yml
+++ b/provider-ci/providers/akamai/repo/.github/workflows/upgrade-provider.yml
@@ -14,6 +14,30 @@ jobs:
       with:
         slack-channel: provider-upgrade-status
         slack-webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
+    - env:
+        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_COLOR: "#FF0000"
+        SLACK_ICON_EMOJI: ":taco:"
+        SLACK_MESSAGE: >-
+          Upgrade succeeded :heart_decoration:
+
+          PR opened at github.com/pulumi/${{ github.event.repository.name }}/pulls
+        SLACK_TITLE: ${{ github.event.repository.name }} upgrade result
+        SLACK_USERNAME: provider-bot
+        SLACK_WEBHOOK: ${{ env.SLACK_WEBHOOK_URL }}
+      name: Send Upgrade Success To Slack
+      uses: rtCamp/action-slack-notify@v2
+    - env:
+        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_COLOR: "#FF0000"
+        SLACK_ICON_EMOJI: ":taco:"
+        SLACK_MESSAGE: " Upgrade failed :x:"
+        SLACK_TITLE: ${{ github.event.repository.name }} upgrade result
+        SLACK_USERNAME: provider-bot
+        SLACK_WEBHOOK: ${{ env.SLACK_WEBHOOK_URL }}
+      if: failure()
+      name: Send Upgrade Failure To Slack
+      uses: rtCamp/action-slack-notify@v2
 name: Upgrade provider
 on:
   issues:

--- a/provider-ci/providers/akamai/repo/.github/workflows/upgrade-provider.yml
+++ b/provider-ci/providers/akamai/repo/.github/workflows/upgrade-provider.yml
@@ -5,7 +5,7 @@ env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 jobs:
   upgrade_provider:
-    if: contains(github.event.issue.title, 'Upgrade terraform-provider-')
+    if: contains(${{ github.event.issue.title }}, 'Upgrade terraform-provider-')
     name: upgrade-provider
     runs-on: ubuntu-latest
     steps:

--- a/provider-ci/providers/alicloud/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/alicloud/repo/.github/workflows/main.yml
@@ -292,7 +292,7 @@ jobs:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
-        SLACK_MESSAGE: " Publish failed :x:"
+        SLACK_MESSAGE: "Publish failed :x:"
         SLACK_TITLE: ${{ github.event.repository.name }} upgrade result
         SLACK_USERNAME: provider-bot
         SLACK_WEBHOOK: ${{ env.SLACK_WEBHOOK_URL }}

--- a/provider-ci/providers/alicloud/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/alicloud/repo/.github/workflows/master.yml
@@ -292,7 +292,7 @@ jobs:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
-        SLACK_MESSAGE: " Publish failed :x:"
+        SLACK_MESSAGE: "Publish failed :x:"
         SLACK_TITLE: ${{ github.event.repository.name }} upgrade result
         SLACK_USERNAME: provider-bot
         SLACK_WEBHOOK: ${{ env.SLACK_WEBHOOK_URL }}

--- a/provider-ci/providers/alicloud/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/alicloud/repo/.github/workflows/prerelease.yml
@@ -242,7 +242,7 @@ jobs:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
-        SLACK_MESSAGE: " Publish failed :x:"
+        SLACK_MESSAGE: "Publish failed :x:"
         SLACK_TITLE: ${{ github.event.repository.name }} upgrade result
         SLACK_USERNAME: provider-bot
         SLACK_WEBHOOK: ${{ env.SLACK_WEBHOOK_URL }}

--- a/provider-ci/providers/alicloud/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/alicloud/repo/.github/workflows/release.yml
@@ -254,7 +254,7 @@ jobs:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
-        SLACK_MESSAGE: " Publish failed :x:"
+        SLACK_MESSAGE: "Publish failed :x:"
         SLACK_TITLE: ${{ github.event.repository.name }} upgrade result
         SLACK_USERNAME: provider-bot
         SLACK_WEBHOOK: ${{ env.SLACK_WEBHOOK_URL }}

--- a/provider-ci/providers/alicloud/repo/.github/workflows/upgrade-provider.yml
+++ b/provider-ci/providers/alicloud/repo/.github/workflows/upgrade-provider.yml
@@ -14,6 +14,30 @@ jobs:
       with:
         slack-channel: provider-upgrade-status
         slack-webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
+    - env:
+        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_COLOR: "#FF0000"
+        SLACK_ICON_EMOJI: ":taco:"
+        SLACK_MESSAGE: >-
+          Upgrade succeeded :heart_decoration:
+
+          PR opened at github.com/pulumi/${{ github.event.repository.name }}/pulls
+        SLACK_TITLE: ${{ github.event.repository.name }} upgrade result
+        SLACK_USERNAME: provider-bot
+        SLACK_WEBHOOK: ${{ env.SLACK_WEBHOOK_URL }}
+      name: Send Upgrade Success To Slack
+      uses: rtCamp/action-slack-notify@v2
+    - env:
+        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_COLOR: "#FF0000"
+        SLACK_ICON_EMOJI: ":taco:"
+        SLACK_MESSAGE: " Upgrade failed :x:"
+        SLACK_TITLE: ${{ github.event.repository.name }} upgrade result
+        SLACK_USERNAME: provider-bot
+        SLACK_WEBHOOK: ${{ env.SLACK_WEBHOOK_URL }}
+      if: failure()
+      name: Send Upgrade Failure To Slack
+      uses: rtCamp/action-slack-notify@v2
 name: Upgrade provider
 on:
   issues:

--- a/provider-ci/providers/alicloud/repo/.github/workflows/upgrade-provider.yml
+++ b/provider-ci/providers/alicloud/repo/.github/workflows/upgrade-provider.yml
@@ -5,7 +5,7 @@ env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 jobs:
   upgrade_provider:
-    if: contains(github.event.issue.title, 'Upgrade terraform-provider-')
+    if: contains(${{ github.event.issue.title }}, 'Upgrade terraform-provider-')
     name: upgrade-provider
     runs-on: ubuntu-latest
     steps:

--- a/provider-ci/providers/artifactory/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/artifactory/repo/.github/workflows/main.yml
@@ -363,7 +363,7 @@ jobs:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
-        SLACK_MESSAGE: " Publish failed :x:"
+        SLACK_MESSAGE: "Publish failed :x:"
         SLACK_TITLE: ${{ github.event.repository.name }} upgrade result
         SLACK_USERNAME: provider-bot
         SLACK_WEBHOOK: ${{ env.SLACK_WEBHOOK_URL }}

--- a/provider-ci/providers/artifactory/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/artifactory/repo/.github/workflows/master.yml
@@ -363,7 +363,7 @@ jobs:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
-        SLACK_MESSAGE: " Publish failed :x:"
+        SLACK_MESSAGE: "Publish failed :x:"
         SLACK_TITLE: ${{ github.event.repository.name }} upgrade result
         SLACK_USERNAME: provider-bot
         SLACK_WEBHOOK: ${{ env.SLACK_WEBHOOK_URL }}

--- a/provider-ci/providers/artifactory/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/artifactory/repo/.github/workflows/prerelease.yml
@@ -313,7 +313,7 @@ jobs:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
-        SLACK_MESSAGE: " Publish failed :x:"
+        SLACK_MESSAGE: "Publish failed :x:"
         SLACK_TITLE: ${{ github.event.repository.name }} upgrade result
         SLACK_USERNAME: provider-bot
         SLACK_WEBHOOK: ${{ env.SLACK_WEBHOOK_URL }}

--- a/provider-ci/providers/artifactory/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/artifactory/repo/.github/workflows/release.yml
@@ -325,7 +325,7 @@ jobs:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
-        SLACK_MESSAGE: " Publish failed :x:"
+        SLACK_MESSAGE: "Publish failed :x:"
         SLACK_TITLE: ${{ github.event.repository.name }} upgrade result
         SLACK_USERNAME: provider-bot
         SLACK_WEBHOOK: ${{ env.SLACK_WEBHOOK_URL }}

--- a/provider-ci/providers/artifactory/repo/.github/workflows/upgrade-provider.yml
+++ b/provider-ci/providers/artifactory/repo/.github/workflows/upgrade-provider.yml
@@ -14,6 +14,30 @@ jobs:
       with:
         slack-channel: provider-upgrade-status
         slack-webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
+    - env:
+        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_COLOR: "#FF0000"
+        SLACK_ICON_EMOJI: ":taco:"
+        SLACK_MESSAGE: >-
+          Upgrade succeeded :heart_decoration:
+
+          PR opened at github.com/pulumi/${{ github.event.repository.name }}/pulls
+        SLACK_TITLE: ${{ github.event.repository.name }} upgrade result
+        SLACK_USERNAME: provider-bot
+        SLACK_WEBHOOK: ${{ env.SLACK_WEBHOOK_URL }}
+      name: Send Upgrade Success To Slack
+      uses: rtCamp/action-slack-notify@v2
+    - env:
+        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_COLOR: "#FF0000"
+        SLACK_ICON_EMOJI: ":taco:"
+        SLACK_MESSAGE: " Upgrade failed :x:"
+        SLACK_TITLE: ${{ github.event.repository.name }} upgrade result
+        SLACK_USERNAME: provider-bot
+        SLACK_WEBHOOK: ${{ env.SLACK_WEBHOOK_URL }}
+      if: failure()
+      name: Send Upgrade Failure To Slack
+      uses: rtCamp/action-slack-notify@v2
 name: Upgrade provider
 on:
   issues:

--- a/provider-ci/providers/artifactory/repo/.github/workflows/upgrade-provider.yml
+++ b/provider-ci/providers/artifactory/repo/.github/workflows/upgrade-provider.yml
@@ -5,7 +5,7 @@ env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 jobs:
   upgrade_provider:
-    if: contains(github.event.issue.title, 'Upgrade terraform-provider-')
+    if: contains(${{ github.event.issue.title }}, 'Upgrade terraform-provider-')
     name: upgrade-provider
     runs-on: ubuntu-latest
     steps:

--- a/provider-ci/providers/auth0/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/auth0/repo/.github/workflows/main.yml
@@ -363,7 +363,7 @@ jobs:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
-        SLACK_MESSAGE: " Publish failed :x:"
+        SLACK_MESSAGE: "Publish failed :x:"
         SLACK_TITLE: ${{ github.event.repository.name }} upgrade result
         SLACK_USERNAME: provider-bot
         SLACK_WEBHOOK: ${{ env.SLACK_WEBHOOK_URL }}

--- a/provider-ci/providers/auth0/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/auth0/repo/.github/workflows/master.yml
@@ -363,7 +363,7 @@ jobs:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
-        SLACK_MESSAGE: " Publish failed :x:"
+        SLACK_MESSAGE: "Publish failed :x:"
         SLACK_TITLE: ${{ github.event.repository.name }} upgrade result
         SLACK_USERNAME: provider-bot
         SLACK_WEBHOOK: ${{ env.SLACK_WEBHOOK_URL }}

--- a/provider-ci/providers/auth0/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/auth0/repo/.github/workflows/prerelease.yml
@@ -313,7 +313,7 @@ jobs:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
-        SLACK_MESSAGE: " Publish failed :x:"
+        SLACK_MESSAGE: "Publish failed :x:"
         SLACK_TITLE: ${{ github.event.repository.name }} upgrade result
         SLACK_USERNAME: provider-bot
         SLACK_WEBHOOK: ${{ env.SLACK_WEBHOOK_URL }}

--- a/provider-ci/providers/auth0/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/auth0/repo/.github/workflows/release.yml
@@ -325,7 +325,7 @@ jobs:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
-        SLACK_MESSAGE: " Publish failed :x:"
+        SLACK_MESSAGE: "Publish failed :x:"
         SLACK_TITLE: ${{ github.event.repository.name }} upgrade result
         SLACK_USERNAME: provider-bot
         SLACK_WEBHOOK: ${{ env.SLACK_WEBHOOK_URL }}

--- a/provider-ci/providers/auth0/repo/.github/workflows/upgrade-provider.yml
+++ b/provider-ci/providers/auth0/repo/.github/workflows/upgrade-provider.yml
@@ -14,6 +14,30 @@ jobs:
       with:
         slack-channel: provider-upgrade-status
         slack-webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
+    - env:
+        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_COLOR: "#FF0000"
+        SLACK_ICON_EMOJI: ":taco:"
+        SLACK_MESSAGE: >-
+          Upgrade succeeded :heart_decoration:
+
+          PR opened at github.com/pulumi/${{ github.event.repository.name }}/pulls
+        SLACK_TITLE: ${{ github.event.repository.name }} upgrade result
+        SLACK_USERNAME: provider-bot
+        SLACK_WEBHOOK: ${{ env.SLACK_WEBHOOK_URL }}
+      name: Send Upgrade Success To Slack
+      uses: rtCamp/action-slack-notify@v2
+    - env:
+        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_COLOR: "#FF0000"
+        SLACK_ICON_EMOJI: ":taco:"
+        SLACK_MESSAGE: " Upgrade failed :x:"
+        SLACK_TITLE: ${{ github.event.repository.name }} upgrade result
+        SLACK_USERNAME: provider-bot
+        SLACK_WEBHOOK: ${{ env.SLACK_WEBHOOK_URL }}
+      if: failure()
+      name: Send Upgrade Failure To Slack
+      uses: rtCamp/action-slack-notify@v2
 name: Upgrade provider
 on:
   issues:

--- a/provider-ci/providers/auth0/repo/.github/workflows/upgrade-provider.yml
+++ b/provider-ci/providers/auth0/repo/.github/workflows/upgrade-provider.yml
@@ -5,7 +5,7 @@ env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 jobs:
   upgrade_provider:
-    if: contains(github.event.issue.title, 'Upgrade terraform-provider-')
+    if: contains(${{ github.event.issue.title }}, 'Upgrade terraform-provider-')
     name: upgrade-provider
     runs-on: ubuntu-latest
     steps:

--- a/provider-ci/providers/aws/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/aws/repo/.github/workflows/main.yml
@@ -291,7 +291,7 @@ jobs:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
-        SLACK_MESSAGE: " Publish failed :x:"
+        SLACK_MESSAGE: "Publish failed :x:"
         SLACK_TITLE: ${{ github.event.repository.name }} upgrade result
         SLACK_USERNAME: provider-bot
         SLACK_WEBHOOK: ${{ env.SLACK_WEBHOOK_URL }}

--- a/provider-ci/providers/aws/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/aws/repo/.github/workflows/master.yml
@@ -291,7 +291,7 @@ jobs:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
-        SLACK_MESSAGE: " Publish failed :x:"
+        SLACK_MESSAGE: "Publish failed :x:"
         SLACK_TITLE: ${{ github.event.repository.name }} upgrade result
         SLACK_USERNAME: provider-bot
         SLACK_WEBHOOK: ${{ env.SLACK_WEBHOOK_URL }}

--- a/provider-ci/providers/aws/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/aws/repo/.github/workflows/prerelease.yml
@@ -241,7 +241,7 @@ jobs:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
-        SLACK_MESSAGE: " Publish failed :x:"
+        SLACK_MESSAGE: "Publish failed :x:"
         SLACK_TITLE: ${{ github.event.repository.name }} upgrade result
         SLACK_USERNAME: provider-bot
         SLACK_WEBHOOK: ${{ env.SLACK_WEBHOOK_URL }}

--- a/provider-ci/providers/aws/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/aws/repo/.github/workflows/release.yml
@@ -253,7 +253,7 @@ jobs:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
-        SLACK_MESSAGE: " Publish failed :x:"
+        SLACK_MESSAGE: "Publish failed :x:"
         SLACK_TITLE: ${{ github.event.repository.name }} upgrade result
         SLACK_USERNAME: provider-bot
         SLACK_WEBHOOK: ${{ env.SLACK_WEBHOOK_URL }}

--- a/provider-ci/providers/aws/repo/.github/workflows/upgrade-provider.yml
+++ b/provider-ci/providers/aws/repo/.github/workflows/upgrade-provider.yml
@@ -14,6 +14,30 @@ jobs:
       with:
         slack-channel: provider-upgrade-status
         slack-webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
+    - env:
+        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_COLOR: "#FF0000"
+        SLACK_ICON_EMOJI: ":taco:"
+        SLACK_MESSAGE: >-
+          Upgrade succeeded :heart_decoration:
+
+          PR opened at github.com/pulumi/${{ github.event.repository.name }}/pulls
+        SLACK_TITLE: ${{ github.event.repository.name }} upgrade result
+        SLACK_USERNAME: provider-bot
+        SLACK_WEBHOOK: ${{ env.SLACK_WEBHOOK_URL }}
+      name: Send Upgrade Success To Slack
+      uses: rtCamp/action-slack-notify@v2
+    - env:
+        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_COLOR: "#FF0000"
+        SLACK_ICON_EMOJI: ":taco:"
+        SLACK_MESSAGE: " Upgrade failed :x:"
+        SLACK_TITLE: ${{ github.event.repository.name }} upgrade result
+        SLACK_USERNAME: provider-bot
+        SLACK_WEBHOOK: ${{ env.SLACK_WEBHOOK_URL }}
+      if: failure()
+      name: Send Upgrade Failure To Slack
+      uses: rtCamp/action-slack-notify@v2
 name: Upgrade provider
 on:
   issues:

--- a/provider-ci/providers/aws/repo/.github/workflows/upgrade-provider.yml
+++ b/provider-ci/providers/aws/repo/.github/workflows/upgrade-provider.yml
@@ -5,7 +5,7 @@ env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 jobs:
   upgrade_provider:
-    if: contains(github.event.issue.title, 'Upgrade terraform-provider-')
+    if: contains(${{ github.event.issue.title }}, 'Upgrade terraform-provider-')
     name: upgrade-provider
     runs-on: ubuntu-latest
     steps:

--- a/provider-ci/providers/azure/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/azure/repo/.github/workflows/main.yml
@@ -296,7 +296,7 @@ jobs:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
-        SLACK_MESSAGE: " Publish failed :x:"
+        SLACK_MESSAGE: "Publish failed :x:"
         SLACK_TITLE: ${{ github.event.repository.name }} upgrade result
         SLACK_USERNAME: provider-bot
         SLACK_WEBHOOK: ${{ env.SLACK_WEBHOOK_URL }}

--- a/provider-ci/providers/azure/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/azure/repo/.github/workflows/master.yml
@@ -296,7 +296,7 @@ jobs:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
-        SLACK_MESSAGE: " Publish failed :x:"
+        SLACK_MESSAGE: "Publish failed :x:"
         SLACK_TITLE: ${{ github.event.repository.name }} upgrade result
         SLACK_USERNAME: provider-bot
         SLACK_WEBHOOK: ${{ env.SLACK_WEBHOOK_URL }}

--- a/provider-ci/providers/azure/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/azure/repo/.github/workflows/prerelease.yml
@@ -246,7 +246,7 @@ jobs:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
-        SLACK_MESSAGE: " Publish failed :x:"
+        SLACK_MESSAGE: "Publish failed :x:"
         SLACK_TITLE: ${{ github.event.repository.name }} upgrade result
         SLACK_USERNAME: provider-bot
         SLACK_WEBHOOK: ${{ env.SLACK_WEBHOOK_URL }}

--- a/provider-ci/providers/azure/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/azure/repo/.github/workflows/release.yml
@@ -258,7 +258,7 @@ jobs:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
-        SLACK_MESSAGE: " Publish failed :x:"
+        SLACK_MESSAGE: "Publish failed :x:"
         SLACK_TITLE: ${{ github.event.repository.name }} upgrade result
         SLACK_USERNAME: provider-bot
         SLACK_WEBHOOK: ${{ env.SLACK_WEBHOOK_URL }}

--- a/provider-ci/providers/azure/repo/.github/workflows/upgrade-provider.yml
+++ b/provider-ci/providers/azure/repo/.github/workflows/upgrade-provider.yml
@@ -14,6 +14,30 @@ jobs:
       with:
         slack-channel: provider-upgrade-status
         slack-webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
+    - env:
+        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_COLOR: "#FF0000"
+        SLACK_ICON_EMOJI: ":taco:"
+        SLACK_MESSAGE: >-
+          Upgrade succeeded :heart_decoration:
+
+          PR opened at github.com/pulumi/${{ github.event.repository.name }}/pulls
+        SLACK_TITLE: ${{ github.event.repository.name }} upgrade result
+        SLACK_USERNAME: provider-bot
+        SLACK_WEBHOOK: ${{ env.SLACK_WEBHOOK_URL }}
+      name: Send Upgrade Success To Slack
+      uses: rtCamp/action-slack-notify@v2
+    - env:
+        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_COLOR: "#FF0000"
+        SLACK_ICON_EMOJI: ":taco:"
+        SLACK_MESSAGE: " Upgrade failed :x:"
+        SLACK_TITLE: ${{ github.event.repository.name }} upgrade result
+        SLACK_USERNAME: provider-bot
+        SLACK_WEBHOOK: ${{ env.SLACK_WEBHOOK_URL }}
+      if: failure()
+      name: Send Upgrade Failure To Slack
+      uses: rtCamp/action-slack-notify@v2
 name: Upgrade provider
 on:
   issues:

--- a/provider-ci/providers/azure/repo/.github/workflows/upgrade-provider.yml
+++ b/provider-ci/providers/azure/repo/.github/workflows/upgrade-provider.yml
@@ -5,7 +5,7 @@ env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 jobs:
   upgrade_provider:
-    if: contains(github.event.issue.title, 'Upgrade terraform-provider-')
+    if: contains(${{ github.event.issue.title }}, 'Upgrade terraform-provider-')
     name: upgrade-provider
     runs-on: ubuntu-latest
     steps:

--- a/provider-ci/providers/azuread/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/azuread/repo/.github/workflows/main.yml
@@ -365,7 +365,7 @@ jobs:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
-        SLACK_MESSAGE: " Publish failed :x:"
+        SLACK_MESSAGE: "Publish failed :x:"
         SLACK_TITLE: ${{ github.event.repository.name }} upgrade result
         SLACK_USERNAME: provider-bot
         SLACK_WEBHOOK: ${{ env.SLACK_WEBHOOK_URL }}

--- a/provider-ci/providers/azuread/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/azuread/repo/.github/workflows/master.yml
@@ -365,7 +365,7 @@ jobs:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
-        SLACK_MESSAGE: " Publish failed :x:"
+        SLACK_MESSAGE: "Publish failed :x:"
         SLACK_TITLE: ${{ github.event.repository.name }} upgrade result
         SLACK_USERNAME: provider-bot
         SLACK_WEBHOOK: ${{ env.SLACK_WEBHOOK_URL }}

--- a/provider-ci/providers/azuread/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/azuread/repo/.github/workflows/prerelease.yml
@@ -315,7 +315,7 @@ jobs:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
-        SLACK_MESSAGE: " Publish failed :x:"
+        SLACK_MESSAGE: "Publish failed :x:"
         SLACK_TITLE: ${{ github.event.repository.name }} upgrade result
         SLACK_USERNAME: provider-bot
         SLACK_WEBHOOK: ${{ env.SLACK_WEBHOOK_URL }}

--- a/provider-ci/providers/azuread/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/azuread/repo/.github/workflows/release.yml
@@ -327,7 +327,7 @@ jobs:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
-        SLACK_MESSAGE: " Publish failed :x:"
+        SLACK_MESSAGE: "Publish failed :x:"
         SLACK_TITLE: ${{ github.event.repository.name }} upgrade result
         SLACK_USERNAME: provider-bot
         SLACK_WEBHOOK: ${{ env.SLACK_WEBHOOK_URL }}

--- a/provider-ci/providers/azuread/repo/.github/workflows/upgrade-provider.yml
+++ b/provider-ci/providers/azuread/repo/.github/workflows/upgrade-provider.yml
@@ -14,6 +14,30 @@ jobs:
       with:
         slack-channel: provider-upgrade-status
         slack-webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
+    - env:
+        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_COLOR: "#FF0000"
+        SLACK_ICON_EMOJI: ":taco:"
+        SLACK_MESSAGE: >-
+          Upgrade succeeded :heart_decoration:
+
+          PR opened at github.com/pulumi/${{ github.event.repository.name }}/pulls
+        SLACK_TITLE: ${{ github.event.repository.name }} upgrade result
+        SLACK_USERNAME: provider-bot
+        SLACK_WEBHOOK: ${{ env.SLACK_WEBHOOK_URL }}
+      name: Send Upgrade Success To Slack
+      uses: rtCamp/action-slack-notify@v2
+    - env:
+        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_COLOR: "#FF0000"
+        SLACK_ICON_EMOJI: ":taco:"
+        SLACK_MESSAGE: " Upgrade failed :x:"
+        SLACK_TITLE: ${{ github.event.repository.name }} upgrade result
+        SLACK_USERNAME: provider-bot
+        SLACK_WEBHOOK: ${{ env.SLACK_WEBHOOK_URL }}
+      if: failure()
+      name: Send Upgrade Failure To Slack
+      uses: rtCamp/action-slack-notify@v2
 name: Upgrade provider
 on:
   issues:

--- a/provider-ci/providers/azuread/repo/.github/workflows/upgrade-provider.yml
+++ b/provider-ci/providers/azuread/repo/.github/workflows/upgrade-provider.yml
@@ -5,7 +5,7 @@ env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 jobs:
   upgrade_provider:
-    if: contains(github.event.issue.title, 'Upgrade terraform-provider-')
+    if: contains(${{ github.event.issue.title }}, 'Upgrade terraform-provider-')
     name: upgrade-provider
     runs-on: ubuntu-latest
     steps:

--- a/provider-ci/providers/azuredevops/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/azuredevops/repo/.github/workflows/main.yml
@@ -291,7 +291,7 @@ jobs:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
-        SLACK_MESSAGE: " Publish failed :x:"
+        SLACK_MESSAGE: "Publish failed :x:"
         SLACK_TITLE: ${{ github.event.repository.name }} upgrade result
         SLACK_USERNAME: provider-bot
         SLACK_WEBHOOK: ${{ env.SLACK_WEBHOOK_URL }}

--- a/provider-ci/providers/azuredevops/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/azuredevops/repo/.github/workflows/master.yml
@@ -291,7 +291,7 @@ jobs:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
-        SLACK_MESSAGE: " Publish failed :x:"
+        SLACK_MESSAGE: "Publish failed :x:"
         SLACK_TITLE: ${{ github.event.repository.name }} upgrade result
         SLACK_USERNAME: provider-bot
         SLACK_WEBHOOK: ${{ env.SLACK_WEBHOOK_URL }}

--- a/provider-ci/providers/azuredevops/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/azuredevops/repo/.github/workflows/prerelease.yml
@@ -241,7 +241,7 @@ jobs:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
-        SLACK_MESSAGE: " Publish failed :x:"
+        SLACK_MESSAGE: "Publish failed :x:"
         SLACK_TITLE: ${{ github.event.repository.name }} upgrade result
         SLACK_USERNAME: provider-bot
         SLACK_WEBHOOK: ${{ env.SLACK_WEBHOOK_URL }}

--- a/provider-ci/providers/azuredevops/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/azuredevops/repo/.github/workflows/release.yml
@@ -253,7 +253,7 @@ jobs:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
-        SLACK_MESSAGE: " Publish failed :x:"
+        SLACK_MESSAGE: "Publish failed :x:"
         SLACK_TITLE: ${{ github.event.repository.name }} upgrade result
         SLACK_USERNAME: provider-bot
         SLACK_WEBHOOK: ${{ env.SLACK_WEBHOOK_URL }}

--- a/provider-ci/providers/azuredevops/repo/.github/workflows/upgrade-provider.yml
+++ b/provider-ci/providers/azuredevops/repo/.github/workflows/upgrade-provider.yml
@@ -14,6 +14,30 @@ jobs:
       with:
         slack-channel: provider-upgrade-status
         slack-webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
+    - env:
+        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_COLOR: "#FF0000"
+        SLACK_ICON_EMOJI: ":taco:"
+        SLACK_MESSAGE: >-
+          Upgrade succeeded :heart_decoration:
+
+          PR opened at github.com/pulumi/${{ github.event.repository.name }}/pulls
+        SLACK_TITLE: ${{ github.event.repository.name }} upgrade result
+        SLACK_USERNAME: provider-bot
+        SLACK_WEBHOOK: ${{ env.SLACK_WEBHOOK_URL }}
+      name: Send Upgrade Success To Slack
+      uses: rtCamp/action-slack-notify@v2
+    - env:
+        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_COLOR: "#FF0000"
+        SLACK_ICON_EMOJI: ":taco:"
+        SLACK_MESSAGE: " Upgrade failed :x:"
+        SLACK_TITLE: ${{ github.event.repository.name }} upgrade result
+        SLACK_USERNAME: provider-bot
+        SLACK_WEBHOOK: ${{ env.SLACK_WEBHOOK_URL }}
+      if: failure()
+      name: Send Upgrade Failure To Slack
+      uses: rtCamp/action-slack-notify@v2
 name: Upgrade provider
 on:
   issues:

--- a/provider-ci/providers/azuredevops/repo/.github/workflows/upgrade-provider.yml
+++ b/provider-ci/providers/azuredevops/repo/.github/workflows/upgrade-provider.yml
@@ -5,7 +5,7 @@ env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 jobs:
   upgrade_provider:
-    if: contains(github.event.issue.title, 'Upgrade terraform-provider-')
+    if: contains(${{ github.event.issue.title }}, 'Upgrade terraform-provider-')
     name: upgrade-provider
     runs-on: ubuntu-latest
     steps:

--- a/provider-ci/providers/civo/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/civo/repo/.github/workflows/main.yml
@@ -361,7 +361,7 @@ jobs:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
-        SLACK_MESSAGE: " Publish failed :x:"
+        SLACK_MESSAGE: "Publish failed :x:"
         SLACK_TITLE: ${{ github.event.repository.name }} upgrade result
         SLACK_USERNAME: provider-bot
         SLACK_WEBHOOK: ${{ env.SLACK_WEBHOOK_URL }}

--- a/provider-ci/providers/civo/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/civo/repo/.github/workflows/master.yml
@@ -361,7 +361,7 @@ jobs:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
-        SLACK_MESSAGE: " Publish failed :x:"
+        SLACK_MESSAGE: "Publish failed :x:"
         SLACK_TITLE: ${{ github.event.repository.name }} upgrade result
         SLACK_USERNAME: provider-bot
         SLACK_WEBHOOK: ${{ env.SLACK_WEBHOOK_URL }}

--- a/provider-ci/providers/civo/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/civo/repo/.github/workflows/prerelease.yml
@@ -311,7 +311,7 @@ jobs:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
-        SLACK_MESSAGE: " Publish failed :x:"
+        SLACK_MESSAGE: "Publish failed :x:"
         SLACK_TITLE: ${{ github.event.repository.name }} upgrade result
         SLACK_USERNAME: provider-bot
         SLACK_WEBHOOK: ${{ env.SLACK_WEBHOOK_URL }}

--- a/provider-ci/providers/civo/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/civo/repo/.github/workflows/release.yml
@@ -323,7 +323,7 @@ jobs:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
-        SLACK_MESSAGE: " Publish failed :x:"
+        SLACK_MESSAGE: "Publish failed :x:"
         SLACK_TITLE: ${{ github.event.repository.name }} upgrade result
         SLACK_USERNAME: provider-bot
         SLACK_WEBHOOK: ${{ env.SLACK_WEBHOOK_URL }}

--- a/provider-ci/providers/civo/repo/.github/workflows/upgrade-provider.yml
+++ b/provider-ci/providers/civo/repo/.github/workflows/upgrade-provider.yml
@@ -14,6 +14,30 @@ jobs:
       with:
         slack-channel: provider-upgrade-status
         slack-webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
+    - env:
+        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_COLOR: "#FF0000"
+        SLACK_ICON_EMOJI: ":taco:"
+        SLACK_MESSAGE: >-
+          Upgrade succeeded :heart_decoration:
+
+          PR opened at github.com/pulumi/${{ github.event.repository.name }}/pulls
+        SLACK_TITLE: ${{ github.event.repository.name }} upgrade result
+        SLACK_USERNAME: provider-bot
+        SLACK_WEBHOOK: ${{ env.SLACK_WEBHOOK_URL }}
+      name: Send Upgrade Success To Slack
+      uses: rtCamp/action-slack-notify@v2
+    - env:
+        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_COLOR: "#FF0000"
+        SLACK_ICON_EMOJI: ":taco:"
+        SLACK_MESSAGE: " Upgrade failed :x:"
+        SLACK_TITLE: ${{ github.event.repository.name }} upgrade result
+        SLACK_USERNAME: provider-bot
+        SLACK_WEBHOOK: ${{ env.SLACK_WEBHOOK_URL }}
+      if: failure()
+      name: Send Upgrade Failure To Slack
+      uses: rtCamp/action-slack-notify@v2
 name: Upgrade provider
 on:
   issues:

--- a/provider-ci/providers/civo/repo/.github/workflows/upgrade-provider.yml
+++ b/provider-ci/providers/civo/repo/.github/workflows/upgrade-provider.yml
@@ -5,7 +5,7 @@ env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 jobs:
   upgrade_provider:
-    if: contains(github.event.issue.title, 'Upgrade terraform-provider-')
+    if: contains(${{ github.event.issue.title }}, 'Upgrade terraform-provider-')
     name: upgrade-provider
     runs-on: ubuntu-latest
     steps:

--- a/provider-ci/providers/cloudamqp/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/cloudamqp/repo/.github/workflows/main.yml
@@ -360,7 +360,7 @@ jobs:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
-        SLACK_MESSAGE: " Publish failed :x:"
+        SLACK_MESSAGE: "Publish failed :x:"
         SLACK_TITLE: ${{ github.event.repository.name }} upgrade result
         SLACK_USERNAME: provider-bot
         SLACK_WEBHOOK: ${{ env.SLACK_WEBHOOK_URL }}

--- a/provider-ci/providers/cloudamqp/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/cloudamqp/repo/.github/workflows/master.yml
@@ -360,7 +360,7 @@ jobs:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
-        SLACK_MESSAGE: " Publish failed :x:"
+        SLACK_MESSAGE: "Publish failed :x:"
         SLACK_TITLE: ${{ github.event.repository.name }} upgrade result
         SLACK_USERNAME: provider-bot
         SLACK_WEBHOOK: ${{ env.SLACK_WEBHOOK_URL }}

--- a/provider-ci/providers/cloudamqp/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/cloudamqp/repo/.github/workflows/prerelease.yml
@@ -310,7 +310,7 @@ jobs:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
-        SLACK_MESSAGE: " Publish failed :x:"
+        SLACK_MESSAGE: "Publish failed :x:"
         SLACK_TITLE: ${{ github.event.repository.name }} upgrade result
         SLACK_USERNAME: provider-bot
         SLACK_WEBHOOK: ${{ env.SLACK_WEBHOOK_URL }}

--- a/provider-ci/providers/cloudamqp/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/cloudamqp/repo/.github/workflows/release.yml
@@ -322,7 +322,7 @@ jobs:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
-        SLACK_MESSAGE: " Publish failed :x:"
+        SLACK_MESSAGE: "Publish failed :x:"
         SLACK_TITLE: ${{ github.event.repository.name }} upgrade result
         SLACK_USERNAME: provider-bot
         SLACK_WEBHOOK: ${{ env.SLACK_WEBHOOK_URL }}

--- a/provider-ci/providers/cloudamqp/repo/.github/workflows/upgrade-provider.yml
+++ b/provider-ci/providers/cloudamqp/repo/.github/workflows/upgrade-provider.yml
@@ -14,6 +14,30 @@ jobs:
       with:
         slack-channel: provider-upgrade-status
         slack-webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
+    - env:
+        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_COLOR: "#FF0000"
+        SLACK_ICON_EMOJI: ":taco:"
+        SLACK_MESSAGE: >-
+          Upgrade succeeded :heart_decoration:
+
+          PR opened at github.com/pulumi/${{ github.event.repository.name }}/pulls
+        SLACK_TITLE: ${{ github.event.repository.name }} upgrade result
+        SLACK_USERNAME: provider-bot
+        SLACK_WEBHOOK: ${{ env.SLACK_WEBHOOK_URL }}
+      name: Send Upgrade Success To Slack
+      uses: rtCamp/action-slack-notify@v2
+    - env:
+        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_COLOR: "#FF0000"
+        SLACK_ICON_EMOJI: ":taco:"
+        SLACK_MESSAGE: " Upgrade failed :x:"
+        SLACK_TITLE: ${{ github.event.repository.name }} upgrade result
+        SLACK_USERNAME: provider-bot
+        SLACK_WEBHOOK: ${{ env.SLACK_WEBHOOK_URL }}
+      if: failure()
+      name: Send Upgrade Failure To Slack
+      uses: rtCamp/action-slack-notify@v2
 name: Upgrade provider
 on:
   issues:

--- a/provider-ci/providers/cloudamqp/repo/.github/workflows/upgrade-provider.yml
+++ b/provider-ci/providers/cloudamqp/repo/.github/workflows/upgrade-provider.yml
@@ -5,7 +5,7 @@ env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 jobs:
   upgrade_provider:
-    if: contains(github.event.issue.title, 'Upgrade terraform-provider-')
+    if: contains(${{ github.event.issue.title }}, 'Upgrade terraform-provider-')
     name: upgrade-provider
     runs-on: ubuntu-latest
     steps:

--- a/provider-ci/providers/cloudflare/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/cloudflare/repo/.github/workflows/main.yml
@@ -360,7 +360,7 @@ jobs:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
-        SLACK_MESSAGE: " Publish failed :x:"
+        SLACK_MESSAGE: "Publish failed :x:"
         SLACK_TITLE: ${{ github.event.repository.name }} upgrade result
         SLACK_USERNAME: provider-bot
         SLACK_WEBHOOK: ${{ env.SLACK_WEBHOOK_URL }}

--- a/provider-ci/providers/cloudflare/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/cloudflare/repo/.github/workflows/master.yml
@@ -360,7 +360,7 @@ jobs:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
-        SLACK_MESSAGE: " Publish failed :x:"
+        SLACK_MESSAGE: "Publish failed :x:"
         SLACK_TITLE: ${{ github.event.repository.name }} upgrade result
         SLACK_USERNAME: provider-bot
         SLACK_WEBHOOK: ${{ env.SLACK_WEBHOOK_URL }}

--- a/provider-ci/providers/cloudflare/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/cloudflare/repo/.github/workflows/prerelease.yml
@@ -310,7 +310,7 @@ jobs:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
-        SLACK_MESSAGE: " Publish failed :x:"
+        SLACK_MESSAGE: "Publish failed :x:"
         SLACK_TITLE: ${{ github.event.repository.name }} upgrade result
         SLACK_USERNAME: provider-bot
         SLACK_WEBHOOK: ${{ env.SLACK_WEBHOOK_URL }}

--- a/provider-ci/providers/cloudflare/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/cloudflare/repo/.github/workflows/release.yml
@@ -322,7 +322,7 @@ jobs:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
-        SLACK_MESSAGE: " Publish failed :x:"
+        SLACK_MESSAGE: "Publish failed :x:"
         SLACK_TITLE: ${{ github.event.repository.name }} upgrade result
         SLACK_USERNAME: provider-bot
         SLACK_WEBHOOK: ${{ env.SLACK_WEBHOOK_URL }}

--- a/provider-ci/providers/cloudflare/repo/.github/workflows/upgrade-provider.yml
+++ b/provider-ci/providers/cloudflare/repo/.github/workflows/upgrade-provider.yml
@@ -14,6 +14,30 @@ jobs:
       with:
         slack-channel: provider-upgrade-status
         slack-webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
+    - env:
+        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_COLOR: "#FF0000"
+        SLACK_ICON_EMOJI: ":taco:"
+        SLACK_MESSAGE: >-
+          Upgrade succeeded :heart_decoration:
+
+          PR opened at github.com/pulumi/${{ github.event.repository.name }}/pulls
+        SLACK_TITLE: ${{ github.event.repository.name }} upgrade result
+        SLACK_USERNAME: provider-bot
+        SLACK_WEBHOOK: ${{ env.SLACK_WEBHOOK_URL }}
+      name: Send Upgrade Success To Slack
+      uses: rtCamp/action-slack-notify@v2
+    - env:
+        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_COLOR: "#FF0000"
+        SLACK_ICON_EMOJI: ":taco:"
+        SLACK_MESSAGE: " Upgrade failed :x:"
+        SLACK_TITLE: ${{ github.event.repository.name }} upgrade result
+        SLACK_USERNAME: provider-bot
+        SLACK_WEBHOOK: ${{ env.SLACK_WEBHOOK_URL }}
+      if: failure()
+      name: Send Upgrade Failure To Slack
+      uses: rtCamp/action-slack-notify@v2
 name: Upgrade provider
 on:
   issues:

--- a/provider-ci/providers/cloudflare/repo/.github/workflows/upgrade-provider.yml
+++ b/provider-ci/providers/cloudflare/repo/.github/workflows/upgrade-provider.yml
@@ -5,7 +5,7 @@ env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 jobs:
   upgrade_provider:
-    if: contains(github.event.issue.title, 'Upgrade terraform-provider-')
+    if: contains(${{ github.event.issue.title }}, 'Upgrade terraform-provider-')
     name: upgrade-provider
     runs-on: ubuntu-latest
     steps:

--- a/provider-ci/providers/cloudinit/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/cloudinit/repo/.github/workflows/main.yml
@@ -289,7 +289,7 @@ jobs:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
-        SLACK_MESSAGE: " Publish failed :x:"
+        SLACK_MESSAGE: "Publish failed :x:"
         SLACK_TITLE: ${{ github.event.repository.name }} upgrade result
         SLACK_USERNAME: provider-bot
         SLACK_WEBHOOK: ${{ env.SLACK_WEBHOOK_URL }}

--- a/provider-ci/providers/cloudinit/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/cloudinit/repo/.github/workflows/master.yml
@@ -289,7 +289,7 @@ jobs:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
-        SLACK_MESSAGE: " Publish failed :x:"
+        SLACK_MESSAGE: "Publish failed :x:"
         SLACK_TITLE: ${{ github.event.repository.name }} upgrade result
         SLACK_USERNAME: provider-bot
         SLACK_WEBHOOK: ${{ env.SLACK_WEBHOOK_URL }}

--- a/provider-ci/providers/cloudinit/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/cloudinit/repo/.github/workflows/prerelease.yml
@@ -239,7 +239,7 @@ jobs:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
-        SLACK_MESSAGE: " Publish failed :x:"
+        SLACK_MESSAGE: "Publish failed :x:"
         SLACK_TITLE: ${{ github.event.repository.name }} upgrade result
         SLACK_USERNAME: provider-bot
         SLACK_WEBHOOK: ${{ env.SLACK_WEBHOOK_URL }}

--- a/provider-ci/providers/cloudinit/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/cloudinit/repo/.github/workflows/release.yml
@@ -251,7 +251,7 @@ jobs:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
-        SLACK_MESSAGE: " Publish failed :x:"
+        SLACK_MESSAGE: "Publish failed :x:"
         SLACK_TITLE: ${{ github.event.repository.name }} upgrade result
         SLACK_USERNAME: provider-bot
         SLACK_WEBHOOK: ${{ env.SLACK_WEBHOOK_URL }}

--- a/provider-ci/providers/cloudinit/repo/.github/workflows/upgrade-provider.yml
+++ b/provider-ci/providers/cloudinit/repo/.github/workflows/upgrade-provider.yml
@@ -14,6 +14,30 @@ jobs:
       with:
         slack-channel: provider-upgrade-status
         slack-webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
+    - env:
+        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_COLOR: "#FF0000"
+        SLACK_ICON_EMOJI: ":taco:"
+        SLACK_MESSAGE: >-
+          Upgrade succeeded :heart_decoration:
+
+          PR opened at github.com/pulumi/${{ github.event.repository.name }}/pulls
+        SLACK_TITLE: ${{ github.event.repository.name }} upgrade result
+        SLACK_USERNAME: provider-bot
+        SLACK_WEBHOOK: ${{ env.SLACK_WEBHOOK_URL }}
+      name: Send Upgrade Success To Slack
+      uses: rtCamp/action-slack-notify@v2
+    - env:
+        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_COLOR: "#FF0000"
+        SLACK_ICON_EMOJI: ":taco:"
+        SLACK_MESSAGE: " Upgrade failed :x:"
+        SLACK_TITLE: ${{ github.event.repository.name }} upgrade result
+        SLACK_USERNAME: provider-bot
+        SLACK_WEBHOOK: ${{ env.SLACK_WEBHOOK_URL }}
+      if: failure()
+      name: Send Upgrade Failure To Slack
+      uses: rtCamp/action-slack-notify@v2
 name: Upgrade provider
 on:
   issues:

--- a/provider-ci/providers/cloudinit/repo/.github/workflows/upgrade-provider.yml
+++ b/provider-ci/providers/cloudinit/repo/.github/workflows/upgrade-provider.yml
@@ -5,7 +5,7 @@ env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 jobs:
   upgrade_provider:
-    if: contains(github.event.issue.title, 'Upgrade terraform-provider-')
+    if: contains(${{ github.event.issue.title }}, 'Upgrade terraform-provider-')
     name: upgrade-provider
     runs-on: ubuntu-latest
     steps:

--- a/provider-ci/providers/confluentcloud/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/confluentcloud/repo/.github/workflows/main.yml
@@ -291,7 +291,7 @@ jobs:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
-        SLACK_MESSAGE: " Publish failed :x:"
+        SLACK_MESSAGE: "Publish failed :x:"
         SLACK_TITLE: ${{ github.event.repository.name }} upgrade result
         SLACK_USERNAME: provider-bot
         SLACK_WEBHOOK: ${{ env.SLACK_WEBHOOK_URL }}

--- a/provider-ci/providers/confluentcloud/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/confluentcloud/repo/.github/workflows/master.yml
@@ -291,7 +291,7 @@ jobs:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
-        SLACK_MESSAGE: " Publish failed :x:"
+        SLACK_MESSAGE: "Publish failed :x:"
         SLACK_TITLE: ${{ github.event.repository.name }} upgrade result
         SLACK_USERNAME: provider-bot
         SLACK_WEBHOOK: ${{ env.SLACK_WEBHOOK_URL }}

--- a/provider-ci/providers/confluentcloud/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/confluentcloud/repo/.github/workflows/prerelease.yml
@@ -241,7 +241,7 @@ jobs:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
-        SLACK_MESSAGE: " Publish failed :x:"
+        SLACK_MESSAGE: "Publish failed :x:"
         SLACK_TITLE: ${{ github.event.repository.name }} upgrade result
         SLACK_USERNAME: provider-bot
         SLACK_WEBHOOK: ${{ env.SLACK_WEBHOOK_URL }}

--- a/provider-ci/providers/confluentcloud/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/confluentcloud/repo/.github/workflows/release.yml
@@ -253,7 +253,7 @@ jobs:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
-        SLACK_MESSAGE: " Publish failed :x:"
+        SLACK_MESSAGE: "Publish failed :x:"
         SLACK_TITLE: ${{ github.event.repository.name }} upgrade result
         SLACK_USERNAME: provider-bot
         SLACK_WEBHOOK: ${{ env.SLACK_WEBHOOK_URL }}

--- a/provider-ci/providers/confluentcloud/repo/.github/workflows/upgrade-provider.yml
+++ b/provider-ci/providers/confluentcloud/repo/.github/workflows/upgrade-provider.yml
@@ -14,6 +14,30 @@ jobs:
       with:
         slack-channel: provider-upgrade-status
         slack-webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
+    - env:
+        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_COLOR: "#FF0000"
+        SLACK_ICON_EMOJI: ":taco:"
+        SLACK_MESSAGE: >-
+          Upgrade succeeded :heart_decoration:
+
+          PR opened at github.com/pulumi/${{ github.event.repository.name }}/pulls
+        SLACK_TITLE: ${{ github.event.repository.name }} upgrade result
+        SLACK_USERNAME: provider-bot
+        SLACK_WEBHOOK: ${{ env.SLACK_WEBHOOK_URL }}
+      name: Send Upgrade Success To Slack
+      uses: rtCamp/action-slack-notify@v2
+    - env:
+        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_COLOR: "#FF0000"
+        SLACK_ICON_EMOJI: ":taco:"
+        SLACK_MESSAGE: " Upgrade failed :x:"
+        SLACK_TITLE: ${{ github.event.repository.name }} upgrade result
+        SLACK_USERNAME: provider-bot
+        SLACK_WEBHOOK: ${{ env.SLACK_WEBHOOK_URL }}
+      if: failure()
+      name: Send Upgrade Failure To Slack
+      uses: rtCamp/action-slack-notify@v2
 name: Upgrade provider
 on:
   issues:

--- a/provider-ci/providers/confluentcloud/repo/.github/workflows/upgrade-provider.yml
+++ b/provider-ci/providers/confluentcloud/repo/.github/workflows/upgrade-provider.yml
@@ -5,7 +5,7 @@ env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 jobs:
   upgrade_provider:
-    if: contains(github.event.issue.title, 'Upgrade terraform-provider-')
+    if: contains(${{ github.event.issue.title }}, 'Upgrade terraform-provider-')
     name: upgrade-provider
     runs-on: ubuntu-latest
     steps:

--- a/provider-ci/providers/consul/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/consul/repo/.github/workflows/main.yml
@@ -360,7 +360,7 @@ jobs:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
-        SLACK_MESSAGE: " Publish failed :x:"
+        SLACK_MESSAGE: "Publish failed :x:"
         SLACK_TITLE: ${{ github.event.repository.name }} upgrade result
         SLACK_USERNAME: provider-bot
         SLACK_WEBHOOK: ${{ env.SLACK_WEBHOOK_URL }}

--- a/provider-ci/providers/consul/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/consul/repo/.github/workflows/master.yml
@@ -360,7 +360,7 @@ jobs:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
-        SLACK_MESSAGE: " Publish failed :x:"
+        SLACK_MESSAGE: "Publish failed :x:"
         SLACK_TITLE: ${{ github.event.repository.name }} upgrade result
         SLACK_USERNAME: provider-bot
         SLACK_WEBHOOK: ${{ env.SLACK_WEBHOOK_URL }}

--- a/provider-ci/providers/consul/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/consul/repo/.github/workflows/prerelease.yml
@@ -310,7 +310,7 @@ jobs:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
-        SLACK_MESSAGE: " Publish failed :x:"
+        SLACK_MESSAGE: "Publish failed :x:"
         SLACK_TITLE: ${{ github.event.repository.name }} upgrade result
         SLACK_USERNAME: provider-bot
         SLACK_WEBHOOK: ${{ env.SLACK_WEBHOOK_URL }}

--- a/provider-ci/providers/consul/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/consul/repo/.github/workflows/release.yml
@@ -322,7 +322,7 @@ jobs:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
-        SLACK_MESSAGE: " Publish failed :x:"
+        SLACK_MESSAGE: "Publish failed :x:"
         SLACK_TITLE: ${{ github.event.repository.name }} upgrade result
         SLACK_USERNAME: provider-bot
         SLACK_WEBHOOK: ${{ env.SLACK_WEBHOOK_URL }}

--- a/provider-ci/providers/consul/repo/.github/workflows/upgrade-provider.yml
+++ b/provider-ci/providers/consul/repo/.github/workflows/upgrade-provider.yml
@@ -14,6 +14,30 @@ jobs:
       with:
         slack-channel: provider-upgrade-status
         slack-webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
+    - env:
+        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_COLOR: "#FF0000"
+        SLACK_ICON_EMOJI: ":taco:"
+        SLACK_MESSAGE: >-
+          Upgrade succeeded :heart_decoration:
+
+          PR opened at github.com/pulumi/${{ github.event.repository.name }}/pulls
+        SLACK_TITLE: ${{ github.event.repository.name }} upgrade result
+        SLACK_USERNAME: provider-bot
+        SLACK_WEBHOOK: ${{ env.SLACK_WEBHOOK_URL }}
+      name: Send Upgrade Success To Slack
+      uses: rtCamp/action-slack-notify@v2
+    - env:
+        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_COLOR: "#FF0000"
+        SLACK_ICON_EMOJI: ":taco:"
+        SLACK_MESSAGE: " Upgrade failed :x:"
+        SLACK_TITLE: ${{ github.event.repository.name }} upgrade result
+        SLACK_USERNAME: provider-bot
+        SLACK_WEBHOOK: ${{ env.SLACK_WEBHOOK_URL }}
+      if: failure()
+      name: Send Upgrade Failure To Slack
+      uses: rtCamp/action-slack-notify@v2
 name: Upgrade provider
 on:
   issues:

--- a/provider-ci/providers/consul/repo/.github/workflows/upgrade-provider.yml
+++ b/provider-ci/providers/consul/repo/.github/workflows/upgrade-provider.yml
@@ -5,7 +5,7 @@ env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 jobs:
   upgrade_provider:
-    if: contains(github.event.issue.title, 'Upgrade terraform-provider-')
+    if: contains(${{ github.event.issue.title }}, 'Upgrade terraform-provider-')
     name: upgrade-provider
     runs-on: ubuntu-latest
     steps:

--- a/provider-ci/providers/databricks/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/databricks/repo/.github/workflows/main.yml
@@ -364,7 +364,7 @@ jobs:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
-        SLACK_MESSAGE: " Publish failed :x:"
+        SLACK_MESSAGE: "Publish failed :x:"
         SLACK_TITLE: ${{ github.event.repository.name }} upgrade result
         SLACK_USERNAME: provider-bot
         SLACK_WEBHOOK: ${{ env.SLACK_WEBHOOK_URL }}

--- a/provider-ci/providers/databricks/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/databricks/repo/.github/workflows/master.yml
@@ -364,7 +364,7 @@ jobs:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
-        SLACK_MESSAGE: " Publish failed :x:"
+        SLACK_MESSAGE: "Publish failed :x:"
         SLACK_TITLE: ${{ github.event.repository.name }} upgrade result
         SLACK_USERNAME: provider-bot
         SLACK_WEBHOOK: ${{ env.SLACK_WEBHOOK_URL }}

--- a/provider-ci/providers/databricks/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/databricks/repo/.github/workflows/prerelease.yml
@@ -314,7 +314,7 @@ jobs:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
-        SLACK_MESSAGE: " Publish failed :x:"
+        SLACK_MESSAGE: "Publish failed :x:"
         SLACK_TITLE: ${{ github.event.repository.name }} upgrade result
         SLACK_USERNAME: provider-bot
         SLACK_WEBHOOK: ${{ env.SLACK_WEBHOOK_URL }}

--- a/provider-ci/providers/databricks/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/databricks/repo/.github/workflows/release.yml
@@ -326,7 +326,7 @@ jobs:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
-        SLACK_MESSAGE: " Publish failed :x:"
+        SLACK_MESSAGE: "Publish failed :x:"
         SLACK_TITLE: ${{ github.event.repository.name }} upgrade result
         SLACK_USERNAME: provider-bot
         SLACK_WEBHOOK: ${{ env.SLACK_WEBHOOK_URL }}

--- a/provider-ci/providers/databricks/repo/.github/workflows/upgrade-provider.yml
+++ b/provider-ci/providers/databricks/repo/.github/workflows/upgrade-provider.yml
@@ -14,6 +14,30 @@ jobs:
       with:
         slack-channel: provider-upgrade-status
         slack-webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
+    - env:
+        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_COLOR: "#FF0000"
+        SLACK_ICON_EMOJI: ":taco:"
+        SLACK_MESSAGE: >-
+          Upgrade succeeded :heart_decoration:
+
+          PR opened at github.com/pulumi/${{ github.event.repository.name }}/pulls
+        SLACK_TITLE: ${{ github.event.repository.name }} upgrade result
+        SLACK_USERNAME: provider-bot
+        SLACK_WEBHOOK: ${{ env.SLACK_WEBHOOK_URL }}
+      name: Send Upgrade Success To Slack
+      uses: rtCamp/action-slack-notify@v2
+    - env:
+        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_COLOR: "#FF0000"
+        SLACK_ICON_EMOJI: ":taco:"
+        SLACK_MESSAGE: " Upgrade failed :x:"
+        SLACK_TITLE: ${{ github.event.repository.name }} upgrade result
+        SLACK_USERNAME: provider-bot
+        SLACK_WEBHOOK: ${{ env.SLACK_WEBHOOK_URL }}
+      if: failure()
+      name: Send Upgrade Failure To Slack
+      uses: rtCamp/action-slack-notify@v2
 name: Upgrade provider
 on:
   issues:

--- a/provider-ci/providers/databricks/repo/.github/workflows/upgrade-provider.yml
+++ b/provider-ci/providers/databricks/repo/.github/workflows/upgrade-provider.yml
@@ -5,7 +5,7 @@ env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 jobs:
   upgrade_provider:
-    if: contains(github.event.issue.title, 'Upgrade terraform-provider-')
+    if: contains(${{ github.event.issue.title }}, 'Upgrade terraform-provider-')
     name: upgrade-provider
     runs-on: ubuntu-latest
     steps:

--- a/provider-ci/providers/datadog/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/datadog/repo/.github/workflows/main.yml
@@ -289,7 +289,7 @@ jobs:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
-        SLACK_MESSAGE: " Publish failed :x:"
+        SLACK_MESSAGE: "Publish failed :x:"
         SLACK_TITLE: ${{ github.event.repository.name }} upgrade result
         SLACK_USERNAME: provider-bot
         SLACK_WEBHOOK: ${{ env.SLACK_WEBHOOK_URL }}

--- a/provider-ci/providers/datadog/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/datadog/repo/.github/workflows/master.yml
@@ -289,7 +289,7 @@ jobs:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
-        SLACK_MESSAGE: " Publish failed :x:"
+        SLACK_MESSAGE: "Publish failed :x:"
         SLACK_TITLE: ${{ github.event.repository.name }} upgrade result
         SLACK_USERNAME: provider-bot
         SLACK_WEBHOOK: ${{ env.SLACK_WEBHOOK_URL }}

--- a/provider-ci/providers/datadog/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/datadog/repo/.github/workflows/prerelease.yml
@@ -239,7 +239,7 @@ jobs:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
-        SLACK_MESSAGE: " Publish failed :x:"
+        SLACK_MESSAGE: "Publish failed :x:"
         SLACK_TITLE: ${{ github.event.repository.name }} upgrade result
         SLACK_USERNAME: provider-bot
         SLACK_WEBHOOK: ${{ env.SLACK_WEBHOOK_URL }}

--- a/provider-ci/providers/datadog/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/datadog/repo/.github/workflows/release.yml
@@ -251,7 +251,7 @@ jobs:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
-        SLACK_MESSAGE: " Publish failed :x:"
+        SLACK_MESSAGE: "Publish failed :x:"
         SLACK_TITLE: ${{ github.event.repository.name }} upgrade result
         SLACK_USERNAME: provider-bot
         SLACK_WEBHOOK: ${{ env.SLACK_WEBHOOK_URL }}

--- a/provider-ci/providers/datadog/repo/.github/workflows/upgrade-provider.yml
+++ b/provider-ci/providers/datadog/repo/.github/workflows/upgrade-provider.yml
@@ -14,6 +14,30 @@ jobs:
       with:
         slack-channel: provider-upgrade-status
         slack-webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
+    - env:
+        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_COLOR: "#FF0000"
+        SLACK_ICON_EMOJI: ":taco:"
+        SLACK_MESSAGE: >-
+          Upgrade succeeded :heart_decoration:
+
+          PR opened at github.com/pulumi/${{ github.event.repository.name }}/pulls
+        SLACK_TITLE: ${{ github.event.repository.name }} upgrade result
+        SLACK_USERNAME: provider-bot
+        SLACK_WEBHOOK: ${{ env.SLACK_WEBHOOK_URL }}
+      name: Send Upgrade Success To Slack
+      uses: rtCamp/action-slack-notify@v2
+    - env:
+        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_COLOR: "#FF0000"
+        SLACK_ICON_EMOJI: ":taco:"
+        SLACK_MESSAGE: " Upgrade failed :x:"
+        SLACK_TITLE: ${{ github.event.repository.name }} upgrade result
+        SLACK_USERNAME: provider-bot
+        SLACK_WEBHOOK: ${{ env.SLACK_WEBHOOK_URL }}
+      if: failure()
+      name: Send Upgrade Failure To Slack
+      uses: rtCamp/action-slack-notify@v2
 name: Upgrade provider
 on:
   issues:

--- a/provider-ci/providers/datadog/repo/.github/workflows/upgrade-provider.yml
+++ b/provider-ci/providers/datadog/repo/.github/workflows/upgrade-provider.yml
@@ -5,7 +5,7 @@ env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 jobs:
   upgrade_provider:
-    if: contains(github.event.issue.title, 'Upgrade terraform-provider-')
+    if: contains(${{ github.event.issue.title }}, 'Upgrade terraform-provider-')
     name: upgrade-provider
     runs-on: ubuntu-latest
     steps:

--- a/provider-ci/providers/digitalocean/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/digitalocean/repo/.github/workflows/main.yml
@@ -361,7 +361,7 @@ jobs:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
-        SLACK_MESSAGE: " Publish failed :x:"
+        SLACK_MESSAGE: "Publish failed :x:"
         SLACK_TITLE: ${{ github.event.repository.name }} upgrade result
         SLACK_USERNAME: provider-bot
         SLACK_WEBHOOK: ${{ env.SLACK_WEBHOOK_URL }}

--- a/provider-ci/providers/digitalocean/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/digitalocean/repo/.github/workflows/master.yml
@@ -361,7 +361,7 @@ jobs:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
-        SLACK_MESSAGE: " Publish failed :x:"
+        SLACK_MESSAGE: "Publish failed :x:"
         SLACK_TITLE: ${{ github.event.repository.name }} upgrade result
         SLACK_USERNAME: provider-bot
         SLACK_WEBHOOK: ${{ env.SLACK_WEBHOOK_URL }}

--- a/provider-ci/providers/digitalocean/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/digitalocean/repo/.github/workflows/prerelease.yml
@@ -311,7 +311,7 @@ jobs:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
-        SLACK_MESSAGE: " Publish failed :x:"
+        SLACK_MESSAGE: "Publish failed :x:"
         SLACK_TITLE: ${{ github.event.repository.name }} upgrade result
         SLACK_USERNAME: provider-bot
         SLACK_WEBHOOK: ${{ env.SLACK_WEBHOOK_URL }}

--- a/provider-ci/providers/digitalocean/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/digitalocean/repo/.github/workflows/release.yml
@@ -323,7 +323,7 @@ jobs:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
-        SLACK_MESSAGE: " Publish failed :x:"
+        SLACK_MESSAGE: "Publish failed :x:"
         SLACK_TITLE: ${{ github.event.repository.name }} upgrade result
         SLACK_USERNAME: provider-bot
         SLACK_WEBHOOK: ${{ env.SLACK_WEBHOOK_URL }}

--- a/provider-ci/providers/digitalocean/repo/.github/workflows/upgrade-provider.yml
+++ b/provider-ci/providers/digitalocean/repo/.github/workflows/upgrade-provider.yml
@@ -14,6 +14,30 @@ jobs:
       with:
         slack-channel: provider-upgrade-status
         slack-webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
+    - env:
+        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_COLOR: "#FF0000"
+        SLACK_ICON_EMOJI: ":taco:"
+        SLACK_MESSAGE: >-
+          Upgrade succeeded :heart_decoration:
+
+          PR opened at github.com/pulumi/${{ github.event.repository.name }}/pulls
+        SLACK_TITLE: ${{ github.event.repository.name }} upgrade result
+        SLACK_USERNAME: provider-bot
+        SLACK_WEBHOOK: ${{ env.SLACK_WEBHOOK_URL }}
+      name: Send Upgrade Success To Slack
+      uses: rtCamp/action-slack-notify@v2
+    - env:
+        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_COLOR: "#FF0000"
+        SLACK_ICON_EMOJI: ":taco:"
+        SLACK_MESSAGE: " Upgrade failed :x:"
+        SLACK_TITLE: ${{ github.event.repository.name }} upgrade result
+        SLACK_USERNAME: provider-bot
+        SLACK_WEBHOOK: ${{ env.SLACK_WEBHOOK_URL }}
+      if: failure()
+      name: Send Upgrade Failure To Slack
+      uses: rtCamp/action-slack-notify@v2
 name: Upgrade provider
 on:
   issues:

--- a/provider-ci/providers/digitalocean/repo/.github/workflows/upgrade-provider.yml
+++ b/provider-ci/providers/digitalocean/repo/.github/workflows/upgrade-provider.yml
@@ -5,7 +5,7 @@ env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 jobs:
   upgrade_provider:
-    if: contains(github.event.issue.title, 'Upgrade terraform-provider-')
+    if: contains(${{ github.event.issue.title }}, 'Upgrade terraform-provider-')
     name: upgrade-provider
     runs-on: ubuntu-latest
     steps:

--- a/provider-ci/providers/dnsimple/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/dnsimple/repo/.github/workflows/main.yml
@@ -362,7 +362,7 @@ jobs:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
-        SLACK_MESSAGE: " Publish failed :x:"
+        SLACK_MESSAGE: "Publish failed :x:"
         SLACK_TITLE: ${{ github.event.repository.name }} upgrade result
         SLACK_USERNAME: provider-bot
         SLACK_WEBHOOK: ${{ env.SLACK_WEBHOOK_URL }}

--- a/provider-ci/providers/dnsimple/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/dnsimple/repo/.github/workflows/master.yml
@@ -362,7 +362,7 @@ jobs:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
-        SLACK_MESSAGE: " Publish failed :x:"
+        SLACK_MESSAGE: "Publish failed :x:"
         SLACK_TITLE: ${{ github.event.repository.name }} upgrade result
         SLACK_USERNAME: provider-bot
         SLACK_WEBHOOK: ${{ env.SLACK_WEBHOOK_URL }}

--- a/provider-ci/providers/dnsimple/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/dnsimple/repo/.github/workflows/prerelease.yml
@@ -312,7 +312,7 @@ jobs:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
-        SLACK_MESSAGE: " Publish failed :x:"
+        SLACK_MESSAGE: "Publish failed :x:"
         SLACK_TITLE: ${{ github.event.repository.name }} upgrade result
         SLACK_USERNAME: provider-bot
         SLACK_WEBHOOK: ${{ env.SLACK_WEBHOOK_URL }}

--- a/provider-ci/providers/dnsimple/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/dnsimple/repo/.github/workflows/release.yml
@@ -324,7 +324,7 @@ jobs:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
-        SLACK_MESSAGE: " Publish failed :x:"
+        SLACK_MESSAGE: "Publish failed :x:"
         SLACK_TITLE: ${{ github.event.repository.name }} upgrade result
         SLACK_USERNAME: provider-bot
         SLACK_WEBHOOK: ${{ env.SLACK_WEBHOOK_URL }}

--- a/provider-ci/providers/dnsimple/repo/.github/workflows/upgrade-provider.yml
+++ b/provider-ci/providers/dnsimple/repo/.github/workflows/upgrade-provider.yml
@@ -14,6 +14,30 @@ jobs:
       with:
         slack-channel: provider-upgrade-status
         slack-webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
+    - env:
+        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_COLOR: "#FF0000"
+        SLACK_ICON_EMOJI: ":taco:"
+        SLACK_MESSAGE: >-
+          Upgrade succeeded :heart_decoration:
+
+          PR opened at github.com/pulumi/${{ github.event.repository.name }}/pulls
+        SLACK_TITLE: ${{ github.event.repository.name }} upgrade result
+        SLACK_USERNAME: provider-bot
+        SLACK_WEBHOOK: ${{ env.SLACK_WEBHOOK_URL }}
+      name: Send Upgrade Success To Slack
+      uses: rtCamp/action-slack-notify@v2
+    - env:
+        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_COLOR: "#FF0000"
+        SLACK_ICON_EMOJI: ":taco:"
+        SLACK_MESSAGE: " Upgrade failed :x:"
+        SLACK_TITLE: ${{ github.event.repository.name }} upgrade result
+        SLACK_USERNAME: provider-bot
+        SLACK_WEBHOOK: ${{ env.SLACK_WEBHOOK_URL }}
+      if: failure()
+      name: Send Upgrade Failure To Slack
+      uses: rtCamp/action-slack-notify@v2
 name: Upgrade provider
 on:
   issues:

--- a/provider-ci/providers/dnsimple/repo/.github/workflows/upgrade-provider.yml
+++ b/provider-ci/providers/dnsimple/repo/.github/workflows/upgrade-provider.yml
@@ -5,7 +5,7 @@ env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 jobs:
   upgrade_provider:
-    if: contains(github.event.issue.title, 'Upgrade terraform-provider-')
+    if: contains(${{ github.event.issue.title }}, 'Upgrade terraform-provider-')
     name: upgrade-provider
     runs-on: ubuntu-latest
     steps:

--- a/provider-ci/providers/docker/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/docker/repo/.github/workflows/main.yml
@@ -374,7 +374,7 @@ jobs:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
-        SLACK_MESSAGE: " Publish failed :x:"
+        SLACK_MESSAGE: "Publish failed :x:"
         SLACK_TITLE: ${{ github.event.repository.name }} upgrade result
         SLACK_USERNAME: provider-bot
         SLACK_WEBHOOK: ${{ env.SLACK_WEBHOOK_URL }}

--- a/provider-ci/providers/docker/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/docker/repo/.github/workflows/master.yml
@@ -374,7 +374,7 @@ jobs:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
-        SLACK_MESSAGE: " Publish failed :x:"
+        SLACK_MESSAGE: "Publish failed :x:"
         SLACK_TITLE: ${{ github.event.repository.name }} upgrade result
         SLACK_USERNAME: provider-bot
         SLACK_WEBHOOK: ${{ env.SLACK_WEBHOOK_URL }}

--- a/provider-ci/providers/docker/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/docker/repo/.github/workflows/prerelease.yml
@@ -324,7 +324,7 @@ jobs:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
-        SLACK_MESSAGE: " Publish failed :x:"
+        SLACK_MESSAGE: "Publish failed :x:"
         SLACK_TITLE: ${{ github.event.repository.name }} upgrade result
         SLACK_USERNAME: provider-bot
         SLACK_WEBHOOK: ${{ env.SLACK_WEBHOOK_URL }}

--- a/provider-ci/providers/docker/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/docker/repo/.github/workflows/release.yml
@@ -336,7 +336,7 @@ jobs:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
-        SLACK_MESSAGE: " Publish failed :x:"
+        SLACK_MESSAGE: "Publish failed :x:"
         SLACK_TITLE: ${{ github.event.repository.name }} upgrade result
         SLACK_USERNAME: provider-bot
         SLACK_WEBHOOK: ${{ env.SLACK_WEBHOOK_URL }}

--- a/provider-ci/providers/docker/repo/.github/workflows/upgrade-provider.yml
+++ b/provider-ci/providers/docker/repo/.github/workflows/upgrade-provider.yml
@@ -14,6 +14,30 @@ jobs:
       with:
         slack-channel: provider-upgrade-status
         slack-webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
+    - env:
+        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_COLOR: "#FF0000"
+        SLACK_ICON_EMOJI: ":taco:"
+        SLACK_MESSAGE: >-
+          Upgrade succeeded :heart_decoration:
+
+          PR opened at github.com/pulumi/${{ github.event.repository.name }}/pulls
+        SLACK_TITLE: ${{ github.event.repository.name }} upgrade result
+        SLACK_USERNAME: provider-bot
+        SLACK_WEBHOOK: ${{ env.SLACK_WEBHOOK_URL }}
+      name: Send Upgrade Success To Slack
+      uses: rtCamp/action-slack-notify@v2
+    - env:
+        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_COLOR: "#FF0000"
+        SLACK_ICON_EMOJI: ":taco:"
+        SLACK_MESSAGE: " Upgrade failed :x:"
+        SLACK_TITLE: ${{ github.event.repository.name }} upgrade result
+        SLACK_USERNAME: provider-bot
+        SLACK_WEBHOOK: ${{ env.SLACK_WEBHOOK_URL }}
+      if: failure()
+      name: Send Upgrade Failure To Slack
+      uses: rtCamp/action-slack-notify@v2
 name: Upgrade provider
 on:
   issues:

--- a/provider-ci/providers/docker/repo/.github/workflows/upgrade-provider.yml
+++ b/provider-ci/providers/docker/repo/.github/workflows/upgrade-provider.yml
@@ -5,7 +5,7 @@ env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 jobs:
   upgrade_provider:
-    if: contains(github.event.issue.title, 'Upgrade terraform-provider-')
+    if: contains(${{ github.event.issue.title }}, 'Upgrade terraform-provider-')
     name: upgrade-provider
     runs-on: ubuntu-latest
     steps:

--- a/provider-ci/providers/ec/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/ec/repo/.github/workflows/main.yml
@@ -361,7 +361,7 @@ jobs:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
-        SLACK_MESSAGE: " Publish failed :x:"
+        SLACK_MESSAGE: "Publish failed :x:"
         SLACK_TITLE: ${{ github.event.repository.name }} upgrade result
         SLACK_USERNAME: provider-bot
         SLACK_WEBHOOK: ${{ env.SLACK_WEBHOOK_URL }}

--- a/provider-ci/providers/ec/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/ec/repo/.github/workflows/master.yml
@@ -361,7 +361,7 @@ jobs:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
-        SLACK_MESSAGE: " Publish failed :x:"
+        SLACK_MESSAGE: "Publish failed :x:"
         SLACK_TITLE: ${{ github.event.repository.name }} upgrade result
         SLACK_USERNAME: provider-bot
         SLACK_WEBHOOK: ${{ env.SLACK_WEBHOOK_URL }}

--- a/provider-ci/providers/ec/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/ec/repo/.github/workflows/prerelease.yml
@@ -311,7 +311,7 @@ jobs:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
-        SLACK_MESSAGE: " Publish failed :x:"
+        SLACK_MESSAGE: "Publish failed :x:"
         SLACK_TITLE: ${{ github.event.repository.name }} upgrade result
         SLACK_USERNAME: provider-bot
         SLACK_WEBHOOK: ${{ env.SLACK_WEBHOOK_URL }}

--- a/provider-ci/providers/ec/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/ec/repo/.github/workflows/release.yml
@@ -323,7 +323,7 @@ jobs:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
-        SLACK_MESSAGE: " Publish failed :x:"
+        SLACK_MESSAGE: "Publish failed :x:"
         SLACK_TITLE: ${{ github.event.repository.name }} upgrade result
         SLACK_USERNAME: provider-bot
         SLACK_WEBHOOK: ${{ env.SLACK_WEBHOOK_URL }}

--- a/provider-ci/providers/ec/repo/.github/workflows/upgrade-provider.yml
+++ b/provider-ci/providers/ec/repo/.github/workflows/upgrade-provider.yml
@@ -14,6 +14,30 @@ jobs:
       with:
         slack-channel: provider-upgrade-status
         slack-webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
+    - env:
+        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_COLOR: "#FF0000"
+        SLACK_ICON_EMOJI: ":taco:"
+        SLACK_MESSAGE: >-
+          Upgrade succeeded :heart_decoration:
+
+          PR opened at github.com/pulumi/${{ github.event.repository.name }}/pulls
+        SLACK_TITLE: ${{ github.event.repository.name }} upgrade result
+        SLACK_USERNAME: provider-bot
+        SLACK_WEBHOOK: ${{ env.SLACK_WEBHOOK_URL }}
+      name: Send Upgrade Success To Slack
+      uses: rtCamp/action-slack-notify@v2
+    - env:
+        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_COLOR: "#FF0000"
+        SLACK_ICON_EMOJI: ":taco:"
+        SLACK_MESSAGE: " Upgrade failed :x:"
+        SLACK_TITLE: ${{ github.event.repository.name }} upgrade result
+        SLACK_USERNAME: provider-bot
+        SLACK_WEBHOOK: ${{ env.SLACK_WEBHOOK_URL }}
+      if: failure()
+      name: Send Upgrade Failure To Slack
+      uses: rtCamp/action-slack-notify@v2
 name: Upgrade provider
 on:
   issues:

--- a/provider-ci/providers/ec/repo/.github/workflows/upgrade-provider.yml
+++ b/provider-ci/providers/ec/repo/.github/workflows/upgrade-provider.yml
@@ -5,7 +5,7 @@ env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 jobs:
   upgrade_provider:
-    if: contains(github.event.issue.title, 'Upgrade terraform-provider-')
+    if: contains(${{ github.event.issue.title }}, 'Upgrade terraform-provider-')
     name: upgrade-provider
     runs-on: ubuntu-latest
     steps:

--- a/provider-ci/providers/equinix-metal/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/equinix-metal/repo/.github/workflows/main.yml
@@ -290,7 +290,7 @@ jobs:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
-        SLACK_MESSAGE: " Publish failed :x:"
+        SLACK_MESSAGE: "Publish failed :x:"
         SLACK_TITLE: ${{ github.event.repository.name }} upgrade result
         SLACK_USERNAME: provider-bot
         SLACK_WEBHOOK: ${{ env.SLACK_WEBHOOK_URL }}

--- a/provider-ci/providers/equinix-metal/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/equinix-metal/repo/.github/workflows/master.yml
@@ -290,7 +290,7 @@ jobs:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
-        SLACK_MESSAGE: " Publish failed :x:"
+        SLACK_MESSAGE: "Publish failed :x:"
         SLACK_TITLE: ${{ github.event.repository.name }} upgrade result
         SLACK_USERNAME: provider-bot
         SLACK_WEBHOOK: ${{ env.SLACK_WEBHOOK_URL }}

--- a/provider-ci/providers/equinix-metal/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/equinix-metal/repo/.github/workflows/prerelease.yml
@@ -240,7 +240,7 @@ jobs:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
-        SLACK_MESSAGE: " Publish failed :x:"
+        SLACK_MESSAGE: "Publish failed :x:"
         SLACK_TITLE: ${{ github.event.repository.name }} upgrade result
         SLACK_USERNAME: provider-bot
         SLACK_WEBHOOK: ${{ env.SLACK_WEBHOOK_URL }}

--- a/provider-ci/providers/equinix-metal/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/equinix-metal/repo/.github/workflows/release.yml
@@ -252,7 +252,7 @@ jobs:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
-        SLACK_MESSAGE: " Publish failed :x:"
+        SLACK_MESSAGE: "Publish failed :x:"
         SLACK_TITLE: ${{ github.event.repository.name }} upgrade result
         SLACK_USERNAME: provider-bot
         SLACK_WEBHOOK: ${{ env.SLACK_WEBHOOK_URL }}

--- a/provider-ci/providers/equinix-metal/repo/.github/workflows/upgrade-provider.yml
+++ b/provider-ci/providers/equinix-metal/repo/.github/workflows/upgrade-provider.yml
@@ -14,6 +14,30 @@ jobs:
       with:
         slack-channel: provider-upgrade-status
         slack-webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
+    - env:
+        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_COLOR: "#FF0000"
+        SLACK_ICON_EMOJI: ":taco:"
+        SLACK_MESSAGE: >-
+          Upgrade succeeded :heart_decoration:
+
+          PR opened at github.com/pulumi/${{ github.event.repository.name }}/pulls
+        SLACK_TITLE: ${{ github.event.repository.name }} upgrade result
+        SLACK_USERNAME: provider-bot
+        SLACK_WEBHOOK: ${{ env.SLACK_WEBHOOK_URL }}
+      name: Send Upgrade Success To Slack
+      uses: rtCamp/action-slack-notify@v2
+    - env:
+        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_COLOR: "#FF0000"
+        SLACK_ICON_EMOJI: ":taco:"
+        SLACK_MESSAGE: " Upgrade failed :x:"
+        SLACK_TITLE: ${{ github.event.repository.name }} upgrade result
+        SLACK_USERNAME: provider-bot
+        SLACK_WEBHOOK: ${{ env.SLACK_WEBHOOK_URL }}
+      if: failure()
+      name: Send Upgrade Failure To Slack
+      uses: rtCamp/action-slack-notify@v2
 name: Upgrade provider
 on:
   issues:

--- a/provider-ci/providers/equinix-metal/repo/.github/workflows/upgrade-provider.yml
+++ b/provider-ci/providers/equinix-metal/repo/.github/workflows/upgrade-provider.yml
@@ -5,7 +5,7 @@ env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 jobs:
   upgrade_provider:
-    if: contains(github.event.issue.title, 'Upgrade terraform-provider-')
+    if: contains(${{ github.event.issue.title }}, 'Upgrade terraform-provider-')
     name: upgrade-provider
     runs-on: ubuntu-latest
     steps:

--- a/provider-ci/providers/f5bigip/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/f5bigip/repo/.github/workflows/main.yml
@@ -364,7 +364,7 @@ jobs:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
-        SLACK_MESSAGE: " Publish failed :x:"
+        SLACK_MESSAGE: "Publish failed :x:"
         SLACK_TITLE: ${{ github.event.repository.name }} upgrade result
         SLACK_USERNAME: provider-bot
         SLACK_WEBHOOK: ${{ env.SLACK_WEBHOOK_URL }}

--- a/provider-ci/providers/f5bigip/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/f5bigip/repo/.github/workflows/master.yml
@@ -364,7 +364,7 @@ jobs:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
-        SLACK_MESSAGE: " Publish failed :x:"
+        SLACK_MESSAGE: "Publish failed :x:"
         SLACK_TITLE: ${{ github.event.repository.name }} upgrade result
         SLACK_USERNAME: provider-bot
         SLACK_WEBHOOK: ${{ env.SLACK_WEBHOOK_URL }}

--- a/provider-ci/providers/f5bigip/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/f5bigip/repo/.github/workflows/prerelease.yml
@@ -314,7 +314,7 @@ jobs:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
-        SLACK_MESSAGE: " Publish failed :x:"
+        SLACK_MESSAGE: "Publish failed :x:"
         SLACK_TITLE: ${{ github.event.repository.name }} upgrade result
         SLACK_USERNAME: provider-bot
         SLACK_WEBHOOK: ${{ env.SLACK_WEBHOOK_URL }}

--- a/provider-ci/providers/f5bigip/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/f5bigip/repo/.github/workflows/release.yml
@@ -326,7 +326,7 @@ jobs:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
-        SLACK_MESSAGE: " Publish failed :x:"
+        SLACK_MESSAGE: "Publish failed :x:"
         SLACK_TITLE: ${{ github.event.repository.name }} upgrade result
         SLACK_USERNAME: provider-bot
         SLACK_WEBHOOK: ${{ env.SLACK_WEBHOOK_URL }}

--- a/provider-ci/providers/f5bigip/repo/.github/workflows/upgrade-provider.yml
+++ b/provider-ci/providers/f5bigip/repo/.github/workflows/upgrade-provider.yml
@@ -14,6 +14,30 @@ jobs:
       with:
         slack-channel: provider-upgrade-status
         slack-webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
+    - env:
+        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_COLOR: "#FF0000"
+        SLACK_ICON_EMOJI: ":taco:"
+        SLACK_MESSAGE: >-
+          Upgrade succeeded :heart_decoration:
+
+          PR opened at github.com/pulumi/${{ github.event.repository.name }}/pulls
+        SLACK_TITLE: ${{ github.event.repository.name }} upgrade result
+        SLACK_USERNAME: provider-bot
+        SLACK_WEBHOOK: ${{ env.SLACK_WEBHOOK_URL }}
+      name: Send Upgrade Success To Slack
+      uses: rtCamp/action-slack-notify@v2
+    - env:
+        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_COLOR: "#FF0000"
+        SLACK_ICON_EMOJI: ":taco:"
+        SLACK_MESSAGE: " Upgrade failed :x:"
+        SLACK_TITLE: ${{ github.event.repository.name }} upgrade result
+        SLACK_USERNAME: provider-bot
+        SLACK_WEBHOOK: ${{ env.SLACK_WEBHOOK_URL }}
+      if: failure()
+      name: Send Upgrade Failure To Slack
+      uses: rtCamp/action-slack-notify@v2
 name: Upgrade provider
 on:
   issues:

--- a/provider-ci/providers/f5bigip/repo/.github/workflows/upgrade-provider.yml
+++ b/provider-ci/providers/f5bigip/repo/.github/workflows/upgrade-provider.yml
@@ -5,7 +5,7 @@ env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 jobs:
   upgrade_provider:
-    if: contains(github.event.issue.title, 'Upgrade terraform-provider-')
+    if: contains(${{ github.event.issue.title }}, 'Upgrade terraform-provider-')
     name: upgrade-provider
     runs-on: ubuntu-latest
     steps:

--- a/provider-ci/providers/fastly/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/fastly/repo/.github/workflows/main.yml
@@ -361,7 +361,7 @@ jobs:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
-        SLACK_MESSAGE: " Publish failed :x:"
+        SLACK_MESSAGE: "Publish failed :x:"
         SLACK_TITLE: ${{ github.event.repository.name }} upgrade result
         SLACK_USERNAME: provider-bot
         SLACK_WEBHOOK: ${{ env.SLACK_WEBHOOK_URL }}

--- a/provider-ci/providers/fastly/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/fastly/repo/.github/workflows/master.yml
@@ -361,7 +361,7 @@ jobs:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
-        SLACK_MESSAGE: " Publish failed :x:"
+        SLACK_MESSAGE: "Publish failed :x:"
         SLACK_TITLE: ${{ github.event.repository.name }} upgrade result
         SLACK_USERNAME: provider-bot
         SLACK_WEBHOOK: ${{ env.SLACK_WEBHOOK_URL }}

--- a/provider-ci/providers/fastly/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/fastly/repo/.github/workflows/prerelease.yml
@@ -311,7 +311,7 @@ jobs:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
-        SLACK_MESSAGE: " Publish failed :x:"
+        SLACK_MESSAGE: "Publish failed :x:"
         SLACK_TITLE: ${{ github.event.repository.name }} upgrade result
         SLACK_USERNAME: provider-bot
         SLACK_WEBHOOK: ${{ env.SLACK_WEBHOOK_URL }}

--- a/provider-ci/providers/fastly/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/fastly/repo/.github/workflows/release.yml
@@ -323,7 +323,7 @@ jobs:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
-        SLACK_MESSAGE: " Publish failed :x:"
+        SLACK_MESSAGE: "Publish failed :x:"
         SLACK_TITLE: ${{ github.event.repository.name }} upgrade result
         SLACK_USERNAME: provider-bot
         SLACK_WEBHOOK: ${{ env.SLACK_WEBHOOK_URL }}

--- a/provider-ci/providers/fastly/repo/.github/workflows/upgrade-provider.yml
+++ b/provider-ci/providers/fastly/repo/.github/workflows/upgrade-provider.yml
@@ -14,6 +14,30 @@ jobs:
       with:
         slack-channel: provider-upgrade-status
         slack-webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
+    - env:
+        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_COLOR: "#FF0000"
+        SLACK_ICON_EMOJI: ":taco:"
+        SLACK_MESSAGE: >-
+          Upgrade succeeded :heart_decoration:
+
+          PR opened at github.com/pulumi/${{ github.event.repository.name }}/pulls
+        SLACK_TITLE: ${{ github.event.repository.name }} upgrade result
+        SLACK_USERNAME: provider-bot
+        SLACK_WEBHOOK: ${{ env.SLACK_WEBHOOK_URL }}
+      name: Send Upgrade Success To Slack
+      uses: rtCamp/action-slack-notify@v2
+    - env:
+        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_COLOR: "#FF0000"
+        SLACK_ICON_EMOJI: ":taco:"
+        SLACK_MESSAGE: " Upgrade failed :x:"
+        SLACK_TITLE: ${{ github.event.repository.name }} upgrade result
+        SLACK_USERNAME: provider-bot
+        SLACK_WEBHOOK: ${{ env.SLACK_WEBHOOK_URL }}
+      if: failure()
+      name: Send Upgrade Failure To Slack
+      uses: rtCamp/action-slack-notify@v2
 name: Upgrade provider
 on:
   issues:

--- a/provider-ci/providers/fastly/repo/.github/workflows/upgrade-provider.yml
+++ b/provider-ci/providers/fastly/repo/.github/workflows/upgrade-provider.yml
@@ -5,7 +5,7 @@ env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 jobs:
   upgrade_provider:
-    if: contains(github.event.issue.title, 'Upgrade terraform-provider-')
+    if: contains(${{ github.event.issue.title }}, 'Upgrade terraform-provider-')
     name: upgrade-provider
     runs-on: ubuntu-latest
     steps:

--- a/provider-ci/providers/gcp/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/gcp/repo/.github/workflows/main.yml
@@ -297,7 +297,7 @@ jobs:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
-        SLACK_MESSAGE: " Publish failed :x:"
+        SLACK_MESSAGE: "Publish failed :x:"
         SLACK_TITLE: ${{ github.event.repository.name }} upgrade result
         SLACK_USERNAME: provider-bot
         SLACK_WEBHOOK: ${{ env.SLACK_WEBHOOK_URL }}

--- a/provider-ci/providers/gcp/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/gcp/repo/.github/workflows/master.yml
@@ -297,7 +297,7 @@ jobs:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
-        SLACK_MESSAGE: " Publish failed :x:"
+        SLACK_MESSAGE: "Publish failed :x:"
         SLACK_TITLE: ${{ github.event.repository.name }} upgrade result
         SLACK_USERNAME: provider-bot
         SLACK_WEBHOOK: ${{ env.SLACK_WEBHOOK_URL }}

--- a/provider-ci/providers/gcp/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/gcp/repo/.github/workflows/prerelease.yml
@@ -247,7 +247,7 @@ jobs:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
-        SLACK_MESSAGE: " Publish failed :x:"
+        SLACK_MESSAGE: "Publish failed :x:"
         SLACK_TITLE: ${{ github.event.repository.name }} upgrade result
         SLACK_USERNAME: provider-bot
         SLACK_WEBHOOK: ${{ env.SLACK_WEBHOOK_URL }}

--- a/provider-ci/providers/gcp/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/gcp/repo/.github/workflows/release.yml
@@ -259,7 +259,7 @@ jobs:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
-        SLACK_MESSAGE: " Publish failed :x:"
+        SLACK_MESSAGE: "Publish failed :x:"
         SLACK_TITLE: ${{ github.event.repository.name }} upgrade result
         SLACK_USERNAME: provider-bot
         SLACK_WEBHOOK: ${{ env.SLACK_WEBHOOK_URL }}

--- a/provider-ci/providers/gcp/repo/.github/workflows/upgrade-provider.yml
+++ b/provider-ci/providers/gcp/repo/.github/workflows/upgrade-provider.yml
@@ -14,6 +14,30 @@ jobs:
       with:
         slack-channel: provider-upgrade-status
         slack-webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
+    - env:
+        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_COLOR: "#FF0000"
+        SLACK_ICON_EMOJI: ":taco:"
+        SLACK_MESSAGE: >-
+          Upgrade succeeded :heart_decoration:
+
+          PR opened at github.com/pulumi/${{ github.event.repository.name }}/pulls
+        SLACK_TITLE: ${{ github.event.repository.name }} upgrade result
+        SLACK_USERNAME: provider-bot
+        SLACK_WEBHOOK: ${{ env.SLACK_WEBHOOK_URL }}
+      name: Send Upgrade Success To Slack
+      uses: rtCamp/action-slack-notify@v2
+    - env:
+        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_COLOR: "#FF0000"
+        SLACK_ICON_EMOJI: ":taco:"
+        SLACK_MESSAGE: " Upgrade failed :x:"
+        SLACK_TITLE: ${{ github.event.repository.name }} upgrade result
+        SLACK_USERNAME: provider-bot
+        SLACK_WEBHOOK: ${{ env.SLACK_WEBHOOK_URL }}
+      if: failure()
+      name: Send Upgrade Failure To Slack
+      uses: rtCamp/action-slack-notify@v2
 name: Upgrade provider
 on:
   issues:

--- a/provider-ci/providers/gcp/repo/.github/workflows/upgrade-provider.yml
+++ b/provider-ci/providers/gcp/repo/.github/workflows/upgrade-provider.yml
@@ -5,7 +5,7 @@ env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 jobs:
   upgrade_provider:
-    if: contains(github.event.issue.title, 'Upgrade terraform-provider-')
+    if: contains(${{ github.event.issue.title }}, 'Upgrade terraform-provider-')
     name: upgrade-provider
     runs-on: ubuntu-latest
     steps:

--- a/provider-ci/providers/github/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/github/repo/.github/workflows/main.yml
@@ -362,7 +362,7 @@ jobs:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
-        SLACK_MESSAGE: " Publish failed :x:"
+        SLACK_MESSAGE: "Publish failed :x:"
         SLACK_TITLE: ${{ github.event.repository.name }} upgrade result
         SLACK_USERNAME: provider-bot
         SLACK_WEBHOOK: ${{ env.SLACK_WEBHOOK_URL }}

--- a/provider-ci/providers/github/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/github/repo/.github/workflows/master.yml
@@ -362,7 +362,7 @@ jobs:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
-        SLACK_MESSAGE: " Publish failed :x:"
+        SLACK_MESSAGE: "Publish failed :x:"
         SLACK_TITLE: ${{ github.event.repository.name }} upgrade result
         SLACK_USERNAME: provider-bot
         SLACK_WEBHOOK: ${{ env.SLACK_WEBHOOK_URL }}

--- a/provider-ci/providers/github/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/github/repo/.github/workflows/prerelease.yml
@@ -312,7 +312,7 @@ jobs:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
-        SLACK_MESSAGE: " Publish failed :x:"
+        SLACK_MESSAGE: "Publish failed :x:"
         SLACK_TITLE: ${{ github.event.repository.name }} upgrade result
         SLACK_USERNAME: provider-bot
         SLACK_WEBHOOK: ${{ env.SLACK_WEBHOOK_URL }}

--- a/provider-ci/providers/github/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/github/repo/.github/workflows/release.yml
@@ -324,7 +324,7 @@ jobs:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
-        SLACK_MESSAGE: " Publish failed :x:"
+        SLACK_MESSAGE: "Publish failed :x:"
         SLACK_TITLE: ${{ github.event.repository.name }} upgrade result
         SLACK_USERNAME: provider-bot
         SLACK_WEBHOOK: ${{ env.SLACK_WEBHOOK_URL }}

--- a/provider-ci/providers/github/repo/.github/workflows/upgrade-provider.yml
+++ b/provider-ci/providers/github/repo/.github/workflows/upgrade-provider.yml
@@ -14,6 +14,30 @@ jobs:
       with:
         slack-channel: provider-upgrade-status
         slack-webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
+    - env:
+        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_COLOR: "#FF0000"
+        SLACK_ICON_EMOJI: ":taco:"
+        SLACK_MESSAGE: >-
+          Upgrade succeeded :heart_decoration:
+
+          PR opened at github.com/pulumi/${{ github.event.repository.name }}/pulls
+        SLACK_TITLE: ${{ github.event.repository.name }} upgrade result
+        SLACK_USERNAME: provider-bot
+        SLACK_WEBHOOK: ${{ env.SLACK_WEBHOOK_URL }}
+      name: Send Upgrade Success To Slack
+      uses: rtCamp/action-slack-notify@v2
+    - env:
+        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_COLOR: "#FF0000"
+        SLACK_ICON_EMOJI: ":taco:"
+        SLACK_MESSAGE: " Upgrade failed :x:"
+        SLACK_TITLE: ${{ github.event.repository.name }} upgrade result
+        SLACK_USERNAME: provider-bot
+        SLACK_WEBHOOK: ${{ env.SLACK_WEBHOOK_URL }}
+      if: failure()
+      name: Send Upgrade Failure To Slack
+      uses: rtCamp/action-slack-notify@v2
 name: Upgrade provider
 on:
   issues:

--- a/provider-ci/providers/github/repo/.github/workflows/upgrade-provider.yml
+++ b/provider-ci/providers/github/repo/.github/workflows/upgrade-provider.yml
@@ -5,7 +5,7 @@ env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 jobs:
   upgrade_provider:
-    if: contains(github.event.issue.title, 'Upgrade terraform-provider-')
+    if: contains(${{ github.event.issue.title }}, 'Upgrade terraform-provider-')
     name: upgrade-provider
     runs-on: ubuntu-latest
     steps:

--- a/provider-ci/providers/gitlab/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/gitlab/repo/.github/workflows/main.yml
@@ -361,7 +361,7 @@ jobs:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
-        SLACK_MESSAGE: " Publish failed :x:"
+        SLACK_MESSAGE: "Publish failed :x:"
         SLACK_TITLE: ${{ github.event.repository.name }} upgrade result
         SLACK_USERNAME: provider-bot
         SLACK_WEBHOOK: ${{ env.SLACK_WEBHOOK_URL }}

--- a/provider-ci/providers/gitlab/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/gitlab/repo/.github/workflows/master.yml
@@ -361,7 +361,7 @@ jobs:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
-        SLACK_MESSAGE: " Publish failed :x:"
+        SLACK_MESSAGE: "Publish failed :x:"
         SLACK_TITLE: ${{ github.event.repository.name }} upgrade result
         SLACK_USERNAME: provider-bot
         SLACK_WEBHOOK: ${{ env.SLACK_WEBHOOK_URL }}

--- a/provider-ci/providers/gitlab/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/gitlab/repo/.github/workflows/prerelease.yml
@@ -311,7 +311,7 @@ jobs:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
-        SLACK_MESSAGE: " Publish failed :x:"
+        SLACK_MESSAGE: "Publish failed :x:"
         SLACK_TITLE: ${{ github.event.repository.name }} upgrade result
         SLACK_USERNAME: provider-bot
         SLACK_WEBHOOK: ${{ env.SLACK_WEBHOOK_URL }}

--- a/provider-ci/providers/gitlab/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/gitlab/repo/.github/workflows/release.yml
@@ -323,7 +323,7 @@ jobs:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
-        SLACK_MESSAGE: " Publish failed :x:"
+        SLACK_MESSAGE: "Publish failed :x:"
         SLACK_TITLE: ${{ github.event.repository.name }} upgrade result
         SLACK_USERNAME: provider-bot
         SLACK_WEBHOOK: ${{ env.SLACK_WEBHOOK_URL }}

--- a/provider-ci/providers/gitlab/repo/.github/workflows/upgrade-provider.yml
+++ b/provider-ci/providers/gitlab/repo/.github/workflows/upgrade-provider.yml
@@ -14,6 +14,30 @@ jobs:
       with:
         slack-channel: provider-upgrade-status
         slack-webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
+    - env:
+        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_COLOR: "#FF0000"
+        SLACK_ICON_EMOJI: ":taco:"
+        SLACK_MESSAGE: >-
+          Upgrade succeeded :heart_decoration:
+
+          PR opened at github.com/pulumi/${{ github.event.repository.name }}/pulls
+        SLACK_TITLE: ${{ github.event.repository.name }} upgrade result
+        SLACK_USERNAME: provider-bot
+        SLACK_WEBHOOK: ${{ env.SLACK_WEBHOOK_URL }}
+      name: Send Upgrade Success To Slack
+      uses: rtCamp/action-slack-notify@v2
+    - env:
+        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_COLOR: "#FF0000"
+        SLACK_ICON_EMOJI: ":taco:"
+        SLACK_MESSAGE: " Upgrade failed :x:"
+        SLACK_TITLE: ${{ github.event.repository.name }} upgrade result
+        SLACK_USERNAME: provider-bot
+        SLACK_WEBHOOK: ${{ env.SLACK_WEBHOOK_URL }}
+      if: failure()
+      name: Send Upgrade Failure To Slack
+      uses: rtCamp/action-slack-notify@v2
 name: Upgrade provider
 on:
   issues:

--- a/provider-ci/providers/gitlab/repo/.github/workflows/upgrade-provider.yml
+++ b/provider-ci/providers/gitlab/repo/.github/workflows/upgrade-provider.yml
@@ -5,7 +5,7 @@ env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 jobs:
   upgrade_provider:
-    if: contains(github.event.issue.title, 'Upgrade terraform-provider-')
+    if: contains(${{ github.event.issue.title }}, 'Upgrade terraform-provider-')
     name: upgrade-provider
     runs-on: ubuntu-latest
     steps:

--- a/provider-ci/providers/hcloud/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/hcloud/repo/.github/workflows/main.yml
@@ -361,7 +361,7 @@ jobs:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
-        SLACK_MESSAGE: " Publish failed :x:"
+        SLACK_MESSAGE: "Publish failed :x:"
         SLACK_TITLE: ${{ github.event.repository.name }} upgrade result
         SLACK_USERNAME: provider-bot
         SLACK_WEBHOOK: ${{ env.SLACK_WEBHOOK_URL }}

--- a/provider-ci/providers/hcloud/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/hcloud/repo/.github/workflows/master.yml
@@ -361,7 +361,7 @@ jobs:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
-        SLACK_MESSAGE: " Publish failed :x:"
+        SLACK_MESSAGE: "Publish failed :x:"
         SLACK_TITLE: ${{ github.event.repository.name }} upgrade result
         SLACK_USERNAME: provider-bot
         SLACK_WEBHOOK: ${{ env.SLACK_WEBHOOK_URL }}

--- a/provider-ci/providers/hcloud/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/hcloud/repo/.github/workflows/prerelease.yml
@@ -311,7 +311,7 @@ jobs:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
-        SLACK_MESSAGE: " Publish failed :x:"
+        SLACK_MESSAGE: "Publish failed :x:"
         SLACK_TITLE: ${{ github.event.repository.name }} upgrade result
         SLACK_USERNAME: provider-bot
         SLACK_WEBHOOK: ${{ env.SLACK_WEBHOOK_URL }}

--- a/provider-ci/providers/hcloud/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/hcloud/repo/.github/workflows/release.yml
@@ -323,7 +323,7 @@ jobs:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
-        SLACK_MESSAGE: " Publish failed :x:"
+        SLACK_MESSAGE: "Publish failed :x:"
         SLACK_TITLE: ${{ github.event.repository.name }} upgrade result
         SLACK_USERNAME: provider-bot
         SLACK_WEBHOOK: ${{ env.SLACK_WEBHOOK_URL }}

--- a/provider-ci/providers/hcloud/repo/.github/workflows/upgrade-provider.yml
+++ b/provider-ci/providers/hcloud/repo/.github/workflows/upgrade-provider.yml
@@ -14,6 +14,30 @@ jobs:
       with:
         slack-channel: provider-upgrade-status
         slack-webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
+    - env:
+        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_COLOR: "#FF0000"
+        SLACK_ICON_EMOJI: ":taco:"
+        SLACK_MESSAGE: >-
+          Upgrade succeeded :heart_decoration:
+
+          PR opened at github.com/pulumi/${{ github.event.repository.name }}/pulls
+        SLACK_TITLE: ${{ github.event.repository.name }} upgrade result
+        SLACK_USERNAME: provider-bot
+        SLACK_WEBHOOK: ${{ env.SLACK_WEBHOOK_URL }}
+      name: Send Upgrade Success To Slack
+      uses: rtCamp/action-slack-notify@v2
+    - env:
+        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_COLOR: "#FF0000"
+        SLACK_ICON_EMOJI: ":taco:"
+        SLACK_MESSAGE: " Upgrade failed :x:"
+        SLACK_TITLE: ${{ github.event.repository.name }} upgrade result
+        SLACK_USERNAME: provider-bot
+        SLACK_WEBHOOK: ${{ env.SLACK_WEBHOOK_URL }}
+      if: failure()
+      name: Send Upgrade Failure To Slack
+      uses: rtCamp/action-slack-notify@v2
 name: Upgrade provider
 on:
   issues:

--- a/provider-ci/providers/hcloud/repo/.github/workflows/upgrade-provider.yml
+++ b/provider-ci/providers/hcloud/repo/.github/workflows/upgrade-provider.yml
@@ -5,7 +5,7 @@ env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 jobs:
   upgrade_provider:
-    if: contains(github.event.issue.title, 'Upgrade terraform-provider-')
+    if: contains(${{ github.event.issue.title }}, 'Upgrade terraform-provider-')
     name: upgrade-provider
     runs-on: ubuntu-latest
     steps:

--- a/provider-ci/providers/kafka/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/kafka/repo/.github/workflows/main.yml
@@ -360,7 +360,7 @@ jobs:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
-        SLACK_MESSAGE: " Publish failed :x:"
+        SLACK_MESSAGE: "Publish failed :x:"
         SLACK_TITLE: ${{ github.event.repository.name }} upgrade result
         SLACK_USERNAME: provider-bot
         SLACK_WEBHOOK: ${{ env.SLACK_WEBHOOK_URL }}

--- a/provider-ci/providers/kafka/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/kafka/repo/.github/workflows/master.yml
@@ -360,7 +360,7 @@ jobs:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
-        SLACK_MESSAGE: " Publish failed :x:"
+        SLACK_MESSAGE: "Publish failed :x:"
         SLACK_TITLE: ${{ github.event.repository.name }} upgrade result
         SLACK_USERNAME: provider-bot
         SLACK_WEBHOOK: ${{ env.SLACK_WEBHOOK_URL }}

--- a/provider-ci/providers/kafka/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/kafka/repo/.github/workflows/prerelease.yml
@@ -310,7 +310,7 @@ jobs:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
-        SLACK_MESSAGE: " Publish failed :x:"
+        SLACK_MESSAGE: "Publish failed :x:"
         SLACK_TITLE: ${{ github.event.repository.name }} upgrade result
         SLACK_USERNAME: provider-bot
         SLACK_WEBHOOK: ${{ env.SLACK_WEBHOOK_URL }}

--- a/provider-ci/providers/kafka/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/kafka/repo/.github/workflows/release.yml
@@ -322,7 +322,7 @@ jobs:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
-        SLACK_MESSAGE: " Publish failed :x:"
+        SLACK_MESSAGE: "Publish failed :x:"
         SLACK_TITLE: ${{ github.event.repository.name }} upgrade result
         SLACK_USERNAME: provider-bot
         SLACK_WEBHOOK: ${{ env.SLACK_WEBHOOK_URL }}

--- a/provider-ci/providers/kafka/repo/.github/workflows/upgrade-provider.yml
+++ b/provider-ci/providers/kafka/repo/.github/workflows/upgrade-provider.yml
@@ -14,6 +14,30 @@ jobs:
       with:
         slack-channel: provider-upgrade-status
         slack-webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
+    - env:
+        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_COLOR: "#FF0000"
+        SLACK_ICON_EMOJI: ":taco:"
+        SLACK_MESSAGE: >-
+          Upgrade succeeded :heart_decoration:
+
+          PR opened at github.com/pulumi/${{ github.event.repository.name }}/pulls
+        SLACK_TITLE: ${{ github.event.repository.name }} upgrade result
+        SLACK_USERNAME: provider-bot
+        SLACK_WEBHOOK: ${{ env.SLACK_WEBHOOK_URL }}
+      name: Send Upgrade Success To Slack
+      uses: rtCamp/action-slack-notify@v2
+    - env:
+        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_COLOR: "#FF0000"
+        SLACK_ICON_EMOJI: ":taco:"
+        SLACK_MESSAGE: " Upgrade failed :x:"
+        SLACK_TITLE: ${{ github.event.repository.name }} upgrade result
+        SLACK_USERNAME: provider-bot
+        SLACK_WEBHOOK: ${{ env.SLACK_WEBHOOK_URL }}
+      if: failure()
+      name: Send Upgrade Failure To Slack
+      uses: rtCamp/action-slack-notify@v2
 name: Upgrade provider
 on:
   issues:

--- a/provider-ci/providers/kafka/repo/.github/workflows/upgrade-provider.yml
+++ b/provider-ci/providers/kafka/repo/.github/workflows/upgrade-provider.yml
@@ -5,7 +5,7 @@ env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 jobs:
   upgrade_provider:
-    if: contains(github.event.issue.title, 'Upgrade terraform-provider-')
+    if: contains(${{ github.event.issue.title }}, 'Upgrade terraform-provider-')
     name: upgrade-provider
     runs-on: ubuntu-latest
     steps:

--- a/provider-ci/providers/keycloak/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/keycloak/repo/.github/workflows/main.yml
@@ -365,7 +365,7 @@ jobs:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
-        SLACK_MESSAGE: " Publish failed :x:"
+        SLACK_MESSAGE: "Publish failed :x:"
         SLACK_TITLE: ${{ github.event.repository.name }} upgrade result
         SLACK_USERNAME: provider-bot
         SLACK_WEBHOOK: ${{ env.SLACK_WEBHOOK_URL }}

--- a/provider-ci/providers/keycloak/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/keycloak/repo/.github/workflows/master.yml
@@ -365,7 +365,7 @@ jobs:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
-        SLACK_MESSAGE: " Publish failed :x:"
+        SLACK_MESSAGE: "Publish failed :x:"
         SLACK_TITLE: ${{ github.event.repository.name }} upgrade result
         SLACK_USERNAME: provider-bot
         SLACK_WEBHOOK: ${{ env.SLACK_WEBHOOK_URL }}

--- a/provider-ci/providers/keycloak/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/keycloak/repo/.github/workflows/prerelease.yml
@@ -315,7 +315,7 @@ jobs:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
-        SLACK_MESSAGE: " Publish failed :x:"
+        SLACK_MESSAGE: "Publish failed :x:"
         SLACK_TITLE: ${{ github.event.repository.name }} upgrade result
         SLACK_USERNAME: provider-bot
         SLACK_WEBHOOK: ${{ env.SLACK_WEBHOOK_URL }}

--- a/provider-ci/providers/keycloak/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/keycloak/repo/.github/workflows/release.yml
@@ -327,7 +327,7 @@ jobs:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
-        SLACK_MESSAGE: " Publish failed :x:"
+        SLACK_MESSAGE: "Publish failed :x:"
         SLACK_TITLE: ${{ github.event.repository.name }} upgrade result
         SLACK_USERNAME: provider-bot
         SLACK_WEBHOOK: ${{ env.SLACK_WEBHOOK_URL }}

--- a/provider-ci/providers/keycloak/repo/.github/workflows/upgrade-provider.yml
+++ b/provider-ci/providers/keycloak/repo/.github/workflows/upgrade-provider.yml
@@ -14,6 +14,30 @@ jobs:
       with:
         slack-channel: provider-upgrade-status
         slack-webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
+    - env:
+        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_COLOR: "#FF0000"
+        SLACK_ICON_EMOJI: ":taco:"
+        SLACK_MESSAGE: >-
+          Upgrade succeeded :heart_decoration:
+
+          PR opened at github.com/pulumi/${{ github.event.repository.name }}/pulls
+        SLACK_TITLE: ${{ github.event.repository.name }} upgrade result
+        SLACK_USERNAME: provider-bot
+        SLACK_WEBHOOK: ${{ env.SLACK_WEBHOOK_URL }}
+      name: Send Upgrade Success To Slack
+      uses: rtCamp/action-slack-notify@v2
+    - env:
+        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_COLOR: "#FF0000"
+        SLACK_ICON_EMOJI: ":taco:"
+        SLACK_MESSAGE: " Upgrade failed :x:"
+        SLACK_TITLE: ${{ github.event.repository.name }} upgrade result
+        SLACK_USERNAME: provider-bot
+        SLACK_WEBHOOK: ${{ env.SLACK_WEBHOOK_URL }}
+      if: failure()
+      name: Send Upgrade Failure To Slack
+      uses: rtCamp/action-slack-notify@v2
 name: Upgrade provider
 on:
   issues:

--- a/provider-ci/providers/keycloak/repo/.github/workflows/upgrade-provider.yml
+++ b/provider-ci/providers/keycloak/repo/.github/workflows/upgrade-provider.yml
@@ -5,7 +5,7 @@ env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 jobs:
   upgrade_provider:
-    if: contains(github.event.issue.title, 'Upgrade terraform-provider-')
+    if: contains(${{ github.event.issue.title }}, 'Upgrade terraform-provider-')
     name: upgrade-provider
     runs-on: ubuntu-latest
     steps:

--- a/provider-ci/providers/kong/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/kong/repo/.github/workflows/main.yml
@@ -360,7 +360,7 @@ jobs:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
-        SLACK_MESSAGE: " Publish failed :x:"
+        SLACK_MESSAGE: "Publish failed :x:"
         SLACK_TITLE: ${{ github.event.repository.name }} upgrade result
         SLACK_USERNAME: provider-bot
         SLACK_WEBHOOK: ${{ env.SLACK_WEBHOOK_URL }}

--- a/provider-ci/providers/kong/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/kong/repo/.github/workflows/master.yml
@@ -360,7 +360,7 @@ jobs:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
-        SLACK_MESSAGE: " Publish failed :x:"
+        SLACK_MESSAGE: "Publish failed :x:"
         SLACK_TITLE: ${{ github.event.repository.name }} upgrade result
         SLACK_USERNAME: provider-bot
         SLACK_WEBHOOK: ${{ env.SLACK_WEBHOOK_URL }}

--- a/provider-ci/providers/kong/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/kong/repo/.github/workflows/prerelease.yml
@@ -310,7 +310,7 @@ jobs:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
-        SLACK_MESSAGE: " Publish failed :x:"
+        SLACK_MESSAGE: "Publish failed :x:"
         SLACK_TITLE: ${{ github.event.repository.name }} upgrade result
         SLACK_USERNAME: provider-bot
         SLACK_WEBHOOK: ${{ env.SLACK_WEBHOOK_URL }}

--- a/provider-ci/providers/kong/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/kong/repo/.github/workflows/release.yml
@@ -322,7 +322,7 @@ jobs:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
-        SLACK_MESSAGE: " Publish failed :x:"
+        SLACK_MESSAGE: "Publish failed :x:"
         SLACK_TITLE: ${{ github.event.repository.name }} upgrade result
         SLACK_USERNAME: provider-bot
         SLACK_WEBHOOK: ${{ env.SLACK_WEBHOOK_URL }}

--- a/provider-ci/providers/kong/repo/.github/workflows/upgrade-provider.yml
+++ b/provider-ci/providers/kong/repo/.github/workflows/upgrade-provider.yml
@@ -14,6 +14,30 @@ jobs:
       with:
         slack-channel: provider-upgrade-status
         slack-webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
+    - env:
+        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_COLOR: "#FF0000"
+        SLACK_ICON_EMOJI: ":taco:"
+        SLACK_MESSAGE: >-
+          Upgrade succeeded :heart_decoration:
+
+          PR opened at github.com/pulumi/${{ github.event.repository.name }}/pulls
+        SLACK_TITLE: ${{ github.event.repository.name }} upgrade result
+        SLACK_USERNAME: provider-bot
+        SLACK_WEBHOOK: ${{ env.SLACK_WEBHOOK_URL }}
+      name: Send Upgrade Success To Slack
+      uses: rtCamp/action-slack-notify@v2
+    - env:
+        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_COLOR: "#FF0000"
+        SLACK_ICON_EMOJI: ":taco:"
+        SLACK_MESSAGE: " Upgrade failed :x:"
+        SLACK_TITLE: ${{ github.event.repository.name }} upgrade result
+        SLACK_USERNAME: provider-bot
+        SLACK_WEBHOOK: ${{ env.SLACK_WEBHOOK_URL }}
+      if: failure()
+      name: Send Upgrade Failure To Slack
+      uses: rtCamp/action-slack-notify@v2
 name: Upgrade provider
 on:
   issues:

--- a/provider-ci/providers/kong/repo/.github/workflows/upgrade-provider.yml
+++ b/provider-ci/providers/kong/repo/.github/workflows/upgrade-provider.yml
@@ -5,7 +5,7 @@ env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 jobs:
   upgrade_provider:
-    if: contains(github.event.issue.title, 'Upgrade terraform-provider-')
+    if: contains(${{ github.event.issue.title }}, 'Upgrade terraform-provider-')
     name: upgrade-provider
     runs-on: ubuntu-latest
     steps:

--- a/provider-ci/providers/libvirt/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/libvirt/repo/.github/workflows/main.yml
@@ -361,7 +361,7 @@ jobs:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
-        SLACK_MESSAGE: " Publish failed :x:"
+        SLACK_MESSAGE: "Publish failed :x:"
         SLACK_TITLE: ${{ github.event.repository.name }} upgrade result
         SLACK_USERNAME: provider-bot
         SLACK_WEBHOOK: ${{ env.SLACK_WEBHOOK_URL }}

--- a/provider-ci/providers/libvirt/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/libvirt/repo/.github/workflows/master.yml
@@ -361,7 +361,7 @@ jobs:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
-        SLACK_MESSAGE: " Publish failed :x:"
+        SLACK_MESSAGE: "Publish failed :x:"
         SLACK_TITLE: ${{ github.event.repository.name }} upgrade result
         SLACK_USERNAME: provider-bot
         SLACK_WEBHOOK: ${{ env.SLACK_WEBHOOK_URL }}

--- a/provider-ci/providers/libvirt/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/libvirt/repo/.github/workflows/prerelease.yml
@@ -311,7 +311,7 @@ jobs:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
-        SLACK_MESSAGE: " Publish failed :x:"
+        SLACK_MESSAGE: "Publish failed :x:"
         SLACK_TITLE: ${{ github.event.repository.name }} upgrade result
         SLACK_USERNAME: provider-bot
         SLACK_WEBHOOK: ${{ env.SLACK_WEBHOOK_URL }}

--- a/provider-ci/providers/libvirt/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/libvirt/repo/.github/workflows/release.yml
@@ -323,7 +323,7 @@ jobs:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
-        SLACK_MESSAGE: " Publish failed :x:"
+        SLACK_MESSAGE: "Publish failed :x:"
         SLACK_TITLE: ${{ github.event.repository.name }} upgrade result
         SLACK_USERNAME: provider-bot
         SLACK_WEBHOOK: ${{ env.SLACK_WEBHOOK_URL }}

--- a/provider-ci/providers/libvirt/repo/.github/workflows/upgrade-provider.yml
+++ b/provider-ci/providers/libvirt/repo/.github/workflows/upgrade-provider.yml
@@ -14,6 +14,30 @@ jobs:
       with:
         slack-channel: provider-upgrade-status
         slack-webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
+    - env:
+        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_COLOR: "#FF0000"
+        SLACK_ICON_EMOJI: ":taco:"
+        SLACK_MESSAGE: >-
+          Upgrade succeeded :heart_decoration:
+
+          PR opened at github.com/pulumi/${{ github.event.repository.name }}/pulls
+        SLACK_TITLE: ${{ github.event.repository.name }} upgrade result
+        SLACK_USERNAME: provider-bot
+        SLACK_WEBHOOK: ${{ env.SLACK_WEBHOOK_URL }}
+      name: Send Upgrade Success To Slack
+      uses: rtCamp/action-slack-notify@v2
+    - env:
+        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_COLOR: "#FF0000"
+        SLACK_ICON_EMOJI: ":taco:"
+        SLACK_MESSAGE: " Upgrade failed :x:"
+        SLACK_TITLE: ${{ github.event.repository.name }} upgrade result
+        SLACK_USERNAME: provider-bot
+        SLACK_WEBHOOK: ${{ env.SLACK_WEBHOOK_URL }}
+      if: failure()
+      name: Send Upgrade Failure To Slack
+      uses: rtCamp/action-slack-notify@v2
 name: Upgrade provider
 on:
   issues:

--- a/provider-ci/providers/libvirt/repo/.github/workflows/upgrade-provider.yml
+++ b/provider-ci/providers/libvirt/repo/.github/workflows/upgrade-provider.yml
@@ -5,7 +5,7 @@ env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 jobs:
   upgrade_provider:
-    if: contains(github.event.issue.title, 'Upgrade terraform-provider-')
+    if: contains(${{ github.event.issue.title }}, 'Upgrade terraform-provider-')
     name: upgrade-provider
     runs-on: ubuntu-latest
     steps:

--- a/provider-ci/providers/linode/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/linode/repo/.github/workflows/main.yml
@@ -361,7 +361,7 @@ jobs:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
-        SLACK_MESSAGE: " Publish failed :x:"
+        SLACK_MESSAGE: "Publish failed :x:"
         SLACK_TITLE: ${{ github.event.repository.name }} upgrade result
         SLACK_USERNAME: provider-bot
         SLACK_WEBHOOK: ${{ env.SLACK_WEBHOOK_URL }}

--- a/provider-ci/providers/linode/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/linode/repo/.github/workflows/master.yml
@@ -361,7 +361,7 @@ jobs:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
-        SLACK_MESSAGE: " Publish failed :x:"
+        SLACK_MESSAGE: "Publish failed :x:"
         SLACK_TITLE: ${{ github.event.repository.name }} upgrade result
         SLACK_USERNAME: provider-bot
         SLACK_WEBHOOK: ${{ env.SLACK_WEBHOOK_URL }}

--- a/provider-ci/providers/linode/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/linode/repo/.github/workflows/prerelease.yml
@@ -311,7 +311,7 @@ jobs:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
-        SLACK_MESSAGE: " Publish failed :x:"
+        SLACK_MESSAGE: "Publish failed :x:"
         SLACK_TITLE: ${{ github.event.repository.name }} upgrade result
         SLACK_USERNAME: provider-bot
         SLACK_WEBHOOK: ${{ env.SLACK_WEBHOOK_URL }}

--- a/provider-ci/providers/linode/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/linode/repo/.github/workflows/release.yml
@@ -323,7 +323,7 @@ jobs:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
-        SLACK_MESSAGE: " Publish failed :x:"
+        SLACK_MESSAGE: "Publish failed :x:"
         SLACK_TITLE: ${{ github.event.repository.name }} upgrade result
         SLACK_USERNAME: provider-bot
         SLACK_WEBHOOK: ${{ env.SLACK_WEBHOOK_URL }}

--- a/provider-ci/providers/linode/repo/.github/workflows/upgrade-provider.yml
+++ b/provider-ci/providers/linode/repo/.github/workflows/upgrade-provider.yml
@@ -14,6 +14,30 @@ jobs:
       with:
         slack-channel: provider-upgrade-status
         slack-webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
+    - env:
+        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_COLOR: "#FF0000"
+        SLACK_ICON_EMOJI: ":taco:"
+        SLACK_MESSAGE: >-
+          Upgrade succeeded :heart_decoration:
+
+          PR opened at github.com/pulumi/${{ github.event.repository.name }}/pulls
+        SLACK_TITLE: ${{ github.event.repository.name }} upgrade result
+        SLACK_USERNAME: provider-bot
+        SLACK_WEBHOOK: ${{ env.SLACK_WEBHOOK_URL }}
+      name: Send Upgrade Success To Slack
+      uses: rtCamp/action-slack-notify@v2
+    - env:
+        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_COLOR: "#FF0000"
+        SLACK_ICON_EMOJI: ":taco:"
+        SLACK_MESSAGE: " Upgrade failed :x:"
+        SLACK_TITLE: ${{ github.event.repository.name }} upgrade result
+        SLACK_USERNAME: provider-bot
+        SLACK_WEBHOOK: ${{ env.SLACK_WEBHOOK_URL }}
+      if: failure()
+      name: Send Upgrade Failure To Slack
+      uses: rtCamp/action-slack-notify@v2
 name: Upgrade provider
 on:
   issues:

--- a/provider-ci/providers/linode/repo/.github/workflows/upgrade-provider.yml
+++ b/provider-ci/providers/linode/repo/.github/workflows/upgrade-provider.yml
@@ -5,7 +5,7 @@ env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 jobs:
   upgrade_provider:
-    if: contains(github.event.issue.title, 'Upgrade terraform-provider-')
+    if: contains(${{ github.event.issue.title }}, 'Upgrade terraform-provider-')
     name: upgrade-provider
     runs-on: ubuntu-latest
     steps:

--- a/provider-ci/providers/mailgun/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/mailgun/repo/.github/workflows/main.yml
@@ -361,7 +361,7 @@ jobs:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
-        SLACK_MESSAGE: " Publish failed :x:"
+        SLACK_MESSAGE: "Publish failed :x:"
         SLACK_TITLE: ${{ github.event.repository.name }} upgrade result
         SLACK_USERNAME: provider-bot
         SLACK_WEBHOOK: ${{ env.SLACK_WEBHOOK_URL }}

--- a/provider-ci/providers/mailgun/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/mailgun/repo/.github/workflows/master.yml
@@ -361,7 +361,7 @@ jobs:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
-        SLACK_MESSAGE: " Publish failed :x:"
+        SLACK_MESSAGE: "Publish failed :x:"
         SLACK_TITLE: ${{ github.event.repository.name }} upgrade result
         SLACK_USERNAME: provider-bot
         SLACK_WEBHOOK: ${{ env.SLACK_WEBHOOK_URL }}

--- a/provider-ci/providers/mailgun/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/mailgun/repo/.github/workflows/prerelease.yml
@@ -311,7 +311,7 @@ jobs:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
-        SLACK_MESSAGE: " Publish failed :x:"
+        SLACK_MESSAGE: "Publish failed :x:"
         SLACK_TITLE: ${{ github.event.repository.name }} upgrade result
         SLACK_USERNAME: provider-bot
         SLACK_WEBHOOK: ${{ env.SLACK_WEBHOOK_URL }}

--- a/provider-ci/providers/mailgun/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/mailgun/repo/.github/workflows/release.yml
@@ -323,7 +323,7 @@ jobs:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
-        SLACK_MESSAGE: " Publish failed :x:"
+        SLACK_MESSAGE: "Publish failed :x:"
         SLACK_TITLE: ${{ github.event.repository.name }} upgrade result
         SLACK_USERNAME: provider-bot
         SLACK_WEBHOOK: ${{ env.SLACK_WEBHOOK_URL }}

--- a/provider-ci/providers/mailgun/repo/.github/workflows/upgrade-provider.yml
+++ b/provider-ci/providers/mailgun/repo/.github/workflows/upgrade-provider.yml
@@ -14,6 +14,30 @@ jobs:
       with:
         slack-channel: provider-upgrade-status
         slack-webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
+    - env:
+        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_COLOR: "#FF0000"
+        SLACK_ICON_EMOJI: ":taco:"
+        SLACK_MESSAGE: >-
+          Upgrade succeeded :heart_decoration:
+
+          PR opened at github.com/pulumi/${{ github.event.repository.name }}/pulls
+        SLACK_TITLE: ${{ github.event.repository.name }} upgrade result
+        SLACK_USERNAME: provider-bot
+        SLACK_WEBHOOK: ${{ env.SLACK_WEBHOOK_URL }}
+      name: Send Upgrade Success To Slack
+      uses: rtCamp/action-slack-notify@v2
+    - env:
+        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_COLOR: "#FF0000"
+        SLACK_ICON_EMOJI: ":taco:"
+        SLACK_MESSAGE: " Upgrade failed :x:"
+        SLACK_TITLE: ${{ github.event.repository.name }} upgrade result
+        SLACK_USERNAME: provider-bot
+        SLACK_WEBHOOK: ${{ env.SLACK_WEBHOOK_URL }}
+      if: failure()
+      name: Send Upgrade Failure To Slack
+      uses: rtCamp/action-slack-notify@v2
 name: Upgrade provider
 on:
   issues:

--- a/provider-ci/providers/mailgun/repo/.github/workflows/upgrade-provider.yml
+++ b/provider-ci/providers/mailgun/repo/.github/workflows/upgrade-provider.yml
@@ -5,7 +5,7 @@ env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 jobs:
   upgrade_provider:
-    if: contains(github.event.issue.title, 'Upgrade terraform-provider-')
+    if: contains(${{ github.event.issue.title }}, 'Upgrade terraform-provider-')
     name: upgrade-provider
     runs-on: ubuntu-latest
     steps:

--- a/provider-ci/providers/minio/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/minio/repo/.github/workflows/main.yml
@@ -364,7 +364,7 @@ jobs:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
-        SLACK_MESSAGE: " Publish failed :x:"
+        SLACK_MESSAGE: "Publish failed :x:"
         SLACK_TITLE: ${{ github.event.repository.name }} upgrade result
         SLACK_USERNAME: provider-bot
         SLACK_WEBHOOK: ${{ env.SLACK_WEBHOOK_URL }}

--- a/provider-ci/providers/minio/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/minio/repo/.github/workflows/master.yml
@@ -364,7 +364,7 @@ jobs:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
-        SLACK_MESSAGE: " Publish failed :x:"
+        SLACK_MESSAGE: "Publish failed :x:"
         SLACK_TITLE: ${{ github.event.repository.name }} upgrade result
         SLACK_USERNAME: provider-bot
         SLACK_WEBHOOK: ${{ env.SLACK_WEBHOOK_URL }}

--- a/provider-ci/providers/minio/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/minio/repo/.github/workflows/prerelease.yml
@@ -314,7 +314,7 @@ jobs:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
-        SLACK_MESSAGE: " Publish failed :x:"
+        SLACK_MESSAGE: "Publish failed :x:"
         SLACK_TITLE: ${{ github.event.repository.name }} upgrade result
         SLACK_USERNAME: provider-bot
         SLACK_WEBHOOK: ${{ env.SLACK_WEBHOOK_URL }}

--- a/provider-ci/providers/minio/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/minio/repo/.github/workflows/release.yml
@@ -326,7 +326,7 @@ jobs:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
-        SLACK_MESSAGE: " Publish failed :x:"
+        SLACK_MESSAGE: "Publish failed :x:"
         SLACK_TITLE: ${{ github.event.repository.name }} upgrade result
         SLACK_USERNAME: provider-bot
         SLACK_WEBHOOK: ${{ env.SLACK_WEBHOOK_URL }}

--- a/provider-ci/providers/minio/repo/.github/workflows/upgrade-provider.yml
+++ b/provider-ci/providers/minio/repo/.github/workflows/upgrade-provider.yml
@@ -14,6 +14,30 @@ jobs:
       with:
         slack-channel: provider-upgrade-status
         slack-webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
+    - env:
+        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_COLOR: "#FF0000"
+        SLACK_ICON_EMOJI: ":taco:"
+        SLACK_MESSAGE: >-
+          Upgrade succeeded :heart_decoration:
+
+          PR opened at github.com/pulumi/${{ github.event.repository.name }}/pulls
+        SLACK_TITLE: ${{ github.event.repository.name }} upgrade result
+        SLACK_USERNAME: provider-bot
+        SLACK_WEBHOOK: ${{ env.SLACK_WEBHOOK_URL }}
+      name: Send Upgrade Success To Slack
+      uses: rtCamp/action-slack-notify@v2
+    - env:
+        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_COLOR: "#FF0000"
+        SLACK_ICON_EMOJI: ":taco:"
+        SLACK_MESSAGE: " Upgrade failed :x:"
+        SLACK_TITLE: ${{ github.event.repository.name }} upgrade result
+        SLACK_USERNAME: provider-bot
+        SLACK_WEBHOOK: ${{ env.SLACK_WEBHOOK_URL }}
+      if: failure()
+      name: Send Upgrade Failure To Slack
+      uses: rtCamp/action-slack-notify@v2
 name: Upgrade provider
 on:
   issues:

--- a/provider-ci/providers/minio/repo/.github/workflows/upgrade-provider.yml
+++ b/provider-ci/providers/minio/repo/.github/workflows/upgrade-provider.yml
@@ -5,7 +5,7 @@ env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 jobs:
   upgrade_provider:
-    if: contains(github.event.issue.title, 'Upgrade terraform-provider-')
+    if: contains(${{ github.event.issue.title }}, 'Upgrade terraform-provider-')
     name: upgrade-provider
     runs-on: ubuntu-latest
     steps:

--- a/provider-ci/providers/mongodbatlas/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/mongodbatlas/repo/.github/workflows/main.yml
@@ -363,7 +363,7 @@ jobs:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
-        SLACK_MESSAGE: " Publish failed :x:"
+        SLACK_MESSAGE: "Publish failed :x:"
         SLACK_TITLE: ${{ github.event.repository.name }} upgrade result
         SLACK_USERNAME: provider-bot
         SLACK_WEBHOOK: ${{ env.SLACK_WEBHOOK_URL }}

--- a/provider-ci/providers/mongodbatlas/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/mongodbatlas/repo/.github/workflows/master.yml
@@ -363,7 +363,7 @@ jobs:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
-        SLACK_MESSAGE: " Publish failed :x:"
+        SLACK_MESSAGE: "Publish failed :x:"
         SLACK_TITLE: ${{ github.event.repository.name }} upgrade result
         SLACK_USERNAME: provider-bot
         SLACK_WEBHOOK: ${{ env.SLACK_WEBHOOK_URL }}

--- a/provider-ci/providers/mongodbatlas/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/mongodbatlas/repo/.github/workflows/prerelease.yml
@@ -313,7 +313,7 @@ jobs:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
-        SLACK_MESSAGE: " Publish failed :x:"
+        SLACK_MESSAGE: "Publish failed :x:"
         SLACK_TITLE: ${{ github.event.repository.name }} upgrade result
         SLACK_USERNAME: provider-bot
         SLACK_WEBHOOK: ${{ env.SLACK_WEBHOOK_URL }}

--- a/provider-ci/providers/mongodbatlas/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/mongodbatlas/repo/.github/workflows/release.yml
@@ -325,7 +325,7 @@ jobs:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
-        SLACK_MESSAGE: " Publish failed :x:"
+        SLACK_MESSAGE: "Publish failed :x:"
         SLACK_TITLE: ${{ github.event.repository.name }} upgrade result
         SLACK_USERNAME: provider-bot
         SLACK_WEBHOOK: ${{ env.SLACK_WEBHOOK_URL }}

--- a/provider-ci/providers/mongodbatlas/repo/.github/workflows/upgrade-provider.yml
+++ b/provider-ci/providers/mongodbatlas/repo/.github/workflows/upgrade-provider.yml
@@ -14,6 +14,30 @@ jobs:
       with:
         slack-channel: provider-upgrade-status
         slack-webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
+    - env:
+        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_COLOR: "#FF0000"
+        SLACK_ICON_EMOJI: ":taco:"
+        SLACK_MESSAGE: >-
+          Upgrade succeeded :heart_decoration:
+
+          PR opened at github.com/pulumi/${{ github.event.repository.name }}/pulls
+        SLACK_TITLE: ${{ github.event.repository.name }} upgrade result
+        SLACK_USERNAME: provider-bot
+        SLACK_WEBHOOK: ${{ env.SLACK_WEBHOOK_URL }}
+      name: Send Upgrade Success To Slack
+      uses: rtCamp/action-slack-notify@v2
+    - env:
+        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_COLOR: "#FF0000"
+        SLACK_ICON_EMOJI: ":taco:"
+        SLACK_MESSAGE: " Upgrade failed :x:"
+        SLACK_TITLE: ${{ github.event.repository.name }} upgrade result
+        SLACK_USERNAME: provider-bot
+        SLACK_WEBHOOK: ${{ env.SLACK_WEBHOOK_URL }}
+      if: failure()
+      name: Send Upgrade Failure To Slack
+      uses: rtCamp/action-slack-notify@v2
 name: Upgrade provider
 on:
   issues:

--- a/provider-ci/providers/mongodbatlas/repo/.github/workflows/upgrade-provider.yml
+++ b/provider-ci/providers/mongodbatlas/repo/.github/workflows/upgrade-provider.yml
@@ -5,7 +5,7 @@ env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 jobs:
   upgrade_provider:
-    if: contains(github.event.issue.title, 'Upgrade terraform-provider-')
+    if: contains(${{ github.event.issue.title }}, 'Upgrade terraform-provider-')
     name: upgrade-provider
     runs-on: ubuntu-latest
     steps:

--- a/provider-ci/providers/mysql/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/mysql/repo/.github/workflows/main.yml
@@ -360,7 +360,7 @@ jobs:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
-        SLACK_MESSAGE: " Publish failed :x:"
+        SLACK_MESSAGE: "Publish failed :x:"
         SLACK_TITLE: ${{ github.event.repository.name }} upgrade result
         SLACK_USERNAME: provider-bot
         SLACK_WEBHOOK: ${{ env.SLACK_WEBHOOK_URL }}

--- a/provider-ci/providers/mysql/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/mysql/repo/.github/workflows/master.yml
@@ -360,7 +360,7 @@ jobs:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
-        SLACK_MESSAGE: " Publish failed :x:"
+        SLACK_MESSAGE: "Publish failed :x:"
         SLACK_TITLE: ${{ github.event.repository.name }} upgrade result
         SLACK_USERNAME: provider-bot
         SLACK_WEBHOOK: ${{ env.SLACK_WEBHOOK_URL }}

--- a/provider-ci/providers/mysql/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/mysql/repo/.github/workflows/prerelease.yml
@@ -310,7 +310,7 @@ jobs:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
-        SLACK_MESSAGE: " Publish failed :x:"
+        SLACK_MESSAGE: "Publish failed :x:"
         SLACK_TITLE: ${{ github.event.repository.name }} upgrade result
         SLACK_USERNAME: provider-bot
         SLACK_WEBHOOK: ${{ env.SLACK_WEBHOOK_URL }}

--- a/provider-ci/providers/mysql/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/mysql/repo/.github/workflows/release.yml
@@ -322,7 +322,7 @@ jobs:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
-        SLACK_MESSAGE: " Publish failed :x:"
+        SLACK_MESSAGE: "Publish failed :x:"
         SLACK_TITLE: ${{ github.event.repository.name }} upgrade result
         SLACK_USERNAME: provider-bot
         SLACK_WEBHOOK: ${{ env.SLACK_WEBHOOK_URL }}

--- a/provider-ci/providers/mysql/repo/.github/workflows/upgrade-provider.yml
+++ b/provider-ci/providers/mysql/repo/.github/workflows/upgrade-provider.yml
@@ -14,6 +14,30 @@ jobs:
       with:
         slack-channel: provider-upgrade-status
         slack-webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
+    - env:
+        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_COLOR: "#FF0000"
+        SLACK_ICON_EMOJI: ":taco:"
+        SLACK_MESSAGE: >-
+          Upgrade succeeded :heart_decoration:
+
+          PR opened at github.com/pulumi/${{ github.event.repository.name }}/pulls
+        SLACK_TITLE: ${{ github.event.repository.name }} upgrade result
+        SLACK_USERNAME: provider-bot
+        SLACK_WEBHOOK: ${{ env.SLACK_WEBHOOK_URL }}
+      name: Send Upgrade Success To Slack
+      uses: rtCamp/action-slack-notify@v2
+    - env:
+        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_COLOR: "#FF0000"
+        SLACK_ICON_EMOJI: ":taco:"
+        SLACK_MESSAGE: " Upgrade failed :x:"
+        SLACK_TITLE: ${{ github.event.repository.name }} upgrade result
+        SLACK_USERNAME: provider-bot
+        SLACK_WEBHOOK: ${{ env.SLACK_WEBHOOK_URL }}
+      if: failure()
+      name: Send Upgrade Failure To Slack
+      uses: rtCamp/action-slack-notify@v2
 name: Upgrade provider
 on:
   issues:

--- a/provider-ci/providers/mysql/repo/.github/workflows/upgrade-provider.yml
+++ b/provider-ci/providers/mysql/repo/.github/workflows/upgrade-provider.yml
@@ -5,7 +5,7 @@ env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 jobs:
   upgrade_provider:
-    if: contains(github.event.issue.title, 'Upgrade terraform-provider-')
+    if: contains(${{ github.event.issue.title }}, 'Upgrade terraform-provider-')
     name: upgrade-provider
     runs-on: ubuntu-latest
     steps:

--- a/provider-ci/providers/newrelic/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/newrelic/repo/.github/workflows/main.yml
@@ -362,7 +362,7 @@ jobs:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
-        SLACK_MESSAGE: " Publish failed :x:"
+        SLACK_MESSAGE: "Publish failed :x:"
         SLACK_TITLE: ${{ github.event.repository.name }} upgrade result
         SLACK_USERNAME: provider-bot
         SLACK_WEBHOOK: ${{ env.SLACK_WEBHOOK_URL }}

--- a/provider-ci/providers/newrelic/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/newrelic/repo/.github/workflows/master.yml
@@ -362,7 +362,7 @@ jobs:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
-        SLACK_MESSAGE: " Publish failed :x:"
+        SLACK_MESSAGE: "Publish failed :x:"
         SLACK_TITLE: ${{ github.event.repository.name }} upgrade result
         SLACK_USERNAME: provider-bot
         SLACK_WEBHOOK: ${{ env.SLACK_WEBHOOK_URL }}

--- a/provider-ci/providers/newrelic/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/newrelic/repo/.github/workflows/prerelease.yml
@@ -312,7 +312,7 @@ jobs:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
-        SLACK_MESSAGE: " Publish failed :x:"
+        SLACK_MESSAGE: "Publish failed :x:"
         SLACK_TITLE: ${{ github.event.repository.name }} upgrade result
         SLACK_USERNAME: provider-bot
         SLACK_WEBHOOK: ${{ env.SLACK_WEBHOOK_URL }}

--- a/provider-ci/providers/newrelic/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/newrelic/repo/.github/workflows/release.yml
@@ -324,7 +324,7 @@ jobs:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
-        SLACK_MESSAGE: " Publish failed :x:"
+        SLACK_MESSAGE: "Publish failed :x:"
         SLACK_TITLE: ${{ github.event.repository.name }} upgrade result
         SLACK_USERNAME: provider-bot
         SLACK_WEBHOOK: ${{ env.SLACK_WEBHOOK_URL }}

--- a/provider-ci/providers/newrelic/repo/.github/workflows/upgrade-provider.yml
+++ b/provider-ci/providers/newrelic/repo/.github/workflows/upgrade-provider.yml
@@ -14,6 +14,30 @@ jobs:
       with:
         slack-channel: provider-upgrade-status
         slack-webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
+    - env:
+        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_COLOR: "#FF0000"
+        SLACK_ICON_EMOJI: ":taco:"
+        SLACK_MESSAGE: >-
+          Upgrade succeeded :heart_decoration:
+
+          PR opened at github.com/pulumi/${{ github.event.repository.name }}/pulls
+        SLACK_TITLE: ${{ github.event.repository.name }} upgrade result
+        SLACK_USERNAME: provider-bot
+        SLACK_WEBHOOK: ${{ env.SLACK_WEBHOOK_URL }}
+      name: Send Upgrade Success To Slack
+      uses: rtCamp/action-slack-notify@v2
+    - env:
+        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_COLOR: "#FF0000"
+        SLACK_ICON_EMOJI: ":taco:"
+        SLACK_MESSAGE: " Upgrade failed :x:"
+        SLACK_TITLE: ${{ github.event.repository.name }} upgrade result
+        SLACK_USERNAME: provider-bot
+        SLACK_WEBHOOK: ${{ env.SLACK_WEBHOOK_URL }}
+      if: failure()
+      name: Send Upgrade Failure To Slack
+      uses: rtCamp/action-slack-notify@v2
 name: Upgrade provider
 on:
   issues:

--- a/provider-ci/providers/newrelic/repo/.github/workflows/upgrade-provider.yml
+++ b/provider-ci/providers/newrelic/repo/.github/workflows/upgrade-provider.yml
@@ -5,7 +5,7 @@ env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 jobs:
   upgrade_provider:
-    if: contains(github.event.issue.title, 'Upgrade terraform-provider-')
+    if: contains(${{ github.event.issue.title }}, 'Upgrade terraform-provider-')
     name: upgrade-provider
     runs-on: ubuntu-latest
     steps:

--- a/provider-ci/providers/nomad/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/nomad/repo/.github/workflows/main.yml
@@ -361,7 +361,7 @@ jobs:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
-        SLACK_MESSAGE: " Publish failed :x:"
+        SLACK_MESSAGE: "Publish failed :x:"
         SLACK_TITLE: ${{ github.event.repository.name }} upgrade result
         SLACK_USERNAME: provider-bot
         SLACK_WEBHOOK: ${{ env.SLACK_WEBHOOK_URL }}

--- a/provider-ci/providers/nomad/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/nomad/repo/.github/workflows/master.yml
@@ -361,7 +361,7 @@ jobs:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
-        SLACK_MESSAGE: " Publish failed :x:"
+        SLACK_MESSAGE: "Publish failed :x:"
         SLACK_TITLE: ${{ github.event.repository.name }} upgrade result
         SLACK_USERNAME: provider-bot
         SLACK_WEBHOOK: ${{ env.SLACK_WEBHOOK_URL }}

--- a/provider-ci/providers/nomad/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/nomad/repo/.github/workflows/prerelease.yml
@@ -311,7 +311,7 @@ jobs:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
-        SLACK_MESSAGE: " Publish failed :x:"
+        SLACK_MESSAGE: "Publish failed :x:"
         SLACK_TITLE: ${{ github.event.repository.name }} upgrade result
         SLACK_USERNAME: provider-bot
         SLACK_WEBHOOK: ${{ env.SLACK_WEBHOOK_URL }}

--- a/provider-ci/providers/nomad/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/nomad/repo/.github/workflows/release.yml
@@ -323,7 +323,7 @@ jobs:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
-        SLACK_MESSAGE: " Publish failed :x:"
+        SLACK_MESSAGE: "Publish failed :x:"
         SLACK_TITLE: ${{ github.event.repository.name }} upgrade result
         SLACK_USERNAME: provider-bot
         SLACK_WEBHOOK: ${{ env.SLACK_WEBHOOK_URL }}

--- a/provider-ci/providers/nomad/repo/.github/workflows/upgrade-provider.yml
+++ b/provider-ci/providers/nomad/repo/.github/workflows/upgrade-provider.yml
@@ -14,6 +14,30 @@ jobs:
       with:
         slack-channel: provider-upgrade-status
         slack-webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
+    - env:
+        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_COLOR: "#FF0000"
+        SLACK_ICON_EMOJI: ":taco:"
+        SLACK_MESSAGE: >-
+          Upgrade succeeded :heart_decoration:
+
+          PR opened at github.com/pulumi/${{ github.event.repository.name }}/pulls
+        SLACK_TITLE: ${{ github.event.repository.name }} upgrade result
+        SLACK_USERNAME: provider-bot
+        SLACK_WEBHOOK: ${{ env.SLACK_WEBHOOK_URL }}
+      name: Send Upgrade Success To Slack
+      uses: rtCamp/action-slack-notify@v2
+    - env:
+        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_COLOR: "#FF0000"
+        SLACK_ICON_EMOJI: ":taco:"
+        SLACK_MESSAGE: " Upgrade failed :x:"
+        SLACK_TITLE: ${{ github.event.repository.name }} upgrade result
+        SLACK_USERNAME: provider-bot
+        SLACK_WEBHOOK: ${{ env.SLACK_WEBHOOK_URL }}
+      if: failure()
+      name: Send Upgrade Failure To Slack
+      uses: rtCamp/action-slack-notify@v2
 name: Upgrade provider
 on:
   issues:

--- a/provider-ci/providers/nomad/repo/.github/workflows/upgrade-provider.yml
+++ b/provider-ci/providers/nomad/repo/.github/workflows/upgrade-provider.yml
@@ -5,7 +5,7 @@ env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 jobs:
   upgrade_provider:
-    if: contains(github.event.issue.title, 'Upgrade terraform-provider-')
+    if: contains(${{ github.event.issue.title }}, 'Upgrade terraform-provider-')
     name: upgrade-provider
     runs-on: ubuntu-latest
     steps:

--- a/provider-ci/providers/ns1/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/ns1/repo/.github/workflows/main.yml
@@ -361,7 +361,7 @@ jobs:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
-        SLACK_MESSAGE: " Publish failed :x:"
+        SLACK_MESSAGE: "Publish failed :x:"
         SLACK_TITLE: ${{ github.event.repository.name }} upgrade result
         SLACK_USERNAME: provider-bot
         SLACK_WEBHOOK: ${{ env.SLACK_WEBHOOK_URL }}

--- a/provider-ci/providers/ns1/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/ns1/repo/.github/workflows/master.yml
@@ -361,7 +361,7 @@ jobs:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
-        SLACK_MESSAGE: " Publish failed :x:"
+        SLACK_MESSAGE: "Publish failed :x:"
         SLACK_TITLE: ${{ github.event.repository.name }} upgrade result
         SLACK_USERNAME: provider-bot
         SLACK_WEBHOOK: ${{ env.SLACK_WEBHOOK_URL }}

--- a/provider-ci/providers/ns1/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/ns1/repo/.github/workflows/prerelease.yml
@@ -311,7 +311,7 @@ jobs:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
-        SLACK_MESSAGE: " Publish failed :x:"
+        SLACK_MESSAGE: "Publish failed :x:"
         SLACK_TITLE: ${{ github.event.repository.name }} upgrade result
         SLACK_USERNAME: provider-bot
         SLACK_WEBHOOK: ${{ env.SLACK_WEBHOOK_URL }}

--- a/provider-ci/providers/ns1/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/ns1/repo/.github/workflows/release.yml
@@ -323,7 +323,7 @@ jobs:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
-        SLACK_MESSAGE: " Publish failed :x:"
+        SLACK_MESSAGE: "Publish failed :x:"
         SLACK_TITLE: ${{ github.event.repository.name }} upgrade result
         SLACK_USERNAME: provider-bot
         SLACK_WEBHOOK: ${{ env.SLACK_WEBHOOK_URL }}

--- a/provider-ci/providers/ns1/repo/.github/workflows/upgrade-provider.yml
+++ b/provider-ci/providers/ns1/repo/.github/workflows/upgrade-provider.yml
@@ -14,6 +14,30 @@ jobs:
       with:
         slack-channel: provider-upgrade-status
         slack-webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
+    - env:
+        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_COLOR: "#FF0000"
+        SLACK_ICON_EMOJI: ":taco:"
+        SLACK_MESSAGE: >-
+          Upgrade succeeded :heart_decoration:
+
+          PR opened at github.com/pulumi/${{ github.event.repository.name }}/pulls
+        SLACK_TITLE: ${{ github.event.repository.name }} upgrade result
+        SLACK_USERNAME: provider-bot
+        SLACK_WEBHOOK: ${{ env.SLACK_WEBHOOK_URL }}
+      name: Send Upgrade Success To Slack
+      uses: rtCamp/action-slack-notify@v2
+    - env:
+        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_COLOR: "#FF0000"
+        SLACK_ICON_EMOJI: ":taco:"
+        SLACK_MESSAGE: " Upgrade failed :x:"
+        SLACK_TITLE: ${{ github.event.repository.name }} upgrade result
+        SLACK_USERNAME: provider-bot
+        SLACK_WEBHOOK: ${{ env.SLACK_WEBHOOK_URL }}
+      if: failure()
+      name: Send Upgrade Failure To Slack
+      uses: rtCamp/action-slack-notify@v2
 name: Upgrade provider
 on:
   issues:

--- a/provider-ci/providers/ns1/repo/.github/workflows/upgrade-provider.yml
+++ b/provider-ci/providers/ns1/repo/.github/workflows/upgrade-provider.yml
@@ -5,7 +5,7 @@ env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 jobs:
   upgrade_provider:
-    if: contains(github.event.issue.title, 'Upgrade terraform-provider-')
+    if: contains(${{ github.event.issue.title }}, 'Upgrade terraform-provider-')
     name: upgrade-provider
     runs-on: ubuntu-latest
     steps:

--- a/provider-ci/providers/oci/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/oci/repo/.github/workflows/main.yml
@@ -293,7 +293,7 @@ jobs:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
-        SLACK_MESSAGE: " Publish failed :x:"
+        SLACK_MESSAGE: "Publish failed :x:"
         SLACK_TITLE: ${{ github.event.repository.name }} upgrade result
         SLACK_USERNAME: provider-bot
         SLACK_WEBHOOK: ${{ env.SLACK_WEBHOOK_URL }}

--- a/provider-ci/providers/oci/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/oci/repo/.github/workflows/master.yml
@@ -293,7 +293,7 @@ jobs:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
-        SLACK_MESSAGE: " Publish failed :x:"
+        SLACK_MESSAGE: "Publish failed :x:"
         SLACK_TITLE: ${{ github.event.repository.name }} upgrade result
         SLACK_USERNAME: provider-bot
         SLACK_WEBHOOK: ${{ env.SLACK_WEBHOOK_URL }}

--- a/provider-ci/providers/oci/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/oci/repo/.github/workflows/prerelease.yml
@@ -243,7 +243,7 @@ jobs:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
-        SLACK_MESSAGE: " Publish failed :x:"
+        SLACK_MESSAGE: "Publish failed :x:"
         SLACK_TITLE: ${{ github.event.repository.name }} upgrade result
         SLACK_USERNAME: provider-bot
         SLACK_WEBHOOK: ${{ env.SLACK_WEBHOOK_URL }}

--- a/provider-ci/providers/oci/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/oci/repo/.github/workflows/release.yml
@@ -255,7 +255,7 @@ jobs:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
-        SLACK_MESSAGE: " Publish failed :x:"
+        SLACK_MESSAGE: "Publish failed :x:"
         SLACK_TITLE: ${{ github.event.repository.name }} upgrade result
         SLACK_USERNAME: provider-bot
         SLACK_WEBHOOK: ${{ env.SLACK_WEBHOOK_URL }}

--- a/provider-ci/providers/oci/repo/.github/workflows/upgrade-provider.yml
+++ b/provider-ci/providers/oci/repo/.github/workflows/upgrade-provider.yml
@@ -14,6 +14,30 @@ jobs:
       with:
         slack-channel: provider-upgrade-status
         slack-webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
+    - env:
+        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_COLOR: "#FF0000"
+        SLACK_ICON_EMOJI: ":taco:"
+        SLACK_MESSAGE: >-
+          Upgrade succeeded :heart_decoration:
+
+          PR opened at github.com/pulumi/${{ github.event.repository.name }}/pulls
+        SLACK_TITLE: ${{ github.event.repository.name }} upgrade result
+        SLACK_USERNAME: provider-bot
+        SLACK_WEBHOOK: ${{ env.SLACK_WEBHOOK_URL }}
+      name: Send Upgrade Success To Slack
+      uses: rtCamp/action-slack-notify@v2
+    - env:
+        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_COLOR: "#FF0000"
+        SLACK_ICON_EMOJI: ":taco:"
+        SLACK_MESSAGE: " Upgrade failed :x:"
+        SLACK_TITLE: ${{ github.event.repository.name }} upgrade result
+        SLACK_USERNAME: provider-bot
+        SLACK_WEBHOOK: ${{ env.SLACK_WEBHOOK_URL }}
+      if: failure()
+      name: Send Upgrade Failure To Slack
+      uses: rtCamp/action-slack-notify@v2
 name: Upgrade provider
 on:
   issues:

--- a/provider-ci/providers/oci/repo/.github/workflows/upgrade-provider.yml
+++ b/provider-ci/providers/oci/repo/.github/workflows/upgrade-provider.yml
@@ -5,7 +5,7 @@ env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 jobs:
   upgrade_provider:
-    if: contains(github.event.issue.title, 'Upgrade terraform-provider-')
+    if: contains(${{ github.event.issue.title }}, 'Upgrade terraform-provider-')
     name: upgrade-provider
     runs-on: ubuntu-latest
     steps:

--- a/provider-ci/providers/okta/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/okta/repo/.github/workflows/main.yml
@@ -363,7 +363,7 @@ jobs:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
-        SLACK_MESSAGE: " Publish failed :x:"
+        SLACK_MESSAGE: "Publish failed :x:"
         SLACK_TITLE: ${{ github.event.repository.name }} upgrade result
         SLACK_USERNAME: provider-bot
         SLACK_WEBHOOK: ${{ env.SLACK_WEBHOOK_URL }}

--- a/provider-ci/providers/okta/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/okta/repo/.github/workflows/master.yml
@@ -363,7 +363,7 @@ jobs:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
-        SLACK_MESSAGE: " Publish failed :x:"
+        SLACK_MESSAGE: "Publish failed :x:"
         SLACK_TITLE: ${{ github.event.repository.name }} upgrade result
         SLACK_USERNAME: provider-bot
         SLACK_WEBHOOK: ${{ env.SLACK_WEBHOOK_URL }}

--- a/provider-ci/providers/okta/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/okta/repo/.github/workflows/prerelease.yml
@@ -313,7 +313,7 @@ jobs:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
-        SLACK_MESSAGE: " Publish failed :x:"
+        SLACK_MESSAGE: "Publish failed :x:"
         SLACK_TITLE: ${{ github.event.repository.name }} upgrade result
         SLACK_USERNAME: provider-bot
         SLACK_WEBHOOK: ${{ env.SLACK_WEBHOOK_URL }}

--- a/provider-ci/providers/okta/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/okta/repo/.github/workflows/release.yml
@@ -325,7 +325,7 @@ jobs:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
-        SLACK_MESSAGE: " Publish failed :x:"
+        SLACK_MESSAGE: "Publish failed :x:"
         SLACK_TITLE: ${{ github.event.repository.name }} upgrade result
         SLACK_USERNAME: provider-bot
         SLACK_WEBHOOK: ${{ env.SLACK_WEBHOOK_URL }}

--- a/provider-ci/providers/okta/repo/.github/workflows/upgrade-provider.yml
+++ b/provider-ci/providers/okta/repo/.github/workflows/upgrade-provider.yml
@@ -14,6 +14,30 @@ jobs:
       with:
         slack-channel: provider-upgrade-status
         slack-webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
+    - env:
+        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_COLOR: "#FF0000"
+        SLACK_ICON_EMOJI: ":taco:"
+        SLACK_MESSAGE: >-
+          Upgrade succeeded :heart_decoration:
+
+          PR opened at github.com/pulumi/${{ github.event.repository.name }}/pulls
+        SLACK_TITLE: ${{ github.event.repository.name }} upgrade result
+        SLACK_USERNAME: provider-bot
+        SLACK_WEBHOOK: ${{ env.SLACK_WEBHOOK_URL }}
+      name: Send Upgrade Success To Slack
+      uses: rtCamp/action-slack-notify@v2
+    - env:
+        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_COLOR: "#FF0000"
+        SLACK_ICON_EMOJI: ":taco:"
+        SLACK_MESSAGE: " Upgrade failed :x:"
+        SLACK_TITLE: ${{ github.event.repository.name }} upgrade result
+        SLACK_USERNAME: provider-bot
+        SLACK_WEBHOOK: ${{ env.SLACK_WEBHOOK_URL }}
+      if: failure()
+      name: Send Upgrade Failure To Slack
+      uses: rtCamp/action-slack-notify@v2
 name: Upgrade provider
 on:
   issues:

--- a/provider-ci/providers/okta/repo/.github/workflows/upgrade-provider.yml
+++ b/provider-ci/providers/okta/repo/.github/workflows/upgrade-provider.yml
@@ -5,7 +5,7 @@ env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 jobs:
   upgrade_provider:
-    if: contains(github.event.issue.title, 'Upgrade terraform-provider-')
+    if: contains(${{ github.event.issue.title }}, 'Upgrade terraform-provider-')
     name: upgrade-provider
     runs-on: ubuntu-latest
     steps:

--- a/provider-ci/providers/onelogin/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/onelogin/repo/.github/workflows/main.yml
@@ -360,7 +360,7 @@ jobs:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
-        SLACK_MESSAGE: " Publish failed :x:"
+        SLACK_MESSAGE: "Publish failed :x:"
         SLACK_TITLE: ${{ github.event.repository.name }} upgrade result
         SLACK_USERNAME: provider-bot
         SLACK_WEBHOOK: ${{ env.SLACK_WEBHOOK_URL }}

--- a/provider-ci/providers/onelogin/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/onelogin/repo/.github/workflows/master.yml
@@ -360,7 +360,7 @@ jobs:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
-        SLACK_MESSAGE: " Publish failed :x:"
+        SLACK_MESSAGE: "Publish failed :x:"
         SLACK_TITLE: ${{ github.event.repository.name }} upgrade result
         SLACK_USERNAME: provider-bot
         SLACK_WEBHOOK: ${{ env.SLACK_WEBHOOK_URL }}

--- a/provider-ci/providers/onelogin/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/onelogin/repo/.github/workflows/prerelease.yml
@@ -310,7 +310,7 @@ jobs:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
-        SLACK_MESSAGE: " Publish failed :x:"
+        SLACK_MESSAGE: "Publish failed :x:"
         SLACK_TITLE: ${{ github.event.repository.name }} upgrade result
         SLACK_USERNAME: provider-bot
         SLACK_WEBHOOK: ${{ env.SLACK_WEBHOOK_URL }}

--- a/provider-ci/providers/onelogin/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/onelogin/repo/.github/workflows/release.yml
@@ -322,7 +322,7 @@ jobs:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
-        SLACK_MESSAGE: " Publish failed :x:"
+        SLACK_MESSAGE: "Publish failed :x:"
         SLACK_TITLE: ${{ github.event.repository.name }} upgrade result
         SLACK_USERNAME: provider-bot
         SLACK_WEBHOOK: ${{ env.SLACK_WEBHOOK_URL }}

--- a/provider-ci/providers/onelogin/repo/.github/workflows/upgrade-provider.yml
+++ b/provider-ci/providers/onelogin/repo/.github/workflows/upgrade-provider.yml
@@ -14,6 +14,30 @@ jobs:
       with:
         slack-channel: provider-upgrade-status
         slack-webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
+    - env:
+        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_COLOR: "#FF0000"
+        SLACK_ICON_EMOJI: ":taco:"
+        SLACK_MESSAGE: >-
+          Upgrade succeeded :heart_decoration:
+
+          PR opened at github.com/pulumi/${{ github.event.repository.name }}/pulls
+        SLACK_TITLE: ${{ github.event.repository.name }} upgrade result
+        SLACK_USERNAME: provider-bot
+        SLACK_WEBHOOK: ${{ env.SLACK_WEBHOOK_URL }}
+      name: Send Upgrade Success To Slack
+      uses: rtCamp/action-slack-notify@v2
+    - env:
+        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_COLOR: "#FF0000"
+        SLACK_ICON_EMOJI: ":taco:"
+        SLACK_MESSAGE: " Upgrade failed :x:"
+        SLACK_TITLE: ${{ github.event.repository.name }} upgrade result
+        SLACK_USERNAME: provider-bot
+        SLACK_WEBHOOK: ${{ env.SLACK_WEBHOOK_URL }}
+      if: failure()
+      name: Send Upgrade Failure To Slack
+      uses: rtCamp/action-slack-notify@v2
 name: Upgrade provider
 on:
   issues:

--- a/provider-ci/providers/onelogin/repo/.github/workflows/upgrade-provider.yml
+++ b/provider-ci/providers/onelogin/repo/.github/workflows/upgrade-provider.yml
@@ -5,7 +5,7 @@ env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 jobs:
   upgrade_provider:
-    if: contains(github.event.issue.title, 'Upgrade terraform-provider-')
+    if: contains(${{ github.event.issue.title }}, 'Upgrade terraform-provider-')
     name: upgrade-provider
     runs-on: ubuntu-latest
     steps:

--- a/provider-ci/providers/openstack/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/openstack/repo/.github/workflows/main.yml
@@ -369,7 +369,7 @@ jobs:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
-        SLACK_MESSAGE: " Publish failed :x:"
+        SLACK_MESSAGE: "Publish failed :x:"
         SLACK_TITLE: ${{ github.event.repository.name }} upgrade result
         SLACK_USERNAME: provider-bot
         SLACK_WEBHOOK: ${{ env.SLACK_WEBHOOK_URL }}

--- a/provider-ci/providers/openstack/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/openstack/repo/.github/workflows/master.yml
@@ -369,7 +369,7 @@ jobs:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
-        SLACK_MESSAGE: " Publish failed :x:"
+        SLACK_MESSAGE: "Publish failed :x:"
         SLACK_TITLE: ${{ github.event.repository.name }} upgrade result
         SLACK_USERNAME: provider-bot
         SLACK_WEBHOOK: ${{ env.SLACK_WEBHOOK_URL }}

--- a/provider-ci/providers/openstack/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/openstack/repo/.github/workflows/prerelease.yml
@@ -319,7 +319,7 @@ jobs:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
-        SLACK_MESSAGE: " Publish failed :x:"
+        SLACK_MESSAGE: "Publish failed :x:"
         SLACK_TITLE: ${{ github.event.repository.name }} upgrade result
         SLACK_USERNAME: provider-bot
         SLACK_WEBHOOK: ${{ env.SLACK_WEBHOOK_URL }}

--- a/provider-ci/providers/openstack/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/openstack/repo/.github/workflows/release.yml
@@ -331,7 +331,7 @@ jobs:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
-        SLACK_MESSAGE: " Publish failed :x:"
+        SLACK_MESSAGE: "Publish failed :x:"
         SLACK_TITLE: ${{ github.event.repository.name }} upgrade result
         SLACK_USERNAME: provider-bot
         SLACK_WEBHOOK: ${{ env.SLACK_WEBHOOK_URL }}

--- a/provider-ci/providers/openstack/repo/.github/workflows/upgrade-provider.yml
+++ b/provider-ci/providers/openstack/repo/.github/workflows/upgrade-provider.yml
@@ -14,6 +14,30 @@ jobs:
       with:
         slack-channel: provider-upgrade-status
         slack-webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
+    - env:
+        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_COLOR: "#FF0000"
+        SLACK_ICON_EMOJI: ":taco:"
+        SLACK_MESSAGE: >-
+          Upgrade succeeded :heart_decoration:
+
+          PR opened at github.com/pulumi/${{ github.event.repository.name }}/pulls
+        SLACK_TITLE: ${{ github.event.repository.name }} upgrade result
+        SLACK_USERNAME: provider-bot
+        SLACK_WEBHOOK: ${{ env.SLACK_WEBHOOK_URL }}
+      name: Send Upgrade Success To Slack
+      uses: rtCamp/action-slack-notify@v2
+    - env:
+        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_COLOR: "#FF0000"
+        SLACK_ICON_EMOJI: ":taco:"
+        SLACK_MESSAGE: " Upgrade failed :x:"
+        SLACK_TITLE: ${{ github.event.repository.name }} upgrade result
+        SLACK_USERNAME: provider-bot
+        SLACK_WEBHOOK: ${{ env.SLACK_WEBHOOK_URL }}
+      if: failure()
+      name: Send Upgrade Failure To Slack
+      uses: rtCamp/action-slack-notify@v2
 name: Upgrade provider
 on:
   issues:

--- a/provider-ci/providers/openstack/repo/.github/workflows/upgrade-provider.yml
+++ b/provider-ci/providers/openstack/repo/.github/workflows/upgrade-provider.yml
@@ -5,7 +5,7 @@ env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 jobs:
   upgrade_provider:
-    if: contains(github.event.issue.title, 'Upgrade terraform-provider-')
+    if: contains(${{ github.event.issue.title }}, 'Upgrade terraform-provider-')
     name: upgrade-provider
     runs-on: ubuntu-latest
     steps:

--- a/provider-ci/providers/opsgenie/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/opsgenie/repo/.github/workflows/main.yml
@@ -361,7 +361,7 @@ jobs:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
-        SLACK_MESSAGE: " Publish failed :x:"
+        SLACK_MESSAGE: "Publish failed :x:"
         SLACK_TITLE: ${{ github.event.repository.name }} upgrade result
         SLACK_USERNAME: provider-bot
         SLACK_WEBHOOK: ${{ env.SLACK_WEBHOOK_URL }}

--- a/provider-ci/providers/opsgenie/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/opsgenie/repo/.github/workflows/master.yml
@@ -361,7 +361,7 @@ jobs:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
-        SLACK_MESSAGE: " Publish failed :x:"
+        SLACK_MESSAGE: "Publish failed :x:"
         SLACK_TITLE: ${{ github.event.repository.name }} upgrade result
         SLACK_USERNAME: provider-bot
         SLACK_WEBHOOK: ${{ env.SLACK_WEBHOOK_URL }}

--- a/provider-ci/providers/opsgenie/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/opsgenie/repo/.github/workflows/prerelease.yml
@@ -311,7 +311,7 @@ jobs:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
-        SLACK_MESSAGE: " Publish failed :x:"
+        SLACK_MESSAGE: "Publish failed :x:"
         SLACK_TITLE: ${{ github.event.repository.name }} upgrade result
         SLACK_USERNAME: provider-bot
         SLACK_WEBHOOK: ${{ env.SLACK_WEBHOOK_URL }}

--- a/provider-ci/providers/opsgenie/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/opsgenie/repo/.github/workflows/release.yml
@@ -323,7 +323,7 @@ jobs:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
-        SLACK_MESSAGE: " Publish failed :x:"
+        SLACK_MESSAGE: "Publish failed :x:"
         SLACK_TITLE: ${{ github.event.repository.name }} upgrade result
         SLACK_USERNAME: provider-bot
         SLACK_WEBHOOK: ${{ env.SLACK_WEBHOOK_URL }}

--- a/provider-ci/providers/opsgenie/repo/.github/workflows/upgrade-provider.yml
+++ b/provider-ci/providers/opsgenie/repo/.github/workflows/upgrade-provider.yml
@@ -14,6 +14,30 @@ jobs:
       with:
         slack-channel: provider-upgrade-status
         slack-webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
+    - env:
+        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_COLOR: "#FF0000"
+        SLACK_ICON_EMOJI: ":taco:"
+        SLACK_MESSAGE: >-
+          Upgrade succeeded :heart_decoration:
+
+          PR opened at github.com/pulumi/${{ github.event.repository.name }}/pulls
+        SLACK_TITLE: ${{ github.event.repository.name }} upgrade result
+        SLACK_USERNAME: provider-bot
+        SLACK_WEBHOOK: ${{ env.SLACK_WEBHOOK_URL }}
+      name: Send Upgrade Success To Slack
+      uses: rtCamp/action-slack-notify@v2
+    - env:
+        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_COLOR: "#FF0000"
+        SLACK_ICON_EMOJI: ":taco:"
+        SLACK_MESSAGE: " Upgrade failed :x:"
+        SLACK_TITLE: ${{ github.event.repository.name }} upgrade result
+        SLACK_USERNAME: provider-bot
+        SLACK_WEBHOOK: ${{ env.SLACK_WEBHOOK_URL }}
+      if: failure()
+      name: Send Upgrade Failure To Slack
+      uses: rtCamp/action-slack-notify@v2
 name: Upgrade provider
 on:
   issues:

--- a/provider-ci/providers/opsgenie/repo/.github/workflows/upgrade-provider.yml
+++ b/provider-ci/providers/opsgenie/repo/.github/workflows/upgrade-provider.yml
@@ -5,7 +5,7 @@ env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 jobs:
   upgrade_provider:
-    if: contains(github.event.issue.title, 'Upgrade terraform-provider-')
+    if: contains(${{ github.event.issue.title }}, 'Upgrade terraform-provider-')
     name: upgrade-provider
     runs-on: ubuntu-latest
     steps:

--- a/provider-ci/providers/pagerduty/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/pagerduty/repo/.github/workflows/main.yml
@@ -361,7 +361,7 @@ jobs:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
-        SLACK_MESSAGE: " Publish failed :x:"
+        SLACK_MESSAGE: "Publish failed :x:"
         SLACK_TITLE: ${{ github.event.repository.name }} upgrade result
         SLACK_USERNAME: provider-bot
         SLACK_WEBHOOK: ${{ env.SLACK_WEBHOOK_URL }}

--- a/provider-ci/providers/pagerduty/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/pagerduty/repo/.github/workflows/master.yml
@@ -361,7 +361,7 @@ jobs:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
-        SLACK_MESSAGE: " Publish failed :x:"
+        SLACK_MESSAGE: "Publish failed :x:"
         SLACK_TITLE: ${{ github.event.repository.name }} upgrade result
         SLACK_USERNAME: provider-bot
         SLACK_WEBHOOK: ${{ env.SLACK_WEBHOOK_URL }}

--- a/provider-ci/providers/pagerduty/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/pagerduty/repo/.github/workflows/prerelease.yml
@@ -311,7 +311,7 @@ jobs:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
-        SLACK_MESSAGE: " Publish failed :x:"
+        SLACK_MESSAGE: "Publish failed :x:"
         SLACK_TITLE: ${{ github.event.repository.name }} upgrade result
         SLACK_USERNAME: provider-bot
         SLACK_WEBHOOK: ${{ env.SLACK_WEBHOOK_URL }}

--- a/provider-ci/providers/pagerduty/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/pagerduty/repo/.github/workflows/release.yml
@@ -323,7 +323,7 @@ jobs:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
-        SLACK_MESSAGE: " Publish failed :x:"
+        SLACK_MESSAGE: "Publish failed :x:"
         SLACK_TITLE: ${{ github.event.repository.name }} upgrade result
         SLACK_USERNAME: provider-bot
         SLACK_WEBHOOK: ${{ env.SLACK_WEBHOOK_URL }}

--- a/provider-ci/providers/pagerduty/repo/.github/workflows/upgrade-provider.yml
+++ b/provider-ci/providers/pagerduty/repo/.github/workflows/upgrade-provider.yml
@@ -14,6 +14,30 @@ jobs:
       with:
         slack-channel: provider-upgrade-status
         slack-webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
+    - env:
+        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_COLOR: "#FF0000"
+        SLACK_ICON_EMOJI: ":taco:"
+        SLACK_MESSAGE: >-
+          Upgrade succeeded :heart_decoration:
+
+          PR opened at github.com/pulumi/${{ github.event.repository.name }}/pulls
+        SLACK_TITLE: ${{ github.event.repository.name }} upgrade result
+        SLACK_USERNAME: provider-bot
+        SLACK_WEBHOOK: ${{ env.SLACK_WEBHOOK_URL }}
+      name: Send Upgrade Success To Slack
+      uses: rtCamp/action-slack-notify@v2
+    - env:
+        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_COLOR: "#FF0000"
+        SLACK_ICON_EMOJI: ":taco:"
+        SLACK_MESSAGE: " Upgrade failed :x:"
+        SLACK_TITLE: ${{ github.event.repository.name }} upgrade result
+        SLACK_USERNAME: provider-bot
+        SLACK_WEBHOOK: ${{ env.SLACK_WEBHOOK_URL }}
+      if: failure()
+      name: Send Upgrade Failure To Slack
+      uses: rtCamp/action-slack-notify@v2
 name: Upgrade provider
 on:
   issues:

--- a/provider-ci/providers/pagerduty/repo/.github/workflows/upgrade-provider.yml
+++ b/provider-ci/providers/pagerduty/repo/.github/workflows/upgrade-provider.yml
@@ -5,7 +5,7 @@ env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 jobs:
   upgrade_provider:
-    if: contains(github.event.issue.title, 'Upgrade terraform-provider-')
+    if: contains(${{ github.event.issue.title }}, 'Upgrade terraform-provider-')
     name: upgrade-provider
     runs-on: ubuntu-latest
     steps:

--- a/provider-ci/providers/postgresql/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/postgresql/repo/.github/workflows/main.yml
@@ -360,7 +360,7 @@ jobs:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
-        SLACK_MESSAGE: " Publish failed :x:"
+        SLACK_MESSAGE: "Publish failed :x:"
         SLACK_TITLE: ${{ github.event.repository.name }} upgrade result
         SLACK_USERNAME: provider-bot
         SLACK_WEBHOOK: ${{ env.SLACK_WEBHOOK_URL }}

--- a/provider-ci/providers/postgresql/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/postgresql/repo/.github/workflows/master.yml
@@ -360,7 +360,7 @@ jobs:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
-        SLACK_MESSAGE: " Publish failed :x:"
+        SLACK_MESSAGE: "Publish failed :x:"
         SLACK_TITLE: ${{ github.event.repository.name }} upgrade result
         SLACK_USERNAME: provider-bot
         SLACK_WEBHOOK: ${{ env.SLACK_WEBHOOK_URL }}

--- a/provider-ci/providers/postgresql/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/postgresql/repo/.github/workflows/prerelease.yml
@@ -310,7 +310,7 @@ jobs:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
-        SLACK_MESSAGE: " Publish failed :x:"
+        SLACK_MESSAGE: "Publish failed :x:"
         SLACK_TITLE: ${{ github.event.repository.name }} upgrade result
         SLACK_USERNAME: provider-bot
         SLACK_WEBHOOK: ${{ env.SLACK_WEBHOOK_URL }}

--- a/provider-ci/providers/postgresql/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/postgresql/repo/.github/workflows/release.yml
@@ -322,7 +322,7 @@ jobs:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
-        SLACK_MESSAGE: " Publish failed :x:"
+        SLACK_MESSAGE: "Publish failed :x:"
         SLACK_TITLE: ${{ github.event.repository.name }} upgrade result
         SLACK_USERNAME: provider-bot
         SLACK_WEBHOOK: ${{ env.SLACK_WEBHOOK_URL }}

--- a/provider-ci/providers/postgresql/repo/.github/workflows/upgrade-provider.yml
+++ b/provider-ci/providers/postgresql/repo/.github/workflows/upgrade-provider.yml
@@ -14,6 +14,30 @@ jobs:
       with:
         slack-channel: provider-upgrade-status
         slack-webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
+    - env:
+        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_COLOR: "#FF0000"
+        SLACK_ICON_EMOJI: ":taco:"
+        SLACK_MESSAGE: >-
+          Upgrade succeeded :heart_decoration:
+
+          PR opened at github.com/pulumi/${{ github.event.repository.name }}/pulls
+        SLACK_TITLE: ${{ github.event.repository.name }} upgrade result
+        SLACK_USERNAME: provider-bot
+        SLACK_WEBHOOK: ${{ env.SLACK_WEBHOOK_URL }}
+      name: Send Upgrade Success To Slack
+      uses: rtCamp/action-slack-notify@v2
+    - env:
+        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_COLOR: "#FF0000"
+        SLACK_ICON_EMOJI: ":taco:"
+        SLACK_MESSAGE: " Upgrade failed :x:"
+        SLACK_TITLE: ${{ github.event.repository.name }} upgrade result
+        SLACK_USERNAME: provider-bot
+        SLACK_WEBHOOK: ${{ env.SLACK_WEBHOOK_URL }}
+      if: failure()
+      name: Send Upgrade Failure To Slack
+      uses: rtCamp/action-slack-notify@v2
 name: Upgrade provider
 on:
   issues:

--- a/provider-ci/providers/postgresql/repo/.github/workflows/upgrade-provider.yml
+++ b/provider-ci/providers/postgresql/repo/.github/workflows/upgrade-provider.yml
@@ -5,7 +5,7 @@ env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 jobs:
   upgrade_provider:
-    if: contains(github.event.issue.title, 'Upgrade terraform-provider-')
+    if: contains(${{ github.event.issue.title }}, 'Upgrade terraform-provider-')
     name: upgrade-provider
     runs-on: ubuntu-latest
     steps:

--- a/provider-ci/providers/rabbitmq/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/rabbitmq/repo/.github/workflows/main.yml
@@ -360,7 +360,7 @@ jobs:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
-        SLACK_MESSAGE: " Publish failed :x:"
+        SLACK_MESSAGE: "Publish failed :x:"
         SLACK_TITLE: ${{ github.event.repository.name }} upgrade result
         SLACK_USERNAME: provider-bot
         SLACK_WEBHOOK: ${{ env.SLACK_WEBHOOK_URL }}

--- a/provider-ci/providers/rabbitmq/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/rabbitmq/repo/.github/workflows/master.yml
@@ -360,7 +360,7 @@ jobs:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
-        SLACK_MESSAGE: " Publish failed :x:"
+        SLACK_MESSAGE: "Publish failed :x:"
         SLACK_TITLE: ${{ github.event.repository.name }} upgrade result
         SLACK_USERNAME: provider-bot
         SLACK_WEBHOOK: ${{ env.SLACK_WEBHOOK_URL }}

--- a/provider-ci/providers/rabbitmq/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/rabbitmq/repo/.github/workflows/prerelease.yml
@@ -310,7 +310,7 @@ jobs:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
-        SLACK_MESSAGE: " Publish failed :x:"
+        SLACK_MESSAGE: "Publish failed :x:"
         SLACK_TITLE: ${{ github.event.repository.name }} upgrade result
         SLACK_USERNAME: provider-bot
         SLACK_WEBHOOK: ${{ env.SLACK_WEBHOOK_URL }}

--- a/provider-ci/providers/rabbitmq/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/rabbitmq/repo/.github/workflows/release.yml
@@ -322,7 +322,7 @@ jobs:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
-        SLACK_MESSAGE: " Publish failed :x:"
+        SLACK_MESSAGE: "Publish failed :x:"
         SLACK_TITLE: ${{ github.event.repository.name }} upgrade result
         SLACK_USERNAME: provider-bot
         SLACK_WEBHOOK: ${{ env.SLACK_WEBHOOK_URL }}

--- a/provider-ci/providers/rabbitmq/repo/.github/workflows/upgrade-provider.yml
+++ b/provider-ci/providers/rabbitmq/repo/.github/workflows/upgrade-provider.yml
@@ -14,6 +14,30 @@ jobs:
       with:
         slack-channel: provider-upgrade-status
         slack-webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
+    - env:
+        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_COLOR: "#FF0000"
+        SLACK_ICON_EMOJI: ":taco:"
+        SLACK_MESSAGE: >-
+          Upgrade succeeded :heart_decoration:
+
+          PR opened at github.com/pulumi/${{ github.event.repository.name }}/pulls
+        SLACK_TITLE: ${{ github.event.repository.name }} upgrade result
+        SLACK_USERNAME: provider-bot
+        SLACK_WEBHOOK: ${{ env.SLACK_WEBHOOK_URL }}
+      name: Send Upgrade Success To Slack
+      uses: rtCamp/action-slack-notify@v2
+    - env:
+        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_COLOR: "#FF0000"
+        SLACK_ICON_EMOJI: ":taco:"
+        SLACK_MESSAGE: " Upgrade failed :x:"
+        SLACK_TITLE: ${{ github.event.repository.name }} upgrade result
+        SLACK_USERNAME: provider-bot
+        SLACK_WEBHOOK: ${{ env.SLACK_WEBHOOK_URL }}
+      if: failure()
+      name: Send Upgrade Failure To Slack
+      uses: rtCamp/action-slack-notify@v2
 name: Upgrade provider
 on:
   issues:

--- a/provider-ci/providers/rabbitmq/repo/.github/workflows/upgrade-provider.yml
+++ b/provider-ci/providers/rabbitmq/repo/.github/workflows/upgrade-provider.yml
@@ -5,7 +5,7 @@ env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 jobs:
   upgrade_provider:
-    if: contains(github.event.issue.title, 'Upgrade terraform-provider-')
+    if: contains(${{ github.event.issue.title }}, 'Upgrade terraform-provider-')
     name: upgrade-provider
     runs-on: ubuntu-latest
     steps:

--- a/provider-ci/providers/rancher2/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/rancher2/repo/.github/workflows/main.yml
@@ -291,7 +291,7 @@ jobs:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
-        SLACK_MESSAGE: " Publish failed :x:"
+        SLACK_MESSAGE: "Publish failed :x:"
         SLACK_TITLE: ${{ github.event.repository.name }} upgrade result
         SLACK_USERNAME: provider-bot
         SLACK_WEBHOOK: ${{ env.SLACK_WEBHOOK_URL }}

--- a/provider-ci/providers/rancher2/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/rancher2/repo/.github/workflows/master.yml
@@ -291,7 +291,7 @@ jobs:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
-        SLACK_MESSAGE: " Publish failed :x:"
+        SLACK_MESSAGE: "Publish failed :x:"
         SLACK_TITLE: ${{ github.event.repository.name }} upgrade result
         SLACK_USERNAME: provider-bot
         SLACK_WEBHOOK: ${{ env.SLACK_WEBHOOK_URL }}

--- a/provider-ci/providers/rancher2/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/rancher2/repo/.github/workflows/prerelease.yml
@@ -241,7 +241,7 @@ jobs:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
-        SLACK_MESSAGE: " Publish failed :x:"
+        SLACK_MESSAGE: "Publish failed :x:"
         SLACK_TITLE: ${{ github.event.repository.name }} upgrade result
         SLACK_USERNAME: provider-bot
         SLACK_WEBHOOK: ${{ env.SLACK_WEBHOOK_URL }}

--- a/provider-ci/providers/rancher2/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/rancher2/repo/.github/workflows/release.yml
@@ -253,7 +253,7 @@ jobs:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
-        SLACK_MESSAGE: " Publish failed :x:"
+        SLACK_MESSAGE: "Publish failed :x:"
         SLACK_TITLE: ${{ github.event.repository.name }} upgrade result
         SLACK_USERNAME: provider-bot
         SLACK_WEBHOOK: ${{ env.SLACK_WEBHOOK_URL }}

--- a/provider-ci/providers/rancher2/repo/.github/workflows/upgrade-provider.yml
+++ b/provider-ci/providers/rancher2/repo/.github/workflows/upgrade-provider.yml
@@ -14,6 +14,30 @@ jobs:
       with:
         slack-channel: provider-upgrade-status
         slack-webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
+    - env:
+        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_COLOR: "#FF0000"
+        SLACK_ICON_EMOJI: ":taco:"
+        SLACK_MESSAGE: >-
+          Upgrade succeeded :heart_decoration:
+
+          PR opened at github.com/pulumi/${{ github.event.repository.name }}/pulls
+        SLACK_TITLE: ${{ github.event.repository.name }} upgrade result
+        SLACK_USERNAME: provider-bot
+        SLACK_WEBHOOK: ${{ env.SLACK_WEBHOOK_URL }}
+      name: Send Upgrade Success To Slack
+      uses: rtCamp/action-slack-notify@v2
+    - env:
+        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_COLOR: "#FF0000"
+        SLACK_ICON_EMOJI: ":taco:"
+        SLACK_MESSAGE: " Upgrade failed :x:"
+        SLACK_TITLE: ${{ github.event.repository.name }} upgrade result
+        SLACK_USERNAME: provider-bot
+        SLACK_WEBHOOK: ${{ env.SLACK_WEBHOOK_URL }}
+      if: failure()
+      name: Send Upgrade Failure To Slack
+      uses: rtCamp/action-slack-notify@v2
 name: Upgrade provider
 on:
   issues:

--- a/provider-ci/providers/rancher2/repo/.github/workflows/upgrade-provider.yml
+++ b/provider-ci/providers/rancher2/repo/.github/workflows/upgrade-provider.yml
@@ -5,7 +5,7 @@ env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 jobs:
   upgrade_provider:
-    if: contains(github.event.issue.title, 'Upgrade terraform-provider-')
+    if: contains(${{ github.event.issue.title }}, 'Upgrade terraform-provider-')
     name: upgrade-provider
     runs-on: ubuntu-latest
     steps:

--- a/provider-ci/providers/random/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/random/repo/.github/workflows/main.yml
@@ -360,7 +360,7 @@ jobs:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
-        SLACK_MESSAGE: " Publish failed :x:"
+        SLACK_MESSAGE: "Publish failed :x:"
         SLACK_TITLE: ${{ github.event.repository.name }} upgrade result
         SLACK_USERNAME: provider-bot
         SLACK_WEBHOOK: ${{ env.SLACK_WEBHOOK_URL }}

--- a/provider-ci/providers/random/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/random/repo/.github/workflows/master.yml
@@ -360,7 +360,7 @@ jobs:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
-        SLACK_MESSAGE: " Publish failed :x:"
+        SLACK_MESSAGE: "Publish failed :x:"
         SLACK_TITLE: ${{ github.event.repository.name }} upgrade result
         SLACK_USERNAME: provider-bot
         SLACK_WEBHOOK: ${{ env.SLACK_WEBHOOK_URL }}

--- a/provider-ci/providers/random/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/random/repo/.github/workflows/prerelease.yml
@@ -310,7 +310,7 @@ jobs:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
-        SLACK_MESSAGE: " Publish failed :x:"
+        SLACK_MESSAGE: "Publish failed :x:"
         SLACK_TITLE: ${{ github.event.repository.name }} upgrade result
         SLACK_USERNAME: provider-bot
         SLACK_WEBHOOK: ${{ env.SLACK_WEBHOOK_URL }}

--- a/provider-ci/providers/random/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/random/repo/.github/workflows/release.yml
@@ -322,7 +322,7 @@ jobs:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
-        SLACK_MESSAGE: " Publish failed :x:"
+        SLACK_MESSAGE: "Publish failed :x:"
         SLACK_TITLE: ${{ github.event.repository.name }} upgrade result
         SLACK_USERNAME: provider-bot
         SLACK_WEBHOOK: ${{ env.SLACK_WEBHOOK_URL }}

--- a/provider-ci/providers/random/repo/.github/workflows/upgrade-provider.yml
+++ b/provider-ci/providers/random/repo/.github/workflows/upgrade-provider.yml
@@ -14,6 +14,30 @@ jobs:
       with:
         slack-channel: provider-upgrade-status
         slack-webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
+    - env:
+        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_COLOR: "#FF0000"
+        SLACK_ICON_EMOJI: ":taco:"
+        SLACK_MESSAGE: >-
+          Upgrade succeeded :heart_decoration:
+
+          PR opened at github.com/pulumi/${{ github.event.repository.name }}/pulls
+        SLACK_TITLE: ${{ github.event.repository.name }} upgrade result
+        SLACK_USERNAME: provider-bot
+        SLACK_WEBHOOK: ${{ env.SLACK_WEBHOOK_URL }}
+      name: Send Upgrade Success To Slack
+      uses: rtCamp/action-slack-notify@v2
+    - env:
+        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_COLOR: "#FF0000"
+        SLACK_ICON_EMOJI: ":taco:"
+        SLACK_MESSAGE: " Upgrade failed :x:"
+        SLACK_TITLE: ${{ github.event.repository.name }} upgrade result
+        SLACK_USERNAME: provider-bot
+        SLACK_WEBHOOK: ${{ env.SLACK_WEBHOOK_URL }}
+      if: failure()
+      name: Send Upgrade Failure To Slack
+      uses: rtCamp/action-slack-notify@v2
 name: Upgrade provider
 on:
   issues:

--- a/provider-ci/providers/random/repo/.github/workflows/upgrade-provider.yml
+++ b/provider-ci/providers/random/repo/.github/workflows/upgrade-provider.yml
@@ -5,7 +5,7 @@ env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 jobs:
   upgrade_provider:
-    if: contains(github.event.issue.title, 'Upgrade terraform-provider-')
+    if: contains(${{ github.event.issue.title }}, 'Upgrade terraform-provider-')
     name: upgrade-provider
     runs-on: ubuntu-latest
     steps:

--- a/provider-ci/providers/rke/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/rke/repo/.github/workflows/main.yml
@@ -361,7 +361,7 @@ jobs:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
-        SLACK_MESSAGE: " Publish failed :x:"
+        SLACK_MESSAGE: "Publish failed :x:"
         SLACK_TITLE: ${{ github.event.repository.name }} upgrade result
         SLACK_USERNAME: provider-bot
         SLACK_WEBHOOK: ${{ env.SLACK_WEBHOOK_URL }}

--- a/provider-ci/providers/rke/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/rke/repo/.github/workflows/master.yml
@@ -361,7 +361,7 @@ jobs:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
-        SLACK_MESSAGE: " Publish failed :x:"
+        SLACK_MESSAGE: "Publish failed :x:"
         SLACK_TITLE: ${{ github.event.repository.name }} upgrade result
         SLACK_USERNAME: provider-bot
         SLACK_WEBHOOK: ${{ env.SLACK_WEBHOOK_URL }}

--- a/provider-ci/providers/rke/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/rke/repo/.github/workflows/prerelease.yml
@@ -311,7 +311,7 @@ jobs:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
-        SLACK_MESSAGE: " Publish failed :x:"
+        SLACK_MESSAGE: "Publish failed :x:"
         SLACK_TITLE: ${{ github.event.repository.name }} upgrade result
         SLACK_USERNAME: provider-bot
         SLACK_WEBHOOK: ${{ env.SLACK_WEBHOOK_URL }}

--- a/provider-ci/providers/rke/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/rke/repo/.github/workflows/release.yml
@@ -323,7 +323,7 @@ jobs:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
-        SLACK_MESSAGE: " Publish failed :x:"
+        SLACK_MESSAGE: "Publish failed :x:"
         SLACK_TITLE: ${{ github.event.repository.name }} upgrade result
         SLACK_USERNAME: provider-bot
         SLACK_WEBHOOK: ${{ env.SLACK_WEBHOOK_URL }}

--- a/provider-ci/providers/rke/repo/.github/workflows/upgrade-provider.yml
+++ b/provider-ci/providers/rke/repo/.github/workflows/upgrade-provider.yml
@@ -14,6 +14,30 @@ jobs:
       with:
         slack-channel: provider-upgrade-status
         slack-webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
+    - env:
+        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_COLOR: "#FF0000"
+        SLACK_ICON_EMOJI: ":taco:"
+        SLACK_MESSAGE: >-
+          Upgrade succeeded :heart_decoration:
+
+          PR opened at github.com/pulumi/${{ github.event.repository.name }}/pulls
+        SLACK_TITLE: ${{ github.event.repository.name }} upgrade result
+        SLACK_USERNAME: provider-bot
+        SLACK_WEBHOOK: ${{ env.SLACK_WEBHOOK_URL }}
+      name: Send Upgrade Success To Slack
+      uses: rtCamp/action-slack-notify@v2
+    - env:
+        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_COLOR: "#FF0000"
+        SLACK_ICON_EMOJI: ":taco:"
+        SLACK_MESSAGE: " Upgrade failed :x:"
+        SLACK_TITLE: ${{ github.event.repository.name }} upgrade result
+        SLACK_USERNAME: provider-bot
+        SLACK_WEBHOOK: ${{ env.SLACK_WEBHOOK_URL }}
+      if: failure()
+      name: Send Upgrade Failure To Slack
+      uses: rtCamp/action-slack-notify@v2
 name: Upgrade provider
 on:
   issues:

--- a/provider-ci/providers/rke/repo/.github/workflows/upgrade-provider.yml
+++ b/provider-ci/providers/rke/repo/.github/workflows/upgrade-provider.yml
@@ -5,7 +5,7 @@ env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 jobs:
   upgrade_provider:
-    if: contains(github.event.issue.title, 'Upgrade terraform-provider-')
+    if: contains(${{ github.event.issue.title }}, 'Upgrade terraform-provider-')
     name: upgrade-provider
     runs-on: ubuntu-latest
     steps:

--- a/provider-ci/providers/signalfx/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/signalfx/repo/.github/workflows/main.yml
@@ -360,7 +360,7 @@ jobs:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
-        SLACK_MESSAGE: " Publish failed :x:"
+        SLACK_MESSAGE: "Publish failed :x:"
         SLACK_TITLE: ${{ github.event.repository.name }} upgrade result
         SLACK_USERNAME: provider-bot
         SLACK_WEBHOOK: ${{ env.SLACK_WEBHOOK_URL }}

--- a/provider-ci/providers/signalfx/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/signalfx/repo/.github/workflows/master.yml
@@ -360,7 +360,7 @@ jobs:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
-        SLACK_MESSAGE: " Publish failed :x:"
+        SLACK_MESSAGE: "Publish failed :x:"
         SLACK_TITLE: ${{ github.event.repository.name }} upgrade result
         SLACK_USERNAME: provider-bot
         SLACK_WEBHOOK: ${{ env.SLACK_WEBHOOK_URL }}

--- a/provider-ci/providers/signalfx/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/signalfx/repo/.github/workflows/prerelease.yml
@@ -310,7 +310,7 @@ jobs:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
-        SLACK_MESSAGE: " Publish failed :x:"
+        SLACK_MESSAGE: "Publish failed :x:"
         SLACK_TITLE: ${{ github.event.repository.name }} upgrade result
         SLACK_USERNAME: provider-bot
         SLACK_WEBHOOK: ${{ env.SLACK_WEBHOOK_URL }}

--- a/provider-ci/providers/signalfx/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/signalfx/repo/.github/workflows/release.yml
@@ -322,7 +322,7 @@ jobs:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
-        SLACK_MESSAGE: " Publish failed :x:"
+        SLACK_MESSAGE: "Publish failed :x:"
         SLACK_TITLE: ${{ github.event.repository.name }} upgrade result
         SLACK_USERNAME: provider-bot
         SLACK_WEBHOOK: ${{ env.SLACK_WEBHOOK_URL }}

--- a/provider-ci/providers/signalfx/repo/.github/workflows/upgrade-provider.yml
+++ b/provider-ci/providers/signalfx/repo/.github/workflows/upgrade-provider.yml
@@ -14,6 +14,30 @@ jobs:
       with:
         slack-channel: provider-upgrade-status
         slack-webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
+    - env:
+        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_COLOR: "#FF0000"
+        SLACK_ICON_EMOJI: ":taco:"
+        SLACK_MESSAGE: >-
+          Upgrade succeeded :heart_decoration:
+
+          PR opened at github.com/pulumi/${{ github.event.repository.name }}/pulls
+        SLACK_TITLE: ${{ github.event.repository.name }} upgrade result
+        SLACK_USERNAME: provider-bot
+        SLACK_WEBHOOK: ${{ env.SLACK_WEBHOOK_URL }}
+      name: Send Upgrade Success To Slack
+      uses: rtCamp/action-slack-notify@v2
+    - env:
+        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_COLOR: "#FF0000"
+        SLACK_ICON_EMOJI: ":taco:"
+        SLACK_MESSAGE: " Upgrade failed :x:"
+        SLACK_TITLE: ${{ github.event.repository.name }} upgrade result
+        SLACK_USERNAME: provider-bot
+        SLACK_WEBHOOK: ${{ env.SLACK_WEBHOOK_URL }}
+      if: failure()
+      name: Send Upgrade Failure To Slack
+      uses: rtCamp/action-slack-notify@v2
 name: Upgrade provider
 on:
   issues:

--- a/provider-ci/providers/signalfx/repo/.github/workflows/upgrade-provider.yml
+++ b/provider-ci/providers/signalfx/repo/.github/workflows/upgrade-provider.yml
@@ -5,7 +5,7 @@ env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 jobs:
   upgrade_provider:
-    if: contains(github.event.issue.title, 'Upgrade terraform-provider-')
+    if: contains(${{ github.event.issue.title }}, 'Upgrade terraform-provider-')
     name: upgrade-provider
     runs-on: ubuntu-latest
     steps:

--- a/provider-ci/providers/slack/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/slack/repo/.github/workflows/main.yml
@@ -361,7 +361,7 @@ jobs:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
-        SLACK_MESSAGE: " Publish failed :x:"
+        SLACK_MESSAGE: "Publish failed :x:"
         SLACK_TITLE: ${{ github.event.repository.name }} upgrade result
         SLACK_USERNAME: provider-bot
         SLACK_WEBHOOK: ${{ env.SLACK_WEBHOOK_URL }}

--- a/provider-ci/providers/slack/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/slack/repo/.github/workflows/master.yml
@@ -361,7 +361,7 @@ jobs:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
-        SLACK_MESSAGE: " Publish failed :x:"
+        SLACK_MESSAGE: "Publish failed :x:"
         SLACK_TITLE: ${{ github.event.repository.name }} upgrade result
         SLACK_USERNAME: provider-bot
         SLACK_WEBHOOK: ${{ env.SLACK_WEBHOOK_URL }}

--- a/provider-ci/providers/slack/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/slack/repo/.github/workflows/prerelease.yml
@@ -311,7 +311,7 @@ jobs:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
-        SLACK_MESSAGE: " Publish failed :x:"
+        SLACK_MESSAGE: "Publish failed :x:"
         SLACK_TITLE: ${{ github.event.repository.name }} upgrade result
         SLACK_USERNAME: provider-bot
         SLACK_WEBHOOK: ${{ env.SLACK_WEBHOOK_URL }}

--- a/provider-ci/providers/slack/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/slack/repo/.github/workflows/release.yml
@@ -323,7 +323,7 @@ jobs:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
-        SLACK_MESSAGE: " Publish failed :x:"
+        SLACK_MESSAGE: "Publish failed :x:"
         SLACK_TITLE: ${{ github.event.repository.name }} upgrade result
         SLACK_USERNAME: provider-bot
         SLACK_WEBHOOK: ${{ env.SLACK_WEBHOOK_URL }}

--- a/provider-ci/providers/slack/repo/.github/workflows/upgrade-provider.yml
+++ b/provider-ci/providers/slack/repo/.github/workflows/upgrade-provider.yml
@@ -14,6 +14,30 @@ jobs:
       with:
         slack-channel: provider-upgrade-status
         slack-webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
+    - env:
+        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_COLOR: "#FF0000"
+        SLACK_ICON_EMOJI: ":taco:"
+        SLACK_MESSAGE: >-
+          Upgrade succeeded :heart_decoration:
+
+          PR opened at github.com/pulumi/${{ github.event.repository.name }}/pulls
+        SLACK_TITLE: ${{ github.event.repository.name }} upgrade result
+        SLACK_USERNAME: provider-bot
+        SLACK_WEBHOOK: ${{ env.SLACK_WEBHOOK_URL }}
+      name: Send Upgrade Success To Slack
+      uses: rtCamp/action-slack-notify@v2
+    - env:
+        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_COLOR: "#FF0000"
+        SLACK_ICON_EMOJI: ":taco:"
+        SLACK_MESSAGE: " Upgrade failed :x:"
+        SLACK_TITLE: ${{ github.event.repository.name }} upgrade result
+        SLACK_USERNAME: provider-bot
+        SLACK_WEBHOOK: ${{ env.SLACK_WEBHOOK_URL }}
+      if: failure()
+      name: Send Upgrade Failure To Slack
+      uses: rtCamp/action-slack-notify@v2
 name: Upgrade provider
 on:
   issues:

--- a/provider-ci/providers/slack/repo/.github/workflows/upgrade-provider.yml
+++ b/provider-ci/providers/slack/repo/.github/workflows/upgrade-provider.yml
@@ -5,7 +5,7 @@ env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 jobs:
   upgrade_provider:
-    if: contains(github.event.issue.title, 'Upgrade terraform-provider-')
+    if: contains(${{ github.event.issue.title }}, 'Upgrade terraform-provider-')
     name: upgrade-provider
     runs-on: ubuntu-latest
     steps:

--- a/provider-ci/providers/snowflake/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/snowflake/repo/.github/workflows/main.yml
@@ -365,7 +365,7 @@ jobs:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
-        SLACK_MESSAGE: " Publish failed :x:"
+        SLACK_MESSAGE: "Publish failed :x:"
         SLACK_TITLE: ${{ github.event.repository.name }} upgrade result
         SLACK_USERNAME: provider-bot
         SLACK_WEBHOOK: ${{ env.SLACK_WEBHOOK_URL }}

--- a/provider-ci/providers/snowflake/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/snowflake/repo/.github/workflows/master.yml
@@ -365,7 +365,7 @@ jobs:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
-        SLACK_MESSAGE: " Publish failed :x:"
+        SLACK_MESSAGE: "Publish failed :x:"
         SLACK_TITLE: ${{ github.event.repository.name }} upgrade result
         SLACK_USERNAME: provider-bot
         SLACK_WEBHOOK: ${{ env.SLACK_WEBHOOK_URL }}

--- a/provider-ci/providers/snowflake/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/snowflake/repo/.github/workflows/prerelease.yml
@@ -315,7 +315,7 @@ jobs:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
-        SLACK_MESSAGE: " Publish failed :x:"
+        SLACK_MESSAGE: "Publish failed :x:"
         SLACK_TITLE: ${{ github.event.repository.name }} upgrade result
         SLACK_USERNAME: provider-bot
         SLACK_WEBHOOK: ${{ env.SLACK_WEBHOOK_URL }}

--- a/provider-ci/providers/snowflake/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/snowflake/repo/.github/workflows/release.yml
@@ -327,7 +327,7 @@ jobs:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
-        SLACK_MESSAGE: " Publish failed :x:"
+        SLACK_MESSAGE: "Publish failed :x:"
         SLACK_TITLE: ${{ github.event.repository.name }} upgrade result
         SLACK_USERNAME: provider-bot
         SLACK_WEBHOOK: ${{ env.SLACK_WEBHOOK_URL }}

--- a/provider-ci/providers/snowflake/repo/.github/workflows/upgrade-provider.yml
+++ b/provider-ci/providers/snowflake/repo/.github/workflows/upgrade-provider.yml
@@ -14,6 +14,30 @@ jobs:
       with:
         slack-channel: provider-upgrade-status
         slack-webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
+    - env:
+        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_COLOR: "#FF0000"
+        SLACK_ICON_EMOJI: ":taco:"
+        SLACK_MESSAGE: >-
+          Upgrade succeeded :heart_decoration:
+
+          PR opened at github.com/pulumi/${{ github.event.repository.name }}/pulls
+        SLACK_TITLE: ${{ github.event.repository.name }} upgrade result
+        SLACK_USERNAME: provider-bot
+        SLACK_WEBHOOK: ${{ env.SLACK_WEBHOOK_URL }}
+      name: Send Upgrade Success To Slack
+      uses: rtCamp/action-slack-notify@v2
+    - env:
+        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_COLOR: "#FF0000"
+        SLACK_ICON_EMOJI: ":taco:"
+        SLACK_MESSAGE: " Upgrade failed :x:"
+        SLACK_TITLE: ${{ github.event.repository.name }} upgrade result
+        SLACK_USERNAME: provider-bot
+        SLACK_WEBHOOK: ${{ env.SLACK_WEBHOOK_URL }}
+      if: failure()
+      name: Send Upgrade Failure To Slack
+      uses: rtCamp/action-slack-notify@v2
 name: Upgrade provider
 on:
   issues:

--- a/provider-ci/providers/snowflake/repo/.github/workflows/upgrade-provider.yml
+++ b/provider-ci/providers/snowflake/repo/.github/workflows/upgrade-provider.yml
@@ -5,7 +5,7 @@ env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 jobs:
   upgrade_provider:
-    if: contains(github.event.issue.title, 'Upgrade terraform-provider-')
+    if: contains(${{ github.event.issue.title }}, 'Upgrade terraform-provider-')
     name: upgrade-provider
     runs-on: ubuntu-latest
     steps:

--- a/provider-ci/providers/splunk/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/splunk/repo/.github/workflows/main.yml
@@ -363,7 +363,7 @@ jobs:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
-        SLACK_MESSAGE: " Publish failed :x:"
+        SLACK_MESSAGE: "Publish failed :x:"
         SLACK_TITLE: ${{ github.event.repository.name }} upgrade result
         SLACK_USERNAME: provider-bot
         SLACK_WEBHOOK: ${{ env.SLACK_WEBHOOK_URL }}

--- a/provider-ci/providers/splunk/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/splunk/repo/.github/workflows/master.yml
@@ -363,7 +363,7 @@ jobs:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
-        SLACK_MESSAGE: " Publish failed :x:"
+        SLACK_MESSAGE: "Publish failed :x:"
         SLACK_TITLE: ${{ github.event.repository.name }} upgrade result
         SLACK_USERNAME: provider-bot
         SLACK_WEBHOOK: ${{ env.SLACK_WEBHOOK_URL }}

--- a/provider-ci/providers/splunk/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/splunk/repo/.github/workflows/prerelease.yml
@@ -313,7 +313,7 @@ jobs:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
-        SLACK_MESSAGE: " Publish failed :x:"
+        SLACK_MESSAGE: "Publish failed :x:"
         SLACK_TITLE: ${{ github.event.repository.name }} upgrade result
         SLACK_USERNAME: provider-bot
         SLACK_WEBHOOK: ${{ env.SLACK_WEBHOOK_URL }}

--- a/provider-ci/providers/splunk/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/splunk/repo/.github/workflows/release.yml
@@ -325,7 +325,7 @@ jobs:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
-        SLACK_MESSAGE: " Publish failed :x:"
+        SLACK_MESSAGE: "Publish failed :x:"
         SLACK_TITLE: ${{ github.event.repository.name }} upgrade result
         SLACK_USERNAME: provider-bot
         SLACK_WEBHOOK: ${{ env.SLACK_WEBHOOK_URL }}

--- a/provider-ci/providers/splunk/repo/.github/workflows/upgrade-provider.yml
+++ b/provider-ci/providers/splunk/repo/.github/workflows/upgrade-provider.yml
@@ -14,6 +14,30 @@ jobs:
       with:
         slack-channel: provider-upgrade-status
         slack-webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
+    - env:
+        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_COLOR: "#FF0000"
+        SLACK_ICON_EMOJI: ":taco:"
+        SLACK_MESSAGE: >-
+          Upgrade succeeded :heart_decoration:
+
+          PR opened at github.com/pulumi/${{ github.event.repository.name }}/pulls
+        SLACK_TITLE: ${{ github.event.repository.name }} upgrade result
+        SLACK_USERNAME: provider-bot
+        SLACK_WEBHOOK: ${{ env.SLACK_WEBHOOK_URL }}
+      name: Send Upgrade Success To Slack
+      uses: rtCamp/action-slack-notify@v2
+    - env:
+        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_COLOR: "#FF0000"
+        SLACK_ICON_EMOJI: ":taco:"
+        SLACK_MESSAGE: " Upgrade failed :x:"
+        SLACK_TITLE: ${{ github.event.repository.name }} upgrade result
+        SLACK_USERNAME: provider-bot
+        SLACK_WEBHOOK: ${{ env.SLACK_WEBHOOK_URL }}
+      if: failure()
+      name: Send Upgrade Failure To Slack
+      uses: rtCamp/action-slack-notify@v2
 name: Upgrade provider
 on:
   issues:

--- a/provider-ci/providers/splunk/repo/.github/workflows/upgrade-provider.yml
+++ b/provider-ci/providers/splunk/repo/.github/workflows/upgrade-provider.yml
@@ -5,7 +5,7 @@ env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 jobs:
   upgrade_provider:
-    if: contains(github.event.issue.title, 'Upgrade terraform-provider-')
+    if: contains(${{ github.event.issue.title }}, 'Upgrade terraform-provider-')
     name: upgrade-provider
     runs-on: ubuntu-latest
     steps:

--- a/provider-ci/providers/spotinst/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/spotinst/repo/.github/workflows/main.yml
@@ -363,7 +363,7 @@ jobs:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
-        SLACK_MESSAGE: " Publish failed :x:"
+        SLACK_MESSAGE: "Publish failed :x:"
         SLACK_TITLE: ${{ github.event.repository.name }} upgrade result
         SLACK_USERNAME: provider-bot
         SLACK_WEBHOOK: ${{ env.SLACK_WEBHOOK_URL }}

--- a/provider-ci/providers/spotinst/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/spotinst/repo/.github/workflows/master.yml
@@ -363,7 +363,7 @@ jobs:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
-        SLACK_MESSAGE: " Publish failed :x:"
+        SLACK_MESSAGE: "Publish failed :x:"
         SLACK_TITLE: ${{ github.event.repository.name }} upgrade result
         SLACK_USERNAME: provider-bot
         SLACK_WEBHOOK: ${{ env.SLACK_WEBHOOK_URL }}

--- a/provider-ci/providers/spotinst/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/spotinst/repo/.github/workflows/prerelease.yml
@@ -313,7 +313,7 @@ jobs:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
-        SLACK_MESSAGE: " Publish failed :x:"
+        SLACK_MESSAGE: "Publish failed :x:"
         SLACK_TITLE: ${{ github.event.repository.name }} upgrade result
         SLACK_USERNAME: provider-bot
         SLACK_WEBHOOK: ${{ env.SLACK_WEBHOOK_URL }}

--- a/provider-ci/providers/spotinst/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/spotinst/repo/.github/workflows/release.yml
@@ -325,7 +325,7 @@ jobs:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
-        SLACK_MESSAGE: " Publish failed :x:"
+        SLACK_MESSAGE: "Publish failed :x:"
         SLACK_TITLE: ${{ github.event.repository.name }} upgrade result
         SLACK_USERNAME: provider-bot
         SLACK_WEBHOOK: ${{ env.SLACK_WEBHOOK_URL }}

--- a/provider-ci/providers/spotinst/repo/.github/workflows/upgrade-provider.yml
+++ b/provider-ci/providers/spotinst/repo/.github/workflows/upgrade-provider.yml
@@ -14,6 +14,30 @@ jobs:
       with:
         slack-channel: provider-upgrade-status
         slack-webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
+    - env:
+        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_COLOR: "#FF0000"
+        SLACK_ICON_EMOJI: ":taco:"
+        SLACK_MESSAGE: >-
+          Upgrade succeeded :heart_decoration:
+
+          PR opened at github.com/pulumi/${{ github.event.repository.name }}/pulls
+        SLACK_TITLE: ${{ github.event.repository.name }} upgrade result
+        SLACK_USERNAME: provider-bot
+        SLACK_WEBHOOK: ${{ env.SLACK_WEBHOOK_URL }}
+      name: Send Upgrade Success To Slack
+      uses: rtCamp/action-slack-notify@v2
+    - env:
+        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_COLOR: "#FF0000"
+        SLACK_ICON_EMOJI: ":taco:"
+        SLACK_MESSAGE: " Upgrade failed :x:"
+        SLACK_TITLE: ${{ github.event.repository.name }} upgrade result
+        SLACK_USERNAME: provider-bot
+        SLACK_WEBHOOK: ${{ env.SLACK_WEBHOOK_URL }}
+      if: failure()
+      name: Send Upgrade Failure To Slack
+      uses: rtCamp/action-slack-notify@v2
 name: Upgrade provider
 on:
   issues:

--- a/provider-ci/providers/spotinst/repo/.github/workflows/upgrade-provider.yml
+++ b/provider-ci/providers/spotinst/repo/.github/workflows/upgrade-provider.yml
@@ -5,7 +5,7 @@ env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 jobs:
   upgrade_provider:
-    if: contains(github.event.issue.title, 'Upgrade terraform-provider-')
+    if: contains(${{ github.event.issue.title }}, 'Upgrade terraform-provider-')
     name: upgrade-provider
     runs-on: ubuntu-latest
     steps:

--- a/provider-ci/providers/sumologic/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/sumologic/repo/.github/workflows/main.yml
@@ -363,7 +363,7 @@ jobs:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
-        SLACK_MESSAGE: " Publish failed :x:"
+        SLACK_MESSAGE: "Publish failed :x:"
         SLACK_TITLE: ${{ github.event.repository.name }} upgrade result
         SLACK_USERNAME: provider-bot
         SLACK_WEBHOOK: ${{ env.SLACK_WEBHOOK_URL }}

--- a/provider-ci/providers/sumologic/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/sumologic/repo/.github/workflows/master.yml
@@ -363,7 +363,7 @@ jobs:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
-        SLACK_MESSAGE: " Publish failed :x:"
+        SLACK_MESSAGE: "Publish failed :x:"
         SLACK_TITLE: ${{ github.event.repository.name }} upgrade result
         SLACK_USERNAME: provider-bot
         SLACK_WEBHOOK: ${{ env.SLACK_WEBHOOK_URL }}

--- a/provider-ci/providers/sumologic/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/sumologic/repo/.github/workflows/prerelease.yml
@@ -313,7 +313,7 @@ jobs:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
-        SLACK_MESSAGE: " Publish failed :x:"
+        SLACK_MESSAGE: "Publish failed :x:"
         SLACK_TITLE: ${{ github.event.repository.name }} upgrade result
         SLACK_USERNAME: provider-bot
         SLACK_WEBHOOK: ${{ env.SLACK_WEBHOOK_URL }}

--- a/provider-ci/providers/sumologic/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/sumologic/repo/.github/workflows/release.yml
@@ -325,7 +325,7 @@ jobs:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
-        SLACK_MESSAGE: " Publish failed :x:"
+        SLACK_MESSAGE: "Publish failed :x:"
         SLACK_TITLE: ${{ github.event.repository.name }} upgrade result
         SLACK_USERNAME: provider-bot
         SLACK_WEBHOOK: ${{ env.SLACK_WEBHOOK_URL }}

--- a/provider-ci/providers/sumologic/repo/.github/workflows/upgrade-provider.yml
+++ b/provider-ci/providers/sumologic/repo/.github/workflows/upgrade-provider.yml
@@ -14,6 +14,30 @@ jobs:
       with:
         slack-channel: provider-upgrade-status
         slack-webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
+    - env:
+        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_COLOR: "#FF0000"
+        SLACK_ICON_EMOJI: ":taco:"
+        SLACK_MESSAGE: >-
+          Upgrade succeeded :heart_decoration:
+
+          PR opened at github.com/pulumi/${{ github.event.repository.name }}/pulls
+        SLACK_TITLE: ${{ github.event.repository.name }} upgrade result
+        SLACK_USERNAME: provider-bot
+        SLACK_WEBHOOK: ${{ env.SLACK_WEBHOOK_URL }}
+      name: Send Upgrade Success To Slack
+      uses: rtCamp/action-slack-notify@v2
+    - env:
+        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_COLOR: "#FF0000"
+        SLACK_ICON_EMOJI: ":taco:"
+        SLACK_MESSAGE: " Upgrade failed :x:"
+        SLACK_TITLE: ${{ github.event.repository.name }} upgrade result
+        SLACK_USERNAME: provider-bot
+        SLACK_WEBHOOK: ${{ env.SLACK_WEBHOOK_URL }}
+      if: failure()
+      name: Send Upgrade Failure To Slack
+      uses: rtCamp/action-slack-notify@v2
 name: Upgrade provider
 on:
   issues:

--- a/provider-ci/providers/sumologic/repo/.github/workflows/upgrade-provider.yml
+++ b/provider-ci/providers/sumologic/repo/.github/workflows/upgrade-provider.yml
@@ -5,7 +5,7 @@ env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 jobs:
   upgrade_provider:
-    if: contains(github.event.issue.title, 'Upgrade terraform-provider-')
+    if: contains(${{ github.event.issue.title }}, 'Upgrade terraform-provider-')
     name: upgrade-provider
     runs-on: ubuntu-latest
     steps:

--- a/provider-ci/providers/tailscale/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/tailscale/repo/.github/workflows/main.yml
@@ -362,7 +362,7 @@ jobs:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
-        SLACK_MESSAGE: " Publish failed :x:"
+        SLACK_MESSAGE: "Publish failed :x:"
         SLACK_TITLE: ${{ github.event.repository.name }} upgrade result
         SLACK_USERNAME: provider-bot
         SLACK_WEBHOOK: ${{ env.SLACK_WEBHOOK_URL }}

--- a/provider-ci/providers/tailscale/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/tailscale/repo/.github/workflows/master.yml
@@ -362,7 +362,7 @@ jobs:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
-        SLACK_MESSAGE: " Publish failed :x:"
+        SLACK_MESSAGE: "Publish failed :x:"
         SLACK_TITLE: ${{ github.event.repository.name }} upgrade result
         SLACK_USERNAME: provider-bot
         SLACK_WEBHOOK: ${{ env.SLACK_WEBHOOK_URL }}

--- a/provider-ci/providers/tailscale/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/tailscale/repo/.github/workflows/prerelease.yml
@@ -312,7 +312,7 @@ jobs:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
-        SLACK_MESSAGE: " Publish failed :x:"
+        SLACK_MESSAGE: "Publish failed :x:"
         SLACK_TITLE: ${{ github.event.repository.name }} upgrade result
         SLACK_USERNAME: provider-bot
         SLACK_WEBHOOK: ${{ env.SLACK_WEBHOOK_URL }}

--- a/provider-ci/providers/tailscale/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/tailscale/repo/.github/workflows/release.yml
@@ -324,7 +324,7 @@ jobs:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
-        SLACK_MESSAGE: " Publish failed :x:"
+        SLACK_MESSAGE: "Publish failed :x:"
         SLACK_TITLE: ${{ github.event.repository.name }} upgrade result
         SLACK_USERNAME: provider-bot
         SLACK_WEBHOOK: ${{ env.SLACK_WEBHOOK_URL }}

--- a/provider-ci/providers/tailscale/repo/.github/workflows/upgrade-provider.yml
+++ b/provider-ci/providers/tailscale/repo/.github/workflows/upgrade-provider.yml
@@ -14,6 +14,30 @@ jobs:
       with:
         slack-channel: provider-upgrade-status
         slack-webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
+    - env:
+        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_COLOR: "#FF0000"
+        SLACK_ICON_EMOJI: ":taco:"
+        SLACK_MESSAGE: >-
+          Upgrade succeeded :heart_decoration:
+
+          PR opened at github.com/pulumi/${{ github.event.repository.name }}/pulls
+        SLACK_TITLE: ${{ github.event.repository.name }} upgrade result
+        SLACK_USERNAME: provider-bot
+        SLACK_WEBHOOK: ${{ env.SLACK_WEBHOOK_URL }}
+      name: Send Upgrade Success To Slack
+      uses: rtCamp/action-slack-notify@v2
+    - env:
+        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_COLOR: "#FF0000"
+        SLACK_ICON_EMOJI: ":taco:"
+        SLACK_MESSAGE: " Upgrade failed :x:"
+        SLACK_TITLE: ${{ github.event.repository.name }} upgrade result
+        SLACK_USERNAME: provider-bot
+        SLACK_WEBHOOK: ${{ env.SLACK_WEBHOOK_URL }}
+      if: failure()
+      name: Send Upgrade Failure To Slack
+      uses: rtCamp/action-slack-notify@v2
 name: Upgrade provider
 on:
   issues:

--- a/provider-ci/providers/tailscale/repo/.github/workflows/upgrade-provider.yml
+++ b/provider-ci/providers/tailscale/repo/.github/workflows/upgrade-provider.yml
@@ -5,7 +5,7 @@ env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 jobs:
   upgrade_provider:
-    if: contains(github.event.issue.title, 'Upgrade terraform-provider-')
+    if: contains(${{ github.event.issue.title }}, 'Upgrade terraform-provider-')
     name: upgrade-provider
     runs-on: ubuntu-latest
     steps:

--- a/provider-ci/providers/tls/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/tls/repo/.github/workflows/main.yml
@@ -360,7 +360,7 @@ jobs:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
-        SLACK_MESSAGE: " Publish failed :x:"
+        SLACK_MESSAGE: "Publish failed :x:"
         SLACK_TITLE: ${{ github.event.repository.name }} upgrade result
         SLACK_USERNAME: provider-bot
         SLACK_WEBHOOK: ${{ env.SLACK_WEBHOOK_URL }}

--- a/provider-ci/providers/tls/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/tls/repo/.github/workflows/master.yml
@@ -360,7 +360,7 @@ jobs:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
-        SLACK_MESSAGE: " Publish failed :x:"
+        SLACK_MESSAGE: "Publish failed :x:"
         SLACK_TITLE: ${{ github.event.repository.name }} upgrade result
         SLACK_USERNAME: provider-bot
         SLACK_WEBHOOK: ${{ env.SLACK_WEBHOOK_URL }}

--- a/provider-ci/providers/tls/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/tls/repo/.github/workflows/prerelease.yml
@@ -310,7 +310,7 @@ jobs:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
-        SLACK_MESSAGE: " Publish failed :x:"
+        SLACK_MESSAGE: "Publish failed :x:"
         SLACK_TITLE: ${{ github.event.repository.name }} upgrade result
         SLACK_USERNAME: provider-bot
         SLACK_WEBHOOK: ${{ env.SLACK_WEBHOOK_URL }}

--- a/provider-ci/providers/tls/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/tls/repo/.github/workflows/release.yml
@@ -322,7 +322,7 @@ jobs:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
-        SLACK_MESSAGE: " Publish failed :x:"
+        SLACK_MESSAGE: "Publish failed :x:"
         SLACK_TITLE: ${{ github.event.repository.name }} upgrade result
         SLACK_USERNAME: provider-bot
         SLACK_WEBHOOK: ${{ env.SLACK_WEBHOOK_URL }}

--- a/provider-ci/providers/tls/repo/.github/workflows/upgrade-provider.yml
+++ b/provider-ci/providers/tls/repo/.github/workflows/upgrade-provider.yml
@@ -14,6 +14,30 @@ jobs:
       with:
         slack-channel: provider-upgrade-status
         slack-webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
+    - env:
+        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_COLOR: "#FF0000"
+        SLACK_ICON_EMOJI: ":taco:"
+        SLACK_MESSAGE: >-
+          Upgrade succeeded :heart_decoration:
+
+          PR opened at github.com/pulumi/${{ github.event.repository.name }}/pulls
+        SLACK_TITLE: ${{ github.event.repository.name }} upgrade result
+        SLACK_USERNAME: provider-bot
+        SLACK_WEBHOOK: ${{ env.SLACK_WEBHOOK_URL }}
+      name: Send Upgrade Success To Slack
+      uses: rtCamp/action-slack-notify@v2
+    - env:
+        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_COLOR: "#FF0000"
+        SLACK_ICON_EMOJI: ":taco:"
+        SLACK_MESSAGE: " Upgrade failed :x:"
+        SLACK_TITLE: ${{ github.event.repository.name }} upgrade result
+        SLACK_USERNAME: provider-bot
+        SLACK_WEBHOOK: ${{ env.SLACK_WEBHOOK_URL }}
+      if: failure()
+      name: Send Upgrade Failure To Slack
+      uses: rtCamp/action-slack-notify@v2
 name: Upgrade provider
 on:
   issues:

--- a/provider-ci/providers/tls/repo/.github/workflows/upgrade-provider.yml
+++ b/provider-ci/providers/tls/repo/.github/workflows/upgrade-provider.yml
@@ -5,7 +5,7 @@ env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 jobs:
   upgrade_provider:
-    if: contains(github.event.issue.title, 'Upgrade terraform-provider-')
+    if: contains(${{ github.event.issue.title }}, 'Upgrade terraform-provider-')
     name: upgrade-provider
     runs-on: ubuntu-latest
     steps:

--- a/provider-ci/providers/vault/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/vault/repo/.github/workflows/main.yml
@@ -360,7 +360,7 @@ jobs:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
-        SLACK_MESSAGE: " Publish failed :x:"
+        SLACK_MESSAGE: "Publish failed :x:"
         SLACK_TITLE: ${{ github.event.repository.name }} upgrade result
         SLACK_USERNAME: provider-bot
         SLACK_WEBHOOK: ${{ env.SLACK_WEBHOOK_URL }}

--- a/provider-ci/providers/vault/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/vault/repo/.github/workflows/master.yml
@@ -360,7 +360,7 @@ jobs:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
-        SLACK_MESSAGE: " Publish failed :x:"
+        SLACK_MESSAGE: "Publish failed :x:"
         SLACK_TITLE: ${{ github.event.repository.name }} upgrade result
         SLACK_USERNAME: provider-bot
         SLACK_WEBHOOK: ${{ env.SLACK_WEBHOOK_URL }}

--- a/provider-ci/providers/vault/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/vault/repo/.github/workflows/prerelease.yml
@@ -310,7 +310,7 @@ jobs:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
-        SLACK_MESSAGE: " Publish failed :x:"
+        SLACK_MESSAGE: "Publish failed :x:"
         SLACK_TITLE: ${{ github.event.repository.name }} upgrade result
         SLACK_USERNAME: provider-bot
         SLACK_WEBHOOK: ${{ env.SLACK_WEBHOOK_URL }}

--- a/provider-ci/providers/vault/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/vault/repo/.github/workflows/release.yml
@@ -322,7 +322,7 @@ jobs:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
-        SLACK_MESSAGE: " Publish failed :x:"
+        SLACK_MESSAGE: "Publish failed :x:"
         SLACK_TITLE: ${{ github.event.repository.name }} upgrade result
         SLACK_USERNAME: provider-bot
         SLACK_WEBHOOK: ${{ env.SLACK_WEBHOOK_URL }}

--- a/provider-ci/providers/vault/repo/.github/workflows/upgrade-provider.yml
+++ b/provider-ci/providers/vault/repo/.github/workflows/upgrade-provider.yml
@@ -14,6 +14,30 @@ jobs:
       with:
         slack-channel: provider-upgrade-status
         slack-webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
+    - env:
+        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_COLOR: "#FF0000"
+        SLACK_ICON_EMOJI: ":taco:"
+        SLACK_MESSAGE: >-
+          Upgrade succeeded :heart_decoration:
+
+          PR opened at github.com/pulumi/${{ github.event.repository.name }}/pulls
+        SLACK_TITLE: ${{ github.event.repository.name }} upgrade result
+        SLACK_USERNAME: provider-bot
+        SLACK_WEBHOOK: ${{ env.SLACK_WEBHOOK_URL }}
+      name: Send Upgrade Success To Slack
+      uses: rtCamp/action-slack-notify@v2
+    - env:
+        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_COLOR: "#FF0000"
+        SLACK_ICON_EMOJI: ":taco:"
+        SLACK_MESSAGE: " Upgrade failed :x:"
+        SLACK_TITLE: ${{ github.event.repository.name }} upgrade result
+        SLACK_USERNAME: provider-bot
+        SLACK_WEBHOOK: ${{ env.SLACK_WEBHOOK_URL }}
+      if: failure()
+      name: Send Upgrade Failure To Slack
+      uses: rtCamp/action-slack-notify@v2
 name: Upgrade provider
 on:
   issues:

--- a/provider-ci/providers/vault/repo/.github/workflows/upgrade-provider.yml
+++ b/provider-ci/providers/vault/repo/.github/workflows/upgrade-provider.yml
@@ -5,7 +5,7 @@ env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 jobs:
   upgrade_provider:
-    if: contains(github.event.issue.title, 'Upgrade terraform-provider-')
+    if: contains(${{ github.event.issue.title }}, 'Upgrade terraform-provider-')
     name: upgrade-provider
     runs-on: ubuntu-latest
     steps:

--- a/provider-ci/providers/venafi/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/venafi/repo/.github/workflows/main.yml
@@ -364,7 +364,7 @@ jobs:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
-        SLACK_MESSAGE: " Publish failed :x:"
+        SLACK_MESSAGE: "Publish failed :x:"
         SLACK_TITLE: ${{ github.event.repository.name }} upgrade result
         SLACK_USERNAME: provider-bot
         SLACK_WEBHOOK: ${{ env.SLACK_WEBHOOK_URL }}

--- a/provider-ci/providers/venafi/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/venafi/repo/.github/workflows/master.yml
@@ -364,7 +364,7 @@ jobs:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
-        SLACK_MESSAGE: " Publish failed :x:"
+        SLACK_MESSAGE: "Publish failed :x:"
         SLACK_TITLE: ${{ github.event.repository.name }} upgrade result
         SLACK_USERNAME: provider-bot
         SLACK_WEBHOOK: ${{ env.SLACK_WEBHOOK_URL }}

--- a/provider-ci/providers/venafi/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/venafi/repo/.github/workflows/prerelease.yml
@@ -314,7 +314,7 @@ jobs:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
-        SLACK_MESSAGE: " Publish failed :x:"
+        SLACK_MESSAGE: "Publish failed :x:"
         SLACK_TITLE: ${{ github.event.repository.name }} upgrade result
         SLACK_USERNAME: provider-bot
         SLACK_WEBHOOK: ${{ env.SLACK_WEBHOOK_URL }}

--- a/provider-ci/providers/venafi/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/venafi/repo/.github/workflows/release.yml
@@ -326,7 +326,7 @@ jobs:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
-        SLACK_MESSAGE: " Publish failed :x:"
+        SLACK_MESSAGE: "Publish failed :x:"
         SLACK_TITLE: ${{ github.event.repository.name }} upgrade result
         SLACK_USERNAME: provider-bot
         SLACK_WEBHOOK: ${{ env.SLACK_WEBHOOK_URL }}

--- a/provider-ci/providers/venafi/repo/.github/workflows/upgrade-provider.yml
+++ b/provider-ci/providers/venafi/repo/.github/workflows/upgrade-provider.yml
@@ -14,6 +14,30 @@ jobs:
       with:
         slack-channel: provider-upgrade-status
         slack-webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
+    - env:
+        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_COLOR: "#FF0000"
+        SLACK_ICON_EMOJI: ":taco:"
+        SLACK_MESSAGE: >-
+          Upgrade succeeded :heart_decoration:
+
+          PR opened at github.com/pulumi/${{ github.event.repository.name }}/pulls
+        SLACK_TITLE: ${{ github.event.repository.name }} upgrade result
+        SLACK_USERNAME: provider-bot
+        SLACK_WEBHOOK: ${{ env.SLACK_WEBHOOK_URL }}
+      name: Send Upgrade Success To Slack
+      uses: rtCamp/action-slack-notify@v2
+    - env:
+        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_COLOR: "#FF0000"
+        SLACK_ICON_EMOJI: ":taco:"
+        SLACK_MESSAGE: " Upgrade failed :x:"
+        SLACK_TITLE: ${{ github.event.repository.name }} upgrade result
+        SLACK_USERNAME: provider-bot
+        SLACK_WEBHOOK: ${{ env.SLACK_WEBHOOK_URL }}
+      if: failure()
+      name: Send Upgrade Failure To Slack
+      uses: rtCamp/action-slack-notify@v2
 name: Upgrade provider
 on:
   issues:

--- a/provider-ci/providers/venafi/repo/.github/workflows/upgrade-provider.yml
+++ b/provider-ci/providers/venafi/repo/.github/workflows/upgrade-provider.yml
@@ -5,7 +5,7 @@ env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 jobs:
   upgrade_provider:
-    if: contains(github.event.issue.title, 'Upgrade terraform-provider-')
+    if: contains(${{ github.event.issue.title }}, 'Upgrade terraform-provider-')
     name: upgrade-provider
     runs-on: ubuntu-latest
     steps:

--- a/provider-ci/providers/vsphere/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/vsphere/repo/.github/workflows/main.yml
@@ -360,7 +360,7 @@ jobs:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
-        SLACK_MESSAGE: " Publish failed :x:"
+        SLACK_MESSAGE: "Publish failed :x:"
         SLACK_TITLE: ${{ github.event.repository.name }} upgrade result
         SLACK_USERNAME: provider-bot
         SLACK_WEBHOOK: ${{ env.SLACK_WEBHOOK_URL }}

--- a/provider-ci/providers/vsphere/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/vsphere/repo/.github/workflows/master.yml
@@ -360,7 +360,7 @@ jobs:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
-        SLACK_MESSAGE: " Publish failed :x:"
+        SLACK_MESSAGE: "Publish failed :x:"
         SLACK_TITLE: ${{ github.event.repository.name }} upgrade result
         SLACK_USERNAME: provider-bot
         SLACK_WEBHOOK: ${{ env.SLACK_WEBHOOK_URL }}

--- a/provider-ci/providers/vsphere/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/vsphere/repo/.github/workflows/prerelease.yml
@@ -310,7 +310,7 @@ jobs:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
-        SLACK_MESSAGE: " Publish failed :x:"
+        SLACK_MESSAGE: "Publish failed :x:"
         SLACK_TITLE: ${{ github.event.repository.name }} upgrade result
         SLACK_USERNAME: provider-bot
         SLACK_WEBHOOK: ${{ env.SLACK_WEBHOOK_URL }}

--- a/provider-ci/providers/vsphere/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/vsphere/repo/.github/workflows/release.yml
@@ -322,7 +322,7 @@ jobs:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
-        SLACK_MESSAGE: " Publish failed :x:"
+        SLACK_MESSAGE: "Publish failed :x:"
         SLACK_TITLE: ${{ github.event.repository.name }} upgrade result
         SLACK_USERNAME: provider-bot
         SLACK_WEBHOOK: ${{ env.SLACK_WEBHOOK_URL }}

--- a/provider-ci/providers/vsphere/repo/.github/workflows/upgrade-provider.yml
+++ b/provider-ci/providers/vsphere/repo/.github/workflows/upgrade-provider.yml
@@ -14,6 +14,30 @@ jobs:
       with:
         slack-channel: provider-upgrade-status
         slack-webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
+    - env:
+        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_COLOR: "#FF0000"
+        SLACK_ICON_EMOJI: ":taco:"
+        SLACK_MESSAGE: >-
+          Upgrade succeeded :heart_decoration:
+
+          PR opened at github.com/pulumi/${{ github.event.repository.name }}/pulls
+        SLACK_TITLE: ${{ github.event.repository.name }} upgrade result
+        SLACK_USERNAME: provider-bot
+        SLACK_WEBHOOK: ${{ env.SLACK_WEBHOOK_URL }}
+      name: Send Upgrade Success To Slack
+      uses: rtCamp/action-slack-notify@v2
+    - env:
+        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_COLOR: "#FF0000"
+        SLACK_ICON_EMOJI: ":taco:"
+        SLACK_MESSAGE: " Upgrade failed :x:"
+        SLACK_TITLE: ${{ github.event.repository.name }} upgrade result
+        SLACK_USERNAME: provider-bot
+        SLACK_WEBHOOK: ${{ env.SLACK_WEBHOOK_URL }}
+      if: failure()
+      name: Send Upgrade Failure To Slack
+      uses: rtCamp/action-slack-notify@v2
 name: Upgrade provider
 on:
   issues:

--- a/provider-ci/providers/vsphere/repo/.github/workflows/upgrade-provider.yml
+++ b/provider-ci/providers/vsphere/repo/.github/workflows/upgrade-provider.yml
@@ -5,7 +5,7 @@ env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 jobs:
   upgrade_provider:
-    if: contains(github.event.issue.title, 'Upgrade terraform-provider-')
+    if: contains(${{ github.event.issue.title }}, 'Upgrade terraform-provider-')
     name: upgrade-provider
     runs-on: ubuntu-latest
     steps:

--- a/provider-ci/providers/wavefront/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/wavefront/repo/.github/workflows/main.yml
@@ -362,7 +362,7 @@ jobs:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
-        SLACK_MESSAGE: " Publish failed :x:"
+        SLACK_MESSAGE: "Publish failed :x:"
         SLACK_TITLE: ${{ github.event.repository.name }} upgrade result
         SLACK_USERNAME: provider-bot
         SLACK_WEBHOOK: ${{ env.SLACK_WEBHOOK_URL }}

--- a/provider-ci/providers/wavefront/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/wavefront/repo/.github/workflows/master.yml
@@ -362,7 +362,7 @@ jobs:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
-        SLACK_MESSAGE: " Publish failed :x:"
+        SLACK_MESSAGE: "Publish failed :x:"
         SLACK_TITLE: ${{ github.event.repository.name }} upgrade result
         SLACK_USERNAME: provider-bot
         SLACK_WEBHOOK: ${{ env.SLACK_WEBHOOK_URL }}

--- a/provider-ci/providers/wavefront/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/wavefront/repo/.github/workflows/prerelease.yml
@@ -312,7 +312,7 @@ jobs:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
-        SLACK_MESSAGE: " Publish failed :x:"
+        SLACK_MESSAGE: "Publish failed :x:"
         SLACK_TITLE: ${{ github.event.repository.name }} upgrade result
         SLACK_USERNAME: provider-bot
         SLACK_WEBHOOK: ${{ env.SLACK_WEBHOOK_URL }}

--- a/provider-ci/providers/wavefront/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/wavefront/repo/.github/workflows/release.yml
@@ -324,7 +324,7 @@ jobs:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
-        SLACK_MESSAGE: " Publish failed :x:"
+        SLACK_MESSAGE: "Publish failed :x:"
         SLACK_TITLE: ${{ github.event.repository.name }} upgrade result
         SLACK_USERNAME: provider-bot
         SLACK_WEBHOOK: ${{ env.SLACK_WEBHOOK_URL }}

--- a/provider-ci/providers/wavefront/repo/.github/workflows/upgrade-provider.yml
+++ b/provider-ci/providers/wavefront/repo/.github/workflows/upgrade-provider.yml
@@ -14,6 +14,30 @@ jobs:
       with:
         slack-channel: provider-upgrade-status
         slack-webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
+    - env:
+        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_COLOR: "#FF0000"
+        SLACK_ICON_EMOJI: ":taco:"
+        SLACK_MESSAGE: >-
+          Upgrade succeeded :heart_decoration:
+
+          PR opened at github.com/pulumi/${{ github.event.repository.name }}/pulls
+        SLACK_TITLE: ${{ github.event.repository.name }} upgrade result
+        SLACK_USERNAME: provider-bot
+        SLACK_WEBHOOK: ${{ env.SLACK_WEBHOOK_URL }}
+      name: Send Upgrade Success To Slack
+      uses: rtCamp/action-slack-notify@v2
+    - env:
+        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_COLOR: "#FF0000"
+        SLACK_ICON_EMOJI: ":taco:"
+        SLACK_MESSAGE: " Upgrade failed :x:"
+        SLACK_TITLE: ${{ github.event.repository.name }} upgrade result
+        SLACK_USERNAME: provider-bot
+        SLACK_WEBHOOK: ${{ env.SLACK_WEBHOOK_URL }}
+      if: failure()
+      name: Send Upgrade Failure To Slack
+      uses: rtCamp/action-slack-notify@v2
 name: Upgrade provider
 on:
   issues:

--- a/provider-ci/providers/wavefront/repo/.github/workflows/upgrade-provider.yml
+++ b/provider-ci/providers/wavefront/repo/.github/workflows/upgrade-provider.yml
@@ -5,7 +5,7 @@ env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 jobs:
   upgrade_provider:
-    if: contains(github.event.issue.title, 'Upgrade terraform-provider-')
+    if: contains(${{ github.event.issue.title }}, 'Upgrade terraform-provider-')
     name: upgrade-provider
     runs-on: ubuntu-latest
     steps:

--- a/provider-ci/src/steps.ts
+++ b/provider-ci/src/steps.ts
@@ -712,10 +712,7 @@ export function SendCodegenWarnCommentPr(): Step {
     },
   };
 }
-export function UpgradeProviderAction(
-  providerName: string,
-  defaultBranch: string
-): Step {
+export function UpgradeProviderAction(): Step {
   return {
     name: "Call upgrade provider action",
     uses: action.upgradeProviderAction,
@@ -733,7 +730,7 @@ export function NotifySlackPublish(): Step {
     env: {
       SLACK_CHANNEL: "provider-upgrade-publish-status",
       SLACK_COLOR: "#FF0000",
-      SLACK_MESSAGE: " Publish failed :x:",
+      SLACK_MESSAGE: "Publish failed :x:",
       SLACK_TITLE: "${{ github.event.repository.name }} upgrade result",
       SLACK_USERNAME: "provider-bot",
       SLACK_WEBHOOK: "${{ env.SLACK_WEBHOOK_URL }}",
@@ -741,4 +738,38 @@ export function NotifySlackPublish(): Step {
     },
     uses: action.slackNotification,
   };
+}
+
+export function NotifySlackUpgradeSuccess(): Step {
+	return {
+		name: "Send Upgrade Success To Slack",
+		env: {
+			SLACK_CHANNEL: "provider-upgrade-publish-status",
+			SLACK_COLOR: "#FF0000",
+			SLACK_MESSAGE: "Upgrade succeeded :heart_decoration:\n" +
+			"PR opened at github.com/pulumi/${{ github.event.repository.name }}/pulls",
+			SLACK_TITLE: "${{ github.event.repository.name }} upgrade result",
+			SLACK_USERNAME: "provider-bot",
+			SLACK_WEBHOOK: "${{ env.SLACK_WEBHOOK_URL }}",
+			SLACK_ICON_EMOJI: ":taco:",
+		},
+		uses: action.slackNotification,
+	};
+}
+
+export function NotifySlackUpgradeFailure(): Step {
+	return {
+		name: "Send Upgrade Failure To Slack",
+		if: "failure()",
+		env: {
+			SLACK_CHANNEL: "provider-upgrade-publish-status",
+			SLACK_COLOR: "#FF0000",
+			SLACK_MESSAGE: " Upgrade failed :x:",
+			SLACK_TITLE: "${{ github.event.repository.name }} upgrade result",
+			SLACK_USERNAME: "provider-bot",
+			SLACK_WEBHOOK: "${{ env.SLACK_WEBHOOK_URL }}",
+			SLACK_ICON_EMOJI: ":taco:",
+		},
+		uses: action.slackNotification,
+	};
 }

--- a/provider-ci/src/workflows.ts
+++ b/provider-ci/src/workflows.ts
@@ -1038,7 +1038,7 @@ export function UpgradeProvider(opts: BridgedConfig): GithubWorkflow {
 			steps.NotifySlackUpgradeFailure()
 		)
         .addConditional(
-          "contains(github.event.issue.title, 'Upgrade terraform-provider-')"
+          "contains(${{ github.event.issue.title }}, 'Upgrade terraform-provider-')"
         ),
     },
   };

--- a/provider-ci/src/workflows.ts
+++ b/provider-ci/src/workflows.ts
@@ -1029,11 +1029,14 @@ export function UpgradeProvider(opts: BridgedConfig): GithubWorkflow {
     jobs: {
       upgrade_provider: new EmptyJob("upgrade-provider")
         .addStep(
-          steps.UpgradeProviderAction(
-            providerName,
-            opts["provider-default-branch"]
-          )
+          steps.UpgradeProviderAction()
         )
+		.addStep(
+			steps.NotifySlackUpgradeSuccess()
+		)
+		.addStep(
+			steps.NotifySlackUpgradeFailure()
+		)
         .addConditional(
           "contains(github.event.issue.title, 'Upgrade terraform-provider-')"
         ),


### PR DESCRIPTION
- Add notification step to send slack message on provider upgrade success or failure
- Also fixes if conditional to run upgrade action on open issue
- Also removes inputs to upgrade provider action that can be determined via github contexts 