### PR TITLE
Remove cleanCacheBetweenBuilds option

### DIFF
--- a/provider-ci/internal/pkg/templates/bridged-provider/.goreleaser.prerelease.yml
+++ b/provider-ci/internal/pkg/templates/bridged-provider/.goreleaser.prerelease.yml
@@ -30,12 +30,6 @@ builds:
     post:
     - env GOOS={{ .Os }} GOARCH={{ .Arch }} go clean -cache
     - env GOOS={{ .Os }} GOARCH={{ .Arch }} go clean -modcache
-  #{{- if .Config.cleanCacheBetweenBuilds }}#
-  hooks:
-    post:
-    - env GOOS={{ .Os }} GOARCH={{ .Arch }} go clean -cache
-    - env GOOS={{ .Os }} GOARCH={{ .Arch }} go clean -modcache
-  #{{- end }}#
   #{{- if .Config.skipWindowsArmBuild }}#
   ignore:
   - goarch: arm64

--- a/provider-ci/internal/pkg/templates/bridged-provider/.goreleaser.yml
+++ b/provider-ci/internal/pkg/templates/bridged-provider/.goreleaser.yml
@@ -30,12 +30,6 @@ builds:
     post:
     - env GOOS={{ .Os }} GOARCH={{ .Arch }} go clean -cache
     - env GOOS={{ .Os }} GOARCH={{ .Arch }} go clean -modcache
-  #{{- if .Config.cleanCacheBetweenBuilds }}#
-  hooks:
-    post:
-    - env GOOS={{ .Os }} GOARCH={{ .Arch }} go clean -cache
-    - env GOOS={{ .Os }} GOARCH={{ .Arch }} go clean -modcache
-  #{{- end }}#
   #{{- if .Config.skipWindowsArmBuild }}#
   ignore:
   - goarch: arm64

--- a/provider-ci/providers/azure/config.yaml
+++ b/provider-ci/providers/azure/config.yaml
@@ -27,4 +27,3 @@ plugins:
 team: ecosystem
 goBuildParallelism: 2
 javaGenVersion: "v0.8.0"
-cleanCacheBetweenBuilds: true

--- a/provider-ci/providers/azure/repo/.goreleaser.prerelease.yml
+++ b/provider-ci/providers/azure/repo/.goreleaser.prerelease.yml
@@ -30,10 +30,6 @@ builds:
     post:
     - env GOOS={{ .Os }} GOARCH={{ .Arch }} go clean -cache
     - env GOOS={{ .Os }} GOARCH={{ .Arch }} go clean -modcache
-  hooks:
-    post:
-    - env GOOS={{ .Os }} GOARCH={{ .Arch }} go clean -cache
-    - env GOOS={{ .Os }} GOARCH={{ .Arch }} go clean -modcache
   ignore: []
   ldflags:
   - -X github.com/pulumi/pulumi-azure/provider/v5/pkg/version.Version={{.Tag}}

--- a/provider-ci/providers/azure/repo/.goreleaser.yml
+++ b/provider-ci/providers/azure/repo/.goreleaser.yml
@@ -30,10 +30,6 @@ builds:
     post:
     - env GOOS={{ .Os }} GOARCH={{ .Arch }} go clean -cache
     - env GOOS={{ .Os }} GOARCH={{ .Arch }} go clean -modcache
-  hooks:
-    post:
-    - env GOOS={{ .Os }} GOARCH={{ .Arch }} go clean -cache
-    - env GOOS={{ .Os }} GOARCH={{ .Arch }} go clean -modcache
   ignore: []
   ldflags:
   - -X github.com/pulumi/pulumi-azure/provider/v5/pkg/version.Version={{.Tag}}


### PR DESCRIPTION
This is causing publish failures in pulumi-azure (they only place where this is enabled) because it duplicates hooks. We now do this by default, so there is no observable change in working CI.