### PR TITLE
Reflect https://github.com/pulumi/pulumi-pagerduty/pull/244

### DIFF
--- a/provider-ci/providers/pagerduty/config.yaml
+++ b/provider-ci/providers/pagerduty/config.yaml
@@ -4,3 +4,7 @@ env:
   PAGERDUTY_TOKEN: ${{ secrets.PAGERDUTY_TOKEN }}
 makeTemplate: bridged
 team: ecosystem
+javaGenVersion: "v0.9.5"
+plugins:
+  - name: time
+    version: "0.0.15"

--- a/provider-ci/providers/pagerduty/repo/Makefile
+++ b/provider-ci/providers/pagerduty/repo/Makefile
@@ -9,7 +9,7 @@ TFGEN := pulumi-tfgen-$(PACK)
 PROVIDER := pulumi-resource-$(PACK)
 VERSION := $(shell pulumictl get version)
 JAVA_GEN := pulumi-java-gen
-JAVA_GEN_VERSION := v0.5.4
+JAVA_GEN_VERSION := v0.9.5
 TESTPARALLELISM := 10
 WORKING_DIR := $(shell pwd)
 
@@ -92,6 +92,7 @@ install_nodejs_sdk:
 
 install_plugins:
 	[ -x "$(shell command -v pulumi 2>/dev/null)" ] || curl -fsSL https://get.pulumi.com | sh
+	pulumi plugin install resource time 0.0.15
 
 lint_provider: provider
 	cd provider && golangci-lint run -c ../.golangci.yml


### PR DESCRIPTION
- Bumps the `pulumi-java` version to v0.9.5.
- Depends on `pulumi-time` at v0.0.15.