### PR TITLE
Add an option to clean go cache between GoReleaser builds

### DIFF
--- a/provider-ci/config-schema.json
+++ b/provider-ci/config-schema.json
@@ -142,6 +142,10 @@
             "goBuildParallelism": {
               "type": "number",
               "default": 0
+            },
+            "cleanCacheBetweenBuilds": {
+              "type": "boolean",
+              "default": false
             }
           },
           "required": [

--- a/provider-ci/providers/azure/config.yaml
+++ b/provider-ci/providers/azure/config.yaml
@@ -23,3 +23,4 @@ plugins:
 team: ecosystem
 goBuildParallelism: 2
 javaGenVersion: "v0.8.0"
+cleanCacheBetweenBuilds: true

--- a/provider-ci/providers/azure/repo/.goreleaser.prerelease.yml
+++ b/provider-ci/providers/azure/repo/.goreleaser.prerelease.yml
@@ -26,6 +26,10 @@ builds:
   - darwin
   - windows
   - linux
+  hooks:
+    post:
+    - env GOOS={{ .Os }} GOARCH={{ .Arch }} go clean -cache
+    - env GOOS={{ .Os }} GOARCH={{ .Arch }} go clean -modcache
   ignore: []
   ldflags:
   - -X github.com/pulumi/pulumi-azure/provider/v5/pkg/version.Version={{.Tag}}

--- a/provider-ci/providers/azure/repo/.goreleaser.yml
+++ b/provider-ci/providers/azure/repo/.goreleaser.yml
@@ -26,6 +26,10 @@ builds:
   - darwin
   - windows
   - linux
+  hooks:
+    post:
+    - env GOOS={{ .Os }} GOARCH={{ .Arch }} go clean -cache
+    - env GOOS={{ .Os }} GOARCH={{ .Arch }} go clean -modcache
   ignore: []
   ldflags:
   - -X github.com/pulumi/pulumi-azure/provider/v5/pkg/version.Version={{.Tag}}

--- a/provider-ci/src/config.ts
+++ b/provider-ci/src/config.ts
@@ -46,6 +46,7 @@ const BridgedConfig = z
     team: z.enum(["ecosystem", "providers"]).default("ecosystem"),
     // Go options
     goBuildParallelism: z.number().default(0), // translates to "go build -p $X" flag, 0=omit.
+    cleanCacheBetweenBuilds: z.boolean().default(false),
   })
   .transform((input) => {
     if (input["upstream-provider-repo"] !== "") {


### PR DESCRIPTION
This chanage addresses a blocker in pulumi-azure.

The cross-build job started failing inside GoReleaser with out-of-disk-space error.

By cleaning Go cache between every architecture build, more wall-clock time is spent but critically less peak disk space is used so the job can succeed again.

This flag assumes that GoReleaser is called with `-p 1` so it does the cross-builds sequentially, which seems to be the case for pulumi-azure.