### PR TITLE
Preserve commit metadata on rebasing patches

### DIFF
--- a/provider-ci/internal/pkg/templates/bridged-provider/scripts/upstream.sh
+++ b/provider-ci/internal/pkg/templates/bridged-provider/scripts/upstream.sh
@@ -92,14 +92,12 @@ start_rebase() {
 
   for patch in ../patches/*.patch; do
     echo "Applying $patch"
-    if ! git apply --3way "$patch"; then
+    if ! git am --3way "$patch"; then
       echo
       echo "Failed to apply patch. Please run 'make upstream.rebase FROM=$TAG' where '$TAG' allows the patch set to apply cleanly"
       echo
       exit 1
     fi
-    patch=${patch#../patches/*-}
-    git commit -am "${patch%.patch}"
   done
 
   touch ../rebase-in-progress

--- a/provider-ci/providers/aiven/repo/scripts/upstream.sh
+++ b/provider-ci/providers/aiven/repo/scripts/upstream.sh
@@ -91,14 +91,12 @@ start_rebase() {
 
   for patch in ../patches/*.patch; do
     echo "Applying $patch"
-    if ! git apply --3way "$patch"; then
+    if ! git am --3way "$patch"; then
       echo
       echo "Failed to apply patch. Please run 'make upstream.rebase FROM=$TAG' where '$TAG' allows the patch set to apply cleanly"
       echo
       exit 1
     fi
-    patch=${patch#../patches/*-}
-    git commit -am "${patch%.patch}"
   done
 
   touch ../rebase-in-progress

--- a/provider-ci/providers/akamai/repo/scripts/upstream.sh
+++ b/provider-ci/providers/akamai/repo/scripts/upstream.sh
@@ -91,14 +91,12 @@ start_rebase() {
 
   for patch in ../patches/*.patch; do
     echo "Applying $patch"
-    if ! git apply --3way "$patch"; then
+    if ! git am --3way "$patch"; then
       echo
       echo "Failed to apply patch. Please run 'make upstream.rebase FROM=$TAG' where '$TAG' allows the patch set to apply cleanly"
       echo
       exit 1
     fi
-    patch=${patch#../patches/*-}
-    git commit -am "${patch%.patch}"
   done
 
   touch ../rebase-in-progress

--- a/provider-ci/providers/alicloud/repo/scripts/upstream.sh
+++ b/provider-ci/providers/alicloud/repo/scripts/upstream.sh
@@ -91,14 +91,12 @@ start_rebase() {
 
   for patch in ../patches/*.patch; do
     echo "Applying $patch"
-    if ! git apply --3way "$patch"; then
+    if ! git am --3way "$patch"; then
       echo
       echo "Failed to apply patch. Please run 'make upstream.rebase FROM=$TAG' where '$TAG' allows the patch set to apply cleanly"
       echo
       exit 1
     fi
-    patch=${patch#../patches/*-}
-    git commit -am "${patch%.patch}"
   done
 
   touch ../rebase-in-progress

--- a/provider-ci/providers/artifactory/repo/scripts/upstream.sh
+++ b/provider-ci/providers/artifactory/repo/scripts/upstream.sh
@@ -91,14 +91,12 @@ start_rebase() {
 
   for patch in ../patches/*.patch; do
     echo "Applying $patch"
-    if ! git apply --3way "$patch"; then
+    if ! git am --3way "$patch"; then
       echo
       echo "Failed to apply patch. Please run 'make upstream.rebase FROM=$TAG' where '$TAG' allows the patch set to apply cleanly"
       echo
       exit 1
     fi
-    patch=${patch#../patches/*-}
-    git commit -am "${patch%.patch}"
   done
 
   touch ../rebase-in-progress

--- a/provider-ci/providers/auth0/repo/scripts/upstream.sh
+++ b/provider-ci/providers/auth0/repo/scripts/upstream.sh
@@ -91,14 +91,12 @@ start_rebase() {
 
   for patch in ../patches/*.patch; do
     echo "Applying $patch"
-    if ! git apply --3way "$patch"; then
+    if ! git am --3way "$patch"; then
       echo
       echo "Failed to apply patch. Please run 'make upstream.rebase FROM=$TAG' where '$TAG' allows the patch set to apply cleanly"
       echo
       exit 1
     fi
-    patch=${patch#../patches/*-}
-    git commit -am "${patch%.patch}"
   done
 
   touch ../rebase-in-progress

--- a/provider-ci/providers/azure/repo/scripts/upstream.sh
+++ b/provider-ci/providers/azure/repo/scripts/upstream.sh
@@ -91,14 +91,12 @@ start_rebase() {
 
   for patch in ../patches/*.patch; do
     echo "Applying $patch"
-    if ! git apply --3way "$patch"; then
+    if ! git am --3way "$patch"; then
       echo
       echo "Failed to apply patch. Please run 'make upstream.rebase FROM=$TAG' where '$TAG' allows the patch set to apply cleanly"
       echo
       exit 1
     fi
-    patch=${patch#../patches/*-}
-    git commit -am "${patch%.patch}"
   done
 
   touch ../rebase-in-progress

--- a/provider-ci/providers/azuread/repo/scripts/upstream.sh
+++ b/provider-ci/providers/azuread/repo/scripts/upstream.sh
@@ -91,14 +91,12 @@ start_rebase() {
 
   for patch in ../patches/*.patch; do
     echo "Applying $patch"
-    if ! git apply --3way "$patch"; then
+    if ! git am --3way "$patch"; then
       echo
       echo "Failed to apply patch. Please run 'make upstream.rebase FROM=$TAG' where '$TAG' allows the patch set to apply cleanly"
       echo
       exit 1
     fi
-    patch=${patch#../patches/*-}
-    git commit -am "${patch%.patch}"
   done
 
   touch ../rebase-in-progress

--- a/provider-ci/providers/civo/repo/scripts/upstream.sh
+++ b/provider-ci/providers/civo/repo/scripts/upstream.sh
@@ -91,14 +91,12 @@ start_rebase() {
 
   for patch in ../patches/*.patch; do
     echo "Applying $patch"
-    if ! git apply --3way "$patch"; then
+    if ! git am --3way "$patch"; then
       echo
       echo "Failed to apply patch. Please run 'make upstream.rebase FROM=$TAG' where '$TAG' allows the patch set to apply cleanly"
       echo
       exit 1
     fi
-    patch=${patch#../patches/*-}
-    git commit -am "${patch%.patch}"
   done
 
   touch ../rebase-in-progress

--- a/provider-ci/providers/cloudamqp/repo/scripts/upstream.sh
+++ b/provider-ci/providers/cloudamqp/repo/scripts/upstream.sh
@@ -91,14 +91,12 @@ start_rebase() {
 
   for patch in ../patches/*.patch; do
     echo "Applying $patch"
-    if ! git apply --3way "$patch"; then
+    if ! git am --3way "$patch"; then
       echo
       echo "Failed to apply patch. Please run 'make upstream.rebase FROM=$TAG' where '$TAG' allows the patch set to apply cleanly"
       echo
       exit 1
     fi
-    patch=${patch#../patches/*-}
-    git commit -am "${patch%.patch}"
   done
 
   touch ../rebase-in-progress

--- a/provider-ci/providers/cloudflare/repo/scripts/upstream.sh
+++ b/provider-ci/providers/cloudflare/repo/scripts/upstream.sh
@@ -91,14 +91,12 @@ start_rebase() {
 
   for patch in ../patches/*.patch; do
     echo "Applying $patch"
-    if ! git apply --3way "$patch"; then
+    if ! git am --3way "$patch"; then
       echo
       echo "Failed to apply patch. Please run 'make upstream.rebase FROM=$TAG' where '$TAG' allows the patch set to apply cleanly"
       echo
       exit 1
     fi
-    patch=${patch#../patches/*-}
-    git commit -am "${patch%.patch}"
   done
 
   touch ../rebase-in-progress

--- a/provider-ci/providers/cloudinit/repo/scripts/upstream.sh
+++ b/provider-ci/providers/cloudinit/repo/scripts/upstream.sh
@@ -91,14 +91,12 @@ start_rebase() {
 
   for patch in ../patches/*.patch; do
     echo "Applying $patch"
-    if ! git apply --3way "$patch"; then
+    if ! git am --3way "$patch"; then
       echo
       echo "Failed to apply patch. Please run 'make upstream.rebase FROM=$TAG' where '$TAG' allows the patch set to apply cleanly"
       echo
       exit 1
     fi
-    patch=${patch#../patches/*-}
-    git commit -am "${patch%.patch}"
   done
 
   touch ../rebase-in-progress

--- a/provider-ci/providers/confluentcloud/repo/scripts/upstream.sh
+++ b/provider-ci/providers/confluentcloud/repo/scripts/upstream.sh
@@ -91,14 +91,12 @@ start_rebase() {
 
   for patch in ../patches/*.patch; do
     echo "Applying $patch"
-    if ! git apply --3way "$patch"; then
+    if ! git am --3way "$patch"; then
       echo
       echo "Failed to apply patch. Please run 'make upstream.rebase FROM=$TAG' where '$TAG' allows the patch set to apply cleanly"
       echo
       exit 1
     fi
-    patch=${patch#../patches/*-}
-    git commit -am "${patch%.patch}"
   done
 
   touch ../rebase-in-progress

--- a/provider-ci/providers/consul/repo/scripts/upstream.sh
+++ b/provider-ci/providers/consul/repo/scripts/upstream.sh
@@ -91,14 +91,12 @@ start_rebase() {
 
   for patch in ../patches/*.patch; do
     echo "Applying $patch"
-    if ! git apply --3way "$patch"; then
+    if ! git am --3way "$patch"; then
       echo
       echo "Failed to apply patch. Please run 'make upstream.rebase FROM=$TAG' where '$TAG' allows the patch set to apply cleanly"
       echo
       exit 1
     fi
-    patch=${patch#../patches/*-}
-    git commit -am "${patch%.patch}"
   done
 
   touch ../rebase-in-progress

--- a/provider-ci/providers/databricks/repo/scripts/upstream.sh
+++ b/provider-ci/providers/databricks/repo/scripts/upstream.sh
@@ -91,14 +91,12 @@ start_rebase() {
 
   for patch in ../patches/*.patch; do
     echo "Applying $patch"
-    if ! git apply --3way "$patch"; then
+    if ! git am --3way "$patch"; then
       echo
       echo "Failed to apply patch. Please run 'make upstream.rebase FROM=$TAG' where '$TAG' allows the patch set to apply cleanly"
       echo
       exit 1
     fi
-    patch=${patch#../patches/*-}
-    git commit -am "${patch%.patch}"
   done
 
   touch ../rebase-in-progress

--- a/provider-ci/providers/datadog/repo/scripts/upstream.sh
+++ b/provider-ci/providers/datadog/repo/scripts/upstream.sh
@@ -91,14 +91,12 @@ start_rebase() {
 
   for patch in ../patches/*.patch; do
     echo "Applying $patch"
-    if ! git apply --3way "$patch"; then
+    if ! git am --3way "$patch"; then
       echo
       echo "Failed to apply patch. Please run 'make upstream.rebase FROM=$TAG' where '$TAG' allows the patch set to apply cleanly"
       echo
       exit 1
     fi
-    patch=${patch#../patches/*-}
-    git commit -am "${patch%.patch}"
   done
 
   touch ../rebase-in-progress

--- a/provider-ci/providers/digitalocean/repo/scripts/upstream.sh
+++ b/provider-ci/providers/digitalocean/repo/scripts/upstream.sh
@@ -91,14 +91,12 @@ start_rebase() {
 
   for patch in ../patches/*.patch; do
     echo "Applying $patch"
-    if ! git apply --3way "$patch"; then
+    if ! git am --3way "$patch"; then
       echo
       echo "Failed to apply patch. Please run 'make upstream.rebase FROM=$TAG' where '$TAG' allows the patch set to apply cleanly"
       echo
       exit 1
     fi
-    patch=${patch#../patches/*-}
-    git commit -am "${patch%.patch}"
   done
 
   touch ../rebase-in-progress

--- a/provider-ci/providers/dnsimple/repo/scripts/upstream.sh
+++ b/provider-ci/providers/dnsimple/repo/scripts/upstream.sh
@@ -91,14 +91,12 @@ start_rebase() {
 
   for patch in ../patches/*.patch; do
     echo "Applying $patch"
-    if ! git apply --3way "$patch"; then
+    if ! git am --3way "$patch"; then
       echo
       echo "Failed to apply patch. Please run 'make upstream.rebase FROM=$TAG' where '$TAG' allows the patch set to apply cleanly"
       echo
       exit 1
     fi
-    patch=${patch#../patches/*-}
-    git commit -am "${patch%.patch}"
   done
 
   touch ../rebase-in-progress

--- a/provider-ci/providers/docker/repo/scripts/upstream.sh
+++ b/provider-ci/providers/docker/repo/scripts/upstream.sh
@@ -91,14 +91,12 @@ start_rebase() {
 
   for patch in ../patches/*.patch; do
     echo "Applying $patch"
-    if ! git apply --3way "$patch"; then
+    if ! git am --3way "$patch"; then
       echo
       echo "Failed to apply patch. Please run 'make upstream.rebase FROM=$TAG' where '$TAG' allows the patch set to apply cleanly"
       echo
       exit 1
     fi
-    patch=${patch#../patches/*-}
-    git commit -am "${patch%.patch}"
   done
 
   touch ../rebase-in-progress

--- a/provider-ci/providers/ec/repo/scripts/upstream.sh
+++ b/provider-ci/providers/ec/repo/scripts/upstream.sh
@@ -91,14 +91,12 @@ start_rebase() {
 
   for patch in ../patches/*.patch; do
     echo "Applying $patch"
-    if ! git apply --3way "$patch"; then
+    if ! git am --3way "$patch"; then
       echo
       echo "Failed to apply patch. Please run 'make upstream.rebase FROM=$TAG' where '$TAG' allows the patch set to apply cleanly"
       echo
       exit 1
     fi
-    patch=${patch#../patches/*-}
-    git commit -am "${patch%.patch}"
   done
 
   touch ../rebase-in-progress

--- a/provider-ci/providers/equinix-metal/repo/scripts/upstream.sh
+++ b/provider-ci/providers/equinix-metal/repo/scripts/upstream.sh
@@ -91,14 +91,12 @@ start_rebase() {
 
   for patch in ../patches/*.patch; do
     echo "Applying $patch"
-    if ! git apply --3way "$patch"; then
+    if ! git am --3way "$patch"; then
       echo
       echo "Failed to apply patch. Please run 'make upstream.rebase FROM=$TAG' where '$TAG' allows the patch set to apply cleanly"
       echo
       exit 1
     fi
-    patch=${patch#../patches/*-}
-    git commit -am "${patch%.patch}"
   done
 
   touch ../rebase-in-progress

--- a/provider-ci/providers/f5bigip/repo/scripts/upstream.sh
+++ b/provider-ci/providers/f5bigip/repo/scripts/upstream.sh
@@ -91,14 +91,12 @@ start_rebase() {
 
   for patch in ../patches/*.patch; do
     echo "Applying $patch"
-    if ! git apply --3way "$patch"; then
+    if ! git am --3way "$patch"; then
       echo
       echo "Failed to apply patch. Please run 'make upstream.rebase FROM=$TAG' where '$TAG' allows the patch set to apply cleanly"
       echo
       exit 1
     fi
-    patch=${patch#../patches/*-}
-    git commit -am "${patch%.patch}"
   done
 
   touch ../rebase-in-progress

--- a/provider-ci/providers/fastly/repo/scripts/upstream.sh
+++ b/provider-ci/providers/fastly/repo/scripts/upstream.sh
@@ -91,14 +91,12 @@ start_rebase() {
 
   for patch in ../patches/*.patch; do
     echo "Applying $patch"
-    if ! git apply --3way "$patch"; then
+    if ! git am --3way "$patch"; then
       echo
       echo "Failed to apply patch. Please run 'make upstream.rebase FROM=$TAG' where '$TAG' allows the patch set to apply cleanly"
       echo
       exit 1
     fi
-    patch=${patch#../patches/*-}
-    git commit -am "${patch%.patch}"
   done
 
   touch ../rebase-in-progress

--- a/provider-ci/providers/gcp/repo/scripts/upstream.sh
+++ b/provider-ci/providers/gcp/repo/scripts/upstream.sh
@@ -91,14 +91,12 @@ start_rebase() {
 
   for patch in ../patches/*.patch; do
     echo "Applying $patch"
-    if ! git apply --3way "$patch"; then
+    if ! git am --3way "$patch"; then
       echo
       echo "Failed to apply patch. Please run 'make upstream.rebase FROM=$TAG' where '$TAG' allows the patch set to apply cleanly"
       echo
       exit 1
     fi
-    patch=${patch#../patches/*-}
-    git commit -am "${patch%.patch}"
   done
 
   touch ../rebase-in-progress

--- a/provider-ci/providers/github/repo/scripts/upstream.sh
+++ b/provider-ci/providers/github/repo/scripts/upstream.sh
@@ -91,14 +91,12 @@ start_rebase() {
 
   for patch in ../patches/*.patch; do
     echo "Applying $patch"
-    if ! git apply --3way "$patch"; then
+    if ! git am --3way "$patch"; then
       echo
       echo "Failed to apply patch. Please run 'make upstream.rebase FROM=$TAG' where '$TAG' allows the patch set to apply cleanly"
       echo
       exit 1
     fi
-    patch=${patch#../patches/*-}
-    git commit -am "${patch%.patch}"
   done
 
   touch ../rebase-in-progress

--- a/provider-ci/providers/gitlab/repo/scripts/upstream.sh
+++ b/provider-ci/providers/gitlab/repo/scripts/upstream.sh
@@ -91,14 +91,12 @@ start_rebase() {
 
   for patch in ../patches/*.patch; do
     echo "Applying $patch"
-    if ! git apply --3way "$patch"; then
+    if ! git am --3way "$patch"; then
       echo
       echo "Failed to apply patch. Please run 'make upstream.rebase FROM=$TAG' where '$TAG' allows the patch set to apply cleanly"
       echo
       exit 1
     fi
-    patch=${patch#../patches/*-}
-    git commit -am "${patch%.patch}"
   done
 
   touch ../rebase-in-progress

--- a/provider-ci/providers/hcloud/repo/scripts/upstream.sh
+++ b/provider-ci/providers/hcloud/repo/scripts/upstream.sh
@@ -91,14 +91,12 @@ start_rebase() {
 
   for patch in ../patches/*.patch; do
     echo "Applying $patch"
-    if ! git apply --3way "$patch"; then
+    if ! git am --3way "$patch"; then
       echo
       echo "Failed to apply patch. Please run 'make upstream.rebase FROM=$TAG' where '$TAG' allows the patch set to apply cleanly"
       echo
       exit 1
     fi
-    patch=${patch#../patches/*-}
-    git commit -am "${patch%.patch}"
   done
 
   touch ../rebase-in-progress

--- a/provider-ci/providers/kafka/repo/scripts/upstream.sh
+++ b/provider-ci/providers/kafka/repo/scripts/upstream.sh
@@ -91,14 +91,12 @@ start_rebase() {
 
   for patch in ../patches/*.patch; do
     echo "Applying $patch"
-    if ! git apply --3way "$patch"; then
+    if ! git am --3way "$patch"; then
       echo
       echo "Failed to apply patch. Please run 'make upstream.rebase FROM=$TAG' where '$TAG' allows the patch set to apply cleanly"
       echo
       exit 1
     fi
-    patch=${patch#../patches/*-}
-    git commit -am "${patch%.patch}"
   done
 
   touch ../rebase-in-progress

--- a/provider-ci/providers/keycloak/repo/scripts/upstream.sh
+++ b/provider-ci/providers/keycloak/repo/scripts/upstream.sh
@@ -91,14 +91,12 @@ start_rebase() {
 
   for patch in ../patches/*.patch; do
     echo "Applying $patch"
-    if ! git apply --3way "$patch"; then
+    if ! git am --3way "$patch"; then
       echo
       echo "Failed to apply patch. Please run 'make upstream.rebase FROM=$TAG' where '$TAG' allows the patch set to apply cleanly"
       echo
       exit 1
     fi
-    patch=${patch#../patches/*-}
-    git commit -am "${patch%.patch}"
   done
 
   touch ../rebase-in-progress

--- a/provider-ci/providers/kong/repo/scripts/upstream.sh
+++ b/provider-ci/providers/kong/repo/scripts/upstream.sh
@@ -91,14 +91,12 @@ start_rebase() {
 
   for patch in ../patches/*.patch; do
     echo "Applying $patch"
-    if ! git apply --3way "$patch"; then
+    if ! git am --3way "$patch"; then
       echo
       echo "Failed to apply patch. Please run 'make upstream.rebase FROM=$TAG' where '$TAG' allows the patch set to apply cleanly"
       echo
       exit 1
     fi
-    patch=${patch#../patches/*-}
-    git commit -am "${patch%.patch}"
   done
 
   touch ../rebase-in-progress

--- a/provider-ci/providers/libvirt/repo/scripts/upstream.sh
+++ b/provider-ci/providers/libvirt/repo/scripts/upstream.sh
@@ -91,14 +91,12 @@ start_rebase() {
 
   for patch in ../patches/*.patch; do
     echo "Applying $patch"
-    if ! git apply --3way "$patch"; then
+    if ! git am --3way "$patch"; then
       echo
       echo "Failed to apply patch. Please run 'make upstream.rebase FROM=$TAG' where '$TAG' allows the patch set to apply cleanly"
       echo
       exit 1
     fi
-    patch=${patch#../patches/*-}
-    git commit -am "${patch%.patch}"
   done
 
   touch ../rebase-in-progress

--- a/provider-ci/providers/linode/repo/scripts/upstream.sh
+++ b/provider-ci/providers/linode/repo/scripts/upstream.sh
@@ -91,14 +91,12 @@ start_rebase() {
 
   for patch in ../patches/*.patch; do
     echo "Applying $patch"
-    if ! git apply --3way "$patch"; then
+    if ! git am --3way "$patch"; then
       echo
       echo "Failed to apply patch. Please run 'make upstream.rebase FROM=$TAG' where '$TAG' allows the patch set to apply cleanly"
       echo
       exit 1
     fi
-    patch=${patch#../patches/*-}
-    git commit -am "${patch%.patch}"
   done
 
   touch ../rebase-in-progress

--- a/provider-ci/providers/mailgun/repo/scripts/upstream.sh
+++ b/provider-ci/providers/mailgun/repo/scripts/upstream.sh
@@ -91,14 +91,12 @@ start_rebase() {
 
   for patch in ../patches/*.patch; do
     echo "Applying $patch"
-    if ! git apply --3way "$patch"; then
+    if ! git am --3way "$patch"; then
       echo
       echo "Failed to apply patch. Please run 'make upstream.rebase FROM=$TAG' where '$TAG' allows the patch set to apply cleanly"
       echo
       exit 1
     fi
-    patch=${patch#../patches/*-}
-    git commit -am "${patch%.patch}"
   done
 
   touch ../rebase-in-progress

--- a/provider-ci/providers/minio/repo/scripts/upstream.sh
+++ b/provider-ci/providers/minio/repo/scripts/upstream.sh
@@ -91,14 +91,12 @@ start_rebase() {
 
   for patch in ../patches/*.patch; do
     echo "Applying $patch"
-    if ! git apply --3way "$patch"; then
+    if ! git am --3way "$patch"; then
       echo
       echo "Failed to apply patch. Please run 'make upstream.rebase FROM=$TAG' where '$TAG' allows the patch set to apply cleanly"
       echo
       exit 1
     fi
-    patch=${patch#../patches/*-}
-    git commit -am "${patch%.patch}"
   done
 
   touch ../rebase-in-progress

--- a/provider-ci/providers/mongodbatlas/repo/scripts/upstream.sh
+++ b/provider-ci/providers/mongodbatlas/repo/scripts/upstream.sh
@@ -91,14 +91,12 @@ start_rebase() {
 
   for patch in ../patches/*.patch; do
     echo "Applying $patch"
-    if ! git apply --3way "$patch"; then
+    if ! git am --3way "$patch"; then
       echo
       echo "Failed to apply patch. Please run 'make upstream.rebase FROM=$TAG' where '$TAG' allows the patch set to apply cleanly"
       echo
       exit 1
     fi
-    patch=${patch#../patches/*-}
-    git commit -am "${patch%.patch}"
   done
 
   touch ../rebase-in-progress

--- a/provider-ci/providers/mysql/repo/scripts/upstream.sh
+++ b/provider-ci/providers/mysql/repo/scripts/upstream.sh
@@ -91,14 +91,12 @@ start_rebase() {
 
   for patch in ../patches/*.patch; do
     echo "Applying $patch"
-    if ! git apply --3way "$patch"; then
+    if ! git am --3way "$patch"; then
       echo
       echo "Failed to apply patch. Please run 'make upstream.rebase FROM=$TAG' where '$TAG' allows the patch set to apply cleanly"
       echo
       exit 1
     fi
-    patch=${patch#../patches/*-}
-    git commit -am "${patch%.patch}"
   done
 
   touch ../rebase-in-progress

--- a/provider-ci/providers/newrelic/repo/scripts/upstream.sh
+++ b/provider-ci/providers/newrelic/repo/scripts/upstream.sh
@@ -91,14 +91,12 @@ start_rebase() {
 
   for patch in ../patches/*.patch; do
     echo "Applying $patch"
-    if ! git apply --3way "$patch"; then
+    if ! git am --3way "$patch"; then
       echo
       echo "Failed to apply patch. Please run 'make upstream.rebase FROM=$TAG' where '$TAG' allows the patch set to apply cleanly"
       echo
       exit 1
     fi
-    patch=${patch#../patches/*-}
-    git commit -am "${patch%.patch}"
   done
 
   touch ../rebase-in-progress

--- a/provider-ci/providers/nomad/repo/scripts/upstream.sh
+++ b/provider-ci/providers/nomad/repo/scripts/upstream.sh
@@ -91,14 +91,12 @@ start_rebase() {
 
   for patch in ../patches/*.patch; do
     echo "Applying $patch"
-    if ! git apply --3way "$patch"; then
+    if ! git am --3way "$patch"; then
       echo
       echo "Failed to apply patch. Please run 'make upstream.rebase FROM=$TAG' where '$TAG' allows the patch set to apply cleanly"
       echo
       exit 1
     fi
-    patch=${patch#../patches/*-}
-    git commit -am "${patch%.patch}"
   done
 
   touch ../rebase-in-progress

--- a/provider-ci/providers/ns1/repo/scripts/upstream.sh
+++ b/provider-ci/providers/ns1/repo/scripts/upstream.sh
@@ -91,14 +91,12 @@ start_rebase() {
 
   for patch in ../patches/*.patch; do
     echo "Applying $patch"
-    if ! git apply --3way "$patch"; then
+    if ! git am --3way "$patch"; then
       echo
       echo "Failed to apply patch. Please run 'make upstream.rebase FROM=$TAG' where '$TAG' allows the patch set to apply cleanly"
       echo
       exit 1
     fi
-    patch=${patch#../patches/*-}
-    git commit -am "${patch%.patch}"
   done
 
   touch ../rebase-in-progress

--- a/provider-ci/providers/oci/repo/scripts/upstream.sh
+++ b/provider-ci/providers/oci/repo/scripts/upstream.sh
@@ -91,14 +91,12 @@ start_rebase() {
 
   for patch in ../patches/*.patch; do
     echo "Applying $patch"
-    if ! git apply --3way "$patch"; then
+    if ! git am --3way "$patch"; then
       echo
       echo "Failed to apply patch. Please run 'make upstream.rebase FROM=$TAG' where '$TAG' allows the patch set to apply cleanly"
       echo
       exit 1
     fi
-    patch=${patch#../patches/*-}
-    git commit -am "${patch%.patch}"
   done
 
   touch ../rebase-in-progress

--- a/provider-ci/providers/okta/repo/scripts/upstream.sh
+++ b/provider-ci/providers/okta/repo/scripts/upstream.sh
@@ -91,14 +91,12 @@ start_rebase() {
 
   for patch in ../patches/*.patch; do
     echo "Applying $patch"
-    if ! git apply --3way "$patch"; then
+    if ! git am --3way "$patch"; then
       echo
       echo "Failed to apply patch. Please run 'make upstream.rebase FROM=$TAG' where '$TAG' allows the patch set to apply cleanly"
       echo
       exit 1
     fi
-    patch=${patch#../patches/*-}
-    git commit -am "${patch%.patch}"
   done
 
   touch ../rebase-in-progress

--- a/provider-ci/providers/onelogin/repo/scripts/upstream.sh
+++ b/provider-ci/providers/onelogin/repo/scripts/upstream.sh
@@ -91,14 +91,12 @@ start_rebase() {
 
   for patch in ../patches/*.patch; do
     echo "Applying $patch"
-    if ! git apply --3way "$patch"; then
+    if ! git am --3way "$patch"; then
       echo
       echo "Failed to apply patch. Please run 'make upstream.rebase FROM=$TAG' where '$TAG' allows the patch set to apply cleanly"
       echo
       exit 1
     fi
-    patch=${patch#../patches/*-}
-    git commit -am "${patch%.patch}"
   done
 
   touch ../rebase-in-progress

--- a/provider-ci/providers/openstack/repo/scripts/upstream.sh
+++ b/provider-ci/providers/openstack/repo/scripts/upstream.sh
@@ -91,14 +91,12 @@ start_rebase() {
 
   for patch in ../patches/*.patch; do
     echo "Applying $patch"
-    if ! git apply --3way "$patch"; then
+    if ! git am --3way "$patch"; then
       echo
       echo "Failed to apply patch. Please run 'make upstream.rebase FROM=$TAG' where '$TAG' allows the patch set to apply cleanly"
       echo
       exit 1
     fi
-    patch=${patch#../patches/*-}
-    git commit -am "${patch%.patch}"
   done
 
   touch ../rebase-in-progress

--- a/provider-ci/providers/opsgenie/repo/scripts/upstream.sh
+++ b/provider-ci/providers/opsgenie/repo/scripts/upstream.sh
@@ -91,14 +91,12 @@ start_rebase() {
 
   for patch in ../patches/*.patch; do
     echo "Applying $patch"
-    if ! git apply --3way "$patch"; then
+    if ! git am --3way "$patch"; then
       echo
       echo "Failed to apply patch. Please run 'make upstream.rebase FROM=$TAG' where '$TAG' allows the patch set to apply cleanly"
       echo
       exit 1
     fi
-    patch=${patch#../patches/*-}
-    git commit -am "${patch%.patch}"
   done
 
   touch ../rebase-in-progress

--- a/provider-ci/providers/pagerduty/repo/scripts/upstream.sh
+++ b/provider-ci/providers/pagerduty/repo/scripts/upstream.sh
@@ -91,14 +91,12 @@ start_rebase() {
 
   for patch in ../patches/*.patch; do
     echo "Applying $patch"
-    if ! git apply --3way "$patch"; then
+    if ! git am --3way "$patch"; then
       echo
       echo "Failed to apply patch. Please run 'make upstream.rebase FROM=$TAG' where '$TAG' allows the patch set to apply cleanly"
       echo
       exit 1
     fi
-    patch=${patch#../patches/*-}
-    git commit -am "${patch%.patch}"
   done
 
   touch ../rebase-in-progress

--- a/provider-ci/providers/postgresql/repo/scripts/upstream.sh
+++ b/provider-ci/providers/postgresql/repo/scripts/upstream.sh
@@ -91,14 +91,12 @@ start_rebase() {
 
   for patch in ../patches/*.patch; do
     echo "Applying $patch"
-    if ! git apply --3way "$patch"; then
+    if ! git am --3way "$patch"; then
       echo
       echo "Failed to apply patch. Please run 'make upstream.rebase FROM=$TAG' where '$TAG' allows the patch set to apply cleanly"
       echo
       exit 1
     fi
-    patch=${patch#../patches/*-}
-    git commit -am "${patch%.patch}"
   done
 
   touch ../rebase-in-progress

--- a/provider-ci/providers/rabbitmq/repo/scripts/upstream.sh
+++ b/provider-ci/providers/rabbitmq/repo/scripts/upstream.sh
@@ -91,14 +91,12 @@ start_rebase() {
 
   for patch in ../patches/*.patch; do
     echo "Applying $patch"
-    if ! git apply --3way "$patch"; then
+    if ! git am --3way "$patch"; then
       echo
       echo "Failed to apply patch. Please run 'make upstream.rebase FROM=$TAG' where '$TAG' allows the patch set to apply cleanly"
       echo
       exit 1
     fi
-    patch=${patch#../patches/*-}
-    git commit -am "${patch%.patch}"
   done
 
   touch ../rebase-in-progress

--- a/provider-ci/providers/rancher2/repo/scripts/upstream.sh
+++ b/provider-ci/providers/rancher2/repo/scripts/upstream.sh
@@ -91,14 +91,12 @@ start_rebase() {
 
   for patch in ../patches/*.patch; do
     echo "Applying $patch"
-    if ! git apply --3way "$patch"; then
+    if ! git am --3way "$patch"; then
       echo
       echo "Failed to apply patch. Please run 'make upstream.rebase FROM=$TAG' where '$TAG' allows the patch set to apply cleanly"
       echo
       exit 1
     fi
-    patch=${patch#../patches/*-}
-    git commit -am "${patch%.patch}"
   done
 
   touch ../rebase-in-progress

--- a/provider-ci/providers/random/repo/scripts/upstream.sh
+++ b/provider-ci/providers/random/repo/scripts/upstream.sh
@@ -91,14 +91,12 @@ start_rebase() {
 
   for patch in ../patches/*.patch; do
     echo "Applying $patch"
-    if ! git apply --3way "$patch"; then
+    if ! git am --3way "$patch"; then
       echo
       echo "Failed to apply patch. Please run 'make upstream.rebase FROM=$TAG' where '$TAG' allows the patch set to apply cleanly"
       echo
       exit 1
     fi
-    patch=${patch#../patches/*-}
-    git commit -am "${patch%.patch}"
   done
 
   touch ../rebase-in-progress

--- a/provider-ci/providers/rke/repo/scripts/upstream.sh
+++ b/provider-ci/providers/rke/repo/scripts/upstream.sh
@@ -91,14 +91,12 @@ start_rebase() {
 
   for patch in ../patches/*.patch; do
     echo "Applying $patch"
-    if ! git apply --3way "$patch"; then
+    if ! git am --3way "$patch"; then
       echo
       echo "Failed to apply patch. Please run 'make upstream.rebase FROM=$TAG' where '$TAG' allows the patch set to apply cleanly"
       echo
       exit 1
     fi
-    patch=${patch#../patches/*-}
-    git commit -am "${patch%.patch}"
   done
 
   touch ../rebase-in-progress

--- a/provider-ci/providers/signalfx/repo/scripts/upstream.sh
+++ b/provider-ci/providers/signalfx/repo/scripts/upstream.sh
@@ -91,14 +91,12 @@ start_rebase() {
 
   for patch in ../patches/*.patch; do
     echo "Applying $patch"
-    if ! git apply --3way "$patch"; then
+    if ! git am --3way "$patch"; then
       echo
       echo "Failed to apply patch. Please run 'make upstream.rebase FROM=$TAG' where '$TAG' allows the patch set to apply cleanly"
       echo
       exit 1
     fi
-    patch=${patch#../patches/*-}
-    git commit -am "${patch%.patch}"
   done
 
   touch ../rebase-in-progress

--- a/provider-ci/providers/slack/repo/scripts/upstream.sh
+++ b/provider-ci/providers/slack/repo/scripts/upstream.sh
@@ -91,14 +91,12 @@ start_rebase() {
 
   for patch in ../patches/*.patch; do
     echo "Applying $patch"
-    if ! git apply --3way "$patch"; then
+    if ! git am --3way "$patch"; then
       echo
       echo "Failed to apply patch. Please run 'make upstream.rebase FROM=$TAG' where '$TAG' allows the patch set to apply cleanly"
       echo
       exit 1
     fi
-    patch=${patch#../patches/*-}
-    git commit -am "${patch%.patch}"
   done
 
   touch ../rebase-in-progress

--- a/provider-ci/providers/snowflake/repo/scripts/upstream.sh
+++ b/provider-ci/providers/snowflake/repo/scripts/upstream.sh
@@ -91,14 +91,12 @@ start_rebase() {
 
   for patch in ../patches/*.patch; do
     echo "Applying $patch"
-    if ! git apply --3way "$patch"; then
+    if ! git am --3way "$patch"; then
       echo
       echo "Failed to apply patch. Please run 'make upstream.rebase FROM=$TAG' where '$TAG' allows the patch set to apply cleanly"
       echo
       exit 1
     fi
-    patch=${patch#../patches/*-}
-    git commit -am "${patch%.patch}"
   done
 
   touch ../rebase-in-progress

--- a/provider-ci/providers/splunk/repo/scripts/upstream.sh
+++ b/provider-ci/providers/splunk/repo/scripts/upstream.sh
@@ -91,14 +91,12 @@ start_rebase() {
 
   for patch in ../patches/*.patch; do
     echo "Applying $patch"
-    if ! git apply --3way "$patch"; then
+    if ! git am --3way "$patch"; then
       echo
       echo "Failed to apply patch. Please run 'make upstream.rebase FROM=$TAG' where '$TAG' allows the patch set to apply cleanly"
       echo
       exit 1
     fi
-    patch=${patch#../patches/*-}
-    git commit -am "${patch%.patch}"
   done
 
   touch ../rebase-in-progress

--- a/provider-ci/providers/spotinst/repo/scripts/upstream.sh
+++ b/provider-ci/providers/spotinst/repo/scripts/upstream.sh
@@ -91,14 +91,12 @@ start_rebase() {
 
   for patch in ../patches/*.patch; do
     echo "Applying $patch"
-    if ! git apply --3way "$patch"; then
+    if ! git am --3way "$patch"; then
       echo
       echo "Failed to apply patch. Please run 'make upstream.rebase FROM=$TAG' where '$TAG' allows the patch set to apply cleanly"
       echo
       exit 1
     fi
-    patch=${patch#../patches/*-}
-    git commit -am "${patch%.patch}"
   done
 
   touch ../rebase-in-progress

--- a/provider-ci/providers/sumologic/repo/scripts/upstream.sh
+++ b/provider-ci/providers/sumologic/repo/scripts/upstream.sh
@@ -91,14 +91,12 @@ start_rebase() {
 
   for patch in ../patches/*.patch; do
     echo "Applying $patch"
-    if ! git apply --3way "$patch"; then
+    if ! git am --3way "$patch"; then
       echo
       echo "Failed to apply patch. Please run 'make upstream.rebase FROM=$TAG' where '$TAG' allows the patch set to apply cleanly"
       echo
       exit 1
     fi
-    patch=${patch#../patches/*-}
-    git commit -am "${patch%.patch}"
   done
 
   touch ../rebase-in-progress

--- a/provider-ci/providers/tailscale/repo/scripts/upstream.sh
+++ b/provider-ci/providers/tailscale/repo/scripts/upstream.sh
@@ -91,14 +91,12 @@ start_rebase() {
 
   for patch in ../patches/*.patch; do
     echo "Applying $patch"
-    if ! git apply --3way "$patch"; then
+    if ! git am --3way "$patch"; then
       echo
       echo "Failed to apply patch. Please run 'make upstream.rebase FROM=$TAG' where '$TAG' allows the patch set to apply cleanly"
       echo
       exit 1
     fi
-    patch=${patch#../patches/*-}
-    git commit -am "${patch%.patch}"
   done
 
   touch ../rebase-in-progress

--- a/provider-ci/providers/tls/repo/scripts/upstream.sh
+++ b/provider-ci/providers/tls/repo/scripts/upstream.sh
@@ -91,14 +91,12 @@ start_rebase() {
 
   for patch in ../patches/*.patch; do
     echo "Applying $patch"
-    if ! git apply --3way "$patch"; then
+    if ! git am --3way "$patch"; then
       echo
       echo "Failed to apply patch. Please run 'make upstream.rebase FROM=$TAG' where '$TAG' allows the patch set to apply cleanly"
       echo
       exit 1
     fi
-    patch=${patch#../patches/*-}
-    git commit -am "${patch%.patch}"
   done
 
   touch ../rebase-in-progress

--- a/provider-ci/providers/vault/repo/scripts/upstream.sh
+++ b/provider-ci/providers/vault/repo/scripts/upstream.sh
@@ -91,14 +91,12 @@ start_rebase() {
 
   for patch in ../patches/*.patch; do
     echo "Applying $patch"
-    if ! git apply --3way "$patch"; then
+    if ! git am --3way "$patch"; then
       echo
       echo "Failed to apply patch. Please run 'make upstream.rebase FROM=$TAG' where '$TAG' allows the patch set to apply cleanly"
       echo
       exit 1
     fi
-    patch=${patch#../patches/*-}
-    git commit -am "${patch%.patch}"
   done
 
   touch ../rebase-in-progress

--- a/provider-ci/providers/venafi/repo/scripts/upstream.sh
+++ b/provider-ci/providers/venafi/repo/scripts/upstream.sh
@@ -91,14 +91,12 @@ start_rebase() {
 
   for patch in ../patches/*.patch; do
     echo "Applying $patch"
-    if ! git apply --3way "$patch"; then
+    if ! git am --3way "$patch"; then
       echo
       echo "Failed to apply patch. Please run 'make upstream.rebase FROM=$TAG' where '$TAG' allows the patch set to apply cleanly"
       echo
       exit 1
     fi
-    patch=${patch#../patches/*-}
-    git commit -am "${patch%.patch}"
   done
 
   touch ../rebase-in-progress

--- a/provider-ci/providers/vsphere/repo/scripts/upstream.sh
+++ b/provider-ci/providers/vsphere/repo/scripts/upstream.sh
@@ -91,14 +91,12 @@ start_rebase() {
 
   for patch in ../patches/*.patch; do
     echo "Applying $patch"
-    if ! git apply --3way "$patch"; then
+    if ! git am --3way "$patch"; then
       echo
       echo "Failed to apply patch. Please run 'make upstream.rebase FROM=$TAG' where '$TAG' allows the patch set to apply cleanly"
       echo
       exit 1
     fi
-    patch=${patch#../patches/*-}
-    git commit -am "${patch%.patch}"
   done
 
   touch ../rebase-in-progress

--- a/provider-ci/providers/wavefront/repo/scripts/upstream.sh
+++ b/provider-ci/providers/wavefront/repo/scripts/upstream.sh
@@ -91,14 +91,12 @@ start_rebase() {
 
   for patch in ../patches/*.patch; do
     echo "Applying $patch"
-    if ! git apply --3way "$patch"; then
+    if ! git am --3way "$patch"; then
       echo
       echo "Failed to apply patch. Please run 'make upstream.rebase FROM=$TAG' where '$TAG' allows the patch set to apply cleanly"
       echo
       exit 1
     fi
-    patch=${patch#../patches/*-}
-    git commit -am "${patch%.patch}"
   done
 
   touch ../rebase-in-progress


### PR DESCRIPTION
Modifies the `make upstream.rebase` and `make upstream.finalize` targets in repo Makefiles to use `git am` to "apply a series of patches from a mailbox", instead of `git apply`. From `git am --help`:

> Splits mail messages in a mailbox into commit log message, authorship
> information and patches, and applies them to the current branch.

This git subcommand is designed to use `git format-patch` output, preserving the metadata from the original patch, unlike `git apply` which applies a diff to the current working tree. As this command replaces both `apply` and `commit`, we also remove the `git commit` command from the loop.

The `make upstream` target is unchanged. That target, which invokes the `apply()` function in `scripts/upstream.sh`, still uses `git apply`. That command is intended to leave the user with a dirty submodule, where the ref of the submodule points at a real upstream commit hash and the patches are staged changes. That makes it possible to stage and commit the submodule (which only updates the ref it points to) and have it be navigable/usable by other users.

Fixes #468.

This change is included in [pull request pulumi-gcp#1106](https://github.com/pulumi/pulumi-gcp/pull/1106).