### PR TITLE
Ensure gitlab does not downgrade from Java 0.9.3

### DIFF
--- a/provider-ci/providers/gitlab/config.yaml
+++ b/provider-ci/providers/gitlab/config.yaml
@@ -4,3 +4,4 @@ env:
   GITLAB_TOKEN: ${{ secrets.GITLAB_TOKEN }}
 makeTemplate: bridged
 team: ecosystem
+javaGenVersion: "v0.9.3"

--- a/provider-ci/providers/gitlab/repo/Makefile
+++ b/provider-ci/providers/gitlab/repo/Makefile
@@ -9,7 +9,7 @@ TFGEN := pulumi-tfgen-$(PACK)
 PROVIDER := pulumi-resource-$(PACK)
 VERSION := $(shell pulumictl get version)
 JAVA_GEN := pulumi-java-gen
-JAVA_GEN_VERSION := v0.5.4
+JAVA_GEN_VERSION := v0.9.3
 TESTPARALLELISM := 10
 WORKING_DIR := $(shell pwd)
 


### PR DESCRIPTION
Currently repository is already using 0.9.3 but automated PRs try to downgrade it.