### PR TITLE
Make `sentinel` useful when determining workflow success

### DIFF
--- a/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/run-acceptance-tests.yml
@@ -233,9 +233,33 @@ jobs:
         fields: repo,commit,author,action
         status: ${{ job.status }}
   sentinel:
-    if: github.event_name == 'repository_dispatch' ||
-      github.event.pull_request.head.repo.full_name == github.repository
     name: sentinel
+    # We would like to be able to specify `sentinel` as the only required job for this
+    # workflow. To do that, we need `sentinel` to succeed only when it is safe to
+    # merge and fail in all other cases.
+    #
+    # We can't use the default `if: success()`, since GitHub interprets a skipped job as a
+    # success, and by default a dependee job failing will skip a dependent job. That means
+    # if a test step fails, then it will skip `sentinel` so GitHub will register
+    # `sentinel` as succeeded.
+    #
+    # GitHub documents `jobs.result` as:
+    #
+    #	The result of a job in the reusable workflow. Possible values are success,
+    #	failure, cancelled, or skipped.
+    #
+    # GitHub documents `cancelled()` as:
+    #
+    #	Returns true if the workflow was canceled.
+    #
+    # Combining these terms gives us an intuitive definition of success:
+    #
+    #	We have succeeded when no dependent workflow has failed and the job was
+    #	not cancelled.
+    #
+    if: (github.event_name == 'repository_dispatch' ||
+      github.event.pull_request.head.repo.full_name == github.repository) &&
+      ! cancelled()
     needs:
     - test
     #{{- if .Config.lint }}#
@@ -246,8 +270,11 @@ jobs:
     #{{- end }}#
     runs-on: #{{ .Config.runner.default }}#
     steps:
-    - name: Is workflow a success
-      run: echo yes
+    - name: Workflow is not a success
+      if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') || contains(needs.*.result, 'skipped')
+      run: exit 1
+    - name: Workflow is a success
+      run: echo "🎉🎈🎉🎈🎉"
   test:
     if: github.event_name == 'repository_dispatch' ||
       github.event.pull_request.head.repo.full_name == github.repository

--- a/provider-ci/providers/aiven/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/aiven/repo/.github/workflows/run-acceptance-tests.yml
@@ -222,15 +222,42 @@ jobs:
         fields: repo,commit,author,action
         status: ${{ job.status }}
   sentinel:
-    if: github.event_name == 'repository_dispatch' ||
-      github.event.pull_request.head.repo.full_name == github.repository
     name: sentinel
+    # We would like to be able to specify `sentinel` as the only required job for this
+    # workflow. To do that, we need `sentinel` to succeed only when it is safe to
+    # merge and fail in all other cases.
+    #
+    # We can't use the default `if: success()`, since GitHub interprets a skipped job as a
+    # success, and by default a dependee job failing will skip a dependent job. That means
+    # if a test step fails, then it will skip `sentinel` so GitHub will register
+    # `sentinel` as succeeded.
+    #
+    # GitHub documents `jobs.result` as:
+    #
+    #	The result of a job in the reusable workflow. Possible values are success,
+    #	failure, cancelled, or skipped.
+    #
+    # GitHub documents `cancelled()` as:
+    #
+    #	Returns true if the workflow was canceled.
+    #
+    # Combining these terms gives us an intuitive definition of success:
+    #
+    #	We have succeeded when no dependent workflow has failed and the job was
+    #	not cancelled.
+    #
+    if: (github.event_name == 'repository_dispatch' ||
+      github.event.pull_request.head.repo.full_name == github.repository) &&
+      ! cancelled()
     needs:
     - test
     runs-on: ubuntu-latest
     steps:
-    - name: Is workflow a success
-      run: echo yes
+    - name: Workflow is not a success
+      if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') || contains(needs.*.result, 'skipped')
+      run: exit 1
+    - name: Workflow is a success
+      run: echo "🎉🎈🎉🎈🎉"
   test:
     if: github.event_name == 'repository_dispatch' ||
       github.event.pull_request.head.repo.full_name == github.repository

--- a/provider-ci/providers/akamai/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/akamai/repo/.github/workflows/run-acceptance-tests.yml
@@ -224,15 +224,42 @@ jobs:
         fields: repo,commit,author,action
         status: ${{ job.status }}
   sentinel:
-    if: github.event_name == 'repository_dispatch' ||
-      github.event.pull_request.head.repo.full_name == github.repository
     name: sentinel
+    # We would like to be able to specify `sentinel` as the only required job for this
+    # workflow. To do that, we need `sentinel` to succeed only when it is safe to
+    # merge and fail in all other cases.
+    #
+    # We can't use the default `if: success()`, since GitHub interprets a skipped job as a
+    # success, and by default a dependee job failing will skip a dependent job. That means
+    # if a test step fails, then it will skip `sentinel` so GitHub will register
+    # `sentinel` as succeeded.
+    #
+    # GitHub documents `jobs.result` as:
+    #
+    #	The result of a job in the reusable workflow. Possible values are success,
+    #	failure, cancelled, or skipped.
+    #
+    # GitHub documents `cancelled()` as:
+    #
+    #	Returns true if the workflow was canceled.
+    #
+    # Combining these terms gives us an intuitive definition of success:
+    #
+    #	We have succeeded when no dependent workflow has failed and the job was
+    #	not cancelled.
+    #
+    if: (github.event_name == 'repository_dispatch' ||
+      github.event.pull_request.head.repo.full_name == github.repository) &&
+      ! cancelled()
     needs:
     - test
     runs-on: ubuntu-latest
     steps:
-    - name: Is workflow a success
-      run: echo yes
+    - name: Workflow is not a success
+      if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') || contains(needs.*.result, 'skipped')
+      run: exit 1
+    - name: Workflow is a success
+      run: echo "🎉🎈🎉🎈🎉"
   test:
     if: github.event_name == 'repository_dispatch' ||
       github.event.pull_request.head.repo.full_name == github.repository

--- a/provider-ci/providers/alicloud/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/alicloud/repo/.github/workflows/run-acceptance-tests.yml
@@ -223,15 +223,42 @@ jobs:
         fields: repo,commit,author,action
         status: ${{ job.status }}
   sentinel:
-    if: github.event_name == 'repository_dispatch' ||
-      github.event.pull_request.head.repo.full_name == github.repository
     name: sentinel
+    # We would like to be able to specify `sentinel` as the only required job for this
+    # workflow. To do that, we need `sentinel` to succeed only when it is safe to
+    # merge and fail in all other cases.
+    #
+    # We can't use the default `if: success()`, since GitHub interprets a skipped job as a
+    # success, and by default a dependee job failing will skip a dependent job. That means
+    # if a test step fails, then it will skip `sentinel` so GitHub will register
+    # `sentinel` as succeeded.
+    #
+    # GitHub documents `jobs.result` as:
+    #
+    #	The result of a job in the reusable workflow. Possible values are success,
+    #	failure, cancelled, or skipped.
+    #
+    # GitHub documents `cancelled()` as:
+    #
+    #	Returns true if the workflow was canceled.
+    #
+    # Combining these terms gives us an intuitive definition of success:
+    #
+    #	We have succeeded when no dependent workflow has failed and the job was
+    #	not cancelled.
+    #
+    if: (github.event_name == 'repository_dispatch' ||
+      github.event.pull_request.head.repo.full_name == github.repository) &&
+      ! cancelled()
     needs:
     - test
     runs-on: ubuntu-latest
     steps:
-    - name: Is workflow a success
-      run: echo yes
+    - name: Workflow is not a success
+      if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') || contains(needs.*.result, 'skipped')
+      run: exit 1
+    - name: Workflow is a success
+      run: echo "🎉🎈🎉🎈🎉"
   test:
     if: github.event_name == 'repository_dispatch' ||
       github.event.pull_request.head.repo.full_name == github.repository

--- a/provider-ci/providers/archive/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/archive/repo/.github/workflows/run-acceptance-tests.yml
@@ -221,15 +221,42 @@ jobs:
         fields: repo,commit,author,action
         status: ${{ job.status }}
   sentinel:
-    if: github.event_name == 'repository_dispatch' ||
-      github.event.pull_request.head.repo.full_name == github.repository
     name: sentinel
+    # We would like to be able to specify `sentinel` as the only required job for this
+    # workflow. To do that, we need `sentinel` to succeed only when it is safe to
+    # merge and fail in all other cases.
+    #
+    # We can't use the default `if: success()`, since GitHub interprets a skipped job as a
+    # success, and by default a dependee job failing will skip a dependent job. That means
+    # if a test step fails, then it will skip `sentinel` so GitHub will register
+    # `sentinel` as succeeded.
+    #
+    # GitHub documents `jobs.result` as:
+    #
+    #	The result of a job in the reusable workflow. Possible values are success,
+    #	failure, cancelled, or skipped.
+    #
+    # GitHub documents `cancelled()` as:
+    #
+    #	Returns true if the workflow was canceled.
+    #
+    # Combining these terms gives us an intuitive definition of success:
+    #
+    #	We have succeeded when no dependent workflow has failed and the job was
+    #	not cancelled.
+    #
+    if: (github.event_name == 'repository_dispatch' ||
+      github.event.pull_request.head.repo.full_name == github.repository) &&
+      ! cancelled()
     needs:
     - test
     runs-on: ubuntu-latest
     steps:
-    - name: Is workflow a success
-      run: echo yes
+    - name: Workflow is not a success
+      if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') || contains(needs.*.result, 'skipped')
+      run: exit 1
+    - name: Workflow is a success
+      run: echo "🎉🎈🎉🎈🎉"
   test:
     if: github.event_name == 'repository_dispatch' ||
       github.event.pull_request.head.repo.full_name == github.repository

--- a/provider-ci/providers/artifactory/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/artifactory/repo/.github/workflows/run-acceptance-tests.yml
@@ -263,16 +263,43 @@ jobs:
         fields: repo,commit,author,action
         status: ${{ job.status }}
   sentinel:
-    if: github.event_name == 'repository_dispatch' ||
-      github.event.pull_request.head.repo.full_name == github.repository
     name: sentinel
+    # We would like to be able to specify `sentinel` as the only required job for this
+    # workflow. To do that, we need `sentinel` to succeed only when it is safe to
+    # merge and fail in all other cases.
+    #
+    # We can't use the default `if: success()`, since GitHub interprets a skipped job as a
+    # success, and by default a dependee job failing will skip a dependent job. That means
+    # if a test step fails, then it will skip `sentinel` so GitHub will register
+    # `sentinel` as succeeded.
+    #
+    # GitHub documents `jobs.result` as:
+    #
+    #	The result of a job in the reusable workflow. Possible values are success,
+    #	failure, cancelled, or skipped.
+    #
+    # GitHub documents `cancelled()` as:
+    #
+    #	Returns true if the workflow was canceled.
+    #
+    # Combining these terms gives us an intuitive definition of success:
+    #
+    #	We have succeeded when no dependent workflow has failed and the job was
+    #	not cancelled.
+    #
+    if: (github.event_name == 'repository_dispatch' ||
+      github.event.pull_request.head.repo.full_name == github.repository) &&
+      ! cancelled()
     needs:
     - test
     - lint
     runs-on: ubuntu-latest
     steps:
-    - name: Is workflow a success
-      run: echo yes
+    - name: Workflow is not a success
+      if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') || contains(needs.*.result, 'skipped')
+      run: exit 1
+    - name: Workflow is a success
+      run: echo "🎉🎈🎉🎈🎉"
   test:
     if: github.event_name == 'repository_dispatch' ||
       github.event.pull_request.head.repo.full_name == github.repository

--- a/provider-ci/providers/auth0/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/auth0/repo/.github/workflows/run-acceptance-tests.yml
@@ -263,16 +263,43 @@ jobs:
         fields: repo,commit,author,action
         status: ${{ job.status }}
   sentinel:
-    if: github.event_name == 'repository_dispatch' ||
-      github.event.pull_request.head.repo.full_name == github.repository
     name: sentinel
+    # We would like to be able to specify `sentinel` as the only required job for this
+    # workflow. To do that, we need `sentinel` to succeed only when it is safe to
+    # merge and fail in all other cases.
+    #
+    # We can't use the default `if: success()`, since GitHub interprets a skipped job as a
+    # success, and by default a dependee job failing will skip a dependent job. That means
+    # if a test step fails, then it will skip `sentinel` so GitHub will register
+    # `sentinel` as succeeded.
+    #
+    # GitHub documents `jobs.result` as:
+    #
+    #	The result of a job in the reusable workflow. Possible values are success,
+    #	failure, cancelled, or skipped.
+    #
+    # GitHub documents `cancelled()` as:
+    #
+    #	Returns true if the workflow was canceled.
+    #
+    # Combining these terms gives us an intuitive definition of success:
+    #
+    #	We have succeeded when no dependent workflow has failed and the job was
+    #	not cancelled.
+    #
+    if: (github.event_name == 'repository_dispatch' ||
+      github.event.pull_request.head.repo.full_name == github.repository) &&
+      ! cancelled()
     needs:
     - test
     - lint
     runs-on: ubuntu-latest
     steps:
-    - name: Is workflow a success
-      run: echo yes
+    - name: Workflow is not a success
+      if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') || contains(needs.*.result, 'skipped')
+      run: exit 1
+    - name: Workflow is a success
+      run: echo "🎉🎈🎉🎈🎉"
   test:
     if: github.event_name == 'repository_dispatch' ||
       github.event.pull_request.head.repo.full_name == github.repository

--- a/provider-ci/providers/aws/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/aws/repo/.github/workflows/run-acceptance-tests.yml
@@ -237,16 +237,43 @@ jobs:
         fields: repo,commit,author,action
         status: ${{ job.status }}
   sentinel:
-    if: github.event_name == 'repository_dispatch' ||
-      github.event.pull_request.head.repo.full_name == github.repository
     name: sentinel
+    # We would like to be able to specify `sentinel` as the only required job for this
+    # workflow. To do that, we need `sentinel` to succeed only when it is safe to
+    # merge and fail in all other cases.
+    #
+    # We can't use the default `if: success()`, since GitHub interprets a skipped job as a
+    # success, and by default a dependee job failing will skip a dependent job. That means
+    # if a test step fails, then it will skip `sentinel` so GitHub will register
+    # `sentinel` as succeeded.
+    #
+    # GitHub documents `jobs.result` as:
+    #
+    #	The result of a job in the reusable workflow. Possible values are success,
+    #	failure, cancelled, or skipped.
+    #
+    # GitHub documents `cancelled()` as:
+    #
+    #	Returns true if the workflow was canceled.
+    #
+    # Combining these terms gives us an intuitive definition of success:
+    #
+    #	We have succeeded when no dependent workflow has failed and the job was
+    #	not cancelled.
+    #
+    if: (github.event_name == 'repository_dispatch' ||
+      github.event.pull_request.head.repo.full_name == github.repository) &&
+      ! cancelled()
     needs:
     - test
     - go_test_shim
     runs-on: ubuntu-latest
     steps:
-    - name: Is workflow a success
-      run: echo yes
+    - name: Workflow is not a success
+      if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') || contains(needs.*.result, 'skipped')
+      run: exit 1
+    - name: Workflow is a success
+      run: echo "🎉🎈🎉🎈🎉"
   test:
     if: github.event_name == 'repository_dispatch' ||
       github.event.pull_request.head.repo.full_name == github.repository

--- a/provider-ci/providers/azure/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/azure/repo/.github/workflows/run-acceptance-tests.yml
@@ -227,15 +227,42 @@ jobs:
         fields: repo,commit,author,action
         status: ${{ job.status }}
   sentinel:
-    if: github.event_name == 'repository_dispatch' ||
-      github.event.pull_request.head.repo.full_name == github.repository
     name: sentinel
+    # We would like to be able to specify `sentinel` as the only required job for this
+    # workflow. To do that, we need `sentinel` to succeed only when it is safe to
+    # merge and fail in all other cases.
+    #
+    # We can't use the default `if: success()`, since GitHub interprets a skipped job as a
+    # success, and by default a dependee job failing will skip a dependent job. That means
+    # if a test step fails, then it will skip `sentinel` so GitHub will register
+    # `sentinel` as succeeded.
+    #
+    # GitHub documents `jobs.result` as:
+    #
+    #	The result of a job in the reusable workflow. Possible values are success,
+    #	failure, cancelled, or skipped.
+    #
+    # GitHub documents `cancelled()` as:
+    #
+    #	Returns true if the workflow was canceled.
+    #
+    # Combining these terms gives us an intuitive definition of success:
+    #
+    #	We have succeeded when no dependent workflow has failed and the job was
+    #	not cancelled.
+    #
+    if: (github.event_name == 'repository_dispatch' ||
+      github.event.pull_request.head.repo.full_name == github.repository) &&
+      ! cancelled()
     needs:
     - test
     runs-on: ubuntu-latest
     steps:
-    - name: Is workflow a success
-      run: echo yes
+    - name: Workflow is not a success
+      if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') || contains(needs.*.result, 'skipped')
+      run: exit 1
+    - name: Workflow is a success
+      run: echo "🎉🎈🎉🎈🎉"
   test:
     if: github.event_name == 'repository_dispatch' ||
       github.event.pull_request.head.repo.full_name == github.repository

--- a/provider-ci/providers/azuread/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/azuread/repo/.github/workflows/run-acceptance-tests.yml
@@ -265,16 +265,43 @@ jobs:
         fields: repo,commit,author,action
         status: ${{ job.status }}
   sentinel:
-    if: github.event_name == 'repository_dispatch' ||
-      github.event.pull_request.head.repo.full_name == github.repository
     name: sentinel
+    # We would like to be able to specify `sentinel` as the only required job for this
+    # workflow. To do that, we need `sentinel` to succeed only when it is safe to
+    # merge and fail in all other cases.
+    #
+    # We can't use the default `if: success()`, since GitHub interprets a skipped job as a
+    # success, and by default a dependee job failing will skip a dependent job. That means
+    # if a test step fails, then it will skip `sentinel` so GitHub will register
+    # `sentinel` as succeeded.
+    #
+    # GitHub documents `jobs.result` as:
+    #
+    #	The result of a job in the reusable workflow. Possible values are success,
+    #	failure, cancelled, or skipped.
+    #
+    # GitHub documents `cancelled()` as:
+    #
+    #	Returns true if the workflow was canceled.
+    #
+    # Combining these terms gives us an intuitive definition of success:
+    #
+    #	We have succeeded when no dependent workflow has failed and the job was
+    #	not cancelled.
+    #
+    if: (github.event_name == 'repository_dispatch' ||
+      github.event.pull_request.head.repo.full_name == github.repository) &&
+      ! cancelled()
     needs:
     - test
     - lint
     runs-on: ubuntu-latest
     steps:
-    - name: Is workflow a success
-      run: echo yes
+    - name: Workflow is not a success
+      if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') || contains(needs.*.result, 'skipped')
+      run: exit 1
+    - name: Workflow is a success
+      run: echo "🎉🎈🎉🎈🎉"
   test:
     if: github.event_name == 'repository_dispatch' ||
       github.event.pull_request.head.repo.full_name == github.repository

--- a/provider-ci/providers/azuredevops/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/azuredevops/repo/.github/workflows/run-acceptance-tests.yml
@@ -222,15 +222,42 @@ jobs:
         fields: repo,commit,author,action
         status: ${{ job.status }}
   sentinel:
-    if: github.event_name == 'repository_dispatch' ||
-      github.event.pull_request.head.repo.full_name == github.repository
     name: sentinel
+    # We would like to be able to specify `sentinel` as the only required job for this
+    # workflow. To do that, we need `sentinel` to succeed only when it is safe to
+    # merge and fail in all other cases.
+    #
+    # We can't use the default `if: success()`, since GitHub interprets a skipped job as a
+    # success, and by default a dependee job failing will skip a dependent job. That means
+    # if a test step fails, then it will skip `sentinel` so GitHub will register
+    # `sentinel` as succeeded.
+    #
+    # GitHub documents `jobs.result` as:
+    #
+    #	The result of a job in the reusable workflow. Possible values are success,
+    #	failure, cancelled, or skipped.
+    #
+    # GitHub documents `cancelled()` as:
+    #
+    #	Returns true if the workflow was canceled.
+    #
+    # Combining these terms gives us an intuitive definition of success:
+    #
+    #	We have succeeded when no dependent workflow has failed and the job was
+    #	not cancelled.
+    #
+    if: (github.event_name == 'repository_dispatch' ||
+      github.event.pull_request.head.repo.full_name == github.repository) &&
+      ! cancelled()
     needs:
     - test
     runs-on: ubuntu-latest
     steps:
-    - name: Is workflow a success
-      run: echo yes
+    - name: Workflow is not a success
+      if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') || contains(needs.*.result, 'skipped')
+      run: exit 1
+    - name: Workflow is a success
+      run: echo "🎉🎈🎉🎈🎉"
   test:
     if: github.event_name == 'repository_dispatch' ||
       github.event.pull_request.head.repo.full_name == github.repository

--- a/provider-ci/providers/civo/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/civo/repo/.github/workflows/run-acceptance-tests.yml
@@ -261,16 +261,43 @@ jobs:
         fields: repo,commit,author,action
         status: ${{ job.status }}
   sentinel:
-    if: github.event_name == 'repository_dispatch' ||
-      github.event.pull_request.head.repo.full_name == github.repository
     name: sentinel
+    # We would like to be able to specify `sentinel` as the only required job for this
+    # workflow. To do that, we need `sentinel` to succeed only when it is safe to
+    # merge and fail in all other cases.
+    #
+    # We can't use the default `if: success()`, since GitHub interprets a skipped job as a
+    # success, and by default a dependee job failing will skip a dependent job. That means
+    # if a test step fails, then it will skip `sentinel` so GitHub will register
+    # `sentinel` as succeeded.
+    #
+    # GitHub documents `jobs.result` as:
+    #
+    #	The result of a job in the reusable workflow. Possible values are success,
+    #	failure, cancelled, or skipped.
+    #
+    # GitHub documents `cancelled()` as:
+    #
+    #	Returns true if the workflow was canceled.
+    #
+    # Combining these terms gives us an intuitive definition of success:
+    #
+    #	We have succeeded when no dependent workflow has failed and the job was
+    #	not cancelled.
+    #
+    if: (github.event_name == 'repository_dispatch' ||
+      github.event.pull_request.head.repo.full_name == github.repository) &&
+      ! cancelled()
     needs:
     - test
     - lint
     runs-on: ubuntu-latest
     steps:
-    - name: Is workflow a success
-      run: echo yes
+    - name: Workflow is not a success
+      if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') || contains(needs.*.result, 'skipped')
+      run: exit 1
+    - name: Workflow is a success
+      run: echo "🎉🎈🎉🎈🎉"
   test:
     if: github.event_name == 'repository_dispatch' ||
       github.event.pull_request.head.repo.full_name == github.repository

--- a/provider-ci/providers/cloudamqp/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/cloudamqp/repo/.github/workflows/run-acceptance-tests.yml
@@ -261,16 +261,43 @@ jobs:
         fields: repo,commit,author,action
         status: ${{ job.status }}
   sentinel:
-    if: github.event_name == 'repository_dispatch' ||
-      github.event.pull_request.head.repo.full_name == github.repository
     name: sentinel
+    # We would like to be able to specify `sentinel` as the only required job for this
+    # workflow. To do that, we need `sentinel` to succeed only when it is safe to
+    # merge and fail in all other cases.
+    #
+    # We can't use the default `if: success()`, since GitHub interprets a skipped job as a
+    # success, and by default a dependee job failing will skip a dependent job. That means
+    # if a test step fails, then it will skip `sentinel` so GitHub will register
+    # `sentinel` as succeeded.
+    #
+    # GitHub documents `jobs.result` as:
+    #
+    #	The result of a job in the reusable workflow. Possible values are success,
+    #	failure, cancelled, or skipped.
+    #
+    # GitHub documents `cancelled()` as:
+    #
+    #	Returns true if the workflow was canceled.
+    #
+    # Combining these terms gives us an intuitive definition of success:
+    #
+    #	We have succeeded when no dependent workflow has failed and the job was
+    #	not cancelled.
+    #
+    if: (github.event_name == 'repository_dispatch' ||
+      github.event.pull_request.head.repo.full_name == github.repository) &&
+      ! cancelled()
     needs:
     - test
     - lint
     runs-on: ubuntu-latest
     steps:
-    - name: Is workflow a success
-      run: echo yes
+    - name: Workflow is not a success
+      if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') || contains(needs.*.result, 'skipped')
+      run: exit 1
+    - name: Workflow is a success
+      run: echo "🎉🎈🎉🎈🎉"
   test:
     if: github.event_name == 'repository_dispatch' ||
       github.event.pull_request.head.repo.full_name == github.repository

--- a/provider-ci/providers/cloudflare/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/cloudflare/repo/.github/workflows/run-acceptance-tests.yml
@@ -262,16 +262,43 @@ jobs:
         fields: repo,commit,author,action
         status: ${{ job.status }}
   sentinel:
-    if: github.event_name == 'repository_dispatch' ||
-      github.event.pull_request.head.repo.full_name == github.repository
     name: sentinel
+    # We would like to be able to specify `sentinel` as the only required job for this
+    # workflow. To do that, we need `sentinel` to succeed only when it is safe to
+    # merge and fail in all other cases.
+    #
+    # We can't use the default `if: success()`, since GitHub interprets a skipped job as a
+    # success, and by default a dependee job failing will skip a dependent job. That means
+    # if a test step fails, then it will skip `sentinel` so GitHub will register
+    # `sentinel` as succeeded.
+    #
+    # GitHub documents `jobs.result` as:
+    #
+    #	The result of a job in the reusable workflow. Possible values are success,
+    #	failure, cancelled, or skipped.
+    #
+    # GitHub documents `cancelled()` as:
+    #
+    #	Returns true if the workflow was canceled.
+    #
+    # Combining these terms gives us an intuitive definition of success:
+    #
+    #	We have succeeded when no dependent workflow has failed and the job was
+    #	not cancelled.
+    #
+    if: (github.event_name == 'repository_dispatch' ||
+      github.event.pull_request.head.repo.full_name == github.repository) &&
+      ! cancelled()
     needs:
     - test
     - lint
     runs-on: ubuntu-latest
     steps:
-    - name: Is workflow a success
-      run: echo yes
+    - name: Workflow is not a success
+      if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') || contains(needs.*.result, 'skipped')
+      run: exit 1
+    - name: Workflow is a success
+      run: echo "🎉🎈🎉🎈🎉"
   test:
     if: github.event_name == 'repository_dispatch' ||
       github.event.pull_request.head.repo.full_name == github.repository

--- a/provider-ci/providers/cloudinit/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/cloudinit/repo/.github/workflows/run-acceptance-tests.yml
@@ -220,15 +220,42 @@ jobs:
         fields: repo,commit,author,action
         status: ${{ job.status }}
   sentinel:
-    if: github.event_name == 'repository_dispatch' ||
-      github.event.pull_request.head.repo.full_name == github.repository
     name: sentinel
+    # We would like to be able to specify `sentinel` as the only required job for this
+    # workflow. To do that, we need `sentinel` to succeed only when it is safe to
+    # merge and fail in all other cases.
+    #
+    # We can't use the default `if: success()`, since GitHub interprets a skipped job as a
+    # success, and by default a dependee job failing will skip a dependent job. That means
+    # if a test step fails, then it will skip `sentinel` so GitHub will register
+    # `sentinel` as succeeded.
+    #
+    # GitHub documents `jobs.result` as:
+    #
+    #	The result of a job in the reusable workflow. Possible values are success,
+    #	failure, cancelled, or skipped.
+    #
+    # GitHub documents `cancelled()` as:
+    #
+    #	Returns true if the workflow was canceled.
+    #
+    # Combining these terms gives us an intuitive definition of success:
+    #
+    #	We have succeeded when no dependent workflow has failed and the job was
+    #	not cancelled.
+    #
+    if: (github.event_name == 'repository_dispatch' ||
+      github.event.pull_request.head.repo.full_name == github.repository) &&
+      ! cancelled()
     needs:
     - test
     runs-on: ubuntu-latest
     steps:
-    - name: Is workflow a success
-      run: echo yes
+    - name: Workflow is not a success
+      if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') || contains(needs.*.result, 'skipped')
+      run: exit 1
+    - name: Workflow is a success
+      run: echo "🎉🎈🎉🎈🎉"
   test:
     if: github.event_name == 'repository_dispatch' ||
       github.event.pull_request.head.repo.full_name == github.repository

--- a/provider-ci/providers/confluentcloud/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/confluentcloud/repo/.github/workflows/run-acceptance-tests.yml
@@ -222,15 +222,42 @@ jobs:
         fields: repo,commit,author,action
         status: ${{ job.status }}
   sentinel:
-    if: github.event_name == 'repository_dispatch' ||
-      github.event.pull_request.head.repo.full_name == github.repository
     name: sentinel
+    # We would like to be able to specify `sentinel` as the only required job for this
+    # workflow. To do that, we need `sentinel` to succeed only when it is safe to
+    # merge and fail in all other cases.
+    #
+    # We can't use the default `if: success()`, since GitHub interprets a skipped job as a
+    # success, and by default a dependee job failing will skip a dependent job. That means
+    # if a test step fails, then it will skip `sentinel` so GitHub will register
+    # `sentinel` as succeeded.
+    #
+    # GitHub documents `jobs.result` as:
+    #
+    #	The result of a job in the reusable workflow. Possible values are success,
+    #	failure, cancelled, or skipped.
+    #
+    # GitHub documents `cancelled()` as:
+    #
+    #	Returns true if the workflow was canceled.
+    #
+    # Combining these terms gives us an intuitive definition of success:
+    #
+    #	We have succeeded when no dependent workflow has failed and the job was
+    #	not cancelled.
+    #
+    if: (github.event_name == 'repository_dispatch' ||
+      github.event.pull_request.head.repo.full_name == github.repository) &&
+      ! cancelled()
     needs:
     - test
     runs-on: ubuntu-latest
     steps:
-    - name: Is workflow a success
-      run: echo yes
+    - name: Workflow is not a success
+      if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') || contains(needs.*.result, 'skipped')
+      run: exit 1
+    - name: Workflow is a success
+      run: echo "🎉🎈🎉🎈🎉"
   test:
     if: github.event_name == 'repository_dispatch' ||
       github.event.pull_request.head.repo.full_name == github.repository

--- a/provider-ci/providers/consul/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/consul/repo/.github/workflows/run-acceptance-tests.yml
@@ -260,16 +260,43 @@ jobs:
         fields: repo,commit,author,action
         status: ${{ job.status }}
   sentinel:
-    if: github.event_name == 'repository_dispatch' ||
-      github.event.pull_request.head.repo.full_name == github.repository
     name: sentinel
+    # We would like to be able to specify `sentinel` as the only required job for this
+    # workflow. To do that, we need `sentinel` to succeed only when it is safe to
+    # merge and fail in all other cases.
+    #
+    # We can't use the default `if: success()`, since GitHub interprets a skipped job as a
+    # success, and by default a dependee job failing will skip a dependent job. That means
+    # if a test step fails, then it will skip `sentinel` so GitHub will register
+    # `sentinel` as succeeded.
+    #
+    # GitHub documents `jobs.result` as:
+    #
+    #	The result of a job in the reusable workflow. Possible values are success,
+    #	failure, cancelled, or skipped.
+    #
+    # GitHub documents `cancelled()` as:
+    #
+    #	Returns true if the workflow was canceled.
+    #
+    # Combining these terms gives us an intuitive definition of success:
+    #
+    #	We have succeeded when no dependent workflow has failed and the job was
+    #	not cancelled.
+    #
+    if: (github.event_name == 'repository_dispatch' ||
+      github.event.pull_request.head.repo.full_name == github.repository) &&
+      ! cancelled()
     needs:
     - test
     - lint
     runs-on: ubuntu-latest
     steps:
-    - name: Is workflow a success
-      run: echo yes
+    - name: Workflow is not a success
+      if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') || contains(needs.*.result, 'skipped')
+      run: exit 1
+    - name: Workflow is a success
+      run: echo "🎉🎈🎉🎈🎉"
   test:
     if: github.event_name == 'repository_dispatch' ||
       github.event.pull_request.head.repo.full_name == github.repository

--- a/provider-ci/providers/databricks/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/databricks/repo/.github/workflows/run-acceptance-tests.yml
@@ -264,16 +264,43 @@ jobs:
         fields: repo,commit,author,action
         status: ${{ job.status }}
   sentinel:
-    if: github.event_name == 'repository_dispatch' ||
-      github.event.pull_request.head.repo.full_name == github.repository
     name: sentinel
+    # We would like to be able to specify `sentinel` as the only required job for this
+    # workflow. To do that, we need `sentinel` to succeed only when it is safe to
+    # merge and fail in all other cases.
+    #
+    # We can't use the default `if: success()`, since GitHub interprets a skipped job as a
+    # success, and by default a dependee job failing will skip a dependent job. That means
+    # if a test step fails, then it will skip `sentinel` so GitHub will register
+    # `sentinel` as succeeded.
+    #
+    # GitHub documents `jobs.result` as:
+    #
+    #	The result of a job in the reusable workflow. Possible values are success,
+    #	failure, cancelled, or skipped.
+    #
+    # GitHub documents `cancelled()` as:
+    #
+    #	Returns true if the workflow was canceled.
+    #
+    # Combining these terms gives us an intuitive definition of success:
+    #
+    #	We have succeeded when no dependent workflow has failed and the job was
+    #	not cancelled.
+    #
+    if: (github.event_name == 'repository_dispatch' ||
+      github.event.pull_request.head.repo.full_name == github.repository) &&
+      ! cancelled()
     needs:
     - test
     - lint
     runs-on: ubuntu-latest
     steps:
-    - name: Is workflow a success
-      run: echo yes
+    - name: Workflow is not a success
+      if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') || contains(needs.*.result, 'skipped')
+      run: exit 1
+    - name: Workflow is a success
+      run: echo "🎉🎈🎉🎈🎉"
   test:
     if: github.event_name == 'repository_dispatch' ||
       github.event.pull_request.head.repo.full_name == github.repository

--- a/provider-ci/providers/datadog/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/datadog/repo/.github/workflows/run-acceptance-tests.yml
@@ -222,15 +222,42 @@ jobs:
         fields: repo,commit,author,action
         status: ${{ job.status }}
   sentinel:
-    if: github.event_name == 'repository_dispatch' ||
-      github.event.pull_request.head.repo.full_name == github.repository
     name: sentinel
+    # We would like to be able to specify `sentinel` as the only required job for this
+    # workflow. To do that, we need `sentinel` to succeed only when it is safe to
+    # merge and fail in all other cases.
+    #
+    # We can't use the default `if: success()`, since GitHub interprets a skipped job as a
+    # success, and by default a dependee job failing will skip a dependent job. That means
+    # if a test step fails, then it will skip `sentinel` so GitHub will register
+    # `sentinel` as succeeded.
+    #
+    # GitHub documents `jobs.result` as:
+    #
+    #	The result of a job in the reusable workflow. Possible values are success,
+    #	failure, cancelled, or skipped.
+    #
+    # GitHub documents `cancelled()` as:
+    #
+    #	Returns true if the workflow was canceled.
+    #
+    # Combining these terms gives us an intuitive definition of success:
+    #
+    #	We have succeeded when no dependent workflow has failed and the job was
+    #	not cancelled.
+    #
+    if: (github.event_name == 'repository_dispatch' ||
+      github.event.pull_request.head.repo.full_name == github.repository) &&
+      ! cancelled()
     needs:
     - test
     runs-on: ubuntu-latest
     steps:
-    - name: Is workflow a success
-      run: echo yes
+    - name: Workflow is not a success
+      if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') || contains(needs.*.result, 'skipped')
+      run: exit 1
+    - name: Workflow is a success
+      run: echo "🎉🎈🎉🎈🎉"
   test:
     if: github.event_name == 'repository_dispatch' ||
       github.event.pull_request.head.repo.full_name == github.repository

--- a/provider-ci/providers/digitalocean/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/digitalocean/repo/.github/workflows/run-acceptance-tests.yml
@@ -261,16 +261,43 @@ jobs:
         fields: repo,commit,author,action
         status: ${{ job.status }}
   sentinel:
-    if: github.event_name == 'repository_dispatch' ||
-      github.event.pull_request.head.repo.full_name == github.repository
     name: sentinel
+    # We would like to be able to specify `sentinel` as the only required job for this
+    # workflow. To do that, we need `sentinel` to succeed only when it is safe to
+    # merge and fail in all other cases.
+    #
+    # We can't use the default `if: success()`, since GitHub interprets a skipped job as a
+    # success, and by default a dependee job failing will skip a dependent job. That means
+    # if a test step fails, then it will skip `sentinel` so GitHub will register
+    # `sentinel` as succeeded.
+    #
+    # GitHub documents `jobs.result` as:
+    #
+    #	The result of a job in the reusable workflow. Possible values are success,
+    #	failure, cancelled, or skipped.
+    #
+    # GitHub documents `cancelled()` as:
+    #
+    #	Returns true if the workflow was canceled.
+    #
+    # Combining these terms gives us an intuitive definition of success:
+    #
+    #	We have succeeded when no dependent workflow has failed and the job was
+    #	not cancelled.
+    #
+    if: (github.event_name == 'repository_dispatch' ||
+      github.event.pull_request.head.repo.full_name == github.repository) &&
+      ! cancelled()
     needs:
     - test
     - lint
     runs-on: ubuntu-latest
     steps:
-    - name: Is workflow a success
-      run: echo yes
+    - name: Workflow is not a success
+      if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') || contains(needs.*.result, 'skipped')
+      run: exit 1
+    - name: Workflow is a success
+      run: echo "🎉🎈🎉🎈🎉"
   test:
     if: github.event_name == 'repository_dispatch' ||
       github.event.pull_request.head.repo.full_name == github.repository

--- a/provider-ci/providers/dnsimple/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/dnsimple/repo/.github/workflows/run-acceptance-tests.yml
@@ -262,16 +262,43 @@ jobs:
         fields: repo,commit,author,action
         status: ${{ job.status }}
   sentinel:
-    if: github.event_name == 'repository_dispatch' ||
-      github.event.pull_request.head.repo.full_name == github.repository
     name: sentinel
+    # We would like to be able to specify `sentinel` as the only required job for this
+    # workflow. To do that, we need `sentinel` to succeed only when it is safe to
+    # merge and fail in all other cases.
+    #
+    # We can't use the default `if: success()`, since GitHub interprets a skipped job as a
+    # success, and by default a dependee job failing will skip a dependent job. That means
+    # if a test step fails, then it will skip `sentinel` so GitHub will register
+    # `sentinel` as succeeded.
+    #
+    # GitHub documents `jobs.result` as:
+    #
+    #	The result of a job in the reusable workflow. Possible values are success,
+    #	failure, cancelled, or skipped.
+    #
+    # GitHub documents `cancelled()` as:
+    #
+    #	Returns true if the workflow was canceled.
+    #
+    # Combining these terms gives us an intuitive definition of success:
+    #
+    #	We have succeeded when no dependent workflow has failed and the job was
+    #	not cancelled.
+    #
+    if: (github.event_name == 'repository_dispatch' ||
+      github.event.pull_request.head.repo.full_name == github.repository) &&
+      ! cancelled()
     needs:
     - test
     - lint
     runs-on: ubuntu-latest
     steps:
-    - name: Is workflow a success
-      run: echo yes
+    - name: Workflow is not a success
+      if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') || contains(needs.*.result, 'skipped')
+      run: exit 1
+    - name: Workflow is a success
+      run: echo "🎉🎈🎉🎈🎉"
   test:
     if: github.event_name == 'repository_dispatch' ||
       github.event.pull_request.head.repo.full_name == github.repository

--- a/provider-ci/providers/docker/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/docker/repo/.github/workflows/run-acceptance-tests.yml
@@ -275,16 +275,43 @@ jobs:
         fields: repo,commit,author,action
         status: ${{ job.status }}
   sentinel:
-    if: github.event_name == 'repository_dispatch' ||
-      github.event.pull_request.head.repo.full_name == github.repository
     name: sentinel
+    # We would like to be able to specify `sentinel` as the only required job for this
+    # workflow. To do that, we need `sentinel` to succeed only when it is safe to
+    # merge and fail in all other cases.
+    #
+    # We can't use the default `if: success()`, since GitHub interprets a skipped job as a
+    # success, and by default a dependee job failing will skip a dependent job. That means
+    # if a test step fails, then it will skip `sentinel` so GitHub will register
+    # `sentinel` as succeeded.
+    #
+    # GitHub documents `jobs.result` as:
+    #
+    #	The result of a job in the reusable workflow. Possible values are success,
+    #	failure, cancelled, or skipped.
+    #
+    # GitHub documents `cancelled()` as:
+    #
+    #	Returns true if the workflow was canceled.
+    #
+    # Combining these terms gives us an intuitive definition of success:
+    #
+    #	We have succeeded when no dependent workflow has failed and the job was
+    #	not cancelled.
+    #
+    if: (github.event_name == 'repository_dispatch' ||
+      github.event.pull_request.head.repo.full_name == github.repository) &&
+      ! cancelled()
     needs:
     - test
     - lint
     runs-on: ubuntu-latest
     steps:
-    - name: Is workflow a success
-      run: echo yes
+    - name: Workflow is not a success
+      if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') || contains(needs.*.result, 'skipped')
+      run: exit 1
+    - name: Workflow is a success
+      run: echo "🎉🎈🎉🎈🎉"
   test:
     if: github.event_name == 'repository_dispatch' ||
       github.event.pull_request.head.repo.full_name == github.repository

--- a/provider-ci/providers/ec/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/ec/repo/.github/workflows/run-acceptance-tests.yml
@@ -261,16 +261,43 @@ jobs:
         fields: repo,commit,author,action
         status: ${{ job.status }}
   sentinel:
-    if: github.event_name == 'repository_dispatch' ||
-      github.event.pull_request.head.repo.full_name == github.repository
     name: sentinel
+    # We would like to be able to specify `sentinel` as the only required job for this
+    # workflow. To do that, we need `sentinel` to succeed only when it is safe to
+    # merge and fail in all other cases.
+    #
+    # We can't use the default `if: success()`, since GitHub interprets a skipped job as a
+    # success, and by default a dependee job failing will skip a dependent job. That means
+    # if a test step fails, then it will skip `sentinel` so GitHub will register
+    # `sentinel` as succeeded.
+    #
+    # GitHub documents `jobs.result` as:
+    #
+    #	The result of a job in the reusable workflow. Possible values are success,
+    #	failure, cancelled, or skipped.
+    #
+    # GitHub documents `cancelled()` as:
+    #
+    #	Returns true if the workflow was canceled.
+    #
+    # Combining these terms gives us an intuitive definition of success:
+    #
+    #	We have succeeded when no dependent workflow has failed and the job was
+    #	not cancelled.
+    #
+    if: (github.event_name == 'repository_dispatch' ||
+      github.event.pull_request.head.repo.full_name == github.repository) &&
+      ! cancelled()
     needs:
     - test
     - lint
     runs-on: ubuntu-latest
     steps:
-    - name: Is workflow a success
-      run: echo yes
+    - name: Workflow is not a success
+      if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') || contains(needs.*.result, 'skipped')
+      run: exit 1
+    - name: Workflow is a success
+      run: echo "🎉🎈🎉🎈🎉"
   test:
     if: github.event_name == 'repository_dispatch' ||
       github.event.pull_request.head.repo.full_name == github.repository

--- a/provider-ci/providers/equinix-metal/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/equinix-metal/repo/.github/workflows/run-acceptance-tests.yml
@@ -221,15 +221,42 @@ jobs:
         fields: repo,commit,author,action
         status: ${{ job.status }}
   sentinel:
-    if: github.event_name == 'repository_dispatch' ||
-      github.event.pull_request.head.repo.full_name == github.repository
     name: sentinel
+    # We would like to be able to specify `sentinel` as the only required job for this
+    # workflow. To do that, we need `sentinel` to succeed only when it is safe to
+    # merge and fail in all other cases.
+    #
+    # We can't use the default `if: success()`, since GitHub interprets a skipped job as a
+    # success, and by default a dependee job failing will skip a dependent job. That means
+    # if a test step fails, then it will skip `sentinel` so GitHub will register
+    # `sentinel` as succeeded.
+    #
+    # GitHub documents `jobs.result` as:
+    #
+    #	The result of a job in the reusable workflow. Possible values are success,
+    #	failure, cancelled, or skipped.
+    #
+    # GitHub documents `cancelled()` as:
+    #
+    #	Returns true if the workflow was canceled.
+    #
+    # Combining these terms gives us an intuitive definition of success:
+    #
+    #	We have succeeded when no dependent workflow has failed and the job was
+    #	not cancelled.
+    #
+    if: (github.event_name == 'repository_dispatch' ||
+      github.event.pull_request.head.repo.full_name == github.repository) &&
+      ! cancelled()
     needs:
     - test
     runs-on: ubuntu-latest
     steps:
-    - name: Is workflow a success
-      run: echo yes
+    - name: Workflow is not a success
+      if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') || contains(needs.*.result, 'skipped')
+      run: exit 1
+    - name: Workflow is a success
+      run: echo "🎉🎈🎉🎈🎉"
   test:
     if: github.event_name == 'repository_dispatch' ||
       github.event.pull_request.head.repo.full_name == github.repository

--- a/provider-ci/providers/external/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/external/repo/.github/workflows/run-acceptance-tests.yml
@@ -221,15 +221,42 @@ jobs:
         fields: repo,commit,author,action
         status: ${{ job.status }}
   sentinel:
-    if: github.event_name == 'repository_dispatch' ||
-      github.event.pull_request.head.repo.full_name == github.repository
     name: sentinel
+    # We would like to be able to specify `sentinel` as the only required job for this
+    # workflow. To do that, we need `sentinel` to succeed only when it is safe to
+    # merge and fail in all other cases.
+    #
+    # We can't use the default `if: success()`, since GitHub interprets a skipped job as a
+    # success, and by default a dependee job failing will skip a dependent job. That means
+    # if a test step fails, then it will skip `sentinel` so GitHub will register
+    # `sentinel` as succeeded.
+    #
+    # GitHub documents `jobs.result` as:
+    #
+    #	The result of a job in the reusable workflow. Possible values are success,
+    #	failure, cancelled, or skipped.
+    #
+    # GitHub documents `cancelled()` as:
+    #
+    #	Returns true if the workflow was canceled.
+    #
+    # Combining these terms gives us an intuitive definition of success:
+    #
+    #	We have succeeded when no dependent workflow has failed and the job was
+    #	not cancelled.
+    #
+    if: (github.event_name == 'repository_dispatch' ||
+      github.event.pull_request.head.repo.full_name == github.repository) &&
+      ! cancelled()
     needs:
     - test
     runs-on: ubuntu-latest
     steps:
-    - name: Is workflow a success
-      run: echo yes
+    - name: Workflow is not a success
+      if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') || contains(needs.*.result, 'skipped')
+      run: exit 1
+    - name: Workflow is a success
+      run: echo "🎉🎈🎉🎈🎉"
   test:
     if: github.event_name == 'repository_dispatch' ||
       github.event.pull_request.head.repo.full_name == github.repository

--- a/provider-ci/providers/f5bigip/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/f5bigip/repo/.github/workflows/run-acceptance-tests.yml
@@ -264,16 +264,43 @@ jobs:
         fields: repo,commit,author,action
         status: ${{ job.status }}
   sentinel:
-    if: github.event_name == 'repository_dispatch' ||
-      github.event.pull_request.head.repo.full_name == github.repository
     name: sentinel
+    # We would like to be able to specify `sentinel` as the only required job for this
+    # workflow. To do that, we need `sentinel` to succeed only when it is safe to
+    # merge and fail in all other cases.
+    #
+    # We can't use the default `if: success()`, since GitHub interprets a skipped job as a
+    # success, and by default a dependee job failing will skip a dependent job. That means
+    # if a test step fails, then it will skip `sentinel` so GitHub will register
+    # `sentinel` as succeeded.
+    #
+    # GitHub documents `jobs.result` as:
+    #
+    #	The result of a job in the reusable workflow. Possible values are success,
+    #	failure, cancelled, or skipped.
+    #
+    # GitHub documents `cancelled()` as:
+    #
+    #	Returns true if the workflow was canceled.
+    #
+    # Combining these terms gives us an intuitive definition of success:
+    #
+    #	We have succeeded when no dependent workflow has failed and the job was
+    #	not cancelled.
+    #
+    if: (github.event_name == 'repository_dispatch' ||
+      github.event.pull_request.head.repo.full_name == github.repository) &&
+      ! cancelled()
     needs:
     - test
     - lint
     runs-on: ubuntu-latest
     steps:
-    - name: Is workflow a success
-      run: echo yes
+    - name: Workflow is not a success
+      if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') || contains(needs.*.result, 'skipped')
+      run: exit 1
+    - name: Workflow is a success
+      run: echo "🎉🎈🎉🎈🎉"
   test:
     if: github.event_name == 'repository_dispatch' ||
       github.event.pull_request.head.repo.full_name == github.repository

--- a/provider-ci/providers/fastly/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/fastly/repo/.github/workflows/run-acceptance-tests.yml
@@ -261,16 +261,43 @@ jobs:
         fields: repo,commit,author,action
         status: ${{ job.status }}
   sentinel:
-    if: github.event_name == 'repository_dispatch' ||
-      github.event.pull_request.head.repo.full_name == github.repository
     name: sentinel
+    # We would like to be able to specify `sentinel` as the only required job for this
+    # workflow. To do that, we need `sentinel` to succeed only when it is safe to
+    # merge and fail in all other cases.
+    #
+    # We can't use the default `if: success()`, since GitHub interprets a skipped job as a
+    # success, and by default a dependee job failing will skip a dependent job. That means
+    # if a test step fails, then it will skip `sentinel` so GitHub will register
+    # `sentinel` as succeeded.
+    #
+    # GitHub documents `jobs.result` as:
+    #
+    #	The result of a job in the reusable workflow. Possible values are success,
+    #	failure, cancelled, or skipped.
+    #
+    # GitHub documents `cancelled()` as:
+    #
+    #	Returns true if the workflow was canceled.
+    #
+    # Combining these terms gives us an intuitive definition of success:
+    #
+    #	We have succeeded when no dependent workflow has failed and the job was
+    #	not cancelled.
+    #
+    if: (github.event_name == 'repository_dispatch' ||
+      github.event.pull_request.head.repo.full_name == github.repository) &&
+      ! cancelled()
     needs:
     - test
     - lint
     runs-on: ubuntu-latest
     steps:
-    - name: Is workflow a success
-      run: echo yes
+    - name: Workflow is not a success
+      if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') || contains(needs.*.result, 'skipped')
+      run: exit 1
+    - name: Workflow is a success
+      run: echo "🎉🎈🎉🎈🎉"
   test:
     if: github.event_name == 'repository_dispatch' ||
       github.event.pull_request.head.repo.full_name == github.repository

--- a/provider-ci/providers/gcp/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/gcp/repo/.github/workflows/run-acceptance-tests.yml
@@ -228,15 +228,42 @@ jobs:
         fields: repo,commit,author,action
         status: ${{ job.status }}
   sentinel:
-    if: github.event_name == 'repository_dispatch' ||
-      github.event.pull_request.head.repo.full_name == github.repository
     name: sentinel
+    # We would like to be able to specify `sentinel` as the only required job for this
+    # workflow. To do that, we need `sentinel` to succeed only when it is safe to
+    # merge and fail in all other cases.
+    #
+    # We can't use the default `if: success()`, since GitHub interprets a skipped job as a
+    # success, and by default a dependee job failing will skip a dependent job. That means
+    # if a test step fails, then it will skip `sentinel` so GitHub will register
+    # `sentinel` as succeeded.
+    #
+    # GitHub documents `jobs.result` as:
+    #
+    #	The result of a job in the reusable workflow. Possible values are success,
+    #	failure, cancelled, or skipped.
+    #
+    # GitHub documents `cancelled()` as:
+    #
+    #	Returns true if the workflow was canceled.
+    #
+    # Combining these terms gives us an intuitive definition of success:
+    #
+    #	We have succeeded when no dependent workflow has failed and the job was
+    #	not cancelled.
+    #
+    if: (github.event_name == 'repository_dispatch' ||
+      github.event.pull_request.head.repo.full_name == github.repository) &&
+      ! cancelled()
     needs:
     - test
     runs-on: ubuntu-latest
     steps:
-    - name: Is workflow a success
-      run: echo yes
+    - name: Workflow is not a success
+      if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') || contains(needs.*.result, 'skipped')
+      run: exit 1
+    - name: Workflow is a success
+      run: echo "🎉🎈🎉🎈🎉"
   test:
     if: github.event_name == 'repository_dispatch' ||
       github.event.pull_request.head.repo.full_name == github.repository

--- a/provider-ci/providers/github/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/github/repo/.github/workflows/run-acceptance-tests.yml
@@ -262,16 +262,43 @@ jobs:
         fields: repo,commit,author,action
         status: ${{ job.status }}
   sentinel:
-    if: github.event_name == 'repository_dispatch' ||
-      github.event.pull_request.head.repo.full_name == github.repository
     name: sentinel
+    # We would like to be able to specify `sentinel` as the only required job for this
+    # workflow. To do that, we need `sentinel` to succeed only when it is safe to
+    # merge and fail in all other cases.
+    #
+    # We can't use the default `if: success()`, since GitHub interprets a skipped job as a
+    # success, and by default a dependee job failing will skip a dependent job. That means
+    # if a test step fails, then it will skip `sentinel` so GitHub will register
+    # `sentinel` as succeeded.
+    #
+    # GitHub documents `jobs.result` as:
+    #
+    #	The result of a job in the reusable workflow. Possible values are success,
+    #	failure, cancelled, or skipped.
+    #
+    # GitHub documents `cancelled()` as:
+    #
+    #	Returns true if the workflow was canceled.
+    #
+    # Combining these terms gives us an intuitive definition of success:
+    #
+    #	We have succeeded when no dependent workflow has failed and the job was
+    #	not cancelled.
+    #
+    if: (github.event_name == 'repository_dispatch' ||
+      github.event.pull_request.head.repo.full_name == github.repository) &&
+      ! cancelled()
     needs:
     - test
     - lint
     runs-on: ubuntu-latest
     steps:
-    - name: Is workflow a success
-      run: echo yes
+    - name: Workflow is not a success
+      if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') || contains(needs.*.result, 'skipped')
+      run: exit 1
+    - name: Workflow is a success
+      run: echo "🎉🎈🎉🎈🎉"
   test:
     if: github.event_name == 'repository_dispatch' ||
       github.event.pull_request.head.repo.full_name == github.repository

--- a/provider-ci/providers/gitlab/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/gitlab/repo/.github/workflows/run-acceptance-tests.yml
@@ -261,16 +261,43 @@ jobs:
         fields: repo,commit,author,action
         status: ${{ job.status }}
   sentinel:
-    if: github.event_name == 'repository_dispatch' ||
-      github.event.pull_request.head.repo.full_name == github.repository
     name: sentinel
+    # We would like to be able to specify `sentinel` as the only required job for this
+    # workflow. To do that, we need `sentinel` to succeed only when it is safe to
+    # merge and fail in all other cases.
+    #
+    # We can't use the default `if: success()`, since GitHub interprets a skipped job as a
+    # success, and by default a dependee job failing will skip a dependent job. That means
+    # if a test step fails, then it will skip `sentinel` so GitHub will register
+    # `sentinel` as succeeded.
+    #
+    # GitHub documents `jobs.result` as:
+    #
+    #	The result of a job in the reusable workflow. Possible values are success,
+    #	failure, cancelled, or skipped.
+    #
+    # GitHub documents `cancelled()` as:
+    #
+    #	Returns true if the workflow was canceled.
+    #
+    # Combining these terms gives us an intuitive definition of success:
+    #
+    #	We have succeeded when no dependent workflow has failed and the job was
+    #	not cancelled.
+    #
+    if: (github.event_name == 'repository_dispatch' ||
+      github.event.pull_request.head.repo.full_name == github.repository) &&
+      ! cancelled()
     needs:
     - test
     - lint
     runs-on: ubuntu-latest
     steps:
-    - name: Is workflow a success
-      run: echo yes
+    - name: Workflow is not a success
+      if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') || contains(needs.*.result, 'skipped')
+      run: exit 1
+    - name: Workflow is a success
+      run: echo "🎉🎈🎉🎈🎉"
   test:
     if: github.event_name == 'repository_dispatch' ||
       github.event.pull_request.head.repo.full_name == github.repository

--- a/provider-ci/providers/hcloud/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/hcloud/repo/.github/workflows/run-acceptance-tests.yml
@@ -261,16 +261,43 @@ jobs:
         fields: repo,commit,author,action
         status: ${{ job.status }}
   sentinel:
-    if: github.event_name == 'repository_dispatch' ||
-      github.event.pull_request.head.repo.full_name == github.repository
     name: sentinel
+    # We would like to be able to specify `sentinel` as the only required job for this
+    # workflow. To do that, we need `sentinel` to succeed only when it is safe to
+    # merge and fail in all other cases.
+    #
+    # We can't use the default `if: success()`, since GitHub interprets a skipped job as a
+    # success, and by default a dependee job failing will skip a dependent job. That means
+    # if a test step fails, then it will skip `sentinel` so GitHub will register
+    # `sentinel` as succeeded.
+    #
+    # GitHub documents `jobs.result` as:
+    #
+    #	The result of a job in the reusable workflow. Possible values are success,
+    #	failure, cancelled, or skipped.
+    #
+    # GitHub documents `cancelled()` as:
+    #
+    #	Returns true if the workflow was canceled.
+    #
+    # Combining these terms gives us an intuitive definition of success:
+    #
+    #	We have succeeded when no dependent workflow has failed and the job was
+    #	not cancelled.
+    #
+    if: (github.event_name == 'repository_dispatch' ||
+      github.event.pull_request.head.repo.full_name == github.repository) &&
+      ! cancelled()
     needs:
     - test
     - lint
     runs-on: ubuntu-latest
     steps:
-    - name: Is workflow a success
-      run: echo yes
+    - name: Workflow is not a success
+      if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') || contains(needs.*.result, 'skipped')
+      run: exit 1
+    - name: Workflow is a success
+      run: echo "🎉🎈🎉🎈🎉"
   test:
     if: github.event_name == 'repository_dispatch' ||
       github.event.pull_request.head.repo.full_name == github.repository

--- a/provider-ci/providers/http/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/http/repo/.github/workflows/run-acceptance-tests.yml
@@ -221,15 +221,42 @@ jobs:
         fields: repo,commit,author,action
         status: ${{ job.status }}
   sentinel:
-    if: github.event_name == 'repository_dispatch' ||
-      github.event.pull_request.head.repo.full_name == github.repository
     name: sentinel
+    # We would like to be able to specify `sentinel` as the only required job for this
+    # workflow. To do that, we need `sentinel` to succeed only when it is safe to
+    # merge and fail in all other cases.
+    #
+    # We can't use the default `if: success()`, since GitHub interprets a skipped job as a
+    # success, and by default a dependee job failing will skip a dependent job. That means
+    # if a test step fails, then it will skip `sentinel` so GitHub will register
+    # `sentinel` as succeeded.
+    #
+    # GitHub documents `jobs.result` as:
+    #
+    #	The result of a job in the reusable workflow. Possible values are success,
+    #	failure, cancelled, or skipped.
+    #
+    # GitHub documents `cancelled()` as:
+    #
+    #	Returns true if the workflow was canceled.
+    #
+    # Combining these terms gives us an intuitive definition of success:
+    #
+    #	We have succeeded when no dependent workflow has failed and the job was
+    #	not cancelled.
+    #
+    if: (github.event_name == 'repository_dispatch' ||
+      github.event.pull_request.head.repo.full_name == github.repository) &&
+      ! cancelled()
     needs:
     - test
     runs-on: ubuntu-latest
     steps:
-    - name: Is workflow a success
-      run: echo yes
+    - name: Workflow is not a success
+      if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') || contains(needs.*.result, 'skipped')
+      run: exit 1
+    - name: Workflow is a success
+      run: echo "🎉🎈🎉🎈🎉"
   test:
     if: github.event_name == 'repository_dispatch' ||
       github.event.pull_request.head.repo.full_name == github.repository

--- a/provider-ci/providers/kafka/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/kafka/repo/.github/workflows/run-acceptance-tests.yml
@@ -260,16 +260,43 @@ jobs:
         fields: repo,commit,author,action
         status: ${{ job.status }}
   sentinel:
-    if: github.event_name == 'repository_dispatch' ||
-      github.event.pull_request.head.repo.full_name == github.repository
     name: sentinel
+    # We would like to be able to specify `sentinel` as the only required job for this
+    # workflow. To do that, we need `sentinel` to succeed only when it is safe to
+    # merge and fail in all other cases.
+    #
+    # We can't use the default `if: success()`, since GitHub interprets a skipped job as a
+    # success, and by default a dependee job failing will skip a dependent job. That means
+    # if a test step fails, then it will skip `sentinel` so GitHub will register
+    # `sentinel` as succeeded.
+    #
+    # GitHub documents `jobs.result` as:
+    #
+    #	The result of a job in the reusable workflow. Possible values are success,
+    #	failure, cancelled, or skipped.
+    #
+    # GitHub documents `cancelled()` as:
+    #
+    #	Returns true if the workflow was canceled.
+    #
+    # Combining these terms gives us an intuitive definition of success:
+    #
+    #	We have succeeded when no dependent workflow has failed and the job was
+    #	not cancelled.
+    #
+    if: (github.event_name == 'repository_dispatch' ||
+      github.event.pull_request.head.repo.full_name == github.repository) &&
+      ! cancelled()
     needs:
     - test
     - lint
     runs-on: ubuntu-latest
     steps:
-    - name: Is workflow a success
-      run: echo yes
+    - name: Workflow is not a success
+      if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') || contains(needs.*.result, 'skipped')
+      run: exit 1
+    - name: Workflow is a success
+      run: echo "🎉🎈🎉🎈🎉"
   test:
     if: github.event_name == 'repository_dispatch' ||
       github.event.pull_request.head.repo.full_name == github.repository

--- a/provider-ci/providers/keycloak/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/keycloak/repo/.github/workflows/run-acceptance-tests.yml
@@ -265,16 +265,43 @@ jobs:
         fields: repo,commit,author,action
         status: ${{ job.status }}
   sentinel:
-    if: github.event_name == 'repository_dispatch' ||
-      github.event.pull_request.head.repo.full_name == github.repository
     name: sentinel
+    # We would like to be able to specify `sentinel` as the only required job for this
+    # workflow. To do that, we need `sentinel` to succeed only when it is safe to
+    # merge and fail in all other cases.
+    #
+    # We can't use the default `if: success()`, since GitHub interprets a skipped job as a
+    # success, and by default a dependee job failing will skip a dependent job. That means
+    # if a test step fails, then it will skip `sentinel` so GitHub will register
+    # `sentinel` as succeeded.
+    #
+    # GitHub documents `jobs.result` as:
+    #
+    #	The result of a job in the reusable workflow. Possible values are success,
+    #	failure, cancelled, or skipped.
+    #
+    # GitHub documents `cancelled()` as:
+    #
+    #	Returns true if the workflow was canceled.
+    #
+    # Combining these terms gives us an intuitive definition of success:
+    #
+    #	We have succeeded when no dependent workflow has failed and the job was
+    #	not cancelled.
+    #
+    if: (github.event_name == 'repository_dispatch' ||
+      github.event.pull_request.head.repo.full_name == github.repository) &&
+      ! cancelled()
     needs:
     - test
     - lint
     runs-on: ubuntu-latest
     steps:
-    - name: Is workflow a success
-      run: echo yes
+    - name: Workflow is not a success
+      if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') || contains(needs.*.result, 'skipped')
+      run: exit 1
+    - name: Workflow is a success
+      run: echo "🎉🎈🎉🎈🎉"
   test:
     if: github.event_name == 'repository_dispatch' ||
       github.event.pull_request.head.repo.full_name == github.repository

--- a/provider-ci/providers/kong/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/kong/repo/.github/workflows/run-acceptance-tests.yml
@@ -260,16 +260,43 @@ jobs:
         fields: repo,commit,author,action
         status: ${{ job.status }}
   sentinel:
-    if: github.event_name == 'repository_dispatch' ||
-      github.event.pull_request.head.repo.full_name == github.repository
     name: sentinel
+    # We would like to be able to specify `sentinel` as the only required job for this
+    # workflow. To do that, we need `sentinel` to succeed only when it is safe to
+    # merge and fail in all other cases.
+    #
+    # We can't use the default `if: success()`, since GitHub interprets a skipped job as a
+    # success, and by default a dependee job failing will skip a dependent job. That means
+    # if a test step fails, then it will skip `sentinel` so GitHub will register
+    # `sentinel` as succeeded.
+    #
+    # GitHub documents `jobs.result` as:
+    #
+    #	The result of a job in the reusable workflow. Possible values are success,
+    #	failure, cancelled, or skipped.
+    #
+    # GitHub documents `cancelled()` as:
+    #
+    #	Returns true if the workflow was canceled.
+    #
+    # Combining these terms gives us an intuitive definition of success:
+    #
+    #	We have succeeded when no dependent workflow has failed and the job was
+    #	not cancelled.
+    #
+    if: (github.event_name == 'repository_dispatch' ||
+      github.event.pull_request.head.repo.full_name == github.repository) &&
+      ! cancelled()
     needs:
     - test
     - lint
     runs-on: ubuntu-latest
     steps:
-    - name: Is workflow a success
-      run: echo yes
+    - name: Workflow is not a success
+      if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') || contains(needs.*.result, 'skipped')
+      run: exit 1
+    - name: Workflow is a success
+      run: echo "🎉🎈🎉🎈🎉"
   test:
     if: github.event_name == 'repository_dispatch' ||
       github.event.pull_request.head.repo.full_name == github.repository

--- a/provider-ci/providers/libvirt/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/libvirt/repo/.github/workflows/run-acceptance-tests.yml
@@ -261,16 +261,43 @@ jobs:
         fields: repo,commit,author,action
         status: ${{ job.status }}
   sentinel:
-    if: github.event_name == 'repository_dispatch' ||
-      github.event.pull_request.head.repo.full_name == github.repository
     name: sentinel
+    # We would like to be able to specify `sentinel` as the only required job for this
+    # workflow. To do that, we need `sentinel` to succeed only when it is safe to
+    # merge and fail in all other cases.
+    #
+    # We can't use the default `if: success()`, since GitHub interprets a skipped job as a
+    # success, and by default a dependee job failing will skip a dependent job. That means
+    # if a test step fails, then it will skip `sentinel` so GitHub will register
+    # `sentinel` as succeeded.
+    #
+    # GitHub documents `jobs.result` as:
+    #
+    #	The result of a job in the reusable workflow. Possible values are success,
+    #	failure, cancelled, or skipped.
+    #
+    # GitHub documents `cancelled()` as:
+    #
+    #	Returns true if the workflow was canceled.
+    #
+    # Combining these terms gives us an intuitive definition of success:
+    #
+    #	We have succeeded when no dependent workflow has failed and the job was
+    #	not cancelled.
+    #
+    if: (github.event_name == 'repository_dispatch' ||
+      github.event.pull_request.head.repo.full_name == github.repository) &&
+      ! cancelled()
     needs:
     - test
     - lint
     runs-on: ubuntu-latest
     steps:
-    - name: Is workflow a success
-      run: echo yes
+    - name: Workflow is not a success
+      if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') || contains(needs.*.result, 'skipped')
+      run: exit 1
+    - name: Workflow is a success
+      run: echo "🎉🎈🎉🎈🎉"
   test:
     if: github.event_name == 'repository_dispatch' ||
       github.event.pull_request.head.repo.full_name == github.repository

--- a/provider-ci/providers/linode/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/linode/repo/.github/workflows/run-acceptance-tests.yml
@@ -261,16 +261,43 @@ jobs:
         fields: repo,commit,author,action
         status: ${{ job.status }}
   sentinel:
-    if: github.event_name == 'repository_dispatch' ||
-      github.event.pull_request.head.repo.full_name == github.repository
     name: sentinel
+    # We would like to be able to specify `sentinel` as the only required job for this
+    # workflow. To do that, we need `sentinel` to succeed only when it is safe to
+    # merge and fail in all other cases.
+    #
+    # We can't use the default `if: success()`, since GitHub interprets a skipped job as a
+    # success, and by default a dependee job failing will skip a dependent job. That means
+    # if a test step fails, then it will skip `sentinel` so GitHub will register
+    # `sentinel` as succeeded.
+    #
+    # GitHub documents `jobs.result` as:
+    #
+    #	The result of a job in the reusable workflow. Possible values are success,
+    #	failure, cancelled, or skipped.
+    #
+    # GitHub documents `cancelled()` as:
+    #
+    #	Returns true if the workflow was canceled.
+    #
+    # Combining these terms gives us an intuitive definition of success:
+    #
+    #	We have succeeded when no dependent workflow has failed and the job was
+    #	not cancelled.
+    #
+    if: (github.event_name == 'repository_dispatch' ||
+      github.event.pull_request.head.repo.full_name == github.repository) &&
+      ! cancelled()
     needs:
     - test
     - lint
     runs-on: ubuntu-latest
     steps:
-    - name: Is workflow a success
-      run: echo yes
+    - name: Workflow is not a success
+      if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') || contains(needs.*.result, 'skipped')
+      run: exit 1
+    - name: Workflow is a success
+      run: echo "🎉🎈🎉🎈🎉"
   test:
     if: github.event_name == 'repository_dispatch' ||
       github.event.pull_request.head.repo.full_name == github.repository

--- a/provider-ci/providers/local/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/local/repo/.github/workflows/run-acceptance-tests.yml
@@ -221,15 +221,42 @@ jobs:
         fields: repo,commit,author,action
         status: ${{ job.status }}
   sentinel:
-    if: github.event_name == 'repository_dispatch' ||
-      github.event.pull_request.head.repo.full_name == github.repository
     name: sentinel
+    # We would like to be able to specify `sentinel` as the only required job for this
+    # workflow. To do that, we need `sentinel` to succeed only when it is safe to
+    # merge and fail in all other cases.
+    #
+    # We can't use the default `if: success()`, since GitHub interprets a skipped job as a
+    # success, and by default a dependee job failing will skip a dependent job. That means
+    # if a test step fails, then it will skip `sentinel` so GitHub will register
+    # `sentinel` as succeeded.
+    #
+    # GitHub documents `jobs.result` as:
+    #
+    #	The result of a job in the reusable workflow. Possible values are success,
+    #	failure, cancelled, or skipped.
+    #
+    # GitHub documents `cancelled()` as:
+    #
+    #	Returns true if the workflow was canceled.
+    #
+    # Combining these terms gives us an intuitive definition of success:
+    #
+    #	We have succeeded when no dependent workflow has failed and the job was
+    #	not cancelled.
+    #
+    if: (github.event_name == 'repository_dispatch' ||
+      github.event.pull_request.head.repo.full_name == github.repository) &&
+      ! cancelled()
     needs:
     - test
     runs-on: ubuntu-latest
     steps:
-    - name: Is workflow a success
-      run: echo yes
+    - name: Workflow is not a success
+      if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') || contains(needs.*.result, 'skipped')
+      run: exit 1
+    - name: Workflow is a success
+      run: echo "🎉🎈🎉🎈🎉"
   test:
     if: github.event_name == 'repository_dispatch' ||
       github.event.pull_request.head.repo.full_name == github.repository

--- a/provider-ci/providers/mailgun/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/mailgun/repo/.github/workflows/run-acceptance-tests.yml
@@ -261,16 +261,43 @@ jobs:
         fields: repo,commit,author,action
         status: ${{ job.status }}
   sentinel:
-    if: github.event_name == 'repository_dispatch' ||
-      github.event.pull_request.head.repo.full_name == github.repository
     name: sentinel
+    # We would like to be able to specify `sentinel` as the only required job for this
+    # workflow. To do that, we need `sentinel` to succeed only when it is safe to
+    # merge and fail in all other cases.
+    #
+    # We can't use the default `if: success()`, since GitHub interprets a skipped job as a
+    # success, and by default a dependee job failing will skip a dependent job. That means
+    # if a test step fails, then it will skip `sentinel` so GitHub will register
+    # `sentinel` as succeeded.
+    #
+    # GitHub documents `jobs.result` as:
+    #
+    #	The result of a job in the reusable workflow. Possible values are success,
+    #	failure, cancelled, or skipped.
+    #
+    # GitHub documents `cancelled()` as:
+    #
+    #	Returns true if the workflow was canceled.
+    #
+    # Combining these terms gives us an intuitive definition of success:
+    #
+    #	We have succeeded when no dependent workflow has failed and the job was
+    #	not cancelled.
+    #
+    if: (github.event_name == 'repository_dispatch' ||
+      github.event.pull_request.head.repo.full_name == github.repository) &&
+      ! cancelled()
     needs:
     - test
     - lint
     runs-on: ubuntu-latest
     steps:
-    - name: Is workflow a success
-      run: echo yes
+    - name: Workflow is not a success
+      if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') || contains(needs.*.result, 'skipped')
+      run: exit 1
+    - name: Workflow is a success
+      run: echo "🎉🎈🎉🎈🎉"
   test:
     if: github.event_name == 'repository_dispatch' ||
       github.event.pull_request.head.repo.full_name == github.repository

--- a/provider-ci/providers/minio/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/minio/repo/.github/workflows/run-acceptance-tests.yml
@@ -264,16 +264,43 @@ jobs:
         fields: repo,commit,author,action
         status: ${{ job.status }}
   sentinel:
-    if: github.event_name == 'repository_dispatch' ||
-      github.event.pull_request.head.repo.full_name == github.repository
     name: sentinel
+    # We would like to be able to specify `sentinel` as the only required job for this
+    # workflow. To do that, we need `sentinel` to succeed only when it is safe to
+    # merge and fail in all other cases.
+    #
+    # We can't use the default `if: success()`, since GitHub interprets a skipped job as a
+    # success, and by default a dependee job failing will skip a dependent job. That means
+    # if a test step fails, then it will skip `sentinel` so GitHub will register
+    # `sentinel` as succeeded.
+    #
+    # GitHub documents `jobs.result` as:
+    #
+    #	The result of a job in the reusable workflow. Possible values are success,
+    #	failure, cancelled, or skipped.
+    #
+    # GitHub documents `cancelled()` as:
+    #
+    #	Returns true if the workflow was canceled.
+    #
+    # Combining these terms gives us an intuitive definition of success:
+    #
+    #	We have succeeded when no dependent workflow has failed and the job was
+    #	not cancelled.
+    #
+    if: (github.event_name == 'repository_dispatch' ||
+      github.event.pull_request.head.repo.full_name == github.repository) &&
+      ! cancelled()
     needs:
     - test
     - lint
     runs-on: ubuntu-latest
     steps:
-    - name: Is workflow a success
-      run: echo yes
+    - name: Workflow is not a success
+      if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') || contains(needs.*.result, 'skipped')
+      run: exit 1
+    - name: Workflow is a success
+      run: echo "🎉🎈🎉🎈🎉"
   test:
     if: github.event_name == 'repository_dispatch' ||
       github.event.pull_request.head.repo.full_name == github.repository

--- a/provider-ci/providers/mongodbatlas/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/mongodbatlas/repo/.github/workflows/run-acceptance-tests.yml
@@ -263,16 +263,43 @@ jobs:
         fields: repo,commit,author,action
         status: ${{ job.status }}
   sentinel:
-    if: github.event_name == 'repository_dispatch' ||
-      github.event.pull_request.head.repo.full_name == github.repository
     name: sentinel
+    # We would like to be able to specify `sentinel` as the only required job for this
+    # workflow. To do that, we need `sentinel` to succeed only when it is safe to
+    # merge and fail in all other cases.
+    #
+    # We can't use the default `if: success()`, since GitHub interprets a skipped job as a
+    # success, and by default a dependee job failing will skip a dependent job. That means
+    # if a test step fails, then it will skip `sentinel` so GitHub will register
+    # `sentinel` as succeeded.
+    #
+    # GitHub documents `jobs.result` as:
+    #
+    #	The result of a job in the reusable workflow. Possible values are success,
+    #	failure, cancelled, or skipped.
+    #
+    # GitHub documents `cancelled()` as:
+    #
+    #	Returns true if the workflow was canceled.
+    #
+    # Combining these terms gives us an intuitive definition of success:
+    #
+    #	We have succeeded when no dependent workflow has failed and the job was
+    #	not cancelled.
+    #
+    if: (github.event_name == 'repository_dispatch' ||
+      github.event.pull_request.head.repo.full_name == github.repository) &&
+      ! cancelled()
     needs:
     - test
     - lint
     runs-on: ubuntu-latest
     steps:
-    - name: Is workflow a success
-      run: echo yes
+    - name: Workflow is not a success
+      if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') || contains(needs.*.result, 'skipped')
+      run: exit 1
+    - name: Workflow is a success
+      run: echo "🎉🎈🎉🎈🎉"
   test:
     if: github.event_name == 'repository_dispatch' ||
       github.event.pull_request.head.repo.full_name == github.repository

--- a/provider-ci/providers/mysql/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/mysql/repo/.github/workflows/run-acceptance-tests.yml
@@ -260,16 +260,43 @@ jobs:
         fields: repo,commit,author,action
         status: ${{ job.status }}
   sentinel:
-    if: github.event_name == 'repository_dispatch' ||
-      github.event.pull_request.head.repo.full_name == github.repository
     name: sentinel
+    # We would like to be able to specify `sentinel` as the only required job for this
+    # workflow. To do that, we need `sentinel` to succeed only when it is safe to
+    # merge and fail in all other cases.
+    #
+    # We can't use the default `if: success()`, since GitHub interprets a skipped job as a
+    # success, and by default a dependee job failing will skip a dependent job. That means
+    # if a test step fails, then it will skip `sentinel` so GitHub will register
+    # `sentinel` as succeeded.
+    #
+    # GitHub documents `jobs.result` as:
+    #
+    #	The result of a job in the reusable workflow. Possible values are success,
+    #	failure, cancelled, or skipped.
+    #
+    # GitHub documents `cancelled()` as:
+    #
+    #	Returns true if the workflow was canceled.
+    #
+    # Combining these terms gives us an intuitive definition of success:
+    #
+    #	We have succeeded when no dependent workflow has failed and the job was
+    #	not cancelled.
+    #
+    if: (github.event_name == 'repository_dispatch' ||
+      github.event.pull_request.head.repo.full_name == github.repository) &&
+      ! cancelled()
     needs:
     - test
     - lint
     runs-on: ubuntu-latest
     steps:
-    - name: Is workflow a success
-      run: echo yes
+    - name: Workflow is not a success
+      if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') || contains(needs.*.result, 'skipped')
+      run: exit 1
+    - name: Workflow is a success
+      run: echo "🎉🎈🎉🎈🎉"
   test:
     if: github.event_name == 'repository_dispatch' ||
       github.event.pull_request.head.repo.full_name == github.repository

--- a/provider-ci/providers/newrelic/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/newrelic/repo/.github/workflows/run-acceptance-tests.yml
@@ -262,16 +262,43 @@ jobs:
         fields: repo,commit,author,action
         status: ${{ job.status }}
   sentinel:
-    if: github.event_name == 'repository_dispatch' ||
-      github.event.pull_request.head.repo.full_name == github.repository
     name: sentinel
+    # We would like to be able to specify `sentinel` as the only required job for this
+    # workflow. To do that, we need `sentinel` to succeed only when it is safe to
+    # merge and fail in all other cases.
+    #
+    # We can't use the default `if: success()`, since GitHub interprets a skipped job as a
+    # success, and by default a dependee job failing will skip a dependent job. That means
+    # if a test step fails, then it will skip `sentinel` so GitHub will register
+    # `sentinel` as succeeded.
+    #
+    # GitHub documents `jobs.result` as:
+    #
+    #	The result of a job in the reusable workflow. Possible values are success,
+    #	failure, cancelled, or skipped.
+    #
+    # GitHub documents `cancelled()` as:
+    #
+    #	Returns true if the workflow was canceled.
+    #
+    # Combining these terms gives us an intuitive definition of success:
+    #
+    #	We have succeeded when no dependent workflow has failed and the job was
+    #	not cancelled.
+    #
+    if: (github.event_name == 'repository_dispatch' ||
+      github.event.pull_request.head.repo.full_name == github.repository) &&
+      ! cancelled()
     needs:
     - test
     - lint
     runs-on: ubuntu-latest
     steps:
-    - name: Is workflow a success
-      run: echo yes
+    - name: Workflow is not a success
+      if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') || contains(needs.*.result, 'skipped')
+      run: exit 1
+    - name: Workflow is a success
+      run: echo "🎉🎈🎉🎈🎉"
   test:
     if: github.event_name == 'repository_dispatch' ||
       github.event.pull_request.head.repo.full_name == github.repository

--- a/provider-ci/providers/nomad/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/nomad/repo/.github/workflows/run-acceptance-tests.yml
@@ -261,16 +261,43 @@ jobs:
         fields: repo,commit,author,action
         status: ${{ job.status }}
   sentinel:
-    if: github.event_name == 'repository_dispatch' ||
-      github.event.pull_request.head.repo.full_name == github.repository
     name: sentinel
+    # We would like to be able to specify `sentinel` as the only required job for this
+    # workflow. To do that, we need `sentinel` to succeed only when it is safe to
+    # merge and fail in all other cases.
+    #
+    # We can't use the default `if: success()`, since GitHub interprets a skipped job as a
+    # success, and by default a dependee job failing will skip a dependent job. That means
+    # if a test step fails, then it will skip `sentinel` so GitHub will register
+    # `sentinel` as succeeded.
+    #
+    # GitHub documents `jobs.result` as:
+    #
+    #	The result of a job in the reusable workflow. Possible values are success,
+    #	failure, cancelled, or skipped.
+    #
+    # GitHub documents `cancelled()` as:
+    #
+    #	Returns true if the workflow was canceled.
+    #
+    # Combining these terms gives us an intuitive definition of success:
+    #
+    #	We have succeeded when no dependent workflow has failed and the job was
+    #	not cancelled.
+    #
+    if: (github.event_name == 'repository_dispatch' ||
+      github.event.pull_request.head.repo.full_name == github.repository) &&
+      ! cancelled()
     needs:
     - test
     - lint
     runs-on: ubuntu-latest
     steps:
-    - name: Is workflow a success
-      run: echo yes
+    - name: Workflow is not a success
+      if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') || contains(needs.*.result, 'skipped')
+      run: exit 1
+    - name: Workflow is a success
+      run: echo "🎉🎈🎉🎈🎉"
   test:
     if: github.event_name == 'repository_dispatch' ||
       github.event.pull_request.head.repo.full_name == github.repository

--- a/provider-ci/providers/ns1/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/ns1/repo/.github/workflows/run-acceptance-tests.yml
@@ -261,16 +261,43 @@ jobs:
         fields: repo,commit,author,action
         status: ${{ job.status }}
   sentinel:
-    if: github.event_name == 'repository_dispatch' ||
-      github.event.pull_request.head.repo.full_name == github.repository
     name: sentinel
+    # We would like to be able to specify `sentinel` as the only required job for this
+    # workflow. To do that, we need `sentinel` to succeed only when it is safe to
+    # merge and fail in all other cases.
+    #
+    # We can't use the default `if: success()`, since GitHub interprets a skipped job as a
+    # success, and by default a dependee job failing will skip a dependent job. That means
+    # if a test step fails, then it will skip `sentinel` so GitHub will register
+    # `sentinel` as succeeded.
+    #
+    # GitHub documents `jobs.result` as:
+    #
+    #	The result of a job in the reusable workflow. Possible values are success,
+    #	failure, cancelled, or skipped.
+    #
+    # GitHub documents `cancelled()` as:
+    #
+    #	Returns true if the workflow was canceled.
+    #
+    # Combining these terms gives us an intuitive definition of success:
+    #
+    #	We have succeeded when no dependent workflow has failed and the job was
+    #	not cancelled.
+    #
+    if: (github.event_name == 'repository_dispatch' ||
+      github.event.pull_request.head.repo.full_name == github.repository) &&
+      ! cancelled()
     needs:
     - test
     - lint
     runs-on: ubuntu-latest
     steps:
-    - name: Is workflow a success
-      run: echo yes
+    - name: Workflow is not a success
+      if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') || contains(needs.*.result, 'skipped')
+      run: exit 1
+    - name: Workflow is a success
+      run: echo "🎉🎈🎉🎈🎉"
   test:
     if: github.event_name == 'repository_dispatch' ||
       github.event.pull_request.head.repo.full_name == github.repository

--- a/provider-ci/providers/null/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/null/repo/.github/workflows/run-acceptance-tests.yml
@@ -221,15 +221,42 @@ jobs:
         fields: repo,commit,author,action
         status: ${{ job.status }}
   sentinel:
-    if: github.event_name == 'repository_dispatch' ||
-      github.event.pull_request.head.repo.full_name == github.repository
     name: sentinel
+    # We would like to be able to specify `sentinel` as the only required job for this
+    # workflow. To do that, we need `sentinel` to succeed only when it is safe to
+    # merge and fail in all other cases.
+    #
+    # We can't use the default `if: success()`, since GitHub interprets a skipped job as a
+    # success, and by default a dependee job failing will skip a dependent job. That means
+    # if a test step fails, then it will skip `sentinel` so GitHub will register
+    # `sentinel` as succeeded.
+    #
+    # GitHub documents `jobs.result` as:
+    #
+    #	The result of a job in the reusable workflow. Possible values are success,
+    #	failure, cancelled, or skipped.
+    #
+    # GitHub documents `cancelled()` as:
+    #
+    #	Returns true if the workflow was canceled.
+    #
+    # Combining these terms gives us an intuitive definition of success:
+    #
+    #	We have succeeded when no dependent workflow has failed and the job was
+    #	not cancelled.
+    #
+    if: (github.event_name == 'repository_dispatch' ||
+      github.event.pull_request.head.repo.full_name == github.repository) &&
+      ! cancelled()
     needs:
     - test
     runs-on: ubuntu-latest
     steps:
-    - name: Is workflow a success
-      run: echo yes
+    - name: Workflow is not a success
+      if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') || contains(needs.*.result, 'skipped')
+      run: exit 1
+    - name: Workflow is a success
+      run: echo "🎉🎈🎉🎈🎉"
   test:
     if: github.event_name == 'repository_dispatch' ||
       github.event.pull_request.head.repo.full_name == github.repository

--- a/provider-ci/providers/oci/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/oci/repo/.github/workflows/run-acceptance-tests.yml
@@ -224,15 +224,42 @@ jobs:
         fields: repo,commit,author,action
         status: ${{ job.status }}
   sentinel:
-    if: github.event_name == 'repository_dispatch' ||
-      github.event.pull_request.head.repo.full_name == github.repository
     name: sentinel
+    # We would like to be able to specify `sentinel` as the only required job for this
+    # workflow. To do that, we need `sentinel` to succeed only when it is safe to
+    # merge and fail in all other cases.
+    #
+    # We can't use the default `if: success()`, since GitHub interprets a skipped job as a
+    # success, and by default a dependee job failing will skip a dependent job. That means
+    # if a test step fails, then it will skip `sentinel` so GitHub will register
+    # `sentinel` as succeeded.
+    #
+    # GitHub documents `jobs.result` as:
+    #
+    #	The result of a job in the reusable workflow. Possible values are success,
+    #	failure, cancelled, or skipped.
+    #
+    # GitHub documents `cancelled()` as:
+    #
+    #	Returns true if the workflow was canceled.
+    #
+    # Combining these terms gives us an intuitive definition of success:
+    #
+    #	We have succeeded when no dependent workflow has failed and the job was
+    #	not cancelled.
+    #
+    if: (github.event_name == 'repository_dispatch' ||
+      github.event.pull_request.head.repo.full_name == github.repository) &&
+      ! cancelled()
     needs:
     - test
     runs-on: ubuntu-latest
     steps:
-    - name: Is workflow a success
-      run: echo yes
+    - name: Workflow is not a success
+      if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') || contains(needs.*.result, 'skipped')
+      run: exit 1
+    - name: Workflow is a success
+      run: echo "🎉🎈🎉🎈🎉"
   test:
     if: github.event_name == 'repository_dispatch' ||
       github.event.pull_request.head.repo.full_name == github.repository

--- a/provider-ci/providers/okta/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/okta/repo/.github/workflows/run-acceptance-tests.yml
@@ -263,16 +263,43 @@ jobs:
         fields: repo,commit,author,action
         status: ${{ job.status }}
   sentinel:
-    if: github.event_name == 'repository_dispatch' ||
-      github.event.pull_request.head.repo.full_name == github.repository
     name: sentinel
+    # We would like to be able to specify `sentinel` as the only required job for this
+    # workflow. To do that, we need `sentinel` to succeed only when it is safe to
+    # merge and fail in all other cases.
+    #
+    # We can't use the default `if: success()`, since GitHub interprets a skipped job as a
+    # success, and by default a dependee job failing will skip a dependent job. That means
+    # if a test step fails, then it will skip `sentinel` so GitHub will register
+    # `sentinel` as succeeded.
+    #
+    # GitHub documents `jobs.result` as:
+    #
+    #	The result of a job in the reusable workflow. Possible values are success,
+    #	failure, cancelled, or skipped.
+    #
+    # GitHub documents `cancelled()` as:
+    #
+    #	Returns true if the workflow was canceled.
+    #
+    # Combining these terms gives us an intuitive definition of success:
+    #
+    #	We have succeeded when no dependent workflow has failed and the job was
+    #	not cancelled.
+    #
+    if: (github.event_name == 'repository_dispatch' ||
+      github.event.pull_request.head.repo.full_name == github.repository) &&
+      ! cancelled()
     needs:
     - test
     - lint
     runs-on: ubuntu-latest
     steps:
-    - name: Is workflow a success
-      run: echo yes
+    - name: Workflow is not a success
+      if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') || contains(needs.*.result, 'skipped')
+      run: exit 1
+    - name: Workflow is a success
+      run: echo "🎉🎈🎉🎈🎉"
   test:
     if: github.event_name == 'repository_dispatch' ||
       github.event.pull_request.head.repo.full_name == github.repository

--- a/provider-ci/providers/onelogin/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/onelogin/repo/.github/workflows/run-acceptance-tests.yml
@@ -260,16 +260,43 @@ jobs:
         fields: repo,commit,author,action
         status: ${{ job.status }}
   sentinel:
-    if: github.event_name == 'repository_dispatch' ||
-      github.event.pull_request.head.repo.full_name == github.repository
     name: sentinel
+    # We would like to be able to specify `sentinel` as the only required job for this
+    # workflow. To do that, we need `sentinel` to succeed only when it is safe to
+    # merge and fail in all other cases.
+    #
+    # We can't use the default `if: success()`, since GitHub interprets a skipped job as a
+    # success, and by default a dependee job failing will skip a dependent job. That means
+    # if a test step fails, then it will skip `sentinel` so GitHub will register
+    # `sentinel` as succeeded.
+    #
+    # GitHub documents `jobs.result` as:
+    #
+    #	The result of a job in the reusable workflow. Possible values are success,
+    #	failure, cancelled, or skipped.
+    #
+    # GitHub documents `cancelled()` as:
+    #
+    #	Returns true if the workflow was canceled.
+    #
+    # Combining these terms gives us an intuitive definition of success:
+    #
+    #	We have succeeded when no dependent workflow has failed and the job was
+    #	not cancelled.
+    #
+    if: (github.event_name == 'repository_dispatch' ||
+      github.event.pull_request.head.repo.full_name == github.repository) &&
+      ! cancelled()
     needs:
     - test
     - lint
     runs-on: ubuntu-latest
     steps:
-    - name: Is workflow a success
-      run: echo yes
+    - name: Workflow is not a success
+      if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') || contains(needs.*.result, 'skipped')
+      run: exit 1
+    - name: Workflow is a success
+      run: echo "🎉🎈🎉🎈🎉"
   test:
     if: github.event_name == 'repository_dispatch' ||
       github.event.pull_request.head.repo.full_name == github.repository

--- a/provider-ci/providers/openstack/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/openstack/repo/.github/workflows/run-acceptance-tests.yml
@@ -269,16 +269,43 @@ jobs:
         fields: repo,commit,author,action
         status: ${{ job.status }}
   sentinel:
-    if: github.event_name == 'repository_dispatch' ||
-      github.event.pull_request.head.repo.full_name == github.repository
     name: sentinel
+    # We would like to be able to specify `sentinel` as the only required job for this
+    # workflow. To do that, we need `sentinel` to succeed only when it is safe to
+    # merge and fail in all other cases.
+    #
+    # We can't use the default `if: success()`, since GitHub interprets a skipped job as a
+    # success, and by default a dependee job failing will skip a dependent job. That means
+    # if a test step fails, then it will skip `sentinel` so GitHub will register
+    # `sentinel` as succeeded.
+    #
+    # GitHub documents `jobs.result` as:
+    #
+    #	The result of a job in the reusable workflow. Possible values are success,
+    #	failure, cancelled, or skipped.
+    #
+    # GitHub documents `cancelled()` as:
+    #
+    #	Returns true if the workflow was canceled.
+    #
+    # Combining these terms gives us an intuitive definition of success:
+    #
+    #	We have succeeded when no dependent workflow has failed and the job was
+    #	not cancelled.
+    #
+    if: (github.event_name == 'repository_dispatch' ||
+      github.event.pull_request.head.repo.full_name == github.repository) &&
+      ! cancelled()
     needs:
     - test
     - lint
     runs-on: ubuntu-latest
     steps:
-    - name: Is workflow a success
-      run: echo yes
+    - name: Workflow is not a success
+      if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') || contains(needs.*.result, 'skipped')
+      run: exit 1
+    - name: Workflow is a success
+      run: echo "🎉🎈🎉🎈🎉"
   test:
     if: github.event_name == 'repository_dispatch' ||
       github.event.pull_request.head.repo.full_name == github.repository

--- a/provider-ci/providers/opsgenie/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/opsgenie/repo/.github/workflows/run-acceptance-tests.yml
@@ -261,16 +261,43 @@ jobs:
         fields: repo,commit,author,action
         status: ${{ job.status }}
   sentinel:
-    if: github.event_name == 'repository_dispatch' ||
-      github.event.pull_request.head.repo.full_name == github.repository
     name: sentinel
+    # We would like to be able to specify `sentinel` as the only required job for this
+    # workflow. To do that, we need `sentinel` to succeed only when it is safe to
+    # merge and fail in all other cases.
+    #
+    # We can't use the default `if: success()`, since GitHub interprets a skipped job as a
+    # success, and by default a dependee job failing will skip a dependent job. That means
+    # if a test step fails, then it will skip `sentinel` so GitHub will register
+    # `sentinel` as succeeded.
+    #
+    # GitHub documents `jobs.result` as:
+    #
+    #	The result of a job in the reusable workflow. Possible values are success,
+    #	failure, cancelled, or skipped.
+    #
+    # GitHub documents `cancelled()` as:
+    #
+    #	Returns true if the workflow was canceled.
+    #
+    # Combining these terms gives us an intuitive definition of success:
+    #
+    #	We have succeeded when no dependent workflow has failed and the job was
+    #	not cancelled.
+    #
+    if: (github.event_name == 'repository_dispatch' ||
+      github.event.pull_request.head.repo.full_name == github.repository) &&
+      ! cancelled()
     needs:
     - test
     - lint
     runs-on: ubuntu-latest
     steps:
-    - name: Is workflow a success
-      run: echo yes
+    - name: Workflow is not a success
+      if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') || contains(needs.*.result, 'skipped')
+      run: exit 1
+    - name: Workflow is a success
+      run: echo "🎉🎈🎉🎈🎉"
   test:
     if: github.event_name == 'repository_dispatch' ||
       github.event.pull_request.head.repo.full_name == github.repository

--- a/provider-ci/providers/pagerduty/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/pagerduty/repo/.github/workflows/run-acceptance-tests.yml
@@ -261,16 +261,43 @@ jobs:
         fields: repo,commit,author,action
         status: ${{ job.status }}
   sentinel:
-    if: github.event_name == 'repository_dispatch' ||
-      github.event.pull_request.head.repo.full_name == github.repository
     name: sentinel
+    # We would like to be able to specify `sentinel` as the only required job for this
+    # workflow. To do that, we need `sentinel` to succeed only when it is safe to
+    # merge and fail in all other cases.
+    #
+    # We can't use the default `if: success()`, since GitHub interprets a skipped job as a
+    # success, and by default a dependee job failing will skip a dependent job. That means
+    # if a test step fails, then it will skip `sentinel` so GitHub will register
+    # `sentinel` as succeeded.
+    #
+    # GitHub documents `jobs.result` as:
+    #
+    #	The result of a job in the reusable workflow. Possible values are success,
+    #	failure, cancelled, or skipped.
+    #
+    # GitHub documents `cancelled()` as:
+    #
+    #	Returns true if the workflow was canceled.
+    #
+    # Combining these terms gives us an intuitive definition of success:
+    #
+    #	We have succeeded when no dependent workflow has failed and the job was
+    #	not cancelled.
+    #
+    if: (github.event_name == 'repository_dispatch' ||
+      github.event.pull_request.head.repo.full_name == github.repository) &&
+      ! cancelled()
     needs:
     - test
     - lint
     runs-on: ubuntu-latest
     steps:
-    - name: Is workflow a success
-      run: echo yes
+    - name: Workflow is not a success
+      if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') || contains(needs.*.result, 'skipped')
+      run: exit 1
+    - name: Workflow is a success
+      run: echo "🎉🎈🎉🎈🎉"
   test:
     if: github.event_name == 'repository_dispatch' ||
       github.event.pull_request.head.repo.full_name == github.repository

--- a/provider-ci/providers/postgresql/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/postgresql/repo/.github/workflows/run-acceptance-tests.yml
@@ -260,16 +260,43 @@ jobs:
         fields: repo,commit,author,action
         status: ${{ job.status }}
   sentinel:
-    if: github.event_name == 'repository_dispatch' ||
-      github.event.pull_request.head.repo.full_name == github.repository
     name: sentinel
+    # We would like to be able to specify `sentinel` as the only required job for this
+    # workflow. To do that, we need `sentinel` to succeed only when it is safe to
+    # merge and fail in all other cases.
+    #
+    # We can't use the default `if: success()`, since GitHub interprets a skipped job as a
+    # success, and by default a dependee job failing will skip a dependent job. That means
+    # if a test step fails, then it will skip `sentinel` so GitHub will register
+    # `sentinel` as succeeded.
+    #
+    # GitHub documents `jobs.result` as:
+    #
+    #	The result of a job in the reusable workflow. Possible values are success,
+    #	failure, cancelled, or skipped.
+    #
+    # GitHub documents `cancelled()` as:
+    #
+    #	Returns true if the workflow was canceled.
+    #
+    # Combining these terms gives us an intuitive definition of success:
+    #
+    #	We have succeeded when no dependent workflow has failed and the job was
+    #	not cancelled.
+    #
+    if: (github.event_name == 'repository_dispatch' ||
+      github.event.pull_request.head.repo.full_name == github.repository) &&
+      ! cancelled()
     needs:
     - test
     - lint
     runs-on: ubuntu-latest
     steps:
-    - name: Is workflow a success
-      run: echo yes
+    - name: Workflow is not a success
+      if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') || contains(needs.*.result, 'skipped')
+      run: exit 1
+    - name: Workflow is a success
+      run: echo "🎉🎈🎉🎈🎉"
   test:
     if: github.event_name == 'repository_dispatch' ||
       github.event.pull_request.head.repo.full_name == github.repository

--- a/provider-ci/providers/rabbitmq/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/rabbitmq/repo/.github/workflows/run-acceptance-tests.yml
@@ -260,16 +260,43 @@ jobs:
         fields: repo,commit,author,action
         status: ${{ job.status }}
   sentinel:
-    if: github.event_name == 'repository_dispatch' ||
-      github.event.pull_request.head.repo.full_name == github.repository
     name: sentinel
+    # We would like to be able to specify `sentinel` as the only required job for this
+    # workflow. To do that, we need `sentinel` to succeed only when it is safe to
+    # merge and fail in all other cases.
+    #
+    # We can't use the default `if: success()`, since GitHub interprets a skipped job as a
+    # success, and by default a dependee job failing will skip a dependent job. That means
+    # if a test step fails, then it will skip `sentinel` so GitHub will register
+    # `sentinel` as succeeded.
+    #
+    # GitHub documents `jobs.result` as:
+    #
+    #	The result of a job in the reusable workflow. Possible values are success,
+    #	failure, cancelled, or skipped.
+    #
+    # GitHub documents `cancelled()` as:
+    #
+    #	Returns true if the workflow was canceled.
+    #
+    # Combining these terms gives us an intuitive definition of success:
+    #
+    #	We have succeeded when no dependent workflow has failed and the job was
+    #	not cancelled.
+    #
+    if: (github.event_name == 'repository_dispatch' ||
+      github.event.pull_request.head.repo.full_name == github.repository) &&
+      ! cancelled()
     needs:
     - test
     - lint
     runs-on: ubuntu-latest
     steps:
-    - name: Is workflow a success
-      run: echo yes
+    - name: Workflow is not a success
+      if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') || contains(needs.*.result, 'skipped')
+      run: exit 1
+    - name: Workflow is a success
+      run: echo "🎉🎈🎉🎈🎉"
   test:
     if: github.event_name == 'repository_dispatch' ||
       github.event.pull_request.head.repo.full_name == github.repository

--- a/provider-ci/providers/rancher2/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/rancher2/repo/.github/workflows/run-acceptance-tests.yml
@@ -222,15 +222,42 @@ jobs:
         fields: repo,commit,author,action
         status: ${{ job.status }}
   sentinel:
-    if: github.event_name == 'repository_dispatch' ||
-      github.event.pull_request.head.repo.full_name == github.repository
     name: sentinel
+    # We would like to be able to specify `sentinel` as the only required job for this
+    # workflow. To do that, we need `sentinel` to succeed only when it is safe to
+    # merge and fail in all other cases.
+    #
+    # We can't use the default `if: success()`, since GitHub interprets a skipped job as a
+    # success, and by default a dependee job failing will skip a dependent job. That means
+    # if a test step fails, then it will skip `sentinel` so GitHub will register
+    # `sentinel` as succeeded.
+    #
+    # GitHub documents `jobs.result` as:
+    #
+    #	The result of a job in the reusable workflow. Possible values are success,
+    #	failure, cancelled, or skipped.
+    #
+    # GitHub documents `cancelled()` as:
+    #
+    #	Returns true if the workflow was canceled.
+    #
+    # Combining these terms gives us an intuitive definition of success:
+    #
+    #	We have succeeded when no dependent workflow has failed and the job was
+    #	not cancelled.
+    #
+    if: (github.event_name == 'repository_dispatch' ||
+      github.event.pull_request.head.repo.full_name == github.repository) &&
+      ! cancelled()
     needs:
     - test
     runs-on: ubuntu-latest
     steps:
-    - name: Is workflow a success
-      run: echo yes
+    - name: Workflow is not a success
+      if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') || contains(needs.*.result, 'skipped')
+      run: exit 1
+    - name: Workflow is a success
+      run: echo "🎉🎈🎉🎈🎉"
   test:
     if: github.event_name == 'repository_dispatch' ||
       github.event.pull_request.head.repo.full_name == github.repository

--- a/provider-ci/providers/random/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/random/repo/.github/workflows/run-acceptance-tests.yml
@@ -260,16 +260,43 @@ jobs:
         fields: repo,commit,author,action
         status: ${{ job.status }}
   sentinel:
-    if: github.event_name == 'repository_dispatch' ||
-      github.event.pull_request.head.repo.full_name == github.repository
     name: sentinel
+    # We would like to be able to specify `sentinel` as the only required job for this
+    # workflow. To do that, we need `sentinel` to succeed only when it is safe to
+    # merge and fail in all other cases.
+    #
+    # We can't use the default `if: success()`, since GitHub interprets a skipped job as a
+    # success, and by default a dependee job failing will skip a dependent job. That means
+    # if a test step fails, then it will skip `sentinel` so GitHub will register
+    # `sentinel` as succeeded.
+    #
+    # GitHub documents `jobs.result` as:
+    #
+    #	The result of a job in the reusable workflow. Possible values are success,
+    #	failure, cancelled, or skipped.
+    #
+    # GitHub documents `cancelled()` as:
+    #
+    #	Returns true if the workflow was canceled.
+    #
+    # Combining these terms gives us an intuitive definition of success:
+    #
+    #	We have succeeded when no dependent workflow has failed and the job was
+    #	not cancelled.
+    #
+    if: (github.event_name == 'repository_dispatch' ||
+      github.event.pull_request.head.repo.full_name == github.repository) &&
+      ! cancelled()
     needs:
     - test
     - lint
     runs-on: ubuntu-latest
     steps:
-    - name: Is workflow a success
-      run: echo yes
+    - name: Workflow is not a success
+      if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') || contains(needs.*.result, 'skipped')
+      run: exit 1
+    - name: Workflow is a success
+      run: echo "🎉🎈🎉🎈🎉"
   test:
     if: github.event_name == 'repository_dispatch' ||
       github.event.pull_request.head.repo.full_name == github.repository

--- a/provider-ci/providers/rke/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/rke/repo/.github/workflows/run-acceptance-tests.yml
@@ -261,16 +261,43 @@ jobs:
         fields: repo,commit,author,action
         status: ${{ job.status }}
   sentinel:
-    if: github.event_name == 'repository_dispatch' ||
-      github.event.pull_request.head.repo.full_name == github.repository
     name: sentinel
+    # We would like to be able to specify `sentinel` as the only required job for this
+    # workflow. To do that, we need `sentinel` to succeed only when it is safe to
+    # merge and fail in all other cases.
+    #
+    # We can't use the default `if: success()`, since GitHub interprets a skipped job as a
+    # success, and by default a dependee job failing will skip a dependent job. That means
+    # if a test step fails, then it will skip `sentinel` so GitHub will register
+    # `sentinel` as succeeded.
+    #
+    # GitHub documents `jobs.result` as:
+    #
+    #	The result of a job in the reusable workflow. Possible values are success,
+    #	failure, cancelled, or skipped.
+    #
+    # GitHub documents `cancelled()` as:
+    #
+    #	Returns true if the workflow was canceled.
+    #
+    # Combining these terms gives us an intuitive definition of success:
+    #
+    #	We have succeeded when no dependent workflow has failed and the job was
+    #	not cancelled.
+    #
+    if: (github.event_name == 'repository_dispatch' ||
+      github.event.pull_request.head.repo.full_name == github.repository) &&
+      ! cancelled()
     needs:
     - test
     - lint
     runs-on: ubuntu-latest
     steps:
-    - name: Is workflow a success
-      run: echo yes
+    - name: Workflow is not a success
+      if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') || contains(needs.*.result, 'skipped')
+      run: exit 1
+    - name: Workflow is a success
+      run: echo "🎉🎈🎉🎈🎉"
   test:
     if: github.event_name == 'repository_dispatch' ||
       github.event.pull_request.head.repo.full_name == github.repository

--- a/provider-ci/providers/signalfx/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/signalfx/repo/.github/workflows/run-acceptance-tests.yml
@@ -260,16 +260,43 @@ jobs:
         fields: repo,commit,author,action
         status: ${{ job.status }}
   sentinel:
-    if: github.event_name == 'repository_dispatch' ||
-      github.event.pull_request.head.repo.full_name == github.repository
     name: sentinel
+    # We would like to be able to specify `sentinel` as the only required job for this
+    # workflow. To do that, we need `sentinel` to succeed only when it is safe to
+    # merge and fail in all other cases.
+    #
+    # We can't use the default `if: success()`, since GitHub interprets a skipped job as a
+    # success, and by default a dependee job failing will skip a dependent job. That means
+    # if a test step fails, then it will skip `sentinel` so GitHub will register
+    # `sentinel` as succeeded.
+    #
+    # GitHub documents `jobs.result` as:
+    #
+    #	The result of a job in the reusable workflow. Possible values are success,
+    #	failure, cancelled, or skipped.
+    #
+    # GitHub documents `cancelled()` as:
+    #
+    #	Returns true if the workflow was canceled.
+    #
+    # Combining these terms gives us an intuitive definition of success:
+    #
+    #	We have succeeded when no dependent workflow has failed and the job was
+    #	not cancelled.
+    #
+    if: (github.event_name == 'repository_dispatch' ||
+      github.event.pull_request.head.repo.full_name == github.repository) &&
+      ! cancelled()
     needs:
     - test
     - lint
     runs-on: ubuntu-latest
     steps:
-    - name: Is workflow a success
-      run: echo yes
+    - name: Workflow is not a success
+      if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') || contains(needs.*.result, 'skipped')
+      run: exit 1
+    - name: Workflow is a success
+      run: echo "🎉🎈🎉🎈🎉"
   test:
     if: github.event_name == 'repository_dispatch' ||
       github.event.pull_request.head.repo.full_name == github.repository

--- a/provider-ci/providers/slack/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/slack/repo/.github/workflows/run-acceptance-tests.yml
@@ -261,16 +261,43 @@ jobs:
         fields: repo,commit,author,action
         status: ${{ job.status }}
   sentinel:
-    if: github.event_name == 'repository_dispatch' ||
-      github.event.pull_request.head.repo.full_name == github.repository
     name: sentinel
+    # We would like to be able to specify `sentinel` as the only required job for this
+    # workflow. To do that, we need `sentinel` to succeed only when it is safe to
+    # merge and fail in all other cases.
+    #
+    # We can't use the default `if: success()`, since GitHub interprets a skipped job as a
+    # success, and by default a dependee job failing will skip a dependent job. That means
+    # if a test step fails, then it will skip `sentinel` so GitHub will register
+    # `sentinel` as succeeded.
+    #
+    # GitHub documents `jobs.result` as:
+    #
+    #	The result of a job in the reusable workflow. Possible values are success,
+    #	failure, cancelled, or skipped.
+    #
+    # GitHub documents `cancelled()` as:
+    #
+    #	Returns true if the workflow was canceled.
+    #
+    # Combining these terms gives us an intuitive definition of success:
+    #
+    #	We have succeeded when no dependent workflow has failed and the job was
+    #	not cancelled.
+    #
+    if: (github.event_name == 'repository_dispatch' ||
+      github.event.pull_request.head.repo.full_name == github.repository) &&
+      ! cancelled()
     needs:
     - test
     - lint
     runs-on: ubuntu-latest
     steps:
-    - name: Is workflow a success
-      run: echo yes
+    - name: Workflow is not a success
+      if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') || contains(needs.*.result, 'skipped')
+      run: exit 1
+    - name: Workflow is a success
+      run: echo "🎉🎈🎉🎈🎉"
   test:
     if: github.event_name == 'repository_dispatch' ||
       github.event.pull_request.head.repo.full_name == github.repository

--- a/provider-ci/providers/snowflake/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/snowflake/repo/.github/workflows/run-acceptance-tests.yml
@@ -265,16 +265,43 @@ jobs:
         fields: repo,commit,author,action
         status: ${{ job.status }}
   sentinel:
-    if: github.event_name == 'repository_dispatch' ||
-      github.event.pull_request.head.repo.full_name == github.repository
     name: sentinel
+    # We would like to be able to specify `sentinel` as the only required job for this
+    # workflow. To do that, we need `sentinel` to succeed only when it is safe to
+    # merge and fail in all other cases.
+    #
+    # We can't use the default `if: success()`, since GitHub interprets a skipped job as a
+    # success, and by default a dependee job failing will skip a dependent job. That means
+    # if a test step fails, then it will skip `sentinel` so GitHub will register
+    # `sentinel` as succeeded.
+    #
+    # GitHub documents `jobs.result` as:
+    #
+    #	The result of a job in the reusable workflow. Possible values are success,
+    #	failure, cancelled, or skipped.
+    #
+    # GitHub documents `cancelled()` as:
+    #
+    #	Returns true if the workflow was canceled.
+    #
+    # Combining these terms gives us an intuitive definition of success:
+    #
+    #	We have succeeded when no dependent workflow has failed and the job was
+    #	not cancelled.
+    #
+    if: (github.event_name == 'repository_dispatch' ||
+      github.event.pull_request.head.repo.full_name == github.repository) &&
+      ! cancelled()
     needs:
     - test
     - lint
     runs-on: ubuntu-latest
     steps:
-    - name: Is workflow a success
-      run: echo yes
+    - name: Workflow is not a success
+      if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') || contains(needs.*.result, 'skipped')
+      run: exit 1
+    - name: Workflow is a success
+      run: echo "🎉🎈🎉🎈🎉"
   test:
     if: github.event_name == 'repository_dispatch' ||
       github.event.pull_request.head.repo.full_name == github.repository

--- a/provider-ci/providers/splunk/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/splunk/repo/.github/workflows/run-acceptance-tests.yml
@@ -263,16 +263,43 @@ jobs:
         fields: repo,commit,author,action
         status: ${{ job.status }}
   sentinel:
-    if: github.event_name == 'repository_dispatch' ||
-      github.event.pull_request.head.repo.full_name == github.repository
     name: sentinel
+    # We would like to be able to specify `sentinel` as the only required job for this
+    # workflow. To do that, we need `sentinel` to succeed only when it is safe to
+    # merge and fail in all other cases.
+    #
+    # We can't use the default `if: success()`, since GitHub interprets a skipped job as a
+    # success, and by default a dependee job failing will skip a dependent job. That means
+    # if a test step fails, then it will skip `sentinel` so GitHub will register
+    # `sentinel` as succeeded.
+    #
+    # GitHub documents `jobs.result` as:
+    #
+    #	The result of a job in the reusable workflow. Possible values are success,
+    #	failure, cancelled, or skipped.
+    #
+    # GitHub documents `cancelled()` as:
+    #
+    #	Returns true if the workflow was canceled.
+    #
+    # Combining these terms gives us an intuitive definition of success:
+    #
+    #	We have succeeded when no dependent workflow has failed and the job was
+    #	not cancelled.
+    #
+    if: (github.event_name == 'repository_dispatch' ||
+      github.event.pull_request.head.repo.full_name == github.repository) &&
+      ! cancelled()
     needs:
     - test
     - lint
     runs-on: ubuntu-latest
     steps:
-    - name: Is workflow a success
-      run: echo yes
+    - name: Workflow is not a success
+      if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') || contains(needs.*.result, 'skipped')
+      run: exit 1
+    - name: Workflow is a success
+      run: echo "🎉🎈🎉🎈🎉"
   test:
     if: github.event_name == 'repository_dispatch' ||
       github.event.pull_request.head.repo.full_name == github.repository

--- a/provider-ci/providers/spotinst/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/spotinst/repo/.github/workflows/run-acceptance-tests.yml
@@ -263,16 +263,43 @@ jobs:
         fields: repo,commit,author,action
         status: ${{ job.status }}
   sentinel:
-    if: github.event_name == 'repository_dispatch' ||
-      github.event.pull_request.head.repo.full_name == github.repository
     name: sentinel
+    # We would like to be able to specify `sentinel` as the only required job for this
+    # workflow. To do that, we need `sentinel` to succeed only when it is safe to
+    # merge and fail in all other cases.
+    #
+    # We can't use the default `if: success()`, since GitHub interprets a skipped job as a
+    # success, and by default a dependee job failing will skip a dependent job. That means
+    # if a test step fails, then it will skip `sentinel` so GitHub will register
+    # `sentinel` as succeeded.
+    #
+    # GitHub documents `jobs.result` as:
+    #
+    #	The result of a job in the reusable workflow. Possible values are success,
+    #	failure, cancelled, or skipped.
+    #
+    # GitHub documents `cancelled()` as:
+    #
+    #	Returns true if the workflow was canceled.
+    #
+    # Combining these terms gives us an intuitive definition of success:
+    #
+    #	We have succeeded when no dependent workflow has failed and the job was
+    #	not cancelled.
+    #
+    if: (github.event_name == 'repository_dispatch' ||
+      github.event.pull_request.head.repo.full_name == github.repository) &&
+      ! cancelled()
     needs:
     - test
     - lint
     runs-on: ubuntu-latest
     steps:
-    - name: Is workflow a success
-      run: echo yes
+    - name: Workflow is not a success
+      if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') || contains(needs.*.result, 'skipped')
+      run: exit 1
+    - name: Workflow is a success
+      run: echo "🎉🎈🎉🎈🎉"
   test:
     if: github.event_name == 'repository_dispatch' ||
       github.event.pull_request.head.repo.full_name == github.repository

--- a/provider-ci/providers/sumologic/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/sumologic/repo/.github/workflows/run-acceptance-tests.yml
@@ -263,16 +263,43 @@ jobs:
         fields: repo,commit,author,action
         status: ${{ job.status }}
   sentinel:
-    if: github.event_name == 'repository_dispatch' ||
-      github.event.pull_request.head.repo.full_name == github.repository
     name: sentinel
+    # We would like to be able to specify `sentinel` as the only required job for this
+    # workflow. To do that, we need `sentinel` to succeed only when it is safe to
+    # merge and fail in all other cases.
+    #
+    # We can't use the default `if: success()`, since GitHub interprets a skipped job as a
+    # success, and by default a dependee job failing will skip a dependent job. That means
+    # if a test step fails, then it will skip `sentinel` so GitHub will register
+    # `sentinel` as succeeded.
+    #
+    # GitHub documents `jobs.result` as:
+    #
+    #	The result of a job in the reusable workflow. Possible values are success,
+    #	failure, cancelled, or skipped.
+    #
+    # GitHub documents `cancelled()` as:
+    #
+    #	Returns true if the workflow was canceled.
+    #
+    # Combining these terms gives us an intuitive definition of success:
+    #
+    #	We have succeeded when no dependent workflow has failed and the job was
+    #	not cancelled.
+    #
+    if: (github.event_name == 'repository_dispatch' ||
+      github.event.pull_request.head.repo.full_name == github.repository) &&
+      ! cancelled()
     needs:
     - test
     - lint
     runs-on: ubuntu-latest
     steps:
-    - name: Is workflow a success
-      run: echo yes
+    - name: Workflow is not a success
+      if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') || contains(needs.*.result, 'skipped')
+      run: exit 1
+    - name: Workflow is a success
+      run: echo "🎉🎈🎉🎈🎉"
   test:
     if: github.event_name == 'repository_dispatch' ||
       github.event.pull_request.head.repo.full_name == github.repository

--- a/provider-ci/providers/tailscale/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/tailscale/repo/.github/workflows/run-acceptance-tests.yml
@@ -263,16 +263,43 @@ jobs:
         fields: repo,commit,author,action
         status: ${{ job.status }}
   sentinel:
-    if: github.event_name == 'repository_dispatch' ||
-      github.event.pull_request.head.repo.full_name == github.repository
     name: sentinel
+    # We would like to be able to specify `sentinel` as the only required job for this
+    # workflow. To do that, we need `sentinel` to succeed only when it is safe to
+    # merge and fail in all other cases.
+    #
+    # We can't use the default `if: success()`, since GitHub interprets a skipped job as a
+    # success, and by default a dependee job failing will skip a dependent job. That means
+    # if a test step fails, then it will skip `sentinel` so GitHub will register
+    # `sentinel` as succeeded.
+    #
+    # GitHub documents `jobs.result` as:
+    #
+    #	The result of a job in the reusable workflow. Possible values are success,
+    #	failure, cancelled, or skipped.
+    #
+    # GitHub documents `cancelled()` as:
+    #
+    #	Returns true if the workflow was canceled.
+    #
+    # Combining these terms gives us an intuitive definition of success:
+    #
+    #	We have succeeded when no dependent workflow has failed and the job was
+    #	not cancelled.
+    #
+    if: (github.event_name == 'repository_dispatch' ||
+      github.event.pull_request.head.repo.full_name == github.repository) &&
+      ! cancelled()
     needs:
     - test
     - lint
     runs-on: ubuntu-latest
     steps:
-    - name: Is workflow a success
-      run: echo yes
+    - name: Workflow is not a success
+      if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') || contains(needs.*.result, 'skipped')
+      run: exit 1
+    - name: Workflow is a success
+      run: echo "🎉🎈🎉🎈🎉"
   test:
     if: github.event_name == 'repository_dispatch' ||
       github.event.pull_request.head.repo.full_name == github.repository

--- a/provider-ci/providers/tls/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/tls/repo/.github/workflows/run-acceptance-tests.yml
@@ -260,16 +260,43 @@ jobs:
         fields: repo,commit,author,action
         status: ${{ job.status }}
   sentinel:
-    if: github.event_name == 'repository_dispatch' ||
-      github.event.pull_request.head.repo.full_name == github.repository
     name: sentinel
+    # We would like to be able to specify `sentinel` as the only required job for this
+    # workflow. To do that, we need `sentinel` to succeed only when it is safe to
+    # merge and fail in all other cases.
+    #
+    # We can't use the default `if: success()`, since GitHub interprets a skipped job as a
+    # success, and by default a dependee job failing will skip a dependent job. That means
+    # if a test step fails, then it will skip `sentinel` so GitHub will register
+    # `sentinel` as succeeded.
+    #
+    # GitHub documents `jobs.result` as:
+    #
+    #	The result of a job in the reusable workflow. Possible values are success,
+    #	failure, cancelled, or skipped.
+    #
+    # GitHub documents `cancelled()` as:
+    #
+    #	Returns true if the workflow was canceled.
+    #
+    # Combining these terms gives us an intuitive definition of success:
+    #
+    #	We have succeeded when no dependent workflow has failed and the job was
+    #	not cancelled.
+    #
+    if: (github.event_name == 'repository_dispatch' ||
+      github.event.pull_request.head.repo.full_name == github.repository) &&
+      ! cancelled()
     needs:
     - test
     - lint
     runs-on: ubuntu-latest
     steps:
-    - name: Is workflow a success
-      run: echo yes
+    - name: Workflow is not a success
+      if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') || contains(needs.*.result, 'skipped')
+      run: exit 1
+    - name: Workflow is a success
+      run: echo "🎉🎈🎉🎈🎉"
   test:
     if: github.event_name == 'repository_dispatch' ||
       github.event.pull_request.head.repo.full_name == github.repository

--- a/provider-ci/providers/vault/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/vault/repo/.github/workflows/run-acceptance-tests.yml
@@ -260,16 +260,43 @@ jobs:
         fields: repo,commit,author,action
         status: ${{ job.status }}
   sentinel:
-    if: github.event_name == 'repository_dispatch' ||
-      github.event.pull_request.head.repo.full_name == github.repository
     name: sentinel
+    # We would like to be able to specify `sentinel` as the only required job for this
+    # workflow. To do that, we need `sentinel` to succeed only when it is safe to
+    # merge and fail in all other cases.
+    #
+    # We can't use the default `if: success()`, since GitHub interprets a skipped job as a
+    # success, and by default a dependee job failing will skip a dependent job. That means
+    # if a test step fails, then it will skip `sentinel` so GitHub will register
+    # `sentinel` as succeeded.
+    #
+    # GitHub documents `jobs.result` as:
+    #
+    #	The result of a job in the reusable workflow. Possible values are success,
+    #	failure, cancelled, or skipped.
+    #
+    # GitHub documents `cancelled()` as:
+    #
+    #	Returns true if the workflow was canceled.
+    #
+    # Combining these terms gives us an intuitive definition of success:
+    #
+    #	We have succeeded when no dependent workflow has failed and the job was
+    #	not cancelled.
+    #
+    if: (github.event_name == 'repository_dispatch' ||
+      github.event.pull_request.head.repo.full_name == github.repository) &&
+      ! cancelled()
     needs:
     - test
     - lint
     runs-on: ubuntu-latest
     steps:
-    - name: Is workflow a success
-      run: echo yes
+    - name: Workflow is not a success
+      if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') || contains(needs.*.result, 'skipped')
+      run: exit 1
+    - name: Workflow is a success
+      run: echo "🎉🎈🎉🎈🎉"
   test:
     if: github.event_name == 'repository_dispatch' ||
       github.event.pull_request.head.repo.full_name == github.repository

--- a/provider-ci/providers/venafi/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/venafi/repo/.github/workflows/run-acceptance-tests.yml
@@ -264,16 +264,43 @@ jobs:
         fields: repo,commit,author,action
         status: ${{ job.status }}
   sentinel:
-    if: github.event_name == 'repository_dispatch' ||
-      github.event.pull_request.head.repo.full_name == github.repository
     name: sentinel
+    # We would like to be able to specify `sentinel` as the only required job for this
+    # workflow. To do that, we need `sentinel` to succeed only when it is safe to
+    # merge and fail in all other cases.
+    #
+    # We can't use the default `if: success()`, since GitHub interprets a skipped job as a
+    # success, and by default a dependee job failing will skip a dependent job. That means
+    # if a test step fails, then it will skip `sentinel` so GitHub will register
+    # `sentinel` as succeeded.
+    #
+    # GitHub documents `jobs.result` as:
+    #
+    #	The result of a job in the reusable workflow. Possible values are success,
+    #	failure, cancelled, or skipped.
+    #
+    # GitHub documents `cancelled()` as:
+    #
+    #	Returns true if the workflow was canceled.
+    #
+    # Combining these terms gives us an intuitive definition of success:
+    #
+    #	We have succeeded when no dependent workflow has failed and the job was
+    #	not cancelled.
+    #
+    if: (github.event_name == 'repository_dispatch' ||
+      github.event.pull_request.head.repo.full_name == github.repository) &&
+      ! cancelled()
     needs:
     - test
     - lint
     runs-on: ubuntu-latest
     steps:
-    - name: Is workflow a success
-      run: echo yes
+    - name: Workflow is not a success
+      if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') || contains(needs.*.result, 'skipped')
+      run: exit 1
+    - name: Workflow is a success
+      run: echo "🎉🎈🎉🎈🎉"
   test:
     if: github.event_name == 'repository_dispatch' ||
       github.event.pull_request.head.repo.full_name == github.repository

--- a/provider-ci/providers/vsphere/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/vsphere/repo/.github/workflows/run-acceptance-tests.yml
@@ -260,16 +260,43 @@ jobs:
         fields: repo,commit,author,action
         status: ${{ job.status }}
   sentinel:
-    if: github.event_name == 'repository_dispatch' ||
-      github.event.pull_request.head.repo.full_name == github.repository
     name: sentinel
+    # We would like to be able to specify `sentinel` as the only required job for this
+    # workflow. To do that, we need `sentinel` to succeed only when it is safe to
+    # merge and fail in all other cases.
+    #
+    # We can't use the default `if: success()`, since GitHub interprets a skipped job as a
+    # success, and by default a dependee job failing will skip a dependent job. That means
+    # if a test step fails, then it will skip `sentinel` so GitHub will register
+    # `sentinel` as succeeded.
+    #
+    # GitHub documents `jobs.result` as:
+    #
+    #	The result of a job in the reusable workflow. Possible values are success,
+    #	failure, cancelled, or skipped.
+    #
+    # GitHub documents `cancelled()` as:
+    #
+    #	Returns true if the workflow was canceled.
+    #
+    # Combining these terms gives us an intuitive definition of success:
+    #
+    #	We have succeeded when no dependent workflow has failed and the job was
+    #	not cancelled.
+    #
+    if: (github.event_name == 'repository_dispatch' ||
+      github.event.pull_request.head.repo.full_name == github.repository) &&
+      ! cancelled()
     needs:
     - test
     - lint
     runs-on: ubuntu-latest
     steps:
-    - name: Is workflow a success
-      run: echo yes
+    - name: Workflow is not a success
+      if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') || contains(needs.*.result, 'skipped')
+      run: exit 1
+    - name: Workflow is a success
+      run: echo "🎉🎈🎉🎈🎉"
   test:
     if: github.event_name == 'repository_dispatch' ||
       github.event.pull_request.head.repo.full_name == github.repository

--- a/provider-ci/providers/wavefront/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/wavefront/repo/.github/workflows/run-acceptance-tests.yml
@@ -262,16 +262,43 @@ jobs:
         fields: repo,commit,author,action
         status: ${{ job.status }}
   sentinel:
-    if: github.event_name == 'repository_dispatch' ||
-      github.event.pull_request.head.repo.full_name == github.repository
     name: sentinel
+    # We would like to be able to specify `sentinel` as the only required job for this
+    # workflow. To do that, we need `sentinel` to succeed only when it is safe to
+    # merge and fail in all other cases.
+    #
+    # We can't use the default `if: success()`, since GitHub interprets a skipped job as a
+    # success, and by default a dependee job failing will skip a dependent job. That means
+    # if a test step fails, then it will skip `sentinel` so GitHub will register
+    # `sentinel` as succeeded.
+    #
+    # GitHub documents `jobs.result` as:
+    #
+    #	The result of a job in the reusable workflow. Possible values are success,
+    #	failure, cancelled, or skipped.
+    #
+    # GitHub documents `cancelled()` as:
+    #
+    #	Returns true if the workflow was canceled.
+    #
+    # Combining these terms gives us an intuitive definition of success:
+    #
+    #	We have succeeded when no dependent workflow has failed and the job was
+    #	not cancelled.
+    #
+    if: (github.event_name == 'repository_dispatch' ||
+      github.event.pull_request.head.repo.full_name == github.repository) &&
+      ! cancelled()
     needs:
     - test
     - lint
     runs-on: ubuntu-latest
     steps:
-    - name: Is workflow a success
-      run: echo yes
+    - name: Workflow is not a success
+      if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') || contains(needs.*.result, 'skipped')
+      run: exit 1
+    - name: Workflow is a success
+      run: echo "🎉🎈🎉🎈🎉"
   test:
     if: github.event_name == 'repository_dispatch' ||
       github.event.pull_request.head.repo.full_name == github.repository


### PR DESCRIPTION
Currently, each repository must set branch protection for a host of jobs to prevent bad PRs merging (for example: https://github.com/pulumi/pulumi-kafka/pull/200). This per repository configuration is exacerbated when the set of ci-mgmt generated jobs changes:

1. If a job is added, then the repo is not actually protected from that job failing until branch protection is manually updated.

2. If a job is removed (and it was required before), no PRs will merge since GitHub waits for the job to succeed before allowing the PR to merge, and the job will never run.

The solution is to provide an abstract required status check, and have it determine if a PR is safe to merge. `sentinel` is the obvious job to choose. This PR will allow repositories to set `sentinel` as a required status check and get expected behavior. For our providers, this will be a no-op since they all require sentinel anyway.

https://github.com/pulumi/pulumi-kafka/actions/runs/6054271833?pr=202 shows `sentinel` as failed when a dependent job has failed.
https://github.com/pulumi/pulumi-kafka/actions/runs/6054404879 shows `sentinel` succeeding when everyone else succeeds.