### PR TITLE
Initialize provider submodule before attempting source code migration

### DIFF
--- a/.github/workflows/update-workflows-ecosystem-providers.yml
+++ b/.github/workflows/update-workflows-ecosystem-providers.yml
@@ -50,6 +50,8 @@ jobs:
         with:
           repository: pulumi/pulumi-${{ matrix.provider }}
           path: pulumi-${{ matrix.provider }}
+      - name: Initialize submodule in pulumi-${{ matrix.provider }}
+        run: cd pulumi-${{ matrix.provider }} && make upstream && cd ..
       - name: Delete existing workflows
         run: rm pulumi-${{ matrix.provider }}/.github/workflows/*.yml
       - name: Copy files from ci-mgmt to pulumi-${{ matrix.provider }}


### PR DESCRIPTION
Fixes https://github.com/pulumi/ci-mgmt/issues/503

Some providers have an upstream submodule that must be initialized first before modifying the provider's dependencies/ go.mod

