### PR TITLE
Add Cloudamqp API key to provider config

### DIFF
--- a/provider-ci/providers/cloudamqp/config.yaml
+++ b/provider-ci/providers/cloudamqp/config.yaml
@@ -2,3 +2,5 @@ provider: cloudamqp
 major-version: 3
 makeTemplate: bridged
 team: ecosystem
+env:
+  CLOUDAMQP_APIKEY: ${{ secrets.CLOUDAMQP_APIKEY }}


### PR DESCRIPTION
Fixes ineffectual integration tests on pulumi-cloudamqp
