### PR TITLE
Create a daily workflow to update native-providers that are opted into ci-mgmt

### DIFF
--- a/.github/workflows/update-native-provider-workflows.yml
+++ b/.github/workflows/update-native-provider-workflows.yml
@@ -1,0 +1,34 @@
+# Generates a PR for the files in native-provider-ci/providers/* to each corresponding Pulumi provider.
+#
+# Note that this workflow does not generate any files - workflows must already be generated and committed to this repo
+# when this workflow is run.
+name: Update GH workflows, native providers (auto-pr)
+on:
+  schedule:
+  # 5 AM UTC ~ 10 PM PDT - specifically selected to avoid putting load on the CI system during working hours.
+  - cron: 0 5 * * *
+jobs:
+  generate-providers-list:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - id: get-providers
+        run: echo "::set-output name=providers::$(python generate_native_providers_list.py --for-auto-pr)'"
+        working-directory: scripts
+    outputs:
+      providers: ${{ steps.get-providers.outputs.providers }}
+  update-provider:
+    needs: generate-providers-list
+    strategy:
+      fail-fast: false
+      # GitHub recommends only issuing 1 API request per second, and never
+      # concurrently.  For more information, see:
+      # https://docs.github.com/en/rest/guides/best-practices-for-integrators#dealing-with-secondary-rate-limits
+      max-parallel: 1
+      matrix:
+        provider: ${{ fromJson(needs.generate-providers-list.outputs.providers ) }}
+    uses: ./.github/workflows/update-single-native-provider.yaml
+    with:
+      provider_name: ${{ matrix.provider }}
+    secrets: inherit
+

--- a/scripts/generate_native_providers_list.py
+++ b/scripts/generate_native_providers_list.py
@@ -1,4 +1,17 @@
+import argparse
 import os
 import json
 
-print(json.dumps(sorted(os.listdir('../native-provider-ci/providers'))))
+
+excluded_from_auto_pr =["azure-native", "google-native", "kubernetes", "command"]
+
+if __name__ == '__main__':
+    ap = argparse.ArgumentParser()
+    ap.add_argument('--for-auto-pr', help="only return the providers that should get an automatic PR", action="store_true")
+    args = ap.parse_args()
+
+    ps = sorted(os.listdir('../native-provider-ci/providers'))
+    if args.for_auto_pr:
+        ps = [p for p in ps if p not in excluded_from_auto_pr]
+
+    print(json.dumps(ps))


### PR DESCRIPTION
We recently got aws-native back in sync with ci-mgmt; this will help us keep it in sync. 