### PR TITLE
Add `time` dependency for pulumi-gcp

### DIFF
--- a/provider-ci/providers/gcp/config.yaml
+++ b/provider-ci/providers/gcp/config.yaml
@@ -25,5 +25,7 @@ plugins:
     version: "4.6.0"
   - name: http
     version: "0.0.1"
+  - name: time
+    version: "0.0.15"
 team: ecosystem
 goBuildParallelism: 2

--- a/provider-ci/providers/gcp/repo/Makefile
+++ b/provider-ci/providers/gcp/repo/Makefile
@@ -97,6 +97,7 @@ install_plugins:
 	pulumi plugin install resource kubernetes 3.20.0
 	pulumi plugin install resource tls 4.6.0
 	pulumi plugin install resource http 0.0.1
+	pulumi plugin install resource time 0.0.15
 
 lint_provider: provider
 	cd provider && golangci-lint run -c ../.golangci.yml


### PR DESCRIPTION
Avoid test failures on upgrades such as https://github.com/pulumi/pulumi-gcp/pull/1145