### PR TITLE
Pin time version

### DIFF
--- a/provider-ci/providers/databricks/config.yaml
+++ b/provider-ci/providers/databricks/config.yaml
@@ -12,4 +12,6 @@ plugins:
     version: "4.8.2"
   - name: aws 
     version: "5.18.0"
+  - name: time
+    version: "0.0.13"
 team: ecosystem

--- a/provider-ci/providers/databricks/repo/Makefile
+++ b/provider-ci/providers/databricks/repo/Makefile
@@ -94,6 +94,7 @@ install_plugins:
 	[ -x "$(shell command -v pulumi 2>/dev/null)" ] || curl -fsSL https://get.pulumi.com | sh
 	pulumi plugin install resource random 4.8.2
 	pulumi plugin install resource aws 5.18.0
+	pulumi plugin install resource time 0.0.13
 
 lint_provider: provider
 	cd provider && golangci-lint run -c ../.golangci.yml


### PR DESCRIPTION
Time is used in generated examples, and failing to pin causes inconstant example generation.