### PR TITLE
Set the right major version for Kubernetes

### DIFF
--- a/native-provider-ci/providers/kubernetes/config.yaml
+++ b/native-provider-ci/providers/kubernetes/config.yaml
@@ -2,7 +2,7 @@ provider: kubernetes
 lint: true
 aws: true
 gcp: true
-major-version: 3
+major-version: 4
 env:
   AWS_REGION: us-west-2
   PULUMI_TEST_OWNER: moolumi

--- a/native-provider-ci/providers/kubernetes/repo/.goreleaser.prerelease.yml
+++ b/native-provider-ci/providers/kubernetes/repo/.goreleaser.prerelease.yml
@@ -22,7 +22,7 @@ builds:
   main: ./cmd/pulumi-resource-kubernetes/
   ldflags:
   - -X
-    github.com/pulumi/pulumi-kubernetes/provider/v3/pkg/version.Version={{.Tag}}
+    github.com/pulumi/pulumi-kubernetes/provider/v4/pkg/version.Version={{.Tag}}
   binary: pulumi-resource-kubernetes
 archives:
 - name_template: "{{ .Binary }}-{{ .Tag }}-{{ .Os }}-{{ .Arch }}"

--- a/native-provider-ci/providers/kubernetes/repo/.goreleaser.yml
+++ b/native-provider-ci/providers/kubernetes/repo/.goreleaser.yml
@@ -22,7 +22,7 @@ builds:
   main: ./cmd/pulumi-resource-kubernetes/
   ldflags:
   - -X
-    github.com/pulumi/pulumi-kubernetes/provider/v3/pkg/version.Version={{.Tag}}
+    github.com/pulumi/pulumi-kubernetes/provider/v4/pkg/version.Version={{.Tag}}
   binary: pulumi-resource-kubernetes
 archives:
 - name_template: "{{ .Binary }}-{{ .Tag }}-{{ .Os }}-{{ .Arch }}"


### PR DESCRIPTION
A test PR (https://github.com/pulumi/pulumi-kubernetes/pull/2548) showed that Kubernetes workflows are almost in sync with ci-mgmt, with the two exceptions:
- major version number
- version of actions/upload-artifact
This PR addresses the former.