### PR TITLE
Upload DigitalOcean SSH key if it exists

### DIFF
--- a/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/run-acceptance-tests.yml
@@ -357,6 +357,12 @@ jobs:
       with:
         token: ${{ secrets.GITHUB_TOKEN }}
         version: v2.4.0
+    #{{- if .Config.digitalOceanSshKey }}#
+    - name: Setup SSH key
+      uses: webfactory/ssh-agent@v0.7.0
+      with:
+        ssh-private-key: ${{ secrets.PRIVATE_SSH_KEY_FOR_DIGITALOCEAN }}
+    #{{- end }}#
     - name: Run tests
       run: cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{
         matrix.language }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt

--- a/provider-ci/providers/docker/config.yaml
+++ b/provider-ci/providers/docker/config.yaml
@@ -3,6 +3,7 @@ major-version: 4
 aws: true
 gcp: true
 gcpRegistry: true
+digitalOceanSshKey: true
 env:
   AWS_REGION: us-west-2
   ARM_CLIENT_ID: "30e520fa-12b4-4e21-b473-9426c5ac2e1e"

--- a/provider-ci/providers/docker/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/docker/repo/.github/workflows/run-acceptance-tests.yml
@@ -397,6 +397,10 @@ jobs:
       with:
         token: ${{ secrets.GITHUB_TOKEN }}
         version: v2.4.0
+    - name: Setup SSH key
+      uses: webfactory/ssh-agent@v0.7.0
+      with:
+        ssh-private-key: ${{ secrets.PRIVATE_SSH_KEY_FOR_DIGITALOCEAN }}
     - name: Run tests
       run: cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{
         matrix.language }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt


### PR DESCRIPTION
This is the second ci-mgmt PR to enable pulumi/pulumi-docker#707. It adds a CI step to provision a required SSH key to DigitalOcean.
