### PR TITLE
Add `remove-plugins: true` to provider upgrade-config.yml

### DIFF
--- a/provider-ci/providers/aiven/repo/.upgrade-config.yml
+++ b/provider-ci/providers/aiven/repo/.upgrade-config.yml
@@ -3,4 +3,5 @@
 ---
 upstream-provider-name: terraform-provider-aiven
 pulumi-infer-version: true
+remove-plugins: true
 

--- a/provider-ci/providers/akamai/repo/.upgrade-config.yml
+++ b/provider-ci/providers/akamai/repo/.upgrade-config.yml
@@ -3,4 +3,5 @@
 ---
 upstream-provider-name: terraform-provider-akamai
 pulumi-infer-version: true
+remove-plugins: true
 

--- a/provider-ci/providers/alicloud/repo/.upgrade-config.yml
+++ b/provider-ci/providers/alicloud/repo/.upgrade-config.yml
@@ -3,4 +3,5 @@
 ---
 upstream-provider-name: terraform-provider-alicloud
 pulumi-infer-version: true
+remove-plugins: true
 

--- a/provider-ci/providers/artifactory/repo/.upgrade-config.yml
+++ b/provider-ci/providers/artifactory/repo/.upgrade-config.yml
@@ -3,4 +3,5 @@
 ---
 upstream-provider-name: terraform-provider-artifactory
 pulumi-infer-version: true
+remove-plugins: true
 

--- a/provider-ci/providers/auth0/repo/.upgrade-config.yml
+++ b/provider-ci/providers/auth0/repo/.upgrade-config.yml
@@ -3,4 +3,5 @@
 ---
 upstream-provider-name: terraform-provider-auth0
 pulumi-infer-version: true
+remove-plugins: true
 

--- a/provider-ci/providers/azure/repo/.upgrade-config.yml
+++ b/provider-ci/providers/azure/repo/.upgrade-config.yml
@@ -3,4 +3,5 @@
 ---
 upstream-provider-name: terraform-provider-azurerm
 pulumi-infer-version: true
+remove-plugins: true
 

--- a/provider-ci/providers/azuread/repo/.upgrade-config.yml
+++ b/provider-ci/providers/azuread/repo/.upgrade-config.yml
@@ -3,4 +3,5 @@
 ---
 upstream-provider-name: terraform-provider-azuread
 pulumi-infer-version: true
+remove-plugins: true
 

--- a/provider-ci/providers/civo/repo/.upgrade-config.yml
+++ b/provider-ci/providers/civo/repo/.upgrade-config.yml
@@ -3,4 +3,5 @@
 ---
 upstream-provider-name: terraform-provider-civo
 pulumi-infer-version: true
+remove-plugins: true
 

--- a/provider-ci/providers/cloudamqp/repo/.upgrade-config.yml
+++ b/provider-ci/providers/cloudamqp/repo/.upgrade-config.yml
@@ -3,4 +3,5 @@
 ---
 upstream-provider-name: terraform-provider-cloudamqp
 pulumi-infer-version: true
+remove-plugins: true
 

--- a/provider-ci/providers/cloudflare/repo/.upgrade-config.yml
+++ b/provider-ci/providers/cloudflare/repo/.upgrade-config.yml
@@ -3,4 +3,5 @@
 ---
 upstream-provider-name: terraform-provider-cloudflare
 pulumi-infer-version: true
+remove-plugins: true
 

--- a/provider-ci/providers/cloudinit/repo/.upgrade-config.yml
+++ b/provider-ci/providers/cloudinit/repo/.upgrade-config.yml
@@ -3,4 +3,5 @@
 ---
 upstream-provider-name: terraform-provider-cloudinit
 pulumi-infer-version: true
+remove-plugins: true
 

--- a/provider-ci/providers/confluentcloud/repo/.upgrade-config.yml
+++ b/provider-ci/providers/confluentcloud/repo/.upgrade-config.yml
@@ -3,4 +3,5 @@
 ---
 upstream-provider-name: terraform-provider-confluent
 pulumi-infer-version: true
+remove-plugins: true
 

--- a/provider-ci/providers/consul/repo/.upgrade-config.yml
+++ b/provider-ci/providers/consul/repo/.upgrade-config.yml
@@ -3,4 +3,5 @@
 ---
 upstream-provider-name: terraform-provider-consul
 pulumi-infer-version: true
+remove-plugins: true
 

--- a/provider-ci/providers/databricks/repo/.upgrade-config.yml
+++ b/provider-ci/providers/databricks/repo/.upgrade-config.yml
@@ -3,4 +3,5 @@
 ---
 upstream-provider-name: terraform-provider-databricks
 pulumi-infer-version: true
+remove-plugins: true
 

--- a/provider-ci/providers/datadog/repo/.upgrade-config.yml
+++ b/provider-ci/providers/datadog/repo/.upgrade-config.yml
@@ -3,4 +3,5 @@
 ---
 upstream-provider-name: terraform-provider-datadog
 pulumi-infer-version: true
+remove-plugins: true
 

--- a/provider-ci/providers/digitalocean/repo/.upgrade-config.yml
+++ b/provider-ci/providers/digitalocean/repo/.upgrade-config.yml
@@ -3,4 +3,5 @@
 ---
 upstream-provider-name: terraform-provider-digitalocean
 pulumi-infer-version: true
+remove-plugins: true
 

--- a/provider-ci/providers/dnsimple/repo/.upgrade-config.yml
+++ b/provider-ci/providers/dnsimple/repo/.upgrade-config.yml
@@ -3,4 +3,5 @@
 ---
 upstream-provider-name: terraform-provider-dnsimple
 pulumi-infer-version: true
+remove-plugins: true
 

--- a/provider-ci/providers/docker/repo/.upgrade-config.yml
+++ b/provider-ci/providers/docker/repo/.upgrade-config.yml
@@ -3,4 +3,5 @@
 ---
 upstream-provider-name: terraform-provider-docker
 pulumi-infer-version: true
+remove-plugins: true
 

--- a/provider-ci/providers/ec/repo/.upgrade-config.yml
+++ b/provider-ci/providers/ec/repo/.upgrade-config.yml
@@ -3,4 +3,5 @@
 ---
 upstream-provider-name: terraform-provider-ec
 pulumi-infer-version: true
+remove-plugins: true
 

--- a/provider-ci/providers/equinix-metal/repo/.upgrade-config.yml
+++ b/provider-ci/providers/equinix-metal/repo/.upgrade-config.yml
@@ -3,4 +3,5 @@
 ---
 upstream-provider-name: terraform-provider-metal
 pulumi-infer-version: true
+remove-plugins: true
 

--- a/provider-ci/providers/f5bigip/repo/.upgrade-config.yml
+++ b/provider-ci/providers/f5bigip/repo/.upgrade-config.yml
@@ -3,4 +3,5 @@
 ---
 upstream-provider-name: terraform-provider-bigip
 pulumi-infer-version: true
+remove-plugins: true
 

--- a/provider-ci/providers/fastly/repo/.upgrade-config.yml
+++ b/provider-ci/providers/fastly/repo/.upgrade-config.yml
@@ -3,4 +3,5 @@
 ---
 upstream-provider-name: terraform-provider-fastly
 pulumi-infer-version: true
+remove-plugins: true
 

--- a/provider-ci/providers/github/repo/.upgrade-config.yml
+++ b/provider-ci/providers/github/repo/.upgrade-config.yml
@@ -3,4 +3,5 @@
 ---
 upstream-provider-name: terraform-provider-github
 pulumi-infer-version: true
+remove-plugins: true
 

--- a/provider-ci/providers/gitlab/repo/.upgrade-config.yml
+++ b/provider-ci/providers/gitlab/repo/.upgrade-config.yml
@@ -3,4 +3,5 @@
 ---
 upstream-provider-name: terraform-provider-gitlab
 pulumi-infer-version: true
+remove-plugins: true
 

--- a/provider-ci/providers/hcloud/repo/.upgrade-config.yml
+++ b/provider-ci/providers/hcloud/repo/.upgrade-config.yml
@@ -3,4 +3,5 @@
 ---
 upstream-provider-name: terraform-provider-hcloud
 pulumi-infer-version: true
+remove-plugins: true
 

--- a/provider-ci/providers/kafka/repo/.upgrade-config.yml
+++ b/provider-ci/providers/kafka/repo/.upgrade-config.yml
@@ -3,4 +3,5 @@
 ---
 upstream-provider-name: terraform-provider-kafka
 pulumi-infer-version: true
+remove-plugins: true
 

--- a/provider-ci/providers/keycloak/repo/.upgrade-config.yml
+++ b/provider-ci/providers/keycloak/repo/.upgrade-config.yml
@@ -3,4 +3,5 @@
 ---
 upstream-provider-name: terraform-provider-keycloak
 pulumi-infer-version: true
+remove-plugins: true
 

--- a/provider-ci/providers/kong/repo/.upgrade-config.yml
+++ b/provider-ci/providers/kong/repo/.upgrade-config.yml
@@ -3,4 +3,5 @@
 ---
 upstream-provider-name: terraform-provider-kong
 pulumi-infer-version: true
+remove-plugins: true
 

--- a/provider-ci/providers/libvirt/repo/.upgrade-config.yml
+++ b/provider-ci/providers/libvirt/repo/.upgrade-config.yml
@@ -3,4 +3,5 @@
 ---
 upstream-provider-name: terraform-provider-libvirt
 pulumi-infer-version: true
+remove-plugins: true
 

--- a/provider-ci/providers/linode/repo/.upgrade-config.yml
+++ b/provider-ci/providers/linode/repo/.upgrade-config.yml
@@ -3,4 +3,5 @@
 ---
 upstream-provider-name: terraform-provider-linode
 pulumi-infer-version: true
+remove-plugins: true
 

--- a/provider-ci/providers/mailgun/repo/.upgrade-config.yml
+++ b/provider-ci/providers/mailgun/repo/.upgrade-config.yml
@@ -3,4 +3,5 @@
 ---
 upstream-provider-name: terraform-provider-mailgun
 pulumi-infer-version: true
+remove-plugins: true
 

--- a/provider-ci/providers/minio/repo/.upgrade-config.yml
+++ b/provider-ci/providers/minio/repo/.upgrade-config.yml
@@ -3,4 +3,5 @@
 ---
 upstream-provider-name: terraform-provider-minio
 pulumi-infer-version: true
+remove-plugins: true
 

--- a/provider-ci/providers/mongodbatlas/repo/.upgrade-config.yml
+++ b/provider-ci/providers/mongodbatlas/repo/.upgrade-config.yml
@@ -3,4 +3,5 @@
 ---
 upstream-provider-name: terraform-provider-mongodbatlas
 pulumi-infer-version: true
+remove-plugins: true
 

--- a/provider-ci/providers/mysql/repo/.upgrade-config.yml
+++ b/provider-ci/providers/mysql/repo/.upgrade-config.yml
@@ -3,4 +3,5 @@
 ---
 upstream-provider-name: terraform-provider-mysql
 pulumi-infer-version: true
+remove-plugins: true
 

--- a/provider-ci/providers/newrelic/repo/.upgrade-config.yml
+++ b/provider-ci/providers/newrelic/repo/.upgrade-config.yml
@@ -3,4 +3,5 @@
 ---
 upstream-provider-name: terraform-provider-newrelic
 pulumi-infer-version: true
+remove-plugins: true
 

--- a/provider-ci/providers/nomad/repo/.upgrade-config.yml
+++ b/provider-ci/providers/nomad/repo/.upgrade-config.yml
@@ -3,4 +3,5 @@
 ---
 upstream-provider-name: terraform-provider-nomad
 pulumi-infer-version: true
+remove-plugins: true
 

--- a/provider-ci/providers/ns1/repo/.upgrade-config.yml
+++ b/provider-ci/providers/ns1/repo/.upgrade-config.yml
@@ -3,4 +3,5 @@
 ---
 upstream-provider-name: terraform-provider-ns1
 pulumi-infer-version: true
+remove-plugins: true
 

--- a/provider-ci/providers/oci/repo/.upgrade-config.yml
+++ b/provider-ci/providers/oci/repo/.upgrade-config.yml
@@ -3,4 +3,5 @@
 ---
 upstream-provider-name: terraform-provider-oci
 pulumi-infer-version: true
+remove-plugins: true
 

--- a/provider-ci/providers/okta/repo/.upgrade-config.yml
+++ b/provider-ci/providers/okta/repo/.upgrade-config.yml
@@ -3,4 +3,5 @@
 ---
 upstream-provider-name: terraform-provider-okta
 pulumi-infer-version: true
+remove-plugins: true
 

--- a/provider-ci/providers/onelogin/repo/.upgrade-config.yml
+++ b/provider-ci/providers/onelogin/repo/.upgrade-config.yml
@@ -3,4 +3,5 @@
 ---
 upstream-provider-name: terraform-provider-onelogin
 pulumi-infer-version: true
+remove-plugins: true
 

--- a/provider-ci/providers/openstack/repo/.upgrade-config.yml
+++ b/provider-ci/providers/openstack/repo/.upgrade-config.yml
@@ -3,4 +3,5 @@
 ---
 upstream-provider-name: terraform-provider-openstack
 pulumi-infer-version: true
+remove-plugins: true
 

--- a/provider-ci/providers/opsgenie/repo/.upgrade-config.yml
+++ b/provider-ci/providers/opsgenie/repo/.upgrade-config.yml
@@ -3,4 +3,5 @@
 ---
 upstream-provider-name: terraform-provider-opsgenie
 pulumi-infer-version: true
+remove-plugins: true
 

--- a/provider-ci/providers/pagerduty/repo/.upgrade-config.yml
+++ b/provider-ci/providers/pagerduty/repo/.upgrade-config.yml
@@ -3,4 +3,5 @@
 ---
 upstream-provider-name: terraform-provider-pagerduty
 pulumi-infer-version: true
+remove-plugins: true
 

--- a/provider-ci/providers/postgresql/repo/.upgrade-config.yml
+++ b/provider-ci/providers/postgresql/repo/.upgrade-config.yml
@@ -3,4 +3,5 @@
 ---
 upstream-provider-name: terraform-provider-postgresql
 pulumi-infer-version: true
+remove-plugins: true
 

--- a/provider-ci/providers/rabbitmq/repo/.upgrade-config.yml
+++ b/provider-ci/providers/rabbitmq/repo/.upgrade-config.yml
@@ -3,4 +3,5 @@
 ---
 upstream-provider-name: terraform-provider-rabbitmq
 pulumi-infer-version: true
+remove-plugins: true
 

--- a/provider-ci/providers/rancher2/repo/.upgrade-config.yml
+++ b/provider-ci/providers/rancher2/repo/.upgrade-config.yml
@@ -3,4 +3,5 @@
 ---
 upstream-provider-name: terraform-provider-rancher2
 pulumi-infer-version: true
+remove-plugins: true
 

--- a/provider-ci/providers/random/repo/.upgrade-config.yml
+++ b/provider-ci/providers/random/repo/.upgrade-config.yml
@@ -3,4 +3,5 @@
 ---
 upstream-provider-name: terraform-provider-random
 pulumi-infer-version: true
+remove-plugins: true
 

--- a/provider-ci/providers/rke/repo/.upgrade-config.yml
+++ b/provider-ci/providers/rke/repo/.upgrade-config.yml
@@ -3,4 +3,5 @@
 ---
 upstream-provider-name: terraform-provider-rke
 pulumi-infer-version: true
+remove-plugins: true
 

--- a/provider-ci/providers/signalfx/repo/.upgrade-config.yml
+++ b/provider-ci/providers/signalfx/repo/.upgrade-config.yml
@@ -3,4 +3,5 @@
 ---
 upstream-provider-name: terraform-provider-signalfx
 pulumi-infer-version: true
+remove-plugins: true
 

--- a/provider-ci/providers/slack/repo/.upgrade-config.yml
+++ b/provider-ci/providers/slack/repo/.upgrade-config.yml
@@ -3,4 +3,5 @@
 ---
 upstream-provider-name: terraform-provider-slack
 pulumi-infer-version: true
+remove-plugins: true
 

--- a/provider-ci/providers/snowflake/repo/.upgrade-config.yml
+++ b/provider-ci/providers/snowflake/repo/.upgrade-config.yml
@@ -3,4 +3,5 @@
 ---
 upstream-provider-name: terraform-provider-snowflake
 pulumi-infer-version: true
+remove-plugins: true
 

--- a/provider-ci/providers/splunk/repo/.upgrade-config.yml
+++ b/provider-ci/providers/splunk/repo/.upgrade-config.yml
@@ -3,4 +3,5 @@
 ---
 upstream-provider-name: terraform-provider-splunk
 pulumi-infer-version: true
+remove-plugins: true
 

--- a/provider-ci/providers/spotinst/repo/.upgrade-config.yml
+++ b/provider-ci/providers/spotinst/repo/.upgrade-config.yml
@@ -3,4 +3,5 @@
 ---
 upstream-provider-name: terraform-provider-spotinst
 pulumi-infer-version: true
+remove-plugins: true
 

--- a/provider-ci/providers/sumologic/repo/.upgrade-config.yml
+++ b/provider-ci/providers/sumologic/repo/.upgrade-config.yml
@@ -3,4 +3,5 @@
 ---
 upstream-provider-name: terraform-provider-sumologic
 pulumi-infer-version: true
+remove-plugins: true
 

--- a/provider-ci/providers/tailscale/repo/.upgrade-config.yml
+++ b/provider-ci/providers/tailscale/repo/.upgrade-config.yml
@@ -3,4 +3,5 @@
 ---
 upstream-provider-name: terraform-provider-tailscale
 pulumi-infer-version: true
+remove-plugins: true
 

--- a/provider-ci/providers/tls/repo/.upgrade-config.yml
+++ b/provider-ci/providers/tls/repo/.upgrade-config.yml
@@ -3,4 +3,5 @@
 ---
 upstream-provider-name: terraform-provider-tls
 pulumi-infer-version: true
+remove-plugins: true
 

--- a/provider-ci/providers/vault/repo/.upgrade-config.yml
+++ b/provider-ci/providers/vault/repo/.upgrade-config.yml
@@ -3,4 +3,5 @@
 ---
 upstream-provider-name: terraform-provider-vault
 pulumi-infer-version: true
+remove-plugins: true
 

--- a/provider-ci/providers/venafi/repo/.upgrade-config.yml
+++ b/provider-ci/providers/venafi/repo/.upgrade-config.yml
@@ -3,4 +3,5 @@
 ---
 upstream-provider-name: terraform-provider-venafi
 pulumi-infer-version: true
+remove-plugins: true
 

--- a/provider-ci/providers/vsphere/repo/.upgrade-config.yml
+++ b/provider-ci/providers/vsphere/repo/.upgrade-config.yml
@@ -3,4 +3,5 @@
 ---
 upstream-provider-name: terraform-provider-vsphere
 pulumi-infer-version: true
+remove-plugins: true
 

--- a/provider-ci/providers/wavefront/repo/.upgrade-config.yml
+++ b/provider-ci/providers/wavefront/repo/.upgrade-config.yml
@@ -3,4 +3,5 @@
 ---
 upstream-provider-name: terraform-provider-wavefront
 pulumi-infer-version: true
+remove-plugins: true
 

--- a/provider-ci/src/makefiles.ts
+++ b/provider-ci/src/makefiles.ts
@@ -214,6 +214,7 @@ export const configFile = {
   upgradeProvider: (upstreamProviderName: string) => `---
 upstream-provider-name: ${upstreamProviderName}
 pulumi-infer-version: true
+remove-plugins: true
 
 `,
 };


### PR DESCRIPTION
Follow up to https://github.com/pulumi/upgrade-provider/pull/90#

Removing plugins before a version upgrade is the safest route to ensure the most up to date plugin is used for generating the examples, but it is now an optional flag so that user's don't have their plugin cache cleared unexpectedly when running `upgrade-provider`