### PR TITLE
Revert "Upgrade `pulumi-oci` major version to v2"

### DIFF
--- a/provider-ci/providers/oci/config.yaml
+++ b/provider-ci/providers/oci/config.yaml
@@ -1,5 +1,5 @@
 provider: oci
-major-version: 2
+major-version: 1
 lint: false
 parallel: 1
 timeout: 90

--- a/provider-ci/providers/oci/repo/.goreleaser.prerelease.yml
+++ b/provider-ci/providers/oci/repo/.goreleaser.prerelease.yml
@@ -28,7 +28,7 @@ builds:
   - linux
   ignore: []
   ldflags:
-  - -X github.com/pulumi/pulumi-oci/provider/v2/pkg/version.Version={{.Tag}}
+  - -X github.com/pulumi/pulumi-oci/provider/pkg/version.Version={{.Tag}}
   main: ./cmd/pulumi-resource-oci/
 changelog:
   skip: true

--- a/provider-ci/providers/oci/repo/.goreleaser.yml
+++ b/provider-ci/providers/oci/repo/.goreleaser.yml
@@ -28,7 +28,7 @@ builds:
   - linux
   ignore: []
   ldflags:
-  - -X github.com/pulumi/pulumi-oci/provider/v2/pkg/version.Version={{.Tag}}
+  - -X github.com/pulumi/pulumi-oci/provider/pkg/version.Version={{.Tag}}
   main: ./cmd/pulumi-resource-oci/
 changelog:
   filters:

--- a/provider-ci/providers/oci/repo/Makefile
+++ b/provider-ci/providers/oci/repo/Makefile
@@ -3,7 +3,7 @@
 PACK := oci
 ORG := pulumi
 PROJECT := github.com/$(ORG)/pulumi-$(PACK)
-PROVIDER_PATH := provider/v2
+PROVIDER_PATH := provider
 VERSION_PATH := $(PROVIDER_PATH)/pkg/version.Version
 TFGEN := pulumi-tfgen-$(PACK)
 PROVIDER := pulumi-resource-$(PACK)


### PR DESCRIPTION
Reverts pulumi/ci-mgmt#449

The major version for oci was upgraded from 0 to 1, not 1 to 2.