### PR TITLE
Fix `upgrade-bridge-ecosystem-providers.yml`

### DIFF
--- a/.github/workflows/update-bridge-ecosystem-providers.yml
+++ b/.github/workflows/update-bridge-ecosystem-providers.yml
@@ -39,13 +39,23 @@ jobs:
       matrix:
         provider: ${{ fromJson(needs.generate-providers-list.outputs.providers ) }}
     steps:
-      - name: pulumi-${{ matrix.provider }}
+      - name: pulumi-${{ matrix.provider }} master
+        id: upgrade-on-master
         uses: benc-uk/workflow-dispatch@v1.2.2
         with:
             workflow: upgrade-bridge.yml
             token: ${{ secrets.PULUMI_BOT_TOKEN }} 
             repo: pulumi/pulumi-${{ matrix.provider }}
-            ref: ${{ github.event.repository.default_branch }}
+            ref: master
+      - name: pulumi-${{ matrix.provider }} main
+        id: upgrade-on-main
+        if: failure() && steps.upgrade-on-master.outcome != 'success'
+        uses: benc-uk/workflow-dispatch@v1.2.2
+        with:
+            workflow: upgrade-bridge.yml
+            token: ${{ secrets.PULUMI_BOT_TOKEN }} 
+            repo: pulumi/pulumi-${{ matrix.provider }}
+            ref: main
       # See: https://docs.github.com/en/rest/guides/best-practices-for-integrators#dealing-with-secondary-rate-limits
       - name: Sleep to prevent hitting secondary rate limits
         run: sleep 1

--- a/.github/workflows/update-bridge-ecosystem-providers.yml
+++ b/.github/workflows/update-bridge-ecosystem-providers.yml
@@ -39,24 +39,24 @@ jobs:
       matrix:
         provider: ${{ fromJson(needs.generate-providers-list.outputs.providers ) }}
     steps:
-      - name: pulumi-${{ matrix.provider }} master
-        id: upgrade-on-master
+      - name: pulumi-${{ matrix.provider }} main
+        id: upgrade-on-main
         uses: benc-uk/workflow-dispatch@v1.2.2
         continue-on-error: true
         with:
             workflow: upgrade-bridge.yml
             token: ${{ secrets.PULUMI_BOT_TOKEN }} 
             repo: pulumi/pulumi-${{ matrix.provider }}
-            ref: master
-      - name: pulumi-${{ matrix.provider }} main
-        id: upgrade-on-main
+            ref: main
+      - name: pulumi-${{ matrix.provider }} master
+        id: upgrade-on-master
         if: steps.upgrade-on-master.outcome != 'success'
         uses: benc-uk/workflow-dispatch@v1.2.2
         with:
             workflow: upgrade-bridge.yml
             token: ${{ secrets.PULUMI_BOT_TOKEN }} 
             repo: pulumi/pulumi-${{ matrix.provider }}
-            ref: main
+            ref: master
       # See: https://docs.github.com/en/rest/guides/best-practices-for-integrators#dealing-with-secondary-rate-limits
       - name: Sleep to prevent hitting secondary rate limits
         run: sleep 1

--- a/.github/workflows/update-bridge-ecosystem-providers.yml
+++ b/.github/workflows/update-bridge-ecosystem-providers.yml
@@ -42,6 +42,7 @@ jobs:
       - name: pulumi-${{ matrix.provider }} master
         id: upgrade-on-master
         uses: benc-uk/workflow-dispatch@v1.2.2
+        continue-on-error: true
         with:
             workflow: upgrade-bridge.yml
             token: ${{ secrets.PULUMI_BOT_TOKEN }} 
@@ -49,7 +50,7 @@ jobs:
             ref: master
       - name: pulumi-${{ matrix.provider }} main
         id: upgrade-on-main
-        if: failure() && steps.upgrade-on-master.outcome != 'success'
+        if: steps.upgrade-on-master.outcome != 'success'
         uses: benc-uk/workflow-dispatch@v1.2.2
         with:
             workflow: upgrade-bridge.yml

--- a/.github/workflows/update-bridge-ecosystem-providers.yml
+++ b/.github/workflows/update-bridge-ecosystem-providers.yml
@@ -45,6 +45,7 @@ jobs:
             workflow: upgrade-bridge.yml
             token: ${{ secrets.PULUMI_BOT_TOKEN }} 
             repo: pulumi/pulumi-${{ matrix.provider }}
+            ref: ${{ github.event.repository.default_branch }}
       # See: https://docs.github.com/en/rest/guides/best-practices-for-integrators#dealing-with-secondary-rate-limits
       - name: Sleep to prevent hitting secondary rate limits
         run: sleep 1


### PR DESCRIPTION
The github action we use in `ci-mgmt` to send a dispatch to each providers `upgrade-bridge` workflow, https://github.com/marketplace/actions/workflow-dispatch, requires `ref` to be set if it differs from the calling repo branch (which is `master` for this repo, `ci-mgmt`.

This changes it to first attempt to use `master`, and then continue if the ref is not found and to use `main` instead. We should still consider moving all provider default branches from `master` -> `main` eventually.