### PR TITLE
Simplify major version updates

### DIFF
--- a/provider-ci/providers/aiven/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/aiven/repo/.github/workflows/main.yml
@@ -92,7 +92,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version.generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -269,7 +269,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version.generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:

--- a/provider-ci/providers/aiven/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/aiven/repo/.github/workflows/main.yml
@@ -92,8 +92,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -270,8 +269,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(pulumictl get version --language generic)"
-        >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:

--- a/provider-ci/providers/aiven/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/aiven/repo/.github/workflows/master.yml
@@ -92,7 +92,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version.generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -269,7 +269,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version.generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:

--- a/provider-ci/providers/aiven/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/aiven/repo/.github/workflows/master.yml
@@ -92,8 +92,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -270,8 +269,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(pulumictl get version --language generic)"
-        >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:

--- a/provider-ci/providers/aiven/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/aiven/repo/.github/workflows/prerelease.yml
@@ -93,7 +93,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version.generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -219,7 +219,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version.generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:

--- a/provider-ci/providers/aiven/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/aiven/repo/.github/workflows/prerelease.yml
@@ -93,8 +93,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -220,8 +219,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(pulumictl get version --language generic)"
-        >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:

--- a/provider-ci/providers/aiven/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/aiven/repo/.github/workflows/release.yml
@@ -92,8 +92,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -233,8 +232,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(pulumictl get version --language generic)"
-        >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:
@@ -277,8 +275,8 @@ jobs:
       with:
         repo: pulumi/pulumictl
     - name: Add SDK version tag
-      run: git tag sdk/v$(pulumictl get version --language generic) && git push origin
-        sdk/v$(pulumictl get version --language generic)
+      run: git tag sdk/v$(make version:generic) && git push origin sdk/v$(make
+        version:generic)
   test:
     name: test
     needs: build_sdk

--- a/provider-ci/providers/aiven/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/aiven/repo/.github/workflows/release.yml
@@ -92,7 +92,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version.generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -232,7 +232,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version.generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:
@@ -275,8 +275,8 @@ jobs:
       with:
         repo: pulumi/pulumictl
     - name: Add SDK version tag
-      run: git tag sdk/v$(make version:generic) && git push origin sdk/v$(make
-        version:generic)
+      run: git tag sdk/v$(make version.generic) && git push origin sdk/v$(make
+        version.generic)
   test:
     name: test
     needs: build_sdk

--- a/provider-ci/providers/aiven/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/aiven/repo/.github/workflows/run-acceptance-tests.yml
@@ -97,7 +97,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version.generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean

--- a/provider-ci/providers/aiven/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/aiven/repo/.github/workflows/run-acceptance-tests.yml
@@ -97,8 +97,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean

--- a/provider-ci/providers/aiven/repo/Makefile
+++ b/provider-ci/providers/aiven/repo/Makefile
@@ -7,7 +7,7 @@ PROVIDER_PATH := provider/v6
 VERSION_PATH := $(PROVIDER_PATH)/pkg/version.Version
 TFGEN := pulumi-tfgen-$(PACK)
 PROVIDER := pulumi-resource-$(PACK)
-VERSION := $(shell pulumictl get version)
+VERSION := $(shell pulumictl get version --language generic)
 JAVA_GEN := pulumi-java-gen
 JAVA_GEN_VERSION := v0.5.4
 TESTPARALLELISM := 10
@@ -29,9 +29,9 @@ install_sdks: install_dotnet_sdk install_python_sdk install_nodejs_sdk install_j
 
 only_build: build
 
-build_dotnet: DOTNET_VERSION := $(shell pulumictl get version --language dotnet)
+build_dotnet: DOTNET_VERSION := $(shell pulumictl convert-version -l dotnet -v "$(VERSION)")
 build_dotnet: upstream
-	pulumictl get version --language dotnet
+	@echo $(DOTNET_VERSION)
 	$(WORKING_DIR)/bin/$(TFGEN) dotnet --out sdk/dotnet/
 	cd sdk/dotnet/ && \
 		echo "module fake_dotnet_module // Exclude this directory from Go tools\n\ngo 1.17" > go.mod && \
@@ -42,14 +42,14 @@ build_go: upstream
 	$(WORKING_DIR)/bin/$(TFGEN) go --out sdk/go/
 	cd sdk && go list `grep -e "^module" go.mod | cut -d ' ' -f 2`/go/... | xargs go build
 
-build_java: PACKAGE_VERSION := $(shell pulumictl get version --language generic)
+build_java: PACKAGE_VERSION := "$(VERSION)"
 build_java: bin/pulumi-java-gen upstream
 	$(WORKING_DIR)/bin/$(JAVA_GEN) generate --schema provider/cmd/$(PROVIDER)/schema.json --out sdk/java  --build gradle-nexus
 	cd sdk/java/ && \
 		echo "module fake_java_module // Exclude this directory from Go tools\n\ngo 1.17" > go.mod && \
 		gradle --console=plain build
 
-build_nodejs: VERSION := $(shell pulumictl get version --language javascript)
+build_nodejs: VERSION := $(shell pulumictl convert-version -l javascript -v "$(VERSION)")
 build_nodejs: upstream
 	$(WORKING_DIR)/bin/$(TFGEN) nodejs --out sdk/nodejs/
 	cd sdk/nodejs/ && \
@@ -59,7 +59,7 @@ build_nodejs: upstream
 		cp ../../README.md ../../LICENSE* package.json yarn.lock ./bin/ && \
 		sed -i.bak -e "s/\$${VERSION}/$(VERSION)/g" ./bin/package.json
 
-build_python: PYPI_VERSION := $(shell pulumictl get version --language python)
+build_python: PYPI_VERSION := $(shell pulumictl convert-version -l python -v "$(VERSION)")
 build_python: upstream
 	$(WORKING_DIR)/bin/$(TFGEN) python --out sdk/python/
 	cd sdk/python/ && \
@@ -118,7 +118,10 @@ upstream.finalize:
 upstream.rebase:
 	@$(SHELL) ./scripts/upstream.sh "$@" start_rebase
 
+version.generic:
+	@echo $(VERSION)
+
 bin/pulumi-java-gen:
 	$(shell pulumictl download-binary -n pulumi-language-java -v $(JAVA_GEN_VERSION) -r pulumi/pulumi-java)
 
-.PHONY: development build build_sdks install_go_sdk install_java_sdk install_python_sdk install_sdks only_build build_dotnet build_go build_java build_nodejs build_python clean cleanup help install_dotnet_sdk install_nodejs_sdk install_plugins lint_provider provider test tfgen upstream upstream.finalize upstream.rebase
+.PHONY: development build build_sdks install_go_sdk install_java_sdk install_python_sdk install_sdks only_build build_dotnet build_go build_java build_nodejs build_python clean cleanup help install_dotnet_sdk install_nodejs_sdk install_plugins lint_provider provider test tfgen upstream upstream.finalize upstream.rebase version.generic

--- a/provider-ci/providers/akamai/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/akamai/repo/.github/workflows/main.yml
@@ -94,8 +94,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -272,8 +271,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(pulumictl get version --language generic)"
-        >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:

--- a/provider-ci/providers/akamai/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/akamai/repo/.github/workflows/main.yml
@@ -94,7 +94,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version.generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -271,7 +271,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version.generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:

--- a/provider-ci/providers/akamai/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/akamai/repo/.github/workflows/master.yml
@@ -94,8 +94,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -272,8 +271,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(pulumictl get version --language generic)"
-        >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:

--- a/provider-ci/providers/akamai/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/akamai/repo/.github/workflows/master.yml
@@ -94,7 +94,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version.generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -271,7 +271,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version.generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:

--- a/provider-ci/providers/akamai/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/akamai/repo/.github/workflows/prerelease.yml
@@ -95,7 +95,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version.generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -221,7 +221,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version.generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:

--- a/provider-ci/providers/akamai/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/akamai/repo/.github/workflows/prerelease.yml
@@ -95,8 +95,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -222,8 +221,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(pulumictl get version --language generic)"
-        >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:

--- a/provider-ci/providers/akamai/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/akamai/repo/.github/workflows/release.yml
@@ -94,7 +94,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version.generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -234,7 +234,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version.generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:
@@ -277,8 +277,8 @@ jobs:
       with:
         repo: pulumi/pulumictl
     - name: Add SDK version tag
-      run: git tag sdk/v$(make version:generic) && git push origin sdk/v$(make
-        version:generic)
+      run: git tag sdk/v$(make version.generic) && git push origin sdk/v$(make
+        version.generic)
   test:
     name: test
     needs: build_sdk

--- a/provider-ci/providers/akamai/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/akamai/repo/.github/workflows/release.yml
@@ -94,8 +94,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -235,8 +234,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(pulumictl get version --language generic)"
-        >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:
@@ -279,8 +277,8 @@ jobs:
       with:
         repo: pulumi/pulumictl
     - name: Add SDK version tag
-      run: git tag sdk/v$(pulumictl get version --language generic) && git push origin
-        sdk/v$(pulumictl get version --language generic)
+      run: git tag sdk/v$(make version:generic) && git push origin sdk/v$(make
+        version:generic)
   test:
     name: test
     needs: build_sdk

--- a/provider-ci/providers/akamai/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/akamai/repo/.github/workflows/run-acceptance-tests.yml
@@ -99,8 +99,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean

--- a/provider-ci/providers/akamai/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/akamai/repo/.github/workflows/run-acceptance-tests.yml
@@ -99,7 +99,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version.generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean

--- a/provider-ci/providers/akamai/repo/Makefile
+++ b/provider-ci/providers/akamai/repo/Makefile
@@ -7,7 +7,7 @@ PROVIDER_PATH := provider/v4
 VERSION_PATH := $(PROVIDER_PATH)/pkg/version.Version
 TFGEN := pulumi-tfgen-$(PACK)
 PROVIDER := pulumi-resource-$(PACK)
-VERSION := $(shell pulumictl get version)
+VERSION := $(shell pulumictl get version --language generic)
 JAVA_GEN := pulumi-java-gen
 JAVA_GEN_VERSION := v0.5.4
 TESTPARALLELISM := 10
@@ -29,9 +29,9 @@ install_sdks: install_dotnet_sdk install_python_sdk install_nodejs_sdk install_j
 
 only_build: build
 
-build_dotnet: DOTNET_VERSION := $(shell pulumictl get version --language dotnet)
+build_dotnet: DOTNET_VERSION := $(shell pulumictl convert-version -l dotnet -v "$(VERSION)")
 build_dotnet: upstream
-	pulumictl get version --language dotnet
+	@echo $(DOTNET_VERSION)
 	$(WORKING_DIR)/bin/$(TFGEN) dotnet --out sdk/dotnet/
 	cd sdk/dotnet/ && \
 		echo "module fake_dotnet_module // Exclude this directory from Go tools\n\ngo 1.17" > go.mod && \
@@ -42,14 +42,14 @@ build_go: upstream
 	$(WORKING_DIR)/bin/$(TFGEN) go --out sdk/go/
 	cd sdk && go list `grep -e "^module" go.mod | cut -d ' ' -f 2`/go/... | xargs go build
 
-build_java: PACKAGE_VERSION := $(shell pulumictl get version --language generic)
+build_java: PACKAGE_VERSION := "$(VERSION)"
 build_java: bin/pulumi-java-gen upstream
 	$(WORKING_DIR)/bin/$(JAVA_GEN) generate --schema provider/cmd/$(PROVIDER)/schema.json --out sdk/java  --build gradle-nexus
 	cd sdk/java/ && \
 		echo "module fake_java_module // Exclude this directory from Go tools\n\ngo 1.17" > go.mod && \
 		gradle --console=plain build
 
-build_nodejs: VERSION := $(shell pulumictl get version --language javascript)
+build_nodejs: VERSION := $(shell pulumictl convert-version -l javascript -v "$(VERSION)")
 build_nodejs: upstream
 	$(WORKING_DIR)/bin/$(TFGEN) nodejs --out sdk/nodejs/
 	cd sdk/nodejs/ && \
@@ -59,7 +59,7 @@ build_nodejs: upstream
 		cp ../../README.md ../../LICENSE* package.json yarn.lock ./bin/ && \
 		sed -i.bak -e "s/\$${VERSION}/$(VERSION)/g" ./bin/package.json
 
-build_python: PYPI_VERSION := $(shell pulumictl get version --language python)
+build_python: PYPI_VERSION := $(shell pulumictl convert-version -l python -v "$(VERSION)")
 build_python: upstream
 	$(WORKING_DIR)/bin/$(TFGEN) python --out sdk/python/
 	cd sdk/python/ && \
@@ -118,7 +118,10 @@ upstream.finalize:
 upstream.rebase:
 	@$(SHELL) ./scripts/upstream.sh "$@" start_rebase
 
+version.generic:
+	@echo $(VERSION)
+
 bin/pulumi-java-gen:
 	$(shell pulumictl download-binary -n pulumi-language-java -v $(JAVA_GEN_VERSION) -r pulumi/pulumi-java)
 
-.PHONY: development build build_sdks install_go_sdk install_java_sdk install_python_sdk install_sdks only_build build_dotnet build_go build_java build_nodejs build_python clean cleanup help install_dotnet_sdk install_nodejs_sdk install_plugins lint_provider provider test tfgen upstream upstream.finalize upstream.rebase
+.PHONY: development build build_sdks install_go_sdk install_java_sdk install_python_sdk install_sdks only_build build_dotnet build_go build_java build_nodejs build_python clean cleanup help install_dotnet_sdk install_nodejs_sdk install_plugins lint_provider provider test tfgen upstream upstream.finalize upstream.rebase version.generic

--- a/provider-ci/providers/alicloud/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/alicloud/repo/.github/workflows/main.yml
@@ -93,8 +93,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -271,8 +270,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(pulumictl get version --language generic)"
-        >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:

--- a/provider-ci/providers/alicloud/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/alicloud/repo/.github/workflows/main.yml
@@ -93,7 +93,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version.generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -270,7 +270,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version.generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:

--- a/provider-ci/providers/alicloud/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/alicloud/repo/.github/workflows/master.yml
@@ -93,8 +93,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -271,8 +270,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(pulumictl get version --language generic)"
-        >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:

--- a/provider-ci/providers/alicloud/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/alicloud/repo/.github/workflows/master.yml
@@ -93,7 +93,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version.generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -270,7 +270,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version.generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:

--- a/provider-ci/providers/alicloud/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/alicloud/repo/.github/workflows/prerelease.yml
@@ -94,8 +94,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -221,8 +220,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(pulumictl get version --language generic)"
-        >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:

--- a/provider-ci/providers/alicloud/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/alicloud/repo/.github/workflows/prerelease.yml
@@ -94,7 +94,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version.generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -220,7 +220,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version.generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:

--- a/provider-ci/providers/alicloud/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/alicloud/repo/.github/workflows/release.yml
@@ -93,7 +93,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version.generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -233,7 +233,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version.generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:
@@ -276,8 +276,8 @@ jobs:
       with:
         repo: pulumi/pulumictl
     - name: Add SDK version tag
-      run: git tag sdk/v$(make version:generic) && git push origin sdk/v$(make
-        version:generic)
+      run: git tag sdk/v$(make version.generic) && git push origin sdk/v$(make
+        version.generic)
   test:
     name: test
     needs: build_sdk

--- a/provider-ci/providers/alicloud/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/alicloud/repo/.github/workflows/release.yml
@@ -93,8 +93,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -234,8 +233,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(pulumictl get version --language generic)"
-        >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:
@@ -278,8 +276,8 @@ jobs:
       with:
         repo: pulumi/pulumictl
     - name: Add SDK version tag
-      run: git tag sdk/v$(pulumictl get version --language generic) && git push origin
-        sdk/v$(pulumictl get version --language generic)
+      run: git tag sdk/v$(make version:generic) && git push origin sdk/v$(make
+        version:generic)
   test:
     name: test
     needs: build_sdk

--- a/provider-ci/providers/alicloud/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/alicloud/repo/.github/workflows/run-acceptance-tests.yml
@@ -98,8 +98,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean

--- a/provider-ci/providers/alicloud/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/alicloud/repo/.github/workflows/run-acceptance-tests.yml
@@ -98,7 +98,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version.generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean

--- a/provider-ci/providers/alicloud/repo/Makefile
+++ b/provider-ci/providers/alicloud/repo/Makefile
@@ -7,7 +7,7 @@ PROVIDER_PATH := provider/v3
 VERSION_PATH := $(PROVIDER_PATH)/pkg/version.Version
 TFGEN := pulumi-tfgen-$(PACK)
 PROVIDER := pulumi-resource-$(PACK)
-VERSION := $(shell pulumictl get version)
+VERSION := $(shell pulumictl get version --language generic)
 JAVA_GEN := pulumi-java-gen
 JAVA_GEN_VERSION := v0.5.4
 TESTPARALLELISM := 10
@@ -29,9 +29,9 @@ install_sdks: install_dotnet_sdk install_python_sdk install_nodejs_sdk install_j
 
 only_build: build
 
-build_dotnet: DOTNET_VERSION := $(shell pulumictl get version --language dotnet)
+build_dotnet: DOTNET_VERSION := $(shell pulumictl convert-version -l dotnet -v "$(VERSION)")
 build_dotnet: upstream
-	pulumictl get version --language dotnet
+	@echo $(DOTNET_VERSION)
 	$(WORKING_DIR)/bin/$(TFGEN) dotnet --out sdk/dotnet/
 	cd sdk/dotnet/ && \
 		echo "module fake_dotnet_module // Exclude this directory from Go tools\n\ngo 1.17" > go.mod && \
@@ -42,14 +42,14 @@ build_go: upstream
 	$(WORKING_DIR)/bin/$(TFGEN) go --out sdk/go/
 	cd sdk && go list `grep -e "^module" go.mod | cut -d ' ' -f 2`/go/... | xargs go build
 
-build_java: PACKAGE_VERSION := $(shell pulumictl get version --language generic)
+build_java: PACKAGE_VERSION := "$(VERSION)"
 build_java: bin/pulumi-java-gen upstream
 	$(WORKING_DIR)/bin/$(JAVA_GEN) generate --schema provider/cmd/$(PROVIDER)/schema.json --out sdk/java  --build gradle-nexus
 	cd sdk/java/ && \
 		echo "module fake_java_module // Exclude this directory from Go tools\n\ngo 1.17" > go.mod && \
 		gradle --console=plain build
 
-build_nodejs: VERSION := $(shell pulumictl get version --language javascript)
+build_nodejs: VERSION := $(shell pulumictl convert-version -l javascript -v "$(VERSION)")
 build_nodejs: upstream
 	$(WORKING_DIR)/bin/$(TFGEN) nodejs --out sdk/nodejs/
 	cd sdk/nodejs/ && \
@@ -59,7 +59,7 @@ build_nodejs: upstream
 		cp ../../README.md ../../LICENSE* package.json yarn.lock ./bin/ && \
 		sed -i.bak -e "s/\$${VERSION}/$(VERSION)/g" ./bin/package.json
 
-build_python: PYPI_VERSION := $(shell pulumictl get version --language python)
+build_python: PYPI_VERSION := $(shell pulumictl convert-version -l python -v "$(VERSION)")
 build_python: upstream
 	$(WORKING_DIR)/bin/$(TFGEN) python --out sdk/python/
 	cd sdk/python/ && \
@@ -119,7 +119,10 @@ upstream.finalize:
 upstream.rebase:
 	@$(SHELL) ./scripts/upstream.sh "$@" start_rebase
 
+version.generic:
+	@echo $(VERSION)
+
 bin/pulumi-java-gen:
 	$(shell pulumictl download-binary -n pulumi-language-java -v $(JAVA_GEN_VERSION) -r pulumi/pulumi-java)
 
-.PHONY: development build build_sdks install_go_sdk install_java_sdk install_python_sdk install_sdks only_build build_dotnet build_go build_java build_nodejs build_python clean cleanup help install_dotnet_sdk install_nodejs_sdk install_plugins lint_provider provider test tfgen upstream upstream.finalize upstream.rebase
+.PHONY: development build build_sdks install_go_sdk install_java_sdk install_python_sdk install_sdks only_build build_dotnet build_go build_java build_nodejs build_python clean cleanup help install_dotnet_sdk install_nodejs_sdk install_plugins lint_provider provider test tfgen upstream upstream.finalize upstream.rebase version.generic

--- a/provider-ci/providers/artifactory/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/artifactory/repo/.github/workflows/main.yml
@@ -93,8 +93,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -342,8 +341,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(pulumictl get version --language generic)"
-        >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:

--- a/provider-ci/providers/artifactory/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/artifactory/repo/.github/workflows/main.yml
@@ -93,7 +93,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version.generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -341,7 +341,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version.generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:

--- a/provider-ci/providers/artifactory/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/artifactory/repo/.github/workflows/master.yml
@@ -93,8 +93,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -342,8 +341,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(pulumictl get version --language generic)"
-        >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:

--- a/provider-ci/providers/artifactory/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/artifactory/repo/.github/workflows/master.yml
@@ -93,7 +93,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version.generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -341,7 +341,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version.generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:

--- a/provider-ci/providers/artifactory/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/artifactory/repo/.github/workflows/prerelease.yml
@@ -94,7 +94,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version.generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -291,7 +291,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version.generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:

--- a/provider-ci/providers/artifactory/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/artifactory/repo/.github/workflows/prerelease.yml
@@ -94,8 +94,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -292,8 +291,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(pulumictl get version --language generic)"
-        >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:

--- a/provider-ci/providers/artifactory/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/artifactory/repo/.github/workflows/release.yml
@@ -93,7 +93,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version.generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -304,7 +304,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version.generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:
@@ -347,8 +347,8 @@ jobs:
       with:
         repo: pulumi/pulumictl
     - name: Add SDK version tag
-      run: git tag sdk/v$(make version:generic) && git push origin sdk/v$(make
-        version:generic)
+      run: git tag sdk/v$(make version.generic) && git push origin sdk/v$(make
+        version.generic)
   test:
     name: test
     needs: build_sdk

--- a/provider-ci/providers/artifactory/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/artifactory/repo/.github/workflows/release.yml
@@ -93,8 +93,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -305,8 +304,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(pulumictl get version --language generic)"
-        >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:
@@ -349,8 +347,8 @@ jobs:
       with:
         repo: pulumi/pulumictl
     - name: Add SDK version tag
-      run: git tag sdk/v$(pulumictl get version --language generic) && git push origin
-        sdk/v$(pulumictl get version --language generic)
+      run: git tag sdk/v$(make version:generic) && git push origin sdk/v$(make
+        version:generic)
   test:
     name: test
     needs: build_sdk

--- a/provider-ci/providers/artifactory/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/artifactory/repo/.github/workflows/run-acceptance-tests.yml
@@ -98,8 +98,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean

--- a/provider-ci/providers/artifactory/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/artifactory/repo/.github/workflows/run-acceptance-tests.yml
@@ -98,7 +98,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version.generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean

--- a/provider-ci/providers/artifactory/repo/Makefile
+++ b/provider-ci/providers/artifactory/repo/Makefile
@@ -7,7 +7,7 @@ PROVIDER_PATH := provider/v3
 VERSION_PATH := $(PROVIDER_PATH)/pkg/version.Version
 TFGEN := pulumi-tfgen-$(PACK)
 PROVIDER := pulumi-resource-$(PACK)
-VERSION := $(shell pulumictl get version)
+VERSION := $(shell pulumictl get version --language generic)
 JAVA_GEN := pulumi-java-gen
 JAVA_GEN_VERSION := v0.5.4
 TESTPARALLELISM := 10
@@ -29,9 +29,9 @@ install_sdks: install_dotnet_sdk install_python_sdk install_nodejs_sdk install_j
 
 only_build: build
 
-build_dotnet: DOTNET_VERSION := $(shell pulumictl get version --language dotnet)
+build_dotnet: DOTNET_VERSION := $(shell pulumictl convert-version -l dotnet -v "$(VERSION)")
 build_dotnet: upstream
-	pulumictl get version --language dotnet
+	@echo $(DOTNET_VERSION)
 	$(WORKING_DIR)/bin/$(TFGEN) dotnet --out sdk/dotnet/
 	cd sdk/dotnet/ && \
 		echo "module fake_dotnet_module // Exclude this directory from Go tools\n\ngo 1.17" > go.mod && \
@@ -42,14 +42,14 @@ build_go: upstream
 	$(WORKING_DIR)/bin/$(TFGEN) go --out sdk/go/
 	cd sdk && go list `grep -e "^module" go.mod | cut -d ' ' -f 2`/go/... | xargs go build
 
-build_java: PACKAGE_VERSION := $(shell pulumictl get version --language generic)
+build_java: PACKAGE_VERSION := "$(VERSION)"
 build_java: bin/pulumi-java-gen upstream
 	$(WORKING_DIR)/bin/$(JAVA_GEN) generate --schema provider/cmd/$(PROVIDER)/schema.json --out sdk/java  --build gradle-nexus
 	cd sdk/java/ && \
 		echo "module fake_java_module // Exclude this directory from Go tools\n\ngo 1.17" > go.mod && \
 		gradle --console=plain build
 
-build_nodejs: VERSION := $(shell pulumictl get version --language javascript)
+build_nodejs: VERSION := $(shell pulumictl convert-version -l javascript -v "$(VERSION)")
 build_nodejs: upstream
 	$(WORKING_DIR)/bin/$(TFGEN) nodejs --out sdk/nodejs/
 	cd sdk/nodejs/ && \
@@ -59,7 +59,7 @@ build_nodejs: upstream
 		cp ../../README.md ../../LICENSE* package.json yarn.lock ./bin/ && \
 		sed -i.bak -e "s/\$${VERSION}/$(VERSION)/g" ./bin/package.json
 
-build_python: PYPI_VERSION := $(shell pulumictl get version --language python)
+build_python: PYPI_VERSION := $(shell pulumictl convert-version -l python -v "$(VERSION)")
 build_python: upstream
 	$(WORKING_DIR)/bin/$(TFGEN) python --out sdk/python/
 	cd sdk/python/ && \
@@ -119,7 +119,10 @@ upstream.finalize:
 upstream.rebase:
 	@$(SHELL) ./scripts/upstream.sh "$@" start_rebase
 
+version.generic:
+	@echo $(VERSION)
+
 bin/pulumi-java-gen:
 	$(shell pulumictl download-binary -n pulumi-language-java -v $(JAVA_GEN_VERSION) -r pulumi/pulumi-java)
 
-.PHONY: development build build_sdks install_go_sdk install_java_sdk install_python_sdk install_sdks only_build build_dotnet build_go build_java build_nodejs build_python clean cleanup help install_dotnet_sdk install_nodejs_sdk install_plugins lint_provider provider test tfgen upstream upstream.finalize upstream.rebase
+.PHONY: development build build_sdks install_go_sdk install_java_sdk install_python_sdk install_sdks only_build build_dotnet build_go build_java build_nodejs build_python clean cleanup help install_dotnet_sdk install_nodejs_sdk install_plugins lint_provider provider test tfgen upstream upstream.finalize upstream.rebase version.generic

--- a/provider-ci/providers/auth0/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/auth0/repo/.github/workflows/main.yml
@@ -93,8 +93,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -342,8 +341,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(pulumictl get version --language generic)"
-        >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:

--- a/provider-ci/providers/auth0/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/auth0/repo/.github/workflows/main.yml
@@ -93,7 +93,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version.generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -341,7 +341,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version.generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:

--- a/provider-ci/providers/auth0/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/auth0/repo/.github/workflows/master.yml
@@ -93,8 +93,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -342,8 +341,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(pulumictl get version --language generic)"
-        >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:

--- a/provider-ci/providers/auth0/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/auth0/repo/.github/workflows/master.yml
@@ -93,7 +93,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version.generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -341,7 +341,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version.generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:

--- a/provider-ci/providers/auth0/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/auth0/repo/.github/workflows/prerelease.yml
@@ -94,7 +94,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version.generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -291,7 +291,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version.generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:

--- a/provider-ci/providers/auth0/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/auth0/repo/.github/workflows/prerelease.yml
@@ -94,8 +94,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -292,8 +291,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(pulumictl get version --language generic)"
-        >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:

--- a/provider-ci/providers/auth0/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/auth0/repo/.github/workflows/release.yml
@@ -93,7 +93,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version.generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -304,7 +304,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version.generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:
@@ -347,8 +347,8 @@ jobs:
       with:
         repo: pulumi/pulumictl
     - name: Add SDK version tag
-      run: git tag sdk/v$(make version:generic) && git push origin sdk/v$(make
-        version:generic)
+      run: git tag sdk/v$(make version.generic) && git push origin sdk/v$(make
+        version.generic)
   test:
     name: test
     needs: build_sdk

--- a/provider-ci/providers/auth0/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/auth0/repo/.github/workflows/release.yml
@@ -93,8 +93,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -305,8 +304,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(pulumictl get version --language generic)"
-        >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:
@@ -349,8 +347,8 @@ jobs:
       with:
         repo: pulumi/pulumictl
     - name: Add SDK version tag
-      run: git tag sdk/v$(pulumictl get version --language generic) && git push origin
-        sdk/v$(pulumictl get version --language generic)
+      run: git tag sdk/v$(make version:generic) && git push origin sdk/v$(make
+        version:generic)
   test:
     name: test
     needs: build_sdk

--- a/provider-ci/providers/auth0/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/auth0/repo/.github/workflows/run-acceptance-tests.yml
@@ -98,8 +98,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean

--- a/provider-ci/providers/auth0/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/auth0/repo/.github/workflows/run-acceptance-tests.yml
@@ -98,7 +98,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version.generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean

--- a/provider-ci/providers/auth0/repo/Makefile
+++ b/provider-ci/providers/auth0/repo/Makefile
@@ -7,7 +7,7 @@ PROVIDER_PATH := provider/v2
 VERSION_PATH := $(PROVIDER_PATH)/pkg/version.Version
 TFGEN := pulumi-tfgen-$(PACK)
 PROVIDER := pulumi-resource-$(PACK)
-VERSION := $(shell pulumictl get version)
+VERSION := $(shell pulumictl get version --language generic)
 JAVA_GEN := pulumi-java-gen
 JAVA_GEN_VERSION := v0.5.4
 TESTPARALLELISM := 10
@@ -29,9 +29,9 @@ install_sdks: install_dotnet_sdk install_python_sdk install_nodejs_sdk install_j
 
 only_build: build
 
-build_dotnet: DOTNET_VERSION := $(shell pulumictl get version --language dotnet)
+build_dotnet: DOTNET_VERSION := $(shell pulumictl convert-version -l dotnet -v "$(VERSION)")
 build_dotnet: upstream
-	pulumictl get version --language dotnet
+	@echo $(DOTNET_VERSION)
 	$(WORKING_DIR)/bin/$(TFGEN) dotnet --out sdk/dotnet/
 	cd sdk/dotnet/ && \
 		echo "module fake_dotnet_module // Exclude this directory from Go tools\n\ngo 1.17" > go.mod && \
@@ -42,14 +42,14 @@ build_go: upstream
 	$(WORKING_DIR)/bin/$(TFGEN) go --out sdk/go/
 	cd sdk && go list `grep -e "^module" go.mod | cut -d ' ' -f 2`/go/... | xargs go build
 
-build_java: PACKAGE_VERSION := $(shell pulumictl get version --language generic)
+build_java: PACKAGE_VERSION := "$(VERSION)"
 build_java: bin/pulumi-java-gen upstream
 	$(WORKING_DIR)/bin/$(JAVA_GEN) generate --schema provider/cmd/$(PROVIDER)/schema.json --out sdk/java  --build gradle-nexus
 	cd sdk/java/ && \
 		echo "module fake_java_module // Exclude this directory from Go tools\n\ngo 1.17" > go.mod && \
 		gradle --console=plain build
 
-build_nodejs: VERSION := $(shell pulumictl get version --language javascript)
+build_nodejs: VERSION := $(shell pulumictl convert-version -l javascript -v "$(VERSION)")
 build_nodejs: upstream
 	$(WORKING_DIR)/bin/$(TFGEN) nodejs --out sdk/nodejs/
 	cd sdk/nodejs/ && \
@@ -59,7 +59,7 @@ build_nodejs: upstream
 		cp ../../README.md ../../LICENSE* package.json yarn.lock ./bin/ && \
 		sed -i.bak -e "s/\$${VERSION}/$(VERSION)/g" ./bin/package.json
 
-build_python: PYPI_VERSION := $(shell pulumictl get version --language python)
+build_python: PYPI_VERSION := $(shell pulumictl convert-version -l python -v "$(VERSION)")
 build_python: upstream
 	$(WORKING_DIR)/bin/$(TFGEN) python --out sdk/python/
 	cd sdk/python/ && \
@@ -118,7 +118,10 @@ upstream.finalize:
 upstream.rebase:
 	@$(SHELL) ./scripts/upstream.sh "$@" start_rebase
 
+version.generic:
+	@echo $(VERSION)
+
 bin/pulumi-java-gen:
 	$(shell pulumictl download-binary -n pulumi-language-java -v $(JAVA_GEN_VERSION) -r pulumi/pulumi-java)
 
-.PHONY: development build build_sdks install_go_sdk install_java_sdk install_python_sdk install_sdks only_build build_dotnet build_go build_java build_nodejs build_python clean cleanup help install_dotnet_sdk install_nodejs_sdk install_plugins lint_provider provider test tfgen upstream upstream.finalize upstream.rebase
+.PHONY: development build build_sdks install_go_sdk install_java_sdk install_python_sdk install_sdks only_build build_dotnet build_go build_java build_nodejs build_python clean cleanup help install_dotnet_sdk install_nodejs_sdk install_plugins lint_provider provider test tfgen upstream upstream.finalize upstream.rebase version.generic

--- a/provider-ci/providers/aws/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/aws/repo/.github/workflows/main.yml
@@ -92,7 +92,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version.generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -269,7 +269,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version.generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:

--- a/provider-ci/providers/aws/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/aws/repo/.github/workflows/main.yml
@@ -92,8 +92,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -270,8 +269,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(pulumictl get version --language generic)"
-        >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:

--- a/provider-ci/providers/aws/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/aws/repo/.github/workflows/master.yml
@@ -92,7 +92,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version.generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -269,7 +269,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version.generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:

--- a/provider-ci/providers/aws/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/aws/repo/.github/workflows/master.yml
@@ -92,8 +92,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -270,8 +269,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(pulumictl get version --language generic)"
-        >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:

--- a/provider-ci/providers/aws/repo/.github/workflows/nightly-test.yml
+++ b/provider-ci/providers/aws/repo/.github/workflows/nightly-test.yml
@@ -92,7 +92,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version.generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean

--- a/provider-ci/providers/aws/repo/.github/workflows/nightly-test.yml
+++ b/provider-ci/providers/aws/repo/.github/workflows/nightly-test.yml
@@ -92,8 +92,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean

--- a/provider-ci/providers/aws/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/aws/repo/.github/workflows/prerelease.yml
@@ -93,7 +93,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version.generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -219,7 +219,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version.generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:

--- a/provider-ci/providers/aws/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/aws/repo/.github/workflows/prerelease.yml
@@ -93,8 +93,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -220,8 +219,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(pulumictl get version --language generic)"
-        >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:

--- a/provider-ci/providers/aws/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/aws/repo/.github/workflows/release.yml
@@ -92,8 +92,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -233,8 +232,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(pulumictl get version --language generic)"
-        >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:
@@ -277,8 +275,8 @@ jobs:
       with:
         repo: pulumi/pulumictl
     - name: Add SDK version tag
-      run: git tag sdk/v$(pulumictl get version --language generic) && git push origin
-        sdk/v$(pulumictl get version --language generic)
+      run: git tag sdk/v$(make version:generic) && git push origin sdk/v$(make
+        version:generic)
   test:
     name: test
     needs: build_sdk

--- a/provider-ci/providers/aws/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/aws/repo/.github/workflows/release.yml
@@ -92,7 +92,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version.generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -232,7 +232,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version.generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:
@@ -275,8 +275,8 @@ jobs:
       with:
         repo: pulumi/pulumictl
     - name: Add SDK version tag
-      run: git tag sdk/v$(make version:generic) && git push origin sdk/v$(make
-        version:generic)
+      run: git tag sdk/v$(make version.generic) && git push origin sdk/v$(make
+        version.generic)
   test:
     name: test
     needs: build_sdk

--- a/provider-ci/providers/aws/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/aws/repo/.github/workflows/run-acceptance-tests.yml
@@ -97,7 +97,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version.generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean

--- a/provider-ci/providers/aws/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/aws/repo/.github/workflows/run-acceptance-tests.yml
@@ -97,8 +97,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean

--- a/provider-ci/providers/aws/repo/Makefile
+++ b/provider-ci/providers/aws/repo/Makefile
@@ -7,7 +7,7 @@ PROVIDER_PATH := provider/v5
 VERSION_PATH := $(PROVIDER_PATH)/pkg/version.Version
 TFGEN := pulumi-tfgen-$(PACK)
 PROVIDER := pulumi-resource-$(PACK)
-VERSION := $(shell pulumictl get version)
+VERSION := $(shell pulumictl get version --language generic)
 JAVA_GEN := pulumi-java-gen
 JAVA_GEN_VERSION := v0.7.1
 TESTPARALLELISM := 10
@@ -30,9 +30,9 @@ install_sdks: install_dotnet_sdk install_python_sdk install_nodejs_sdk install_j
 
 only_build: build
 
-build_dotnet: DOTNET_VERSION := $(shell pulumictl get version --language dotnet)
+build_dotnet: DOTNET_VERSION := $(shell pulumictl convert-version -l dotnet -v "$(VERSION)")
 build_dotnet:
-	pulumictl get version --language dotnet
+	@echo $(DOTNET_VERSION)
 	$(WORKING_DIR)/bin/$(TFGEN) dotnet --out sdk/dotnet/
 	cd sdk/dotnet/ && \
 		echo "module fake_dotnet_module // Exclude this directory from Go tools\n\ngo 1.17" > go.mod && \
@@ -43,14 +43,14 @@ build_go:
 	$(WORKING_DIR)/bin/$(TFGEN) go --out sdk/go/
 	cd sdk && go list `grep -e "^module" go.mod | cut -d ' ' -f 2`/go/... | xargs go build
 
-build_java: PACKAGE_VERSION := $(shell pulumictl get version --language generic)
+build_java: PACKAGE_VERSION := "$(VERSION)"
 build_java: bin/pulumi-java-gen
 	$(WORKING_DIR)/bin/$(JAVA_GEN) generate --schema provider/cmd/$(PROVIDER)/schema.json --out sdk/java  --build gradle-nexus
 	cd sdk/java/ && \
 		echo "module fake_java_module // Exclude this directory from Go tools\n\ngo 1.17" > go.mod && \
 		gradle --console=plain build
 
-build_nodejs: VERSION := $(shell pulumictl get version --language javascript)
+build_nodejs: VERSION := $(shell pulumictl convert-version -l javascript -v "$(VERSION)")
 build_nodejs:
 	$(WORKING_DIR)/bin/$(TFGEN) nodejs --out sdk/nodejs/
 	cd sdk/nodejs/ && \
@@ -60,7 +60,7 @@ build_nodejs:
 		cp ../../README.md ../../LICENSE* package.json yarn.lock ./bin/ && \
 		sed -i.bak -e "s/\$${VERSION}/$(VERSION)/g" ./bin/package.json
 
-build_python: PYPI_VERSION := $(shell pulumictl get version --language python)
+build_python: PYPI_VERSION := $(shell pulumictl convert-version -l python -v "$(VERSION)")
 build_python:
 	$(WORKING_DIR)/bin/$(TFGEN) python --out sdk/python/
 	cd sdk/python/ && \
@@ -112,7 +112,10 @@ tfgen: install_plugins
 	$(WORKING_DIR)/bin/$(TFGEN) schema --out provider/cmd/$(PROVIDER)
 	(cd provider && VERSION=$(VERSION) go generate cmd/$(PROVIDER)/main.go)
 
+version.generic:
+	@echo $(VERSION)
+
 bin/pulumi-java-gen:
 	$(shell pulumictl download-binary -n pulumi-language-java -v $(JAVA_GEN_VERSION) -r pulumi/pulumi-java)
 
-.PHONY: development build build_sdks install_go_sdk install_java_sdk install_python_sdk install_sdks only_build build_dotnet build_go build_java build_nodejs build_python clean cleanup help install_dotnet_sdk install_nodejs_sdk install_plugins lint_provider provider test tfgen
+.PHONY: development build build_sdks install_go_sdk install_java_sdk install_python_sdk install_sdks only_build build_dotnet build_go build_java build_nodejs build_python clean cleanup help install_dotnet_sdk install_nodejs_sdk install_plugins lint_provider provider test tfgen version.generic

--- a/provider-ci/providers/azure/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/azure/repo/.github/workflows/main.yml
@@ -97,7 +97,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version.generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -274,7 +274,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version.generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:

--- a/provider-ci/providers/azure/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/azure/repo/.github/workflows/main.yml
@@ -97,8 +97,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -275,8 +274,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(pulumictl get version --language generic)"
-        >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:

--- a/provider-ci/providers/azure/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/azure/repo/.github/workflows/master.yml
@@ -97,7 +97,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version.generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -274,7 +274,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version.generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:

--- a/provider-ci/providers/azure/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/azure/repo/.github/workflows/master.yml
@@ -97,8 +97,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -275,8 +274,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(pulumictl get version --language generic)"
-        >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:

--- a/provider-ci/providers/azure/repo/.github/workflows/nightly-test.yml
+++ b/provider-ci/providers/azure/repo/.github/workflows/nightly-test.yml
@@ -97,7 +97,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version.generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean

--- a/provider-ci/providers/azure/repo/.github/workflows/nightly-test.yml
+++ b/provider-ci/providers/azure/repo/.github/workflows/nightly-test.yml
@@ -97,8 +97,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean

--- a/provider-ci/providers/azure/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/azure/repo/.github/workflows/prerelease.yml
@@ -98,8 +98,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -225,8 +224,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(pulumictl get version --language generic)"
-        >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:

--- a/provider-ci/providers/azure/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/azure/repo/.github/workflows/prerelease.yml
@@ -98,7 +98,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version.generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -224,7 +224,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version.generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:

--- a/provider-ci/providers/azure/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/azure/repo/.github/workflows/release.yml
@@ -97,8 +97,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -238,8 +237,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(pulumictl get version --language generic)"
-        >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:
@@ -282,8 +280,8 @@ jobs:
       with:
         repo: pulumi/pulumictl
     - name: Add SDK version tag
-      run: git tag sdk/v$(pulumictl get version --language generic) && git push origin
-        sdk/v$(pulumictl get version --language generic)
+      run: git tag sdk/v$(make version:generic) && git push origin sdk/v$(make
+        version:generic)
   test:
     name: test
     needs: build_sdk

--- a/provider-ci/providers/azure/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/azure/repo/.github/workflows/release.yml
@@ -97,7 +97,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version.generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -237,7 +237,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version.generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:
@@ -280,8 +280,8 @@ jobs:
       with:
         repo: pulumi/pulumictl
     - name: Add SDK version tag
-      run: git tag sdk/v$(make version:generic) && git push origin sdk/v$(make
-        version:generic)
+      run: git tag sdk/v$(make version.generic) && git push origin sdk/v$(make
+        version.generic)
   test:
     name: test
     needs: build_sdk

--- a/provider-ci/providers/azure/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/azure/repo/.github/workflows/run-acceptance-tests.yml
@@ -102,8 +102,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean

--- a/provider-ci/providers/azure/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/azure/repo/.github/workflows/run-acceptance-tests.yml
@@ -102,7 +102,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version.generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean

--- a/provider-ci/providers/azure/repo/Makefile
+++ b/provider-ci/providers/azure/repo/Makefile
@@ -7,7 +7,7 @@ PROVIDER_PATH := provider/v5
 VERSION_PATH := $(PROVIDER_PATH)/pkg/version.Version
 TFGEN := pulumi-tfgen-$(PACK)
 PROVIDER := pulumi-resource-$(PACK)
-VERSION := $(shell pulumictl get version)
+VERSION := $(shell pulumictl get version --language generic)
 JAVA_GEN := pulumi-java-gen
 JAVA_GEN_VERSION := v0.8.0
 TESTPARALLELISM := 10
@@ -30,9 +30,9 @@ install_sdks: install_dotnet_sdk install_python_sdk install_nodejs_sdk install_j
 
 only_build: build
 
-build_dotnet: DOTNET_VERSION := $(shell pulumictl get version --language dotnet)
+build_dotnet: DOTNET_VERSION := $(shell pulumictl convert-version -l dotnet -v "$(VERSION)")
 build_dotnet: upstream
-	pulumictl get version --language dotnet
+	@echo $(DOTNET_VERSION)
 	$(WORKING_DIR)/bin/$(TFGEN) dotnet --out sdk/dotnet/
 	cd sdk/dotnet/ && \
 		echo "module fake_dotnet_module // Exclude this directory from Go tools\n\ngo 1.17" > go.mod && \
@@ -43,14 +43,14 @@ build_go: upstream
 	$(WORKING_DIR)/bin/$(TFGEN) go --out sdk/go/
 	cd sdk && go list `grep -e "^module" go.mod | cut -d ' ' -f 2`/go/... | xargs go build
 
-build_java: PACKAGE_VERSION := $(shell pulumictl get version --language generic)
+build_java: PACKAGE_VERSION := "$(VERSION)"
 build_java: bin/pulumi-java-gen upstream
 	$(WORKING_DIR)/bin/$(JAVA_GEN) generate --schema provider/cmd/$(PROVIDER)/schema.json --out sdk/java  --build gradle-nexus
 	cd sdk/java/ && \
 		echo "module fake_java_module // Exclude this directory from Go tools\n\ngo 1.17" > go.mod && \
 		gradle --console=plain build
 
-build_nodejs: VERSION := $(shell pulumictl get version --language javascript)
+build_nodejs: VERSION := $(shell pulumictl convert-version -l javascript -v "$(VERSION)")
 build_nodejs: upstream
 	$(WORKING_DIR)/bin/$(TFGEN) nodejs --out sdk/nodejs/
 	cd sdk/nodejs/ && \
@@ -60,7 +60,7 @@ build_nodejs: upstream
 		cp ../../README.md ../../LICENSE* package.json yarn.lock ./bin/ && \
 		sed -i.bak -e "s/\$${VERSION}/$(VERSION)/g" ./bin/package.json
 
-build_python: PYPI_VERSION := $(shell pulumictl get version --language python)
+build_python: PYPI_VERSION := $(shell pulumictl convert-version -l python -v "$(VERSION)")
 build_python: upstream
 	$(WORKING_DIR)/bin/$(TFGEN) python --out sdk/python/
 	cd sdk/python/ && \
@@ -121,7 +121,10 @@ upstream.finalize:
 upstream.rebase:
 	@$(SHELL) ./scripts/upstream.sh "$@" start_rebase
 
+version.generic:
+	@echo $(VERSION)
+
 bin/pulumi-java-gen:
 	$(shell pulumictl download-binary -n pulumi-language-java -v $(JAVA_GEN_VERSION) -r pulumi/pulumi-java)
 
-.PHONY: development build build_sdks install_go_sdk install_java_sdk install_python_sdk install_sdks only_build build_dotnet build_go build_java build_nodejs build_python clean cleanup help install_dotnet_sdk install_nodejs_sdk install_plugins lint_provider provider test tfgen upstream upstream.finalize upstream.rebase
+.PHONY: development build build_sdks install_go_sdk install_java_sdk install_python_sdk install_sdks only_build build_dotnet build_go build_java build_nodejs build_python clean cleanup help install_dotnet_sdk install_nodejs_sdk install_plugins lint_provider provider test tfgen upstream upstream.finalize upstream.rebase version.generic

--- a/provider-ci/providers/azuread/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/azuread/repo/.github/workflows/main.yml
@@ -95,7 +95,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version.generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -343,7 +343,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version.generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:

--- a/provider-ci/providers/azuread/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/azuread/repo/.github/workflows/main.yml
@@ -95,8 +95,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -344,8 +343,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(pulumictl get version --language generic)"
-        >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:

--- a/provider-ci/providers/azuread/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/azuread/repo/.github/workflows/master.yml
@@ -95,7 +95,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version.generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -343,7 +343,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version.generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:

--- a/provider-ci/providers/azuread/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/azuread/repo/.github/workflows/master.yml
@@ -95,8 +95,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -344,8 +343,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(pulumictl get version --language generic)"
-        >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:

--- a/provider-ci/providers/azuread/repo/.github/workflows/nightly-test.yml
+++ b/provider-ci/providers/azuread/repo/.github/workflows/nightly-test.yml
@@ -95,7 +95,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version.generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean

--- a/provider-ci/providers/azuread/repo/.github/workflows/nightly-test.yml
+++ b/provider-ci/providers/azuread/repo/.github/workflows/nightly-test.yml
@@ -95,8 +95,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean

--- a/provider-ci/providers/azuread/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/azuread/repo/.github/workflows/prerelease.yml
@@ -96,7 +96,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version.generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -293,7 +293,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version.generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:

--- a/provider-ci/providers/azuread/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/azuread/repo/.github/workflows/prerelease.yml
@@ -96,8 +96,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -294,8 +293,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(pulumictl get version --language generic)"
-        >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:

--- a/provider-ci/providers/azuread/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/azuread/repo/.github/workflows/release.yml
@@ -95,7 +95,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version.generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -306,7 +306,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version.generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:
@@ -349,8 +349,8 @@ jobs:
       with:
         repo: pulumi/pulumictl
     - name: Add SDK version tag
-      run: git tag sdk/v$(make version:generic) && git push origin sdk/v$(make
-        version:generic)
+      run: git tag sdk/v$(make version.generic) && git push origin sdk/v$(make
+        version.generic)
   test:
     name: test
     needs: build_sdk

--- a/provider-ci/providers/azuread/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/azuread/repo/.github/workflows/release.yml
@@ -95,8 +95,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -307,8 +306,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(pulumictl get version --language generic)"
-        >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:
@@ -351,8 +349,8 @@ jobs:
       with:
         repo: pulumi/pulumictl
     - name: Add SDK version tag
-      run: git tag sdk/v$(pulumictl get version --language generic) && git push origin
-        sdk/v$(pulumictl get version --language generic)
+      run: git tag sdk/v$(make version:generic) && git push origin sdk/v$(make
+        version:generic)
   test:
     name: test
     needs: build_sdk

--- a/provider-ci/providers/azuread/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/azuread/repo/.github/workflows/run-acceptance-tests.yml
@@ -100,8 +100,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean

--- a/provider-ci/providers/azuread/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/azuread/repo/.github/workflows/run-acceptance-tests.yml
@@ -100,7 +100,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version.generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean

--- a/provider-ci/providers/azuread/repo/Makefile
+++ b/provider-ci/providers/azuread/repo/Makefile
@@ -7,7 +7,7 @@ PROVIDER_PATH := provider/v5
 VERSION_PATH := $(PROVIDER_PATH)/pkg/version.Version
 TFGEN := pulumi-tfgen-$(PACK)
 PROVIDER := pulumi-resource-$(PACK)
-VERSION := $(shell pulumictl get version)
+VERSION := $(shell pulumictl get version --language generic)
 JAVA_GEN := pulumi-java-gen
 JAVA_GEN_VERSION := v0.5.4
 TESTPARALLELISM := 10
@@ -29,9 +29,9 @@ install_sdks: install_dotnet_sdk install_python_sdk install_nodejs_sdk install_j
 
 only_build: build
 
-build_dotnet: DOTNET_VERSION := $(shell pulumictl get version --language dotnet)
+build_dotnet: DOTNET_VERSION := $(shell pulumictl convert-version -l dotnet -v "$(VERSION)")
 build_dotnet: upstream
-	pulumictl get version --language dotnet
+	@echo $(DOTNET_VERSION)
 	$(WORKING_DIR)/bin/$(TFGEN) dotnet --out sdk/dotnet/
 	cd sdk/dotnet/ && \
 		echo "module fake_dotnet_module // Exclude this directory from Go tools\n\ngo 1.17" > go.mod && \
@@ -42,14 +42,14 @@ build_go: upstream
 	$(WORKING_DIR)/bin/$(TFGEN) go --out sdk/go/
 	cd sdk && go list `grep -e "^module" go.mod | cut -d ' ' -f 2`/go/... | xargs go build
 
-build_java: PACKAGE_VERSION := $(shell pulumictl get version --language generic)
+build_java: PACKAGE_VERSION := "$(VERSION)"
 build_java: bin/pulumi-java-gen upstream
 	$(WORKING_DIR)/bin/$(JAVA_GEN) generate --schema provider/cmd/$(PROVIDER)/schema.json --out sdk/java  --build gradle-nexus
 	cd sdk/java/ && \
 		echo "module fake_java_module // Exclude this directory from Go tools\n\ngo 1.17" > go.mod && \
 		gradle --console=plain build
 
-build_nodejs: VERSION := $(shell pulumictl get version --language javascript)
+build_nodejs: VERSION := $(shell pulumictl convert-version -l javascript -v "$(VERSION)")
 build_nodejs: upstream
 	$(WORKING_DIR)/bin/$(TFGEN) nodejs --out sdk/nodejs/
 	cd sdk/nodejs/ && \
@@ -59,7 +59,7 @@ build_nodejs: upstream
 		cp ../../README.md ../../LICENSE* package.json yarn.lock ./bin/ && \
 		sed -i.bak -e "s/\$${VERSION}/$(VERSION)/g" ./bin/package.json
 
-build_python: PYPI_VERSION := $(shell pulumictl get version --language python)
+build_python: PYPI_VERSION := $(shell pulumictl convert-version -l python -v "$(VERSION)")
 build_python: upstream
 	$(WORKING_DIR)/bin/$(TFGEN) python --out sdk/python/
 	cd sdk/python/ && \
@@ -118,7 +118,10 @@ upstream.finalize:
 upstream.rebase:
 	@$(SHELL) ./scripts/upstream.sh "$@" start_rebase
 
+version.generic:
+	@echo $(VERSION)
+
 bin/pulumi-java-gen:
 	$(shell pulumictl download-binary -n pulumi-language-java -v $(JAVA_GEN_VERSION) -r pulumi/pulumi-java)
 
-.PHONY: development build build_sdks install_go_sdk install_java_sdk install_python_sdk install_sdks only_build build_dotnet build_go build_java build_nodejs build_python clean cleanup help install_dotnet_sdk install_nodejs_sdk install_plugins lint_provider provider test tfgen upstream upstream.finalize upstream.rebase
+.PHONY: development build build_sdks install_go_sdk install_java_sdk install_python_sdk install_sdks only_build build_dotnet build_go build_java build_nodejs build_python clean cleanup help install_dotnet_sdk install_nodejs_sdk install_plugins lint_provider provider test tfgen upstream upstream.finalize upstream.rebase version.generic

--- a/provider-ci/providers/azuredevops/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/azuredevops/repo/.github/workflows/main.yml
@@ -92,7 +92,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version.generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -269,7 +269,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version.generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:

--- a/provider-ci/providers/azuredevops/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/azuredevops/repo/.github/workflows/main.yml
@@ -92,8 +92,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -270,8 +269,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(pulumictl get version --language generic)"
-        >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:

--- a/provider-ci/providers/azuredevops/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/azuredevops/repo/.github/workflows/master.yml
@@ -92,7 +92,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version.generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -269,7 +269,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version.generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:

--- a/provider-ci/providers/azuredevops/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/azuredevops/repo/.github/workflows/master.yml
@@ -92,8 +92,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -270,8 +269,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(pulumictl get version --language generic)"
-        >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:

--- a/provider-ci/providers/azuredevops/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/azuredevops/repo/.github/workflows/prerelease.yml
@@ -93,7 +93,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version.generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -219,7 +219,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version.generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:

--- a/provider-ci/providers/azuredevops/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/azuredevops/repo/.github/workflows/prerelease.yml
@@ -93,8 +93,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -220,8 +219,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(pulumictl get version --language generic)"
-        >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:

--- a/provider-ci/providers/azuredevops/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/azuredevops/repo/.github/workflows/release.yml
@@ -92,8 +92,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -233,8 +232,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(pulumictl get version --language generic)"
-        >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:
@@ -277,8 +275,8 @@ jobs:
       with:
         repo: pulumi/pulumictl
     - name: Add SDK version tag
-      run: git tag sdk/v$(pulumictl get version --language generic) && git push origin
-        sdk/v$(pulumictl get version --language generic)
+      run: git tag sdk/v$(make version:generic) && git push origin sdk/v$(make
+        version:generic)
   test:
     name: test
     needs: build_sdk

--- a/provider-ci/providers/azuredevops/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/azuredevops/repo/.github/workflows/release.yml
@@ -92,7 +92,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version.generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -232,7 +232,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version.generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:
@@ -275,8 +275,8 @@ jobs:
       with:
         repo: pulumi/pulumictl
     - name: Add SDK version tag
-      run: git tag sdk/v$(make version:generic) && git push origin sdk/v$(make
-        version:generic)
+      run: git tag sdk/v$(make version.generic) && git push origin sdk/v$(make
+        version.generic)
   test:
     name: test
     needs: build_sdk

--- a/provider-ci/providers/azuredevops/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/azuredevops/repo/.github/workflows/run-acceptance-tests.yml
@@ -97,7 +97,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version.generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean

--- a/provider-ci/providers/azuredevops/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/azuredevops/repo/.github/workflows/run-acceptance-tests.yml
@@ -97,8 +97,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean

--- a/provider-ci/providers/azuredevops/repo/Makefile
+++ b/provider-ci/providers/azuredevops/repo/Makefile
@@ -7,7 +7,7 @@ PROVIDER_PATH := provider/v2
 VERSION_PATH := $(PROVIDER_PATH)/pkg/version.Version
 TFGEN := pulumi-tfgen-$(PACK)
 PROVIDER := pulumi-resource-$(PACK)
-VERSION := $(shell pulumictl get version)
+VERSION := $(shell pulumictl get version --language generic)
 JAVA_GEN := pulumi-java-gen
 JAVA_GEN_VERSION := v0.5.4
 TESTPARALLELISM := 10
@@ -29,9 +29,9 @@ install_sdks: install_dotnet_sdk install_python_sdk install_nodejs_sdk install_j
 
 only_build: build
 
-build_dotnet: DOTNET_VERSION := $(shell pulumictl get version --language dotnet)
+build_dotnet: DOTNET_VERSION := $(shell pulumictl convert-version -l dotnet -v "$(VERSION)")
 build_dotnet:
-	pulumictl get version --language dotnet
+	@echo $(DOTNET_VERSION)
 	$(WORKING_DIR)/bin/$(TFGEN) dotnet --out sdk/dotnet/
 	cd sdk/dotnet/ && \
 		echo "module fake_dotnet_module // Exclude this directory from Go tools\n\ngo 1.17" > go.mod && \
@@ -42,14 +42,14 @@ build_go:
 	$(WORKING_DIR)/bin/$(TFGEN) go --out sdk/go/
 	cd sdk && go list `grep -e "^module" go.mod | cut -d ' ' -f 2`/go/... | xargs go build
 
-build_java: PACKAGE_VERSION := $(shell pulumictl get version --language generic)
+build_java: PACKAGE_VERSION := "$(VERSION)"
 build_java: bin/pulumi-java-gen
 	$(WORKING_DIR)/bin/$(JAVA_GEN) generate --schema provider/cmd/$(PROVIDER)/schema.json --out sdk/java  --build gradle-nexus
 	cd sdk/java/ && \
 		echo "module fake_java_module // Exclude this directory from Go tools\n\ngo 1.17" > go.mod && \
 		gradle --console=plain build
 
-build_nodejs: VERSION := $(shell pulumictl get version --language javascript)
+build_nodejs: VERSION := $(shell pulumictl convert-version -l javascript -v "$(VERSION)")
 build_nodejs:
 	$(WORKING_DIR)/bin/$(TFGEN) nodejs --out sdk/nodejs/
 	cd sdk/nodejs/ && \
@@ -59,7 +59,7 @@ build_nodejs:
 		cp ../../README.md ../../LICENSE* package.json yarn.lock ./bin/ && \
 		sed -i.bak -e "s/\$${VERSION}/$(VERSION)/g" ./bin/package.json
 
-build_python: PYPI_VERSION := $(shell pulumictl get version --language python)
+build_python: PYPI_VERSION := $(shell pulumictl convert-version -l python -v "$(VERSION)")
 build_python:
 	$(WORKING_DIR)/bin/$(TFGEN) python --out sdk/python/
 	cd sdk/python/ && \
@@ -107,7 +107,10 @@ tfgen: install_plugins
 	$(WORKING_DIR)/bin/$(TFGEN) schema --out provider/cmd/$(PROVIDER)
 	(cd provider && VERSION=$(VERSION) go generate cmd/$(PROVIDER)/main.go)
 
+version.generic:
+	@echo $(VERSION)
+
 bin/pulumi-java-gen:
 	$(shell pulumictl download-binary -n pulumi-language-java -v $(JAVA_GEN_VERSION) -r pulumi/pulumi-java)
 
-.PHONY: development build build_sdks install_go_sdk install_java_sdk install_python_sdk install_sdks only_build build_dotnet build_go build_java build_nodejs build_python clean cleanup help install_dotnet_sdk install_nodejs_sdk install_plugins lint_provider provider test tfgen
+.PHONY: development build build_sdks install_go_sdk install_java_sdk install_python_sdk install_sdks only_build build_dotnet build_go build_java build_nodejs build_python clean cleanup help install_dotnet_sdk install_nodejs_sdk install_plugins lint_provider provider test tfgen version.generic

--- a/provider-ci/providers/civo/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/civo/repo/.github/workflows/main.yml
@@ -91,7 +91,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version.generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -339,7 +339,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version.generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:

--- a/provider-ci/providers/civo/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/civo/repo/.github/workflows/main.yml
@@ -91,8 +91,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -340,8 +339,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(pulumictl get version --language generic)"
-        >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:

--- a/provider-ci/providers/civo/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/civo/repo/.github/workflows/master.yml
@@ -91,7 +91,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version.generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -339,7 +339,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version.generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:

--- a/provider-ci/providers/civo/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/civo/repo/.github/workflows/master.yml
@@ -91,8 +91,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -340,8 +339,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(pulumictl get version --language generic)"
-        >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:

--- a/provider-ci/providers/civo/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/civo/repo/.github/workflows/prerelease.yml
@@ -92,8 +92,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -290,8 +289,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(pulumictl get version --language generic)"
-        >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:

--- a/provider-ci/providers/civo/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/civo/repo/.github/workflows/prerelease.yml
@@ -92,7 +92,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version.generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -289,7 +289,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version.generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:

--- a/provider-ci/providers/civo/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/civo/repo/.github/workflows/release.yml
@@ -91,8 +91,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -303,8 +302,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(pulumictl get version --language generic)"
-        >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:
@@ -347,8 +345,8 @@ jobs:
       with:
         repo: pulumi/pulumictl
     - name: Add SDK version tag
-      run: git tag sdk/v$(pulumictl get version --language generic) && git push origin
-        sdk/v$(pulumictl get version --language generic)
+      run: git tag sdk/v$(make version:generic) && git push origin sdk/v$(make
+        version:generic)
   test:
     name: test
     needs: build_sdk

--- a/provider-ci/providers/civo/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/civo/repo/.github/workflows/release.yml
@@ -91,7 +91,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version.generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -302,7 +302,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version.generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:
@@ -345,8 +345,8 @@ jobs:
       with:
         repo: pulumi/pulumictl
     - name: Add SDK version tag
-      run: git tag sdk/v$(make version:generic) && git push origin sdk/v$(make
-        version:generic)
+      run: git tag sdk/v$(make version.generic) && git push origin sdk/v$(make
+        version.generic)
   test:
     name: test
     needs: build_sdk

--- a/provider-ci/providers/civo/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/civo/repo/.github/workflows/run-acceptance-tests.yml
@@ -96,7 +96,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version.generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean

--- a/provider-ci/providers/civo/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/civo/repo/.github/workflows/run-acceptance-tests.yml
@@ -96,8 +96,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean

--- a/provider-ci/providers/civo/repo/Makefile
+++ b/provider-ci/providers/civo/repo/Makefile
@@ -7,7 +7,7 @@ PROVIDER_PATH := provider/v2
 VERSION_PATH := $(PROVIDER_PATH)/pkg/version.Version
 TFGEN := pulumi-tfgen-$(PACK)
 PROVIDER := pulumi-resource-$(PACK)
-VERSION := $(shell pulumictl get version)
+VERSION := $(shell pulumictl get version --language generic)
 JAVA_GEN := pulumi-java-gen
 JAVA_GEN_VERSION := v0.5.4
 TESTPARALLELISM := 10
@@ -29,9 +29,9 @@ install_sdks: install_dotnet_sdk install_python_sdk install_nodejs_sdk install_j
 
 only_build: build
 
-build_dotnet: DOTNET_VERSION := $(shell pulumictl get version --language dotnet)
+build_dotnet: DOTNET_VERSION := $(shell pulumictl convert-version -l dotnet -v "$(VERSION)")
 build_dotnet: upstream
-	pulumictl get version --language dotnet
+	@echo $(DOTNET_VERSION)
 	$(WORKING_DIR)/bin/$(TFGEN) dotnet --out sdk/dotnet/
 	cd sdk/dotnet/ && \
 		echo "module fake_dotnet_module // Exclude this directory from Go tools\n\ngo 1.17" > go.mod && \
@@ -42,14 +42,14 @@ build_go: upstream
 	$(WORKING_DIR)/bin/$(TFGEN) go --out sdk/go/
 	cd sdk && go list `grep -e "^module" go.mod | cut -d ' ' -f 2`/go/... | xargs go build
 
-build_java: PACKAGE_VERSION := $(shell pulumictl get version --language generic)
+build_java: PACKAGE_VERSION := "$(VERSION)"
 build_java: bin/pulumi-java-gen upstream
 	$(WORKING_DIR)/bin/$(JAVA_GEN) generate --schema provider/cmd/$(PROVIDER)/schema.json --out sdk/java  --build gradle-nexus
 	cd sdk/java/ && \
 		echo "module fake_java_module // Exclude this directory from Go tools\n\ngo 1.17" > go.mod && \
 		gradle --console=plain build
 
-build_nodejs: VERSION := $(shell pulumictl get version --language javascript)
+build_nodejs: VERSION := $(shell pulumictl convert-version -l javascript -v "$(VERSION)")
 build_nodejs: upstream
 	$(WORKING_DIR)/bin/$(TFGEN) nodejs --out sdk/nodejs/
 	cd sdk/nodejs/ && \
@@ -59,7 +59,7 @@ build_nodejs: upstream
 		cp ../../README.md ../../LICENSE* package.json yarn.lock ./bin/ && \
 		sed -i.bak -e "s/\$${VERSION}/$(VERSION)/g" ./bin/package.json
 
-build_python: PYPI_VERSION := $(shell pulumictl get version --language python)
+build_python: PYPI_VERSION := $(shell pulumictl convert-version -l python -v "$(VERSION)")
 build_python: upstream
 	$(WORKING_DIR)/bin/$(TFGEN) python --out sdk/python/
 	cd sdk/python/ && \
@@ -118,7 +118,10 @@ upstream.finalize:
 upstream.rebase:
 	@$(SHELL) ./scripts/upstream.sh "$@" start_rebase
 
+version.generic:
+	@echo $(VERSION)
+
 bin/pulumi-java-gen:
 	$(shell pulumictl download-binary -n pulumi-language-java -v $(JAVA_GEN_VERSION) -r pulumi/pulumi-java)
 
-.PHONY: development build build_sdks install_go_sdk install_java_sdk install_python_sdk install_sdks only_build build_dotnet build_go build_java build_nodejs build_python clean cleanup help install_dotnet_sdk install_nodejs_sdk install_plugins lint_provider provider test tfgen upstream upstream.finalize upstream.rebase
+.PHONY: development build build_sdks install_go_sdk install_java_sdk install_python_sdk install_sdks only_build build_dotnet build_go build_java build_nodejs build_python clean cleanup help install_dotnet_sdk install_nodejs_sdk install_plugins lint_provider provider test tfgen upstream upstream.finalize upstream.rebase version.generic

--- a/provider-ci/providers/cloudamqp/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/cloudamqp/repo/.github/workflows/main.yml
@@ -90,7 +90,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version.generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -338,7 +338,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version.generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:

--- a/provider-ci/providers/cloudamqp/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/cloudamqp/repo/.github/workflows/main.yml
@@ -90,8 +90,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -339,8 +338,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(pulumictl get version --language generic)"
-        >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:

--- a/provider-ci/providers/cloudamqp/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/cloudamqp/repo/.github/workflows/master.yml
@@ -90,7 +90,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version.generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -338,7 +338,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version.generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:

--- a/provider-ci/providers/cloudamqp/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/cloudamqp/repo/.github/workflows/master.yml
@@ -90,8 +90,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -339,8 +338,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(pulumictl get version --language generic)"
-        >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:

--- a/provider-ci/providers/cloudamqp/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/cloudamqp/repo/.github/workflows/prerelease.yml
@@ -91,7 +91,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version.generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -288,7 +288,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version.generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:

--- a/provider-ci/providers/cloudamqp/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/cloudamqp/repo/.github/workflows/prerelease.yml
@@ -91,8 +91,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -289,8 +288,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(pulumictl get version --language generic)"
-        >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:

--- a/provider-ci/providers/cloudamqp/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/cloudamqp/repo/.github/workflows/release.yml
@@ -90,7 +90,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version.generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -301,7 +301,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version.generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:
@@ -344,8 +344,8 @@ jobs:
       with:
         repo: pulumi/pulumictl
     - name: Add SDK version tag
-      run: git tag sdk/v$(make version:generic) && git push origin sdk/v$(make
-        version:generic)
+      run: git tag sdk/v$(make version.generic) && git push origin sdk/v$(make
+        version.generic)
   test:
     name: test
     needs: build_sdk

--- a/provider-ci/providers/cloudamqp/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/cloudamqp/repo/.github/workflows/release.yml
@@ -90,8 +90,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -302,8 +301,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(pulumictl get version --language generic)"
-        >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:
@@ -346,8 +344,8 @@ jobs:
       with:
         repo: pulumi/pulumictl
     - name: Add SDK version tag
-      run: git tag sdk/v$(pulumictl get version --language generic) && git push origin
-        sdk/v$(pulumictl get version --language generic)
+      run: git tag sdk/v$(make version:generic) && git push origin sdk/v$(make
+        version:generic)
   test:
     name: test
     needs: build_sdk

--- a/provider-ci/providers/cloudamqp/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/cloudamqp/repo/.github/workflows/run-acceptance-tests.yml
@@ -95,7 +95,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version.generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean

--- a/provider-ci/providers/cloudamqp/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/cloudamqp/repo/.github/workflows/run-acceptance-tests.yml
@@ -95,8 +95,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean

--- a/provider-ci/providers/cloudamqp/repo/Makefile
+++ b/provider-ci/providers/cloudamqp/repo/Makefile
@@ -7,7 +7,7 @@ PROVIDER_PATH := provider/v3
 VERSION_PATH := $(PROVIDER_PATH)/pkg/version.Version
 TFGEN := pulumi-tfgen-$(PACK)
 PROVIDER := pulumi-resource-$(PACK)
-VERSION := $(shell pulumictl get version)
+VERSION := $(shell pulumictl get version --language generic)
 JAVA_GEN := pulumi-java-gen
 JAVA_GEN_VERSION := v0.5.4
 TESTPARALLELISM := 10
@@ -29,9 +29,9 @@ install_sdks: install_dotnet_sdk install_python_sdk install_nodejs_sdk install_j
 
 only_build: build
 
-build_dotnet: DOTNET_VERSION := $(shell pulumictl get version --language dotnet)
+build_dotnet: DOTNET_VERSION := $(shell pulumictl convert-version -l dotnet -v "$(VERSION)")
 build_dotnet: upstream
-	pulumictl get version --language dotnet
+	@echo $(DOTNET_VERSION)
 	$(WORKING_DIR)/bin/$(TFGEN) dotnet --out sdk/dotnet/
 	cd sdk/dotnet/ && \
 		echo "module fake_dotnet_module // Exclude this directory from Go tools\n\ngo 1.17" > go.mod && \
@@ -42,14 +42,14 @@ build_go: upstream
 	$(WORKING_DIR)/bin/$(TFGEN) go --out sdk/go/
 	cd sdk && go list `grep -e "^module" go.mod | cut -d ' ' -f 2`/go/... | xargs go build
 
-build_java: PACKAGE_VERSION := $(shell pulumictl get version --language generic)
+build_java: PACKAGE_VERSION := "$(VERSION)"
 build_java: bin/pulumi-java-gen upstream
 	$(WORKING_DIR)/bin/$(JAVA_GEN) generate --schema provider/cmd/$(PROVIDER)/schema.json --out sdk/java  --build gradle-nexus
 	cd sdk/java/ && \
 		echo "module fake_java_module // Exclude this directory from Go tools\n\ngo 1.17" > go.mod && \
 		gradle --console=plain build
 
-build_nodejs: VERSION := $(shell pulumictl get version --language javascript)
+build_nodejs: VERSION := $(shell pulumictl convert-version -l javascript -v "$(VERSION)")
 build_nodejs: upstream
 	$(WORKING_DIR)/bin/$(TFGEN) nodejs --out sdk/nodejs/
 	cd sdk/nodejs/ && \
@@ -59,7 +59,7 @@ build_nodejs: upstream
 		cp ../../README.md ../../LICENSE* package.json yarn.lock ./bin/ && \
 		sed -i.bak -e "s/\$${VERSION}/$(VERSION)/g" ./bin/package.json
 
-build_python: PYPI_VERSION := $(shell pulumictl get version --language python)
+build_python: PYPI_VERSION := $(shell pulumictl convert-version -l python -v "$(VERSION)")
 build_python: upstream
 	$(WORKING_DIR)/bin/$(TFGEN) python --out sdk/python/
 	cd sdk/python/ && \
@@ -118,7 +118,10 @@ upstream.finalize:
 upstream.rebase:
 	@$(SHELL) ./scripts/upstream.sh "$@" start_rebase
 
+version.generic:
+	@echo $(VERSION)
+
 bin/pulumi-java-gen:
 	$(shell pulumictl download-binary -n pulumi-language-java -v $(JAVA_GEN_VERSION) -r pulumi/pulumi-java)
 
-.PHONY: development build build_sdks install_go_sdk install_java_sdk install_python_sdk install_sdks only_build build_dotnet build_go build_java build_nodejs build_python clean cleanup help install_dotnet_sdk install_nodejs_sdk install_plugins lint_provider provider test tfgen upstream upstream.finalize upstream.rebase
+.PHONY: development build build_sdks install_go_sdk install_java_sdk install_python_sdk install_sdks only_build build_dotnet build_go build_java build_nodejs build_python clean cleanup help install_dotnet_sdk install_nodejs_sdk install_plugins lint_provider provider test tfgen upstream upstream.finalize upstream.rebase version.generic

--- a/provider-ci/providers/cloudflare/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/cloudflare/repo/.github/workflows/main.yml
@@ -92,8 +92,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -341,8 +340,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(pulumictl get version --language generic)"
-        >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:

--- a/provider-ci/providers/cloudflare/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/cloudflare/repo/.github/workflows/main.yml
@@ -92,7 +92,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version.generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -340,7 +340,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version.generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:

--- a/provider-ci/providers/cloudflare/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/cloudflare/repo/.github/workflows/master.yml
@@ -92,8 +92,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -341,8 +340,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(pulumictl get version --language generic)"
-        >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:

--- a/provider-ci/providers/cloudflare/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/cloudflare/repo/.github/workflows/master.yml
@@ -92,7 +92,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version.generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -340,7 +340,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version.generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:

--- a/provider-ci/providers/cloudflare/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/cloudflare/repo/.github/workflows/prerelease.yml
@@ -93,8 +93,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -291,8 +290,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(pulumictl get version --language generic)"
-        >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:

--- a/provider-ci/providers/cloudflare/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/cloudflare/repo/.github/workflows/prerelease.yml
@@ -93,7 +93,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version.generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -290,7 +290,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version.generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:

--- a/provider-ci/providers/cloudflare/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/cloudflare/repo/.github/workflows/release.yml
@@ -92,7 +92,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version.generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -303,7 +303,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version.generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:
@@ -346,8 +346,8 @@ jobs:
       with:
         repo: pulumi/pulumictl
     - name: Add SDK version tag
-      run: git tag sdk/v$(make version:generic) && git push origin sdk/v$(make
-        version:generic)
+      run: git tag sdk/v$(make version.generic) && git push origin sdk/v$(make
+        version.generic)
   test:
     name: test
     needs: build_sdk

--- a/provider-ci/providers/cloudflare/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/cloudflare/repo/.github/workflows/release.yml
@@ -92,8 +92,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -304,8 +303,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(pulumictl get version --language generic)"
-        >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:
@@ -348,8 +346,8 @@ jobs:
       with:
         repo: pulumi/pulumictl
     - name: Add SDK version tag
-      run: git tag sdk/v$(pulumictl get version --language generic) && git push origin
-        sdk/v$(pulumictl get version --language generic)
+      run: git tag sdk/v$(make version:generic) && git push origin sdk/v$(make
+        version:generic)
   test:
     name: test
     needs: build_sdk

--- a/provider-ci/providers/cloudflare/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/cloudflare/repo/.github/workflows/run-acceptance-tests.yml
@@ -97,7 +97,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version.generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean

--- a/provider-ci/providers/cloudflare/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/cloudflare/repo/.github/workflows/run-acceptance-tests.yml
@@ -97,8 +97,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean

--- a/provider-ci/providers/cloudflare/repo/Makefile
+++ b/provider-ci/providers/cloudflare/repo/Makefile
@@ -7,7 +7,7 @@ PROVIDER_PATH := provider/v5
 VERSION_PATH := $(PROVIDER_PATH)/pkg/version.Version
 TFGEN := pulumi-tfgen-$(PACK)
 PROVIDER := pulumi-resource-$(PACK)
-VERSION := $(shell pulumictl get version)
+VERSION := $(shell pulumictl get version --language generic)
 JAVA_GEN := pulumi-java-gen
 JAVA_GEN_VERSION := v0.9.3
 TESTPARALLELISM := 10
@@ -29,9 +29,9 @@ install_sdks: install_dotnet_sdk install_python_sdk install_nodejs_sdk install_j
 
 only_build: build
 
-build_dotnet: DOTNET_VERSION := $(shell pulumictl get version --language dotnet)
+build_dotnet: DOTNET_VERSION := $(shell pulumictl convert-version -l dotnet -v "$(VERSION)")
 build_dotnet: upstream
-	pulumictl get version --language dotnet
+	@echo $(DOTNET_VERSION)
 	$(WORKING_DIR)/bin/$(TFGEN) dotnet --out sdk/dotnet/
 	cd sdk/dotnet/ && \
 		echo "module fake_dotnet_module // Exclude this directory from Go tools\n\ngo 1.17" > go.mod && \
@@ -42,14 +42,14 @@ build_go: upstream
 	$(WORKING_DIR)/bin/$(TFGEN) go --out sdk/go/
 	cd sdk && go list `grep -e "^module" go.mod | cut -d ' ' -f 2`/go/... | xargs go build
 
-build_java: PACKAGE_VERSION := $(shell pulumictl get version --language generic)
+build_java: PACKAGE_VERSION := "$(VERSION)"
 build_java: bin/pulumi-java-gen upstream
 	$(WORKING_DIR)/bin/$(JAVA_GEN) generate --schema provider/cmd/$(PROVIDER)/schema.json --out sdk/java  --build gradle-nexus
 	cd sdk/java/ && \
 		echo "module fake_java_module // Exclude this directory from Go tools\n\ngo 1.17" > go.mod && \
 		gradle --console=plain build
 
-build_nodejs: VERSION := $(shell pulumictl get version --language javascript)
+build_nodejs: VERSION := $(shell pulumictl convert-version -l javascript -v "$(VERSION)")
 build_nodejs: upstream
 	$(WORKING_DIR)/bin/$(TFGEN) nodejs --out sdk/nodejs/
 	cd sdk/nodejs/ && \
@@ -59,7 +59,7 @@ build_nodejs: upstream
 		cp ../../README.md ../../LICENSE* package.json yarn.lock ./bin/ && \
 		sed -i.bak -e "s/\$${VERSION}/$(VERSION)/g" ./bin/package.json
 
-build_python: PYPI_VERSION := $(shell pulumictl get version --language python)
+build_python: PYPI_VERSION := $(shell pulumictl convert-version -l python -v "$(VERSION)")
 build_python: upstream
 	$(WORKING_DIR)/bin/$(TFGEN) python --out sdk/python/
 	cd sdk/python/ && \
@@ -120,7 +120,10 @@ upstream.finalize:
 upstream.rebase:
 	@$(SHELL) ./scripts/upstream.sh "$@" start_rebase
 
+version.generic:
+	@echo $(VERSION)
+
 bin/pulumi-java-gen:
 	$(shell pulumictl download-binary -n pulumi-language-java -v $(JAVA_GEN_VERSION) -r pulumi/pulumi-java)
 
-.PHONY: development build build_sdks install_go_sdk install_java_sdk install_python_sdk install_sdks only_build build_dotnet build_go build_java build_nodejs build_python clean cleanup help install_dotnet_sdk install_nodejs_sdk install_plugins lint_provider provider test tfgen upstream upstream.finalize upstream.rebase
+.PHONY: development build build_sdks install_go_sdk install_java_sdk install_python_sdk install_sdks only_build build_dotnet build_go build_java build_nodejs build_python clean cleanup help install_dotnet_sdk install_nodejs_sdk install_plugins lint_provider provider test tfgen upstream upstream.finalize upstream.rebase version.generic

--- a/provider-ci/providers/cloudinit/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/cloudinit/repo/.github/workflows/main.yml
@@ -90,7 +90,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version.generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -267,7 +267,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version.generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:

--- a/provider-ci/providers/cloudinit/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/cloudinit/repo/.github/workflows/main.yml
@@ -90,8 +90,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -268,8 +267,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(pulumictl get version --language generic)"
-        >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:

--- a/provider-ci/providers/cloudinit/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/cloudinit/repo/.github/workflows/master.yml
@@ -90,7 +90,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version.generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -267,7 +267,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version.generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:

--- a/provider-ci/providers/cloudinit/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/cloudinit/repo/.github/workflows/master.yml
@@ -90,8 +90,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -268,8 +267,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(pulumictl get version --language generic)"
-        >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:

--- a/provider-ci/providers/cloudinit/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/cloudinit/repo/.github/workflows/prerelease.yml
@@ -91,7 +91,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version.generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -217,7 +217,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version.generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:

--- a/provider-ci/providers/cloudinit/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/cloudinit/repo/.github/workflows/prerelease.yml
@@ -91,8 +91,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -218,8 +217,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(pulumictl get version --language generic)"
-        >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:

--- a/provider-ci/providers/cloudinit/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/cloudinit/repo/.github/workflows/release.yml
@@ -90,8 +90,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -231,8 +230,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(pulumictl get version --language generic)"
-        >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:
@@ -275,8 +273,8 @@ jobs:
       with:
         repo: pulumi/pulumictl
     - name: Add SDK version tag
-      run: git tag sdk/v$(pulumictl get version --language generic) && git push origin
-        sdk/v$(pulumictl get version --language generic)
+      run: git tag sdk/v$(make version:generic) && git push origin sdk/v$(make
+        version:generic)
   test:
     name: test
     needs: build_sdk

--- a/provider-ci/providers/cloudinit/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/cloudinit/repo/.github/workflows/release.yml
@@ -90,7 +90,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version.generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -230,7 +230,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version.generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:
@@ -273,8 +273,8 @@ jobs:
       with:
         repo: pulumi/pulumictl
     - name: Add SDK version tag
-      run: git tag sdk/v$(make version:generic) && git push origin sdk/v$(make
-        version:generic)
+      run: git tag sdk/v$(make version.generic) && git push origin sdk/v$(make
+        version.generic)
   test:
     name: test
     needs: build_sdk

--- a/provider-ci/providers/cloudinit/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/cloudinit/repo/.github/workflows/run-acceptance-tests.yml
@@ -95,7 +95,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version.generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean

--- a/provider-ci/providers/cloudinit/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/cloudinit/repo/.github/workflows/run-acceptance-tests.yml
@@ -95,8 +95,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean

--- a/provider-ci/providers/cloudinit/repo/Makefile
+++ b/provider-ci/providers/cloudinit/repo/Makefile
@@ -7,7 +7,7 @@ PROVIDER_PATH := provider
 VERSION_PATH := $(PROVIDER_PATH)/pkg/version.Version
 TFGEN := pulumi-tfgen-$(PACK)
 PROVIDER := pulumi-resource-$(PACK)
-VERSION := $(shell pulumictl get version)
+VERSION := $(shell pulumictl get version --language generic)
 JAVA_GEN := pulumi-java-gen
 JAVA_GEN_VERSION := v0.5.4
 TESTPARALLELISM := 10
@@ -29,9 +29,9 @@ install_sdks: install_dotnet_sdk install_python_sdk install_nodejs_sdk install_j
 
 only_build: build
 
-build_dotnet: DOTNET_VERSION := $(shell pulumictl get version --language dotnet)
+build_dotnet: DOTNET_VERSION := $(shell pulumictl convert-version -l dotnet -v "$(VERSION)")
 build_dotnet: upstream
-	pulumictl get version --language dotnet
+	@echo $(DOTNET_VERSION)
 	$(WORKING_DIR)/bin/$(TFGEN) dotnet --out sdk/dotnet/
 	cd sdk/dotnet/ && \
 		echo "module fake_dotnet_module // Exclude this directory from Go tools\n\ngo 1.17" > go.mod && \
@@ -42,14 +42,14 @@ build_go: upstream
 	$(WORKING_DIR)/bin/$(TFGEN) go --out sdk/go/
 	cd sdk && go list `grep -e "^module" go.mod | cut -d ' ' -f 2`/go/... | xargs go build
 
-build_java: PACKAGE_VERSION := $(shell pulumictl get version --language generic)
+build_java: PACKAGE_VERSION := "$(VERSION)"
 build_java: bin/pulumi-java-gen upstream
 	$(WORKING_DIR)/bin/$(JAVA_GEN) generate --schema provider/cmd/$(PROVIDER)/schema.json --out sdk/java  --build gradle-nexus
 	cd sdk/java/ && \
 		echo "module fake_java_module // Exclude this directory from Go tools\n\ngo 1.17" > go.mod && \
 		gradle --console=plain build
 
-build_nodejs: VERSION := $(shell pulumictl get version --language javascript)
+build_nodejs: VERSION := $(shell pulumictl convert-version -l javascript -v "$(VERSION)")
 build_nodejs: upstream
 	$(WORKING_DIR)/bin/$(TFGEN) nodejs --out sdk/nodejs/
 	cd sdk/nodejs/ && \
@@ -59,7 +59,7 @@ build_nodejs: upstream
 		cp ../../README.md ../../LICENSE* package.json yarn.lock ./bin/ && \
 		sed -i.bak -e "s/\$${VERSION}/$(VERSION)/g" ./bin/package.json
 
-build_python: PYPI_VERSION := $(shell pulumictl get version --language python)
+build_python: PYPI_VERSION := $(shell pulumictl convert-version -l python -v "$(VERSION)")
 build_python: upstream
 	$(WORKING_DIR)/bin/$(TFGEN) python --out sdk/python/
 	cd sdk/python/ && \
@@ -118,7 +118,10 @@ upstream.finalize:
 upstream.rebase:
 	@$(SHELL) ./scripts/upstream.sh "$@" start_rebase
 
+version.generic:
+	@echo $(VERSION)
+
 bin/pulumi-java-gen:
 	$(shell pulumictl download-binary -n pulumi-language-java -v $(JAVA_GEN_VERSION) -r pulumi/pulumi-java)
 
-.PHONY: development build build_sdks install_go_sdk install_java_sdk install_python_sdk install_sdks only_build build_dotnet build_go build_java build_nodejs build_python clean cleanup help install_dotnet_sdk install_nodejs_sdk install_plugins lint_provider provider test tfgen upstream upstream.finalize upstream.rebase
+.PHONY: development build build_sdks install_go_sdk install_java_sdk install_python_sdk install_sdks only_build build_dotnet build_go build_java build_nodejs build_python clean cleanup help install_dotnet_sdk install_nodejs_sdk install_plugins lint_provider provider test tfgen upstream upstream.finalize upstream.rebase version.generic

--- a/provider-ci/providers/confluentcloud/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/confluentcloud/repo/.github/workflows/main.yml
@@ -92,7 +92,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version.generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -269,7 +269,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version.generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:

--- a/provider-ci/providers/confluentcloud/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/confluentcloud/repo/.github/workflows/main.yml
@@ -92,8 +92,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -270,8 +269,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(pulumictl get version --language generic)"
-        >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:

--- a/provider-ci/providers/confluentcloud/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/confluentcloud/repo/.github/workflows/master.yml
@@ -92,7 +92,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version.generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -269,7 +269,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version.generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:

--- a/provider-ci/providers/confluentcloud/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/confluentcloud/repo/.github/workflows/master.yml
@@ -92,8 +92,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -270,8 +269,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(pulumictl get version --language generic)"
-        >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:

--- a/provider-ci/providers/confluentcloud/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/confluentcloud/repo/.github/workflows/prerelease.yml
@@ -93,7 +93,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version.generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -219,7 +219,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version.generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:

--- a/provider-ci/providers/confluentcloud/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/confluentcloud/repo/.github/workflows/prerelease.yml
@@ -93,8 +93,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -220,8 +219,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(pulumictl get version --language generic)"
-        >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:

--- a/provider-ci/providers/confluentcloud/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/confluentcloud/repo/.github/workflows/release.yml
@@ -92,8 +92,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -233,8 +232,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(pulumictl get version --language generic)"
-        >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:
@@ -277,8 +275,8 @@ jobs:
       with:
         repo: pulumi/pulumictl
     - name: Add SDK version tag
-      run: git tag sdk/v$(pulumictl get version --language generic) && git push origin
-        sdk/v$(pulumictl get version --language generic)
+      run: git tag sdk/v$(make version:generic) && git push origin sdk/v$(make
+        version:generic)
   test:
     name: test
     needs: build_sdk

--- a/provider-ci/providers/confluentcloud/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/confluentcloud/repo/.github/workflows/release.yml
@@ -92,7 +92,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version.generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -232,7 +232,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version.generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:
@@ -275,8 +275,8 @@ jobs:
       with:
         repo: pulumi/pulumictl
     - name: Add SDK version tag
-      run: git tag sdk/v$(make version:generic) && git push origin sdk/v$(make
-        version:generic)
+      run: git tag sdk/v$(make version.generic) && git push origin sdk/v$(make
+        version.generic)
   test:
     name: test
     needs: build_sdk

--- a/provider-ci/providers/confluentcloud/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/confluentcloud/repo/.github/workflows/run-acceptance-tests.yml
@@ -97,7 +97,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version.generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean

--- a/provider-ci/providers/confluentcloud/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/confluentcloud/repo/.github/workflows/run-acceptance-tests.yml
@@ -97,8 +97,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean

--- a/provider-ci/providers/confluentcloud/repo/Makefile
+++ b/provider-ci/providers/confluentcloud/repo/Makefile
@@ -7,7 +7,7 @@ PROVIDER_PATH := provider
 VERSION_PATH := $(PROVIDER_PATH)/pkg/version.Version
 TFGEN := pulumi-tfgen-$(PACK)
 PROVIDER := pulumi-resource-$(PACK)
-VERSION := $(shell pulumictl get version)
+VERSION := $(shell pulumictl get version --language generic)
 JAVA_GEN := pulumi-java-gen
 JAVA_GEN_VERSION := v0.5.4
 TESTPARALLELISM := 10
@@ -29,9 +29,9 @@ install_sdks: install_dotnet_sdk install_python_sdk install_nodejs_sdk install_j
 
 only_build: build
 
-build_dotnet: DOTNET_VERSION := $(shell pulumictl get version --language dotnet)
+build_dotnet: DOTNET_VERSION := $(shell pulumictl convert-version -l dotnet -v "$(VERSION)")
 build_dotnet: upstream
-	pulumictl get version --language dotnet
+	@echo $(DOTNET_VERSION)
 	$(WORKING_DIR)/bin/$(TFGEN) dotnet --out sdk/dotnet/
 	cd sdk/dotnet/ && \
 		echo "module fake_dotnet_module // Exclude this directory from Go tools\n\ngo 1.17" > go.mod && \
@@ -42,14 +42,14 @@ build_go: upstream
 	$(WORKING_DIR)/bin/$(TFGEN) go --out sdk/go/
 	cd sdk && go list `grep -e "^module" go.mod | cut -d ' ' -f 2`/go/... | xargs go build
 
-build_java: PACKAGE_VERSION := $(shell pulumictl get version --language generic)
+build_java: PACKAGE_VERSION := "$(VERSION)"
 build_java: bin/pulumi-java-gen upstream
 	$(WORKING_DIR)/bin/$(JAVA_GEN) generate --schema provider/cmd/$(PROVIDER)/schema.json --out sdk/java  --build gradle-nexus
 	cd sdk/java/ && \
 		echo "module fake_java_module // Exclude this directory from Go tools\n\ngo 1.17" > go.mod && \
 		gradle --console=plain build
 
-build_nodejs: VERSION := $(shell pulumictl get version --language javascript)
+build_nodejs: VERSION := $(shell pulumictl convert-version -l javascript -v "$(VERSION)")
 build_nodejs: upstream
 	$(WORKING_DIR)/bin/$(TFGEN) nodejs --out sdk/nodejs/
 	cd sdk/nodejs/ && \
@@ -59,7 +59,7 @@ build_nodejs: upstream
 		cp ../../README.md ../../LICENSE* package.json yarn.lock ./bin/ && \
 		sed -i.bak -e "s/\$${VERSION}/$(VERSION)/g" ./bin/package.json
 
-build_python: PYPI_VERSION := $(shell pulumictl get version --language python)
+build_python: PYPI_VERSION := $(shell pulumictl convert-version -l python -v "$(VERSION)")
 build_python: upstream
 	$(WORKING_DIR)/bin/$(TFGEN) python --out sdk/python/
 	cd sdk/python/ && \
@@ -119,7 +119,10 @@ upstream.finalize:
 upstream.rebase:
 	@$(SHELL) ./scripts/upstream.sh "$@" start_rebase
 
+version.generic:
+	@echo $(VERSION)
+
 bin/pulumi-java-gen:
 	$(shell pulumictl download-binary -n pulumi-language-java -v $(JAVA_GEN_VERSION) -r pulumi/pulumi-java)
 
-.PHONY: development build build_sdks install_go_sdk install_java_sdk install_python_sdk install_sdks only_build build_dotnet build_go build_java build_nodejs build_python clean cleanup help install_dotnet_sdk install_nodejs_sdk install_plugins lint_provider provider test tfgen upstream upstream.finalize upstream.rebase
+.PHONY: development build build_sdks install_go_sdk install_java_sdk install_python_sdk install_sdks only_build build_dotnet build_go build_java build_nodejs build_python clean cleanup help install_dotnet_sdk install_nodejs_sdk install_plugins lint_provider provider test tfgen upstream upstream.finalize upstream.rebase version.generic

--- a/provider-ci/providers/consul/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/consul/repo/.github/workflows/main.yml
@@ -90,7 +90,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version.generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -338,7 +338,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version.generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:

--- a/provider-ci/providers/consul/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/consul/repo/.github/workflows/main.yml
@@ -90,8 +90,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -339,8 +338,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(pulumictl get version --language generic)"
-        >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:

--- a/provider-ci/providers/consul/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/consul/repo/.github/workflows/master.yml
@@ -90,7 +90,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version.generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -338,7 +338,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version.generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:

--- a/provider-ci/providers/consul/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/consul/repo/.github/workflows/master.yml
@@ -90,8 +90,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -339,8 +338,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(pulumictl get version --language generic)"
-        >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:

--- a/provider-ci/providers/consul/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/consul/repo/.github/workflows/prerelease.yml
@@ -91,7 +91,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version.generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -288,7 +288,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version.generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:

--- a/provider-ci/providers/consul/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/consul/repo/.github/workflows/prerelease.yml
@@ -91,8 +91,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -289,8 +288,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(pulumictl get version --language generic)"
-        >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:

--- a/provider-ci/providers/consul/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/consul/repo/.github/workflows/release.yml
@@ -90,7 +90,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version.generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -301,7 +301,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version.generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:
@@ -344,8 +344,8 @@ jobs:
       with:
         repo: pulumi/pulumictl
     - name: Add SDK version tag
-      run: git tag sdk/v$(make version:generic) && git push origin sdk/v$(make
-        version:generic)
+      run: git tag sdk/v$(make version.generic) && git push origin sdk/v$(make
+        version.generic)
   test:
     name: test
     needs: build_sdk

--- a/provider-ci/providers/consul/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/consul/repo/.github/workflows/release.yml
@@ -90,8 +90,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -302,8 +301,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(pulumictl get version --language generic)"
-        >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:
@@ -346,8 +344,8 @@ jobs:
       with:
         repo: pulumi/pulumictl
     - name: Add SDK version tag
-      run: git tag sdk/v$(pulumictl get version --language generic) && git push origin
-        sdk/v$(pulumictl get version --language generic)
+      run: git tag sdk/v$(make version:generic) && git push origin sdk/v$(make
+        version:generic)
   test:
     name: test
     needs: build_sdk

--- a/provider-ci/providers/consul/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/consul/repo/.github/workflows/run-acceptance-tests.yml
@@ -95,7 +95,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version.generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean

--- a/provider-ci/providers/consul/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/consul/repo/.github/workflows/run-acceptance-tests.yml
@@ -95,8 +95,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean

--- a/provider-ci/providers/consul/repo/Makefile
+++ b/provider-ci/providers/consul/repo/Makefile
@@ -7,7 +7,7 @@ PROVIDER_PATH := provider/v3
 VERSION_PATH := $(PROVIDER_PATH)/pkg/version.Version
 TFGEN := pulumi-tfgen-$(PACK)
 PROVIDER := pulumi-resource-$(PACK)
-VERSION := $(shell pulumictl get version)
+VERSION := $(shell pulumictl get version --language generic)
 JAVA_GEN := pulumi-java-gen
 JAVA_GEN_VERSION := v0.5.4
 TESTPARALLELISM := 10
@@ -29,9 +29,9 @@ install_sdks: install_dotnet_sdk install_python_sdk install_nodejs_sdk install_j
 
 only_build: build
 
-build_dotnet: DOTNET_VERSION := $(shell pulumictl get version --language dotnet)
+build_dotnet: DOTNET_VERSION := $(shell pulumictl convert-version -l dotnet -v "$(VERSION)")
 build_dotnet: upstream
-	pulumictl get version --language dotnet
+	@echo $(DOTNET_VERSION)
 	$(WORKING_DIR)/bin/$(TFGEN) dotnet --out sdk/dotnet/
 	cd sdk/dotnet/ && \
 		echo "module fake_dotnet_module // Exclude this directory from Go tools\n\ngo 1.17" > go.mod && \
@@ -42,14 +42,14 @@ build_go: upstream
 	$(WORKING_DIR)/bin/$(TFGEN) go --out sdk/go/
 	cd sdk && go list `grep -e "^module" go.mod | cut -d ' ' -f 2`/go/... | xargs go build
 
-build_java: PACKAGE_VERSION := $(shell pulumictl get version --language generic)
+build_java: PACKAGE_VERSION := "$(VERSION)"
 build_java: bin/pulumi-java-gen upstream
 	$(WORKING_DIR)/bin/$(JAVA_GEN) generate --schema provider/cmd/$(PROVIDER)/schema.json --out sdk/java  --build gradle-nexus
 	cd sdk/java/ && \
 		echo "module fake_java_module // Exclude this directory from Go tools\n\ngo 1.17" > go.mod && \
 		gradle --console=plain build
 
-build_nodejs: VERSION := $(shell pulumictl get version --language javascript)
+build_nodejs: VERSION := $(shell pulumictl convert-version -l javascript -v "$(VERSION)")
 build_nodejs: upstream
 	$(WORKING_DIR)/bin/$(TFGEN) nodejs --out sdk/nodejs/
 	cd sdk/nodejs/ && \
@@ -59,7 +59,7 @@ build_nodejs: upstream
 		cp ../../README.md ../../LICENSE* package.json yarn.lock ./bin/ && \
 		sed -i.bak -e "s/\$${VERSION}/$(VERSION)/g" ./bin/package.json
 
-build_python: PYPI_VERSION := $(shell pulumictl get version --language python)
+build_python: PYPI_VERSION := $(shell pulumictl convert-version -l python -v "$(VERSION)")
 build_python: upstream
 	$(WORKING_DIR)/bin/$(TFGEN) python --out sdk/python/
 	cd sdk/python/ && \
@@ -120,7 +120,10 @@ upstream.finalize:
 upstream.rebase:
 	@$(SHELL) ./scripts/upstream.sh "$@" start_rebase
 
+version.generic:
+	@echo $(VERSION)
+
 bin/pulumi-java-gen:
 	$(shell pulumictl download-binary -n pulumi-language-java -v $(JAVA_GEN_VERSION) -r pulumi/pulumi-java)
 
-.PHONY: development build build_sdks install_go_sdk install_java_sdk install_python_sdk install_sdks only_build build_dotnet build_go build_java build_nodejs build_python clean cleanup help install_dotnet_sdk install_nodejs_sdk install_plugins lint_provider provider test tfgen upstream upstream.finalize upstream.rebase
+.PHONY: development build build_sdks install_go_sdk install_java_sdk install_python_sdk install_sdks only_build build_dotnet build_go build_java build_nodejs build_python clean cleanup help install_dotnet_sdk install_nodejs_sdk install_plugins lint_provider provider test tfgen upstream upstream.finalize upstream.rebase version.generic

--- a/provider-ci/providers/databricks/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/databricks/repo/.github/workflows/main.yml
@@ -94,7 +94,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version.generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -342,7 +342,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version.generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:

--- a/provider-ci/providers/databricks/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/databricks/repo/.github/workflows/main.yml
@@ -94,8 +94,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -343,8 +342,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(pulumictl get version --language generic)"
-        >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:

--- a/provider-ci/providers/databricks/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/databricks/repo/.github/workflows/master.yml
@@ -94,7 +94,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version.generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -342,7 +342,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version.generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:

--- a/provider-ci/providers/databricks/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/databricks/repo/.github/workflows/master.yml
@@ -94,8 +94,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -343,8 +342,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(pulumictl get version --language generic)"
-        >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:

--- a/provider-ci/providers/databricks/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/databricks/repo/.github/workflows/prerelease.yml
@@ -95,8 +95,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -293,8 +292,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(pulumictl get version --language generic)"
-        >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:

--- a/provider-ci/providers/databricks/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/databricks/repo/.github/workflows/prerelease.yml
@@ -95,7 +95,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version.generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -292,7 +292,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version.generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:

--- a/provider-ci/providers/databricks/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/databricks/repo/.github/workflows/release.yml
@@ -94,8 +94,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -306,8 +305,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(pulumictl get version --language generic)"
-        >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:
@@ -350,8 +348,8 @@ jobs:
       with:
         repo: pulumi/pulumictl
     - name: Add SDK version tag
-      run: git tag sdk/v$(pulumictl get version --language generic) && git push origin
-        sdk/v$(pulumictl get version --language generic)
+      run: git tag sdk/v$(make version:generic) && git push origin sdk/v$(make
+        version:generic)
   test:
     name: test
     needs: build_sdk

--- a/provider-ci/providers/databricks/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/databricks/repo/.github/workflows/release.yml
@@ -94,7 +94,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version.generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -305,7 +305,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version.generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:
@@ -348,8 +348,8 @@ jobs:
       with:
         repo: pulumi/pulumictl
     - name: Add SDK version tag
-      run: git tag sdk/v$(make version:generic) && git push origin sdk/v$(make
-        version:generic)
+      run: git tag sdk/v$(make version.generic) && git push origin sdk/v$(make
+        version.generic)
   test:
     name: test
     needs: build_sdk

--- a/provider-ci/providers/databricks/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/databricks/repo/.github/workflows/run-acceptance-tests.yml
@@ -99,8 +99,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean

--- a/provider-ci/providers/databricks/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/databricks/repo/.github/workflows/run-acceptance-tests.yml
@@ -99,7 +99,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version.generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean

--- a/provider-ci/providers/databricks/repo/Makefile
+++ b/provider-ci/providers/databricks/repo/Makefile
@@ -7,7 +7,7 @@ PROVIDER_PATH := provider
 VERSION_PATH := $(PROVIDER_PATH)/pkg/version.Version
 TFGEN := pulumi-tfgen-$(PACK)
 PROVIDER := pulumi-resource-$(PACK)
-VERSION := $(shell pulumictl get version)
+VERSION := $(shell pulumictl get version --language generic)
 JAVA_GEN := pulumi-java-gen
 JAVA_GEN_VERSION := v0.5.4
 TESTPARALLELISM := 10
@@ -29,9 +29,9 @@ install_sdks: install_dotnet_sdk install_python_sdk install_nodejs_sdk install_j
 
 only_build: build
 
-build_dotnet: DOTNET_VERSION := $(shell pulumictl get version --language dotnet)
+build_dotnet: DOTNET_VERSION := $(shell pulumictl convert-version -l dotnet -v "$(VERSION)")
 build_dotnet: upstream
-	pulumictl get version --language dotnet
+	@echo $(DOTNET_VERSION)
 	$(WORKING_DIR)/bin/$(TFGEN) dotnet --out sdk/dotnet/
 	cd sdk/dotnet/ && \
 		echo "module fake_dotnet_module // Exclude this directory from Go tools\n\ngo 1.17" > go.mod && \
@@ -42,14 +42,14 @@ build_go: upstream
 	$(WORKING_DIR)/bin/$(TFGEN) go --out sdk/go/
 	cd sdk && go list `grep -e "^module" go.mod | cut -d ' ' -f 2`/go/... | xargs go build
 
-build_java: PACKAGE_VERSION := $(shell pulumictl get version --language generic)
+build_java: PACKAGE_VERSION := "$(VERSION)"
 build_java: bin/pulumi-java-gen upstream
 	$(WORKING_DIR)/bin/$(JAVA_GEN) generate --schema provider/cmd/$(PROVIDER)/schema.json --out sdk/java  --build gradle-nexus
 	cd sdk/java/ && \
 		echo "module fake_java_module // Exclude this directory from Go tools\n\ngo 1.17" > go.mod && \
 		gradle --console=plain build
 
-build_nodejs: VERSION := $(shell pulumictl get version --language javascript)
+build_nodejs: VERSION := $(shell pulumictl convert-version -l javascript -v "$(VERSION)")
 build_nodejs: upstream
 	$(WORKING_DIR)/bin/$(TFGEN) nodejs --out sdk/nodejs/
 	cd sdk/nodejs/ && \
@@ -59,7 +59,7 @@ build_nodejs: upstream
 		cp ../../README.md ../../LICENSE* package.json yarn.lock ./bin/ && \
 		sed -i.bak -e "s/\$${VERSION}/$(VERSION)/g" ./bin/package.json
 
-build_python: PYPI_VERSION := $(shell pulumictl get version --language python)
+build_python: PYPI_VERSION := $(shell pulumictl convert-version -l python -v "$(VERSION)")
 build_python: upstream
 	$(WORKING_DIR)/bin/$(TFGEN) python --out sdk/python/
 	cd sdk/python/ && \
@@ -120,7 +120,10 @@ upstream.finalize:
 upstream.rebase:
 	@$(SHELL) ./scripts/upstream.sh "$@" start_rebase
 
+version.generic:
+	@echo $(VERSION)
+
 bin/pulumi-java-gen:
 	$(shell pulumictl download-binary -n pulumi-language-java -v $(JAVA_GEN_VERSION) -r pulumi/pulumi-java)
 
-.PHONY: development build build_sdks install_go_sdk install_java_sdk install_python_sdk install_sdks only_build build_dotnet build_go build_java build_nodejs build_python clean cleanup help install_dotnet_sdk install_nodejs_sdk install_plugins lint_provider provider test tfgen upstream upstream.finalize upstream.rebase
+.PHONY: development build build_sdks install_go_sdk install_java_sdk install_python_sdk install_sdks only_build build_dotnet build_go build_java build_nodejs build_python clean cleanup help install_dotnet_sdk install_nodejs_sdk install_plugins lint_provider provider test tfgen upstream upstream.finalize upstream.rebase version.generic

--- a/provider-ci/providers/datadog/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/datadog/repo/.github/workflows/main.yml
@@ -90,7 +90,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version.generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -267,7 +267,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version.generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:

--- a/provider-ci/providers/datadog/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/datadog/repo/.github/workflows/main.yml
@@ -90,8 +90,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -268,8 +267,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(pulumictl get version --language generic)"
-        >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:

--- a/provider-ci/providers/datadog/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/datadog/repo/.github/workflows/master.yml
@@ -90,7 +90,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version.generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -267,7 +267,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version.generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:

--- a/provider-ci/providers/datadog/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/datadog/repo/.github/workflows/master.yml
@@ -90,8 +90,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -268,8 +267,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(pulumictl get version --language generic)"
-        >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:

--- a/provider-ci/providers/datadog/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/datadog/repo/.github/workflows/prerelease.yml
@@ -91,7 +91,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version.generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -217,7 +217,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version.generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:

--- a/provider-ci/providers/datadog/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/datadog/repo/.github/workflows/prerelease.yml
@@ -91,8 +91,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -218,8 +217,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(pulumictl get version --language generic)"
-        >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:

--- a/provider-ci/providers/datadog/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/datadog/repo/.github/workflows/release.yml
@@ -90,8 +90,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -231,8 +230,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(pulumictl get version --language generic)"
-        >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:
@@ -275,8 +273,8 @@ jobs:
       with:
         repo: pulumi/pulumictl
     - name: Add SDK version tag
-      run: git tag sdk/v$(pulumictl get version --language generic) && git push origin
-        sdk/v$(pulumictl get version --language generic)
+      run: git tag sdk/v$(make version:generic) && git push origin sdk/v$(make
+        version:generic)
   test:
     name: test
     needs: build_sdk

--- a/provider-ci/providers/datadog/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/datadog/repo/.github/workflows/release.yml
@@ -90,7 +90,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version.generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -230,7 +230,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version.generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:
@@ -273,8 +273,8 @@ jobs:
       with:
         repo: pulumi/pulumictl
     - name: Add SDK version tag
-      run: git tag sdk/v$(make version:generic) && git push origin sdk/v$(make
-        version:generic)
+      run: git tag sdk/v$(make version.generic) && git push origin sdk/v$(make
+        version.generic)
   test:
     name: test
     needs: build_sdk

--- a/provider-ci/providers/datadog/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/datadog/repo/.github/workflows/run-acceptance-tests.yml
@@ -95,7 +95,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version.generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean

--- a/provider-ci/providers/datadog/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/datadog/repo/.github/workflows/run-acceptance-tests.yml
@@ -95,8 +95,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean

--- a/provider-ci/providers/datadog/repo/Makefile
+++ b/provider-ci/providers/datadog/repo/Makefile
@@ -7,7 +7,7 @@ PROVIDER_PATH := provider/v4
 VERSION_PATH := $(PROVIDER_PATH)/pkg/version.Version
 TFGEN := pulumi-tfgen-$(PACK)
 PROVIDER := pulumi-resource-$(PACK)
-VERSION := $(shell pulumictl get version)
+VERSION := $(shell pulumictl get version --language generic)
 JAVA_GEN := pulumi-java-gen
 JAVA_GEN_VERSION := v0.5.4
 TESTPARALLELISM := 10
@@ -29,9 +29,9 @@ install_sdks: install_dotnet_sdk install_python_sdk install_nodejs_sdk install_j
 
 only_build: build
 
-build_dotnet: DOTNET_VERSION := $(shell pulumictl get version --language dotnet)
+build_dotnet: DOTNET_VERSION := $(shell pulumictl convert-version -l dotnet -v "$(VERSION)")
 build_dotnet: upstream
-	pulumictl get version --language dotnet
+	@echo $(DOTNET_VERSION)
 	$(WORKING_DIR)/bin/$(TFGEN) dotnet --out sdk/dotnet/
 	cd sdk/dotnet/ && \
 		echo "module fake_dotnet_module // Exclude this directory from Go tools\n\ngo 1.17" > go.mod && \
@@ -42,14 +42,14 @@ build_go: upstream
 	$(WORKING_DIR)/bin/$(TFGEN) go --out sdk/go/
 	cd sdk && go list `grep -e "^module" go.mod | cut -d ' ' -f 2`/go/... | xargs go build
 
-build_java: PACKAGE_VERSION := $(shell pulumictl get version --language generic)
+build_java: PACKAGE_VERSION := "$(VERSION)"
 build_java: bin/pulumi-java-gen upstream
 	$(WORKING_DIR)/bin/$(JAVA_GEN) generate --schema provider/cmd/$(PROVIDER)/schema.json --out sdk/java  --build gradle-nexus
 	cd sdk/java/ && \
 		echo "module fake_java_module // Exclude this directory from Go tools\n\ngo 1.17" > go.mod && \
 		gradle --console=plain build
 
-build_nodejs: VERSION := $(shell pulumictl get version --language javascript)
+build_nodejs: VERSION := $(shell pulumictl convert-version -l javascript -v "$(VERSION)")
 build_nodejs: upstream
 	$(WORKING_DIR)/bin/$(TFGEN) nodejs --out sdk/nodejs/
 	cd sdk/nodejs/ && \
@@ -59,7 +59,7 @@ build_nodejs: upstream
 		cp ../../README.md ../../LICENSE* package.json yarn.lock ./bin/ && \
 		sed -i.bak -e "s/\$${VERSION}/$(VERSION)/g" ./bin/package.json
 
-build_python: PYPI_VERSION := $(shell pulumictl get version --language python)
+build_python: PYPI_VERSION := $(shell pulumictl convert-version -l python -v "$(VERSION)")
 build_python: upstream
 	$(WORKING_DIR)/bin/$(TFGEN) python --out sdk/python/
 	cd sdk/python/ && \
@@ -118,7 +118,10 @@ upstream.finalize:
 upstream.rebase:
 	@$(SHELL) ./scripts/upstream.sh "$@" start_rebase
 
+version.generic:
+	@echo $(VERSION)
+
 bin/pulumi-java-gen:
 	$(shell pulumictl download-binary -n pulumi-language-java -v $(JAVA_GEN_VERSION) -r pulumi/pulumi-java)
 
-.PHONY: development build build_sdks install_go_sdk install_java_sdk install_python_sdk install_sdks only_build build_dotnet build_go build_java build_nodejs build_python clean cleanup help install_dotnet_sdk install_nodejs_sdk install_plugins lint_provider provider test tfgen upstream upstream.finalize upstream.rebase
+.PHONY: development build build_sdks install_go_sdk install_java_sdk install_python_sdk install_sdks only_build build_dotnet build_go build_java build_nodejs build_python clean cleanup help install_dotnet_sdk install_nodejs_sdk install_plugins lint_provider provider test tfgen upstream upstream.finalize upstream.rebase version.generic

--- a/provider-ci/providers/digitalocean/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/digitalocean/repo/.github/workflows/main.yml
@@ -91,7 +91,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version.generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -339,7 +339,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version.generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:

--- a/provider-ci/providers/digitalocean/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/digitalocean/repo/.github/workflows/main.yml
@@ -91,8 +91,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -340,8 +339,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(pulumictl get version --language generic)"
-        >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:

--- a/provider-ci/providers/digitalocean/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/digitalocean/repo/.github/workflows/master.yml
@@ -91,7 +91,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version.generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -339,7 +339,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version.generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:

--- a/provider-ci/providers/digitalocean/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/digitalocean/repo/.github/workflows/master.yml
@@ -91,8 +91,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -340,8 +339,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(pulumictl get version --language generic)"
-        >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:

--- a/provider-ci/providers/digitalocean/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/digitalocean/repo/.github/workflows/prerelease.yml
@@ -92,8 +92,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -290,8 +289,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(pulumictl get version --language generic)"
-        >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:

--- a/provider-ci/providers/digitalocean/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/digitalocean/repo/.github/workflows/prerelease.yml
@@ -92,7 +92,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version.generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -289,7 +289,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version.generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:

--- a/provider-ci/providers/digitalocean/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/digitalocean/repo/.github/workflows/release.yml
@@ -91,8 +91,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -303,8 +302,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(pulumictl get version --language generic)"
-        >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:
@@ -347,8 +345,8 @@ jobs:
       with:
         repo: pulumi/pulumictl
     - name: Add SDK version tag
-      run: git tag sdk/v$(pulumictl get version --language generic) && git push origin
-        sdk/v$(pulumictl get version --language generic)
+      run: git tag sdk/v$(make version:generic) && git push origin sdk/v$(make
+        version:generic)
   test:
     name: test
     needs: build_sdk

--- a/provider-ci/providers/digitalocean/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/digitalocean/repo/.github/workflows/release.yml
@@ -91,7 +91,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version.generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -302,7 +302,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version.generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:
@@ -345,8 +345,8 @@ jobs:
       with:
         repo: pulumi/pulumictl
     - name: Add SDK version tag
-      run: git tag sdk/v$(make version:generic) && git push origin sdk/v$(make
-        version:generic)
+      run: git tag sdk/v$(make version.generic) && git push origin sdk/v$(make
+        version.generic)
   test:
     name: test
     needs: build_sdk

--- a/provider-ci/providers/digitalocean/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/digitalocean/repo/.github/workflows/run-acceptance-tests.yml
@@ -96,7 +96,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version.generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean

--- a/provider-ci/providers/digitalocean/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/digitalocean/repo/.github/workflows/run-acceptance-tests.yml
@@ -96,8 +96,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean

--- a/provider-ci/providers/digitalocean/repo/Makefile
+++ b/provider-ci/providers/digitalocean/repo/Makefile
@@ -7,7 +7,7 @@ PROVIDER_PATH := provider/v4
 VERSION_PATH := $(PROVIDER_PATH)/pkg/version.Version
 TFGEN := pulumi-tfgen-$(PACK)
 PROVIDER := pulumi-resource-$(PACK)
-VERSION := $(shell pulumictl get version)
+VERSION := $(shell pulumictl get version --language generic)
 JAVA_GEN := pulumi-java-gen
 JAVA_GEN_VERSION := v0.5.4
 TESTPARALLELISM := 10
@@ -29,9 +29,9 @@ install_sdks: install_dotnet_sdk install_python_sdk install_nodejs_sdk install_j
 
 only_build: build
 
-build_dotnet: DOTNET_VERSION := $(shell pulumictl get version --language dotnet)
+build_dotnet: DOTNET_VERSION := $(shell pulumictl convert-version -l dotnet -v "$(VERSION)")
 build_dotnet: upstream
-	pulumictl get version --language dotnet
+	@echo $(DOTNET_VERSION)
 	$(WORKING_DIR)/bin/$(TFGEN) dotnet --out sdk/dotnet/
 	cd sdk/dotnet/ && \
 		echo "module fake_dotnet_module // Exclude this directory from Go tools\n\ngo 1.17" > go.mod && \
@@ -42,14 +42,14 @@ build_go: upstream
 	$(WORKING_DIR)/bin/$(TFGEN) go --out sdk/go/
 	cd sdk && go list `grep -e "^module" go.mod | cut -d ' ' -f 2`/go/... | xargs go build
 
-build_java: PACKAGE_VERSION := $(shell pulumictl get version --language generic)
+build_java: PACKAGE_VERSION := "$(VERSION)"
 build_java: bin/pulumi-java-gen upstream
 	$(WORKING_DIR)/bin/$(JAVA_GEN) generate --schema provider/cmd/$(PROVIDER)/schema.json --out sdk/java  --build gradle-nexus
 	cd sdk/java/ && \
 		echo "module fake_java_module // Exclude this directory from Go tools\n\ngo 1.17" > go.mod && \
 		gradle --console=plain build
 
-build_nodejs: VERSION := $(shell pulumictl get version --language javascript)
+build_nodejs: VERSION := $(shell pulumictl convert-version -l javascript -v "$(VERSION)")
 build_nodejs: upstream
 	$(WORKING_DIR)/bin/$(TFGEN) nodejs --out sdk/nodejs/
 	cd sdk/nodejs/ && \
@@ -59,7 +59,7 @@ build_nodejs: upstream
 		cp ../../README.md ../../LICENSE* package.json yarn.lock ./bin/ && \
 		sed -i.bak -e "s/\$${VERSION}/$(VERSION)/g" ./bin/package.json
 
-build_python: PYPI_VERSION := $(shell pulumictl get version --language python)
+build_python: PYPI_VERSION := $(shell pulumictl convert-version -l python -v "$(VERSION)")
 build_python: upstream
 	$(WORKING_DIR)/bin/$(TFGEN) python --out sdk/python/
 	cd sdk/python/ && \
@@ -119,7 +119,10 @@ upstream.finalize:
 upstream.rebase:
 	@$(SHELL) ./scripts/upstream.sh "$@" start_rebase
 
+version.generic:
+	@echo $(VERSION)
+
 bin/pulumi-java-gen:
 	$(shell pulumictl download-binary -n pulumi-language-java -v $(JAVA_GEN_VERSION) -r pulumi/pulumi-java)
 
-.PHONY: development build build_sdks install_go_sdk install_java_sdk install_python_sdk install_sdks only_build build_dotnet build_go build_java build_nodejs build_python clean cleanup help install_dotnet_sdk install_nodejs_sdk install_plugins lint_provider provider test tfgen upstream upstream.finalize upstream.rebase
+.PHONY: development build build_sdks install_go_sdk install_java_sdk install_python_sdk install_sdks only_build build_dotnet build_go build_java build_nodejs build_python clean cleanup help install_dotnet_sdk install_nodejs_sdk install_plugins lint_provider provider test tfgen upstream upstream.finalize upstream.rebase version.generic

--- a/provider-ci/providers/dnsimple/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/dnsimple/repo/.github/workflows/main.yml
@@ -92,8 +92,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -341,8 +340,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(pulumictl get version --language generic)"
-        >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:

--- a/provider-ci/providers/dnsimple/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/dnsimple/repo/.github/workflows/main.yml
@@ -92,7 +92,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version.generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -340,7 +340,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version.generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:

--- a/provider-ci/providers/dnsimple/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/dnsimple/repo/.github/workflows/master.yml
@@ -92,8 +92,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -341,8 +340,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(pulumictl get version --language generic)"
-        >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:

--- a/provider-ci/providers/dnsimple/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/dnsimple/repo/.github/workflows/master.yml
@@ -92,7 +92,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version.generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -340,7 +340,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version.generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:

--- a/provider-ci/providers/dnsimple/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/dnsimple/repo/.github/workflows/prerelease.yml
@@ -93,8 +93,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -291,8 +290,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(pulumictl get version --language generic)"
-        >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:

--- a/provider-ci/providers/dnsimple/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/dnsimple/repo/.github/workflows/prerelease.yml
@@ -93,7 +93,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version.generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -290,7 +290,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version.generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:

--- a/provider-ci/providers/dnsimple/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/dnsimple/repo/.github/workflows/release.yml
@@ -92,7 +92,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version.generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -303,7 +303,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version.generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:
@@ -346,8 +346,8 @@ jobs:
       with:
         repo: pulumi/pulumictl
     - name: Add SDK version tag
-      run: git tag sdk/v$(make version:generic) && git push origin sdk/v$(make
-        version:generic)
+      run: git tag sdk/v$(make version.generic) && git push origin sdk/v$(make
+        version.generic)
   test:
     name: test
     needs: build_sdk

--- a/provider-ci/providers/dnsimple/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/dnsimple/repo/.github/workflows/release.yml
@@ -92,8 +92,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -304,8 +303,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(pulumictl get version --language generic)"
-        >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:
@@ -348,8 +346,8 @@ jobs:
       with:
         repo: pulumi/pulumictl
     - name: Add SDK version tag
-      run: git tag sdk/v$(pulumictl get version --language generic) && git push origin
-        sdk/v$(pulumictl get version --language generic)
+      run: git tag sdk/v$(make version:generic) && git push origin sdk/v$(make
+        version:generic)
   test:
     name: test
     needs: build_sdk

--- a/provider-ci/providers/dnsimple/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/dnsimple/repo/.github/workflows/run-acceptance-tests.yml
@@ -97,7 +97,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version.generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean

--- a/provider-ci/providers/dnsimple/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/dnsimple/repo/.github/workflows/run-acceptance-tests.yml
@@ -97,8 +97,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean

--- a/provider-ci/providers/dnsimple/repo/Makefile
+++ b/provider-ci/providers/dnsimple/repo/Makefile
@@ -7,7 +7,7 @@ PROVIDER_PATH := provider/v3
 VERSION_PATH := $(PROVIDER_PATH)/pkg/version.Version
 TFGEN := pulumi-tfgen-$(PACK)
 PROVIDER := pulumi-resource-$(PACK)
-VERSION := $(shell pulumictl get version)
+VERSION := $(shell pulumictl get version --language generic)
 JAVA_GEN := pulumi-java-gen
 JAVA_GEN_VERSION := v0.5.4
 TESTPARALLELISM := 10
@@ -29,9 +29,9 @@ install_sdks: install_dotnet_sdk install_python_sdk install_nodejs_sdk install_j
 
 only_build: build
 
-build_dotnet: DOTNET_VERSION := $(shell pulumictl get version --language dotnet)
+build_dotnet: DOTNET_VERSION := $(shell pulumictl convert-version -l dotnet -v "$(VERSION)")
 build_dotnet: upstream
-	pulumictl get version --language dotnet
+	@echo $(DOTNET_VERSION)
 	$(WORKING_DIR)/bin/$(TFGEN) dotnet --out sdk/dotnet/
 	cd sdk/dotnet/ && \
 		echo "module fake_dotnet_module // Exclude this directory from Go tools\n\ngo 1.17" > go.mod && \
@@ -42,14 +42,14 @@ build_go: upstream
 	$(WORKING_DIR)/bin/$(TFGEN) go --out sdk/go/
 	cd sdk && go list `grep -e "^module" go.mod | cut -d ' ' -f 2`/go/... | xargs go build
 
-build_java: PACKAGE_VERSION := $(shell pulumictl get version --language generic)
+build_java: PACKAGE_VERSION := "$(VERSION)"
 build_java: bin/pulumi-java-gen upstream
 	$(WORKING_DIR)/bin/$(JAVA_GEN) generate --schema provider/cmd/$(PROVIDER)/schema.json --out sdk/java  --build gradle-nexus
 	cd sdk/java/ && \
 		echo "module fake_java_module // Exclude this directory from Go tools\n\ngo 1.17" > go.mod && \
 		gradle --console=plain build
 
-build_nodejs: VERSION := $(shell pulumictl get version --language javascript)
+build_nodejs: VERSION := $(shell pulumictl convert-version -l javascript -v "$(VERSION)")
 build_nodejs: upstream
 	$(WORKING_DIR)/bin/$(TFGEN) nodejs --out sdk/nodejs/
 	cd sdk/nodejs/ && \
@@ -59,7 +59,7 @@ build_nodejs: upstream
 		cp ../../README.md ../../LICENSE* package.json yarn.lock ./bin/ && \
 		sed -i.bak -e "s/\$${VERSION}/$(VERSION)/g" ./bin/package.json
 
-build_python: PYPI_VERSION := $(shell pulumictl get version --language python)
+build_python: PYPI_VERSION := $(shell pulumictl convert-version -l python -v "$(VERSION)")
 build_python: upstream
 	$(WORKING_DIR)/bin/$(TFGEN) python --out sdk/python/
 	cd sdk/python/ && \
@@ -118,7 +118,10 @@ upstream.finalize:
 upstream.rebase:
 	@$(SHELL) ./scripts/upstream.sh "$@" start_rebase
 
+version.generic:
+	@echo $(VERSION)
+
 bin/pulumi-java-gen:
 	$(shell pulumictl download-binary -n pulumi-language-java -v $(JAVA_GEN_VERSION) -r pulumi/pulumi-java)
 
-.PHONY: development build build_sdks install_go_sdk install_java_sdk install_python_sdk install_sdks only_build build_dotnet build_go build_java build_nodejs build_python clean cleanup help install_dotnet_sdk install_nodejs_sdk install_plugins lint_provider provider test tfgen upstream upstream.finalize upstream.rebase
+.PHONY: development build build_sdks install_go_sdk install_java_sdk install_python_sdk install_sdks only_build build_dotnet build_go build_java build_nodejs build_python clean cleanup help install_dotnet_sdk install_nodejs_sdk install_plugins lint_provider provider test tfgen upstream upstream.finalize upstream.rebase version.generic

--- a/provider-ci/providers/docker/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/docker/repo/.github/workflows/main.yml
@@ -104,7 +104,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version.generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -352,7 +352,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version.generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:

--- a/provider-ci/providers/docker/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/docker/repo/.github/workflows/main.yml
@@ -104,8 +104,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -353,8 +352,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(pulumictl get version --language generic)"
-        >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:

--- a/provider-ci/providers/docker/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/docker/repo/.github/workflows/master.yml
@@ -104,7 +104,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version.generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -352,7 +352,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version.generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:

--- a/provider-ci/providers/docker/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/docker/repo/.github/workflows/master.yml
@@ -104,8 +104,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -353,8 +352,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(pulumictl get version --language generic)"
-        >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:

--- a/provider-ci/providers/docker/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/docker/repo/.github/workflows/prerelease.yml
@@ -105,7 +105,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version.generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -302,7 +302,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version.generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:

--- a/provider-ci/providers/docker/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/docker/repo/.github/workflows/prerelease.yml
@@ -105,8 +105,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -303,8 +302,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(pulumictl get version --language generic)"
-        >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:

--- a/provider-ci/providers/docker/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/docker/repo/.github/workflows/release.yml
@@ -104,8 +104,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -316,8 +315,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(pulumictl get version --language generic)"
-        >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:
@@ -360,8 +358,8 @@ jobs:
       with:
         repo: pulumi/pulumictl
     - name: Add SDK version tag
-      run: git tag sdk/v$(pulumictl get version --language generic) && git push origin
-        sdk/v$(pulumictl get version --language generic)
+      run: git tag sdk/v$(make version:generic) && git push origin sdk/v$(make
+        version:generic)
   test:
     name: test
     needs: build_sdk

--- a/provider-ci/providers/docker/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/docker/repo/.github/workflows/release.yml
@@ -104,7 +104,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version.generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -315,7 +315,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version.generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:
@@ -358,8 +358,8 @@ jobs:
       with:
         repo: pulumi/pulumictl
     - name: Add SDK version tag
-      run: git tag sdk/v$(make version:generic) && git push origin sdk/v$(make
-        version:generic)
+      run: git tag sdk/v$(make version.generic) && git push origin sdk/v$(make
+        version.generic)
   test:
     name: test
     needs: build_sdk

--- a/provider-ci/providers/docker/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/docker/repo/.github/workflows/run-acceptance-tests.yml
@@ -109,7 +109,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version.generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean

--- a/provider-ci/providers/docker/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/docker/repo/.github/workflows/run-acceptance-tests.yml
@@ -109,8 +109,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean

--- a/provider-ci/providers/docker/repo/Makefile
+++ b/provider-ci/providers/docker/repo/Makefile
@@ -7,7 +7,7 @@ PROVIDER_PATH := provider/v4
 VERSION_PATH := $(PROVIDER_PATH)/pkg/version.Version
 TFGEN := pulumi-tfgen-$(PACK)
 PROVIDER := pulumi-resource-$(PACK)
-VERSION := $(shell pulumictl get version)
+VERSION := $(shell pulumictl get version --language generic)
 JAVA_GEN := pulumi-java-gen
 JAVA_GEN_VERSION := v0.5.4
 TESTPARALLELISM := 10
@@ -29,9 +29,9 @@ install_sdks: install_dotnet_sdk install_python_sdk install_nodejs_sdk install_j
 
 only_build: build
 
-build_dotnet: DOTNET_VERSION := $(shell pulumictl get version --language dotnet)
+build_dotnet: DOTNET_VERSION := $(shell pulumictl convert-version -l dotnet -v "$(VERSION)")
 build_dotnet: upstream
-	pulumictl get version --language dotnet
+	@echo $(DOTNET_VERSION)
 	$(WORKING_DIR)/bin/$(TFGEN) dotnet --out sdk/dotnet/
 	cd sdk/dotnet/ && \
 		echo "module fake_dotnet_module // Exclude this directory from Go tools\n\ngo 1.17" > go.mod && \
@@ -42,14 +42,14 @@ build_go: upstream
 	$(WORKING_DIR)/bin/$(TFGEN) go --out sdk/go/
 	cd sdk && go list `grep -e "^module" go.mod | cut -d ' ' -f 2`/go/... | xargs go build
 
-build_java: PACKAGE_VERSION := $(shell pulumictl get version --language generic)
+build_java: PACKAGE_VERSION := "$(VERSION)"
 build_java: bin/pulumi-java-gen upstream
 	$(WORKING_DIR)/bin/$(JAVA_GEN) generate --schema provider/cmd/$(PROVIDER)/schema.json --out sdk/java  --build gradle-nexus
 	cd sdk/java/ && \
 		echo "module fake_java_module // Exclude this directory from Go tools\n\ngo 1.17" > go.mod && \
 		gradle --console=plain build
 
-build_nodejs: VERSION := $(shell pulumictl get version --language javascript)
+build_nodejs: VERSION := $(shell pulumictl convert-version -l javascript -v "$(VERSION)")
 build_nodejs: upstream
 	$(WORKING_DIR)/bin/$(TFGEN) nodejs --out sdk/nodejs/
 	cd sdk/nodejs/ && \
@@ -59,7 +59,7 @@ build_nodejs: upstream
 		cp ../../README.md ../../LICENSE* package.json yarn.lock ./bin/ && \
 		sed -i.bak -e "s/\$${VERSION}/$(VERSION)/g" ./bin/package.json
 
-build_python: PYPI_VERSION := $(shell pulumictl get version --language python)
+build_python: PYPI_VERSION := $(shell pulumictl convert-version -l python -v "$(VERSION)")
 build_python: upstream
 	$(WORKING_DIR)/bin/$(TFGEN) python --out sdk/python/
 	cd sdk/python/ && \
@@ -122,7 +122,10 @@ upstream.finalize:
 upstream.rebase:
 	@$(SHELL) ./scripts/upstream.sh "$@" start_rebase
 
+version.generic:
+	@echo $(VERSION)
+
 bin/pulumi-java-gen:
 	$(shell pulumictl download-binary -n pulumi-language-java -v $(JAVA_GEN_VERSION) -r pulumi/pulumi-java)
 
-.PHONY: development build build_sdks install_go_sdk install_java_sdk install_python_sdk install_sdks only_build build_dotnet build_go build_java build_nodejs build_python clean cleanup docs help install_dotnet_sdk install_nodejs_sdk install_plugins lint_provider provider test tfgen upstream upstream.finalize upstream.rebase
+.PHONY: development build build_sdks install_go_sdk install_java_sdk install_python_sdk install_sdks only_build build_dotnet build_go build_java build_nodejs build_python clean cleanup docs help install_dotnet_sdk install_nodejs_sdk install_plugins lint_provider provider test tfgen upstream upstream.finalize upstream.rebase version.generic

--- a/provider-ci/providers/ec/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/ec/repo/.github/workflows/main.yml
@@ -91,7 +91,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version.generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -339,7 +339,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version.generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:

--- a/provider-ci/providers/ec/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/ec/repo/.github/workflows/main.yml
@@ -91,8 +91,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -340,8 +339,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(pulumictl get version --language generic)"
-        >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:

--- a/provider-ci/providers/ec/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/ec/repo/.github/workflows/master.yml
@@ -91,7 +91,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version.generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -339,7 +339,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version.generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:

--- a/provider-ci/providers/ec/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/ec/repo/.github/workflows/master.yml
@@ -91,8 +91,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -340,8 +339,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(pulumictl get version --language generic)"
-        >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:

--- a/provider-ci/providers/ec/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/ec/repo/.github/workflows/prerelease.yml
@@ -92,8 +92,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -290,8 +289,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(pulumictl get version --language generic)"
-        >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:

--- a/provider-ci/providers/ec/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/ec/repo/.github/workflows/prerelease.yml
@@ -92,7 +92,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version.generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -289,7 +289,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version.generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:

--- a/provider-ci/providers/ec/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/ec/repo/.github/workflows/release.yml
@@ -91,8 +91,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -303,8 +302,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(pulumictl get version --language generic)"
-        >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:
@@ -347,8 +345,8 @@ jobs:
       with:
         repo: pulumi/pulumictl
     - name: Add SDK version tag
-      run: git tag sdk/v$(pulumictl get version --language generic) && git push origin
-        sdk/v$(pulumictl get version --language generic)
+      run: git tag sdk/v$(make version:generic) && git push origin sdk/v$(make
+        version:generic)
   test:
     name: test
     needs: build_sdk

--- a/provider-ci/providers/ec/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/ec/repo/.github/workflows/release.yml
@@ -91,7 +91,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version.generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -302,7 +302,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version.generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:
@@ -345,8 +345,8 @@ jobs:
       with:
         repo: pulumi/pulumictl
     - name: Add SDK version tag
-      run: git tag sdk/v$(make version:generic) && git push origin sdk/v$(make
-        version:generic)
+      run: git tag sdk/v$(make version.generic) && git push origin sdk/v$(make
+        version.generic)
   test:
     name: test
     needs: build_sdk

--- a/provider-ci/providers/ec/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/ec/repo/.github/workflows/run-acceptance-tests.yml
@@ -96,7 +96,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version.generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean

--- a/provider-ci/providers/ec/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/ec/repo/.github/workflows/run-acceptance-tests.yml
@@ -96,8 +96,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean

--- a/provider-ci/providers/ec/repo/Makefile
+++ b/provider-ci/providers/ec/repo/Makefile
@@ -7,7 +7,7 @@ PROVIDER_PATH := provider
 VERSION_PATH := $(PROVIDER_PATH)/pkg/version.Version
 TFGEN := pulumi-tfgen-$(PACK)
 PROVIDER := pulumi-resource-$(PACK)
-VERSION := $(shell pulumictl get version)
+VERSION := $(shell pulumictl get version --language generic)
 JAVA_GEN := pulumi-java-gen
 JAVA_GEN_VERSION := v0.5.4
 TESTPARALLELISM := 10
@@ -29,9 +29,9 @@ install_sdks: install_dotnet_sdk install_python_sdk install_nodejs_sdk install_j
 
 only_build: build
 
-build_dotnet: DOTNET_VERSION := $(shell pulumictl get version --language dotnet)
+build_dotnet: DOTNET_VERSION := $(shell pulumictl convert-version -l dotnet -v "$(VERSION)")
 build_dotnet: upstream
-	pulumictl get version --language dotnet
+	@echo $(DOTNET_VERSION)
 	$(WORKING_DIR)/bin/$(TFGEN) dotnet --out sdk/dotnet/
 	cd sdk/dotnet/ && \
 		echo "module fake_dotnet_module // Exclude this directory from Go tools\n\ngo 1.17" > go.mod && \
@@ -42,14 +42,14 @@ build_go: upstream
 	$(WORKING_DIR)/bin/$(TFGEN) go --out sdk/go/
 	cd sdk && go list `grep -e "^module" go.mod | cut -d ' ' -f 2`/go/... | xargs go build
 
-build_java: PACKAGE_VERSION := $(shell pulumictl get version --language generic)
+build_java: PACKAGE_VERSION := "$(VERSION)"
 build_java: bin/pulumi-java-gen upstream
 	$(WORKING_DIR)/bin/$(JAVA_GEN) generate --schema provider/cmd/$(PROVIDER)/schema.json --out sdk/java  --build gradle-nexus
 	cd sdk/java/ && \
 		echo "module fake_java_module // Exclude this directory from Go tools\n\ngo 1.17" > go.mod && \
 		gradle --console=plain build
 
-build_nodejs: VERSION := $(shell pulumictl get version --language javascript)
+build_nodejs: VERSION := $(shell pulumictl convert-version -l javascript -v "$(VERSION)")
 build_nodejs: upstream
 	$(WORKING_DIR)/bin/$(TFGEN) nodejs --out sdk/nodejs/
 	cd sdk/nodejs/ && \
@@ -59,7 +59,7 @@ build_nodejs: upstream
 		cp ../../README.md ../../LICENSE* package.json yarn.lock ./bin/ && \
 		sed -i.bak -e "s/\$${VERSION}/$(VERSION)/g" ./bin/package.json
 
-build_python: PYPI_VERSION := $(shell pulumictl get version --language python)
+build_python: PYPI_VERSION := $(shell pulumictl convert-version -l python -v "$(VERSION)")
 build_python: upstream
 	$(WORKING_DIR)/bin/$(TFGEN) python --out sdk/python/
 	cd sdk/python/ && \
@@ -119,7 +119,10 @@ upstream.finalize:
 upstream.rebase:
 	@$(SHELL) ./scripts/upstream.sh "$@" start_rebase
 
+version.generic:
+	@echo $(VERSION)
+
 bin/pulumi-java-gen:
 	$(shell pulumictl download-binary -n pulumi-language-java -v $(JAVA_GEN_VERSION) -r pulumi/pulumi-java)
 
-.PHONY: development build build_sdks install_go_sdk install_java_sdk install_python_sdk install_sdks only_build build_dotnet build_go build_java build_nodejs build_python clean cleanup help install_dotnet_sdk install_nodejs_sdk install_plugins lint_provider provider test tfgen upstream upstream.finalize upstream.rebase
+.PHONY: development build build_sdks install_go_sdk install_java_sdk install_python_sdk install_sdks only_build build_dotnet build_go build_java build_nodejs build_python clean cleanup help install_dotnet_sdk install_nodejs_sdk install_plugins lint_provider provider test tfgen upstream upstream.finalize upstream.rebase version.generic

--- a/provider-ci/providers/equinix-metal/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/equinix-metal/repo/.github/workflows/main.yml
@@ -91,8 +91,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -269,8 +268,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(pulumictl get version --language generic)"
-        >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:

--- a/provider-ci/providers/equinix-metal/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/equinix-metal/repo/.github/workflows/main.yml
@@ -91,7 +91,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version.generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -268,7 +268,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version.generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:

--- a/provider-ci/providers/equinix-metal/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/equinix-metal/repo/.github/workflows/master.yml
@@ -91,8 +91,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -269,8 +268,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(pulumictl get version --language generic)"
-        >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:

--- a/provider-ci/providers/equinix-metal/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/equinix-metal/repo/.github/workflows/master.yml
@@ -91,7 +91,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version.generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -268,7 +268,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version.generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:

--- a/provider-ci/providers/equinix-metal/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/equinix-metal/repo/.github/workflows/prerelease.yml
@@ -92,8 +92,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -219,8 +218,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(pulumictl get version --language generic)"
-        >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:

--- a/provider-ci/providers/equinix-metal/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/equinix-metal/repo/.github/workflows/prerelease.yml
@@ -92,7 +92,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version.generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -218,7 +218,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version.generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:

--- a/provider-ci/providers/equinix-metal/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/equinix-metal/repo/.github/workflows/release.yml
@@ -91,8 +91,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -232,8 +231,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(pulumictl get version --language generic)"
-        >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:
@@ -276,8 +274,8 @@ jobs:
       with:
         repo: pulumi/pulumictl
     - name: Add SDK version tag
-      run: git tag sdk/v$(pulumictl get version --language generic) && git push origin
-        sdk/v$(pulumictl get version --language generic)
+      run: git tag sdk/v$(make version:generic) && git push origin sdk/v$(make
+        version:generic)
   test:
     name: test
     needs: build_sdk

--- a/provider-ci/providers/equinix-metal/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/equinix-metal/repo/.github/workflows/release.yml
@@ -91,7 +91,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version.generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -231,7 +231,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version.generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:
@@ -274,8 +274,8 @@ jobs:
       with:
         repo: pulumi/pulumictl
     - name: Add SDK version tag
-      run: git tag sdk/v$(make version:generic) && git push origin sdk/v$(make
-        version:generic)
+      run: git tag sdk/v$(make version.generic) && git push origin sdk/v$(make
+        version.generic)
   test:
     name: test
     needs: build_sdk

--- a/provider-ci/providers/equinix-metal/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/equinix-metal/repo/.github/workflows/run-acceptance-tests.yml
@@ -96,7 +96,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version.generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean

--- a/provider-ci/providers/equinix-metal/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/equinix-metal/repo/.github/workflows/run-acceptance-tests.yml
@@ -96,8 +96,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean

--- a/provider-ci/providers/equinix-metal/repo/Makefile
+++ b/provider-ci/providers/equinix-metal/repo/Makefile
@@ -7,7 +7,7 @@ PROVIDER_PATH := provider/v3
 VERSION_PATH := $(PROVIDER_PATH)/pkg/version.Version
 TFGEN := pulumi-tfgen-$(PACK)
 PROVIDER := pulumi-resource-$(PACK)
-VERSION := $(shell pulumictl get version)
+VERSION := $(shell pulumictl get version --language generic)
 JAVA_GEN := pulumi-java-gen
 JAVA_GEN_VERSION := v0.5.4
 TESTPARALLELISM := 10
@@ -29,9 +29,9 @@ install_sdks: install_dotnet_sdk install_python_sdk install_nodejs_sdk install_j
 
 only_build: build
 
-build_dotnet: DOTNET_VERSION := $(shell pulumictl get version --language dotnet)
+build_dotnet: DOTNET_VERSION := $(shell pulumictl convert-version -l dotnet -v "$(VERSION)")
 build_dotnet: upstream
-	pulumictl get version --language dotnet
+	@echo $(DOTNET_VERSION)
 	$(WORKING_DIR)/bin/$(TFGEN) dotnet --out sdk/dotnet/
 	cd sdk/dotnet/ && \
 		echo "module fake_dotnet_module // Exclude this directory from Go tools\n\ngo 1.17" > go.mod && \
@@ -42,14 +42,14 @@ build_go: upstream
 	$(WORKING_DIR)/bin/$(TFGEN) go --out sdk/go/
 	cd sdk && go list `grep -e "^module" go.mod | cut -d ' ' -f 2`/go/... | xargs go build
 
-build_java: PACKAGE_VERSION := $(shell pulumictl get version --language generic)
+build_java: PACKAGE_VERSION := "$(VERSION)"
 build_java: bin/pulumi-java-gen upstream
 	$(WORKING_DIR)/bin/$(JAVA_GEN) generate --schema provider/cmd/$(PROVIDER)/schema.json --out sdk/java  --build gradle-nexus
 	cd sdk/java/ && \
 		echo "module fake_java_module // Exclude this directory from Go tools\n\ngo 1.17" > go.mod && \
 		gradle --console=plain build
 
-build_nodejs: VERSION := $(shell pulumictl get version --language javascript)
+build_nodejs: VERSION := $(shell pulumictl convert-version -l javascript -v "$(VERSION)")
 build_nodejs: upstream
 	$(WORKING_DIR)/bin/$(TFGEN) nodejs --out sdk/nodejs/
 	cd sdk/nodejs/ && \
@@ -59,7 +59,7 @@ build_nodejs: upstream
 		cp ../../README.md ../../LICENSE* package.json yarn.lock ./bin/ && \
 		sed -i.bak -e "s/\$${VERSION}/$(VERSION)/g" ./bin/package.json
 
-build_python: PYPI_VERSION := $(shell pulumictl get version --language python)
+build_python: PYPI_VERSION := $(shell pulumictl convert-version -l python -v "$(VERSION)")
 build_python: upstream
 	$(WORKING_DIR)/bin/$(TFGEN) python --out sdk/python/
 	cd sdk/python/ && \
@@ -118,7 +118,10 @@ upstream.finalize:
 upstream.rebase:
 	@$(SHELL) ./scripts/upstream.sh "$@" start_rebase
 
+version.generic:
+	@echo $(VERSION)
+
 bin/pulumi-java-gen:
 	$(shell pulumictl download-binary -n pulumi-language-java -v $(JAVA_GEN_VERSION) -r pulumi/pulumi-java)
 
-.PHONY: development build build_sdks install_go_sdk install_java_sdk install_python_sdk install_sdks only_build build_dotnet build_go build_java build_nodejs build_python clean cleanup help install_dotnet_sdk install_nodejs_sdk install_plugins lint_provider provider test tfgen upstream upstream.finalize upstream.rebase
+.PHONY: development build build_sdks install_go_sdk install_java_sdk install_python_sdk install_sdks only_build build_dotnet build_go build_java build_nodejs build_python clean cleanup help install_dotnet_sdk install_nodejs_sdk install_plugins lint_provider provider test tfgen upstream upstream.finalize upstream.rebase version.generic

--- a/provider-ci/providers/f5bigip/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/f5bigip/repo/.github/workflows/main.yml
@@ -94,7 +94,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version.generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -342,7 +342,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version.generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:

--- a/provider-ci/providers/f5bigip/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/f5bigip/repo/.github/workflows/main.yml
@@ -94,8 +94,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -343,8 +342,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(pulumictl get version --language generic)"
-        >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:

--- a/provider-ci/providers/f5bigip/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/f5bigip/repo/.github/workflows/master.yml
@@ -94,7 +94,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version.generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -342,7 +342,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version.generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:

--- a/provider-ci/providers/f5bigip/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/f5bigip/repo/.github/workflows/master.yml
@@ -94,8 +94,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -343,8 +342,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(pulumictl get version --language generic)"
-        >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:

--- a/provider-ci/providers/f5bigip/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/f5bigip/repo/.github/workflows/prerelease.yml
@@ -95,8 +95,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -293,8 +292,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(pulumictl get version --language generic)"
-        >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:

--- a/provider-ci/providers/f5bigip/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/f5bigip/repo/.github/workflows/prerelease.yml
@@ -95,7 +95,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version.generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -292,7 +292,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version.generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:

--- a/provider-ci/providers/f5bigip/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/f5bigip/repo/.github/workflows/release.yml
@@ -94,8 +94,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -306,8 +305,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(pulumictl get version --language generic)"
-        >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:
@@ -350,8 +348,8 @@ jobs:
       with:
         repo: pulumi/pulumictl
     - name: Add SDK version tag
-      run: git tag sdk/v$(pulumictl get version --language generic) && git push origin
-        sdk/v$(pulumictl get version --language generic)
+      run: git tag sdk/v$(make version:generic) && git push origin sdk/v$(make
+        version:generic)
   test:
     name: test
     needs: build_sdk

--- a/provider-ci/providers/f5bigip/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/f5bigip/repo/.github/workflows/release.yml
@@ -94,7 +94,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version.generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -305,7 +305,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version.generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:
@@ -348,8 +348,8 @@ jobs:
       with:
         repo: pulumi/pulumictl
     - name: Add SDK version tag
-      run: git tag sdk/v$(make version:generic) && git push origin sdk/v$(make
-        version:generic)
+      run: git tag sdk/v$(make version.generic) && git push origin sdk/v$(make
+        version.generic)
   test:
     name: test
     needs: build_sdk

--- a/provider-ci/providers/f5bigip/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/f5bigip/repo/.github/workflows/run-acceptance-tests.yml
@@ -99,8 +99,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean

--- a/provider-ci/providers/f5bigip/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/f5bigip/repo/.github/workflows/run-acceptance-tests.yml
@@ -99,7 +99,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version.generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean

--- a/provider-ci/providers/f5bigip/repo/Makefile
+++ b/provider-ci/providers/f5bigip/repo/Makefile
@@ -7,7 +7,7 @@ PROVIDER_PATH := provider/v3
 VERSION_PATH := $(PROVIDER_PATH)/pkg/version.Version
 TFGEN := pulumi-tfgen-$(PACK)
 PROVIDER := pulumi-resource-$(PACK)
-VERSION := $(shell pulumictl get version)
+VERSION := $(shell pulumictl get version --language generic)
 JAVA_GEN := pulumi-java-gen
 JAVA_GEN_VERSION := v0.5.4
 TESTPARALLELISM := 10
@@ -29,9 +29,9 @@ install_sdks: install_dotnet_sdk install_python_sdk install_nodejs_sdk install_j
 
 only_build: build
 
-build_dotnet: DOTNET_VERSION := $(shell pulumictl get version --language dotnet)
+build_dotnet: DOTNET_VERSION := $(shell pulumictl convert-version -l dotnet -v "$(VERSION)")
 build_dotnet: upstream
-	pulumictl get version --language dotnet
+	@echo $(DOTNET_VERSION)
 	$(WORKING_DIR)/bin/$(TFGEN) dotnet --out sdk/dotnet/
 	cd sdk/dotnet/ && \
 		echo "module fake_dotnet_module // Exclude this directory from Go tools\n\ngo 1.17" > go.mod && \
@@ -42,14 +42,14 @@ build_go: upstream
 	$(WORKING_DIR)/bin/$(TFGEN) go --out sdk/go/
 	cd sdk && go list `grep -e "^module" go.mod | cut -d ' ' -f 2`/go/... | xargs go build
 
-build_java: PACKAGE_VERSION := $(shell pulumictl get version --language generic)
+build_java: PACKAGE_VERSION := "$(VERSION)"
 build_java: bin/pulumi-java-gen upstream
 	$(WORKING_DIR)/bin/$(JAVA_GEN) generate --schema provider/cmd/$(PROVIDER)/schema.json --out sdk/java  --build gradle-nexus
 	cd sdk/java/ && \
 		echo "module fake_java_module // Exclude this directory from Go tools\n\ngo 1.17" > go.mod && \
 		gradle --console=plain build
 
-build_nodejs: VERSION := $(shell pulumictl get version --language javascript)
+build_nodejs: VERSION := $(shell pulumictl convert-version -l javascript -v "$(VERSION)")
 build_nodejs: upstream
 	$(WORKING_DIR)/bin/$(TFGEN) nodejs --out sdk/nodejs/
 	cd sdk/nodejs/ && \
@@ -59,7 +59,7 @@ build_nodejs: upstream
 		cp ../../README.md ../../LICENSE* package.json yarn.lock ./bin/ && \
 		sed -i.bak -e "s/\$${VERSION}/$(VERSION)/g" ./bin/package.json
 
-build_python: PYPI_VERSION := $(shell pulumictl get version --language python)
+build_python: PYPI_VERSION := $(shell pulumictl convert-version -l python -v "$(VERSION)")
 build_python: upstream
 	$(WORKING_DIR)/bin/$(TFGEN) python --out sdk/python/
 	cd sdk/python/ && \
@@ -118,7 +118,10 @@ upstream.finalize:
 upstream.rebase:
 	@$(SHELL) ./scripts/upstream.sh "$@" start_rebase
 
+version.generic:
+	@echo $(VERSION)
+
 bin/pulumi-java-gen:
 	$(shell pulumictl download-binary -n pulumi-language-java -v $(JAVA_GEN_VERSION) -r pulumi/pulumi-java)
 
-.PHONY: development build build_sdks install_go_sdk install_java_sdk install_python_sdk install_sdks only_build build_dotnet build_go build_java build_nodejs build_python clean cleanup help install_dotnet_sdk install_nodejs_sdk install_plugins lint_provider provider test tfgen upstream upstream.finalize upstream.rebase
+.PHONY: development build build_sdks install_go_sdk install_java_sdk install_python_sdk install_sdks only_build build_dotnet build_go build_java build_nodejs build_python clean cleanup help install_dotnet_sdk install_nodejs_sdk install_plugins lint_provider provider test tfgen upstream upstream.finalize upstream.rebase version.generic

--- a/provider-ci/providers/fastly/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/fastly/repo/.github/workflows/main.yml
@@ -91,7 +91,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version.generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -339,7 +339,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version.generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:

--- a/provider-ci/providers/fastly/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/fastly/repo/.github/workflows/main.yml
@@ -91,8 +91,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -340,8 +339,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(pulumictl get version --language generic)"
-        >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:

--- a/provider-ci/providers/fastly/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/fastly/repo/.github/workflows/master.yml
@@ -91,7 +91,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version.generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -339,7 +339,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version.generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:

--- a/provider-ci/providers/fastly/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/fastly/repo/.github/workflows/master.yml
@@ -91,8 +91,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -340,8 +339,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(pulumictl get version --language generic)"
-        >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:

--- a/provider-ci/providers/fastly/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/fastly/repo/.github/workflows/prerelease.yml
@@ -92,8 +92,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -290,8 +289,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(pulumictl get version --language generic)"
-        >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:

--- a/provider-ci/providers/fastly/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/fastly/repo/.github/workflows/prerelease.yml
@@ -92,7 +92,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version.generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -289,7 +289,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version.generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:

--- a/provider-ci/providers/fastly/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/fastly/repo/.github/workflows/release.yml
@@ -91,8 +91,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -303,8 +302,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(pulumictl get version --language generic)"
-        >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:
@@ -347,8 +345,8 @@ jobs:
       with:
         repo: pulumi/pulumictl
     - name: Add SDK version tag
-      run: git tag sdk/v$(pulumictl get version --language generic) && git push origin
-        sdk/v$(pulumictl get version --language generic)
+      run: git tag sdk/v$(make version:generic) && git push origin sdk/v$(make
+        version:generic)
   test:
     name: test
     needs: build_sdk

--- a/provider-ci/providers/fastly/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/fastly/repo/.github/workflows/release.yml
@@ -91,7 +91,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version.generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -302,7 +302,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version.generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:
@@ -345,8 +345,8 @@ jobs:
       with:
         repo: pulumi/pulumictl
     - name: Add SDK version tag
-      run: git tag sdk/v$(make version:generic) && git push origin sdk/v$(make
-        version:generic)
+      run: git tag sdk/v$(make version.generic) && git push origin sdk/v$(make
+        version.generic)
   test:
     name: test
     needs: build_sdk

--- a/provider-ci/providers/fastly/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/fastly/repo/.github/workflows/run-acceptance-tests.yml
@@ -96,7 +96,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version.generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean

--- a/provider-ci/providers/fastly/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/fastly/repo/.github/workflows/run-acceptance-tests.yml
@@ -96,8 +96,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean

--- a/provider-ci/providers/fastly/repo/Makefile
+++ b/provider-ci/providers/fastly/repo/Makefile
@@ -7,7 +7,7 @@ PROVIDER_PATH := provider/v7
 VERSION_PATH := $(PROVIDER_PATH)/pkg/version.Version
 TFGEN := pulumi-tfgen-$(PACK)
 PROVIDER := pulumi-resource-$(PACK)
-VERSION := $(shell pulumictl get version)
+VERSION := $(shell pulumictl get version --language generic)
 JAVA_GEN := pulumi-java-gen
 JAVA_GEN_VERSION := v0.5.4
 TESTPARALLELISM := 10
@@ -29,9 +29,9 @@ install_sdks: install_dotnet_sdk install_python_sdk install_nodejs_sdk install_j
 
 only_build: build
 
-build_dotnet: DOTNET_VERSION := $(shell pulumictl get version --language dotnet)
+build_dotnet: DOTNET_VERSION := $(shell pulumictl convert-version -l dotnet -v "$(VERSION)")
 build_dotnet: upstream
-	pulumictl get version --language dotnet
+	@echo $(DOTNET_VERSION)
 	$(WORKING_DIR)/bin/$(TFGEN) dotnet --out sdk/dotnet/
 	cd sdk/dotnet/ && \
 		echo "module fake_dotnet_module // Exclude this directory from Go tools\n\ngo 1.17" > go.mod && \
@@ -42,14 +42,14 @@ build_go: upstream
 	$(WORKING_DIR)/bin/$(TFGEN) go --out sdk/go/
 	cd sdk && go list `grep -e "^module" go.mod | cut -d ' ' -f 2`/go/... | xargs go build
 
-build_java: PACKAGE_VERSION := $(shell pulumictl get version --language generic)
+build_java: PACKAGE_VERSION := "$(VERSION)"
 build_java: bin/pulumi-java-gen upstream
 	$(WORKING_DIR)/bin/$(JAVA_GEN) generate --schema provider/cmd/$(PROVIDER)/schema.json --out sdk/java  --build gradle-nexus
 	cd sdk/java/ && \
 		echo "module fake_java_module // Exclude this directory from Go tools\n\ngo 1.17" > go.mod && \
 		gradle --console=plain build
 
-build_nodejs: VERSION := $(shell pulumictl get version --language javascript)
+build_nodejs: VERSION := $(shell pulumictl convert-version -l javascript -v "$(VERSION)")
 build_nodejs: upstream
 	$(WORKING_DIR)/bin/$(TFGEN) nodejs --out sdk/nodejs/
 	cd sdk/nodejs/ && \
@@ -59,7 +59,7 @@ build_nodejs: upstream
 		cp ../../README.md ../../LICENSE* package.json yarn.lock ./bin/ && \
 		sed -i.bak -e "s/\$${VERSION}/$(VERSION)/g" ./bin/package.json
 
-build_python: PYPI_VERSION := $(shell pulumictl get version --language python)
+build_python: PYPI_VERSION := $(shell pulumictl convert-version -l python -v "$(VERSION)")
 build_python: upstream
 	$(WORKING_DIR)/bin/$(TFGEN) python --out sdk/python/
 	cd sdk/python/ && \
@@ -120,7 +120,10 @@ upstream.finalize:
 upstream.rebase:
 	@$(SHELL) ./scripts/upstream.sh "$@" start_rebase
 
+version.generic:
+	@echo $(VERSION)
+
 bin/pulumi-java-gen:
 	$(shell pulumictl download-binary -n pulumi-language-java -v $(JAVA_GEN_VERSION) -r pulumi/pulumi-java)
 
-.PHONY: development build build_sdks install_go_sdk install_java_sdk install_python_sdk install_sdks only_build build_dotnet build_go build_java build_nodejs build_python clean cleanup help install_dotnet_sdk install_nodejs_sdk install_plugins lint_provider provider test tfgen upstream upstream.finalize upstream.rebase
+.PHONY: development build build_sdks install_go_sdk install_java_sdk install_python_sdk install_sdks only_build build_dotnet build_go build_java build_nodejs build_python clean cleanup help install_dotnet_sdk install_nodejs_sdk install_plugins lint_provider provider test tfgen upstream upstream.finalize upstream.rebase version.generic

--- a/provider-ci/providers/gcp/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/gcp/repo/.github/workflows/main.yml
@@ -98,8 +98,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -276,8 +275,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(pulumictl get version --language generic)"
-        >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:

--- a/provider-ci/providers/gcp/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/gcp/repo/.github/workflows/main.yml
@@ -98,7 +98,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version.generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -275,7 +275,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version.generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:

--- a/provider-ci/providers/gcp/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/gcp/repo/.github/workflows/master.yml
@@ -98,8 +98,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -276,8 +275,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(pulumictl get version --language generic)"
-        >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:

--- a/provider-ci/providers/gcp/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/gcp/repo/.github/workflows/master.yml
@@ -98,7 +98,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version.generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -275,7 +275,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version.generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:

--- a/provider-ci/providers/gcp/repo/.github/workflows/nightly-test.yml
+++ b/provider-ci/providers/gcp/repo/.github/workflows/nightly-test.yml
@@ -98,8 +98,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean

--- a/provider-ci/providers/gcp/repo/.github/workflows/nightly-test.yml
+++ b/provider-ci/providers/gcp/repo/.github/workflows/nightly-test.yml
@@ -98,7 +98,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version.generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean

--- a/provider-ci/providers/gcp/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/gcp/repo/.github/workflows/prerelease.yml
@@ -99,7 +99,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version.generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -225,7 +225,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version.generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:

--- a/provider-ci/providers/gcp/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/gcp/repo/.github/workflows/prerelease.yml
@@ -99,8 +99,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -226,8 +225,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(pulumictl get version --language generic)"
-        >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:

--- a/provider-ci/providers/gcp/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/gcp/repo/.github/workflows/release.yml
@@ -98,8 +98,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -239,8 +238,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(pulumictl get version --language generic)"
-        >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:
@@ -283,8 +281,8 @@ jobs:
       with:
         repo: pulumi/pulumictl
     - name: Add SDK version tag
-      run: git tag sdk/v$(pulumictl get version --language generic) && git push origin
-        sdk/v$(pulumictl get version --language generic)
+      run: git tag sdk/v$(make version:generic) && git push origin sdk/v$(make
+        version:generic)
   test:
     name: test
     needs: build_sdk

--- a/provider-ci/providers/gcp/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/gcp/repo/.github/workflows/release.yml
@@ -98,7 +98,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version.generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -238,7 +238,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version.generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:
@@ -281,8 +281,8 @@ jobs:
       with:
         repo: pulumi/pulumictl
     - name: Add SDK version tag
-      run: git tag sdk/v$(make version:generic) && git push origin sdk/v$(make
-        version:generic)
+      run: git tag sdk/v$(make version.generic) && git push origin sdk/v$(make
+        version.generic)
   test:
     name: test
     needs: build_sdk

--- a/provider-ci/providers/gcp/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/gcp/repo/.github/workflows/run-acceptance-tests.yml
@@ -103,7 +103,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version.generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean

--- a/provider-ci/providers/gcp/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/gcp/repo/.github/workflows/run-acceptance-tests.yml
@@ -103,8 +103,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean

--- a/provider-ci/providers/gcp/repo/Makefile
+++ b/provider-ci/providers/gcp/repo/Makefile
@@ -7,7 +7,7 @@ PROVIDER_PATH := provider/v6
 VERSION_PATH := $(PROVIDER_PATH)/pkg/version.Version
 TFGEN := pulumi-tfgen-$(PACK)
 PROVIDER := pulumi-resource-$(PACK)
-VERSION := $(shell pulumictl get version)
+VERSION := $(shell pulumictl get version --language generic)
 JAVA_GEN := pulumi-java-gen
 JAVA_GEN_VERSION := v0.5.4
 TESTPARALLELISM := 10
@@ -30,9 +30,9 @@ install_sdks: install_dotnet_sdk install_python_sdk install_nodejs_sdk install_j
 
 only_build: build
 
-build_dotnet: DOTNET_VERSION := $(shell pulumictl get version --language dotnet)
+build_dotnet: DOTNET_VERSION := $(shell pulumictl convert-version -l dotnet -v "$(VERSION)")
 build_dotnet:
-	pulumictl get version --language dotnet
+	@echo $(DOTNET_VERSION)
 	$(WORKING_DIR)/bin/$(TFGEN) dotnet --out sdk/dotnet/
 	cd sdk/dotnet/ && \
 		echo "module fake_dotnet_module // Exclude this directory from Go tools\n\ngo 1.17" > go.mod && \
@@ -43,14 +43,14 @@ build_go:
 	$(WORKING_DIR)/bin/$(TFGEN) go --out sdk/go/
 	cd sdk && go list `grep -e "^module" go.mod | cut -d ' ' -f 2`/go/... | xargs go build
 
-build_java: PACKAGE_VERSION := $(shell pulumictl get version --language generic)
+build_java: PACKAGE_VERSION := "$(VERSION)"
 build_java: bin/pulumi-java-gen
 	$(WORKING_DIR)/bin/$(JAVA_GEN) generate --schema provider/cmd/$(PROVIDER)/schema.json --out sdk/java  --build gradle-nexus
 	cd sdk/java/ && \
 		echo "module fake_java_module // Exclude this directory from Go tools\n\ngo 1.17" > go.mod && \
 		gradle --console=plain build
 
-build_nodejs: VERSION := $(shell pulumictl get version --language javascript)
+build_nodejs: VERSION := $(shell pulumictl convert-version -l javascript -v "$(VERSION)")
 build_nodejs:
 	$(WORKING_DIR)/bin/$(TFGEN) nodejs --out sdk/nodejs/
 	cd sdk/nodejs/ && \
@@ -60,7 +60,7 @@ build_nodejs:
 		cp ../../README.md ../../LICENSE* package.json yarn.lock ./bin/ && \
 		sed -i.bak -e "s/\$${VERSION}/$(VERSION)/g" ./bin/package.json
 
-build_python: PYPI_VERSION := $(shell pulumictl get version --language python)
+build_python: PYPI_VERSION := $(shell pulumictl convert-version -l python -v "$(VERSION)")
 build_python:
 	$(WORKING_DIR)/bin/$(TFGEN) python --out sdk/python/
 	cd sdk/python/ && \
@@ -111,7 +111,10 @@ tfgen: install_plugins
 	$(WORKING_DIR)/bin/$(TFGEN) schema --out provider/cmd/$(PROVIDER)
 	(cd provider && VERSION=$(VERSION) go generate cmd/$(PROVIDER)/main.go)
 
+version.generic:
+	@echo $(VERSION)
+
 bin/pulumi-java-gen:
 	$(shell pulumictl download-binary -n pulumi-language-java -v $(JAVA_GEN_VERSION) -r pulumi/pulumi-java)
 
-.PHONY: development build build_sdks install_go_sdk install_java_sdk install_python_sdk install_sdks only_build build_dotnet build_go build_java build_nodejs build_python clean cleanup help install_dotnet_sdk install_nodejs_sdk install_plugins lint_provider provider test tfgen
+.PHONY: development build build_sdks install_go_sdk install_java_sdk install_python_sdk install_sdks only_build build_dotnet build_go build_java build_nodejs build_python clean cleanup help install_dotnet_sdk install_nodejs_sdk install_plugins lint_provider provider test tfgen version.generic

--- a/provider-ci/providers/github/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/github/repo/.github/workflows/main.yml
@@ -92,8 +92,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -341,8 +340,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(pulumictl get version --language generic)"
-        >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:

--- a/provider-ci/providers/github/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/github/repo/.github/workflows/main.yml
@@ -92,7 +92,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version.generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -340,7 +340,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version.generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:

--- a/provider-ci/providers/github/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/github/repo/.github/workflows/master.yml
@@ -92,8 +92,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -341,8 +340,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(pulumictl get version --language generic)"
-        >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:

--- a/provider-ci/providers/github/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/github/repo/.github/workflows/master.yml
@@ -92,7 +92,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version.generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -340,7 +340,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version.generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:

--- a/provider-ci/providers/github/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/github/repo/.github/workflows/prerelease.yml
@@ -93,8 +93,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -291,8 +290,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(pulumictl get version --language generic)"
-        >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:

--- a/provider-ci/providers/github/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/github/repo/.github/workflows/prerelease.yml
@@ -93,7 +93,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version.generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -290,7 +290,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version.generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:

--- a/provider-ci/providers/github/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/github/repo/.github/workflows/release.yml
@@ -92,7 +92,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version.generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -303,7 +303,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version.generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:
@@ -346,8 +346,8 @@ jobs:
       with:
         repo: pulumi/pulumictl
     - name: Add SDK version tag
-      run: git tag sdk/v$(make version:generic) && git push origin sdk/v$(make
-        version:generic)
+      run: git tag sdk/v$(make version.generic) && git push origin sdk/v$(make
+        version.generic)
   test:
     name: test
     needs: build_sdk

--- a/provider-ci/providers/github/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/github/repo/.github/workflows/release.yml
@@ -92,8 +92,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -304,8 +303,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(pulumictl get version --language generic)"
-        >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:
@@ -348,8 +346,8 @@ jobs:
       with:
         repo: pulumi/pulumictl
     - name: Add SDK version tag
-      run: git tag sdk/v$(pulumictl get version --language generic) && git push origin
-        sdk/v$(pulumictl get version --language generic)
+      run: git tag sdk/v$(make version:generic) && git push origin sdk/v$(make
+        version:generic)
   test:
     name: test
     needs: build_sdk

--- a/provider-ci/providers/github/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/github/repo/.github/workflows/run-acceptance-tests.yml
@@ -97,7 +97,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version.generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean

--- a/provider-ci/providers/github/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/github/repo/.github/workflows/run-acceptance-tests.yml
@@ -97,8 +97,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean

--- a/provider-ci/providers/github/repo/Makefile
+++ b/provider-ci/providers/github/repo/Makefile
@@ -7,7 +7,7 @@ PROVIDER_PATH := provider/v5
 VERSION_PATH := $(PROVIDER_PATH)/pkg/version.Version
 TFGEN := pulumi-tfgen-$(PACK)
 PROVIDER := pulumi-resource-$(PACK)
-VERSION := $(shell pulumictl get version)
+VERSION := $(shell pulumictl get version --language generic)
 JAVA_GEN := pulumi-java-gen
 JAVA_GEN_VERSION := v0.5.4
 TESTPARALLELISM := 10
@@ -29,9 +29,9 @@ install_sdks: install_dotnet_sdk install_python_sdk install_nodejs_sdk install_j
 
 only_build: build
 
-build_dotnet: DOTNET_VERSION := $(shell pulumictl get version --language dotnet)
+build_dotnet: DOTNET_VERSION := $(shell pulumictl convert-version -l dotnet -v "$(VERSION)")
 build_dotnet: upstream
-	pulumictl get version --language dotnet
+	@echo $(DOTNET_VERSION)
 	$(WORKING_DIR)/bin/$(TFGEN) dotnet --out sdk/dotnet/
 	cd sdk/dotnet/ && \
 		echo "module fake_dotnet_module // Exclude this directory from Go tools\n\ngo 1.17" > go.mod && \
@@ -42,14 +42,14 @@ build_go: upstream
 	$(WORKING_DIR)/bin/$(TFGEN) go --out sdk/go/
 	cd sdk && go list `grep -e "^module" go.mod | cut -d ' ' -f 2`/go/... | xargs go build
 
-build_java: PACKAGE_VERSION := $(shell pulumictl get version --language generic)
+build_java: PACKAGE_VERSION := "$(VERSION)"
 build_java: bin/pulumi-java-gen upstream
 	$(WORKING_DIR)/bin/$(JAVA_GEN) generate --schema provider/cmd/$(PROVIDER)/schema.json --out sdk/java  --build gradle-nexus
 	cd sdk/java/ && \
 		echo "module fake_java_module // Exclude this directory from Go tools\n\ngo 1.17" > go.mod && \
 		gradle --console=plain build
 
-build_nodejs: VERSION := $(shell pulumictl get version --language javascript)
+build_nodejs: VERSION := $(shell pulumictl convert-version -l javascript -v "$(VERSION)")
 build_nodejs: upstream
 	$(WORKING_DIR)/bin/$(TFGEN) nodejs --out sdk/nodejs/
 	cd sdk/nodejs/ && \
@@ -59,7 +59,7 @@ build_nodejs: upstream
 		cp ../../README.md ../../LICENSE* package.json yarn.lock ./bin/ && \
 		sed -i.bak -e "s/\$${VERSION}/$(VERSION)/g" ./bin/package.json
 
-build_python: PYPI_VERSION := $(shell pulumictl get version --language python)
+build_python: PYPI_VERSION := $(shell pulumictl convert-version -l python -v "$(VERSION)")
 build_python: upstream
 	$(WORKING_DIR)/bin/$(TFGEN) python --out sdk/python/
 	cd sdk/python/ && \
@@ -118,7 +118,10 @@ upstream.finalize:
 upstream.rebase:
 	@$(SHELL) ./scripts/upstream.sh "$@" start_rebase
 
+version.generic:
+	@echo $(VERSION)
+
 bin/pulumi-java-gen:
 	$(shell pulumictl download-binary -n pulumi-language-java -v $(JAVA_GEN_VERSION) -r pulumi/pulumi-java)
 
-.PHONY: development build build_sdks install_go_sdk install_java_sdk install_python_sdk install_sdks only_build build_dotnet build_go build_java build_nodejs build_python clean cleanup help install_dotnet_sdk install_nodejs_sdk install_plugins lint_provider provider test tfgen upstream upstream.finalize upstream.rebase
+.PHONY: development build build_sdks install_go_sdk install_java_sdk install_python_sdk install_sdks only_build build_dotnet build_go build_java build_nodejs build_python clean cleanup help install_dotnet_sdk install_nodejs_sdk install_plugins lint_provider provider test tfgen upstream upstream.finalize upstream.rebase version.generic

--- a/provider-ci/providers/gitlab/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/gitlab/repo/.github/workflows/main.yml
@@ -91,7 +91,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version.generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -339,7 +339,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version.generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:

--- a/provider-ci/providers/gitlab/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/gitlab/repo/.github/workflows/main.yml
@@ -91,8 +91,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -340,8 +339,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(pulumictl get version --language generic)"
-        >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:

--- a/provider-ci/providers/gitlab/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/gitlab/repo/.github/workflows/master.yml
@@ -91,7 +91,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version.generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -339,7 +339,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version.generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:

--- a/provider-ci/providers/gitlab/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/gitlab/repo/.github/workflows/master.yml
@@ -91,8 +91,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -340,8 +339,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(pulumictl get version --language generic)"
-        >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:

--- a/provider-ci/providers/gitlab/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/gitlab/repo/.github/workflows/prerelease.yml
@@ -92,8 +92,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -290,8 +289,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(pulumictl get version --language generic)"
-        >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:

--- a/provider-ci/providers/gitlab/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/gitlab/repo/.github/workflows/prerelease.yml
@@ -92,7 +92,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version.generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -289,7 +289,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version.generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:

--- a/provider-ci/providers/gitlab/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/gitlab/repo/.github/workflows/release.yml
@@ -91,8 +91,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -303,8 +302,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(pulumictl get version --language generic)"
-        >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:
@@ -347,8 +345,8 @@ jobs:
       with:
         repo: pulumi/pulumictl
     - name: Add SDK version tag
-      run: git tag sdk/v$(pulumictl get version --language generic) && git push origin
-        sdk/v$(pulumictl get version --language generic)
+      run: git tag sdk/v$(make version:generic) && git push origin sdk/v$(make
+        version:generic)
   test:
     name: test
     needs: build_sdk

--- a/provider-ci/providers/gitlab/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/gitlab/repo/.github/workflows/release.yml
@@ -91,7 +91,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version.generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -302,7 +302,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version.generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:
@@ -345,8 +345,8 @@ jobs:
       with:
         repo: pulumi/pulumictl
     - name: Add SDK version tag
-      run: git tag sdk/v$(make version:generic) && git push origin sdk/v$(make
-        version:generic)
+      run: git tag sdk/v$(make version.generic) && git push origin sdk/v$(make
+        version.generic)
   test:
     name: test
     needs: build_sdk

--- a/provider-ci/providers/gitlab/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/gitlab/repo/.github/workflows/run-acceptance-tests.yml
@@ -96,7 +96,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version.generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean

--- a/provider-ci/providers/gitlab/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/gitlab/repo/.github/workflows/run-acceptance-tests.yml
@@ -96,8 +96,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean

--- a/provider-ci/providers/gitlab/repo/Makefile
+++ b/provider-ci/providers/gitlab/repo/Makefile
@@ -7,7 +7,7 @@ PROVIDER_PATH := provider/v5
 VERSION_PATH := $(PROVIDER_PATH)/pkg/version.Version
 TFGEN := pulumi-tfgen-$(PACK)
 PROVIDER := pulumi-resource-$(PACK)
-VERSION := $(shell pulumictl get version)
+VERSION := $(shell pulumictl get version --language generic)
 JAVA_GEN := pulumi-java-gen
 JAVA_GEN_VERSION := v0.9.3
 TESTPARALLELISM := 10
@@ -29,9 +29,9 @@ install_sdks: install_dotnet_sdk install_python_sdk install_nodejs_sdk install_j
 
 only_build: build
 
-build_dotnet: DOTNET_VERSION := $(shell pulumictl get version --language dotnet)
+build_dotnet: DOTNET_VERSION := $(shell pulumictl convert-version -l dotnet -v "$(VERSION)")
 build_dotnet: upstream
-	pulumictl get version --language dotnet
+	@echo $(DOTNET_VERSION)
 	$(WORKING_DIR)/bin/$(TFGEN) dotnet --out sdk/dotnet/
 	cd sdk/dotnet/ && \
 		echo "module fake_dotnet_module // Exclude this directory from Go tools\n\ngo 1.17" > go.mod && \
@@ -42,14 +42,14 @@ build_go: upstream
 	$(WORKING_DIR)/bin/$(TFGEN) go --out sdk/go/
 	cd sdk && go list `grep -e "^module" go.mod | cut -d ' ' -f 2`/go/... | xargs go build
 
-build_java: PACKAGE_VERSION := $(shell pulumictl get version --language generic)
+build_java: PACKAGE_VERSION := "$(VERSION)"
 build_java: bin/pulumi-java-gen upstream
 	$(WORKING_DIR)/bin/$(JAVA_GEN) generate --schema provider/cmd/$(PROVIDER)/schema.json --out sdk/java  --build gradle-nexus
 	cd sdk/java/ && \
 		echo "module fake_java_module // Exclude this directory from Go tools\n\ngo 1.17" > go.mod && \
 		gradle --console=plain build
 
-build_nodejs: VERSION := $(shell pulumictl get version --language javascript)
+build_nodejs: VERSION := $(shell pulumictl convert-version -l javascript -v "$(VERSION)")
 build_nodejs: upstream
 	$(WORKING_DIR)/bin/$(TFGEN) nodejs --out sdk/nodejs/
 	cd sdk/nodejs/ && \
@@ -59,7 +59,7 @@ build_nodejs: upstream
 		cp ../../README.md ../../LICENSE* package.json yarn.lock ./bin/ && \
 		sed -i.bak -e "s/\$${VERSION}/$(VERSION)/g" ./bin/package.json
 
-build_python: PYPI_VERSION := $(shell pulumictl get version --language python)
+build_python: PYPI_VERSION := $(shell pulumictl convert-version -l python -v "$(VERSION)")
 build_python: upstream
 	$(WORKING_DIR)/bin/$(TFGEN) python --out sdk/python/
 	cd sdk/python/ && \
@@ -118,7 +118,10 @@ upstream.finalize:
 upstream.rebase:
 	@$(SHELL) ./scripts/upstream.sh "$@" start_rebase
 
+version.generic:
+	@echo $(VERSION)
+
 bin/pulumi-java-gen:
 	$(shell pulumictl download-binary -n pulumi-language-java -v $(JAVA_GEN_VERSION) -r pulumi/pulumi-java)
 
-.PHONY: development build build_sdks install_go_sdk install_java_sdk install_python_sdk install_sdks only_build build_dotnet build_go build_java build_nodejs build_python clean cleanup help install_dotnet_sdk install_nodejs_sdk install_plugins lint_provider provider test tfgen upstream upstream.finalize upstream.rebase
+.PHONY: development build build_sdks install_go_sdk install_java_sdk install_python_sdk install_sdks only_build build_dotnet build_go build_java build_nodejs build_python clean cleanup help install_dotnet_sdk install_nodejs_sdk install_plugins lint_provider provider test tfgen upstream upstream.finalize upstream.rebase version.generic

--- a/provider-ci/providers/hcloud/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/hcloud/repo/.github/workflows/main.yml
@@ -91,7 +91,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version.generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -339,7 +339,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version.generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:

--- a/provider-ci/providers/hcloud/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/hcloud/repo/.github/workflows/main.yml
@@ -91,8 +91,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -340,8 +339,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(pulumictl get version --language generic)"
-        >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:

--- a/provider-ci/providers/hcloud/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/hcloud/repo/.github/workflows/master.yml
@@ -91,7 +91,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version.generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -339,7 +339,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version.generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:

--- a/provider-ci/providers/hcloud/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/hcloud/repo/.github/workflows/master.yml
@@ -91,8 +91,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -340,8 +339,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(pulumictl get version --language generic)"
-        >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:

--- a/provider-ci/providers/hcloud/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/hcloud/repo/.github/workflows/prerelease.yml
@@ -92,8 +92,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -290,8 +289,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(pulumictl get version --language generic)"
-        >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:

--- a/provider-ci/providers/hcloud/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/hcloud/repo/.github/workflows/prerelease.yml
@@ -92,7 +92,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version.generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -289,7 +289,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version.generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:

--- a/provider-ci/providers/hcloud/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/hcloud/repo/.github/workflows/release.yml
@@ -91,8 +91,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -303,8 +302,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(pulumictl get version --language generic)"
-        >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:
@@ -347,8 +345,8 @@ jobs:
       with:
         repo: pulumi/pulumictl
     - name: Add SDK version tag
-      run: git tag sdk/v$(pulumictl get version --language generic) && git push origin
-        sdk/v$(pulumictl get version --language generic)
+      run: git tag sdk/v$(make version:generic) && git push origin sdk/v$(make
+        version:generic)
   test:
     name: test
     needs: build_sdk

--- a/provider-ci/providers/hcloud/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/hcloud/repo/.github/workflows/release.yml
@@ -91,7 +91,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version.generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -302,7 +302,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version.generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:
@@ -345,8 +345,8 @@ jobs:
       with:
         repo: pulumi/pulumictl
     - name: Add SDK version tag
-      run: git tag sdk/v$(make version:generic) && git push origin sdk/v$(make
-        version:generic)
+      run: git tag sdk/v$(make version.generic) && git push origin sdk/v$(make
+        version.generic)
   test:
     name: test
     needs: build_sdk

--- a/provider-ci/providers/hcloud/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/hcloud/repo/.github/workflows/run-acceptance-tests.yml
@@ -96,7 +96,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version.generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean

--- a/provider-ci/providers/hcloud/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/hcloud/repo/.github/workflows/run-acceptance-tests.yml
@@ -96,8 +96,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean

--- a/provider-ci/providers/hcloud/repo/Makefile
+++ b/provider-ci/providers/hcloud/repo/Makefile
@@ -7,7 +7,7 @@ PROVIDER_PATH := provider
 VERSION_PATH := $(PROVIDER_PATH)/pkg/version.Version
 TFGEN := pulumi-tfgen-$(PACK)
 PROVIDER := pulumi-resource-$(PACK)
-VERSION := $(shell pulumictl get version)
+VERSION := $(shell pulumictl get version --language generic)
 JAVA_GEN := pulumi-java-gen
 JAVA_GEN_VERSION := v0.5.4
 TESTPARALLELISM := 10
@@ -29,9 +29,9 @@ install_sdks: install_dotnet_sdk install_python_sdk install_nodejs_sdk install_j
 
 only_build: build
 
-build_dotnet: DOTNET_VERSION := $(shell pulumictl get version --language dotnet)
+build_dotnet: DOTNET_VERSION := $(shell pulumictl convert-version -l dotnet -v "$(VERSION)")
 build_dotnet: upstream
-	pulumictl get version --language dotnet
+	@echo $(DOTNET_VERSION)
 	$(WORKING_DIR)/bin/$(TFGEN) dotnet --out sdk/dotnet/
 	cd sdk/dotnet/ && \
 		echo "module fake_dotnet_module // Exclude this directory from Go tools\n\ngo 1.17" > go.mod && \
@@ -42,14 +42,14 @@ build_go: upstream
 	$(WORKING_DIR)/bin/$(TFGEN) go --out sdk/go/
 	cd sdk && go list `grep -e "^module" go.mod | cut -d ' ' -f 2`/go/... | xargs go build
 
-build_java: PACKAGE_VERSION := $(shell pulumictl get version --language generic)
+build_java: PACKAGE_VERSION := "$(VERSION)"
 build_java: bin/pulumi-java-gen upstream
 	$(WORKING_DIR)/bin/$(JAVA_GEN) generate --schema provider/cmd/$(PROVIDER)/schema.json --out sdk/java  --build gradle-nexus
 	cd sdk/java/ && \
 		echo "module fake_java_module // Exclude this directory from Go tools\n\ngo 1.17" > go.mod && \
 		gradle --console=plain build
 
-build_nodejs: VERSION := $(shell pulumictl get version --language javascript)
+build_nodejs: VERSION := $(shell pulumictl convert-version -l javascript -v "$(VERSION)")
 build_nodejs: upstream
 	$(WORKING_DIR)/bin/$(TFGEN) nodejs --out sdk/nodejs/
 	cd sdk/nodejs/ && \
@@ -59,7 +59,7 @@ build_nodejs: upstream
 		cp ../../README.md ../../LICENSE* package.json yarn.lock ./bin/ && \
 		sed -i.bak -e "s/\$${VERSION}/$(VERSION)/g" ./bin/package.json
 
-build_python: PYPI_VERSION := $(shell pulumictl get version --language python)
+build_python: PYPI_VERSION := $(shell pulumictl convert-version -l python -v "$(VERSION)")
 build_python: upstream
 	$(WORKING_DIR)/bin/$(TFGEN) python --out sdk/python/
 	cd sdk/python/ && \
@@ -118,7 +118,10 @@ upstream.finalize:
 upstream.rebase:
 	@$(SHELL) ./scripts/upstream.sh "$@" start_rebase
 
+version.generic:
+	@echo $(VERSION)
+
 bin/pulumi-java-gen:
 	$(shell pulumictl download-binary -n pulumi-language-java -v $(JAVA_GEN_VERSION) -r pulumi/pulumi-java)
 
-.PHONY: development build build_sdks install_go_sdk install_java_sdk install_python_sdk install_sdks only_build build_dotnet build_go build_java build_nodejs build_python clean cleanup help install_dotnet_sdk install_nodejs_sdk install_plugins lint_provider provider test tfgen upstream upstream.finalize upstream.rebase
+.PHONY: development build build_sdks install_go_sdk install_java_sdk install_python_sdk install_sdks only_build build_dotnet build_go build_java build_nodejs build_python clean cleanup help install_dotnet_sdk install_nodejs_sdk install_plugins lint_provider provider test tfgen upstream upstream.finalize upstream.rebase version.generic

--- a/provider-ci/providers/kafka/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/kafka/repo/.github/workflows/main.yml
@@ -90,7 +90,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version.generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -338,7 +338,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version.generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:

--- a/provider-ci/providers/kafka/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/kafka/repo/.github/workflows/main.yml
@@ -90,8 +90,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -339,8 +338,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(pulumictl get version --language generic)"
-        >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:

--- a/provider-ci/providers/kafka/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/kafka/repo/.github/workflows/master.yml
@@ -90,7 +90,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version.generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -338,7 +338,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version.generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:

--- a/provider-ci/providers/kafka/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/kafka/repo/.github/workflows/master.yml
@@ -90,8 +90,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -339,8 +338,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(pulumictl get version --language generic)"
-        >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:

--- a/provider-ci/providers/kafka/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/kafka/repo/.github/workflows/prerelease.yml
@@ -91,7 +91,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version.generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -288,7 +288,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version.generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:

--- a/provider-ci/providers/kafka/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/kafka/repo/.github/workflows/prerelease.yml
@@ -91,8 +91,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -289,8 +288,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(pulumictl get version --language generic)"
-        >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:

--- a/provider-ci/providers/kafka/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/kafka/repo/.github/workflows/release.yml
@@ -90,7 +90,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version.generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -301,7 +301,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version.generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:
@@ -344,8 +344,8 @@ jobs:
       with:
         repo: pulumi/pulumictl
     - name: Add SDK version tag
-      run: git tag sdk/v$(make version:generic) && git push origin sdk/v$(make
-        version:generic)
+      run: git tag sdk/v$(make version.generic) && git push origin sdk/v$(make
+        version.generic)
   test:
     name: test
     needs: build_sdk

--- a/provider-ci/providers/kafka/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/kafka/repo/.github/workflows/release.yml
@@ -90,8 +90,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -302,8 +301,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(pulumictl get version --language generic)"
-        >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:
@@ -346,8 +344,8 @@ jobs:
       with:
         repo: pulumi/pulumictl
     - name: Add SDK version tag
-      run: git tag sdk/v$(pulumictl get version --language generic) && git push origin
-        sdk/v$(pulumictl get version --language generic)
+      run: git tag sdk/v$(make version:generic) && git push origin sdk/v$(make
+        version:generic)
   test:
     name: test
     needs: build_sdk

--- a/provider-ci/providers/kafka/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/kafka/repo/.github/workflows/run-acceptance-tests.yml
@@ -95,7 +95,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version.generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean

--- a/provider-ci/providers/kafka/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/kafka/repo/.github/workflows/run-acceptance-tests.yml
@@ -95,8 +95,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean

--- a/provider-ci/providers/kafka/repo/Makefile
+++ b/provider-ci/providers/kafka/repo/Makefile
@@ -7,7 +7,7 @@ PROVIDER_PATH := provider/v3
 VERSION_PATH := $(PROVIDER_PATH)/pkg/version.Version
 TFGEN := pulumi-tfgen-$(PACK)
 PROVIDER := pulumi-resource-$(PACK)
-VERSION := $(shell pulumictl get version)
+VERSION := $(shell pulumictl get version --language generic)
 JAVA_GEN := pulumi-java-gen
 JAVA_GEN_VERSION := v0.5.4
 TESTPARALLELISM := 10
@@ -29,9 +29,9 @@ install_sdks: install_dotnet_sdk install_python_sdk install_nodejs_sdk install_j
 
 only_build: build
 
-build_dotnet: DOTNET_VERSION := $(shell pulumictl get version --language dotnet)
+build_dotnet: DOTNET_VERSION := $(shell pulumictl convert-version -l dotnet -v "$(VERSION)")
 build_dotnet: upstream
-	pulumictl get version --language dotnet
+	@echo $(DOTNET_VERSION)
 	$(WORKING_DIR)/bin/$(TFGEN) dotnet --out sdk/dotnet/
 	cd sdk/dotnet/ && \
 		echo "module fake_dotnet_module // Exclude this directory from Go tools\n\ngo 1.17" > go.mod && \
@@ -42,14 +42,14 @@ build_go: upstream
 	$(WORKING_DIR)/bin/$(TFGEN) go --out sdk/go/
 	cd sdk && go list `grep -e "^module" go.mod | cut -d ' ' -f 2`/go/... | xargs go build
 
-build_java: PACKAGE_VERSION := $(shell pulumictl get version --language generic)
+build_java: PACKAGE_VERSION := "$(VERSION)"
 build_java: bin/pulumi-java-gen upstream
 	$(WORKING_DIR)/bin/$(JAVA_GEN) generate --schema provider/cmd/$(PROVIDER)/schema.json --out sdk/java  --build gradle-nexus
 	cd sdk/java/ && \
 		echo "module fake_java_module // Exclude this directory from Go tools\n\ngo 1.17" > go.mod && \
 		gradle --console=plain build
 
-build_nodejs: VERSION := $(shell pulumictl get version --language javascript)
+build_nodejs: VERSION := $(shell pulumictl convert-version -l javascript -v "$(VERSION)")
 build_nodejs: upstream
 	$(WORKING_DIR)/bin/$(TFGEN) nodejs --out sdk/nodejs/
 	cd sdk/nodejs/ && \
@@ -59,7 +59,7 @@ build_nodejs: upstream
 		cp ../../README.md ../../LICENSE* package.json yarn.lock ./bin/ && \
 		sed -i.bak -e "s/\$${VERSION}/$(VERSION)/g" ./bin/package.json
 
-build_python: PYPI_VERSION := $(shell pulumictl get version --language python)
+build_python: PYPI_VERSION := $(shell pulumictl convert-version -l python -v "$(VERSION)")
 build_python: upstream
 	$(WORKING_DIR)/bin/$(TFGEN) python --out sdk/python/
 	cd sdk/python/ && \
@@ -118,7 +118,10 @@ upstream.finalize:
 upstream.rebase:
 	@$(SHELL) ./scripts/upstream.sh "$@" start_rebase
 
+version.generic:
+	@echo $(VERSION)
+
 bin/pulumi-java-gen:
 	$(shell pulumictl download-binary -n pulumi-language-java -v $(JAVA_GEN_VERSION) -r pulumi/pulumi-java)
 
-.PHONY: development build build_sdks install_go_sdk install_java_sdk install_python_sdk install_sdks only_build build_dotnet build_go build_java build_nodejs build_python clean cleanup help install_dotnet_sdk install_nodejs_sdk install_plugins lint_provider provider test tfgen upstream upstream.finalize upstream.rebase
+.PHONY: development build build_sdks install_go_sdk install_java_sdk install_python_sdk install_sdks only_build build_dotnet build_go build_java build_nodejs build_python clean cleanup help install_dotnet_sdk install_nodejs_sdk install_plugins lint_provider provider test tfgen upstream upstream.finalize upstream.rebase version.generic

--- a/provider-ci/providers/keycloak/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/keycloak/repo/.github/workflows/main.yml
@@ -95,7 +95,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version.generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -343,7 +343,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version.generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:

--- a/provider-ci/providers/keycloak/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/keycloak/repo/.github/workflows/main.yml
@@ -95,8 +95,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -344,8 +343,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(pulumictl get version --language generic)"
-        >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:

--- a/provider-ci/providers/keycloak/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/keycloak/repo/.github/workflows/master.yml
@@ -95,7 +95,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version.generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -343,7 +343,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version.generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:

--- a/provider-ci/providers/keycloak/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/keycloak/repo/.github/workflows/master.yml
@@ -95,8 +95,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -344,8 +343,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(pulumictl get version --language generic)"
-        >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:

--- a/provider-ci/providers/keycloak/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/keycloak/repo/.github/workflows/prerelease.yml
@@ -96,7 +96,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version.generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -293,7 +293,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version.generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:

--- a/provider-ci/providers/keycloak/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/keycloak/repo/.github/workflows/prerelease.yml
@@ -96,8 +96,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -294,8 +293,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(pulumictl get version --language generic)"
-        >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:

--- a/provider-ci/providers/keycloak/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/keycloak/repo/.github/workflows/release.yml
@@ -95,7 +95,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version.generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -306,7 +306,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version.generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:
@@ -349,8 +349,8 @@ jobs:
       with:
         repo: pulumi/pulumictl
     - name: Add SDK version tag
-      run: git tag sdk/v$(make version:generic) && git push origin sdk/v$(make
-        version:generic)
+      run: git tag sdk/v$(make version.generic) && git push origin sdk/v$(make
+        version.generic)
   test:
     name: test
     needs: build_sdk

--- a/provider-ci/providers/keycloak/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/keycloak/repo/.github/workflows/release.yml
@@ -95,8 +95,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -307,8 +306,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(pulumictl get version --language generic)"
-        >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:
@@ -351,8 +349,8 @@ jobs:
       with:
         repo: pulumi/pulumictl
     - name: Add SDK version tag
-      run: git tag sdk/v$(pulumictl get version --language generic) && git push origin
-        sdk/v$(pulumictl get version --language generic)
+      run: git tag sdk/v$(make version:generic) && git push origin sdk/v$(make
+        version:generic)
   test:
     name: test
     needs: build_sdk

--- a/provider-ci/providers/keycloak/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/keycloak/repo/.github/workflows/run-acceptance-tests.yml
@@ -100,8 +100,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean

--- a/provider-ci/providers/keycloak/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/keycloak/repo/.github/workflows/run-acceptance-tests.yml
@@ -100,7 +100,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version.generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean

--- a/provider-ci/providers/keycloak/repo/Makefile
+++ b/provider-ci/providers/keycloak/repo/Makefile
@@ -7,7 +7,7 @@ PROVIDER_PATH := provider/v5
 VERSION_PATH := $(PROVIDER_PATH)/pkg/version.Version
 TFGEN := pulumi-tfgen-$(PACK)
 PROVIDER := pulumi-resource-$(PACK)
-VERSION := $(shell pulumictl get version)
+VERSION := $(shell pulumictl get version --language generic)
 JAVA_GEN := pulumi-java-gen
 JAVA_GEN_VERSION := v0.5.4
 TESTPARALLELISM := 10
@@ -29,9 +29,9 @@ install_sdks: install_dotnet_sdk install_python_sdk install_nodejs_sdk install_j
 
 only_build: build
 
-build_dotnet: DOTNET_VERSION := $(shell pulumictl get version --language dotnet)
+build_dotnet: DOTNET_VERSION := $(shell pulumictl convert-version -l dotnet -v "$(VERSION)")
 build_dotnet: upstream
-	pulumictl get version --language dotnet
+	@echo $(DOTNET_VERSION)
 	$(WORKING_DIR)/bin/$(TFGEN) dotnet --out sdk/dotnet/
 	cd sdk/dotnet/ && \
 		echo "module fake_dotnet_module // Exclude this directory from Go tools\n\ngo 1.17" > go.mod && \
@@ -42,14 +42,14 @@ build_go: upstream
 	$(WORKING_DIR)/bin/$(TFGEN) go --out sdk/go/
 	cd sdk && go list `grep -e "^module" go.mod | cut -d ' ' -f 2`/go/... | xargs go build
 
-build_java: PACKAGE_VERSION := $(shell pulumictl get version --language generic)
+build_java: PACKAGE_VERSION := "$(VERSION)"
 build_java: bin/pulumi-java-gen upstream
 	$(WORKING_DIR)/bin/$(JAVA_GEN) generate --schema provider/cmd/$(PROVIDER)/schema.json --out sdk/java  --build gradle-nexus
 	cd sdk/java/ && \
 		echo "module fake_java_module // Exclude this directory from Go tools\n\ngo 1.17" > go.mod && \
 		gradle --console=plain build
 
-build_nodejs: VERSION := $(shell pulumictl get version --language javascript)
+build_nodejs: VERSION := $(shell pulumictl convert-version -l javascript -v "$(VERSION)")
 build_nodejs: upstream
 	$(WORKING_DIR)/bin/$(TFGEN) nodejs --out sdk/nodejs/
 	cd sdk/nodejs/ && \
@@ -59,7 +59,7 @@ build_nodejs: upstream
 		cp ../../README.md ../../LICENSE* package.json yarn.lock ./bin/ && \
 		sed -i.bak -e "s/\$${VERSION}/$(VERSION)/g" ./bin/package.json
 
-build_python: PYPI_VERSION := $(shell pulumictl get version --language python)
+build_python: PYPI_VERSION := $(shell pulumictl convert-version -l python -v "$(VERSION)")
 build_python: upstream
 	$(WORKING_DIR)/bin/$(TFGEN) python --out sdk/python/
 	cd sdk/python/ && \
@@ -119,7 +119,10 @@ upstream.finalize:
 upstream.rebase:
 	@$(SHELL) ./scripts/upstream.sh "$@" start_rebase
 
+version.generic:
+	@echo $(VERSION)
+
 bin/pulumi-java-gen:
 	$(shell pulumictl download-binary -n pulumi-language-java -v $(JAVA_GEN_VERSION) -r pulumi/pulumi-java)
 
-.PHONY: development build build_sdks install_go_sdk install_java_sdk install_python_sdk install_sdks only_build build_dotnet build_go build_java build_nodejs build_python clean cleanup help install_dotnet_sdk install_nodejs_sdk install_plugins lint_provider provider test tfgen upstream upstream.finalize upstream.rebase
+.PHONY: development build build_sdks install_go_sdk install_java_sdk install_python_sdk install_sdks only_build build_dotnet build_go build_java build_nodejs build_python clean cleanup help install_dotnet_sdk install_nodejs_sdk install_plugins lint_provider provider test tfgen upstream upstream.finalize upstream.rebase version.generic

--- a/provider-ci/providers/kong/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/kong/repo/.github/workflows/main.yml
@@ -90,7 +90,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version.generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -338,7 +338,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version.generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:

--- a/provider-ci/providers/kong/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/kong/repo/.github/workflows/main.yml
@@ -90,8 +90,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -339,8 +338,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(pulumictl get version --language generic)"
-        >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:

--- a/provider-ci/providers/kong/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/kong/repo/.github/workflows/master.yml
@@ -90,7 +90,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version.generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -338,7 +338,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version.generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:

--- a/provider-ci/providers/kong/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/kong/repo/.github/workflows/master.yml
@@ -90,8 +90,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -339,8 +338,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(pulumictl get version --language generic)"
-        >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:

--- a/provider-ci/providers/kong/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/kong/repo/.github/workflows/prerelease.yml
@@ -91,7 +91,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version.generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -288,7 +288,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version.generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:

--- a/provider-ci/providers/kong/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/kong/repo/.github/workflows/prerelease.yml
@@ -91,8 +91,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -289,8 +288,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(pulumictl get version --language generic)"
-        >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:

--- a/provider-ci/providers/kong/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/kong/repo/.github/workflows/release.yml
@@ -90,7 +90,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version.generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -301,7 +301,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version.generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:
@@ -344,8 +344,8 @@ jobs:
       with:
         repo: pulumi/pulumictl
     - name: Add SDK version tag
-      run: git tag sdk/v$(make version:generic) && git push origin sdk/v$(make
-        version:generic)
+      run: git tag sdk/v$(make version.generic) && git push origin sdk/v$(make
+        version.generic)
   test:
     name: test
     needs: build_sdk

--- a/provider-ci/providers/kong/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/kong/repo/.github/workflows/release.yml
@@ -90,8 +90,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -302,8 +301,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(pulumictl get version --language generic)"
-        >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:
@@ -346,8 +344,8 @@ jobs:
       with:
         repo: pulumi/pulumictl
     - name: Add SDK version tag
-      run: git tag sdk/v$(pulumictl get version --language generic) && git push origin
-        sdk/v$(pulumictl get version --language generic)
+      run: git tag sdk/v$(make version:generic) && git push origin sdk/v$(make
+        version:generic)
   test:
     name: test
     needs: build_sdk

--- a/provider-ci/providers/kong/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/kong/repo/.github/workflows/run-acceptance-tests.yml
@@ -95,7 +95,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version.generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean

--- a/provider-ci/providers/kong/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/kong/repo/.github/workflows/run-acceptance-tests.yml
@@ -95,8 +95,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean

--- a/provider-ci/providers/kong/repo/Makefile
+++ b/provider-ci/providers/kong/repo/Makefile
@@ -7,7 +7,7 @@ PROVIDER_PATH := provider/v4
 VERSION_PATH := $(PROVIDER_PATH)/pkg/version.Version
 TFGEN := pulumi-tfgen-$(PACK)
 PROVIDER := pulumi-resource-$(PACK)
-VERSION := $(shell pulumictl get version)
+VERSION := $(shell pulumictl get version --language generic)
 JAVA_GEN := pulumi-java-gen
 JAVA_GEN_VERSION := v0.5.4
 TESTPARALLELISM := 10
@@ -29,9 +29,9 @@ install_sdks: install_dotnet_sdk install_python_sdk install_nodejs_sdk install_j
 
 only_build: build
 
-build_dotnet: DOTNET_VERSION := $(shell pulumictl get version --language dotnet)
+build_dotnet: DOTNET_VERSION := $(shell pulumictl convert-version -l dotnet -v "$(VERSION)")
 build_dotnet: upstream
-	pulumictl get version --language dotnet
+	@echo $(DOTNET_VERSION)
 	$(WORKING_DIR)/bin/$(TFGEN) dotnet --out sdk/dotnet/
 	cd sdk/dotnet/ && \
 		echo "module fake_dotnet_module // Exclude this directory from Go tools\n\ngo 1.17" > go.mod && \
@@ -42,14 +42,14 @@ build_go: upstream
 	$(WORKING_DIR)/bin/$(TFGEN) go --out sdk/go/
 	cd sdk && go list `grep -e "^module" go.mod | cut -d ' ' -f 2`/go/... | xargs go build
 
-build_java: PACKAGE_VERSION := $(shell pulumictl get version --language generic)
+build_java: PACKAGE_VERSION := "$(VERSION)"
 build_java: bin/pulumi-java-gen upstream
 	$(WORKING_DIR)/bin/$(JAVA_GEN) generate --schema provider/cmd/$(PROVIDER)/schema.json --out sdk/java  --build gradle-nexus
 	cd sdk/java/ && \
 		echo "module fake_java_module // Exclude this directory from Go tools\n\ngo 1.17" > go.mod && \
 		gradle --console=plain build
 
-build_nodejs: VERSION := $(shell pulumictl get version --language javascript)
+build_nodejs: VERSION := $(shell pulumictl convert-version -l javascript -v "$(VERSION)")
 build_nodejs: upstream
 	$(WORKING_DIR)/bin/$(TFGEN) nodejs --out sdk/nodejs/
 	cd sdk/nodejs/ && \
@@ -59,7 +59,7 @@ build_nodejs: upstream
 		cp ../../README.md ../../LICENSE* package.json yarn.lock ./bin/ && \
 		sed -i.bak -e "s/\$${VERSION}/$(VERSION)/g" ./bin/package.json
 
-build_python: PYPI_VERSION := $(shell pulumictl get version --language python)
+build_python: PYPI_VERSION := $(shell pulumictl convert-version -l python -v "$(VERSION)")
 build_python: upstream
 	$(WORKING_DIR)/bin/$(TFGEN) python --out sdk/python/
 	cd sdk/python/ && \
@@ -118,7 +118,10 @@ upstream.finalize:
 upstream.rebase:
 	@$(SHELL) ./scripts/upstream.sh "$@" start_rebase
 
+version.generic:
+	@echo $(VERSION)
+
 bin/pulumi-java-gen:
 	$(shell pulumictl download-binary -n pulumi-language-java -v $(JAVA_GEN_VERSION) -r pulumi/pulumi-java)
 
-.PHONY: development build build_sdks install_go_sdk install_java_sdk install_python_sdk install_sdks only_build build_dotnet build_go build_java build_nodejs build_python clean cleanup help install_dotnet_sdk install_nodejs_sdk install_plugins lint_provider provider test tfgen upstream upstream.finalize upstream.rebase
+.PHONY: development build build_sdks install_go_sdk install_java_sdk install_python_sdk install_sdks only_build build_dotnet build_go build_java build_nodejs build_python clean cleanup help install_dotnet_sdk install_nodejs_sdk install_plugins lint_provider provider test tfgen upstream upstream.finalize upstream.rebase version.generic

--- a/provider-ci/providers/libvirt/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/libvirt/repo/.github/workflows/main.yml
@@ -91,7 +91,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version.generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -339,7 +339,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version.generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:

--- a/provider-ci/providers/libvirt/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/libvirt/repo/.github/workflows/main.yml
@@ -91,8 +91,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -340,8 +339,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(pulumictl get version --language generic)"
-        >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:

--- a/provider-ci/providers/libvirt/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/libvirt/repo/.github/workflows/master.yml
@@ -91,7 +91,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version.generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -339,7 +339,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version.generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:

--- a/provider-ci/providers/libvirt/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/libvirt/repo/.github/workflows/master.yml
@@ -91,8 +91,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -340,8 +339,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(pulumictl get version --language generic)"
-        >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:

--- a/provider-ci/providers/libvirt/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/libvirt/repo/.github/workflows/prerelease.yml
@@ -92,8 +92,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -290,8 +289,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(pulumictl get version --language generic)"
-        >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:

--- a/provider-ci/providers/libvirt/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/libvirt/repo/.github/workflows/prerelease.yml
@@ -92,7 +92,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version.generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -289,7 +289,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version.generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:

--- a/provider-ci/providers/libvirt/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/libvirt/repo/.github/workflows/release.yml
@@ -91,8 +91,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -303,8 +302,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(pulumictl get version --language generic)"
-        >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:
@@ -347,8 +345,8 @@ jobs:
       with:
         repo: pulumi/pulumictl
     - name: Add SDK version tag
-      run: git tag sdk/v$(pulumictl get version --language generic) && git push origin
-        sdk/v$(pulumictl get version --language generic)
+      run: git tag sdk/v$(make version:generic) && git push origin sdk/v$(make
+        version:generic)
   test:
     name: test
     needs: build_sdk

--- a/provider-ci/providers/libvirt/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/libvirt/repo/.github/workflows/release.yml
@@ -91,7 +91,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version.generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -302,7 +302,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version.generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:
@@ -345,8 +345,8 @@ jobs:
       with:
         repo: pulumi/pulumictl
     - name: Add SDK version tag
-      run: git tag sdk/v$(make version:generic) && git push origin sdk/v$(make
-        version:generic)
+      run: git tag sdk/v$(make version.generic) && git push origin sdk/v$(make
+        version.generic)
   test:
     name: test
     needs: build_sdk

--- a/provider-ci/providers/libvirt/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/libvirt/repo/.github/workflows/run-acceptance-tests.yml
@@ -96,7 +96,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version.generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean

--- a/provider-ci/providers/libvirt/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/libvirt/repo/.github/workflows/run-acceptance-tests.yml
@@ -96,8 +96,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean

--- a/provider-ci/providers/libvirt/repo/Makefile
+++ b/provider-ci/providers/libvirt/repo/Makefile
@@ -7,7 +7,7 @@ PROVIDER_PATH := provider
 VERSION_PATH := $(PROVIDER_PATH)/pkg/version.Version
 TFGEN := pulumi-tfgen-$(PACK)
 PROVIDER := pulumi-resource-$(PACK)
-VERSION := $(shell pulumictl get version)
+VERSION := $(shell pulumictl get version --language generic)
 JAVA_GEN := pulumi-java-gen
 JAVA_GEN_VERSION := v0.5.4
 TESTPARALLELISM := 10
@@ -29,9 +29,9 @@ install_sdks: install_dotnet_sdk install_python_sdk install_nodejs_sdk install_j
 
 only_build: build
 
-build_dotnet: DOTNET_VERSION := $(shell pulumictl get version --language dotnet)
+build_dotnet: DOTNET_VERSION := $(shell pulumictl convert-version -l dotnet -v "$(VERSION)")
 build_dotnet: upstream
-	pulumictl get version --language dotnet
+	@echo $(DOTNET_VERSION)
 	$(WORKING_DIR)/bin/$(TFGEN) dotnet --out sdk/dotnet/
 	cd sdk/dotnet/ && \
 		echo "module fake_dotnet_module // Exclude this directory from Go tools\n\ngo 1.17" > go.mod && \
@@ -42,14 +42,14 @@ build_go: upstream
 	$(WORKING_DIR)/bin/$(TFGEN) go --out sdk/go/
 	cd sdk && go list `grep -e "^module" go.mod | cut -d ' ' -f 2`/go/... | xargs go build
 
-build_java: PACKAGE_VERSION := $(shell pulumictl get version --language generic)
+build_java: PACKAGE_VERSION := "$(VERSION)"
 build_java: bin/pulumi-java-gen upstream
 	$(WORKING_DIR)/bin/$(JAVA_GEN) generate --schema provider/cmd/$(PROVIDER)/schema.json --out sdk/java  --build gradle-nexus
 	cd sdk/java/ && \
 		echo "module fake_java_module // Exclude this directory from Go tools\n\ngo 1.17" > go.mod && \
 		gradle --console=plain build
 
-build_nodejs: VERSION := $(shell pulumictl get version --language javascript)
+build_nodejs: VERSION := $(shell pulumictl convert-version -l javascript -v "$(VERSION)")
 build_nodejs: upstream
 	$(WORKING_DIR)/bin/$(TFGEN) nodejs --out sdk/nodejs/
 	cd sdk/nodejs/ && \
@@ -59,7 +59,7 @@ build_nodejs: upstream
 		cp ../../README.md ../../LICENSE* package.json yarn.lock ./bin/ && \
 		sed -i.bak -e "s/\$${VERSION}/$(VERSION)/g" ./bin/package.json
 
-build_python: PYPI_VERSION := $(shell pulumictl get version --language python)
+build_python: PYPI_VERSION := $(shell pulumictl convert-version -l python -v "$(VERSION)")
 build_python: upstream
 	$(WORKING_DIR)/bin/$(TFGEN) python --out sdk/python/
 	cd sdk/python/ && \
@@ -118,7 +118,10 @@ upstream.finalize:
 upstream.rebase:
 	@$(SHELL) ./scripts/upstream.sh "$@" start_rebase
 
+version.generic:
+	@echo $(VERSION)
+
 bin/pulumi-java-gen:
 	$(shell pulumictl download-binary -n pulumi-language-java -v $(JAVA_GEN_VERSION) -r pulumi/pulumi-java)
 
-.PHONY: development build build_sdks install_go_sdk install_java_sdk install_python_sdk install_sdks only_build build_dotnet build_go build_java build_nodejs build_python clean cleanup help install_dotnet_sdk install_nodejs_sdk install_plugins lint_provider provider test tfgen upstream upstream.finalize upstream.rebase
+.PHONY: development build build_sdks install_go_sdk install_java_sdk install_python_sdk install_sdks only_build build_dotnet build_go build_java build_nodejs build_python clean cleanup help install_dotnet_sdk install_nodejs_sdk install_plugins lint_provider provider test tfgen upstream upstream.finalize upstream.rebase version.generic

--- a/provider-ci/providers/linode/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/linode/repo/.github/workflows/main.yml
@@ -91,7 +91,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version.generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -339,7 +339,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version.generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:

--- a/provider-ci/providers/linode/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/linode/repo/.github/workflows/main.yml
@@ -91,8 +91,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -340,8 +339,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(pulumictl get version --language generic)"
-        >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:

--- a/provider-ci/providers/linode/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/linode/repo/.github/workflows/master.yml
@@ -91,7 +91,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version.generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -339,7 +339,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version.generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:

--- a/provider-ci/providers/linode/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/linode/repo/.github/workflows/master.yml
@@ -91,8 +91,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -340,8 +339,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(pulumictl get version --language generic)"
-        >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:

--- a/provider-ci/providers/linode/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/linode/repo/.github/workflows/prerelease.yml
@@ -92,8 +92,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -290,8 +289,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(pulumictl get version --language generic)"
-        >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:

--- a/provider-ci/providers/linode/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/linode/repo/.github/workflows/prerelease.yml
@@ -92,7 +92,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version.generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -289,7 +289,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version.generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:

--- a/provider-ci/providers/linode/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/linode/repo/.github/workflows/release.yml
@@ -91,8 +91,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -303,8 +302,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(pulumictl get version --language generic)"
-        >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:
@@ -347,8 +345,8 @@ jobs:
       with:
         repo: pulumi/pulumictl
     - name: Add SDK version tag
-      run: git tag sdk/v$(pulumictl get version --language generic) && git push origin
-        sdk/v$(pulumictl get version --language generic)
+      run: git tag sdk/v$(make version:generic) && git push origin sdk/v$(make
+        version:generic)
   test:
     name: test
     needs: build_sdk

--- a/provider-ci/providers/linode/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/linode/repo/.github/workflows/release.yml
@@ -91,7 +91,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version.generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -302,7 +302,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version.generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:
@@ -345,8 +345,8 @@ jobs:
       with:
         repo: pulumi/pulumictl
     - name: Add SDK version tag
-      run: git tag sdk/v$(make version:generic) && git push origin sdk/v$(make
-        version:generic)
+      run: git tag sdk/v$(make version.generic) && git push origin sdk/v$(make
+        version.generic)
   test:
     name: test
     needs: build_sdk

--- a/provider-ci/providers/linode/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/linode/repo/.github/workflows/run-acceptance-tests.yml
@@ -96,7 +96,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version.generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean

--- a/provider-ci/providers/linode/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/linode/repo/.github/workflows/run-acceptance-tests.yml
@@ -96,8 +96,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean

--- a/provider-ci/providers/linode/repo/Makefile
+++ b/provider-ci/providers/linode/repo/Makefile
@@ -7,7 +7,7 @@ PROVIDER_PATH := provider/v4
 VERSION_PATH := $(PROVIDER_PATH)/pkg/version.Version
 TFGEN := pulumi-tfgen-$(PACK)
 PROVIDER := pulumi-resource-$(PACK)
-VERSION := $(shell pulumictl get version)
+VERSION := $(shell pulumictl get version --language generic)
 JAVA_GEN := pulumi-java-gen
 JAVA_GEN_VERSION := v0.5.4
 TESTPARALLELISM := 10
@@ -29,9 +29,9 @@ install_sdks: install_dotnet_sdk install_python_sdk install_nodejs_sdk install_j
 
 only_build: build
 
-build_dotnet: DOTNET_VERSION := $(shell pulumictl get version --language dotnet)
+build_dotnet: DOTNET_VERSION := $(shell pulumictl convert-version -l dotnet -v "$(VERSION)")
 build_dotnet: upstream
-	pulumictl get version --language dotnet
+	@echo $(DOTNET_VERSION)
 	$(WORKING_DIR)/bin/$(TFGEN) dotnet --out sdk/dotnet/
 	cd sdk/dotnet/ && \
 		echo "module fake_dotnet_module // Exclude this directory from Go tools\n\ngo 1.17" > go.mod && \
@@ -42,14 +42,14 @@ build_go: upstream
 	$(WORKING_DIR)/bin/$(TFGEN) go --out sdk/go/
 	cd sdk && go list `grep -e "^module" go.mod | cut -d ' ' -f 2`/go/... | xargs go build
 
-build_java: PACKAGE_VERSION := $(shell pulumictl get version --language generic)
+build_java: PACKAGE_VERSION := "$(VERSION)"
 build_java: bin/pulumi-java-gen upstream
 	$(WORKING_DIR)/bin/$(JAVA_GEN) generate --schema provider/cmd/$(PROVIDER)/schema.json --out sdk/java  --build gradle-nexus
 	cd sdk/java/ && \
 		echo "module fake_java_module // Exclude this directory from Go tools\n\ngo 1.17" > go.mod && \
 		gradle --console=plain build
 
-build_nodejs: VERSION := $(shell pulumictl get version --language javascript)
+build_nodejs: VERSION := $(shell pulumictl convert-version -l javascript -v "$(VERSION)")
 build_nodejs: upstream
 	$(WORKING_DIR)/bin/$(TFGEN) nodejs --out sdk/nodejs/
 	cd sdk/nodejs/ && \
@@ -59,7 +59,7 @@ build_nodejs: upstream
 		cp ../../README.md ../../LICENSE* package.json yarn.lock ./bin/ && \
 		sed -i.bak -e "s/\$${VERSION}/$(VERSION)/g" ./bin/package.json
 
-build_python: PYPI_VERSION := $(shell pulumictl get version --language python)
+build_python: PYPI_VERSION := $(shell pulumictl convert-version -l python -v "$(VERSION)")
 build_python: upstream
 	$(WORKING_DIR)/bin/$(TFGEN) python --out sdk/python/
 	cd sdk/python/ && \
@@ -118,7 +118,10 @@ upstream.finalize:
 upstream.rebase:
 	@$(SHELL) ./scripts/upstream.sh "$@" start_rebase
 
+version.generic:
+	@echo $(VERSION)
+
 bin/pulumi-java-gen:
 	$(shell pulumictl download-binary -n pulumi-language-java -v $(JAVA_GEN_VERSION) -r pulumi/pulumi-java)
 
-.PHONY: development build build_sdks install_go_sdk install_java_sdk install_python_sdk install_sdks only_build build_dotnet build_go build_java build_nodejs build_python clean cleanup help install_dotnet_sdk install_nodejs_sdk install_plugins lint_provider provider test tfgen upstream upstream.finalize upstream.rebase
+.PHONY: development build build_sdks install_go_sdk install_java_sdk install_python_sdk install_sdks only_build build_dotnet build_go build_java build_nodejs build_python clean cleanup help install_dotnet_sdk install_nodejs_sdk install_plugins lint_provider provider test tfgen upstream upstream.finalize upstream.rebase version.generic

--- a/provider-ci/providers/mailgun/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/mailgun/repo/.github/workflows/main.yml
@@ -91,7 +91,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version.generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -339,7 +339,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version.generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:

--- a/provider-ci/providers/mailgun/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/mailgun/repo/.github/workflows/main.yml
@@ -91,8 +91,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -340,8 +339,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(pulumictl get version --language generic)"
-        >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:

--- a/provider-ci/providers/mailgun/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/mailgun/repo/.github/workflows/master.yml
@@ -91,7 +91,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version.generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -339,7 +339,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version.generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:

--- a/provider-ci/providers/mailgun/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/mailgun/repo/.github/workflows/master.yml
@@ -91,8 +91,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -340,8 +339,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(pulumictl get version --language generic)"
-        >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:

--- a/provider-ci/providers/mailgun/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/mailgun/repo/.github/workflows/prerelease.yml
@@ -92,8 +92,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -290,8 +289,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(pulumictl get version --language generic)"
-        >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:

--- a/provider-ci/providers/mailgun/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/mailgun/repo/.github/workflows/prerelease.yml
@@ -92,7 +92,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version.generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -289,7 +289,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version.generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:

--- a/provider-ci/providers/mailgun/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/mailgun/repo/.github/workflows/release.yml
@@ -91,8 +91,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -303,8 +302,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(pulumictl get version --language generic)"
-        >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:
@@ -347,8 +345,8 @@ jobs:
       with:
         repo: pulumi/pulumictl
     - name: Add SDK version tag
-      run: git tag sdk/v$(pulumictl get version --language generic) && git push origin
-        sdk/v$(pulumictl get version --language generic)
+      run: git tag sdk/v$(make version:generic) && git push origin sdk/v$(make
+        version:generic)
   test:
     name: test
     needs: build_sdk

--- a/provider-ci/providers/mailgun/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/mailgun/repo/.github/workflows/release.yml
@@ -91,7 +91,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version.generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -302,7 +302,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version.generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:
@@ -345,8 +345,8 @@ jobs:
       with:
         repo: pulumi/pulumictl
     - name: Add SDK version tag
-      run: git tag sdk/v$(make version:generic) && git push origin sdk/v$(make
-        version:generic)
+      run: git tag sdk/v$(make version.generic) && git push origin sdk/v$(make
+        version.generic)
   test:
     name: test
     needs: build_sdk

--- a/provider-ci/providers/mailgun/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/mailgun/repo/.github/workflows/run-acceptance-tests.yml
@@ -96,7 +96,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version.generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean

--- a/provider-ci/providers/mailgun/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/mailgun/repo/.github/workflows/run-acceptance-tests.yml
@@ -96,8 +96,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean

--- a/provider-ci/providers/mailgun/repo/Makefile
+++ b/provider-ci/providers/mailgun/repo/Makefile
@@ -7,7 +7,7 @@ PROVIDER_PATH := provider/v3
 VERSION_PATH := $(PROVIDER_PATH)/pkg/version.Version
 TFGEN := pulumi-tfgen-$(PACK)
 PROVIDER := pulumi-resource-$(PACK)
-VERSION := $(shell pulumictl get version)
+VERSION := $(shell pulumictl get version --language generic)
 JAVA_GEN := pulumi-java-gen
 JAVA_GEN_VERSION := v0.5.4
 TESTPARALLELISM := 10
@@ -29,9 +29,9 @@ install_sdks: install_dotnet_sdk install_python_sdk install_nodejs_sdk install_j
 
 only_build: build
 
-build_dotnet: DOTNET_VERSION := $(shell pulumictl get version --language dotnet)
+build_dotnet: DOTNET_VERSION := $(shell pulumictl convert-version -l dotnet -v "$(VERSION)")
 build_dotnet: upstream
-	pulumictl get version --language dotnet
+	@echo $(DOTNET_VERSION)
 	$(WORKING_DIR)/bin/$(TFGEN) dotnet --out sdk/dotnet/
 	cd sdk/dotnet/ && \
 		echo "module fake_dotnet_module // Exclude this directory from Go tools\n\ngo 1.17" > go.mod && \
@@ -42,14 +42,14 @@ build_go: upstream
 	$(WORKING_DIR)/bin/$(TFGEN) go --out sdk/go/
 	cd sdk && go list `grep -e "^module" go.mod | cut -d ' ' -f 2`/go/... | xargs go build
 
-build_java: PACKAGE_VERSION := $(shell pulumictl get version --language generic)
+build_java: PACKAGE_VERSION := "$(VERSION)"
 build_java: bin/pulumi-java-gen upstream
 	$(WORKING_DIR)/bin/$(JAVA_GEN) generate --schema provider/cmd/$(PROVIDER)/schema.json --out sdk/java  --build gradle-nexus
 	cd sdk/java/ && \
 		echo "module fake_java_module // Exclude this directory from Go tools\n\ngo 1.17" > go.mod && \
 		gradle --console=plain build
 
-build_nodejs: VERSION := $(shell pulumictl get version --language javascript)
+build_nodejs: VERSION := $(shell pulumictl convert-version -l javascript -v "$(VERSION)")
 build_nodejs: upstream
 	$(WORKING_DIR)/bin/$(TFGEN) nodejs --out sdk/nodejs/
 	cd sdk/nodejs/ && \
@@ -59,7 +59,7 @@ build_nodejs: upstream
 		cp ../../README.md ../../LICENSE* package.json yarn.lock ./bin/ && \
 		sed -i.bak -e "s/\$${VERSION}/$(VERSION)/g" ./bin/package.json
 
-build_python: PYPI_VERSION := $(shell pulumictl get version --language python)
+build_python: PYPI_VERSION := $(shell pulumictl convert-version -l python -v "$(VERSION)")
 build_python: upstream
 	$(WORKING_DIR)/bin/$(TFGEN) python --out sdk/python/
 	cd sdk/python/ && \
@@ -119,7 +119,10 @@ upstream.finalize:
 upstream.rebase:
 	@$(SHELL) ./scripts/upstream.sh "$@" start_rebase
 
+version.generic:
+	@echo $(VERSION)
+
 bin/pulumi-java-gen:
 	$(shell pulumictl download-binary -n pulumi-language-java -v $(JAVA_GEN_VERSION) -r pulumi/pulumi-java)
 
-.PHONY: development build build_sdks install_go_sdk install_java_sdk install_python_sdk install_sdks only_build build_dotnet build_go build_java build_nodejs build_python clean cleanup help install_dotnet_sdk install_nodejs_sdk install_plugins lint_provider provider test tfgen upstream upstream.finalize upstream.rebase
+.PHONY: development build build_sdks install_go_sdk install_java_sdk install_python_sdk install_sdks only_build build_dotnet build_go build_java build_nodejs build_python clean cleanup help install_dotnet_sdk install_nodejs_sdk install_plugins lint_provider provider test tfgen upstream upstream.finalize upstream.rebase version.generic

--- a/provider-ci/providers/minio/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/minio/repo/.github/workflows/main.yml
@@ -94,7 +94,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version.generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -342,7 +342,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version.generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:

--- a/provider-ci/providers/minio/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/minio/repo/.github/workflows/main.yml
@@ -94,8 +94,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -343,8 +342,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(pulumictl get version --language generic)"
-        >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:

--- a/provider-ci/providers/minio/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/minio/repo/.github/workflows/master.yml
@@ -94,7 +94,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version.generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -342,7 +342,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version.generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:

--- a/provider-ci/providers/minio/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/minio/repo/.github/workflows/master.yml
@@ -94,8 +94,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -343,8 +342,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(pulumictl get version --language generic)"
-        >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:

--- a/provider-ci/providers/minio/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/minio/repo/.github/workflows/prerelease.yml
@@ -95,8 +95,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -293,8 +292,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(pulumictl get version --language generic)"
-        >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:

--- a/provider-ci/providers/minio/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/minio/repo/.github/workflows/prerelease.yml
@@ -95,7 +95,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version.generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -292,7 +292,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version.generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:

--- a/provider-ci/providers/minio/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/minio/repo/.github/workflows/release.yml
@@ -94,8 +94,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -306,8 +305,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(pulumictl get version --language generic)"
-        >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:
@@ -350,8 +348,8 @@ jobs:
       with:
         repo: pulumi/pulumictl
     - name: Add SDK version tag
-      run: git tag sdk/v$(pulumictl get version --language generic) && git push origin
-        sdk/v$(pulumictl get version --language generic)
+      run: git tag sdk/v$(make version:generic) && git push origin sdk/v$(make
+        version:generic)
   test:
     name: test
     needs: build_sdk

--- a/provider-ci/providers/minio/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/minio/repo/.github/workflows/release.yml
@@ -94,7 +94,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version.generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -305,7 +305,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version.generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:
@@ -348,8 +348,8 @@ jobs:
       with:
         repo: pulumi/pulumictl
     - name: Add SDK version tag
-      run: git tag sdk/v$(make version:generic) && git push origin sdk/v$(make
-        version:generic)
+      run: git tag sdk/v$(make version.generic) && git push origin sdk/v$(make
+        version.generic)
   test:
     name: test
     needs: build_sdk

--- a/provider-ci/providers/minio/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/minio/repo/.github/workflows/run-acceptance-tests.yml
@@ -99,8 +99,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean

--- a/provider-ci/providers/minio/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/minio/repo/.github/workflows/run-acceptance-tests.yml
@@ -99,7 +99,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version.generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean

--- a/provider-ci/providers/minio/repo/Makefile
+++ b/provider-ci/providers/minio/repo/Makefile
@@ -7,7 +7,7 @@ PROVIDER_PATH := provider
 VERSION_PATH := $(PROVIDER_PATH)/pkg/version.Version
 TFGEN := pulumi-tfgen-$(PACK)
 PROVIDER := pulumi-resource-$(PACK)
-VERSION := $(shell pulumictl get version)
+VERSION := $(shell pulumictl get version --language generic)
 JAVA_GEN := pulumi-java-gen
 JAVA_GEN_VERSION := v0.5.4
 TESTPARALLELISM := 10
@@ -29,9 +29,9 @@ install_sdks: install_dotnet_sdk install_python_sdk install_nodejs_sdk install_j
 
 only_build: build
 
-build_dotnet: DOTNET_VERSION := $(shell pulumictl get version --language dotnet)
+build_dotnet: DOTNET_VERSION := $(shell pulumictl convert-version -l dotnet -v "$(VERSION)")
 build_dotnet: upstream
-	pulumictl get version --language dotnet
+	@echo $(DOTNET_VERSION)
 	$(WORKING_DIR)/bin/$(TFGEN) dotnet --out sdk/dotnet/
 	cd sdk/dotnet/ && \
 		echo "module fake_dotnet_module // Exclude this directory from Go tools\n\ngo 1.17" > go.mod && \
@@ -42,14 +42,14 @@ build_go: upstream
 	$(WORKING_DIR)/bin/$(TFGEN) go --out sdk/go/
 	cd sdk && go list `grep -e "^module" go.mod | cut -d ' ' -f 2`/go/... | xargs go build
 
-build_java: PACKAGE_VERSION := $(shell pulumictl get version --language generic)
+build_java: PACKAGE_VERSION := "$(VERSION)"
 build_java: bin/pulumi-java-gen upstream
 	$(WORKING_DIR)/bin/$(JAVA_GEN) generate --schema provider/cmd/$(PROVIDER)/schema.json --out sdk/java  --build gradle-nexus
 	cd sdk/java/ && \
 		echo "module fake_java_module // Exclude this directory from Go tools\n\ngo 1.17" > go.mod && \
 		gradle --console=plain build
 
-build_nodejs: VERSION := $(shell pulumictl get version --language javascript)
+build_nodejs: VERSION := $(shell pulumictl convert-version -l javascript -v "$(VERSION)")
 build_nodejs: upstream
 	$(WORKING_DIR)/bin/$(TFGEN) nodejs --out sdk/nodejs/
 	cd sdk/nodejs/ && \
@@ -59,7 +59,7 @@ build_nodejs: upstream
 		cp ../../README.md ../../LICENSE* package.json yarn.lock ./bin/ && \
 		sed -i.bak -e "s/\$${VERSION}/$(VERSION)/g" ./bin/package.json
 
-build_python: PYPI_VERSION := $(shell pulumictl get version --language python)
+build_python: PYPI_VERSION := $(shell pulumictl convert-version -l python -v "$(VERSION)")
 build_python: upstream
 	$(WORKING_DIR)/bin/$(TFGEN) python --out sdk/python/
 	cd sdk/python/ && \
@@ -119,7 +119,10 @@ upstream.finalize:
 upstream.rebase:
 	@$(SHELL) ./scripts/upstream.sh "$@" start_rebase
 
+version.generic:
+	@echo $(VERSION)
+
 bin/pulumi-java-gen:
 	$(shell pulumictl download-binary -n pulumi-language-java -v $(JAVA_GEN_VERSION) -r pulumi/pulumi-java)
 
-.PHONY: development build build_sdks install_go_sdk install_java_sdk install_python_sdk install_sdks only_build build_dotnet build_go build_java build_nodejs build_python clean cleanup help install_dotnet_sdk install_nodejs_sdk install_plugins lint_provider provider test tfgen upstream upstream.finalize upstream.rebase
+.PHONY: development build build_sdks install_go_sdk install_java_sdk install_python_sdk install_sdks only_build build_dotnet build_go build_java build_nodejs build_python clean cleanup help install_dotnet_sdk install_nodejs_sdk install_plugins lint_provider provider test tfgen upstream upstream.finalize upstream.rebase version.generic

--- a/provider-ci/providers/mongodbatlas/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/mongodbatlas/repo/.github/workflows/main.yml
@@ -93,8 +93,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -342,8 +341,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(pulumictl get version --language generic)"
-        >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:

--- a/provider-ci/providers/mongodbatlas/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/mongodbatlas/repo/.github/workflows/main.yml
@@ -93,7 +93,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version.generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -341,7 +341,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version.generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:

--- a/provider-ci/providers/mongodbatlas/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/mongodbatlas/repo/.github/workflows/master.yml
@@ -93,8 +93,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -342,8 +341,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(pulumictl get version --language generic)"
-        >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:

--- a/provider-ci/providers/mongodbatlas/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/mongodbatlas/repo/.github/workflows/master.yml
@@ -93,7 +93,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version.generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -341,7 +341,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version.generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:

--- a/provider-ci/providers/mongodbatlas/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/mongodbatlas/repo/.github/workflows/prerelease.yml
@@ -94,7 +94,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version.generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -291,7 +291,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version.generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:

--- a/provider-ci/providers/mongodbatlas/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/mongodbatlas/repo/.github/workflows/prerelease.yml
@@ -94,8 +94,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -292,8 +291,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(pulumictl get version --language generic)"
-        >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:

--- a/provider-ci/providers/mongodbatlas/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/mongodbatlas/repo/.github/workflows/release.yml
@@ -93,7 +93,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version.generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -304,7 +304,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version.generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:
@@ -347,8 +347,8 @@ jobs:
       with:
         repo: pulumi/pulumictl
     - name: Add SDK version tag
-      run: git tag sdk/v$(make version:generic) && git push origin sdk/v$(make
-        version:generic)
+      run: git tag sdk/v$(make version.generic) && git push origin sdk/v$(make
+        version.generic)
   test:
     name: test
     needs: build_sdk

--- a/provider-ci/providers/mongodbatlas/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/mongodbatlas/repo/.github/workflows/release.yml
@@ -93,8 +93,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -305,8 +304,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(pulumictl get version --language generic)"
-        >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:
@@ -349,8 +347,8 @@ jobs:
       with:
         repo: pulumi/pulumictl
     - name: Add SDK version tag
-      run: git tag sdk/v$(pulumictl get version --language generic) && git push origin
-        sdk/v$(pulumictl get version --language generic)
+      run: git tag sdk/v$(make version:generic) && git push origin sdk/v$(make
+        version:generic)
   test:
     name: test
     needs: build_sdk

--- a/provider-ci/providers/mongodbatlas/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/mongodbatlas/repo/.github/workflows/run-acceptance-tests.yml
@@ -98,8 +98,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean

--- a/provider-ci/providers/mongodbatlas/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/mongodbatlas/repo/.github/workflows/run-acceptance-tests.yml
@@ -98,7 +98,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version.generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean

--- a/provider-ci/providers/mongodbatlas/repo/Makefile
+++ b/provider-ci/providers/mongodbatlas/repo/Makefile
@@ -7,7 +7,7 @@ PROVIDER_PATH := provider/v3
 VERSION_PATH := $(PROVIDER_PATH)/pkg/version.Version
 TFGEN := pulumi-tfgen-$(PACK)
 PROVIDER := pulumi-resource-$(PACK)
-VERSION := $(shell pulumictl get version)
+VERSION := $(shell pulumictl get version --language generic)
 JAVA_GEN := pulumi-java-gen
 JAVA_GEN_VERSION := v0.5.4
 TESTPARALLELISM := 10
@@ -29,9 +29,9 @@ install_sdks: install_dotnet_sdk install_python_sdk install_nodejs_sdk install_j
 
 only_build: build
 
-build_dotnet: DOTNET_VERSION := $(shell pulumictl get version --language dotnet)
+build_dotnet: DOTNET_VERSION := $(shell pulumictl convert-version -l dotnet -v "$(VERSION)")
 build_dotnet: upstream
-	pulumictl get version --language dotnet
+	@echo $(DOTNET_VERSION)
 	$(WORKING_DIR)/bin/$(TFGEN) dotnet --out sdk/dotnet/
 	cd sdk/dotnet/ && \
 		echo "module fake_dotnet_module // Exclude this directory from Go tools\n\ngo 1.17" > go.mod && \
@@ -42,14 +42,14 @@ build_go: upstream
 	$(WORKING_DIR)/bin/$(TFGEN) go --out sdk/go/
 	cd sdk && go list `grep -e "^module" go.mod | cut -d ' ' -f 2`/go/... | xargs go build
 
-build_java: PACKAGE_VERSION := $(shell pulumictl get version --language generic)
+build_java: PACKAGE_VERSION := "$(VERSION)"
 build_java: bin/pulumi-java-gen upstream
 	$(WORKING_DIR)/bin/$(JAVA_GEN) generate --schema provider/cmd/$(PROVIDER)/schema.json --out sdk/java  --build gradle-nexus
 	cd sdk/java/ && \
 		echo "module fake_java_module // Exclude this directory from Go tools\n\ngo 1.17" > go.mod && \
 		gradle --console=plain build
 
-build_nodejs: VERSION := $(shell pulumictl get version --language javascript)
+build_nodejs: VERSION := $(shell pulumictl convert-version -l javascript -v "$(VERSION)")
 build_nodejs: upstream
 	$(WORKING_DIR)/bin/$(TFGEN) nodejs --out sdk/nodejs/
 	cd sdk/nodejs/ && \
@@ -59,7 +59,7 @@ build_nodejs: upstream
 		cp ../../README.md ../../LICENSE* package.json yarn.lock ./bin/ && \
 		sed -i.bak -e "s/\$${VERSION}/$(VERSION)/g" ./bin/package.json
 
-build_python: PYPI_VERSION := $(shell pulumictl get version --language python)
+build_python: PYPI_VERSION := $(shell pulumictl convert-version -l python -v "$(VERSION)")
 build_python: upstream
 	$(WORKING_DIR)/bin/$(TFGEN) python --out sdk/python/
 	cd sdk/python/ && \
@@ -121,7 +121,10 @@ upstream.finalize:
 upstream.rebase:
 	@$(SHELL) ./scripts/upstream.sh "$@" start_rebase
 
+version.generic:
+	@echo $(VERSION)
+
 bin/pulumi-java-gen:
 	$(shell pulumictl download-binary -n pulumi-language-java -v $(JAVA_GEN_VERSION) -r pulumi/pulumi-java)
 
-.PHONY: development build build_sdks install_go_sdk install_java_sdk install_python_sdk install_sdks only_build build_dotnet build_go build_java build_nodejs build_python clean cleanup help install_dotnet_sdk install_nodejs_sdk install_plugins lint_provider provider test tfgen upstream upstream.finalize upstream.rebase
+.PHONY: development build build_sdks install_go_sdk install_java_sdk install_python_sdk install_sdks only_build build_dotnet build_go build_java build_nodejs build_python clean cleanup help install_dotnet_sdk install_nodejs_sdk install_plugins lint_provider provider test tfgen upstream upstream.finalize upstream.rebase version.generic

--- a/provider-ci/providers/mysql/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/mysql/repo/.github/workflows/main.yml
@@ -90,7 +90,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version.generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -338,7 +338,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version.generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:

--- a/provider-ci/providers/mysql/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/mysql/repo/.github/workflows/main.yml
@@ -90,8 +90,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -339,8 +338,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(pulumictl get version --language generic)"
-        >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:

--- a/provider-ci/providers/mysql/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/mysql/repo/.github/workflows/master.yml
@@ -90,7 +90,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version.generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -338,7 +338,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version.generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:

--- a/provider-ci/providers/mysql/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/mysql/repo/.github/workflows/master.yml
@@ -90,8 +90,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -339,8 +338,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(pulumictl get version --language generic)"
-        >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:

--- a/provider-ci/providers/mysql/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/mysql/repo/.github/workflows/prerelease.yml
@@ -91,7 +91,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version.generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -288,7 +288,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version.generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:

--- a/provider-ci/providers/mysql/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/mysql/repo/.github/workflows/prerelease.yml
@@ -91,8 +91,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -289,8 +288,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(pulumictl get version --language generic)"
-        >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:

--- a/provider-ci/providers/mysql/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/mysql/repo/.github/workflows/release.yml
@@ -90,7 +90,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version.generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -301,7 +301,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version.generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:
@@ -344,8 +344,8 @@ jobs:
       with:
         repo: pulumi/pulumictl
     - name: Add SDK version tag
-      run: git tag sdk/v$(make version:generic) && git push origin sdk/v$(make
-        version:generic)
+      run: git tag sdk/v$(make version.generic) && git push origin sdk/v$(make
+        version.generic)
   test:
     name: test
     needs: build_sdk

--- a/provider-ci/providers/mysql/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/mysql/repo/.github/workflows/release.yml
@@ -90,8 +90,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -302,8 +301,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(pulumictl get version --language generic)"
-        >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:
@@ -346,8 +344,8 @@ jobs:
       with:
         repo: pulumi/pulumictl
     - name: Add SDK version tag
-      run: git tag sdk/v$(pulumictl get version --language generic) && git push origin
-        sdk/v$(pulumictl get version --language generic)
+      run: git tag sdk/v$(make version:generic) && git push origin sdk/v$(make
+        version:generic)
   test:
     name: test
     needs: build_sdk

--- a/provider-ci/providers/mysql/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/mysql/repo/.github/workflows/run-acceptance-tests.yml
@@ -95,7 +95,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version.generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean

--- a/provider-ci/providers/mysql/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/mysql/repo/.github/workflows/run-acceptance-tests.yml
@@ -95,8 +95,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean

--- a/provider-ci/providers/mysql/repo/Makefile
+++ b/provider-ci/providers/mysql/repo/Makefile
@@ -7,7 +7,7 @@ PROVIDER_PATH := provider/v3
 VERSION_PATH := $(PROVIDER_PATH)/pkg/version.Version
 TFGEN := pulumi-tfgen-$(PACK)
 PROVIDER := pulumi-resource-$(PACK)
-VERSION := $(shell pulumictl get version)
+VERSION := $(shell pulumictl get version --language generic)
 JAVA_GEN := pulumi-java-gen
 JAVA_GEN_VERSION := v0.5.4
 TESTPARALLELISM := 10
@@ -29,9 +29,9 @@ install_sdks: install_dotnet_sdk install_python_sdk install_nodejs_sdk install_j
 
 only_build: build
 
-build_dotnet: DOTNET_VERSION := $(shell pulumictl get version --language dotnet)
+build_dotnet: DOTNET_VERSION := $(shell pulumictl convert-version -l dotnet -v "$(VERSION)")
 build_dotnet: upstream
-	pulumictl get version --language dotnet
+	@echo $(DOTNET_VERSION)
 	$(WORKING_DIR)/bin/$(TFGEN) dotnet --out sdk/dotnet/
 	cd sdk/dotnet/ && \
 		echo "module fake_dotnet_module // Exclude this directory from Go tools\n\ngo 1.17" > go.mod && \
@@ -42,14 +42,14 @@ build_go: upstream
 	$(WORKING_DIR)/bin/$(TFGEN) go --out sdk/go/
 	cd sdk && go list `grep -e "^module" go.mod | cut -d ' ' -f 2`/go/... | xargs go build
 
-build_java: PACKAGE_VERSION := $(shell pulumictl get version --language generic)
+build_java: PACKAGE_VERSION := "$(VERSION)"
 build_java: bin/pulumi-java-gen upstream
 	$(WORKING_DIR)/bin/$(JAVA_GEN) generate --schema provider/cmd/$(PROVIDER)/schema.json --out sdk/java  --build gradle-nexus
 	cd sdk/java/ && \
 		echo "module fake_java_module // Exclude this directory from Go tools\n\ngo 1.17" > go.mod && \
 		gradle --console=plain build
 
-build_nodejs: VERSION := $(shell pulumictl get version --language javascript)
+build_nodejs: VERSION := $(shell pulumictl convert-version -l javascript -v "$(VERSION)")
 build_nodejs: upstream
 	$(WORKING_DIR)/bin/$(TFGEN) nodejs --out sdk/nodejs/
 	cd sdk/nodejs/ && \
@@ -59,7 +59,7 @@ build_nodejs: upstream
 		cp ../../README.md ../../LICENSE* package.json yarn.lock ./bin/ && \
 		sed -i.bak -e "s/\$${VERSION}/$(VERSION)/g" ./bin/package.json
 
-build_python: PYPI_VERSION := $(shell pulumictl get version --language python)
+build_python: PYPI_VERSION := $(shell pulumictl convert-version -l python -v "$(VERSION)")
 build_python: upstream
 	$(WORKING_DIR)/bin/$(TFGEN) python --out sdk/python/
 	cd sdk/python/ && \
@@ -118,7 +118,10 @@ upstream.finalize:
 upstream.rebase:
 	@$(SHELL) ./scripts/upstream.sh "$@" start_rebase
 
+version.generic:
+	@echo $(VERSION)
+
 bin/pulumi-java-gen:
 	$(shell pulumictl download-binary -n pulumi-language-java -v $(JAVA_GEN_VERSION) -r pulumi/pulumi-java)
 
-.PHONY: development build build_sdks install_go_sdk install_java_sdk install_python_sdk install_sdks only_build build_dotnet build_go build_java build_nodejs build_python clean cleanup help install_dotnet_sdk install_nodejs_sdk install_plugins lint_provider provider test tfgen upstream upstream.finalize upstream.rebase
+.PHONY: development build build_sdks install_go_sdk install_java_sdk install_python_sdk install_sdks only_build build_dotnet build_go build_java build_nodejs build_python clean cleanup help install_dotnet_sdk install_nodejs_sdk install_plugins lint_provider provider test tfgen upstream upstream.finalize upstream.rebase version.generic

--- a/provider-ci/providers/newrelic/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/newrelic/repo/.github/workflows/main.yml
@@ -92,8 +92,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -341,8 +340,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(pulumictl get version --language generic)"
-        >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:

--- a/provider-ci/providers/newrelic/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/newrelic/repo/.github/workflows/main.yml
@@ -92,7 +92,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version.generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -340,7 +340,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version.generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:

--- a/provider-ci/providers/newrelic/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/newrelic/repo/.github/workflows/master.yml
@@ -92,8 +92,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -341,8 +340,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(pulumictl get version --language generic)"
-        >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:

--- a/provider-ci/providers/newrelic/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/newrelic/repo/.github/workflows/master.yml
@@ -92,7 +92,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version.generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -340,7 +340,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version.generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:

--- a/provider-ci/providers/newrelic/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/newrelic/repo/.github/workflows/prerelease.yml
@@ -93,8 +93,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -291,8 +290,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(pulumictl get version --language generic)"
-        >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:

--- a/provider-ci/providers/newrelic/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/newrelic/repo/.github/workflows/prerelease.yml
@@ -93,7 +93,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version.generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -290,7 +290,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version.generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:

--- a/provider-ci/providers/newrelic/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/newrelic/repo/.github/workflows/release.yml
@@ -92,7 +92,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version.generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -303,7 +303,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version.generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:
@@ -346,8 +346,8 @@ jobs:
       with:
         repo: pulumi/pulumictl
     - name: Add SDK version tag
-      run: git tag sdk/v$(make version:generic) && git push origin sdk/v$(make
-        version:generic)
+      run: git tag sdk/v$(make version.generic) && git push origin sdk/v$(make
+        version.generic)
   test:
     name: test
     needs: build_sdk

--- a/provider-ci/providers/newrelic/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/newrelic/repo/.github/workflows/release.yml
@@ -92,8 +92,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -304,8 +303,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(pulumictl get version --language generic)"
-        >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:
@@ -348,8 +346,8 @@ jobs:
       with:
         repo: pulumi/pulumictl
     - name: Add SDK version tag
-      run: git tag sdk/v$(pulumictl get version --language generic) && git push origin
-        sdk/v$(pulumictl get version --language generic)
+      run: git tag sdk/v$(make version:generic) && git push origin sdk/v$(make
+        version:generic)
   test:
     name: test
     needs: build_sdk

--- a/provider-ci/providers/newrelic/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/newrelic/repo/.github/workflows/run-acceptance-tests.yml
@@ -97,7 +97,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version.generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean

--- a/provider-ci/providers/newrelic/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/newrelic/repo/.github/workflows/run-acceptance-tests.yml
@@ -97,8 +97,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean

--- a/provider-ci/providers/newrelic/repo/Makefile
+++ b/provider-ci/providers/newrelic/repo/Makefile
@@ -7,7 +7,7 @@ PROVIDER_PATH := provider/v5
 VERSION_PATH := $(PROVIDER_PATH)/pkg/version.Version
 TFGEN := pulumi-tfgen-$(PACK)
 PROVIDER := pulumi-resource-$(PACK)
-VERSION := $(shell pulumictl get version)
+VERSION := $(shell pulumictl get version --language generic)
 JAVA_GEN := pulumi-java-gen
 JAVA_GEN_VERSION := v0.5.4
 TESTPARALLELISM := 10
@@ -29,9 +29,9 @@ install_sdks: install_dotnet_sdk install_python_sdk install_nodejs_sdk install_j
 
 only_build: build
 
-build_dotnet: DOTNET_VERSION := $(shell pulumictl get version --language dotnet)
+build_dotnet: DOTNET_VERSION := $(shell pulumictl convert-version -l dotnet -v "$(VERSION)")
 build_dotnet: upstream
-	pulumictl get version --language dotnet
+	@echo $(DOTNET_VERSION)
 	$(WORKING_DIR)/bin/$(TFGEN) dotnet --out sdk/dotnet/
 	cd sdk/dotnet/ && \
 		echo "module fake_dotnet_module // Exclude this directory from Go tools\n\ngo 1.17" > go.mod && \
@@ -42,14 +42,14 @@ build_go: upstream
 	$(WORKING_DIR)/bin/$(TFGEN) go --out sdk/go/
 	cd sdk && go list `grep -e "^module" go.mod | cut -d ' ' -f 2`/go/... | xargs go build
 
-build_java: PACKAGE_VERSION := $(shell pulumictl get version --language generic)
+build_java: PACKAGE_VERSION := "$(VERSION)"
 build_java: bin/pulumi-java-gen upstream
 	$(WORKING_DIR)/bin/$(JAVA_GEN) generate --schema provider/cmd/$(PROVIDER)/schema.json --out sdk/java  --build gradle-nexus
 	cd sdk/java/ && \
 		echo "module fake_java_module // Exclude this directory from Go tools\n\ngo 1.17" > go.mod && \
 		gradle --console=plain build
 
-build_nodejs: VERSION := $(shell pulumictl get version --language javascript)
+build_nodejs: VERSION := $(shell pulumictl convert-version -l javascript -v "$(VERSION)")
 build_nodejs: upstream
 	$(WORKING_DIR)/bin/$(TFGEN) nodejs --out sdk/nodejs/
 	cd sdk/nodejs/ && \
@@ -59,7 +59,7 @@ build_nodejs: upstream
 		cp ../../README.md ../../LICENSE* package.json yarn.lock ./bin/ && \
 		sed -i.bak -e "s/\$${VERSION}/$(VERSION)/g" ./bin/package.json
 
-build_python: PYPI_VERSION := $(shell pulumictl get version --language python)
+build_python: PYPI_VERSION := $(shell pulumictl convert-version -l python -v "$(VERSION)")
 build_python: upstream
 	$(WORKING_DIR)/bin/$(TFGEN) python --out sdk/python/
 	cd sdk/python/ && \
@@ -118,7 +118,10 @@ upstream.finalize:
 upstream.rebase:
 	@$(SHELL) ./scripts/upstream.sh "$@" start_rebase
 
+version.generic:
+	@echo $(VERSION)
+
 bin/pulumi-java-gen:
 	$(shell pulumictl download-binary -n pulumi-language-java -v $(JAVA_GEN_VERSION) -r pulumi/pulumi-java)
 
-.PHONY: development build build_sdks install_go_sdk install_java_sdk install_python_sdk install_sdks only_build build_dotnet build_go build_java build_nodejs build_python clean cleanup help install_dotnet_sdk install_nodejs_sdk install_plugins lint_provider provider test tfgen upstream upstream.finalize upstream.rebase
+.PHONY: development build build_sdks install_go_sdk install_java_sdk install_python_sdk install_sdks only_build build_dotnet build_go build_java build_nodejs build_python clean cleanup help install_dotnet_sdk install_nodejs_sdk install_plugins lint_provider provider test tfgen upstream upstream.finalize upstream.rebase version.generic

--- a/provider-ci/providers/nomad/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/nomad/repo/.github/workflows/main.yml
@@ -91,7 +91,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version.generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -339,7 +339,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version.generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:

--- a/provider-ci/providers/nomad/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/nomad/repo/.github/workflows/main.yml
@@ -91,8 +91,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -340,8 +339,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(pulumictl get version --language generic)"
-        >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:

--- a/provider-ci/providers/nomad/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/nomad/repo/.github/workflows/master.yml
@@ -91,7 +91,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version.generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -339,7 +339,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version.generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:

--- a/provider-ci/providers/nomad/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/nomad/repo/.github/workflows/master.yml
@@ -91,8 +91,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -340,8 +339,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(pulumictl get version --language generic)"
-        >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:

--- a/provider-ci/providers/nomad/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/nomad/repo/.github/workflows/prerelease.yml
@@ -92,8 +92,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -290,8 +289,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(pulumictl get version --language generic)"
-        >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:

--- a/provider-ci/providers/nomad/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/nomad/repo/.github/workflows/prerelease.yml
@@ -92,7 +92,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version.generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -289,7 +289,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version.generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:

--- a/provider-ci/providers/nomad/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/nomad/repo/.github/workflows/release.yml
@@ -91,8 +91,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -303,8 +302,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(pulumictl get version --language generic)"
-        >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:
@@ -347,8 +345,8 @@ jobs:
       with:
         repo: pulumi/pulumictl
     - name: Add SDK version tag
-      run: git tag sdk/v$(pulumictl get version --language generic) && git push origin
-        sdk/v$(pulumictl get version --language generic)
+      run: git tag sdk/v$(make version:generic) && git push origin sdk/v$(make
+        version:generic)
   test:
     name: test
     needs: build_sdk

--- a/provider-ci/providers/nomad/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/nomad/repo/.github/workflows/release.yml
@@ -91,7 +91,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version.generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -302,7 +302,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version.generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:
@@ -345,8 +345,8 @@ jobs:
       with:
         repo: pulumi/pulumictl
     - name: Add SDK version tag
-      run: git tag sdk/v$(make version:generic) && git push origin sdk/v$(make
-        version:generic)
+      run: git tag sdk/v$(make version.generic) && git push origin sdk/v$(make
+        version.generic)
   test:
     name: test
     needs: build_sdk

--- a/provider-ci/providers/nomad/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/nomad/repo/.github/workflows/run-acceptance-tests.yml
@@ -96,7 +96,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version.generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean

--- a/provider-ci/providers/nomad/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/nomad/repo/.github/workflows/run-acceptance-tests.yml
@@ -96,8 +96,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean

--- a/provider-ci/providers/nomad/repo/Makefile
+++ b/provider-ci/providers/nomad/repo/Makefile
@@ -7,7 +7,7 @@ PROVIDER_PATH := provider
 VERSION_PATH := $(PROVIDER_PATH)/pkg/version.Version
 TFGEN := pulumi-tfgen-$(PACK)
 PROVIDER := pulumi-resource-$(PACK)
-VERSION := $(shell pulumictl get version)
+VERSION := $(shell pulumictl get version --language generic)
 JAVA_GEN := pulumi-java-gen
 JAVA_GEN_VERSION := v0.5.4
 TESTPARALLELISM := 10
@@ -29,9 +29,9 @@ install_sdks: install_dotnet_sdk install_python_sdk install_nodejs_sdk install_j
 
 only_build: build
 
-build_dotnet: DOTNET_VERSION := $(shell pulumictl get version --language dotnet)
+build_dotnet: DOTNET_VERSION := $(shell pulumictl convert-version -l dotnet -v "$(VERSION)")
 build_dotnet: upstream
-	pulumictl get version --language dotnet
+	@echo $(DOTNET_VERSION)
 	$(WORKING_DIR)/bin/$(TFGEN) dotnet --out sdk/dotnet/
 	cd sdk/dotnet/ && \
 		echo "module fake_dotnet_module // Exclude this directory from Go tools\n\ngo 1.17" > go.mod && \
@@ -42,14 +42,14 @@ build_go: upstream
 	$(WORKING_DIR)/bin/$(TFGEN) go --out sdk/go/
 	cd sdk && go list `grep -e "^module" go.mod | cut -d ' ' -f 2`/go/... | xargs go build
 
-build_java: PACKAGE_VERSION := $(shell pulumictl get version --language generic)
+build_java: PACKAGE_VERSION := "$(VERSION)"
 build_java: bin/pulumi-java-gen upstream
 	$(WORKING_DIR)/bin/$(JAVA_GEN) generate --schema provider/cmd/$(PROVIDER)/schema.json --out sdk/java  --build gradle-nexus
 	cd sdk/java/ && \
 		echo "module fake_java_module // Exclude this directory from Go tools\n\ngo 1.17" > go.mod && \
 		gradle --console=plain build
 
-build_nodejs: VERSION := $(shell pulumictl get version --language javascript)
+build_nodejs: VERSION := $(shell pulumictl convert-version -l javascript -v "$(VERSION)")
 build_nodejs: upstream
 	$(WORKING_DIR)/bin/$(TFGEN) nodejs --out sdk/nodejs/
 	cd sdk/nodejs/ && \
@@ -59,7 +59,7 @@ build_nodejs: upstream
 		cp ../../README.md ../../LICENSE* package.json yarn.lock ./bin/ && \
 		sed -i.bak -e "s/\$${VERSION}/$(VERSION)/g" ./bin/package.json
 
-build_python: PYPI_VERSION := $(shell pulumictl get version --language python)
+build_python: PYPI_VERSION := $(shell pulumictl convert-version -l python -v "$(VERSION)")
 build_python: upstream
 	$(WORKING_DIR)/bin/$(TFGEN) python --out sdk/python/
 	cd sdk/python/ && \
@@ -119,7 +119,10 @@ upstream.finalize:
 upstream.rebase:
 	@$(SHELL) ./scripts/upstream.sh "$@" start_rebase
 
+version.generic:
+	@echo $(VERSION)
+
 bin/pulumi-java-gen:
 	$(shell pulumictl download-binary -n pulumi-language-java -v $(JAVA_GEN_VERSION) -r pulumi/pulumi-java)
 
-.PHONY: development build build_sdks install_go_sdk install_java_sdk install_python_sdk install_sdks only_build build_dotnet build_go build_java build_nodejs build_python clean cleanup help install_dotnet_sdk install_nodejs_sdk install_plugins lint_provider provider test tfgen upstream upstream.finalize upstream.rebase
+.PHONY: development build build_sdks install_go_sdk install_java_sdk install_python_sdk install_sdks only_build build_dotnet build_go build_java build_nodejs build_python clean cleanup help install_dotnet_sdk install_nodejs_sdk install_plugins lint_provider provider test tfgen upstream upstream.finalize upstream.rebase version.generic

--- a/provider-ci/providers/ns1/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/ns1/repo/.github/workflows/main.yml
@@ -91,7 +91,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version.generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -339,7 +339,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version.generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:

--- a/provider-ci/providers/ns1/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/ns1/repo/.github/workflows/main.yml
@@ -91,8 +91,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -340,8 +339,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(pulumictl get version --language generic)"
-        >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:

--- a/provider-ci/providers/ns1/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/ns1/repo/.github/workflows/master.yml
@@ -91,7 +91,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version.generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -339,7 +339,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version.generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:

--- a/provider-ci/providers/ns1/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/ns1/repo/.github/workflows/master.yml
@@ -91,8 +91,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -340,8 +339,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(pulumictl get version --language generic)"
-        >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:

--- a/provider-ci/providers/ns1/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/ns1/repo/.github/workflows/prerelease.yml
@@ -92,8 +92,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -290,8 +289,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(pulumictl get version --language generic)"
-        >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:

--- a/provider-ci/providers/ns1/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/ns1/repo/.github/workflows/prerelease.yml
@@ -92,7 +92,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version.generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -289,7 +289,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version.generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:

--- a/provider-ci/providers/ns1/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/ns1/repo/.github/workflows/release.yml
@@ -91,8 +91,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -303,8 +302,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(pulumictl get version --language generic)"
-        >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:
@@ -347,8 +345,8 @@ jobs:
       with:
         repo: pulumi/pulumictl
     - name: Add SDK version tag
-      run: git tag sdk/v$(pulumictl get version --language generic) && git push origin
-        sdk/v$(pulumictl get version --language generic)
+      run: git tag sdk/v$(make version:generic) && git push origin sdk/v$(make
+        version:generic)
   test:
     name: test
     needs: build_sdk

--- a/provider-ci/providers/ns1/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/ns1/repo/.github/workflows/release.yml
@@ -91,7 +91,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version.generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -302,7 +302,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version.generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:
@@ -345,8 +345,8 @@ jobs:
       with:
         repo: pulumi/pulumictl
     - name: Add SDK version tag
-      run: git tag sdk/v$(make version:generic) && git push origin sdk/v$(make
-        version:generic)
+      run: git tag sdk/v$(make version.generic) && git push origin sdk/v$(make
+        version.generic)
   test:
     name: test
     needs: build_sdk

--- a/provider-ci/providers/ns1/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/ns1/repo/.github/workflows/run-acceptance-tests.yml
@@ -96,7 +96,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version.generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean

--- a/provider-ci/providers/ns1/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/ns1/repo/.github/workflows/run-acceptance-tests.yml
@@ -96,8 +96,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean

--- a/provider-ci/providers/ns1/repo/Makefile
+++ b/provider-ci/providers/ns1/repo/Makefile
@@ -7,7 +7,7 @@ PROVIDER_PATH := provider/v3
 VERSION_PATH := $(PROVIDER_PATH)/pkg/version.Version
 TFGEN := pulumi-tfgen-$(PACK)
 PROVIDER := pulumi-resource-$(PACK)
-VERSION := $(shell pulumictl get version)
+VERSION := $(shell pulumictl get version --language generic)
 JAVA_GEN := pulumi-java-gen
 JAVA_GEN_VERSION := v0.5.4
 TESTPARALLELISM := 10
@@ -29,9 +29,9 @@ install_sdks: install_dotnet_sdk install_python_sdk install_nodejs_sdk install_j
 
 only_build: build
 
-build_dotnet: DOTNET_VERSION := $(shell pulumictl get version --language dotnet)
+build_dotnet: DOTNET_VERSION := $(shell pulumictl convert-version -l dotnet -v "$(VERSION)")
 build_dotnet: upstream
-	pulumictl get version --language dotnet
+	@echo $(DOTNET_VERSION)
 	$(WORKING_DIR)/bin/$(TFGEN) dotnet --out sdk/dotnet/
 	cd sdk/dotnet/ && \
 		echo "module fake_dotnet_module // Exclude this directory from Go tools\n\ngo 1.17" > go.mod && \
@@ -42,14 +42,14 @@ build_go: upstream
 	$(WORKING_DIR)/bin/$(TFGEN) go --out sdk/go/
 	cd sdk && go list `grep -e "^module" go.mod | cut -d ' ' -f 2`/go/... | xargs go build
 
-build_java: PACKAGE_VERSION := $(shell pulumictl get version --language generic)
+build_java: PACKAGE_VERSION := "$(VERSION)"
 build_java: bin/pulumi-java-gen upstream
 	$(WORKING_DIR)/bin/$(JAVA_GEN) generate --schema provider/cmd/$(PROVIDER)/schema.json --out sdk/java  --build gradle-nexus
 	cd sdk/java/ && \
 		echo "module fake_java_module // Exclude this directory from Go tools\n\ngo 1.17" > go.mod && \
 		gradle --console=plain build
 
-build_nodejs: VERSION := $(shell pulumictl get version --language javascript)
+build_nodejs: VERSION := $(shell pulumictl convert-version -l javascript -v "$(VERSION)")
 build_nodejs: upstream
 	$(WORKING_DIR)/bin/$(TFGEN) nodejs --out sdk/nodejs/
 	cd sdk/nodejs/ && \
@@ -59,7 +59,7 @@ build_nodejs: upstream
 		cp ../../README.md ../../LICENSE* package.json yarn.lock ./bin/ && \
 		sed -i.bak -e "s/\$${VERSION}/$(VERSION)/g" ./bin/package.json
 
-build_python: PYPI_VERSION := $(shell pulumictl get version --language python)
+build_python: PYPI_VERSION := $(shell pulumictl convert-version -l python -v "$(VERSION)")
 build_python: upstream
 	$(WORKING_DIR)/bin/$(TFGEN) python --out sdk/python/
 	cd sdk/python/ && \
@@ -118,7 +118,10 @@ upstream.finalize:
 upstream.rebase:
 	@$(SHELL) ./scripts/upstream.sh "$@" start_rebase
 
+version.generic:
+	@echo $(VERSION)
+
 bin/pulumi-java-gen:
 	$(shell pulumictl download-binary -n pulumi-language-java -v $(JAVA_GEN_VERSION) -r pulumi/pulumi-java)
 
-.PHONY: development build build_sdks install_go_sdk install_java_sdk install_python_sdk install_sdks only_build build_dotnet build_go build_java build_nodejs build_python clean cleanup help install_dotnet_sdk install_nodejs_sdk install_plugins lint_provider provider test tfgen upstream upstream.finalize upstream.rebase
+.PHONY: development build build_sdks install_go_sdk install_java_sdk install_python_sdk install_sdks only_build build_dotnet build_go build_java build_nodejs build_python clean cleanup help install_dotnet_sdk install_nodejs_sdk install_plugins lint_provider provider test tfgen upstream upstream.finalize upstream.rebase version.generic

--- a/provider-ci/providers/oci/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/oci/repo/.github/workflows/main.yml
@@ -94,8 +94,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -272,8 +271,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(pulumictl get version --language generic)"
-        >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:

--- a/provider-ci/providers/oci/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/oci/repo/.github/workflows/main.yml
@@ -94,7 +94,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version.generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -271,7 +271,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version.generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:

--- a/provider-ci/providers/oci/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/oci/repo/.github/workflows/master.yml
@@ -94,8 +94,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -272,8 +271,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(pulumictl get version --language generic)"
-        >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:

--- a/provider-ci/providers/oci/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/oci/repo/.github/workflows/master.yml
@@ -94,7 +94,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version.generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -271,7 +271,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version.generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:

--- a/provider-ci/providers/oci/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/oci/repo/.github/workflows/prerelease.yml
@@ -95,7 +95,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version.generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -221,7 +221,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version.generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:

--- a/provider-ci/providers/oci/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/oci/repo/.github/workflows/prerelease.yml
@@ -95,8 +95,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -222,8 +221,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(pulumictl get version --language generic)"
-        >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:

--- a/provider-ci/providers/oci/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/oci/repo/.github/workflows/release.yml
@@ -94,7 +94,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version.generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -234,7 +234,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version.generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:
@@ -277,8 +277,8 @@ jobs:
       with:
         repo: pulumi/pulumictl
     - name: Add SDK version tag
-      run: git tag sdk/v$(make version:generic) && git push origin sdk/v$(make
-        version:generic)
+      run: git tag sdk/v$(make version.generic) && git push origin sdk/v$(make
+        version.generic)
   test:
     name: test
     needs: build_sdk

--- a/provider-ci/providers/oci/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/oci/repo/.github/workflows/release.yml
@@ -94,8 +94,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -235,8 +234,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(pulumictl get version --language generic)"
-        >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:
@@ -279,8 +277,8 @@ jobs:
       with:
         repo: pulumi/pulumictl
     - name: Add SDK version tag
-      run: git tag sdk/v$(pulumictl get version --language generic) && git push origin
-        sdk/v$(pulumictl get version --language generic)
+      run: git tag sdk/v$(make version:generic) && git push origin sdk/v$(make
+        version:generic)
   test:
     name: test
     needs: build_sdk

--- a/provider-ci/providers/oci/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/oci/repo/.github/workflows/run-acceptance-tests.yml
@@ -99,8 +99,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean

--- a/provider-ci/providers/oci/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/oci/repo/.github/workflows/run-acceptance-tests.yml
@@ -99,7 +99,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version.generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean

--- a/provider-ci/providers/oci/repo/Makefile
+++ b/provider-ci/providers/oci/repo/Makefile
@@ -7,7 +7,7 @@ PROVIDER_PATH := provider
 VERSION_PATH := $(PROVIDER_PATH)/pkg/version.Version
 TFGEN := pulumi-tfgen-$(PACK)
 PROVIDER := pulumi-resource-$(PACK)
-VERSION := $(shell pulumictl get version)
+VERSION := $(shell pulumictl get version --language generic)
 JAVA_GEN := pulumi-java-gen
 JAVA_GEN_VERSION := v0.5.4
 TESTPARALLELISM := 10
@@ -30,9 +30,9 @@ install_sdks: install_dotnet_sdk install_python_sdk install_nodejs_sdk install_j
 
 only_build: build
 
-build_dotnet: DOTNET_VERSION := $(shell pulumictl get version --language dotnet)
+build_dotnet: DOTNET_VERSION := $(shell pulumictl convert-version -l dotnet -v "$(VERSION)")
 build_dotnet: upstream
-	pulumictl get version --language dotnet
+	@echo $(DOTNET_VERSION)
 	$(WORKING_DIR)/bin/$(TFGEN) dotnet --out sdk/dotnet/
 	cd sdk/dotnet/ && \
 		echo "module fake_dotnet_module // Exclude this directory from Go tools\n\ngo 1.17" > go.mod && \
@@ -43,14 +43,14 @@ build_go: upstream
 	$(WORKING_DIR)/bin/$(TFGEN) go --out sdk/go/
 	cd sdk && go list `grep -e "^module" go.mod | cut -d ' ' -f 2`/go/... | xargs go build
 
-build_java: PACKAGE_VERSION := $(shell pulumictl get version --language generic)
+build_java: PACKAGE_VERSION := "$(VERSION)"
 build_java: bin/pulumi-java-gen upstream
 	$(WORKING_DIR)/bin/$(JAVA_GEN) generate --schema provider/cmd/$(PROVIDER)/schema.json --out sdk/java  --build gradle-nexus
 	cd sdk/java/ && \
 		echo "module fake_java_module // Exclude this directory from Go tools\n\ngo 1.17" > go.mod && \
 		gradle --console=plain build
 
-build_nodejs: VERSION := $(shell pulumictl get version --language javascript)
+build_nodejs: VERSION := $(shell pulumictl convert-version -l javascript -v "$(VERSION)")
 build_nodejs: upstream
 	$(WORKING_DIR)/bin/$(TFGEN) nodejs --out sdk/nodejs/
 	cd sdk/nodejs/ && \
@@ -60,7 +60,7 @@ build_nodejs: upstream
 		cp ../../README.md ../../LICENSE* package.json yarn.lock ./bin/ && \
 		sed -i.bak -e "s/\$${VERSION}/$(VERSION)/g" ./bin/package.json
 
-build_python: PYPI_VERSION := $(shell pulumictl get version --language python)
+build_python: PYPI_VERSION := $(shell pulumictl convert-version -l python -v "$(VERSION)")
 build_python: upstream
 	$(WORKING_DIR)/bin/$(TFGEN) python --out sdk/python/
 	cd sdk/python/ && \
@@ -123,7 +123,10 @@ upstream.finalize:
 upstream.rebase:
 	@$(SHELL) ./scripts/upstream.sh "$@" start_rebase
 
+version.generic:
+	@echo $(VERSION)
+
 bin/pulumi-java-gen:
 	$(shell pulumictl download-binary -n pulumi-language-java -v $(JAVA_GEN_VERSION) -r pulumi/pulumi-java)
 
-.PHONY: development build build_sdks install_go_sdk install_java_sdk install_python_sdk install_sdks only_build build_dotnet build_go build_java build_nodejs build_python clean cleanup help install_dotnet_sdk install_nodejs_sdk install_plugins lint_provider provider test tfgen upstream upstream.finalize upstream.rebase
+.PHONY: development build build_sdks install_go_sdk install_java_sdk install_python_sdk install_sdks only_build build_dotnet build_go build_java build_nodejs build_python clean cleanup help install_dotnet_sdk install_nodejs_sdk install_plugins lint_provider provider test tfgen upstream upstream.finalize upstream.rebase version.generic

--- a/provider-ci/providers/okta/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/okta/repo/.github/workflows/main.yml
@@ -93,8 +93,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -342,8 +341,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(pulumictl get version --language generic)"
-        >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:

--- a/provider-ci/providers/okta/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/okta/repo/.github/workflows/main.yml
@@ -93,7 +93,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version.generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -341,7 +341,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version.generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:

--- a/provider-ci/providers/okta/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/okta/repo/.github/workflows/master.yml
@@ -93,8 +93,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -342,8 +341,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(pulumictl get version --language generic)"
-        >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:

--- a/provider-ci/providers/okta/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/okta/repo/.github/workflows/master.yml
@@ -93,7 +93,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version.generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -341,7 +341,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version.generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:

--- a/provider-ci/providers/okta/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/okta/repo/.github/workflows/prerelease.yml
@@ -94,7 +94,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version.generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -291,7 +291,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version.generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:

--- a/provider-ci/providers/okta/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/okta/repo/.github/workflows/prerelease.yml
@@ -94,8 +94,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -292,8 +291,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(pulumictl get version --language generic)"
-        >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:

--- a/provider-ci/providers/okta/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/okta/repo/.github/workflows/release.yml
@@ -93,7 +93,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version.generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -304,7 +304,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version.generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:
@@ -347,8 +347,8 @@ jobs:
       with:
         repo: pulumi/pulumictl
     - name: Add SDK version tag
-      run: git tag sdk/v$(make version:generic) && git push origin sdk/v$(make
-        version:generic)
+      run: git tag sdk/v$(make version.generic) && git push origin sdk/v$(make
+        version.generic)
   test:
     name: test
     needs: build_sdk

--- a/provider-ci/providers/okta/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/okta/repo/.github/workflows/release.yml
@@ -93,8 +93,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -305,8 +304,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(pulumictl get version --language generic)"
-        >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:
@@ -349,8 +347,8 @@ jobs:
       with:
         repo: pulumi/pulumictl
     - name: Add SDK version tag
-      run: git tag sdk/v$(pulumictl get version --language generic) && git push origin
-        sdk/v$(pulumictl get version --language generic)
+      run: git tag sdk/v$(make version:generic) && git push origin sdk/v$(make
+        version:generic)
   test:
     name: test
     needs: build_sdk

--- a/provider-ci/providers/okta/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/okta/repo/.github/workflows/run-acceptance-tests.yml
@@ -98,8 +98,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean

--- a/provider-ci/providers/okta/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/okta/repo/.github/workflows/run-acceptance-tests.yml
@@ -98,7 +98,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version.generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean

--- a/provider-ci/providers/okta/repo/Makefile
+++ b/provider-ci/providers/okta/repo/Makefile
@@ -7,7 +7,7 @@ PROVIDER_PATH := provider/v3
 VERSION_PATH := $(PROVIDER_PATH)/pkg/version.Version
 TFGEN := pulumi-tfgen-$(PACK)
 PROVIDER := pulumi-resource-$(PACK)
-VERSION := $(shell pulumictl get version)
+VERSION := $(shell pulumictl get version --language generic)
 JAVA_GEN := pulumi-java-gen
 JAVA_GEN_VERSION := v0.5.4
 TESTPARALLELISM := 10
@@ -29,9 +29,9 @@ install_sdks: install_dotnet_sdk install_python_sdk install_nodejs_sdk install_j
 
 only_build: build
 
-build_dotnet: DOTNET_VERSION := $(shell pulumictl get version --language dotnet)
+build_dotnet: DOTNET_VERSION := $(shell pulumictl convert-version -l dotnet -v "$(VERSION)")
 build_dotnet: upstream
-	pulumictl get version --language dotnet
+	@echo $(DOTNET_VERSION)
 	$(WORKING_DIR)/bin/$(TFGEN) dotnet --out sdk/dotnet/
 	cd sdk/dotnet/ && \
 		echo "module fake_dotnet_module // Exclude this directory from Go tools\n\ngo 1.17" > go.mod && \
@@ -42,14 +42,14 @@ build_go: upstream
 	$(WORKING_DIR)/bin/$(TFGEN) go --out sdk/go/
 	cd sdk && go list `grep -e "^module" go.mod | cut -d ' ' -f 2`/go/... | xargs go build
 
-build_java: PACKAGE_VERSION := $(shell pulumictl get version --language generic)
+build_java: PACKAGE_VERSION := "$(VERSION)"
 build_java: bin/pulumi-java-gen upstream
 	$(WORKING_DIR)/bin/$(JAVA_GEN) generate --schema provider/cmd/$(PROVIDER)/schema.json --out sdk/java  --build gradle-nexus
 	cd sdk/java/ && \
 		echo "module fake_java_module // Exclude this directory from Go tools\n\ngo 1.17" > go.mod && \
 		gradle --console=plain build
 
-build_nodejs: VERSION := $(shell pulumictl get version --language javascript)
+build_nodejs: VERSION := $(shell pulumictl convert-version -l javascript -v "$(VERSION)")
 build_nodejs: upstream
 	$(WORKING_DIR)/bin/$(TFGEN) nodejs --out sdk/nodejs/
 	cd sdk/nodejs/ && \
@@ -59,7 +59,7 @@ build_nodejs: upstream
 		cp ../../README.md ../../LICENSE* package.json yarn.lock ./bin/ && \
 		sed -i.bak -e "s/\$${VERSION}/$(VERSION)/g" ./bin/package.json
 
-build_python: PYPI_VERSION := $(shell pulumictl get version --language python)
+build_python: PYPI_VERSION := $(shell pulumictl convert-version -l python -v "$(VERSION)")
 build_python: upstream
 	$(WORKING_DIR)/bin/$(TFGEN) python --out sdk/python/
 	cd sdk/python/ && \
@@ -119,7 +119,10 @@ upstream.finalize:
 upstream.rebase:
 	@$(SHELL) ./scripts/upstream.sh "$@" start_rebase
 
+version.generic:
+	@echo $(VERSION)
+
 bin/pulumi-java-gen:
 	$(shell pulumictl download-binary -n pulumi-language-java -v $(JAVA_GEN_VERSION) -r pulumi/pulumi-java)
 
-.PHONY: development build build_sdks install_go_sdk install_java_sdk install_python_sdk install_sdks only_build build_dotnet build_go build_java build_nodejs build_python clean cleanup help install_dotnet_sdk install_nodejs_sdk install_plugins lint_provider provider test tfgen upstream upstream.finalize upstream.rebase
+.PHONY: development build build_sdks install_go_sdk install_java_sdk install_python_sdk install_sdks only_build build_dotnet build_go build_java build_nodejs build_python clean cleanup help install_dotnet_sdk install_nodejs_sdk install_plugins lint_provider provider test tfgen upstream upstream.finalize upstream.rebase version.generic

--- a/provider-ci/providers/onelogin/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/onelogin/repo/.github/workflows/main.yml
@@ -90,7 +90,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version.generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -338,7 +338,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version.generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:

--- a/provider-ci/providers/onelogin/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/onelogin/repo/.github/workflows/main.yml
@@ -90,8 +90,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -339,8 +338,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(pulumictl get version --language generic)"
-        >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:

--- a/provider-ci/providers/onelogin/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/onelogin/repo/.github/workflows/master.yml
@@ -90,7 +90,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version.generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -338,7 +338,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version.generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:

--- a/provider-ci/providers/onelogin/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/onelogin/repo/.github/workflows/master.yml
@@ -90,8 +90,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -339,8 +338,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(pulumictl get version --language generic)"
-        >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:

--- a/provider-ci/providers/onelogin/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/onelogin/repo/.github/workflows/prerelease.yml
@@ -91,7 +91,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version.generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -288,7 +288,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version.generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:

--- a/provider-ci/providers/onelogin/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/onelogin/repo/.github/workflows/prerelease.yml
@@ -91,8 +91,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -289,8 +288,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(pulumictl get version --language generic)"
-        >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:

--- a/provider-ci/providers/onelogin/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/onelogin/repo/.github/workflows/release.yml
@@ -90,7 +90,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version.generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -301,7 +301,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version.generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:
@@ -344,8 +344,8 @@ jobs:
       with:
         repo: pulumi/pulumictl
     - name: Add SDK version tag
-      run: git tag sdk/v$(make version:generic) && git push origin sdk/v$(make
-        version:generic)
+      run: git tag sdk/v$(make version.generic) && git push origin sdk/v$(make
+        version.generic)
   test:
     name: test
     needs: build_sdk

--- a/provider-ci/providers/onelogin/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/onelogin/repo/.github/workflows/release.yml
@@ -90,8 +90,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -302,8 +301,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(pulumictl get version --language generic)"
-        >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:
@@ -346,8 +344,8 @@ jobs:
       with:
         repo: pulumi/pulumictl
     - name: Add SDK version tag
-      run: git tag sdk/v$(pulumictl get version --language generic) && git push origin
-        sdk/v$(pulumictl get version --language generic)
+      run: git tag sdk/v$(make version:generic) && git push origin sdk/v$(make
+        version:generic)
   test:
     name: test
     needs: build_sdk

--- a/provider-ci/providers/onelogin/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/onelogin/repo/.github/workflows/run-acceptance-tests.yml
@@ -95,7 +95,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version.generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean

--- a/provider-ci/providers/onelogin/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/onelogin/repo/.github/workflows/run-acceptance-tests.yml
@@ -95,8 +95,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean

--- a/provider-ci/providers/onelogin/repo/Makefile
+++ b/provider-ci/providers/onelogin/repo/Makefile
@@ -7,7 +7,7 @@ PROVIDER_PATH := provider
 VERSION_PATH := $(PROVIDER_PATH)/pkg/version.Version
 TFGEN := pulumi-tfgen-$(PACK)
 PROVIDER := pulumi-resource-$(PACK)
-VERSION := $(shell pulumictl get version)
+VERSION := $(shell pulumictl get version --language generic)
 JAVA_GEN := pulumi-java-gen
 JAVA_GEN_VERSION := v0.5.4
 TESTPARALLELISM := 10
@@ -29,9 +29,9 @@ install_sdks: install_dotnet_sdk install_python_sdk install_nodejs_sdk install_j
 
 only_build: build
 
-build_dotnet: DOTNET_VERSION := $(shell pulumictl get version --language dotnet)
+build_dotnet: DOTNET_VERSION := $(shell pulumictl convert-version -l dotnet -v "$(VERSION)")
 build_dotnet: upstream
-	pulumictl get version --language dotnet
+	@echo $(DOTNET_VERSION)
 	$(WORKING_DIR)/bin/$(TFGEN) dotnet --out sdk/dotnet/
 	cd sdk/dotnet/ && \
 		echo "module fake_dotnet_module // Exclude this directory from Go tools\n\ngo 1.17" > go.mod && \
@@ -42,14 +42,14 @@ build_go: upstream
 	$(WORKING_DIR)/bin/$(TFGEN) go --out sdk/go/
 	cd sdk && go list `grep -e "^module" go.mod | cut -d ' ' -f 2`/go/... | xargs go build
 
-build_java: PACKAGE_VERSION := $(shell pulumictl get version --language generic)
+build_java: PACKAGE_VERSION := "$(VERSION)"
 build_java: bin/pulumi-java-gen upstream
 	$(WORKING_DIR)/bin/$(JAVA_GEN) generate --schema provider/cmd/$(PROVIDER)/schema.json --out sdk/java  --build gradle-nexus
 	cd sdk/java/ && \
 		echo "module fake_java_module // Exclude this directory from Go tools\n\ngo 1.17" > go.mod && \
 		gradle --console=plain build
 
-build_nodejs: VERSION := $(shell pulumictl get version --language javascript)
+build_nodejs: VERSION := $(shell pulumictl convert-version -l javascript -v "$(VERSION)")
 build_nodejs: upstream
 	$(WORKING_DIR)/bin/$(TFGEN) nodejs --out sdk/nodejs/
 	cd sdk/nodejs/ && \
@@ -59,7 +59,7 @@ build_nodejs: upstream
 		cp ../../README.md ../../LICENSE* package.json yarn.lock ./bin/ && \
 		sed -i.bak -e "s/\$${VERSION}/$(VERSION)/g" ./bin/package.json
 
-build_python: PYPI_VERSION := $(shell pulumictl get version --language python)
+build_python: PYPI_VERSION := $(shell pulumictl convert-version -l python -v "$(VERSION)")
 build_python: upstream
 	$(WORKING_DIR)/bin/$(TFGEN) python --out sdk/python/
 	cd sdk/python/ && \
@@ -119,7 +119,10 @@ upstream.finalize:
 upstream.rebase:
 	@$(SHELL) ./scripts/upstream.sh "$@" start_rebase
 
+version.generic:
+	@echo $(VERSION)
+
 bin/pulumi-java-gen:
 	$(shell pulumictl download-binary -n pulumi-language-java -v $(JAVA_GEN_VERSION) -r pulumi/pulumi-java)
 
-.PHONY: development build build_sdks install_go_sdk install_java_sdk install_python_sdk install_sdks only_build build_dotnet build_go build_java build_nodejs build_python clean cleanup help install_dotnet_sdk install_nodejs_sdk install_plugins lint_provider provider test tfgen upstream upstream.finalize upstream.rebase
+.PHONY: development build build_sdks install_go_sdk install_java_sdk install_python_sdk install_sdks only_build build_dotnet build_go build_java build_nodejs build_python clean cleanup help install_dotnet_sdk install_nodejs_sdk install_plugins lint_provider provider test tfgen upstream upstream.finalize upstream.rebase version.generic

--- a/provider-ci/providers/openstack/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/openstack/repo/.github/workflows/main.yml
@@ -99,8 +99,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -348,8 +347,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(pulumictl get version --language generic)"
-        >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:

--- a/provider-ci/providers/openstack/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/openstack/repo/.github/workflows/main.yml
@@ -99,7 +99,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version.generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -347,7 +347,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version.generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:

--- a/provider-ci/providers/openstack/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/openstack/repo/.github/workflows/master.yml
@@ -99,8 +99,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -348,8 +347,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(pulumictl get version --language generic)"
-        >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:

--- a/provider-ci/providers/openstack/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/openstack/repo/.github/workflows/master.yml
@@ -99,7 +99,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version.generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -347,7 +347,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version.generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:

--- a/provider-ci/providers/openstack/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/openstack/repo/.github/workflows/prerelease.yml
@@ -100,8 +100,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -298,8 +297,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(pulumictl get version --language generic)"
-        >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:

--- a/provider-ci/providers/openstack/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/openstack/repo/.github/workflows/prerelease.yml
@@ -100,7 +100,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version.generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -297,7 +297,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version.generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:

--- a/provider-ci/providers/openstack/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/openstack/repo/.github/workflows/release.yml
@@ -99,8 +99,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -311,8 +310,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(pulumictl get version --language generic)"
-        >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:
@@ -355,8 +353,8 @@ jobs:
       with:
         repo: pulumi/pulumictl
     - name: Add SDK version tag
-      run: git tag sdk/v$(pulumictl get version --language generic) && git push origin
-        sdk/v$(pulumictl get version --language generic)
+      run: git tag sdk/v$(make version:generic) && git push origin sdk/v$(make
+        version:generic)
   test:
     name: test
     needs: build_sdk

--- a/provider-ci/providers/openstack/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/openstack/repo/.github/workflows/release.yml
@@ -99,7 +99,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version.generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -310,7 +310,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version.generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:
@@ -353,8 +353,8 @@ jobs:
       with:
         repo: pulumi/pulumictl
     - name: Add SDK version tag
-      run: git tag sdk/v$(make version:generic) && git push origin sdk/v$(make
-        version:generic)
+      run: git tag sdk/v$(make version.generic) && git push origin sdk/v$(make
+        version.generic)
   test:
     name: test
     needs: build_sdk

--- a/provider-ci/providers/openstack/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/openstack/repo/.github/workflows/run-acceptance-tests.yml
@@ -104,8 +104,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean

--- a/provider-ci/providers/openstack/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/openstack/repo/.github/workflows/run-acceptance-tests.yml
@@ -104,7 +104,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version.generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean

--- a/provider-ci/providers/openstack/repo/Makefile
+++ b/provider-ci/providers/openstack/repo/Makefile
@@ -7,7 +7,7 @@ PROVIDER_PATH := provider/v3
 VERSION_PATH := $(PROVIDER_PATH)/pkg/version.Version
 TFGEN := pulumi-tfgen-$(PACK)
 PROVIDER := pulumi-resource-$(PACK)
-VERSION := $(shell pulumictl get version)
+VERSION := $(shell pulumictl get version --language generic)
 JAVA_GEN := pulumi-java-gen
 JAVA_GEN_VERSION := v0.5.4
 TESTPARALLELISM := 10
@@ -29,9 +29,9 @@ install_sdks: install_dotnet_sdk install_python_sdk install_nodejs_sdk install_j
 
 only_build: build
 
-build_dotnet: DOTNET_VERSION := $(shell pulumictl get version --language dotnet)
+build_dotnet: DOTNET_VERSION := $(shell pulumictl convert-version -l dotnet -v "$(VERSION)")
 build_dotnet: upstream
-	pulumictl get version --language dotnet
+	@echo $(DOTNET_VERSION)
 	$(WORKING_DIR)/bin/$(TFGEN) dotnet --out sdk/dotnet/
 	cd sdk/dotnet/ && \
 		echo "module fake_dotnet_module // Exclude this directory from Go tools\n\ngo 1.17" > go.mod && \
@@ -42,14 +42,14 @@ build_go: upstream
 	$(WORKING_DIR)/bin/$(TFGEN) go --out sdk/go/
 	cd sdk && go list `grep -e "^module" go.mod | cut -d ' ' -f 2`/go/... | xargs go build
 
-build_java: PACKAGE_VERSION := $(shell pulumictl get version --language generic)
+build_java: PACKAGE_VERSION := "$(VERSION)"
 build_java: bin/pulumi-java-gen upstream
 	$(WORKING_DIR)/bin/$(JAVA_GEN) generate --schema provider/cmd/$(PROVIDER)/schema.json --out sdk/java  --build gradle-nexus
 	cd sdk/java/ && \
 		echo "module fake_java_module // Exclude this directory from Go tools\n\ngo 1.17" > go.mod && \
 		gradle --console=plain build
 
-build_nodejs: VERSION := $(shell pulumictl get version --language javascript)
+build_nodejs: VERSION := $(shell pulumictl convert-version -l javascript -v "$(VERSION)")
 build_nodejs: upstream
 	$(WORKING_DIR)/bin/$(TFGEN) nodejs --out sdk/nodejs/
 	cd sdk/nodejs/ && \
@@ -59,7 +59,7 @@ build_nodejs: upstream
 		cp ../../README.md ../../LICENSE* package.json yarn.lock ./bin/ && \
 		sed -i.bak -e "s/\$${VERSION}/$(VERSION)/g" ./bin/package.json
 
-build_python: PYPI_VERSION := $(shell pulumictl get version --language python)
+build_python: PYPI_VERSION := $(shell pulumictl convert-version -l python -v "$(VERSION)")
 build_python: upstream
 	$(WORKING_DIR)/bin/$(TFGEN) python --out sdk/python/
 	cd sdk/python/ && \
@@ -118,7 +118,10 @@ upstream.finalize:
 upstream.rebase:
 	@$(SHELL) ./scripts/upstream.sh "$@" start_rebase
 
+version.generic:
+	@echo $(VERSION)
+
 bin/pulumi-java-gen:
 	$(shell pulumictl download-binary -n pulumi-language-java -v $(JAVA_GEN_VERSION) -r pulumi/pulumi-java)
 
-.PHONY: development build build_sdks install_go_sdk install_java_sdk install_python_sdk install_sdks only_build build_dotnet build_go build_java build_nodejs build_python clean cleanup help install_dotnet_sdk install_nodejs_sdk install_plugins lint_provider provider test tfgen upstream upstream.finalize upstream.rebase
+.PHONY: development build build_sdks install_go_sdk install_java_sdk install_python_sdk install_sdks only_build build_dotnet build_go build_java build_nodejs build_python clean cleanup help install_dotnet_sdk install_nodejs_sdk install_plugins lint_provider provider test tfgen upstream upstream.finalize upstream.rebase version.generic

--- a/provider-ci/providers/opsgenie/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/opsgenie/repo/.github/workflows/main.yml
@@ -91,7 +91,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version.generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -339,7 +339,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version.generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:

--- a/provider-ci/providers/opsgenie/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/opsgenie/repo/.github/workflows/main.yml
@@ -91,8 +91,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -340,8 +339,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(pulumictl get version --language generic)"
-        >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:

--- a/provider-ci/providers/opsgenie/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/opsgenie/repo/.github/workflows/master.yml
@@ -91,7 +91,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version.generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -339,7 +339,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version.generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:

--- a/provider-ci/providers/opsgenie/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/opsgenie/repo/.github/workflows/master.yml
@@ -91,8 +91,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -340,8 +339,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(pulumictl get version --language generic)"
-        >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:

--- a/provider-ci/providers/opsgenie/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/opsgenie/repo/.github/workflows/prerelease.yml
@@ -92,8 +92,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -290,8 +289,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(pulumictl get version --language generic)"
-        >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:

--- a/provider-ci/providers/opsgenie/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/opsgenie/repo/.github/workflows/prerelease.yml
@@ -92,7 +92,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version.generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -289,7 +289,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version.generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:

--- a/provider-ci/providers/opsgenie/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/opsgenie/repo/.github/workflows/release.yml
@@ -91,8 +91,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -303,8 +302,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(pulumictl get version --language generic)"
-        >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:
@@ -347,8 +345,8 @@ jobs:
       with:
         repo: pulumi/pulumictl
     - name: Add SDK version tag
-      run: git tag sdk/v$(pulumictl get version --language generic) && git push origin
-        sdk/v$(pulumictl get version --language generic)
+      run: git tag sdk/v$(make version:generic) && git push origin sdk/v$(make
+        version:generic)
   test:
     name: test
     needs: build_sdk

--- a/provider-ci/providers/opsgenie/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/opsgenie/repo/.github/workflows/release.yml
@@ -91,7 +91,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version.generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -302,7 +302,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version.generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:
@@ -345,8 +345,8 @@ jobs:
       with:
         repo: pulumi/pulumictl
     - name: Add SDK version tag
-      run: git tag sdk/v$(make version:generic) && git push origin sdk/v$(make
-        version:generic)
+      run: git tag sdk/v$(make version.generic) && git push origin sdk/v$(make
+        version.generic)
   test:
     name: test
     needs: build_sdk

--- a/provider-ci/providers/opsgenie/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/opsgenie/repo/.github/workflows/run-acceptance-tests.yml
@@ -96,7 +96,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version.generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean

--- a/provider-ci/providers/opsgenie/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/opsgenie/repo/.github/workflows/run-acceptance-tests.yml
@@ -96,8 +96,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean

--- a/provider-ci/providers/opsgenie/repo/Makefile
+++ b/provider-ci/providers/opsgenie/repo/Makefile
@@ -7,7 +7,7 @@ PROVIDER_PATH := provider
 VERSION_PATH := $(PROVIDER_PATH)/pkg/version.Version
 TFGEN := pulumi-tfgen-$(PACK)
 PROVIDER := pulumi-resource-$(PACK)
-VERSION := $(shell pulumictl get version)
+VERSION := $(shell pulumictl get version --language generic)
 JAVA_GEN := pulumi-java-gen
 JAVA_GEN_VERSION := v0.5.4
 TESTPARALLELISM := 10
@@ -29,9 +29,9 @@ install_sdks: install_dotnet_sdk install_python_sdk install_nodejs_sdk install_j
 
 only_build: build
 
-build_dotnet: DOTNET_VERSION := $(shell pulumictl get version --language dotnet)
+build_dotnet: DOTNET_VERSION := $(shell pulumictl convert-version -l dotnet -v "$(VERSION)")
 build_dotnet: upstream
-	pulumictl get version --language dotnet
+	@echo $(DOTNET_VERSION)
 	$(WORKING_DIR)/bin/$(TFGEN) dotnet --out sdk/dotnet/
 	cd sdk/dotnet/ && \
 		echo "module fake_dotnet_module // Exclude this directory from Go tools\n\ngo 1.17" > go.mod && \
@@ -42,14 +42,14 @@ build_go: upstream
 	$(WORKING_DIR)/bin/$(TFGEN) go --out sdk/go/
 	cd sdk && go list `grep -e "^module" go.mod | cut -d ' ' -f 2`/go/... | xargs go build
 
-build_java: PACKAGE_VERSION := $(shell pulumictl get version --language generic)
+build_java: PACKAGE_VERSION := "$(VERSION)"
 build_java: bin/pulumi-java-gen upstream
 	$(WORKING_DIR)/bin/$(JAVA_GEN) generate --schema provider/cmd/$(PROVIDER)/schema.json --out sdk/java  --build gradle-nexus
 	cd sdk/java/ && \
 		echo "module fake_java_module // Exclude this directory from Go tools\n\ngo 1.17" > go.mod && \
 		gradle --console=plain build
 
-build_nodejs: VERSION := $(shell pulumictl get version --language javascript)
+build_nodejs: VERSION := $(shell pulumictl convert-version -l javascript -v "$(VERSION)")
 build_nodejs: upstream
 	$(WORKING_DIR)/bin/$(TFGEN) nodejs --out sdk/nodejs/
 	cd sdk/nodejs/ && \
@@ -59,7 +59,7 @@ build_nodejs: upstream
 		cp ../../README.md ../../LICENSE* package.json yarn.lock ./bin/ && \
 		sed -i.bak -e "s/\$${VERSION}/$(VERSION)/g" ./bin/package.json
 
-build_python: PYPI_VERSION := $(shell pulumictl get version --language python)
+build_python: PYPI_VERSION := $(shell pulumictl convert-version -l python -v "$(VERSION)")
 build_python: upstream
 	$(WORKING_DIR)/bin/$(TFGEN) python --out sdk/python/
 	cd sdk/python/ && \
@@ -118,7 +118,10 @@ upstream.finalize:
 upstream.rebase:
 	@$(SHELL) ./scripts/upstream.sh "$@" start_rebase
 
+version.generic:
+	@echo $(VERSION)
+
 bin/pulumi-java-gen:
 	$(shell pulumictl download-binary -n pulumi-language-java -v $(JAVA_GEN_VERSION) -r pulumi/pulumi-java)
 
-.PHONY: development build build_sdks install_go_sdk install_java_sdk install_python_sdk install_sdks only_build build_dotnet build_go build_java build_nodejs build_python clean cleanup help install_dotnet_sdk install_nodejs_sdk install_plugins lint_provider provider test tfgen upstream upstream.finalize upstream.rebase
+.PHONY: development build build_sdks install_go_sdk install_java_sdk install_python_sdk install_sdks only_build build_dotnet build_go build_java build_nodejs build_python clean cleanup help install_dotnet_sdk install_nodejs_sdk install_plugins lint_provider provider test tfgen upstream upstream.finalize upstream.rebase version.generic

--- a/provider-ci/providers/pagerduty/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/pagerduty/repo/.github/workflows/main.yml
@@ -91,7 +91,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version.generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -339,7 +339,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version.generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:

--- a/provider-ci/providers/pagerduty/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/pagerduty/repo/.github/workflows/main.yml
@@ -91,8 +91,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -340,8 +339,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(pulumictl get version --language generic)"
-        >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:

--- a/provider-ci/providers/pagerduty/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/pagerduty/repo/.github/workflows/master.yml
@@ -91,7 +91,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version.generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -339,7 +339,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version.generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:

--- a/provider-ci/providers/pagerduty/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/pagerduty/repo/.github/workflows/master.yml
@@ -91,8 +91,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -340,8 +339,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(pulumictl get version --language generic)"
-        >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:

--- a/provider-ci/providers/pagerduty/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/pagerduty/repo/.github/workflows/prerelease.yml
@@ -92,8 +92,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -290,8 +289,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(pulumictl get version --language generic)"
-        >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:

--- a/provider-ci/providers/pagerduty/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/pagerduty/repo/.github/workflows/prerelease.yml
@@ -92,7 +92,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version.generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -289,7 +289,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version.generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:

--- a/provider-ci/providers/pagerduty/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/pagerduty/repo/.github/workflows/release.yml
@@ -91,8 +91,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -303,8 +302,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(pulumictl get version --language generic)"
-        >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:
@@ -347,8 +345,8 @@ jobs:
       with:
         repo: pulumi/pulumictl
     - name: Add SDK version tag
-      run: git tag sdk/v$(pulumictl get version --language generic) && git push origin
-        sdk/v$(pulumictl get version --language generic)
+      run: git tag sdk/v$(make version:generic) && git push origin sdk/v$(make
+        version:generic)
   test:
     name: test
     needs: build_sdk

--- a/provider-ci/providers/pagerduty/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/pagerduty/repo/.github/workflows/release.yml
@@ -91,7 +91,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version.generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -302,7 +302,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version.generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:
@@ -345,8 +345,8 @@ jobs:
       with:
         repo: pulumi/pulumictl
     - name: Add SDK version tag
-      run: git tag sdk/v$(make version:generic) && git push origin sdk/v$(make
-        version:generic)
+      run: git tag sdk/v$(make version.generic) && git push origin sdk/v$(make
+        version.generic)
   test:
     name: test
     needs: build_sdk

--- a/provider-ci/providers/pagerduty/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/pagerduty/repo/.github/workflows/run-acceptance-tests.yml
@@ -96,7 +96,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version.generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean

--- a/provider-ci/providers/pagerduty/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/pagerduty/repo/.github/workflows/run-acceptance-tests.yml
@@ -96,8 +96,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean

--- a/provider-ci/providers/pagerduty/repo/Makefile
+++ b/provider-ci/providers/pagerduty/repo/Makefile
@@ -7,7 +7,7 @@ PROVIDER_PATH := provider/v3
 VERSION_PATH := $(PROVIDER_PATH)/pkg/version.Version
 TFGEN := pulumi-tfgen-$(PACK)
 PROVIDER := pulumi-resource-$(PACK)
-VERSION := $(shell pulumictl get version)
+VERSION := $(shell pulumictl get version --language generic)
 JAVA_GEN := pulumi-java-gen
 JAVA_GEN_VERSION := v0.5.4
 TESTPARALLELISM := 10
@@ -29,9 +29,9 @@ install_sdks: install_dotnet_sdk install_python_sdk install_nodejs_sdk install_j
 
 only_build: build
 
-build_dotnet: DOTNET_VERSION := $(shell pulumictl get version --language dotnet)
+build_dotnet: DOTNET_VERSION := $(shell pulumictl convert-version -l dotnet -v "$(VERSION)")
 build_dotnet: upstream
-	pulumictl get version --language dotnet
+	@echo $(DOTNET_VERSION)
 	$(WORKING_DIR)/bin/$(TFGEN) dotnet --out sdk/dotnet/
 	cd sdk/dotnet/ && \
 		echo "module fake_dotnet_module // Exclude this directory from Go tools\n\ngo 1.17" > go.mod && \
@@ -42,14 +42,14 @@ build_go: upstream
 	$(WORKING_DIR)/bin/$(TFGEN) go --out sdk/go/
 	cd sdk && go list `grep -e "^module" go.mod | cut -d ' ' -f 2`/go/... | xargs go build
 
-build_java: PACKAGE_VERSION := $(shell pulumictl get version --language generic)
+build_java: PACKAGE_VERSION := "$(VERSION)"
 build_java: bin/pulumi-java-gen upstream
 	$(WORKING_DIR)/bin/$(JAVA_GEN) generate --schema provider/cmd/$(PROVIDER)/schema.json --out sdk/java  --build gradle-nexus
 	cd sdk/java/ && \
 		echo "module fake_java_module // Exclude this directory from Go tools\n\ngo 1.17" > go.mod && \
 		gradle --console=plain build
 
-build_nodejs: VERSION := $(shell pulumictl get version --language javascript)
+build_nodejs: VERSION := $(shell pulumictl convert-version -l javascript -v "$(VERSION)")
 build_nodejs: upstream
 	$(WORKING_DIR)/bin/$(TFGEN) nodejs --out sdk/nodejs/
 	cd sdk/nodejs/ && \
@@ -59,7 +59,7 @@ build_nodejs: upstream
 		cp ../../README.md ../../LICENSE* package.json yarn.lock ./bin/ && \
 		sed -i.bak -e "s/\$${VERSION}/$(VERSION)/g" ./bin/package.json
 
-build_python: PYPI_VERSION := $(shell pulumictl get version --language python)
+build_python: PYPI_VERSION := $(shell pulumictl convert-version -l python -v "$(VERSION)")
 build_python: upstream
 	$(WORKING_DIR)/bin/$(TFGEN) python --out sdk/python/
 	cd sdk/python/ && \
@@ -118,7 +118,10 @@ upstream.finalize:
 upstream.rebase:
 	@$(SHELL) ./scripts/upstream.sh "$@" start_rebase
 
+version.generic:
+	@echo $(VERSION)
+
 bin/pulumi-java-gen:
 	$(shell pulumictl download-binary -n pulumi-language-java -v $(JAVA_GEN_VERSION) -r pulumi/pulumi-java)
 
-.PHONY: development build build_sdks install_go_sdk install_java_sdk install_python_sdk install_sdks only_build build_dotnet build_go build_java build_nodejs build_python clean cleanup help install_dotnet_sdk install_nodejs_sdk install_plugins lint_provider provider test tfgen upstream upstream.finalize upstream.rebase
+.PHONY: development build build_sdks install_go_sdk install_java_sdk install_python_sdk install_sdks only_build build_dotnet build_go build_java build_nodejs build_python clean cleanup help install_dotnet_sdk install_nodejs_sdk install_plugins lint_provider provider test tfgen upstream upstream.finalize upstream.rebase version.generic

--- a/provider-ci/providers/postgresql/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/postgresql/repo/.github/workflows/main.yml
@@ -90,7 +90,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version.generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -338,7 +338,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version.generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:

--- a/provider-ci/providers/postgresql/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/postgresql/repo/.github/workflows/main.yml
@@ -90,8 +90,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -339,8 +338,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(pulumictl get version --language generic)"
-        >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:

--- a/provider-ci/providers/postgresql/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/postgresql/repo/.github/workflows/master.yml
@@ -90,7 +90,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version.generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -338,7 +338,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version.generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:

--- a/provider-ci/providers/postgresql/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/postgresql/repo/.github/workflows/master.yml
@@ -90,8 +90,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -339,8 +338,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(pulumictl get version --language generic)"
-        >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:

--- a/provider-ci/providers/postgresql/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/postgresql/repo/.github/workflows/prerelease.yml
@@ -91,7 +91,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version.generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -288,7 +288,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version.generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:

--- a/provider-ci/providers/postgresql/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/postgresql/repo/.github/workflows/prerelease.yml
@@ -91,8 +91,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -289,8 +288,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(pulumictl get version --language generic)"
-        >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:

--- a/provider-ci/providers/postgresql/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/postgresql/repo/.github/workflows/release.yml
@@ -90,7 +90,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version.generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -301,7 +301,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version.generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:
@@ -344,8 +344,8 @@ jobs:
       with:
         repo: pulumi/pulumictl
     - name: Add SDK version tag
-      run: git tag sdk/v$(make version:generic) && git push origin sdk/v$(make
-        version:generic)
+      run: git tag sdk/v$(make version.generic) && git push origin sdk/v$(make
+        version.generic)
   test:
     name: test
     needs: build_sdk

--- a/provider-ci/providers/postgresql/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/postgresql/repo/.github/workflows/release.yml
@@ -90,8 +90,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -302,8 +301,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(pulumictl get version --language generic)"
-        >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:
@@ -346,8 +344,8 @@ jobs:
       with:
         repo: pulumi/pulumictl
     - name: Add SDK version tag
-      run: git tag sdk/v$(pulumictl get version --language generic) && git push origin
-        sdk/v$(pulumictl get version --language generic)
+      run: git tag sdk/v$(make version:generic) && git push origin sdk/v$(make
+        version:generic)
   test:
     name: test
     needs: build_sdk

--- a/provider-ci/providers/postgresql/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/postgresql/repo/.github/workflows/run-acceptance-tests.yml
@@ -95,7 +95,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version.generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean

--- a/provider-ci/providers/postgresql/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/postgresql/repo/.github/workflows/run-acceptance-tests.yml
@@ -95,8 +95,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean

--- a/provider-ci/providers/postgresql/repo/Makefile
+++ b/provider-ci/providers/postgresql/repo/Makefile
@@ -7,7 +7,7 @@ PROVIDER_PATH := provider/v3
 VERSION_PATH := $(PROVIDER_PATH)/pkg/version.Version
 TFGEN := pulumi-tfgen-$(PACK)
 PROVIDER := pulumi-resource-$(PACK)
-VERSION := $(shell pulumictl get version)
+VERSION := $(shell pulumictl get version --language generic)
 JAVA_GEN := pulumi-java-gen
 JAVA_GEN_VERSION := v0.5.4
 TESTPARALLELISM := 10
@@ -29,9 +29,9 @@ install_sdks: install_dotnet_sdk install_python_sdk install_nodejs_sdk install_j
 
 only_build: build
 
-build_dotnet: DOTNET_VERSION := $(shell pulumictl get version --language dotnet)
+build_dotnet: DOTNET_VERSION := $(shell pulumictl convert-version -l dotnet -v "$(VERSION)")
 build_dotnet: upstream
-	pulumictl get version --language dotnet
+	@echo $(DOTNET_VERSION)
 	$(WORKING_DIR)/bin/$(TFGEN) dotnet --out sdk/dotnet/
 	cd sdk/dotnet/ && \
 		echo "module fake_dotnet_module // Exclude this directory from Go tools\n\ngo 1.17" > go.mod && \
@@ -42,14 +42,14 @@ build_go: upstream
 	$(WORKING_DIR)/bin/$(TFGEN) go --out sdk/go/
 	cd sdk && go list `grep -e "^module" go.mod | cut -d ' ' -f 2`/go/... | xargs go build
 
-build_java: PACKAGE_VERSION := $(shell pulumictl get version --language generic)
+build_java: PACKAGE_VERSION := "$(VERSION)"
 build_java: bin/pulumi-java-gen upstream
 	$(WORKING_DIR)/bin/$(JAVA_GEN) generate --schema provider/cmd/$(PROVIDER)/schema.json --out sdk/java  --build gradle-nexus
 	cd sdk/java/ && \
 		echo "module fake_java_module // Exclude this directory from Go tools\n\ngo 1.17" > go.mod && \
 		gradle --console=plain build
 
-build_nodejs: VERSION := $(shell pulumictl get version --language javascript)
+build_nodejs: VERSION := $(shell pulumictl convert-version -l javascript -v "$(VERSION)")
 build_nodejs: upstream
 	$(WORKING_DIR)/bin/$(TFGEN) nodejs --out sdk/nodejs/
 	cd sdk/nodejs/ && \
@@ -59,7 +59,7 @@ build_nodejs: upstream
 		cp ../../README.md ../../LICENSE* package.json yarn.lock ./bin/ && \
 		sed -i.bak -e "s/\$${VERSION}/$(VERSION)/g" ./bin/package.json
 
-build_python: PYPI_VERSION := $(shell pulumictl get version --language python)
+build_python: PYPI_VERSION := $(shell pulumictl convert-version -l python -v "$(VERSION)")
 build_python: upstream
 	$(WORKING_DIR)/bin/$(TFGEN) python --out sdk/python/
 	cd sdk/python/ && \
@@ -118,7 +118,10 @@ upstream.finalize:
 upstream.rebase:
 	@$(SHELL) ./scripts/upstream.sh "$@" start_rebase
 
+version.generic:
+	@echo $(VERSION)
+
 bin/pulumi-java-gen:
 	$(shell pulumictl download-binary -n pulumi-language-java -v $(JAVA_GEN_VERSION) -r pulumi/pulumi-java)
 
-.PHONY: development build build_sdks install_go_sdk install_java_sdk install_python_sdk install_sdks only_build build_dotnet build_go build_java build_nodejs build_python clean cleanup help install_dotnet_sdk install_nodejs_sdk install_plugins lint_provider provider test tfgen upstream upstream.finalize upstream.rebase
+.PHONY: development build build_sdks install_go_sdk install_java_sdk install_python_sdk install_sdks only_build build_dotnet build_go build_java build_nodejs build_python clean cleanup help install_dotnet_sdk install_nodejs_sdk install_plugins lint_provider provider test tfgen upstream upstream.finalize upstream.rebase version.generic

--- a/provider-ci/providers/rabbitmq/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/rabbitmq/repo/.github/workflows/main.yml
@@ -90,7 +90,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version.generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -338,7 +338,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version.generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:

--- a/provider-ci/providers/rabbitmq/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/rabbitmq/repo/.github/workflows/main.yml
@@ -90,8 +90,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -339,8 +338,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(pulumictl get version --language generic)"
-        >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:

--- a/provider-ci/providers/rabbitmq/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/rabbitmq/repo/.github/workflows/master.yml
@@ -90,7 +90,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version.generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -338,7 +338,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version.generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:

--- a/provider-ci/providers/rabbitmq/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/rabbitmq/repo/.github/workflows/master.yml
@@ -90,8 +90,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -339,8 +338,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(pulumictl get version --language generic)"
-        >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:

--- a/provider-ci/providers/rabbitmq/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/rabbitmq/repo/.github/workflows/prerelease.yml
@@ -91,7 +91,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version.generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -288,7 +288,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version.generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:

--- a/provider-ci/providers/rabbitmq/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/rabbitmq/repo/.github/workflows/prerelease.yml
@@ -91,8 +91,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -289,8 +288,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(pulumictl get version --language generic)"
-        >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:

--- a/provider-ci/providers/rabbitmq/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/rabbitmq/repo/.github/workflows/release.yml
@@ -90,7 +90,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version.generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -301,7 +301,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version.generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:
@@ -344,8 +344,8 @@ jobs:
       with:
         repo: pulumi/pulumictl
     - name: Add SDK version tag
-      run: git tag sdk/v$(make version:generic) && git push origin sdk/v$(make
-        version:generic)
+      run: git tag sdk/v$(make version.generic) && git push origin sdk/v$(make
+        version.generic)
   test:
     name: test
     needs: build_sdk

--- a/provider-ci/providers/rabbitmq/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/rabbitmq/repo/.github/workflows/release.yml
@@ -90,8 +90,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -302,8 +301,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(pulumictl get version --language generic)"
-        >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:
@@ -346,8 +344,8 @@ jobs:
       with:
         repo: pulumi/pulumictl
     - name: Add SDK version tag
-      run: git tag sdk/v$(pulumictl get version --language generic) && git push origin
-        sdk/v$(pulumictl get version --language generic)
+      run: git tag sdk/v$(make version:generic) && git push origin sdk/v$(make
+        version:generic)
   test:
     name: test
     needs: build_sdk

--- a/provider-ci/providers/rabbitmq/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/rabbitmq/repo/.github/workflows/run-acceptance-tests.yml
@@ -95,7 +95,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version.generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean

--- a/provider-ci/providers/rabbitmq/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/rabbitmq/repo/.github/workflows/run-acceptance-tests.yml
@@ -95,8 +95,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean

--- a/provider-ci/providers/rabbitmq/repo/Makefile
+++ b/provider-ci/providers/rabbitmq/repo/Makefile
@@ -7,7 +7,7 @@ PROVIDER_PATH := provider/v3
 VERSION_PATH := $(PROVIDER_PATH)/pkg/version.Version
 TFGEN := pulumi-tfgen-$(PACK)
 PROVIDER := pulumi-resource-$(PACK)
-VERSION := $(shell pulumictl get version)
+VERSION := $(shell pulumictl get version --language generic)
 JAVA_GEN := pulumi-java-gen
 JAVA_GEN_VERSION := v0.5.4
 TESTPARALLELISM := 10
@@ -29,9 +29,9 @@ install_sdks: install_dotnet_sdk install_python_sdk install_nodejs_sdk install_j
 
 only_build: build
 
-build_dotnet: DOTNET_VERSION := $(shell pulumictl get version --language dotnet)
+build_dotnet: DOTNET_VERSION := $(shell pulumictl convert-version -l dotnet -v "$(VERSION)")
 build_dotnet: upstream
-	pulumictl get version --language dotnet
+	@echo $(DOTNET_VERSION)
 	$(WORKING_DIR)/bin/$(TFGEN) dotnet --out sdk/dotnet/
 	cd sdk/dotnet/ && \
 		echo "module fake_dotnet_module // Exclude this directory from Go tools\n\ngo 1.17" > go.mod && \
@@ -42,14 +42,14 @@ build_go: upstream
 	$(WORKING_DIR)/bin/$(TFGEN) go --out sdk/go/
 	cd sdk && go list `grep -e "^module" go.mod | cut -d ' ' -f 2`/go/... | xargs go build
 
-build_java: PACKAGE_VERSION := $(shell pulumictl get version --language generic)
+build_java: PACKAGE_VERSION := "$(VERSION)"
 build_java: bin/pulumi-java-gen upstream
 	$(WORKING_DIR)/bin/$(JAVA_GEN) generate --schema provider/cmd/$(PROVIDER)/schema.json --out sdk/java  --build gradle-nexus
 	cd sdk/java/ && \
 		echo "module fake_java_module // Exclude this directory from Go tools\n\ngo 1.17" > go.mod && \
 		gradle --console=plain build
 
-build_nodejs: VERSION := $(shell pulumictl get version --language javascript)
+build_nodejs: VERSION := $(shell pulumictl convert-version -l javascript -v "$(VERSION)")
 build_nodejs: upstream
 	$(WORKING_DIR)/bin/$(TFGEN) nodejs --out sdk/nodejs/
 	cd sdk/nodejs/ && \
@@ -59,7 +59,7 @@ build_nodejs: upstream
 		cp ../../README.md ../../LICENSE* package.json yarn.lock ./bin/ && \
 		sed -i.bak -e "s/\$${VERSION}/$(VERSION)/g" ./bin/package.json
 
-build_python: PYPI_VERSION := $(shell pulumictl get version --language python)
+build_python: PYPI_VERSION := $(shell pulumictl convert-version -l python -v "$(VERSION)")
 build_python: upstream
 	$(WORKING_DIR)/bin/$(TFGEN) python --out sdk/python/
 	cd sdk/python/ && \
@@ -118,7 +118,10 @@ upstream.finalize:
 upstream.rebase:
 	@$(SHELL) ./scripts/upstream.sh "$@" start_rebase
 
+version.generic:
+	@echo $(VERSION)
+
 bin/pulumi-java-gen:
 	$(shell pulumictl download-binary -n pulumi-language-java -v $(JAVA_GEN_VERSION) -r pulumi/pulumi-java)
 
-.PHONY: development build build_sdks install_go_sdk install_java_sdk install_python_sdk install_sdks only_build build_dotnet build_go build_java build_nodejs build_python clean cleanup help install_dotnet_sdk install_nodejs_sdk install_plugins lint_provider provider test tfgen upstream upstream.finalize upstream.rebase
+.PHONY: development build build_sdks install_go_sdk install_java_sdk install_python_sdk install_sdks only_build build_dotnet build_go build_java build_nodejs build_python clean cleanup help install_dotnet_sdk install_nodejs_sdk install_plugins lint_provider provider test tfgen upstream upstream.finalize upstream.rebase version.generic

--- a/provider-ci/providers/rancher2/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/rancher2/repo/.github/workflows/main.yml
@@ -92,7 +92,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version.generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -269,7 +269,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version.generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:

--- a/provider-ci/providers/rancher2/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/rancher2/repo/.github/workflows/main.yml
@@ -92,8 +92,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -270,8 +269,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(pulumictl get version --language generic)"
-        >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:

--- a/provider-ci/providers/rancher2/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/rancher2/repo/.github/workflows/master.yml
@@ -92,7 +92,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version.generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -269,7 +269,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version.generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:

--- a/provider-ci/providers/rancher2/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/rancher2/repo/.github/workflows/master.yml
@@ -92,8 +92,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -270,8 +269,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(pulumictl get version --language generic)"
-        >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:

--- a/provider-ci/providers/rancher2/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/rancher2/repo/.github/workflows/prerelease.yml
@@ -93,7 +93,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version.generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -219,7 +219,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version.generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:

--- a/provider-ci/providers/rancher2/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/rancher2/repo/.github/workflows/prerelease.yml
@@ -93,8 +93,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -220,8 +219,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(pulumictl get version --language generic)"
-        >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:

--- a/provider-ci/providers/rancher2/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/rancher2/repo/.github/workflows/release.yml
@@ -92,8 +92,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -233,8 +232,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(pulumictl get version --language generic)"
-        >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:
@@ -277,8 +275,8 @@ jobs:
       with:
         repo: pulumi/pulumictl
     - name: Add SDK version tag
-      run: git tag sdk/v$(pulumictl get version --language generic) && git push origin
-        sdk/v$(pulumictl get version --language generic)
+      run: git tag sdk/v$(make version:generic) && git push origin sdk/v$(make
+        version:generic)
   test:
     name: test
     needs: build_sdk

--- a/provider-ci/providers/rancher2/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/rancher2/repo/.github/workflows/release.yml
@@ -92,7 +92,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version.generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -232,7 +232,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version.generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:
@@ -275,8 +275,8 @@ jobs:
       with:
         repo: pulumi/pulumictl
     - name: Add SDK version tag
-      run: git tag sdk/v$(make version:generic) && git push origin sdk/v$(make
-        version:generic)
+      run: git tag sdk/v$(make version.generic) && git push origin sdk/v$(make
+        version.generic)
   test:
     name: test
     needs: build_sdk

--- a/provider-ci/providers/rancher2/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/rancher2/repo/.github/workflows/run-acceptance-tests.yml
@@ -97,7 +97,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version.generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean

--- a/provider-ci/providers/rancher2/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/rancher2/repo/.github/workflows/run-acceptance-tests.yml
@@ -97,8 +97,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean

--- a/provider-ci/providers/rancher2/repo/Makefile
+++ b/provider-ci/providers/rancher2/repo/Makefile
@@ -7,7 +7,7 @@ PROVIDER_PATH := provider/v4
 VERSION_PATH := $(PROVIDER_PATH)/pkg/version.Version
 TFGEN := pulumi-tfgen-$(PACK)
 PROVIDER := pulumi-resource-$(PACK)
-VERSION := $(shell pulumictl get version)
+VERSION := $(shell pulumictl get version --language generic)
 JAVA_GEN := pulumi-java-gen
 JAVA_GEN_VERSION := v0.5.4
 TESTPARALLELISM := 10
@@ -29,9 +29,9 @@ install_sdks: install_dotnet_sdk install_python_sdk install_nodejs_sdk install_j
 
 only_build: build
 
-build_dotnet: DOTNET_VERSION := $(shell pulumictl get version --language dotnet)
+build_dotnet: DOTNET_VERSION := $(shell pulumictl convert-version -l dotnet -v "$(VERSION)")
 build_dotnet: upstream
-	pulumictl get version --language dotnet
+	@echo $(DOTNET_VERSION)
 	$(WORKING_DIR)/bin/$(TFGEN) dotnet --out sdk/dotnet/
 	cd sdk/dotnet/ && \
 		echo "module fake_dotnet_module // Exclude this directory from Go tools\n\ngo 1.17" > go.mod && \
@@ -42,14 +42,14 @@ build_go: upstream
 	$(WORKING_DIR)/bin/$(TFGEN) go --out sdk/go/
 	cd sdk && go list `grep -e "^module" go.mod | cut -d ' ' -f 2`/go/... | xargs go build
 
-build_java: PACKAGE_VERSION := $(shell pulumictl get version --language generic)
+build_java: PACKAGE_VERSION := "$(VERSION)"
 build_java: bin/pulumi-java-gen upstream
 	$(WORKING_DIR)/bin/$(JAVA_GEN) generate --schema provider/cmd/$(PROVIDER)/schema.json --out sdk/java  --build gradle-nexus
 	cd sdk/java/ && \
 		echo "module fake_java_module // Exclude this directory from Go tools\n\ngo 1.17" > go.mod && \
 		gradle --console=plain build
 
-build_nodejs: VERSION := $(shell pulumictl get version --language javascript)
+build_nodejs: VERSION := $(shell pulumictl convert-version -l javascript -v "$(VERSION)")
 build_nodejs: upstream
 	$(WORKING_DIR)/bin/$(TFGEN) nodejs --out sdk/nodejs/
 	cd sdk/nodejs/ && \
@@ -59,7 +59,7 @@ build_nodejs: upstream
 		cp ../../README.md ../../LICENSE* package.json yarn.lock ./bin/ && \
 		sed -i.bak -e "s/\$${VERSION}/$(VERSION)/g" ./bin/package.json
 
-build_python: PYPI_VERSION := $(shell pulumictl get version --language python)
+build_python: PYPI_VERSION := $(shell pulumictl convert-version -l python -v "$(VERSION)")
 build_python: upstream
 	$(WORKING_DIR)/bin/$(TFGEN) python --out sdk/python/
 	cd sdk/python/ && \
@@ -118,7 +118,10 @@ upstream.finalize:
 upstream.rebase:
 	@$(SHELL) ./scripts/upstream.sh "$@" start_rebase
 
+version.generic:
+	@echo $(VERSION)
+
 bin/pulumi-java-gen:
 	$(shell pulumictl download-binary -n pulumi-language-java -v $(JAVA_GEN_VERSION) -r pulumi/pulumi-java)
 
-.PHONY: development build build_sdks install_go_sdk install_java_sdk install_python_sdk install_sdks only_build build_dotnet build_go build_java build_nodejs build_python clean cleanup help install_dotnet_sdk install_nodejs_sdk install_plugins lint_provider provider test tfgen upstream upstream.finalize upstream.rebase
+.PHONY: development build build_sdks install_go_sdk install_java_sdk install_python_sdk install_sdks only_build build_dotnet build_go build_java build_nodejs build_python clean cleanup help install_dotnet_sdk install_nodejs_sdk install_plugins lint_provider provider test tfgen upstream upstream.finalize upstream.rebase version.generic

--- a/provider-ci/providers/random/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/random/repo/.github/workflows/main.yml
@@ -90,7 +90,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version.generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -338,7 +338,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version.generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:

--- a/provider-ci/providers/random/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/random/repo/.github/workflows/main.yml
@@ -90,8 +90,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -339,8 +338,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(pulumictl get version --language generic)"
-        >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:

--- a/provider-ci/providers/random/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/random/repo/.github/workflows/master.yml
@@ -90,7 +90,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version.generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -338,7 +338,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version.generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:

--- a/provider-ci/providers/random/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/random/repo/.github/workflows/master.yml
@@ -90,8 +90,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -339,8 +338,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(pulumictl get version --language generic)"
-        >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:

--- a/provider-ci/providers/random/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/random/repo/.github/workflows/prerelease.yml
@@ -91,7 +91,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version.generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -288,7 +288,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version.generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:

--- a/provider-ci/providers/random/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/random/repo/.github/workflows/prerelease.yml
@@ -91,8 +91,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -289,8 +288,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(pulumictl get version --language generic)"
-        >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:

--- a/provider-ci/providers/random/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/random/repo/.github/workflows/release.yml
@@ -90,7 +90,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version.generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -301,7 +301,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version.generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:
@@ -344,8 +344,8 @@ jobs:
       with:
         repo: pulumi/pulumictl
     - name: Add SDK version tag
-      run: git tag sdk/v$(make version:generic) && git push origin sdk/v$(make
-        version:generic)
+      run: git tag sdk/v$(make version.generic) && git push origin sdk/v$(make
+        version.generic)
   test:
     name: test
     needs: build_sdk

--- a/provider-ci/providers/random/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/random/repo/.github/workflows/release.yml
@@ -90,8 +90,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -302,8 +301,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(pulumictl get version --language generic)"
-        >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:
@@ -346,8 +344,8 @@ jobs:
       with:
         repo: pulumi/pulumictl
     - name: Add SDK version tag
-      run: git tag sdk/v$(pulumictl get version --language generic) && git push origin
-        sdk/v$(pulumictl get version --language generic)
+      run: git tag sdk/v$(make version:generic) && git push origin sdk/v$(make
+        version:generic)
   test:
     name: test
     needs: build_sdk

--- a/provider-ci/providers/random/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/random/repo/.github/workflows/run-acceptance-tests.yml
@@ -95,7 +95,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version.generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean

--- a/provider-ci/providers/random/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/random/repo/.github/workflows/run-acceptance-tests.yml
@@ -95,8 +95,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean

--- a/provider-ci/providers/random/repo/Makefile
+++ b/provider-ci/providers/random/repo/Makefile
@@ -7,7 +7,7 @@ PROVIDER_PATH := provider/v4
 VERSION_PATH := $(PROVIDER_PATH)/pkg/version.Version
 TFGEN := pulumi-tfgen-$(PACK)
 PROVIDER := pulumi-resource-$(PACK)
-VERSION := $(shell pulumictl get version)
+VERSION := $(shell pulumictl get version --language generic)
 JAVA_GEN := pulumi-java-gen
 JAVA_GEN_VERSION := v0.5.4
 TESTPARALLELISM := 10
@@ -29,9 +29,9 @@ install_sdks: install_dotnet_sdk install_python_sdk install_nodejs_sdk install_j
 
 only_build: build
 
-build_dotnet: DOTNET_VERSION := $(shell pulumictl get version --language dotnet)
+build_dotnet: DOTNET_VERSION := $(shell pulumictl convert-version -l dotnet -v "$(VERSION)")
 build_dotnet: upstream
-	pulumictl get version --language dotnet
+	@echo $(DOTNET_VERSION)
 	$(WORKING_DIR)/bin/$(TFGEN) dotnet --out sdk/dotnet/
 	cd sdk/dotnet/ && \
 		echo "module fake_dotnet_module // Exclude this directory from Go tools\n\ngo 1.17" > go.mod && \
@@ -42,14 +42,14 @@ build_go: upstream
 	$(WORKING_DIR)/bin/$(TFGEN) go --out sdk/go/
 	cd sdk && go list `grep -e "^module" go.mod | cut -d ' ' -f 2`/go/... | xargs go build
 
-build_java: PACKAGE_VERSION := $(shell pulumictl get version --language generic)
+build_java: PACKAGE_VERSION := "$(VERSION)"
 build_java: bin/pulumi-java-gen upstream
 	$(WORKING_DIR)/bin/$(JAVA_GEN) generate --schema provider/cmd/$(PROVIDER)/schema.json --out sdk/java  --build gradle-nexus
 	cd sdk/java/ && \
 		echo "module fake_java_module // Exclude this directory from Go tools\n\ngo 1.17" > go.mod && \
 		gradle --console=plain build
 
-build_nodejs: VERSION := $(shell pulumictl get version --language javascript)
+build_nodejs: VERSION := $(shell pulumictl convert-version -l javascript -v "$(VERSION)")
 build_nodejs: upstream
 	$(WORKING_DIR)/bin/$(TFGEN) nodejs --out sdk/nodejs/
 	cd sdk/nodejs/ && \
@@ -59,7 +59,7 @@ build_nodejs: upstream
 		cp ../../README.md ../../LICENSE* package.json yarn.lock ./bin/ && \
 		sed -i.bak -e "s/\$${VERSION}/$(VERSION)/g" ./bin/package.json
 
-build_python: PYPI_VERSION := $(shell pulumictl get version --language python)
+build_python: PYPI_VERSION := $(shell pulumictl convert-version -l python -v "$(VERSION)")
 build_python: upstream
 	$(WORKING_DIR)/bin/$(TFGEN) python --out sdk/python/
 	cd sdk/python/ && \
@@ -120,7 +120,10 @@ upstream.finalize:
 upstream.rebase:
 	@$(SHELL) ./scripts/upstream.sh "$@" start_rebase
 
+version.generic:
+	@echo $(VERSION)
+
 bin/pulumi-java-gen:
 	$(shell pulumictl download-binary -n pulumi-language-java -v $(JAVA_GEN_VERSION) -r pulumi/pulumi-java)
 
-.PHONY: development build build_sdks install_go_sdk install_java_sdk install_python_sdk install_sdks only_build build_dotnet build_go build_java build_nodejs build_python clean cleanup help install_dotnet_sdk install_nodejs_sdk install_plugins lint_provider provider test tfgen upstream upstream.finalize upstream.rebase
+.PHONY: development build build_sdks install_go_sdk install_java_sdk install_python_sdk install_sdks only_build build_dotnet build_go build_java build_nodejs build_python clean cleanup help install_dotnet_sdk install_nodejs_sdk install_plugins lint_provider provider test tfgen upstream upstream.finalize upstream.rebase version.generic

--- a/provider-ci/providers/rke/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/rke/repo/.github/workflows/main.yml
@@ -91,7 +91,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version.generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -339,7 +339,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version.generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:

--- a/provider-ci/providers/rke/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/rke/repo/.github/workflows/main.yml
@@ -91,8 +91,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -340,8 +339,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(pulumictl get version --language generic)"
-        >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:

--- a/provider-ci/providers/rke/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/rke/repo/.github/workflows/master.yml
@@ -91,7 +91,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version.generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -339,7 +339,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version.generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:

--- a/provider-ci/providers/rke/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/rke/repo/.github/workflows/master.yml
@@ -91,8 +91,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -340,8 +339,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(pulumictl get version --language generic)"
-        >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:

--- a/provider-ci/providers/rke/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/rke/repo/.github/workflows/prerelease.yml
@@ -92,8 +92,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -290,8 +289,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(pulumictl get version --language generic)"
-        >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:

--- a/provider-ci/providers/rke/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/rke/repo/.github/workflows/prerelease.yml
@@ -92,7 +92,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version.generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -289,7 +289,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version.generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:

--- a/provider-ci/providers/rke/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/rke/repo/.github/workflows/release.yml
@@ -91,8 +91,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -303,8 +302,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(pulumictl get version --language generic)"
-        >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:
@@ -347,8 +345,8 @@ jobs:
       with:
         repo: pulumi/pulumictl
     - name: Add SDK version tag
-      run: git tag sdk/v$(pulumictl get version --language generic) && git push origin
-        sdk/v$(pulumictl get version --language generic)
+      run: git tag sdk/v$(make version:generic) && git push origin sdk/v$(make
+        version:generic)
   test:
     name: test
     needs: build_sdk

--- a/provider-ci/providers/rke/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/rke/repo/.github/workflows/release.yml
@@ -91,7 +91,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version.generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -302,7 +302,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version.generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:
@@ -345,8 +345,8 @@ jobs:
       with:
         repo: pulumi/pulumictl
     - name: Add SDK version tag
-      run: git tag sdk/v$(make version:generic) && git push origin sdk/v$(make
-        version:generic)
+      run: git tag sdk/v$(make version.generic) && git push origin sdk/v$(make
+        version.generic)
   test:
     name: test
     needs: build_sdk

--- a/provider-ci/providers/rke/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/rke/repo/.github/workflows/run-acceptance-tests.yml
@@ -96,7 +96,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version.generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean

--- a/provider-ci/providers/rke/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/rke/repo/.github/workflows/run-acceptance-tests.yml
@@ -96,8 +96,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean

--- a/provider-ci/providers/rke/repo/Makefile
+++ b/provider-ci/providers/rke/repo/Makefile
@@ -7,7 +7,7 @@ PROVIDER_PATH := provider/v3
 VERSION_PATH := $(PROVIDER_PATH)/pkg/version.Version
 TFGEN := pulumi-tfgen-$(PACK)
 PROVIDER := pulumi-resource-$(PACK)
-VERSION := $(shell pulumictl get version)
+VERSION := $(shell pulumictl get version --language generic)
 JAVA_GEN := pulumi-java-gen
 JAVA_GEN_VERSION := v0.5.4
 TESTPARALLELISM := 10
@@ -29,9 +29,9 @@ install_sdks: install_dotnet_sdk install_python_sdk install_nodejs_sdk install_j
 
 only_build: build
 
-build_dotnet: DOTNET_VERSION := $(shell pulumictl get version --language dotnet)
+build_dotnet: DOTNET_VERSION := $(shell pulumictl convert-version -l dotnet -v "$(VERSION)")
 build_dotnet: upstream
-	pulumictl get version --language dotnet
+	@echo $(DOTNET_VERSION)
 	$(WORKING_DIR)/bin/$(TFGEN) dotnet --out sdk/dotnet/
 	cd sdk/dotnet/ && \
 		echo "module fake_dotnet_module // Exclude this directory from Go tools\n\ngo 1.17" > go.mod && \
@@ -42,14 +42,14 @@ build_go: upstream
 	$(WORKING_DIR)/bin/$(TFGEN) go --out sdk/go/
 	cd sdk && go list `grep -e "^module" go.mod | cut -d ' ' -f 2`/go/... | xargs go build
 
-build_java: PACKAGE_VERSION := $(shell pulumictl get version --language generic)
+build_java: PACKAGE_VERSION := "$(VERSION)"
 build_java: bin/pulumi-java-gen upstream
 	$(WORKING_DIR)/bin/$(JAVA_GEN) generate --schema provider/cmd/$(PROVIDER)/schema.json --out sdk/java  --build gradle-nexus
 	cd sdk/java/ && \
 		echo "module fake_java_module // Exclude this directory from Go tools\n\ngo 1.17" > go.mod && \
 		gradle --console=plain build
 
-build_nodejs: VERSION := $(shell pulumictl get version --language javascript)
+build_nodejs: VERSION := $(shell pulumictl convert-version -l javascript -v "$(VERSION)")
 build_nodejs: upstream
 	$(WORKING_DIR)/bin/$(TFGEN) nodejs --out sdk/nodejs/
 	cd sdk/nodejs/ && \
@@ -59,7 +59,7 @@ build_nodejs: upstream
 		cp ../../README.md ../../LICENSE* package.json yarn.lock ./bin/ && \
 		sed -i.bak -e "s/\$${VERSION}/$(VERSION)/g" ./bin/package.json
 
-build_python: PYPI_VERSION := $(shell pulumictl get version --language python)
+build_python: PYPI_VERSION := $(shell pulumictl convert-version -l python -v "$(VERSION)")
 build_python: upstream
 	$(WORKING_DIR)/bin/$(TFGEN) python --out sdk/python/
 	cd sdk/python/ && \
@@ -118,7 +118,10 @@ upstream.finalize:
 upstream.rebase:
 	@$(SHELL) ./scripts/upstream.sh "$@" start_rebase
 
+version.generic:
+	@echo $(VERSION)
+
 bin/pulumi-java-gen:
 	$(shell pulumictl download-binary -n pulumi-language-java -v $(JAVA_GEN_VERSION) -r pulumi/pulumi-java)
 
-.PHONY: development build build_sdks install_go_sdk install_java_sdk install_python_sdk install_sdks only_build build_dotnet build_go build_java build_nodejs build_python clean cleanup help install_dotnet_sdk install_nodejs_sdk install_plugins lint_provider provider test tfgen upstream upstream.finalize upstream.rebase
+.PHONY: development build build_sdks install_go_sdk install_java_sdk install_python_sdk install_sdks only_build build_dotnet build_go build_java build_nodejs build_python clean cleanup help install_dotnet_sdk install_nodejs_sdk install_plugins lint_provider provider test tfgen upstream upstream.finalize upstream.rebase version.generic

--- a/provider-ci/providers/signalfx/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/signalfx/repo/.github/workflows/main.yml
@@ -90,7 +90,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version.generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -338,7 +338,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version.generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:

--- a/provider-ci/providers/signalfx/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/signalfx/repo/.github/workflows/main.yml
@@ -90,8 +90,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -339,8 +338,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(pulumictl get version --language generic)"
-        >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:

--- a/provider-ci/providers/signalfx/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/signalfx/repo/.github/workflows/master.yml
@@ -90,7 +90,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version.generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -338,7 +338,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version.generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:

--- a/provider-ci/providers/signalfx/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/signalfx/repo/.github/workflows/master.yml
@@ -90,8 +90,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -339,8 +338,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(pulumictl get version --language generic)"
-        >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:

--- a/provider-ci/providers/signalfx/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/signalfx/repo/.github/workflows/prerelease.yml
@@ -91,7 +91,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version.generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -288,7 +288,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version.generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:

--- a/provider-ci/providers/signalfx/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/signalfx/repo/.github/workflows/prerelease.yml
@@ -91,8 +91,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -289,8 +288,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(pulumictl get version --language generic)"
-        >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:

--- a/provider-ci/providers/signalfx/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/signalfx/repo/.github/workflows/release.yml
@@ -90,7 +90,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version.generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -301,7 +301,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version.generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:
@@ -344,8 +344,8 @@ jobs:
       with:
         repo: pulumi/pulumictl
     - name: Add SDK version tag
-      run: git tag sdk/v$(make version:generic) && git push origin sdk/v$(make
-        version:generic)
+      run: git tag sdk/v$(make version.generic) && git push origin sdk/v$(make
+        version.generic)
   test:
     name: test
     needs: build_sdk

--- a/provider-ci/providers/signalfx/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/signalfx/repo/.github/workflows/release.yml
@@ -90,8 +90,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -302,8 +301,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(pulumictl get version --language generic)"
-        >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:
@@ -346,8 +344,8 @@ jobs:
       with:
         repo: pulumi/pulumictl
     - name: Add SDK version tag
-      run: git tag sdk/v$(pulumictl get version --language generic) && git push origin
-        sdk/v$(pulumictl get version --language generic)
+      run: git tag sdk/v$(make version:generic) && git push origin sdk/v$(make
+        version:generic)
   test:
     name: test
     needs: build_sdk

--- a/provider-ci/providers/signalfx/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/signalfx/repo/.github/workflows/run-acceptance-tests.yml
@@ -95,7 +95,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version.generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean

--- a/provider-ci/providers/signalfx/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/signalfx/repo/.github/workflows/run-acceptance-tests.yml
@@ -95,8 +95,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean

--- a/provider-ci/providers/signalfx/repo/Makefile
+++ b/provider-ci/providers/signalfx/repo/Makefile
@@ -7,7 +7,7 @@ PROVIDER_PATH := provider/v5
 VERSION_PATH := $(PROVIDER_PATH)/pkg/version.Version
 TFGEN := pulumi-tfgen-$(PACK)
 PROVIDER := pulumi-resource-$(PACK)
-VERSION := $(shell pulumictl get version)
+VERSION := $(shell pulumictl get version --language generic)
 JAVA_GEN := pulumi-java-gen
 JAVA_GEN_VERSION := v0.5.4
 TESTPARALLELISM := 10
@@ -29,9 +29,9 @@ install_sdks: install_dotnet_sdk install_python_sdk install_nodejs_sdk install_j
 
 only_build: build
 
-build_dotnet: DOTNET_VERSION := $(shell pulumictl get version --language dotnet)
+build_dotnet: DOTNET_VERSION := $(shell pulumictl convert-version -l dotnet -v "$(VERSION)")
 build_dotnet: upstream
-	pulumictl get version --language dotnet
+	@echo $(DOTNET_VERSION)
 	$(WORKING_DIR)/bin/$(TFGEN) dotnet --out sdk/dotnet/
 	cd sdk/dotnet/ && \
 		echo "module fake_dotnet_module // Exclude this directory from Go tools\n\ngo 1.17" > go.mod && \
@@ -42,14 +42,14 @@ build_go: upstream
 	$(WORKING_DIR)/bin/$(TFGEN) go --out sdk/go/
 	cd sdk && go list `grep -e "^module" go.mod | cut -d ' ' -f 2`/go/... | xargs go build
 
-build_java: PACKAGE_VERSION := $(shell pulumictl get version --language generic)
+build_java: PACKAGE_VERSION := "$(VERSION)"
 build_java: bin/pulumi-java-gen upstream
 	$(WORKING_DIR)/bin/$(JAVA_GEN) generate --schema provider/cmd/$(PROVIDER)/schema.json --out sdk/java  --build gradle-nexus
 	cd sdk/java/ && \
 		echo "module fake_java_module // Exclude this directory from Go tools\n\ngo 1.17" > go.mod && \
 		gradle --console=plain build
 
-build_nodejs: VERSION := $(shell pulumictl get version --language javascript)
+build_nodejs: VERSION := $(shell pulumictl convert-version -l javascript -v "$(VERSION)")
 build_nodejs: upstream
 	$(WORKING_DIR)/bin/$(TFGEN) nodejs --out sdk/nodejs/
 	cd sdk/nodejs/ && \
@@ -59,7 +59,7 @@ build_nodejs: upstream
 		cp ../../README.md ../../LICENSE* package.json yarn.lock ./bin/ && \
 		sed -i.bak -e "s/\$${VERSION}/$(VERSION)/g" ./bin/package.json
 
-build_python: PYPI_VERSION := $(shell pulumictl get version --language python)
+build_python: PYPI_VERSION := $(shell pulumictl convert-version -l python -v "$(VERSION)")
 build_python: upstream
 	$(WORKING_DIR)/bin/$(TFGEN) python --out sdk/python/
 	cd sdk/python/ && \
@@ -119,7 +119,10 @@ upstream.finalize:
 upstream.rebase:
 	@$(SHELL) ./scripts/upstream.sh "$@" start_rebase
 
+version.generic:
+	@echo $(VERSION)
+
 bin/pulumi-java-gen:
 	$(shell pulumictl download-binary -n pulumi-language-java -v $(JAVA_GEN_VERSION) -r pulumi/pulumi-java)
 
-.PHONY: development build build_sdks install_go_sdk install_java_sdk install_python_sdk install_sdks only_build build_dotnet build_go build_java build_nodejs build_python clean cleanup help install_dotnet_sdk install_nodejs_sdk install_plugins lint_provider provider test tfgen upstream upstream.finalize upstream.rebase
+.PHONY: development build build_sdks install_go_sdk install_java_sdk install_python_sdk install_sdks only_build build_dotnet build_go build_java build_nodejs build_python clean cleanup help install_dotnet_sdk install_nodejs_sdk install_plugins lint_provider provider test tfgen upstream upstream.finalize upstream.rebase version.generic

--- a/provider-ci/providers/slack/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/slack/repo/.github/workflows/main.yml
@@ -91,7 +91,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version.generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -339,7 +339,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version.generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:

--- a/provider-ci/providers/slack/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/slack/repo/.github/workflows/main.yml
@@ -91,8 +91,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -340,8 +339,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(pulumictl get version --language generic)"
-        >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:

--- a/provider-ci/providers/slack/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/slack/repo/.github/workflows/master.yml
@@ -91,7 +91,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version.generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -339,7 +339,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version.generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:

--- a/provider-ci/providers/slack/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/slack/repo/.github/workflows/master.yml
@@ -91,8 +91,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -340,8 +339,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(pulumictl get version --language generic)"
-        >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:

--- a/provider-ci/providers/slack/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/slack/repo/.github/workflows/prerelease.yml
@@ -92,8 +92,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -290,8 +289,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(pulumictl get version --language generic)"
-        >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:

--- a/provider-ci/providers/slack/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/slack/repo/.github/workflows/prerelease.yml
@@ -92,7 +92,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version.generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -289,7 +289,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version.generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:

--- a/provider-ci/providers/slack/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/slack/repo/.github/workflows/release.yml
@@ -91,8 +91,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -303,8 +302,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(pulumictl get version --language generic)"
-        >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:
@@ -347,8 +345,8 @@ jobs:
       with:
         repo: pulumi/pulumictl
     - name: Add SDK version tag
-      run: git tag sdk/v$(pulumictl get version --language generic) && git push origin
-        sdk/v$(pulumictl get version --language generic)
+      run: git tag sdk/v$(make version:generic) && git push origin sdk/v$(make
+        version:generic)
   test:
     name: test
     needs: build_sdk

--- a/provider-ci/providers/slack/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/slack/repo/.github/workflows/release.yml
@@ -91,7 +91,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version.generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -302,7 +302,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version.generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:
@@ -345,8 +345,8 @@ jobs:
       with:
         repo: pulumi/pulumictl
     - name: Add SDK version tag
-      run: git tag sdk/v$(make version:generic) && git push origin sdk/v$(make
-        version:generic)
+      run: git tag sdk/v$(make version.generic) && git push origin sdk/v$(make
+        version.generic)
   test:
     name: test
     needs: build_sdk

--- a/provider-ci/providers/slack/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/slack/repo/.github/workflows/run-acceptance-tests.yml
@@ -96,7 +96,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version.generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean

--- a/provider-ci/providers/slack/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/slack/repo/.github/workflows/run-acceptance-tests.yml
@@ -96,8 +96,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean

--- a/provider-ci/providers/slack/repo/Makefile
+++ b/provider-ci/providers/slack/repo/Makefile
@@ -7,7 +7,7 @@ PROVIDER_PATH := provider
 VERSION_PATH := $(PROVIDER_PATH)/pkg/version.Version
 TFGEN := pulumi-tfgen-$(PACK)
 PROVIDER := pulumi-resource-$(PACK)
-VERSION := $(shell pulumictl get version)
+VERSION := $(shell pulumictl get version --language generic)
 JAVA_GEN := pulumi-java-gen
 JAVA_GEN_VERSION := v0.5.4
 TESTPARALLELISM := 10
@@ -29,9 +29,9 @@ install_sdks: install_dotnet_sdk install_python_sdk install_nodejs_sdk install_j
 
 only_build: build
 
-build_dotnet: DOTNET_VERSION := $(shell pulumictl get version --language dotnet)
+build_dotnet: DOTNET_VERSION := $(shell pulumictl convert-version -l dotnet -v "$(VERSION)")
 build_dotnet: upstream
-	pulumictl get version --language dotnet
+	@echo $(DOTNET_VERSION)
 	$(WORKING_DIR)/bin/$(TFGEN) dotnet --out sdk/dotnet/
 	cd sdk/dotnet/ && \
 		echo "module fake_dotnet_module // Exclude this directory from Go tools\n\ngo 1.17" > go.mod && \
@@ -42,14 +42,14 @@ build_go: upstream
 	$(WORKING_DIR)/bin/$(TFGEN) go --out sdk/go/
 	cd sdk && go list `grep -e "^module" go.mod | cut -d ' ' -f 2`/go/... | xargs go build
 
-build_java: PACKAGE_VERSION := $(shell pulumictl get version --language generic)
+build_java: PACKAGE_VERSION := "$(VERSION)"
 build_java: bin/pulumi-java-gen upstream
 	$(WORKING_DIR)/bin/$(JAVA_GEN) generate --schema provider/cmd/$(PROVIDER)/schema.json --out sdk/java  --build gradle-nexus
 	cd sdk/java/ && \
 		echo "module fake_java_module // Exclude this directory from Go tools\n\ngo 1.17" > go.mod && \
 		gradle --console=plain build
 
-build_nodejs: VERSION := $(shell pulumictl get version --language javascript)
+build_nodejs: VERSION := $(shell pulumictl convert-version -l javascript -v "$(VERSION)")
 build_nodejs: upstream
 	$(WORKING_DIR)/bin/$(TFGEN) nodejs --out sdk/nodejs/
 	cd sdk/nodejs/ && \
@@ -59,7 +59,7 @@ build_nodejs: upstream
 		cp ../../README.md ../../LICENSE* package.json yarn.lock ./bin/ && \
 		sed -i.bak -e "s/\$${VERSION}/$(VERSION)/g" ./bin/package.json
 
-build_python: PYPI_VERSION := $(shell pulumictl get version --language python)
+build_python: PYPI_VERSION := $(shell pulumictl convert-version -l python -v "$(VERSION)")
 build_python: upstream
 	$(WORKING_DIR)/bin/$(TFGEN) python --out sdk/python/
 	cd sdk/python/ && \
@@ -119,7 +119,10 @@ upstream.finalize:
 upstream.rebase:
 	@$(SHELL) ./scripts/upstream.sh "$@" start_rebase
 
+version.generic:
+	@echo $(VERSION)
+
 bin/pulumi-java-gen:
 	$(shell pulumictl download-binary -n pulumi-language-java -v $(JAVA_GEN_VERSION) -r pulumi/pulumi-java)
 
-.PHONY: development build build_sdks install_go_sdk install_java_sdk install_python_sdk install_sdks only_build build_dotnet build_go build_java build_nodejs build_python clean cleanup help install_dotnet_sdk install_nodejs_sdk install_plugins lint_provider provider test tfgen upstream upstream.finalize upstream.rebase
+.PHONY: development build build_sdks install_go_sdk install_java_sdk install_python_sdk install_sdks only_build build_dotnet build_go build_java build_nodejs build_python clean cleanup help install_dotnet_sdk install_nodejs_sdk install_plugins lint_provider provider test tfgen upstream upstream.finalize upstream.rebase version.generic

--- a/provider-ci/providers/snowflake/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/snowflake/repo/.github/workflows/main.yml
@@ -95,7 +95,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version.generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -343,7 +343,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version.generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:

--- a/provider-ci/providers/snowflake/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/snowflake/repo/.github/workflows/main.yml
@@ -95,8 +95,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -344,8 +343,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(pulumictl get version --language generic)"
-        >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:

--- a/provider-ci/providers/snowflake/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/snowflake/repo/.github/workflows/master.yml
@@ -95,7 +95,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version.generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -343,7 +343,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version.generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:

--- a/provider-ci/providers/snowflake/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/snowflake/repo/.github/workflows/master.yml
@@ -95,8 +95,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -344,8 +343,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(pulumictl get version --language generic)"
-        >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:

--- a/provider-ci/providers/snowflake/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/snowflake/repo/.github/workflows/prerelease.yml
@@ -96,7 +96,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version.generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -293,7 +293,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version.generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:

--- a/provider-ci/providers/snowflake/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/snowflake/repo/.github/workflows/prerelease.yml
@@ -96,8 +96,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -294,8 +293,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(pulumictl get version --language generic)"
-        >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:

--- a/provider-ci/providers/snowflake/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/snowflake/repo/.github/workflows/release.yml
@@ -95,7 +95,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version.generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -306,7 +306,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version.generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:
@@ -349,8 +349,8 @@ jobs:
       with:
         repo: pulumi/pulumictl
     - name: Add SDK version tag
-      run: git tag sdk/v$(make version:generic) && git push origin sdk/v$(make
-        version:generic)
+      run: git tag sdk/v$(make version.generic) && git push origin sdk/v$(make
+        version.generic)
   test:
     name: test
     needs: build_sdk

--- a/provider-ci/providers/snowflake/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/snowflake/repo/.github/workflows/release.yml
@@ -95,8 +95,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -307,8 +306,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(pulumictl get version --language generic)"
-        >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:
@@ -351,8 +349,8 @@ jobs:
       with:
         repo: pulumi/pulumictl
     - name: Add SDK version tag
-      run: git tag sdk/v$(pulumictl get version --language generic) && git push origin
-        sdk/v$(pulumictl get version --language generic)
+      run: git tag sdk/v$(make version:generic) && git push origin sdk/v$(make
+        version:generic)
   test:
     name: test
     needs: build_sdk

--- a/provider-ci/providers/snowflake/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/snowflake/repo/.github/workflows/run-acceptance-tests.yml
@@ -100,8 +100,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean

--- a/provider-ci/providers/snowflake/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/snowflake/repo/.github/workflows/run-acceptance-tests.yml
@@ -100,7 +100,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version.generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean

--- a/provider-ci/providers/snowflake/repo/Makefile
+++ b/provider-ci/providers/snowflake/repo/Makefile
@@ -7,7 +7,7 @@ PROVIDER_PATH := provider
 VERSION_PATH := $(PROVIDER_PATH)/pkg/version.Version
 TFGEN := pulumi-tfgen-$(PACK)
 PROVIDER := pulumi-resource-$(PACK)
-VERSION := $(shell pulumictl get version)
+VERSION := $(shell pulumictl get version --language generic)
 JAVA_GEN := pulumi-java-gen
 JAVA_GEN_VERSION := v0.5.4
 TESTPARALLELISM := 10
@@ -29,9 +29,9 @@ install_sdks: install_dotnet_sdk install_python_sdk install_nodejs_sdk install_j
 
 only_build: build
 
-build_dotnet: DOTNET_VERSION := $(shell pulumictl get version --language dotnet)
+build_dotnet: DOTNET_VERSION := $(shell pulumictl convert-version -l dotnet -v "$(VERSION)")
 build_dotnet: upstream
-	pulumictl get version --language dotnet
+	@echo $(DOTNET_VERSION)
 	$(WORKING_DIR)/bin/$(TFGEN) dotnet --out sdk/dotnet/
 	cd sdk/dotnet/ && \
 		echo "module fake_dotnet_module // Exclude this directory from Go tools\n\ngo 1.17" > go.mod && \
@@ -42,14 +42,14 @@ build_go: upstream
 	$(WORKING_DIR)/bin/$(TFGEN) go --out sdk/go/
 	cd sdk && go list `grep -e "^module" go.mod | cut -d ' ' -f 2`/go/... | xargs go build
 
-build_java: PACKAGE_VERSION := $(shell pulumictl get version --language generic)
+build_java: PACKAGE_VERSION := "$(VERSION)"
 build_java: bin/pulumi-java-gen upstream
 	$(WORKING_DIR)/bin/$(JAVA_GEN) generate --schema provider/cmd/$(PROVIDER)/schema.json --out sdk/java  --build gradle-nexus
 	cd sdk/java/ && \
 		echo "module fake_java_module // Exclude this directory from Go tools\n\ngo 1.17" > go.mod && \
 		gradle --console=plain build
 
-build_nodejs: VERSION := $(shell pulumictl get version --language javascript)
+build_nodejs: VERSION := $(shell pulumictl convert-version -l javascript -v "$(VERSION)")
 build_nodejs: upstream
 	$(WORKING_DIR)/bin/$(TFGEN) nodejs --out sdk/nodejs/
 	cd sdk/nodejs/ && \
@@ -59,7 +59,7 @@ build_nodejs: upstream
 		cp ../../README.md ../../LICENSE* package.json yarn.lock ./bin/ && \
 		sed -i.bak -e "s/\$${VERSION}/$(VERSION)/g" ./bin/package.json
 
-build_python: PYPI_VERSION := $(shell pulumictl get version --language python)
+build_python: PYPI_VERSION := $(shell pulumictl convert-version -l python -v "$(VERSION)")
 build_python: upstream
 	$(WORKING_DIR)/bin/$(TFGEN) python --out sdk/python/
 	cd sdk/python/ && \
@@ -122,7 +122,10 @@ upstream.finalize:
 upstream.rebase:
 	@$(SHELL) ./scripts/upstream.sh "$@" start_rebase
 
+version.generic:
+	@echo $(VERSION)
+
 bin/pulumi-java-gen:
 	$(shell pulumictl download-binary -n pulumi-language-java -v $(JAVA_GEN_VERSION) -r pulumi/pulumi-java)
 
-.PHONY: development build build_sdks install_go_sdk install_java_sdk install_python_sdk install_sdks only_build build_dotnet build_go build_java build_nodejs build_python clean cleanup help install_dotnet_sdk install_nodejs_sdk install_plugins lint_provider provider test tfgen upstream upstream.finalize upstream.rebase
+.PHONY: development build build_sdks install_go_sdk install_java_sdk install_python_sdk install_sdks only_build build_dotnet build_go build_java build_nodejs build_python clean cleanup help install_dotnet_sdk install_nodejs_sdk install_plugins lint_provider provider test tfgen upstream upstream.finalize upstream.rebase version.generic

--- a/provider-ci/providers/splunk/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/splunk/repo/.github/workflows/main.yml
@@ -93,8 +93,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -342,8 +341,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(pulumictl get version --language generic)"
-        >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:

--- a/provider-ci/providers/splunk/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/splunk/repo/.github/workflows/main.yml
@@ -93,7 +93,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version.generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -341,7 +341,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version.generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:

--- a/provider-ci/providers/splunk/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/splunk/repo/.github/workflows/master.yml
@@ -93,8 +93,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -342,8 +341,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(pulumictl get version --language generic)"
-        >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:

--- a/provider-ci/providers/splunk/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/splunk/repo/.github/workflows/master.yml
@@ -93,7 +93,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version.generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -341,7 +341,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version.generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:

--- a/provider-ci/providers/splunk/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/splunk/repo/.github/workflows/prerelease.yml
@@ -94,7 +94,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version.generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -291,7 +291,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version.generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:

--- a/provider-ci/providers/splunk/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/splunk/repo/.github/workflows/prerelease.yml
@@ -94,8 +94,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -292,8 +291,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(pulumictl get version --language generic)"
-        >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:

--- a/provider-ci/providers/splunk/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/splunk/repo/.github/workflows/release.yml
@@ -93,7 +93,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version.generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -304,7 +304,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version.generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:
@@ -347,8 +347,8 @@ jobs:
       with:
         repo: pulumi/pulumictl
     - name: Add SDK version tag
-      run: git tag sdk/v$(make version:generic) && git push origin sdk/v$(make
-        version:generic)
+      run: git tag sdk/v$(make version.generic) && git push origin sdk/v$(make
+        version.generic)
   test:
     name: test
     needs: build_sdk

--- a/provider-ci/providers/splunk/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/splunk/repo/.github/workflows/release.yml
@@ -93,8 +93,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -305,8 +304,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(pulumictl get version --language generic)"
-        >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:
@@ -349,8 +347,8 @@ jobs:
       with:
         repo: pulumi/pulumictl
     - name: Add SDK version tag
-      run: git tag sdk/v$(pulumictl get version --language generic) && git push origin
-        sdk/v$(pulumictl get version --language generic)
+      run: git tag sdk/v$(make version:generic) && git push origin sdk/v$(make
+        version:generic)
   test:
     name: test
     needs: build_sdk

--- a/provider-ci/providers/splunk/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/splunk/repo/.github/workflows/run-acceptance-tests.yml
@@ -98,8 +98,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean

--- a/provider-ci/providers/splunk/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/splunk/repo/.github/workflows/run-acceptance-tests.yml
@@ -98,7 +98,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version.generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean

--- a/provider-ci/providers/splunk/repo/Makefile
+++ b/provider-ci/providers/splunk/repo/Makefile
@@ -7,7 +7,7 @@ PROVIDER_PATH := provider
 VERSION_PATH := $(PROVIDER_PATH)/pkg/version.Version
 TFGEN := pulumi-tfgen-$(PACK)
 PROVIDER := pulumi-resource-$(PACK)
-VERSION := $(shell pulumictl get version)
+VERSION := $(shell pulumictl get version --language generic)
 JAVA_GEN := pulumi-java-gen
 JAVA_GEN_VERSION := v0.5.4
 TESTPARALLELISM := 10
@@ -29,9 +29,9 @@ install_sdks: install_dotnet_sdk install_python_sdk install_nodejs_sdk install_j
 
 only_build: build
 
-build_dotnet: DOTNET_VERSION := $(shell pulumictl get version --language dotnet)
+build_dotnet: DOTNET_VERSION := $(shell pulumictl convert-version -l dotnet -v "$(VERSION)")
 build_dotnet: upstream
-	pulumictl get version --language dotnet
+	@echo $(DOTNET_VERSION)
 	$(WORKING_DIR)/bin/$(TFGEN) dotnet --out sdk/dotnet/
 	cd sdk/dotnet/ && \
 		echo "module fake_dotnet_module // Exclude this directory from Go tools\n\ngo 1.17" > go.mod && \
@@ -42,14 +42,14 @@ build_go: upstream
 	$(WORKING_DIR)/bin/$(TFGEN) go --out sdk/go/
 	cd sdk && go list `grep -e "^module" go.mod | cut -d ' ' -f 2`/go/... | xargs go build
 
-build_java: PACKAGE_VERSION := $(shell pulumictl get version --language generic)
+build_java: PACKAGE_VERSION := "$(VERSION)"
 build_java: bin/pulumi-java-gen upstream
 	$(WORKING_DIR)/bin/$(JAVA_GEN) generate --schema provider/cmd/$(PROVIDER)/schema.json --out sdk/java  --build gradle-nexus
 	cd sdk/java/ && \
 		echo "module fake_java_module // Exclude this directory from Go tools\n\ngo 1.17" > go.mod && \
 		gradle --console=plain build
 
-build_nodejs: VERSION := $(shell pulumictl get version --language javascript)
+build_nodejs: VERSION := $(shell pulumictl convert-version -l javascript -v "$(VERSION)")
 build_nodejs: upstream
 	$(WORKING_DIR)/bin/$(TFGEN) nodejs --out sdk/nodejs/
 	cd sdk/nodejs/ && \
@@ -59,7 +59,7 @@ build_nodejs: upstream
 		cp ../../README.md ../../LICENSE* package.json yarn.lock ./bin/ && \
 		sed -i.bak -e "s/\$${VERSION}/$(VERSION)/g" ./bin/package.json
 
-build_python: PYPI_VERSION := $(shell pulumictl get version --language python)
+build_python: PYPI_VERSION := $(shell pulumictl convert-version -l python -v "$(VERSION)")
 build_python: upstream
 	$(WORKING_DIR)/bin/$(TFGEN) python --out sdk/python/
 	cd sdk/python/ && \
@@ -118,7 +118,10 @@ upstream.finalize:
 upstream.rebase:
 	@$(SHELL) ./scripts/upstream.sh "$@" start_rebase
 
+version.generic:
+	@echo $(VERSION)
+
 bin/pulumi-java-gen:
 	$(shell pulumictl download-binary -n pulumi-language-java -v $(JAVA_GEN_VERSION) -r pulumi/pulumi-java)
 
-.PHONY: development build build_sdks install_go_sdk install_java_sdk install_python_sdk install_sdks only_build build_dotnet build_go build_java build_nodejs build_python clean cleanup help install_dotnet_sdk install_nodejs_sdk install_plugins lint_provider provider test tfgen upstream upstream.finalize upstream.rebase
+.PHONY: development build build_sdks install_go_sdk install_java_sdk install_python_sdk install_sdks only_build build_dotnet build_go build_java build_nodejs build_python clean cleanup help install_dotnet_sdk install_nodejs_sdk install_plugins lint_provider provider test tfgen upstream upstream.finalize upstream.rebase version.generic

--- a/provider-ci/providers/spotinst/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/spotinst/repo/.github/workflows/main.yml
@@ -93,8 +93,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -342,8 +341,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(pulumictl get version --language generic)"
-        >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:

--- a/provider-ci/providers/spotinst/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/spotinst/repo/.github/workflows/main.yml
@@ -93,7 +93,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version.generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -341,7 +341,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version.generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:

--- a/provider-ci/providers/spotinst/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/spotinst/repo/.github/workflows/master.yml
@@ -93,8 +93,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -342,8 +341,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(pulumictl get version --language generic)"
-        >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:

--- a/provider-ci/providers/spotinst/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/spotinst/repo/.github/workflows/master.yml
@@ -93,7 +93,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version.generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -341,7 +341,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version.generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:

--- a/provider-ci/providers/spotinst/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/spotinst/repo/.github/workflows/prerelease.yml
@@ -94,7 +94,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version.generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -291,7 +291,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version.generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:

--- a/provider-ci/providers/spotinst/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/spotinst/repo/.github/workflows/prerelease.yml
@@ -94,8 +94,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -292,8 +291,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(pulumictl get version --language generic)"
-        >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:

--- a/provider-ci/providers/spotinst/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/spotinst/repo/.github/workflows/release.yml
@@ -93,7 +93,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version.generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -304,7 +304,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version.generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:
@@ -347,8 +347,8 @@ jobs:
       with:
         repo: pulumi/pulumictl
     - name: Add SDK version tag
-      run: git tag sdk/v$(make version:generic) && git push origin sdk/v$(make
-        version:generic)
+      run: git tag sdk/v$(make version.generic) && git push origin sdk/v$(make
+        version.generic)
   test:
     name: test
     needs: build_sdk

--- a/provider-ci/providers/spotinst/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/spotinst/repo/.github/workflows/release.yml
@@ -93,8 +93,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -305,8 +304,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(pulumictl get version --language generic)"
-        >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:
@@ -349,8 +347,8 @@ jobs:
       with:
         repo: pulumi/pulumictl
     - name: Add SDK version tag
-      run: git tag sdk/v$(pulumictl get version --language generic) && git push origin
-        sdk/v$(pulumictl get version --language generic)
+      run: git tag sdk/v$(make version:generic) && git push origin sdk/v$(make
+        version:generic)
   test:
     name: test
     needs: build_sdk

--- a/provider-ci/providers/spotinst/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/spotinst/repo/.github/workflows/run-acceptance-tests.yml
@@ -98,8 +98,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean

--- a/provider-ci/providers/spotinst/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/spotinst/repo/.github/workflows/run-acceptance-tests.yml
@@ -98,7 +98,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version.generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean

--- a/provider-ci/providers/spotinst/repo/Makefile
+++ b/provider-ci/providers/spotinst/repo/Makefile
@@ -7,7 +7,7 @@ PROVIDER_PATH := provider/v3
 VERSION_PATH := $(PROVIDER_PATH)/pkg/version.Version
 TFGEN := pulumi-tfgen-$(PACK)
 PROVIDER := pulumi-resource-$(PACK)
-VERSION := $(shell pulumictl get version)
+VERSION := $(shell pulumictl get version --language generic)
 JAVA_GEN := pulumi-java-gen
 JAVA_GEN_VERSION := v0.5.4
 TESTPARALLELISM := 10
@@ -29,9 +29,9 @@ install_sdks: install_dotnet_sdk install_python_sdk install_nodejs_sdk install_j
 
 only_build: build
 
-build_dotnet: DOTNET_VERSION := $(shell pulumictl get version --language dotnet)
+build_dotnet: DOTNET_VERSION := $(shell pulumictl convert-version -l dotnet -v "$(VERSION)")
 build_dotnet: upstream
-	pulumictl get version --language dotnet
+	@echo $(DOTNET_VERSION)
 	$(WORKING_DIR)/bin/$(TFGEN) dotnet --out sdk/dotnet/
 	cd sdk/dotnet/ && \
 		echo "module fake_dotnet_module // Exclude this directory from Go tools\n\ngo 1.17" > go.mod && \
@@ -42,14 +42,14 @@ build_go: upstream
 	$(WORKING_DIR)/bin/$(TFGEN) go --out sdk/go/
 	cd sdk && go list `grep -e "^module" go.mod | cut -d ' ' -f 2`/go/... | xargs go build
 
-build_java: PACKAGE_VERSION := $(shell pulumictl get version --language generic)
+build_java: PACKAGE_VERSION := "$(VERSION)"
 build_java: bin/pulumi-java-gen upstream
 	$(WORKING_DIR)/bin/$(JAVA_GEN) generate --schema provider/cmd/$(PROVIDER)/schema.json --out sdk/java  --build gradle-nexus
 	cd sdk/java/ && \
 		echo "module fake_java_module // Exclude this directory from Go tools\n\ngo 1.17" > go.mod && \
 		gradle --console=plain build
 
-build_nodejs: VERSION := $(shell pulumictl get version --language javascript)
+build_nodejs: VERSION := $(shell pulumictl convert-version -l javascript -v "$(VERSION)")
 build_nodejs: upstream
 	$(WORKING_DIR)/bin/$(TFGEN) nodejs --out sdk/nodejs/
 	cd sdk/nodejs/ && \
@@ -59,7 +59,7 @@ build_nodejs: upstream
 		cp ../../README.md ../../LICENSE* package.json yarn.lock ./bin/ && \
 		sed -i.bak -e "s/\$${VERSION}/$(VERSION)/g" ./bin/package.json
 
-build_python: PYPI_VERSION := $(shell pulumictl get version --language python)
+build_python: PYPI_VERSION := $(shell pulumictl convert-version -l python -v "$(VERSION)")
 build_python: upstream
 	$(WORKING_DIR)/bin/$(TFGEN) python --out sdk/python/
 	cd sdk/python/ && \
@@ -121,7 +121,10 @@ upstream.finalize:
 upstream.rebase:
 	@$(SHELL) ./scripts/upstream.sh "$@" start_rebase
 
+version.generic:
+	@echo $(VERSION)
+
 bin/pulumi-java-gen:
 	$(shell pulumictl download-binary -n pulumi-language-java -v $(JAVA_GEN_VERSION) -r pulumi/pulumi-java)
 
-.PHONY: development build build_sdks install_go_sdk install_java_sdk install_python_sdk install_sdks only_build build_dotnet build_go build_java build_nodejs build_python clean cleanup help install_dotnet_sdk install_nodejs_sdk install_plugins lint_provider provider test tfgen upstream upstream.finalize upstream.rebase
+.PHONY: development build build_sdks install_go_sdk install_java_sdk install_python_sdk install_sdks only_build build_dotnet build_go build_java build_nodejs build_python clean cleanup help install_dotnet_sdk install_nodejs_sdk install_plugins lint_provider provider test tfgen upstream upstream.finalize upstream.rebase version.generic

--- a/provider-ci/providers/sumologic/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/sumologic/repo/.github/workflows/main.yml
@@ -93,8 +93,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -342,8 +341,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(pulumictl get version --language generic)"
-        >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:

--- a/provider-ci/providers/sumologic/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/sumologic/repo/.github/workflows/main.yml
@@ -93,7 +93,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version.generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -341,7 +341,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version.generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:

--- a/provider-ci/providers/sumologic/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/sumologic/repo/.github/workflows/master.yml
@@ -93,8 +93,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -342,8 +341,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(pulumictl get version --language generic)"
-        >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:

--- a/provider-ci/providers/sumologic/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/sumologic/repo/.github/workflows/master.yml
@@ -93,7 +93,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version.generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -341,7 +341,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version.generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:

--- a/provider-ci/providers/sumologic/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/sumologic/repo/.github/workflows/prerelease.yml
@@ -94,7 +94,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version.generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -291,7 +291,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version.generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:

--- a/provider-ci/providers/sumologic/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/sumologic/repo/.github/workflows/prerelease.yml
@@ -94,8 +94,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -292,8 +291,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(pulumictl get version --language generic)"
-        >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:

--- a/provider-ci/providers/sumologic/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/sumologic/repo/.github/workflows/release.yml
@@ -93,7 +93,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version.generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -304,7 +304,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version.generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:
@@ -347,8 +347,8 @@ jobs:
       with:
         repo: pulumi/pulumictl
     - name: Add SDK version tag
-      run: git tag sdk/v$(make version:generic) && git push origin sdk/v$(make
-        version:generic)
+      run: git tag sdk/v$(make version.generic) && git push origin sdk/v$(make
+        version.generic)
   test:
     name: test
     needs: build_sdk

--- a/provider-ci/providers/sumologic/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/sumologic/repo/.github/workflows/release.yml
@@ -93,8 +93,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -305,8 +304,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(pulumictl get version --language generic)"
-        >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:
@@ -349,8 +347,8 @@ jobs:
       with:
         repo: pulumi/pulumictl
     - name: Add SDK version tag
-      run: git tag sdk/v$(pulumictl get version --language generic) && git push origin
-        sdk/v$(pulumictl get version --language generic)
+      run: git tag sdk/v$(make version:generic) && git push origin sdk/v$(make
+        version:generic)
   test:
     name: test
     needs: build_sdk

--- a/provider-ci/providers/sumologic/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/sumologic/repo/.github/workflows/run-acceptance-tests.yml
@@ -98,8 +98,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean

--- a/provider-ci/providers/sumologic/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/sumologic/repo/.github/workflows/run-acceptance-tests.yml
@@ -98,7 +98,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version.generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean

--- a/provider-ci/providers/sumologic/repo/Makefile
+++ b/provider-ci/providers/sumologic/repo/Makefile
@@ -7,7 +7,7 @@ PROVIDER_PATH := provider
 VERSION_PATH := $(PROVIDER_PATH)/pkg/version.Version
 TFGEN := pulumi-tfgen-$(PACK)
 PROVIDER := pulumi-resource-$(PACK)
-VERSION := $(shell pulumictl get version)
+VERSION := $(shell pulumictl get version --language generic)
 JAVA_GEN := pulumi-java-gen
 JAVA_GEN_VERSION := v0.5.4
 TESTPARALLELISM := 10
@@ -29,9 +29,9 @@ install_sdks: install_dotnet_sdk install_python_sdk install_nodejs_sdk install_j
 
 only_build: build
 
-build_dotnet: DOTNET_VERSION := $(shell pulumictl get version --language dotnet)
+build_dotnet: DOTNET_VERSION := $(shell pulumictl convert-version -l dotnet -v "$(VERSION)")
 build_dotnet: upstream
-	pulumictl get version --language dotnet
+	@echo $(DOTNET_VERSION)
 	$(WORKING_DIR)/bin/$(TFGEN) dotnet --out sdk/dotnet/
 	cd sdk/dotnet/ && \
 		echo "module fake_dotnet_module // Exclude this directory from Go tools\n\ngo 1.17" > go.mod && \
@@ -42,14 +42,14 @@ build_go: upstream
 	$(WORKING_DIR)/bin/$(TFGEN) go --out sdk/go/
 	cd sdk && go list `grep -e "^module" go.mod | cut -d ' ' -f 2`/go/... | xargs go build
 
-build_java: PACKAGE_VERSION := $(shell pulumictl get version --language generic)
+build_java: PACKAGE_VERSION := "$(VERSION)"
 build_java: bin/pulumi-java-gen upstream
 	$(WORKING_DIR)/bin/$(JAVA_GEN) generate --schema provider/cmd/$(PROVIDER)/schema.json --out sdk/java  --build gradle-nexus
 	cd sdk/java/ && \
 		echo "module fake_java_module // Exclude this directory from Go tools\n\ngo 1.17" > go.mod && \
 		gradle --console=plain build
 
-build_nodejs: VERSION := $(shell pulumictl get version --language javascript)
+build_nodejs: VERSION := $(shell pulumictl convert-version -l javascript -v "$(VERSION)")
 build_nodejs: upstream
 	$(WORKING_DIR)/bin/$(TFGEN) nodejs --out sdk/nodejs/
 	cd sdk/nodejs/ && \
@@ -59,7 +59,7 @@ build_nodejs: upstream
 		cp ../../README.md ../../LICENSE* package.json yarn.lock ./bin/ && \
 		sed -i.bak -e "s/\$${VERSION}/$(VERSION)/g" ./bin/package.json
 
-build_python: PYPI_VERSION := $(shell pulumictl get version --language python)
+build_python: PYPI_VERSION := $(shell pulumictl convert-version -l python -v "$(VERSION)")
 build_python: upstream
 	$(WORKING_DIR)/bin/$(TFGEN) python --out sdk/python/
 	cd sdk/python/ && \
@@ -120,7 +120,10 @@ upstream.finalize:
 upstream.rebase:
 	@$(SHELL) ./scripts/upstream.sh "$@" start_rebase
 
+version.generic:
+	@echo $(VERSION)
+
 bin/pulumi-java-gen:
 	$(shell pulumictl download-binary -n pulumi-language-java -v $(JAVA_GEN_VERSION) -r pulumi/pulumi-java)
 
-.PHONY: development build build_sdks install_go_sdk install_java_sdk install_python_sdk install_sdks only_build build_dotnet build_go build_java build_nodejs build_python clean cleanup help install_dotnet_sdk install_nodejs_sdk install_plugins lint_provider provider test tfgen upstream upstream.finalize upstream.rebase
+.PHONY: development build build_sdks install_go_sdk install_java_sdk install_python_sdk install_sdks only_build build_dotnet build_go build_java build_nodejs build_python clean cleanup help install_dotnet_sdk install_nodejs_sdk install_plugins lint_provider provider test tfgen upstream upstream.finalize upstream.rebase version.generic

--- a/provider-ci/providers/tailscale/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/tailscale/repo/.github/workflows/main.yml
@@ -92,8 +92,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -341,8 +340,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(pulumictl get version --language generic)"
-        >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:

--- a/provider-ci/providers/tailscale/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/tailscale/repo/.github/workflows/main.yml
@@ -92,7 +92,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version.generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -340,7 +340,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version.generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:

--- a/provider-ci/providers/tailscale/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/tailscale/repo/.github/workflows/master.yml
@@ -92,8 +92,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -341,8 +340,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(pulumictl get version --language generic)"
-        >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:

--- a/provider-ci/providers/tailscale/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/tailscale/repo/.github/workflows/master.yml
@@ -92,7 +92,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version.generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -340,7 +340,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version.generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:

--- a/provider-ci/providers/tailscale/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/tailscale/repo/.github/workflows/prerelease.yml
@@ -93,8 +93,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -291,8 +290,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(pulumictl get version --language generic)"
-        >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:

--- a/provider-ci/providers/tailscale/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/tailscale/repo/.github/workflows/prerelease.yml
@@ -93,7 +93,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version.generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -290,7 +290,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version.generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:

--- a/provider-ci/providers/tailscale/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/tailscale/repo/.github/workflows/release.yml
@@ -92,7 +92,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version.generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -303,7 +303,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version.generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:
@@ -346,8 +346,8 @@ jobs:
       with:
         repo: pulumi/pulumictl
     - name: Add SDK version tag
-      run: git tag sdk/v$(make version:generic) && git push origin sdk/v$(make
-        version:generic)
+      run: git tag sdk/v$(make version.generic) && git push origin sdk/v$(make
+        version.generic)
   test:
     name: test
     needs: build_sdk

--- a/provider-ci/providers/tailscale/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/tailscale/repo/.github/workflows/release.yml
@@ -92,8 +92,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -304,8 +303,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(pulumictl get version --language generic)"
-        >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:
@@ -348,8 +346,8 @@ jobs:
       with:
         repo: pulumi/pulumictl
     - name: Add SDK version tag
-      run: git tag sdk/v$(pulumictl get version --language generic) && git push origin
-        sdk/v$(pulumictl get version --language generic)
+      run: git tag sdk/v$(make version:generic) && git push origin sdk/v$(make
+        version:generic)
   test:
     name: test
     needs: build_sdk

--- a/provider-ci/providers/tailscale/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/tailscale/repo/.github/workflows/run-acceptance-tests.yml
@@ -97,7 +97,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version.generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean

--- a/provider-ci/providers/tailscale/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/tailscale/repo/.github/workflows/run-acceptance-tests.yml
@@ -97,8 +97,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean

--- a/provider-ci/providers/tailscale/repo/Makefile
+++ b/provider-ci/providers/tailscale/repo/Makefile
@@ -7,7 +7,7 @@ PROVIDER_PATH := provider
 VERSION_PATH := $(PROVIDER_PATH)/pkg/version.Version
 TFGEN := pulumi-tfgen-$(PACK)
 PROVIDER := pulumi-resource-$(PACK)
-VERSION := $(shell pulumictl get version)
+VERSION := $(shell pulumictl get version --language generic)
 JAVA_GEN := pulumi-java-gen
 JAVA_GEN_VERSION := v0.5.4
 TESTPARALLELISM := 10
@@ -29,9 +29,9 @@ install_sdks: install_dotnet_sdk install_python_sdk install_nodejs_sdk install_j
 
 only_build: build
 
-build_dotnet: DOTNET_VERSION := $(shell pulumictl get version --language dotnet)
+build_dotnet: DOTNET_VERSION := $(shell pulumictl convert-version -l dotnet -v "$(VERSION)")
 build_dotnet: upstream
-	pulumictl get version --language dotnet
+	@echo $(DOTNET_VERSION)
 	$(WORKING_DIR)/bin/$(TFGEN) dotnet --out sdk/dotnet/
 	cd sdk/dotnet/ && \
 		echo "module fake_dotnet_module // Exclude this directory from Go tools\n\ngo 1.17" > go.mod && \
@@ -42,14 +42,14 @@ build_go: upstream
 	$(WORKING_DIR)/bin/$(TFGEN) go --out sdk/go/
 	cd sdk && go list `grep -e "^module" go.mod | cut -d ' ' -f 2`/go/... | xargs go build
 
-build_java: PACKAGE_VERSION := $(shell pulumictl get version --language generic)
+build_java: PACKAGE_VERSION := "$(VERSION)"
 build_java: bin/pulumi-java-gen upstream
 	$(WORKING_DIR)/bin/$(JAVA_GEN) generate --schema provider/cmd/$(PROVIDER)/schema.json --out sdk/java  --build gradle-nexus
 	cd sdk/java/ && \
 		echo "module fake_java_module // Exclude this directory from Go tools\n\ngo 1.17" > go.mod && \
 		gradle --console=plain build
 
-build_nodejs: VERSION := $(shell pulumictl get version --language javascript)
+build_nodejs: VERSION := $(shell pulumictl convert-version -l javascript -v "$(VERSION)")
 build_nodejs: upstream
 	$(WORKING_DIR)/bin/$(TFGEN) nodejs --out sdk/nodejs/
 	cd sdk/nodejs/ && \
@@ -59,7 +59,7 @@ build_nodejs: upstream
 		cp ../../README.md ../../LICENSE* package.json yarn.lock ./bin/ && \
 		sed -i.bak -e "s/\$${VERSION}/$(VERSION)/g" ./bin/package.json
 
-build_python: PYPI_VERSION := $(shell pulumictl get version --language python)
+build_python: PYPI_VERSION := $(shell pulumictl convert-version -l python -v "$(VERSION)")
 build_python: upstream
 	$(WORKING_DIR)/bin/$(TFGEN) python --out sdk/python/
 	cd sdk/python/ && \
@@ -119,7 +119,10 @@ upstream.finalize:
 upstream.rebase:
 	@$(SHELL) ./scripts/upstream.sh "$@" start_rebase
 
+version.generic:
+	@echo $(VERSION)
+
 bin/pulumi-java-gen:
 	$(shell pulumictl download-binary -n pulumi-language-java -v $(JAVA_GEN_VERSION) -r pulumi/pulumi-java)
 
-.PHONY: development build build_sdks install_go_sdk install_java_sdk install_python_sdk install_sdks only_build build_dotnet build_go build_java build_nodejs build_python clean cleanup help install_dotnet_sdk install_nodejs_sdk install_plugins lint_provider provider test tfgen upstream upstream.finalize upstream.rebase
+.PHONY: development build build_sdks install_go_sdk install_java_sdk install_python_sdk install_sdks only_build build_dotnet build_go build_java build_nodejs build_python clean cleanup help install_dotnet_sdk install_nodejs_sdk install_plugins lint_provider provider test tfgen upstream upstream.finalize upstream.rebase version.generic

--- a/provider-ci/providers/tls/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/tls/repo/.github/workflows/main.yml
@@ -90,7 +90,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version.generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -338,7 +338,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version.generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:

--- a/provider-ci/providers/tls/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/tls/repo/.github/workflows/main.yml
@@ -90,8 +90,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -339,8 +338,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(pulumictl get version --language generic)"
-        >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:

--- a/provider-ci/providers/tls/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/tls/repo/.github/workflows/master.yml
@@ -90,7 +90,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version.generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -338,7 +338,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version.generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:

--- a/provider-ci/providers/tls/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/tls/repo/.github/workflows/master.yml
@@ -90,8 +90,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -339,8 +338,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(pulumictl get version --language generic)"
-        >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:

--- a/provider-ci/providers/tls/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/tls/repo/.github/workflows/prerelease.yml
@@ -91,7 +91,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version.generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -288,7 +288,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version.generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:

--- a/provider-ci/providers/tls/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/tls/repo/.github/workflows/prerelease.yml
@@ -91,8 +91,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -289,8 +288,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(pulumictl get version --language generic)"
-        >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:

--- a/provider-ci/providers/tls/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/tls/repo/.github/workflows/release.yml
@@ -90,7 +90,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version.generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -301,7 +301,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version.generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:
@@ -344,8 +344,8 @@ jobs:
       with:
         repo: pulumi/pulumictl
     - name: Add SDK version tag
-      run: git tag sdk/v$(make version:generic) && git push origin sdk/v$(make
-        version:generic)
+      run: git tag sdk/v$(make version.generic) && git push origin sdk/v$(make
+        version.generic)
   test:
     name: test
     needs: build_sdk

--- a/provider-ci/providers/tls/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/tls/repo/.github/workflows/release.yml
@@ -90,8 +90,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -302,8 +301,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(pulumictl get version --language generic)"
-        >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:
@@ -346,8 +344,8 @@ jobs:
       with:
         repo: pulumi/pulumictl
     - name: Add SDK version tag
-      run: git tag sdk/v$(pulumictl get version --language generic) && git push origin
-        sdk/v$(pulumictl get version --language generic)
+      run: git tag sdk/v$(make version:generic) && git push origin sdk/v$(make
+        version:generic)
   test:
     name: test
     needs: build_sdk

--- a/provider-ci/providers/tls/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/tls/repo/.github/workflows/run-acceptance-tests.yml
@@ -95,7 +95,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version.generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean

--- a/provider-ci/providers/tls/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/tls/repo/.github/workflows/run-acceptance-tests.yml
@@ -95,8 +95,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean

--- a/provider-ci/providers/tls/repo/Makefile
+++ b/provider-ci/providers/tls/repo/Makefile
@@ -7,7 +7,7 @@ PROVIDER_PATH := provider/v5
 VERSION_PATH := $(PROVIDER_PATH)/pkg/version.Version
 TFGEN := pulumi-tfgen-$(PACK)
 PROVIDER := pulumi-resource-$(PACK)
-VERSION := $(shell pulumictl get version)
+VERSION := $(shell pulumictl get version --language generic)
 JAVA_GEN := pulumi-java-gen
 JAVA_GEN_VERSION := v0.5.4
 TESTPARALLELISM := 10
@@ -29,9 +29,9 @@ install_sdks: install_dotnet_sdk install_python_sdk install_nodejs_sdk install_j
 
 only_build: build
 
-build_dotnet: DOTNET_VERSION := $(shell pulumictl get version --language dotnet)
+build_dotnet: DOTNET_VERSION := $(shell pulumictl convert-version -l dotnet -v "$(VERSION)")
 build_dotnet: upstream
-	pulumictl get version --language dotnet
+	@echo $(DOTNET_VERSION)
 	$(WORKING_DIR)/bin/$(TFGEN) dotnet --out sdk/dotnet/
 	cd sdk/dotnet/ && \
 		echo "module fake_dotnet_module // Exclude this directory from Go tools\n\ngo 1.17" > go.mod && \
@@ -42,14 +42,14 @@ build_go: upstream
 	$(WORKING_DIR)/bin/$(TFGEN) go --out sdk/go/
 	cd sdk && go list `grep -e "^module" go.mod | cut -d ' ' -f 2`/go/... | xargs go build
 
-build_java: PACKAGE_VERSION := $(shell pulumictl get version --language generic)
+build_java: PACKAGE_VERSION := "$(VERSION)"
 build_java: bin/pulumi-java-gen upstream
 	$(WORKING_DIR)/bin/$(JAVA_GEN) generate --schema provider/cmd/$(PROVIDER)/schema.json --out sdk/java  --build gradle-nexus
 	cd sdk/java/ && \
 		echo "module fake_java_module // Exclude this directory from Go tools\n\ngo 1.17" > go.mod && \
 		gradle --console=plain build
 
-build_nodejs: VERSION := $(shell pulumictl get version --language javascript)
+build_nodejs: VERSION := $(shell pulumictl convert-version -l javascript -v "$(VERSION)")
 build_nodejs: upstream
 	$(WORKING_DIR)/bin/$(TFGEN) nodejs --out sdk/nodejs/
 	cd sdk/nodejs/ && \
@@ -59,7 +59,7 @@ build_nodejs: upstream
 		cp ../../README.md ../../LICENSE* package.json yarn.lock ./bin/ && \
 		sed -i.bak -e "s/\$${VERSION}/$(VERSION)/g" ./bin/package.json
 
-build_python: PYPI_VERSION := $(shell pulumictl get version --language python)
+build_python: PYPI_VERSION := $(shell pulumictl convert-version -l python -v "$(VERSION)")
 build_python: upstream
 	$(WORKING_DIR)/bin/$(TFGEN) python --out sdk/python/
 	cd sdk/python/ && \
@@ -119,7 +119,10 @@ upstream.finalize:
 upstream.rebase:
 	@$(SHELL) ./scripts/upstream.sh "$@" start_rebase
 
+version.generic:
+	@echo $(VERSION)
+
 bin/pulumi-java-gen:
 	$(shell pulumictl download-binary -n pulumi-language-java -v $(JAVA_GEN_VERSION) -r pulumi/pulumi-java)
 
-.PHONY: development build build_sdks install_go_sdk install_java_sdk install_python_sdk install_sdks only_build build_dotnet build_go build_java build_nodejs build_python clean cleanup help install_dotnet_sdk install_nodejs_sdk install_plugins lint_provider provider test tfgen upstream upstream.finalize upstream.rebase
+.PHONY: development build build_sdks install_go_sdk install_java_sdk install_python_sdk install_sdks only_build build_dotnet build_go build_java build_nodejs build_python clean cleanup help install_dotnet_sdk install_nodejs_sdk install_plugins lint_provider provider test tfgen upstream upstream.finalize upstream.rebase version.generic

--- a/provider-ci/providers/vault/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/vault/repo/.github/workflows/main.yml
@@ -90,7 +90,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version.generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -338,7 +338,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version.generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:

--- a/provider-ci/providers/vault/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/vault/repo/.github/workflows/main.yml
@@ -90,8 +90,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -339,8 +338,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(pulumictl get version --language generic)"
-        >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:

--- a/provider-ci/providers/vault/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/vault/repo/.github/workflows/master.yml
@@ -90,7 +90,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version.generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -338,7 +338,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version.generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:

--- a/provider-ci/providers/vault/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/vault/repo/.github/workflows/master.yml
@@ -90,8 +90,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -339,8 +338,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(pulumictl get version --language generic)"
-        >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:

--- a/provider-ci/providers/vault/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/vault/repo/.github/workflows/prerelease.yml
@@ -91,7 +91,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version.generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -288,7 +288,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version.generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:

--- a/provider-ci/providers/vault/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/vault/repo/.github/workflows/prerelease.yml
@@ -91,8 +91,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -289,8 +288,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(pulumictl get version --language generic)"
-        >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:

--- a/provider-ci/providers/vault/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/vault/repo/.github/workflows/release.yml
@@ -90,7 +90,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version.generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -301,7 +301,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version.generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:
@@ -344,8 +344,8 @@ jobs:
       with:
         repo: pulumi/pulumictl
     - name: Add SDK version tag
-      run: git tag sdk/v$(make version:generic) && git push origin sdk/v$(make
-        version:generic)
+      run: git tag sdk/v$(make version.generic) && git push origin sdk/v$(make
+        version.generic)
   test:
     name: test
     needs: build_sdk

--- a/provider-ci/providers/vault/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/vault/repo/.github/workflows/release.yml
@@ -90,8 +90,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -302,8 +301,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(pulumictl get version --language generic)"
-        >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:
@@ -346,8 +344,8 @@ jobs:
       with:
         repo: pulumi/pulumictl
     - name: Add SDK version tag
-      run: git tag sdk/v$(pulumictl get version --language generic) && git push origin
-        sdk/v$(pulumictl get version --language generic)
+      run: git tag sdk/v$(make version:generic) && git push origin sdk/v$(make
+        version:generic)
   test:
     name: test
     needs: build_sdk

--- a/provider-ci/providers/vault/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/vault/repo/.github/workflows/run-acceptance-tests.yml
@@ -95,7 +95,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version.generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean

--- a/provider-ci/providers/vault/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/vault/repo/.github/workflows/run-acceptance-tests.yml
@@ -95,8 +95,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean

--- a/provider-ci/providers/vault/repo/Makefile
+++ b/provider-ci/providers/vault/repo/Makefile
@@ -7,7 +7,7 @@ PROVIDER_PATH := provider/v5
 VERSION_PATH := $(PROVIDER_PATH)/pkg/version.Version
 TFGEN := pulumi-tfgen-$(PACK)
 PROVIDER := pulumi-resource-$(PACK)
-VERSION := $(shell pulumictl get version)
+VERSION := $(shell pulumictl get version --language generic)
 JAVA_GEN := pulumi-java-gen
 JAVA_GEN_VERSION := v0.5.4
 TESTPARALLELISM := 10
@@ -29,9 +29,9 @@ install_sdks: install_dotnet_sdk install_python_sdk install_nodejs_sdk install_j
 
 only_build: build
 
-build_dotnet: DOTNET_VERSION := $(shell pulumictl get version --language dotnet)
+build_dotnet: DOTNET_VERSION := $(shell pulumictl convert-version -l dotnet -v "$(VERSION)")
 build_dotnet: upstream
-	pulumictl get version --language dotnet
+	@echo $(DOTNET_VERSION)
 	$(WORKING_DIR)/bin/$(TFGEN) dotnet --out sdk/dotnet/
 	cd sdk/dotnet/ && \
 		echo "module fake_dotnet_module // Exclude this directory from Go tools\n\ngo 1.17" > go.mod && \
@@ -42,14 +42,14 @@ build_go: upstream
 	$(WORKING_DIR)/bin/$(TFGEN) go --out sdk/go/
 	cd sdk && go list `grep -e "^module" go.mod | cut -d ' ' -f 2`/go/... | xargs go build
 
-build_java: PACKAGE_VERSION := $(shell pulumictl get version --language generic)
+build_java: PACKAGE_VERSION := "$(VERSION)"
 build_java: bin/pulumi-java-gen upstream
 	$(WORKING_DIR)/bin/$(JAVA_GEN) generate --schema provider/cmd/$(PROVIDER)/schema.json --out sdk/java  --build gradle-nexus
 	cd sdk/java/ && \
 		echo "module fake_java_module // Exclude this directory from Go tools\n\ngo 1.17" > go.mod && \
 		gradle --console=plain build
 
-build_nodejs: VERSION := $(shell pulumictl get version --language javascript)
+build_nodejs: VERSION := $(shell pulumictl convert-version -l javascript -v "$(VERSION)")
 build_nodejs: upstream
 	$(WORKING_DIR)/bin/$(TFGEN) nodejs --out sdk/nodejs/
 	cd sdk/nodejs/ && \
@@ -59,7 +59,7 @@ build_nodejs: upstream
 		cp ../../README.md ../../LICENSE* package.json yarn.lock ./bin/ && \
 		sed -i.bak -e "s/\$${VERSION}/$(VERSION)/g" ./bin/package.json
 
-build_python: PYPI_VERSION := $(shell pulumictl get version --language python)
+build_python: PYPI_VERSION := $(shell pulumictl convert-version -l python -v "$(VERSION)")
 build_python: upstream
 	$(WORKING_DIR)/bin/$(TFGEN) python --out sdk/python/
 	cd sdk/python/ && \
@@ -119,7 +119,10 @@ upstream.finalize:
 upstream.rebase:
 	@$(SHELL) ./scripts/upstream.sh "$@" start_rebase
 
+version.generic:
+	@echo $(VERSION)
+
 bin/pulumi-java-gen:
 	$(shell pulumictl download-binary -n pulumi-language-java -v $(JAVA_GEN_VERSION) -r pulumi/pulumi-java)
 
-.PHONY: development build build_sdks install_go_sdk install_java_sdk install_python_sdk install_sdks only_build build_dotnet build_go build_java build_nodejs build_python clean cleanup help install_dotnet_sdk install_nodejs_sdk install_plugins lint_provider provider test tfgen upstream upstream.finalize upstream.rebase
+.PHONY: development build build_sdks install_go_sdk install_java_sdk install_python_sdk install_sdks only_build build_dotnet build_go build_java build_nodejs build_python clean cleanup help install_dotnet_sdk install_nodejs_sdk install_plugins lint_provider provider test tfgen upstream upstream.finalize upstream.rebase version.generic

--- a/provider-ci/providers/venafi/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/venafi/repo/.github/workflows/main.yml
@@ -94,7 +94,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version.generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -342,7 +342,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version.generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:

--- a/provider-ci/providers/venafi/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/venafi/repo/.github/workflows/main.yml
@@ -94,8 +94,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -343,8 +342,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(pulumictl get version --language generic)"
-        >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:

--- a/provider-ci/providers/venafi/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/venafi/repo/.github/workflows/master.yml
@@ -94,7 +94,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version.generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -342,7 +342,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version.generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:

--- a/provider-ci/providers/venafi/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/venafi/repo/.github/workflows/master.yml
@@ -94,8 +94,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -343,8 +342,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(pulumictl get version --language generic)"
-        >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:

--- a/provider-ci/providers/venafi/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/venafi/repo/.github/workflows/prerelease.yml
@@ -95,8 +95,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -293,8 +292,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(pulumictl get version --language generic)"
-        >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:

--- a/provider-ci/providers/venafi/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/venafi/repo/.github/workflows/prerelease.yml
@@ -95,7 +95,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version.generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -292,7 +292,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version.generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:

--- a/provider-ci/providers/venafi/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/venafi/repo/.github/workflows/release.yml
@@ -94,8 +94,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -306,8 +305,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(pulumictl get version --language generic)"
-        >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:
@@ -350,8 +348,8 @@ jobs:
       with:
         repo: pulumi/pulumictl
     - name: Add SDK version tag
-      run: git tag sdk/v$(pulumictl get version --language generic) && git push origin
-        sdk/v$(pulumictl get version --language generic)
+      run: git tag sdk/v$(make version:generic) && git push origin sdk/v$(make
+        version:generic)
   test:
     name: test
     needs: build_sdk

--- a/provider-ci/providers/venafi/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/venafi/repo/.github/workflows/release.yml
@@ -94,7 +94,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version.generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -305,7 +305,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version.generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:
@@ -348,8 +348,8 @@ jobs:
       with:
         repo: pulumi/pulumictl
     - name: Add SDK version tag
-      run: git tag sdk/v$(make version:generic) && git push origin sdk/v$(make
-        version:generic)
+      run: git tag sdk/v$(make version.generic) && git push origin sdk/v$(make
+        version.generic)
   test:
     name: test
     needs: build_sdk

--- a/provider-ci/providers/venafi/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/venafi/repo/.github/workflows/run-acceptance-tests.yml
@@ -99,8 +99,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean

--- a/provider-ci/providers/venafi/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/venafi/repo/.github/workflows/run-acceptance-tests.yml
@@ -99,7 +99,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version.generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean

--- a/provider-ci/providers/venafi/repo/Makefile
+++ b/provider-ci/providers/venafi/repo/Makefile
@@ -7,7 +7,7 @@ PROVIDER_PATH := provider
 VERSION_PATH := $(PROVIDER_PATH)/pkg/version.Version
 TFGEN := pulumi-tfgen-$(PACK)
 PROVIDER := pulumi-resource-$(PACK)
-VERSION := $(shell pulumictl get version)
+VERSION := $(shell pulumictl get version --language generic)
 JAVA_GEN := pulumi-java-gen
 JAVA_GEN_VERSION := v0.5.4
 TESTPARALLELISM := 10
@@ -29,9 +29,9 @@ install_sdks: install_dotnet_sdk install_python_sdk install_nodejs_sdk install_j
 
 only_build: build
 
-build_dotnet: DOTNET_VERSION := $(shell pulumictl get version --language dotnet)
+build_dotnet: DOTNET_VERSION := $(shell pulumictl convert-version -l dotnet -v "$(VERSION)")
 build_dotnet: upstream
-	pulumictl get version --language dotnet
+	@echo $(DOTNET_VERSION)
 	$(WORKING_DIR)/bin/$(TFGEN) dotnet --out sdk/dotnet/
 	cd sdk/dotnet/ && \
 		echo "module fake_dotnet_module // Exclude this directory from Go tools\n\ngo 1.17" > go.mod && \
@@ -42,14 +42,14 @@ build_go: upstream
 	$(WORKING_DIR)/bin/$(TFGEN) go --out sdk/go/
 	cd sdk && go list `grep -e "^module" go.mod | cut -d ' ' -f 2`/go/... | xargs go build
 
-build_java: PACKAGE_VERSION := $(shell pulumictl get version --language generic)
+build_java: PACKAGE_VERSION := "$(VERSION)"
 build_java: bin/pulumi-java-gen upstream
 	$(WORKING_DIR)/bin/$(JAVA_GEN) generate --schema provider/cmd/$(PROVIDER)/schema.json --out sdk/java  --build gradle-nexus
 	cd sdk/java/ && \
 		echo "module fake_java_module // Exclude this directory from Go tools\n\ngo 1.17" > go.mod && \
 		gradle --console=plain build
 
-build_nodejs: VERSION := $(shell pulumictl get version --language javascript)
+build_nodejs: VERSION := $(shell pulumictl convert-version -l javascript -v "$(VERSION)")
 build_nodejs: upstream
 	$(WORKING_DIR)/bin/$(TFGEN) nodejs --out sdk/nodejs/
 	cd sdk/nodejs/ && \
@@ -59,7 +59,7 @@ build_nodejs: upstream
 		cp ../../README.md ../../LICENSE* package.json yarn.lock ./bin/ && \
 		sed -i.bak -e "s/\$${VERSION}/$(VERSION)/g" ./bin/package.json
 
-build_python: PYPI_VERSION := $(shell pulumictl get version --language python)
+build_python: PYPI_VERSION := $(shell pulumictl convert-version -l python -v "$(VERSION)")
 build_python: upstream
 	$(WORKING_DIR)/bin/$(TFGEN) python --out sdk/python/
 	cd sdk/python/ && \
@@ -118,7 +118,10 @@ upstream.finalize:
 upstream.rebase:
 	@$(SHELL) ./scripts/upstream.sh "$@" start_rebase
 
+version.generic:
+	@echo $(VERSION)
+
 bin/pulumi-java-gen:
 	$(shell pulumictl download-binary -n pulumi-language-java -v $(JAVA_GEN_VERSION) -r pulumi/pulumi-java)
 
-.PHONY: development build build_sdks install_go_sdk install_java_sdk install_python_sdk install_sdks only_build build_dotnet build_go build_java build_nodejs build_python clean cleanup help install_dotnet_sdk install_nodejs_sdk install_plugins lint_provider provider test tfgen upstream upstream.finalize upstream.rebase
+.PHONY: development build build_sdks install_go_sdk install_java_sdk install_python_sdk install_sdks only_build build_dotnet build_go build_java build_nodejs build_python clean cleanup help install_dotnet_sdk install_nodejs_sdk install_plugins lint_provider provider test tfgen upstream upstream.finalize upstream.rebase version.generic

--- a/provider-ci/providers/vsphere/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/vsphere/repo/.github/workflows/main.yml
@@ -90,7 +90,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version.generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -338,7 +338,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version.generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:

--- a/provider-ci/providers/vsphere/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/vsphere/repo/.github/workflows/main.yml
@@ -90,8 +90,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -339,8 +338,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(pulumictl get version --language generic)"
-        >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:

--- a/provider-ci/providers/vsphere/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/vsphere/repo/.github/workflows/master.yml
@@ -90,7 +90,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version.generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -338,7 +338,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version.generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:

--- a/provider-ci/providers/vsphere/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/vsphere/repo/.github/workflows/master.yml
@@ -90,8 +90,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -339,8 +338,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(pulumictl get version --language generic)"
-        >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:

--- a/provider-ci/providers/vsphere/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/vsphere/repo/.github/workflows/prerelease.yml
@@ -91,7 +91,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version.generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -288,7 +288,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version.generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:

--- a/provider-ci/providers/vsphere/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/vsphere/repo/.github/workflows/prerelease.yml
@@ -91,8 +91,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -289,8 +288,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(pulumictl get version --language generic)"
-        >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:

--- a/provider-ci/providers/vsphere/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/vsphere/repo/.github/workflows/release.yml
@@ -90,7 +90,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version.generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -301,7 +301,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version.generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:
@@ -344,8 +344,8 @@ jobs:
       with:
         repo: pulumi/pulumictl
     - name: Add SDK version tag
-      run: git tag sdk/v$(make version:generic) && git push origin sdk/v$(make
-        version:generic)
+      run: git tag sdk/v$(make version.generic) && git push origin sdk/v$(make
+        version.generic)
   test:
     name: test
     needs: build_sdk

--- a/provider-ci/providers/vsphere/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/vsphere/repo/.github/workflows/release.yml
@@ -90,8 +90,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -302,8 +301,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(pulumictl get version --language generic)"
-        >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:
@@ -346,8 +344,8 @@ jobs:
       with:
         repo: pulumi/pulumictl
     - name: Add SDK version tag
-      run: git tag sdk/v$(pulumictl get version --language generic) && git push origin
-        sdk/v$(pulumictl get version --language generic)
+      run: git tag sdk/v$(make version:generic) && git push origin sdk/v$(make
+        version:generic)
   test:
     name: test
     needs: build_sdk

--- a/provider-ci/providers/vsphere/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/vsphere/repo/.github/workflows/run-acceptance-tests.yml
@@ -95,7 +95,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version.generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean

--- a/provider-ci/providers/vsphere/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/vsphere/repo/.github/workflows/run-acceptance-tests.yml
@@ -95,8 +95,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean

--- a/provider-ci/providers/vsphere/repo/Makefile
+++ b/provider-ci/providers/vsphere/repo/Makefile
@@ -7,7 +7,7 @@ PROVIDER_PATH := provider/v4
 VERSION_PATH := $(PROVIDER_PATH)/pkg/version.Version
 TFGEN := pulumi-tfgen-$(PACK)
 PROVIDER := pulumi-resource-$(PACK)
-VERSION := $(shell pulumictl get version)
+VERSION := $(shell pulumictl get version --language generic)
 JAVA_GEN := pulumi-java-gen
 JAVA_GEN_VERSION := v0.5.4
 TESTPARALLELISM := 10
@@ -29,9 +29,9 @@ install_sdks: install_dotnet_sdk install_python_sdk install_nodejs_sdk install_j
 
 only_build: build
 
-build_dotnet: DOTNET_VERSION := $(shell pulumictl get version --language dotnet)
+build_dotnet: DOTNET_VERSION := $(shell pulumictl convert-version -l dotnet -v "$(VERSION)")
 build_dotnet: upstream
-	pulumictl get version --language dotnet
+	@echo $(DOTNET_VERSION)
 	$(WORKING_DIR)/bin/$(TFGEN) dotnet --out sdk/dotnet/
 	cd sdk/dotnet/ && \
 		echo "module fake_dotnet_module // Exclude this directory from Go tools\n\ngo 1.17" > go.mod && \
@@ -42,14 +42,14 @@ build_go: upstream
 	$(WORKING_DIR)/bin/$(TFGEN) go --out sdk/go/
 	cd sdk && go list `grep -e "^module" go.mod | cut -d ' ' -f 2`/go/... | xargs go build
 
-build_java: PACKAGE_VERSION := $(shell pulumictl get version --language generic)
+build_java: PACKAGE_VERSION := "$(VERSION)"
 build_java: bin/pulumi-java-gen upstream
 	$(WORKING_DIR)/bin/$(JAVA_GEN) generate --schema provider/cmd/$(PROVIDER)/schema.json --out sdk/java  --build gradle-nexus
 	cd sdk/java/ && \
 		echo "module fake_java_module // Exclude this directory from Go tools\n\ngo 1.17" > go.mod && \
 		gradle --console=plain build
 
-build_nodejs: VERSION := $(shell pulumictl get version --language javascript)
+build_nodejs: VERSION := $(shell pulumictl convert-version -l javascript -v "$(VERSION)")
 build_nodejs: upstream
 	$(WORKING_DIR)/bin/$(TFGEN) nodejs --out sdk/nodejs/
 	cd sdk/nodejs/ && \
@@ -59,7 +59,7 @@ build_nodejs: upstream
 		cp ../../README.md ../../LICENSE* package.json yarn.lock ./bin/ && \
 		sed -i.bak -e "s/\$${VERSION}/$(VERSION)/g" ./bin/package.json
 
-build_python: PYPI_VERSION := $(shell pulumictl get version --language python)
+build_python: PYPI_VERSION := $(shell pulumictl convert-version -l python -v "$(VERSION)")
 build_python: upstream
 	$(WORKING_DIR)/bin/$(TFGEN) python --out sdk/python/
 	cd sdk/python/ && \
@@ -118,7 +118,10 @@ upstream.finalize:
 upstream.rebase:
 	@$(SHELL) ./scripts/upstream.sh "$@" start_rebase
 
+version.generic:
+	@echo $(VERSION)
+
 bin/pulumi-java-gen:
 	$(shell pulumictl download-binary -n pulumi-language-java -v $(JAVA_GEN_VERSION) -r pulumi/pulumi-java)
 
-.PHONY: development build build_sdks install_go_sdk install_java_sdk install_python_sdk install_sdks only_build build_dotnet build_go build_java build_nodejs build_python clean cleanup help install_dotnet_sdk install_nodejs_sdk install_plugins lint_provider provider test tfgen upstream upstream.finalize upstream.rebase
+.PHONY: development build build_sdks install_go_sdk install_java_sdk install_python_sdk install_sdks only_build build_dotnet build_go build_java build_nodejs build_python clean cleanup help install_dotnet_sdk install_nodejs_sdk install_plugins lint_provider provider test tfgen upstream upstream.finalize upstream.rebase version.generic

--- a/provider-ci/providers/wavefront/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/wavefront/repo/.github/workflows/main.yml
@@ -92,8 +92,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -341,8 +340,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(pulumictl get version --language generic)"
-        >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:

--- a/provider-ci/providers/wavefront/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/wavefront/repo/.github/workflows/main.yml
@@ -92,7 +92,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version.generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -340,7 +340,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version.generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:

--- a/provider-ci/providers/wavefront/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/wavefront/repo/.github/workflows/master.yml
@@ -92,8 +92,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -341,8 +340,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(pulumictl get version --language generic)"
-        >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:

--- a/provider-ci/providers/wavefront/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/wavefront/repo/.github/workflows/master.yml
@@ -92,7 +92,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version.generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -340,7 +340,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version.generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:

--- a/provider-ci/providers/wavefront/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/wavefront/repo/.github/workflows/prerelease.yml
@@ -93,8 +93,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -291,8 +290,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(pulumictl get version --language generic)"
-        >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:

--- a/provider-ci/providers/wavefront/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/wavefront/repo/.github/workflows/prerelease.yml
@@ -93,7 +93,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version.generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -290,7 +290,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version.generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:

--- a/provider-ci/providers/wavefront/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/wavefront/repo/.github/workflows/release.yml
@@ -92,7 +92,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version.generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -303,7 +303,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version.generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:
@@ -346,8 +346,8 @@ jobs:
       with:
         repo: pulumi/pulumictl
     - name: Add SDK version tag
-      run: git tag sdk/v$(make version:generic) && git push origin sdk/v$(make
-        version:generic)
+      run: git tag sdk/v$(make version.generic) && git push origin sdk/v$(make
+        version.generic)
   test:
     name: test
     needs: build_sdk

--- a/provider-ci/providers/wavefront/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/wavefront/repo/.github/workflows/release.yml
@@ -92,8 +92,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
@@ -304,8 +303,7 @@ jobs:
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(pulumictl get version --language generic)"
-        >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:
@@ -348,8 +346,8 @@ jobs:
       with:
         repo: pulumi/pulumictl
     - name: Add SDK version tag
-      run: git tag sdk/v$(pulumictl get version --language generic) && git push origin
-        sdk/v$(pulumictl get version --language generic)
+      run: git tag sdk/v$(make version:generic) && git push origin sdk/v$(make
+        version:generic)
   test:
     name: test
     needs: build_sdk

--- a/provider-ci/providers/wavefront/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/wavefront/repo/.github/workflows/run-acceptance-tests.yml
@@ -97,7 +97,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version.generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean

--- a/provider-ci/providers/wavefront/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/wavefront/repo/.github/workflows/run-acceptance-tests.yml
@@ -97,8 +97,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean

--- a/provider-ci/providers/wavefront/repo/Makefile
+++ b/provider-ci/providers/wavefront/repo/Makefile
@@ -7,7 +7,7 @@ PROVIDER_PATH := provider
 VERSION_PATH := $(PROVIDER_PATH)/pkg/version.Version
 TFGEN := pulumi-tfgen-$(PACK)
 PROVIDER := pulumi-resource-$(PACK)
-VERSION := $(shell pulumictl get version)
+VERSION := $(shell pulumictl get version --language generic)
 JAVA_GEN := pulumi-java-gen
 JAVA_GEN_VERSION := v0.5.4
 TESTPARALLELISM := 10
@@ -29,9 +29,9 @@ install_sdks: install_dotnet_sdk install_python_sdk install_nodejs_sdk install_j
 
 only_build: build
 
-build_dotnet: DOTNET_VERSION := $(shell pulumictl get version --language dotnet)
+build_dotnet: DOTNET_VERSION := $(shell pulumictl convert-version -l dotnet -v "$(VERSION)")
 build_dotnet: upstream
-	pulumictl get version --language dotnet
+	@echo $(DOTNET_VERSION)
 	$(WORKING_DIR)/bin/$(TFGEN) dotnet --out sdk/dotnet/
 	cd sdk/dotnet/ && \
 		echo "module fake_dotnet_module // Exclude this directory from Go tools\n\ngo 1.17" > go.mod && \
@@ -42,14 +42,14 @@ build_go: upstream
 	$(WORKING_DIR)/bin/$(TFGEN) go --out sdk/go/
 	cd sdk && go list `grep -e "^module" go.mod | cut -d ' ' -f 2`/go/... | xargs go build
 
-build_java: PACKAGE_VERSION := $(shell pulumictl get version --language generic)
+build_java: PACKAGE_VERSION := "$(VERSION)"
 build_java: bin/pulumi-java-gen upstream
 	$(WORKING_DIR)/bin/$(JAVA_GEN) generate --schema provider/cmd/$(PROVIDER)/schema.json --out sdk/java  --build gradle-nexus
 	cd sdk/java/ && \
 		echo "module fake_java_module // Exclude this directory from Go tools\n\ngo 1.17" > go.mod && \
 		gradle --console=plain build
 
-build_nodejs: VERSION := $(shell pulumictl get version --language javascript)
+build_nodejs: VERSION := $(shell pulumictl convert-version -l javascript -v "$(VERSION)")
 build_nodejs: upstream
 	$(WORKING_DIR)/bin/$(TFGEN) nodejs --out sdk/nodejs/
 	cd sdk/nodejs/ && \
@@ -59,7 +59,7 @@ build_nodejs: upstream
 		cp ../../README.md ../../LICENSE* package.json yarn.lock ./bin/ && \
 		sed -i.bak -e "s/\$${VERSION}/$(VERSION)/g" ./bin/package.json
 
-build_python: PYPI_VERSION := $(shell pulumictl get version --language python)
+build_python: PYPI_VERSION := $(shell pulumictl convert-version -l python -v "$(VERSION)")
 build_python: upstream
 	$(WORKING_DIR)/bin/$(TFGEN) python --out sdk/python/
 	cd sdk/python/ && \
@@ -118,7 +118,10 @@ upstream.finalize:
 upstream.rebase:
 	@$(SHELL) ./scripts/upstream.sh "$@" start_rebase
 
+version.generic:
+	@echo $(VERSION)
+
 bin/pulumi-java-gen:
 	$(shell pulumictl download-binary -n pulumi-language-java -v $(JAVA_GEN_VERSION) -r pulumi/pulumi-java)
 
-.PHONY: development build build_sdks install_go_sdk install_java_sdk install_python_sdk install_sdks only_build build_dotnet build_go build_java build_nodejs build_python clean cleanup help install_dotnet_sdk install_nodejs_sdk install_plugins lint_provider provider test tfgen upstream upstream.finalize upstream.rebase
+.PHONY: development build build_sdks install_go_sdk install_java_sdk install_python_sdk install_sdks only_build build_dotnet build_go build_java build_nodejs build_python clean cleanup help install_dotnet_sdk install_nodejs_sdk install_plugins lint_provider provider test tfgen upstream upstream.finalize upstream.rebase version.generic

--- a/provider-ci/src/make-bridged-provider-2.ts
+++ b/provider-ci/src/make-bridged-provider-2.ts
@@ -380,11 +380,6 @@ export function bridgedProviderV2(config: BridgedConfig): Makefile {
       "cd examples && go test -v -tags=all -parallel $(TESTPARALLELISM) -timeout 2h",
     ],
   };
-  // const versionGeneric: Target = {
-  //   name: "version:generic",
-  //   phony: true,
-  //   commands: ["pulumictl get version --language generic"],
-  // };
   return {
     variables,
     defaultTarget: development,
@@ -397,7 +392,6 @@ export function bridgedProviderV2(config: BridgedConfig): Makefile {
       clean,
       test,
       tfgen,
-      //versionGeneric,
     ],
   };
 }

--- a/provider-ci/src/make-bridged-provider-2.ts
+++ b/provider-ci/src/make-bridged-provider-2.ts
@@ -380,6 +380,11 @@ export function bridgedProviderV2(config: BridgedConfig): Makefile {
       "cd examples && go test -v -tags=all -parallel $(TESTPARALLELISM) -timeout 2h",
     ],
   };
+  // const versionGeneric: Target = {
+  //   name: "version:generic",
+  //   phony: true,
+  //   commands: ["pulumictl get version --language generic"],
+  // };
   return {
     variables,
     defaultTarget: development,
@@ -392,6 +397,7 @@ export function bridgedProviderV2(config: BridgedConfig): Makefile {
       clean,
       test,
       tfgen,
+      //versionGeneric,
     ],
   };
 }

--- a/provider-ci/src/make-bridged-provider.ts
+++ b/provider-ci/src/make-bridged-provider.ts
@@ -122,7 +122,8 @@ export function bridgedProvider(config: BridgedConfig): Makefile {
     phony: true,
     dependencies: [upstream],
     variables: {
-      VERSION: '$(shell pulumictl convert-version -l javascript -v "$(VERSION)")',
+      VERSION:
+        '$(shell pulumictl convert-version -l javascript -v "$(VERSION)")',
     },
     commands: [
       "$(WORKING_DIR)/bin/$(TFGEN) nodejs --out sdk/nodejs/",
@@ -141,7 +142,8 @@ export function bridgedProvider(config: BridgedConfig): Makefile {
     phony: true,
     dependencies: [upstream],
     variables: {
-      PYPI_VERSION: '$(shell pulumictl convert-version -l python -v "$(VERSION)")',
+      PYPI_VERSION:
+        '$(shell pulumictl convert-version -l python -v "$(VERSION)")',
     },
     commands: [
       "$(WORKING_DIR)/bin/$(TFGEN) python --out sdk/python/",
@@ -174,7 +176,8 @@ export function bridgedProvider(config: BridgedConfig): Makefile {
     name: "build_dotnet",
     phony: true,
     variables: {
-      DOTNET_VERSION: '$(shell pulumictl convert-version -l dotnet -v "$(VERSION)")',
+      DOTNET_VERSION:
+        '$(shell pulumictl convert-version -l dotnet -v "$(VERSION)")',
     },
     dependencies: [upstream],
     commands: [

--- a/provider-ci/src/make-bridged-provider.ts
+++ b/provider-ci/src/make-bridged-provider.ts
@@ -304,7 +304,7 @@ export function bridgedProvider(config: BridgedConfig): Makefile {
     ],
   };
   const versionGeneric: Target = {
-    name: "version:generic",
+    name: "version.generic",
     phony: true,
     commands: ["@echo $(VERSION)"],
   };

--- a/provider-ci/src/steps.ts
+++ b/provider-ci/src/steps.ts
@@ -456,7 +456,7 @@ export function SetPackageVersionToEnv(): Step {
   return {
     // This is required for the Java Provider Build + Publish Steps
     name: "Set PACKAGE_VERSION to Env",
-    run: 'echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV',
+    run: 'echo "PACKAGE_VERSION=$(make version.generic)" >> $GITHUB_ENV',
   };
 }
 
@@ -470,7 +470,7 @@ export function RunTests(): Step {
 export function SetPreReleaseVersion(): Step {
   return {
     name: "Set PreRelease Version",
-    run: 'echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV',
+    run: 'echo "GORELEASER_CURRENT_TAG=v$(make version.generic)" >> $GITHUB_ENV',
   };
 }
 
@@ -501,7 +501,7 @@ export function RunPublishSDK(): Step {
 export function TagSDKTag(): Step {
   return {
     name: "Add SDK version tag",
-    run: "git tag sdk/v$(make version:generic) && git push origin sdk/v$(make version:generic)",
+    run: "git tag sdk/v$(make version.generic) && git push origin sdk/v$(make version.generic)",
   };
 }
 

--- a/provider-ci/src/steps.ts
+++ b/provider-ci/src/steps.ts
@@ -456,7 +456,7 @@ export function SetPackageVersionToEnv(): Step {
   return {
     // This is required for the Java Provider Build + Publish Steps
     name: "Set PACKAGE_VERSION to Env",
-    run: 'echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >> $GITHUB_ENV',
+    run: 'echo "PACKAGE_VERSION=$(make version:generic)" >> $GITHUB_ENV',
   };
 }
 
@@ -470,7 +470,7 @@ export function RunTests(): Step {
 export function SetPreReleaseVersion(): Step {
   return {
     name: "Set PreRelease Version",
-    run: 'echo "GORELEASER_CURRENT_TAG=v$(pulumictl get version --language generic)" >> $GITHUB_ENV',
+    run: 'echo "GORELEASER_CURRENT_TAG=v$(make version:generic)" >> $GITHUB_ENV',
   };
 }
 
@@ -501,7 +501,7 @@ export function RunPublishSDK(): Step {
 export function TagSDKTag(): Step {
   return {
     name: "Add SDK version tag",
-    run: "git tag sdk/v$(pulumictl get version --language generic) && git push origin sdk/v$(pulumictl get version --language generic)",
+    run: "git tag sdk/v$(make version:generic) && git push origin sdk/v$(make version:generic)",
   };
 }
 


### PR DESCRIPTION
Having recently updated the playbook for major version upgrades to avoid skipping tests and creating P1s down the line,
https://github.com/pulumi/platform-providers-team/pull/103 I tried with pulumi-okta with poor success. This process
remains problematic.

The key issue is that alpha tag tricks fail to convince pulumictl to compute the right (new) major version in CI to run
the tests. The fix involved using VERSION_PREFIX to force pulumictl to compute the right version.

Unfortunately setting VERSION_PREFIX everywhere in CI in itself is a pain.

This PR takes a small step toward addressing that latter problem.

All invocations of pulumictl pertaining to computing versions are centralized; GitHub actions are now asking the
Makefile for version, and Makefile is deciding the version on one line corresponding to VERSION and using pulumictl
elsewhere as a pure converter to find language-specific variants.

With version decided in *one place* a major version upgrade can simply edit the makefile to set VERSION_PREFIX in one
place. If we follow up with swapping out of pulumictl as the source of versions this PR also makes that easier as there
is only one place to edit.

I have tested that local builds of pulumi-okta succeed with these Makefile changes.

Before mering what still remains is testing the changes in CI, to ensure the GitHub actions interact with the Makefile
correctly; need to try this on one of the bridged providers.
