### PR TITLE
Fix Kubernetes provider test output formatting

### DIFF
--- a/native-provider-ci/src/steps.ts
+++ b/native-provider-ci/src/steps.ts
@@ -473,7 +473,7 @@ export function RunTests(provider: string): Step {
   if (provider === "kubernetes") {
     return {
       name: "Run tests",
-      run: "cd tests/sdk/${{ matrix.language }} && go test -v -count=1 -cover -timeout 2h -parallel 4 ./...",
+      run: "cd tests/sdk/${{ matrix.language }} && go test -v -count=1 -cover -timeout 2h -parallel 4 ./... 2>&1 | tee /tmp/gotest.log | gotestfmt",
     };
   }
   return {

--- a/native-provider-ci/src/steps.ts
+++ b/native-provider-ci/src/steps.ts
@@ -473,7 +473,7 @@ export function RunTests(provider: string): Step {
   if (provider === "kubernetes") {
     return {
       name: "Run tests",
-      run: "cd tests/sdk/${{ matrix.language }} && go test -v -count=1 -cover -timeout 2h -parallel 4 ./... 2>&1 | tee /tmp/gotest.log | gotestfmt",
+      run: "cd tests/sdk/${{ matrix.language }} && go test -v -json -count=1 -cover -timeout 2h -parallel 4 ./... 2>&1 | tee /tmp/gotest.log | gotestfmt",
     };
   }
   return {


### PR DESCRIPTION
Use `gotestfmt` to make GH Actions test output readable for the Kubernetes provider.

Example test run: https://github.com/pulumi/pulumi-kubernetes/actions/runs/5407130413/jobs/9824871199