### PR TITLE
Add missing team in config

### DIFF
--- a/provider-ci/providers/archive/config.yaml
+++ b/provider-ci/providers/archive/config.yaml
@@ -5,3 +5,4 @@ makeTemplate: bridged
 publishRegistry: false
 env:
   ARCHIVE_TOKEN: ${{ secrets.ARCHIVE_TOKEN }}
+team: ecosystem

--- a/provider-ci/providers/external/config.yaml
+++ b/provider-ci/providers/external/config.yaml
@@ -5,3 +5,4 @@ makeTemplate: bridged
 publishRegistry: false
 env:
   EXTERNAL_TOKEN: ${{ secrets.EXTERNAL_TOKEN }}
+team: ecosystem

--- a/provider-ci/providers/http/config.yaml
+++ b/provider-ci/providers/http/config.yaml
@@ -5,3 +5,4 @@ makeTemplate: bridged
 publishRegistry: false
 env:
   HTTP_TOKEN: ${{ secrets.HTTP_TOKEN }}
+team: ecosystem

--- a/provider-ci/providers/local/config.yaml
+++ b/provider-ci/providers/local/config.yaml
@@ -5,3 +5,4 @@ makeTemplate: bridged
 publishRegistry: false
 env:
   LOCAL_TOKEN: ${{ secrets.LOCAL_TOKEN }}
+team: ecosystem

--- a/provider-ci/providers/null/config.yaml
+++ b/provider-ci/providers/null/config.yaml
@@ -5,3 +5,4 @@ makeTemplate: bridged
 publishRegistry: false
 env:
   NULL_TOKEN: ${{ secrets.NULL_TOKEN }}
+team: ecosystem


### PR DESCRIPTION
Fixes #491 

Error in CI:

```
Traceback (most recent call last):
  File "/home/runner/work/ci-mgmt/ci-mgmt/scripts/generate_providers_list.py", line 24, in <module>
    raise Exception(f"Provider {p} is lacking team: assignment in config.yaml")
Exception: Provider archive is lacking team: assignment in config.yaml
```

It looks like the most recently added providers are missing `team: ecosystem` in the `config.yaml`. This adds the missing field to match other similar providers.

Ideally, if this is a required field, we should fail the PR workflow (but we don't have any PR workflow).