### PR TITLE
Update go version to update to from `1.19` to `1.20`

### DIFF
--- a/tools/sourcemigrator/index.ts
+++ b/tools/sourcemigrator/index.ts
@@ -58,11 +58,11 @@ function updatePulumiCoreRefTo3x(): SourceMigration {
     return sm;
 }
 
-function updateGo_1_19(): SourceMigration {
+function updateGo_1_20(): SourceMigration {
     let pattern = new RegExp('^go \\d+[.]\\d+$', 'm');
-    let replacement = "go 1.19";
+    let replacement = "go 1.20";
     let sm: SourceMigration = {
-        name: "updateGo_1_19",
+        name: "updateGo_1_20",
         execute: (ctx: MigrateContext) => {
             let stdout = child.execSync("git ls-files -- '**/go.mod'", {cwd: ctx.dir});
             let filesEdited = String(stdout).split("\n")
@@ -117,7 +117,7 @@ function allMigrations(): SourceMigration[] {
     return [
         updateExamplesFromCore31DotNet6(),
         updatePulumiCoreRefTo3x(),
-        updateGo_1_19(),
+        updateGo_1_20(),
     ];
 }
 


### PR DESCRIPTION
We should be targeting `1.20` now, so workflow updates such as https://github.com/pulumi/pulumi-aws-native/pull/1014 don't attempt to downgrade the go version