### PR TITLE
Remove `lint_sdk` from sentinel

### DIFF
--- a/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/run-acceptance-tests.yml
@@ -238,7 +238,6 @@ jobs:
     - test
     #{{ if .Config.lint -}}#
     - lint
-    - lint_sdk
     #{{ end -}}#
     runs-on: ubuntu-latest
     steps:

--- a/provider-ci/providers/artifactory/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/artifactory/repo/.github/workflows/run-acceptance-tests.yml
@@ -261,7 +261,6 @@ jobs:
     needs:
     - test
     - lint
-    - lint_sdk
     runs-on: ubuntu-latest
     steps:
     - name: Is workflow a success

--- a/provider-ci/providers/auth0/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/auth0/repo/.github/workflows/run-acceptance-tests.yml
@@ -261,7 +261,6 @@ jobs:
     needs:
     - test
     - lint
-    - lint_sdk
     runs-on: ubuntu-latest
     steps:
     - name: Is workflow a success

--- a/provider-ci/providers/azuread/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/azuread/repo/.github/workflows/run-acceptance-tests.yml
@@ -263,7 +263,6 @@ jobs:
     needs:
     - test
     - lint
-    - lint_sdk
     runs-on: ubuntu-latest
     steps:
     - name: Is workflow a success

--- a/provider-ci/providers/civo/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/civo/repo/.github/workflows/run-acceptance-tests.yml
@@ -259,7 +259,6 @@ jobs:
     needs:
     - test
     - lint
-    - lint_sdk
     runs-on: ubuntu-latest
     steps:
     - name: Is workflow a success

--- a/provider-ci/providers/cloudamqp/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/cloudamqp/repo/.github/workflows/run-acceptance-tests.yml
@@ -259,7 +259,6 @@ jobs:
     needs:
     - test
     - lint
-    - lint_sdk
     runs-on: ubuntu-latest
     steps:
     - name: Is workflow a success

--- a/provider-ci/providers/cloudflare/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/cloudflare/repo/.github/workflows/run-acceptance-tests.yml
@@ -260,7 +260,6 @@ jobs:
     needs:
     - test
     - lint
-    - lint_sdk
     runs-on: ubuntu-latest
     steps:
     - name: Is workflow a success

--- a/provider-ci/providers/consul/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/consul/repo/.github/workflows/run-acceptance-tests.yml
@@ -258,7 +258,6 @@ jobs:
     needs:
     - test
     - lint
-    - lint_sdk
     runs-on: ubuntu-latest
     steps:
     - name: Is workflow a success

--- a/provider-ci/providers/databricks/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/databricks/repo/.github/workflows/run-acceptance-tests.yml
@@ -262,7 +262,6 @@ jobs:
     needs:
     - test
     - lint
-    - lint_sdk
     runs-on: ubuntu-latest
     steps:
     - name: Is workflow a success

--- a/provider-ci/providers/digitalocean/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/digitalocean/repo/.github/workflows/run-acceptance-tests.yml
@@ -259,7 +259,6 @@ jobs:
     needs:
     - test
     - lint
-    - lint_sdk
     runs-on: ubuntu-latest
     steps:
     - name: Is workflow a success

--- a/provider-ci/providers/dnsimple/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/dnsimple/repo/.github/workflows/run-acceptance-tests.yml
@@ -260,7 +260,6 @@ jobs:
     needs:
     - test
     - lint
-    - lint_sdk
     runs-on: ubuntu-latest
     steps:
     - name: Is workflow a success

--- a/provider-ci/providers/docker/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/docker/repo/.github/workflows/run-acceptance-tests.yml
@@ -272,7 +272,6 @@ jobs:
     needs:
     - test
     - lint
-    - lint_sdk
     runs-on: ubuntu-latest
     steps:
     - name: Is workflow a success

--- a/provider-ci/providers/ec/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/ec/repo/.github/workflows/run-acceptance-tests.yml
@@ -259,7 +259,6 @@ jobs:
     needs:
     - test
     - lint
-    - lint_sdk
     runs-on: ubuntu-latest
     steps:
     - name: Is workflow a success

--- a/provider-ci/providers/f5bigip/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/f5bigip/repo/.github/workflows/run-acceptance-tests.yml
@@ -262,7 +262,6 @@ jobs:
     needs:
     - test
     - lint
-    - lint_sdk
     runs-on: ubuntu-latest
     steps:
     - name: Is workflow a success

--- a/provider-ci/providers/fastly/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/fastly/repo/.github/workflows/run-acceptance-tests.yml
@@ -259,7 +259,6 @@ jobs:
     needs:
     - test
     - lint
-    - lint_sdk
     runs-on: ubuntu-latest
     steps:
     - name: Is workflow a success

--- a/provider-ci/providers/github/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/github/repo/.github/workflows/run-acceptance-tests.yml
@@ -260,7 +260,6 @@ jobs:
     needs:
     - test
     - lint
-    - lint_sdk
     runs-on: ubuntu-latest
     steps:
     - name: Is workflow a success

--- a/provider-ci/providers/gitlab/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/gitlab/repo/.github/workflows/run-acceptance-tests.yml
@@ -259,7 +259,6 @@ jobs:
     needs:
     - test
     - lint
-    - lint_sdk
     runs-on: ubuntu-latest
     steps:
     - name: Is workflow a success

--- a/provider-ci/providers/hcloud/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/hcloud/repo/.github/workflows/run-acceptance-tests.yml
@@ -259,7 +259,6 @@ jobs:
     needs:
     - test
     - lint
-    - lint_sdk
     runs-on: ubuntu-latest
     steps:
     - name: Is workflow a success

--- a/provider-ci/providers/kafka/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/kafka/repo/.github/workflows/run-acceptance-tests.yml
@@ -258,7 +258,6 @@ jobs:
     needs:
     - test
     - lint
-    - lint_sdk
     runs-on: ubuntu-latest
     steps:
     - name: Is workflow a success

--- a/provider-ci/providers/keycloak/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/keycloak/repo/.github/workflows/run-acceptance-tests.yml
@@ -263,7 +263,6 @@ jobs:
     needs:
     - test
     - lint
-    - lint_sdk
     runs-on: ubuntu-latest
     steps:
     - name: Is workflow a success

--- a/provider-ci/providers/kong/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/kong/repo/.github/workflows/run-acceptance-tests.yml
@@ -258,7 +258,6 @@ jobs:
     needs:
     - test
     - lint
-    - lint_sdk
     runs-on: ubuntu-latest
     steps:
     - name: Is workflow a success

--- a/provider-ci/providers/libvirt/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/libvirt/repo/.github/workflows/run-acceptance-tests.yml
@@ -259,7 +259,6 @@ jobs:
     needs:
     - test
     - lint
-    - lint_sdk
     runs-on: ubuntu-latest
     steps:
     - name: Is workflow a success

--- a/provider-ci/providers/linode/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/linode/repo/.github/workflows/run-acceptance-tests.yml
@@ -259,7 +259,6 @@ jobs:
     needs:
     - test
     - lint
-    - lint_sdk
     runs-on: ubuntu-latest
     steps:
     - name: Is workflow a success

--- a/provider-ci/providers/mailgun/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/mailgun/repo/.github/workflows/run-acceptance-tests.yml
@@ -259,7 +259,6 @@ jobs:
     needs:
     - test
     - lint
-    - lint_sdk
     runs-on: ubuntu-latest
     steps:
     - name: Is workflow a success

--- a/provider-ci/providers/minio/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/minio/repo/.github/workflows/run-acceptance-tests.yml
@@ -262,7 +262,6 @@ jobs:
     needs:
     - test
     - lint
-    - lint_sdk
     runs-on: ubuntu-latest
     steps:
     - name: Is workflow a success

--- a/provider-ci/providers/mongodbatlas/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/mongodbatlas/repo/.github/workflows/run-acceptance-tests.yml
@@ -261,7 +261,6 @@ jobs:
     needs:
     - test
     - lint
-    - lint_sdk
     runs-on: ubuntu-latest
     steps:
     - name: Is workflow a success

--- a/provider-ci/providers/mysql/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/mysql/repo/.github/workflows/run-acceptance-tests.yml
@@ -258,7 +258,6 @@ jobs:
     needs:
     - test
     - lint
-    - lint_sdk
     runs-on: ubuntu-latest
     steps:
     - name: Is workflow a success

--- a/provider-ci/providers/newrelic/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/newrelic/repo/.github/workflows/run-acceptance-tests.yml
@@ -260,7 +260,6 @@ jobs:
     needs:
     - test
     - lint
-    - lint_sdk
     runs-on: ubuntu-latest
     steps:
     - name: Is workflow a success

--- a/provider-ci/providers/nomad/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/nomad/repo/.github/workflows/run-acceptance-tests.yml
@@ -259,7 +259,6 @@ jobs:
     needs:
     - test
     - lint
-    - lint_sdk
     runs-on: ubuntu-latest
     steps:
     - name: Is workflow a success

--- a/provider-ci/providers/ns1/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/ns1/repo/.github/workflows/run-acceptance-tests.yml
@@ -259,7 +259,6 @@ jobs:
     needs:
     - test
     - lint
-    - lint_sdk
     runs-on: ubuntu-latest
     steps:
     - name: Is workflow a success

--- a/provider-ci/providers/okta/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/okta/repo/.github/workflows/run-acceptance-tests.yml
@@ -261,7 +261,6 @@ jobs:
     needs:
     - test
     - lint
-    - lint_sdk
     runs-on: ubuntu-latest
     steps:
     - name: Is workflow a success

--- a/provider-ci/providers/onelogin/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/onelogin/repo/.github/workflows/run-acceptance-tests.yml
@@ -258,7 +258,6 @@ jobs:
     needs:
     - test
     - lint
-    - lint_sdk
     runs-on: ubuntu-latest
     steps:
     - name: Is workflow a success

--- a/provider-ci/providers/openstack/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/openstack/repo/.github/workflows/run-acceptance-tests.yml
@@ -267,7 +267,6 @@ jobs:
     needs:
     - test
     - lint
-    - lint_sdk
     runs-on: ubuntu-latest
     steps:
     - name: Is workflow a success

--- a/provider-ci/providers/opsgenie/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/opsgenie/repo/.github/workflows/run-acceptance-tests.yml
@@ -259,7 +259,6 @@ jobs:
     needs:
     - test
     - lint
-    - lint_sdk
     runs-on: ubuntu-latest
     steps:
     - name: Is workflow a success

--- a/provider-ci/providers/pagerduty/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/pagerduty/repo/.github/workflows/run-acceptance-tests.yml
@@ -259,7 +259,6 @@ jobs:
     needs:
     - test
     - lint
-    - lint_sdk
     runs-on: ubuntu-latest
     steps:
     - name: Is workflow a success

--- a/provider-ci/providers/postgresql/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/postgresql/repo/.github/workflows/run-acceptance-tests.yml
@@ -258,7 +258,6 @@ jobs:
     needs:
     - test
     - lint
-    - lint_sdk
     runs-on: ubuntu-latest
     steps:
     - name: Is workflow a success

--- a/provider-ci/providers/rabbitmq/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/rabbitmq/repo/.github/workflows/run-acceptance-tests.yml
@@ -258,7 +258,6 @@ jobs:
     needs:
     - test
     - lint
-    - lint_sdk
     runs-on: ubuntu-latest
     steps:
     - name: Is workflow a success

--- a/provider-ci/providers/random/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/random/repo/.github/workflows/run-acceptance-tests.yml
@@ -258,7 +258,6 @@ jobs:
     needs:
     - test
     - lint
-    - lint_sdk
     runs-on: ubuntu-latest
     steps:
     - name: Is workflow a success

--- a/provider-ci/providers/rke/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/rke/repo/.github/workflows/run-acceptance-tests.yml
@@ -259,7 +259,6 @@ jobs:
     needs:
     - test
     - lint
-    - lint_sdk
     runs-on: ubuntu-latest
     steps:
     - name: Is workflow a success

--- a/provider-ci/providers/signalfx/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/signalfx/repo/.github/workflows/run-acceptance-tests.yml
@@ -258,7 +258,6 @@ jobs:
     needs:
     - test
     - lint
-    - lint_sdk
     runs-on: ubuntu-latest
     steps:
     - name: Is workflow a success

--- a/provider-ci/providers/slack/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/slack/repo/.github/workflows/run-acceptance-tests.yml
@@ -259,7 +259,6 @@ jobs:
     needs:
     - test
     - lint
-    - lint_sdk
     runs-on: ubuntu-latest
     steps:
     - name: Is workflow a success

--- a/provider-ci/providers/snowflake/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/snowflake/repo/.github/workflows/run-acceptance-tests.yml
@@ -263,7 +263,6 @@ jobs:
     needs:
     - test
     - lint
-    - lint_sdk
     runs-on: ubuntu-latest
     steps:
     - name: Is workflow a success

--- a/provider-ci/providers/splunk/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/splunk/repo/.github/workflows/run-acceptance-tests.yml
@@ -261,7 +261,6 @@ jobs:
     needs:
     - test
     - lint
-    - lint_sdk
     runs-on: ubuntu-latest
     steps:
     - name: Is workflow a success

--- a/provider-ci/providers/spotinst/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/spotinst/repo/.github/workflows/run-acceptance-tests.yml
@@ -261,7 +261,6 @@ jobs:
     needs:
     - test
     - lint
-    - lint_sdk
     runs-on: ubuntu-latest
     steps:
     - name: Is workflow a success

--- a/provider-ci/providers/sumologic/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/sumologic/repo/.github/workflows/run-acceptance-tests.yml
@@ -261,7 +261,6 @@ jobs:
     needs:
     - test
     - lint
-    - lint_sdk
     runs-on: ubuntu-latest
     steps:
     - name: Is workflow a success

--- a/provider-ci/providers/tailscale/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/tailscale/repo/.github/workflows/run-acceptance-tests.yml
@@ -261,7 +261,6 @@ jobs:
     needs:
     - test
     - lint
-    - lint_sdk
     runs-on: ubuntu-latest
     steps:
     - name: Is workflow a success

--- a/provider-ci/providers/tls/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/tls/repo/.github/workflows/run-acceptance-tests.yml
@@ -258,7 +258,6 @@ jobs:
     needs:
     - test
     - lint
-    - lint_sdk
     runs-on: ubuntu-latest
     steps:
     - name: Is workflow a success

--- a/provider-ci/providers/vault/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/vault/repo/.github/workflows/run-acceptance-tests.yml
@@ -258,7 +258,6 @@ jobs:
     needs:
     - test
     - lint
-    - lint_sdk
     runs-on: ubuntu-latest
     steps:
     - name: Is workflow a success

--- a/provider-ci/providers/venafi/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/venafi/repo/.github/workflows/run-acceptance-tests.yml
@@ -262,7 +262,6 @@ jobs:
     needs:
     - test
     - lint
-    - lint_sdk
     runs-on: ubuntu-latest
     steps:
     - name: Is workflow a success

--- a/provider-ci/providers/vsphere/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/vsphere/repo/.github/workflows/run-acceptance-tests.yml
@@ -258,7 +258,6 @@ jobs:
     needs:
     - test
     - lint
-    - lint_sdk
     runs-on: ubuntu-latest
     steps:
     - name: Is workflow a success

--- a/provider-ci/providers/wavefront/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/wavefront/repo/.github/workflows/run-acceptance-tests.yml
@@ -260,7 +260,6 @@ jobs:
     needs:
     - test
     - lint
-    - lint_sdk
     runs-on: ubuntu-latest
     steps:
     - name: Is workflow a success


### PR DESCRIPTION
We removed `lint_sdk` in https://github.com/pulumi/ci-mgmt/pull/480, but failed to remove the dangling ref to it. This caused workflows to hang.