### PR TITLE
Bump wavefront major version

### DIFF
--- a/provider-ci/providers/wavefront/config.yaml
+++ b/provider-ci/providers/wavefront/config.yaml
@@ -1,7 +1,8 @@
 provider: wavefront
-major-version: 1
+major-version: 3
 env:
   WAVEFRONT_ADDRESS: ${{ secrets.WAVEFRONT_ADDRESS }}
   WAVEFRONT_TOKEN: ${{ secrets.WAVEFRONT_TOKEN }}
 makeTemplate: bridged
 team: ecosystem
+javaGenVersion: "v0.9.5"

--- a/provider-ci/providers/wavefront/repo/.goreleaser.prerelease.yml
+++ b/provider-ci/providers/wavefront/repo/.goreleaser.prerelease.yml
@@ -32,7 +32,7 @@ builds:
     - env GOOS={{ .Os }} GOARCH={{ .Arch }} go clean -modcache
   ignore: []
   ldflags:
-  - -X github.com/pulumi/pulumi-wavefront/provider/pkg/version.Version={{.Tag}}
+  - -X github.com/pulumi/pulumi-wavefront/provider/v3/pkg/version.Version={{.Tag}}
   main: ./cmd/pulumi-resource-wavefront/
 changelog:
   skip: true

--- a/provider-ci/providers/wavefront/repo/.goreleaser.yml
+++ b/provider-ci/providers/wavefront/repo/.goreleaser.yml
@@ -32,7 +32,8 @@ builds:
     - env GOOS={{ .Os }} GOARCH={{ .Arch }} go clean -modcache
   ignore: []
   ldflags:
-  - -X github.com/pulumi/pulumi-wavefront/provider/pkg/version.Version={{.Tag}}
+  - -X
+    github.com/pulumi/pulumi-wavefront/provider/v3/pkg/version.Version={{.Tag}}
   main: ./cmd/pulumi-resource-wavefront/
 changelog:
   filters:

--- a/provider-ci/providers/wavefront/repo/Makefile
+++ b/provider-ci/providers/wavefront/repo/Makefile
@@ -3,13 +3,13 @@
 PACK := wavefront
 ORG := pulumi
 PROJECT := github.com/$(ORG)/pulumi-$(PACK)
-PROVIDER_PATH := provider
+PROVIDER_PATH := provider/v3
 VERSION_PATH := $(PROVIDER_PATH)/pkg/version.Version
 TFGEN := pulumi-tfgen-$(PACK)
 PROVIDER := pulumi-resource-$(PACK)
 VERSION := $(shell pulumictl get version)
 JAVA_GEN := pulumi-java-gen
-JAVA_GEN_VERSION := v0.5.4
+JAVA_GEN_VERSION := v0.9.5
 TESTPARALLELISM := 10
 WORKING_DIR := $(shell pwd)
 


### PR DESCRIPTION
This also bumps the java version.

Needs to wait for https://github.com/pulumi/pulumi-wavefront/issues/178 to land.