### PR TITLE
Fix upstream rebase

### DIFF
--- a/provider-ci/providers/aiven/repo/scripts/upstream.sh
+++ b/provider-ci/providers/aiven/repo/scripts/upstream.sh
@@ -79,11 +79,12 @@ start_rebase() {
   cd upstream && git fetch
 
   if [ -z "$TO" ]; then
-     echo '$TO not set, assuming TO is the upstream SHAH currently committed.'
+     echo '$TO not set, assuming TO is the upstream SHA currently committed.'
   else
      git checkout "$TO"
   fi
 
+  git branch -f local
   git checkout -B pulumi-patch ${FROM}
   git branch --set-upstream-to=local pulumi-patch
 

--- a/provider-ci/providers/akamai/repo/scripts/upstream.sh
+++ b/provider-ci/providers/akamai/repo/scripts/upstream.sh
@@ -79,11 +79,12 @@ start_rebase() {
   cd upstream && git fetch
 
   if [ -z "$TO" ]; then
-     echo '$TO not set, assuming TO is the upstream SHAH currently committed.'
+     echo '$TO not set, assuming TO is the upstream SHA currently committed.'
   else
      git checkout "$TO"
   fi
 
+  git branch -f local
   git checkout -B pulumi-patch ${FROM}
   git branch --set-upstream-to=local pulumi-patch
 

--- a/provider-ci/providers/alicloud/repo/scripts/upstream.sh
+++ b/provider-ci/providers/alicloud/repo/scripts/upstream.sh
@@ -79,11 +79,12 @@ start_rebase() {
   cd upstream && git fetch
 
   if [ -z "$TO" ]; then
-     echo '$TO not set, assuming TO is the upstream SHAH currently committed.'
+     echo '$TO not set, assuming TO is the upstream SHA currently committed.'
   else
      git checkout "$TO"
   fi
 
+  git branch -f local
   git checkout -B pulumi-patch ${FROM}
   git branch --set-upstream-to=local pulumi-patch
 

--- a/provider-ci/providers/artifactory/repo/scripts/upstream.sh
+++ b/provider-ci/providers/artifactory/repo/scripts/upstream.sh
@@ -79,11 +79,12 @@ start_rebase() {
   cd upstream && git fetch
 
   if [ -z "$TO" ]; then
-     echo '$TO not set, assuming TO is the upstream SHAH currently committed.'
+     echo '$TO not set, assuming TO is the upstream SHA currently committed.'
   else
      git checkout "$TO"
   fi
 
+  git branch -f local
   git checkout -B pulumi-patch ${FROM}
   git branch --set-upstream-to=local pulumi-patch
 

--- a/provider-ci/providers/auth0/repo/scripts/upstream.sh
+++ b/provider-ci/providers/auth0/repo/scripts/upstream.sh
@@ -79,11 +79,12 @@ start_rebase() {
   cd upstream && git fetch
 
   if [ -z "$TO" ]; then
-     echo '$TO not set, assuming TO is the upstream SHAH currently committed.'
+     echo '$TO not set, assuming TO is the upstream SHA currently committed.'
   else
      git checkout "$TO"
   fi
 
+  git branch -f local
   git checkout -B pulumi-patch ${FROM}
   git branch --set-upstream-to=local pulumi-patch
 

--- a/provider-ci/providers/azuread/repo/scripts/upstream.sh
+++ b/provider-ci/providers/azuread/repo/scripts/upstream.sh
@@ -79,11 +79,12 @@ start_rebase() {
   cd upstream && git fetch
 
   if [ -z "$TO" ]; then
-     echo '$TO not set, assuming TO is the upstream SHAH currently committed.'
+     echo '$TO not set, assuming TO is the upstream SHA currently committed.'
   else
      git checkout "$TO"
   fi
 
+  git branch -f local
   git checkout -B pulumi-patch ${FROM}
   git branch --set-upstream-to=local pulumi-patch
 

--- a/provider-ci/providers/civo/repo/scripts/upstream.sh
+++ b/provider-ci/providers/civo/repo/scripts/upstream.sh
@@ -79,11 +79,12 @@ start_rebase() {
   cd upstream && git fetch
 
   if [ -z "$TO" ]; then
-     echo '$TO not set, assuming TO is the upstream SHAH currently committed.'
+     echo '$TO not set, assuming TO is the upstream SHA currently committed.'
   else
      git checkout "$TO"
   fi
 
+  git branch -f local
   git checkout -B pulumi-patch ${FROM}
   git branch --set-upstream-to=local pulumi-patch
 

--- a/provider-ci/providers/cloudamqp/repo/scripts/upstream.sh
+++ b/provider-ci/providers/cloudamqp/repo/scripts/upstream.sh
@@ -79,11 +79,12 @@ start_rebase() {
   cd upstream && git fetch
 
   if [ -z "$TO" ]; then
-     echo '$TO not set, assuming TO is the upstream SHAH currently committed.'
+     echo '$TO not set, assuming TO is the upstream SHA currently committed.'
   else
      git checkout "$TO"
   fi
 
+  git branch -f local
   git checkout -B pulumi-patch ${FROM}
   git branch --set-upstream-to=local pulumi-patch
 

--- a/provider-ci/providers/cloudflare/repo/scripts/upstream.sh
+++ b/provider-ci/providers/cloudflare/repo/scripts/upstream.sh
@@ -79,11 +79,12 @@ start_rebase() {
   cd upstream && git fetch
 
   if [ -z "$TO" ]; then
-     echo '$TO not set, assuming TO is the upstream SHAH currently committed.'
+     echo '$TO not set, assuming TO is the upstream SHA currently committed.'
   else
      git checkout "$TO"
   fi
 
+  git branch -f local
   git checkout -B pulumi-patch ${FROM}
   git branch --set-upstream-to=local pulumi-patch
 

--- a/provider-ci/providers/cloudinit/repo/scripts/upstream.sh
+++ b/provider-ci/providers/cloudinit/repo/scripts/upstream.sh
@@ -79,11 +79,12 @@ start_rebase() {
   cd upstream && git fetch
 
   if [ -z "$TO" ]; then
-     echo '$TO not set, assuming TO is the upstream SHAH currently committed.'
+     echo '$TO not set, assuming TO is the upstream SHA currently committed.'
   else
      git checkout "$TO"
   fi
 
+  git branch -f local
   git checkout -B pulumi-patch ${FROM}
   git branch --set-upstream-to=local pulumi-patch
 

--- a/provider-ci/providers/confluentcloud/repo/scripts/upstream.sh
+++ b/provider-ci/providers/confluentcloud/repo/scripts/upstream.sh
@@ -79,11 +79,12 @@ start_rebase() {
   cd upstream && git fetch
 
   if [ -z "$TO" ]; then
-     echo '$TO not set, assuming TO is the upstream SHAH currently committed.'
+     echo '$TO not set, assuming TO is the upstream SHA currently committed.'
   else
      git checkout "$TO"
   fi
 
+  git branch -f local
   git checkout -B pulumi-patch ${FROM}
   git branch --set-upstream-to=local pulumi-patch
 

--- a/provider-ci/providers/consul/repo/scripts/upstream.sh
+++ b/provider-ci/providers/consul/repo/scripts/upstream.sh
@@ -79,11 +79,12 @@ start_rebase() {
   cd upstream && git fetch
 
   if [ -z "$TO" ]; then
-     echo '$TO not set, assuming TO is the upstream SHAH currently committed.'
+     echo '$TO not set, assuming TO is the upstream SHA currently committed.'
   else
      git checkout "$TO"
   fi
 
+  git branch -f local
   git checkout -B pulumi-patch ${FROM}
   git branch --set-upstream-to=local pulumi-patch
 

--- a/provider-ci/providers/databricks/repo/scripts/upstream.sh
+++ b/provider-ci/providers/databricks/repo/scripts/upstream.sh
@@ -79,11 +79,12 @@ start_rebase() {
   cd upstream && git fetch
 
   if [ -z "$TO" ]; then
-     echo '$TO not set, assuming TO is the upstream SHAH currently committed.'
+     echo '$TO not set, assuming TO is the upstream SHA currently committed.'
   else
      git checkout "$TO"
   fi
 
+  git branch -f local
   git checkout -B pulumi-patch ${FROM}
   git branch --set-upstream-to=local pulumi-patch
 

--- a/provider-ci/providers/datadog/repo/scripts/upstream.sh
+++ b/provider-ci/providers/datadog/repo/scripts/upstream.sh
@@ -79,11 +79,12 @@ start_rebase() {
   cd upstream && git fetch
 
   if [ -z "$TO" ]; then
-     echo '$TO not set, assuming TO is the upstream SHAH currently committed.'
+     echo '$TO not set, assuming TO is the upstream SHA currently committed.'
   else
      git checkout "$TO"
   fi
 
+  git branch -f local
   git checkout -B pulumi-patch ${FROM}
   git branch --set-upstream-to=local pulumi-patch
 

--- a/provider-ci/providers/digitalocean/repo/scripts/upstream.sh
+++ b/provider-ci/providers/digitalocean/repo/scripts/upstream.sh
@@ -79,11 +79,12 @@ start_rebase() {
   cd upstream && git fetch
 
   if [ -z "$TO" ]; then
-     echo '$TO not set, assuming TO is the upstream SHAH currently committed.'
+     echo '$TO not set, assuming TO is the upstream SHA currently committed.'
   else
      git checkout "$TO"
   fi
 
+  git branch -f local
   git checkout -B pulumi-patch ${FROM}
   git branch --set-upstream-to=local pulumi-patch
 

--- a/provider-ci/providers/dnsimple/repo/scripts/upstream.sh
+++ b/provider-ci/providers/dnsimple/repo/scripts/upstream.sh
@@ -79,11 +79,12 @@ start_rebase() {
   cd upstream && git fetch
 
   if [ -z "$TO" ]; then
-     echo '$TO not set, assuming TO is the upstream SHAH currently committed.'
+     echo '$TO not set, assuming TO is the upstream SHA currently committed.'
   else
      git checkout "$TO"
   fi
 
+  git branch -f local
   git checkout -B pulumi-patch ${FROM}
   git branch --set-upstream-to=local pulumi-patch
 

--- a/provider-ci/providers/docker/repo/scripts/upstream.sh
+++ b/provider-ci/providers/docker/repo/scripts/upstream.sh
@@ -79,11 +79,12 @@ start_rebase() {
   cd upstream && git fetch
 
   if [ -z "$TO" ]; then
-     echo '$TO not set, assuming TO is the upstream SHAH currently committed.'
+     echo '$TO not set, assuming TO is the upstream SHA currently committed.'
   else
      git checkout "$TO"
   fi
 
+  git branch -f local
   git checkout -B pulumi-patch ${FROM}
   git branch --set-upstream-to=local pulumi-patch
 

--- a/provider-ci/providers/ec/repo/scripts/upstream.sh
+++ b/provider-ci/providers/ec/repo/scripts/upstream.sh
@@ -79,11 +79,12 @@ start_rebase() {
   cd upstream && git fetch
 
   if [ -z "$TO" ]; then
-     echo '$TO not set, assuming TO is the upstream SHAH currently committed.'
+     echo '$TO not set, assuming TO is the upstream SHA currently committed.'
   else
      git checkout "$TO"
   fi
 
+  git branch -f local
   git checkout -B pulumi-patch ${FROM}
   git branch --set-upstream-to=local pulumi-patch
 

--- a/provider-ci/providers/equinix-metal/repo/scripts/upstream.sh
+++ b/provider-ci/providers/equinix-metal/repo/scripts/upstream.sh
@@ -79,11 +79,12 @@ start_rebase() {
   cd upstream && git fetch
 
   if [ -z "$TO" ]; then
-     echo '$TO not set, assuming TO is the upstream SHAH currently committed.'
+     echo '$TO not set, assuming TO is the upstream SHA currently committed.'
   else
      git checkout "$TO"
   fi
 
+  git branch -f local
   git checkout -B pulumi-patch ${FROM}
   git branch --set-upstream-to=local pulumi-patch
 

--- a/provider-ci/providers/f5bigip/repo/scripts/upstream.sh
+++ b/provider-ci/providers/f5bigip/repo/scripts/upstream.sh
@@ -79,11 +79,12 @@ start_rebase() {
   cd upstream && git fetch
 
   if [ -z "$TO" ]; then
-     echo '$TO not set, assuming TO is the upstream SHAH currently committed.'
+     echo '$TO not set, assuming TO is the upstream SHA currently committed.'
   else
      git checkout "$TO"
   fi
 
+  git branch -f local
   git checkout -B pulumi-patch ${FROM}
   git branch --set-upstream-to=local pulumi-patch
 

--- a/provider-ci/providers/fastly/repo/scripts/upstream.sh
+++ b/provider-ci/providers/fastly/repo/scripts/upstream.sh
@@ -79,11 +79,12 @@ start_rebase() {
   cd upstream && git fetch
 
   if [ -z "$TO" ]; then
-     echo '$TO not set, assuming TO is the upstream SHAH currently committed.'
+     echo '$TO not set, assuming TO is the upstream SHA currently committed.'
   else
      git checkout "$TO"
   fi
 
+  git branch -f local
   git checkout -B pulumi-patch ${FROM}
   git branch --set-upstream-to=local pulumi-patch
 

--- a/provider-ci/providers/github/repo/scripts/upstream.sh
+++ b/provider-ci/providers/github/repo/scripts/upstream.sh
@@ -79,11 +79,12 @@ start_rebase() {
   cd upstream && git fetch
 
   if [ -z "$TO" ]; then
-     echo '$TO not set, assuming TO is the upstream SHAH currently committed.'
+     echo '$TO not set, assuming TO is the upstream SHA currently committed.'
   else
      git checkout "$TO"
   fi
 
+  git branch -f local
   git checkout -B pulumi-patch ${FROM}
   git branch --set-upstream-to=local pulumi-patch
 

--- a/provider-ci/providers/gitlab/repo/scripts/upstream.sh
+++ b/provider-ci/providers/gitlab/repo/scripts/upstream.sh
@@ -79,11 +79,12 @@ start_rebase() {
   cd upstream && git fetch
 
   if [ -z "$TO" ]; then
-     echo '$TO not set, assuming TO is the upstream SHAH currently committed.'
+     echo '$TO not set, assuming TO is the upstream SHA currently committed.'
   else
      git checkout "$TO"
   fi
 
+  git branch -f local
   git checkout -B pulumi-patch ${FROM}
   git branch --set-upstream-to=local pulumi-patch
 

--- a/provider-ci/providers/hcloud/repo/scripts/upstream.sh
+++ b/provider-ci/providers/hcloud/repo/scripts/upstream.sh
@@ -79,11 +79,12 @@ start_rebase() {
   cd upstream && git fetch
 
   if [ -z "$TO" ]; then
-     echo '$TO not set, assuming TO is the upstream SHAH currently committed.'
+     echo '$TO not set, assuming TO is the upstream SHA currently committed.'
   else
      git checkout "$TO"
   fi
 
+  git branch -f local
   git checkout -B pulumi-patch ${FROM}
   git branch --set-upstream-to=local pulumi-patch
 

--- a/provider-ci/providers/kafka/repo/scripts/upstream.sh
+++ b/provider-ci/providers/kafka/repo/scripts/upstream.sh
@@ -79,11 +79,12 @@ start_rebase() {
   cd upstream && git fetch
 
   if [ -z "$TO" ]; then
-     echo '$TO not set, assuming TO is the upstream SHAH currently committed.'
+     echo '$TO not set, assuming TO is the upstream SHA currently committed.'
   else
      git checkout "$TO"
   fi
 
+  git branch -f local
   git checkout -B pulumi-patch ${FROM}
   git branch --set-upstream-to=local pulumi-patch
 

--- a/provider-ci/providers/keycloak/repo/scripts/upstream.sh
+++ b/provider-ci/providers/keycloak/repo/scripts/upstream.sh
@@ -79,11 +79,12 @@ start_rebase() {
   cd upstream && git fetch
 
   if [ -z "$TO" ]; then
-     echo '$TO not set, assuming TO is the upstream SHAH currently committed.'
+     echo '$TO not set, assuming TO is the upstream SHA currently committed.'
   else
      git checkout "$TO"
   fi
 
+  git branch -f local
   git checkout -B pulumi-patch ${FROM}
   git branch --set-upstream-to=local pulumi-patch
 

--- a/provider-ci/providers/kong/repo/scripts/upstream.sh
+++ b/provider-ci/providers/kong/repo/scripts/upstream.sh
@@ -79,11 +79,12 @@ start_rebase() {
   cd upstream && git fetch
 
   if [ -z "$TO" ]; then
-     echo '$TO not set, assuming TO is the upstream SHAH currently committed.'
+     echo '$TO not set, assuming TO is the upstream SHA currently committed.'
   else
      git checkout "$TO"
   fi
 
+  git branch -f local
   git checkout -B pulumi-patch ${FROM}
   git branch --set-upstream-to=local pulumi-patch
 

--- a/provider-ci/providers/libvirt/repo/scripts/upstream.sh
+++ b/provider-ci/providers/libvirt/repo/scripts/upstream.sh
@@ -79,11 +79,12 @@ start_rebase() {
   cd upstream && git fetch
 
   if [ -z "$TO" ]; then
-     echo '$TO not set, assuming TO is the upstream SHAH currently committed.'
+     echo '$TO not set, assuming TO is the upstream SHA currently committed.'
   else
      git checkout "$TO"
   fi
 
+  git branch -f local
   git checkout -B pulumi-patch ${FROM}
   git branch --set-upstream-to=local pulumi-patch
 

--- a/provider-ci/providers/linode/repo/scripts/upstream.sh
+++ b/provider-ci/providers/linode/repo/scripts/upstream.sh
@@ -79,11 +79,12 @@ start_rebase() {
   cd upstream && git fetch
 
   if [ -z "$TO" ]; then
-     echo '$TO not set, assuming TO is the upstream SHAH currently committed.'
+     echo '$TO not set, assuming TO is the upstream SHA currently committed.'
   else
      git checkout "$TO"
   fi
 
+  git branch -f local
   git checkout -B pulumi-patch ${FROM}
   git branch --set-upstream-to=local pulumi-patch
 

--- a/provider-ci/providers/mailgun/repo/scripts/upstream.sh
+++ b/provider-ci/providers/mailgun/repo/scripts/upstream.sh
@@ -79,11 +79,12 @@ start_rebase() {
   cd upstream && git fetch
 
   if [ -z "$TO" ]; then
-     echo '$TO not set, assuming TO is the upstream SHAH currently committed.'
+     echo '$TO not set, assuming TO is the upstream SHA currently committed.'
   else
      git checkout "$TO"
   fi
 
+  git branch -f local
   git checkout -B pulumi-patch ${FROM}
   git branch --set-upstream-to=local pulumi-patch
 

--- a/provider-ci/providers/minio/repo/scripts/upstream.sh
+++ b/provider-ci/providers/minio/repo/scripts/upstream.sh
@@ -79,11 +79,12 @@ start_rebase() {
   cd upstream && git fetch
 
   if [ -z "$TO" ]; then
-     echo '$TO not set, assuming TO is the upstream SHAH currently committed.'
+     echo '$TO not set, assuming TO is the upstream SHA currently committed.'
   else
      git checkout "$TO"
   fi
 
+  git branch -f local
   git checkout -B pulumi-patch ${FROM}
   git branch --set-upstream-to=local pulumi-patch
 

--- a/provider-ci/providers/mongodbatlas/repo/scripts/upstream.sh
+++ b/provider-ci/providers/mongodbatlas/repo/scripts/upstream.sh
@@ -79,11 +79,12 @@ start_rebase() {
   cd upstream && git fetch
 
   if [ -z "$TO" ]; then
-     echo '$TO not set, assuming TO is the upstream SHAH currently committed.'
+     echo '$TO not set, assuming TO is the upstream SHA currently committed.'
   else
      git checkout "$TO"
   fi
 
+  git branch -f local
   git checkout -B pulumi-patch ${FROM}
   git branch --set-upstream-to=local pulumi-patch
 

--- a/provider-ci/providers/mysql/repo/scripts/upstream.sh
+++ b/provider-ci/providers/mysql/repo/scripts/upstream.sh
@@ -79,11 +79,12 @@ start_rebase() {
   cd upstream && git fetch
 
   if [ -z "$TO" ]; then
-     echo '$TO not set, assuming TO is the upstream SHAH currently committed.'
+     echo '$TO not set, assuming TO is the upstream SHA currently committed.'
   else
      git checkout "$TO"
   fi
 
+  git branch -f local
   git checkout -B pulumi-patch ${FROM}
   git branch --set-upstream-to=local pulumi-patch
 

--- a/provider-ci/providers/newrelic/repo/scripts/upstream.sh
+++ b/provider-ci/providers/newrelic/repo/scripts/upstream.sh
@@ -79,11 +79,12 @@ start_rebase() {
   cd upstream && git fetch
 
   if [ -z "$TO" ]; then
-     echo '$TO not set, assuming TO is the upstream SHAH currently committed.'
+     echo '$TO not set, assuming TO is the upstream SHA currently committed.'
   else
      git checkout "$TO"
   fi
 
+  git branch -f local
   git checkout -B pulumi-patch ${FROM}
   git branch --set-upstream-to=local pulumi-patch
 

--- a/provider-ci/providers/nomad/repo/scripts/upstream.sh
+++ b/provider-ci/providers/nomad/repo/scripts/upstream.sh
@@ -79,11 +79,12 @@ start_rebase() {
   cd upstream && git fetch
 
   if [ -z "$TO" ]; then
-     echo '$TO not set, assuming TO is the upstream SHAH currently committed.'
+     echo '$TO not set, assuming TO is the upstream SHA currently committed.'
   else
      git checkout "$TO"
   fi
 
+  git branch -f local
   git checkout -B pulumi-patch ${FROM}
   git branch --set-upstream-to=local pulumi-patch
 

--- a/provider-ci/providers/ns1/repo/scripts/upstream.sh
+++ b/provider-ci/providers/ns1/repo/scripts/upstream.sh
@@ -79,11 +79,12 @@ start_rebase() {
   cd upstream && git fetch
 
   if [ -z "$TO" ]; then
-     echo '$TO not set, assuming TO is the upstream SHAH currently committed.'
+     echo '$TO not set, assuming TO is the upstream SHA currently committed.'
   else
      git checkout "$TO"
   fi
 
+  git branch -f local
   git checkout -B pulumi-patch ${FROM}
   git branch --set-upstream-to=local pulumi-patch
 

--- a/provider-ci/providers/oci/repo/scripts/upstream.sh
+++ b/provider-ci/providers/oci/repo/scripts/upstream.sh
@@ -79,11 +79,12 @@ start_rebase() {
   cd upstream && git fetch
 
   if [ -z "$TO" ]; then
-     echo '$TO not set, assuming TO is the upstream SHAH currently committed.'
+     echo '$TO not set, assuming TO is the upstream SHA currently committed.'
   else
      git checkout "$TO"
   fi
 
+  git branch -f local
   git checkout -B pulumi-patch ${FROM}
   git branch --set-upstream-to=local pulumi-patch
 

--- a/provider-ci/providers/okta/repo/scripts/upstream.sh
+++ b/provider-ci/providers/okta/repo/scripts/upstream.sh
@@ -79,11 +79,12 @@ start_rebase() {
   cd upstream && git fetch
 
   if [ -z "$TO" ]; then
-     echo '$TO not set, assuming TO is the upstream SHAH currently committed.'
+     echo '$TO not set, assuming TO is the upstream SHA currently committed.'
   else
      git checkout "$TO"
   fi
 
+  git branch -f local
   git checkout -B pulumi-patch ${FROM}
   git branch --set-upstream-to=local pulumi-patch
 

--- a/provider-ci/providers/onelogin/repo/scripts/upstream.sh
+++ b/provider-ci/providers/onelogin/repo/scripts/upstream.sh
@@ -79,11 +79,12 @@ start_rebase() {
   cd upstream && git fetch
 
   if [ -z "$TO" ]; then
-     echo '$TO not set, assuming TO is the upstream SHAH currently committed.'
+     echo '$TO not set, assuming TO is the upstream SHA currently committed.'
   else
      git checkout "$TO"
   fi
 
+  git branch -f local
   git checkout -B pulumi-patch ${FROM}
   git branch --set-upstream-to=local pulumi-patch
 

--- a/provider-ci/providers/openstack/repo/scripts/upstream.sh
+++ b/provider-ci/providers/openstack/repo/scripts/upstream.sh
@@ -79,11 +79,12 @@ start_rebase() {
   cd upstream && git fetch
 
   if [ -z "$TO" ]; then
-     echo '$TO not set, assuming TO is the upstream SHAH currently committed.'
+     echo '$TO not set, assuming TO is the upstream SHA currently committed.'
   else
      git checkout "$TO"
   fi
 
+  git branch -f local
   git checkout -B pulumi-patch ${FROM}
   git branch --set-upstream-to=local pulumi-patch
 

--- a/provider-ci/providers/opsgenie/repo/scripts/upstream.sh
+++ b/provider-ci/providers/opsgenie/repo/scripts/upstream.sh
@@ -79,11 +79,12 @@ start_rebase() {
   cd upstream && git fetch
 
   if [ -z "$TO" ]; then
-     echo '$TO not set, assuming TO is the upstream SHAH currently committed.'
+     echo '$TO not set, assuming TO is the upstream SHA currently committed.'
   else
      git checkout "$TO"
   fi
 
+  git branch -f local
   git checkout -B pulumi-patch ${FROM}
   git branch --set-upstream-to=local pulumi-patch
 

--- a/provider-ci/providers/pagerduty/repo/scripts/upstream.sh
+++ b/provider-ci/providers/pagerduty/repo/scripts/upstream.sh
@@ -79,11 +79,12 @@ start_rebase() {
   cd upstream && git fetch
 
   if [ -z "$TO" ]; then
-     echo '$TO not set, assuming TO is the upstream SHAH currently committed.'
+     echo '$TO not set, assuming TO is the upstream SHA currently committed.'
   else
      git checkout "$TO"
   fi
 
+  git branch -f local
   git checkout -B pulumi-patch ${FROM}
   git branch --set-upstream-to=local pulumi-patch
 

--- a/provider-ci/providers/postgresql/repo/scripts/upstream.sh
+++ b/provider-ci/providers/postgresql/repo/scripts/upstream.sh
@@ -79,11 +79,12 @@ start_rebase() {
   cd upstream && git fetch
 
   if [ -z "$TO" ]; then
-     echo '$TO not set, assuming TO is the upstream SHAH currently committed.'
+     echo '$TO not set, assuming TO is the upstream SHA currently committed.'
   else
      git checkout "$TO"
   fi
 
+  git branch -f local
   git checkout -B pulumi-patch ${FROM}
   git branch --set-upstream-to=local pulumi-patch
 

--- a/provider-ci/providers/rabbitmq/repo/scripts/upstream.sh
+++ b/provider-ci/providers/rabbitmq/repo/scripts/upstream.sh
@@ -79,11 +79,12 @@ start_rebase() {
   cd upstream && git fetch
 
   if [ -z "$TO" ]; then
-     echo '$TO not set, assuming TO is the upstream SHAH currently committed.'
+     echo '$TO not set, assuming TO is the upstream SHA currently committed.'
   else
      git checkout "$TO"
   fi
 
+  git branch -f local
   git checkout -B pulumi-patch ${FROM}
   git branch --set-upstream-to=local pulumi-patch
 

--- a/provider-ci/providers/rancher2/repo/scripts/upstream.sh
+++ b/provider-ci/providers/rancher2/repo/scripts/upstream.sh
@@ -79,11 +79,12 @@ start_rebase() {
   cd upstream && git fetch
 
   if [ -z "$TO" ]; then
-     echo '$TO not set, assuming TO is the upstream SHAH currently committed.'
+     echo '$TO not set, assuming TO is the upstream SHA currently committed.'
   else
      git checkout "$TO"
   fi
 
+  git branch -f local
   git checkout -B pulumi-patch ${FROM}
   git branch --set-upstream-to=local pulumi-patch
 

--- a/provider-ci/providers/random/repo/scripts/upstream.sh
+++ b/provider-ci/providers/random/repo/scripts/upstream.sh
@@ -79,11 +79,12 @@ start_rebase() {
   cd upstream && git fetch
 
   if [ -z "$TO" ]; then
-     echo '$TO not set, assuming TO is the upstream SHAH currently committed.'
+     echo '$TO not set, assuming TO is the upstream SHA currently committed.'
   else
      git checkout "$TO"
   fi
 
+  git branch -f local
   git checkout -B pulumi-patch ${FROM}
   git branch --set-upstream-to=local pulumi-patch
 

--- a/provider-ci/providers/rke/repo/scripts/upstream.sh
+++ b/provider-ci/providers/rke/repo/scripts/upstream.sh
@@ -79,11 +79,12 @@ start_rebase() {
   cd upstream && git fetch
 
   if [ -z "$TO" ]; then
-     echo '$TO not set, assuming TO is the upstream SHAH currently committed.'
+     echo '$TO not set, assuming TO is the upstream SHA currently committed.'
   else
      git checkout "$TO"
   fi
 
+  git branch -f local
   git checkout -B pulumi-patch ${FROM}
   git branch --set-upstream-to=local pulumi-patch
 

--- a/provider-ci/providers/signalfx/repo/scripts/upstream.sh
+++ b/provider-ci/providers/signalfx/repo/scripts/upstream.sh
@@ -79,11 +79,12 @@ start_rebase() {
   cd upstream && git fetch
 
   if [ -z "$TO" ]; then
-     echo '$TO not set, assuming TO is the upstream SHAH currently committed.'
+     echo '$TO not set, assuming TO is the upstream SHA currently committed.'
   else
      git checkout "$TO"
   fi
 
+  git branch -f local
   git checkout -B pulumi-patch ${FROM}
   git branch --set-upstream-to=local pulumi-patch
 

--- a/provider-ci/providers/slack/repo/scripts/upstream.sh
+++ b/provider-ci/providers/slack/repo/scripts/upstream.sh
@@ -79,11 +79,12 @@ start_rebase() {
   cd upstream && git fetch
 
   if [ -z "$TO" ]; then
-     echo '$TO not set, assuming TO is the upstream SHAH currently committed.'
+     echo '$TO not set, assuming TO is the upstream SHA currently committed.'
   else
      git checkout "$TO"
   fi
 
+  git branch -f local
   git checkout -B pulumi-patch ${FROM}
   git branch --set-upstream-to=local pulumi-patch
 

--- a/provider-ci/providers/snowflake/repo/scripts/upstream.sh
+++ b/provider-ci/providers/snowflake/repo/scripts/upstream.sh
@@ -79,11 +79,12 @@ start_rebase() {
   cd upstream && git fetch
 
   if [ -z "$TO" ]; then
-     echo '$TO not set, assuming TO is the upstream SHAH currently committed.'
+     echo '$TO not set, assuming TO is the upstream SHA currently committed.'
   else
      git checkout "$TO"
   fi
 
+  git branch -f local
   git checkout -B pulumi-patch ${FROM}
   git branch --set-upstream-to=local pulumi-patch
 

--- a/provider-ci/providers/splunk/repo/scripts/upstream.sh
+++ b/provider-ci/providers/splunk/repo/scripts/upstream.sh
@@ -79,11 +79,12 @@ start_rebase() {
   cd upstream && git fetch
 
   if [ -z "$TO" ]; then
-     echo '$TO not set, assuming TO is the upstream SHAH currently committed.'
+     echo '$TO not set, assuming TO is the upstream SHA currently committed.'
   else
      git checkout "$TO"
   fi
 
+  git branch -f local
   git checkout -B pulumi-patch ${FROM}
   git branch --set-upstream-to=local pulumi-patch
 

--- a/provider-ci/providers/spotinst/repo/scripts/upstream.sh
+++ b/provider-ci/providers/spotinst/repo/scripts/upstream.sh
@@ -79,11 +79,12 @@ start_rebase() {
   cd upstream && git fetch
 
   if [ -z "$TO" ]; then
-     echo '$TO not set, assuming TO is the upstream SHAH currently committed.'
+     echo '$TO not set, assuming TO is the upstream SHA currently committed.'
   else
      git checkout "$TO"
   fi
 
+  git branch -f local
   git checkout -B pulumi-patch ${FROM}
   git branch --set-upstream-to=local pulumi-patch
 

--- a/provider-ci/providers/sumologic/repo/scripts/upstream.sh
+++ b/provider-ci/providers/sumologic/repo/scripts/upstream.sh
@@ -79,11 +79,12 @@ start_rebase() {
   cd upstream && git fetch
 
   if [ -z "$TO" ]; then
-     echo '$TO not set, assuming TO is the upstream SHAH currently committed.'
+     echo '$TO not set, assuming TO is the upstream SHA currently committed.'
   else
      git checkout "$TO"
   fi
 
+  git branch -f local
   git checkout -B pulumi-patch ${FROM}
   git branch --set-upstream-to=local pulumi-patch
 

--- a/provider-ci/providers/tailscale/repo/scripts/upstream.sh
+++ b/provider-ci/providers/tailscale/repo/scripts/upstream.sh
@@ -79,11 +79,12 @@ start_rebase() {
   cd upstream && git fetch
 
   if [ -z "$TO" ]; then
-     echo '$TO not set, assuming TO is the upstream SHAH currently committed.'
+     echo '$TO not set, assuming TO is the upstream SHA currently committed.'
   else
      git checkout "$TO"
   fi
 
+  git branch -f local
   git checkout -B pulumi-patch ${FROM}
   git branch --set-upstream-to=local pulumi-patch
 

--- a/provider-ci/providers/tls/repo/scripts/upstream.sh
+++ b/provider-ci/providers/tls/repo/scripts/upstream.sh
@@ -79,11 +79,12 @@ start_rebase() {
   cd upstream && git fetch
 
   if [ -z "$TO" ]; then
-     echo '$TO not set, assuming TO is the upstream SHAH currently committed.'
+     echo '$TO not set, assuming TO is the upstream SHA currently committed.'
   else
      git checkout "$TO"
   fi
 
+  git branch -f local
   git checkout -B pulumi-patch ${FROM}
   git branch --set-upstream-to=local pulumi-patch
 

--- a/provider-ci/providers/vault/repo/scripts/upstream.sh
+++ b/provider-ci/providers/vault/repo/scripts/upstream.sh
@@ -79,11 +79,12 @@ start_rebase() {
   cd upstream && git fetch
 
   if [ -z "$TO" ]; then
-     echo '$TO not set, assuming TO is the upstream SHAH currently committed.'
+     echo '$TO not set, assuming TO is the upstream SHA currently committed.'
   else
      git checkout "$TO"
   fi
 
+  git branch -f local
   git checkout -B pulumi-patch ${FROM}
   git branch --set-upstream-to=local pulumi-patch
 

--- a/provider-ci/providers/venafi/repo/scripts/upstream.sh
+++ b/provider-ci/providers/venafi/repo/scripts/upstream.sh
@@ -79,11 +79,12 @@ start_rebase() {
   cd upstream && git fetch
 
   if [ -z "$TO" ]; then
-     echo '$TO not set, assuming TO is the upstream SHAH currently committed.'
+     echo '$TO not set, assuming TO is the upstream SHA currently committed.'
   else
      git checkout "$TO"
   fi
 
+  git branch -f local
   git checkout -B pulumi-patch ${FROM}
   git branch --set-upstream-to=local pulumi-patch
 

--- a/provider-ci/providers/vsphere/repo/scripts/upstream.sh
+++ b/provider-ci/providers/vsphere/repo/scripts/upstream.sh
@@ -79,11 +79,12 @@ start_rebase() {
   cd upstream && git fetch
 
   if [ -z "$TO" ]; then
-     echo '$TO not set, assuming TO is the upstream SHAH currently committed.'
+     echo '$TO not set, assuming TO is the upstream SHA currently committed.'
   else
      git checkout "$TO"
   fi
 
+  git branch -f local
   git checkout -B pulumi-patch ${FROM}
   git branch --set-upstream-to=local pulumi-patch
 

--- a/provider-ci/providers/wavefront/repo/scripts/upstream.sh
+++ b/provider-ci/providers/wavefront/repo/scripts/upstream.sh
@@ -79,11 +79,12 @@ start_rebase() {
   cd upstream && git fetch
 
   if [ -z "$TO" ]; then
-     echo '$TO not set, assuming TO is the upstream SHAH currently committed.'
+     echo '$TO not set, assuming TO is the upstream SHA currently committed.'
   else
      git checkout "$TO"
   fi
 
+  git branch -f local
   git checkout -B pulumi-patch ${FROM}
   git branch --set-upstream-to=local pulumi-patch
 

--- a/provider-ci/src/makefiles.ts
+++ b/provider-ci/src/makefiles.ts
@@ -94,11 +94,12 @@ start_rebase() {
   cd upstream && git fetch
 
   if [ -z "$TO" ]; then
-     echo '$TO not set, assuming TO is the upstream SHAH currently committed.'
+     echo '$TO not set, assuming TO is the upstream SHA currently committed.'
   else
      git checkout "$TO"
   fi
 
+  git branch -f local
   git checkout -B pulumi-patch \${FROM}
   git branch --set-upstream-to=local pulumi-patch
 


### PR DESCRIPTION
The current rebase script assumes a branch called `local`, but we should create one. Also `SHAH` -> `SHA`.