### PR TITLE
Bump golangci-lint version to v1.54.1

### DIFF
--- a/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/main.yml
+++ b/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/main.yml
@@ -150,7 +150,7 @@ jobs:
         aws s3 cp "${{ env.COVERAGE_OUTPUT_DIR }}/summary.json" "${s3FullURI}" --acl bucket-owner-full-control
   #{{ if .Config.lint -}}#
   lint:
-    container: golangci/golangci-lint:v1.51
+    container: golangci/golangci-lint:v1.54.1
     name: lint
     runs-on: #{{ .Config.runner.default }}#
     steps:

--- a/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/master.yml
+++ b/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/master.yml
@@ -150,7 +150,7 @@ jobs:
         aws s3 cp "${{ env.COVERAGE_OUTPUT_DIR }}/summary.json" "${s3FullURI}" --acl bucket-owner-full-control
   #{{ if .Config.lint -}}#
   lint:
-    container: golangci/golangci-lint:v1.51
+    container: golangci/golangci-lint:v1.54.1
     name: lint
     runs-on: #{{ .Config.runner.default }}#
     steps:

--- a/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/prerelease.yml
+++ b/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/prerelease.yml
@@ -99,7 +99,7 @@ jobs:
         - java
   #{{ if .Config.lint -}}#
   lint:
-    container: golangci/golangci-lint:v1.51
+    container: golangci/golangci-lint:v1.54.1
     name: lint
     runs-on: #{{ .Config.runner.default }}#
     steps:

--- a/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/release.yml
+++ b/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/release.yml
@@ -114,7 +114,7 @@ jobs:
   #{{ end -}}#
   #{{ if .Config.lint -}}#
   lint:
-    container: golangci/golangci-lint:v1.51
+    container: golangci/golangci-lint:v1.54.1
     name: lint
     runs-on: #{{ .Config.runner.default }}#
     steps:

--- a/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/run-acceptance-tests.yml
@@ -118,7 +118,7 @@ jobs:
         token: ${{ secrets.PULUMI_BOT_TOKEN }}
   #{{ if .Config.lint -}}#
   lint:
-    container: golangci/golangci-lint:v1.51
+    container: golangci/golangci-lint:v1.54.1
     if: github.event_name == 'repository_dispatch' ||
       github.event.pull_request.head.repo.full_name == github.repository
     name: lint

--- a/provider-ci/providers/artifactory/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/artifactory/repo/.github/workflows/main.yml
@@ -179,7 +179,7 @@ jobs:
 
         aws s3 cp "${{ env.COVERAGE_OUTPUT_DIR }}/summary.json" "${s3FullURI}" --acl bucket-owner-full-control
   lint:
-    container: golangci/golangci-lint:v1.51
+    container: golangci/golangci-lint:v1.54.1
     name: lint
     runs-on: ubuntu-latest
     steps:

--- a/provider-ci/providers/artifactory/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/artifactory/repo/.github/workflows/master.yml
@@ -179,7 +179,7 @@ jobs:
 
         aws s3 cp "${{ env.COVERAGE_OUTPUT_DIR }}/summary.json" "${s3FullURI}" --acl bucket-owner-full-control
   lint:
-    container: golangci/golangci-lint:v1.51
+    container: golangci/golangci-lint:v1.54.1
     name: lint
     runs-on: ubuntu-latest
     steps:

--- a/provider-ci/providers/artifactory/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/artifactory/repo/.github/workflows/prerelease.yml
@@ -126,7 +126,7 @@ jobs:
         - go
         - java
   lint:
-    container: golangci/golangci-lint:v1.51
+    container: golangci/golangci-lint:v1.54.1
     name: lint
     runs-on: ubuntu-latest
     steps:

--- a/provider-ci/providers/artifactory/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/artifactory/repo/.github/workflows/release.yml
@@ -139,7 +139,7 @@ jobs:
       run: pulumictl create docs-build pulumi-${{ env.PROVIDER }}
         "${GITHUB_REF#refs/tags/}"
   lint:
-    container: golangci/golangci-lint:v1.51
+    container: golangci/golangci-lint:v1.54.1
     name: lint
     runs-on: ubuntu-latest
     steps:

--- a/provider-ci/providers/artifactory/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/artifactory/repo/.github/workflows/run-acceptance-tests.yml
@@ -146,7 +146,7 @@ jobs:
         repository: ${{ github.event.client_payload.github.payload.repository.full_name }}
         token: ${{ secrets.PULUMI_BOT_TOKEN }}
   lint:
-    container: golangci/golangci-lint:v1.51
+    container: golangci/golangci-lint:v1.54.1
     if: github.event_name == 'repository_dispatch' ||
       github.event.pull_request.head.repo.full_name == github.repository
     name: lint

--- a/provider-ci/providers/auth0/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/auth0/repo/.github/workflows/main.yml
@@ -179,7 +179,7 @@ jobs:
 
         aws s3 cp "${{ env.COVERAGE_OUTPUT_DIR }}/summary.json" "${s3FullURI}" --acl bucket-owner-full-control
   lint:
-    container: golangci/golangci-lint:v1.51
+    container: golangci/golangci-lint:v1.54.1
     name: lint
     runs-on: ubuntu-latest
     steps:

--- a/provider-ci/providers/auth0/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/auth0/repo/.github/workflows/master.yml
@@ -179,7 +179,7 @@ jobs:
 
         aws s3 cp "${{ env.COVERAGE_OUTPUT_DIR }}/summary.json" "${s3FullURI}" --acl bucket-owner-full-control
   lint:
-    container: golangci/golangci-lint:v1.51
+    container: golangci/golangci-lint:v1.54.1
     name: lint
     runs-on: ubuntu-latest
     steps:

--- a/provider-ci/providers/auth0/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/auth0/repo/.github/workflows/prerelease.yml
@@ -126,7 +126,7 @@ jobs:
         - go
         - java
   lint:
-    container: golangci/golangci-lint:v1.51
+    container: golangci/golangci-lint:v1.54.1
     name: lint
     runs-on: ubuntu-latest
     steps:

--- a/provider-ci/providers/auth0/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/auth0/repo/.github/workflows/release.yml
@@ -139,7 +139,7 @@ jobs:
       run: pulumictl create docs-build pulumi-${{ env.PROVIDER }}
         "${GITHUB_REF#refs/tags/}"
   lint:
-    container: golangci/golangci-lint:v1.51
+    container: golangci/golangci-lint:v1.54.1
     name: lint
     runs-on: ubuntu-latest
     steps:

--- a/provider-ci/providers/auth0/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/auth0/repo/.github/workflows/run-acceptance-tests.yml
@@ -146,7 +146,7 @@ jobs:
         repository: ${{ github.event.client_payload.github.payload.repository.full_name }}
         token: ${{ secrets.PULUMI_BOT_TOKEN }}
   lint:
-    container: golangci/golangci-lint:v1.51
+    container: golangci/golangci-lint:v1.54.1
     if: github.event_name == 'repository_dispatch' ||
       github.event.pull_request.head.repo.full_name == github.repository
     name: lint

--- a/provider-ci/providers/azuread/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/azuread/repo/.github/workflows/main.yml
@@ -181,7 +181,7 @@ jobs:
 
         aws s3 cp "${{ env.COVERAGE_OUTPUT_DIR }}/summary.json" "${s3FullURI}" --acl bucket-owner-full-control
   lint:
-    container: golangci/golangci-lint:v1.51
+    container: golangci/golangci-lint:v1.54.1
     name: lint
     runs-on: ubuntu-latest
     steps:

--- a/provider-ci/providers/azuread/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/azuread/repo/.github/workflows/master.yml
@@ -181,7 +181,7 @@ jobs:
 
         aws s3 cp "${{ env.COVERAGE_OUTPUT_DIR }}/summary.json" "${s3FullURI}" --acl bucket-owner-full-control
   lint:
-    container: golangci/golangci-lint:v1.51
+    container: golangci/golangci-lint:v1.54.1
     name: lint
     runs-on: ubuntu-latest
     steps:

--- a/provider-ci/providers/azuread/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/azuread/repo/.github/workflows/prerelease.yml
@@ -128,7 +128,7 @@ jobs:
         - go
         - java
   lint:
-    container: golangci/golangci-lint:v1.51
+    container: golangci/golangci-lint:v1.54.1
     name: lint
     runs-on: ubuntu-latest
     steps:

--- a/provider-ci/providers/azuread/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/azuread/repo/.github/workflows/release.yml
@@ -141,7 +141,7 @@ jobs:
       run: pulumictl create docs-build pulumi-${{ env.PROVIDER }}
         "${GITHUB_REF#refs/tags/}"
   lint:
-    container: golangci/golangci-lint:v1.51
+    container: golangci/golangci-lint:v1.54.1
     name: lint
     runs-on: ubuntu-latest
     steps:

--- a/provider-ci/providers/azuread/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/azuread/repo/.github/workflows/run-acceptance-tests.yml
@@ -148,7 +148,7 @@ jobs:
         repository: ${{ github.event.client_payload.github.payload.repository.full_name }}
         token: ${{ secrets.PULUMI_BOT_TOKEN }}
   lint:
-    container: golangci/golangci-lint:v1.51
+    container: golangci/golangci-lint:v1.54.1
     if: github.event_name == 'repository_dispatch' ||
       github.event.pull_request.head.repo.full_name == github.repository
     name: lint

--- a/provider-ci/providers/civo/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/civo/repo/.github/workflows/main.yml
@@ -177,7 +177,7 @@ jobs:
 
         aws s3 cp "${{ env.COVERAGE_OUTPUT_DIR }}/summary.json" "${s3FullURI}" --acl bucket-owner-full-control
   lint:
-    container: golangci/golangci-lint:v1.51
+    container: golangci/golangci-lint:v1.54.1
     name: lint
     runs-on: ubuntu-latest
     steps:

--- a/provider-ci/providers/civo/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/civo/repo/.github/workflows/master.yml
@@ -177,7 +177,7 @@ jobs:
 
         aws s3 cp "${{ env.COVERAGE_OUTPUT_DIR }}/summary.json" "${s3FullURI}" --acl bucket-owner-full-control
   lint:
-    container: golangci/golangci-lint:v1.51
+    container: golangci/golangci-lint:v1.54.1
     name: lint
     runs-on: ubuntu-latest
     steps:

--- a/provider-ci/providers/civo/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/civo/repo/.github/workflows/prerelease.yml
@@ -124,7 +124,7 @@ jobs:
         - go
         - java
   lint:
-    container: golangci/golangci-lint:v1.51
+    container: golangci/golangci-lint:v1.54.1
     name: lint
     runs-on: ubuntu-latest
     steps:

--- a/provider-ci/providers/civo/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/civo/repo/.github/workflows/release.yml
@@ -137,7 +137,7 @@ jobs:
       run: pulumictl create docs-build pulumi-${{ env.PROVIDER }}
         "${GITHUB_REF#refs/tags/}"
   lint:
-    container: golangci/golangci-lint:v1.51
+    container: golangci/golangci-lint:v1.54.1
     name: lint
     runs-on: ubuntu-latest
     steps:

--- a/provider-ci/providers/civo/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/civo/repo/.github/workflows/run-acceptance-tests.yml
@@ -144,7 +144,7 @@ jobs:
         repository: ${{ github.event.client_payload.github.payload.repository.full_name }}
         token: ${{ secrets.PULUMI_BOT_TOKEN }}
   lint:
-    container: golangci/golangci-lint:v1.51
+    container: golangci/golangci-lint:v1.54.1
     if: github.event_name == 'repository_dispatch' ||
       github.event.pull_request.head.repo.full_name == github.repository
     name: lint

--- a/provider-ci/providers/cloudamqp/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/cloudamqp/repo/.github/workflows/main.yml
@@ -177,7 +177,7 @@ jobs:
 
         aws s3 cp "${{ env.COVERAGE_OUTPUT_DIR }}/summary.json" "${s3FullURI}" --acl bucket-owner-full-control
   lint:
-    container: golangci/golangci-lint:v1.51
+    container: golangci/golangci-lint:v1.54.1
     name: lint
     runs-on: ubuntu-latest
     steps:

--- a/provider-ci/providers/cloudamqp/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/cloudamqp/repo/.github/workflows/master.yml
@@ -177,7 +177,7 @@ jobs:
 
         aws s3 cp "${{ env.COVERAGE_OUTPUT_DIR }}/summary.json" "${s3FullURI}" --acl bucket-owner-full-control
   lint:
-    container: golangci/golangci-lint:v1.51
+    container: golangci/golangci-lint:v1.54.1
     name: lint
     runs-on: ubuntu-latest
     steps:

--- a/provider-ci/providers/cloudamqp/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/cloudamqp/repo/.github/workflows/prerelease.yml
@@ -124,7 +124,7 @@ jobs:
         - go
         - java
   lint:
-    container: golangci/golangci-lint:v1.51
+    container: golangci/golangci-lint:v1.54.1
     name: lint
     runs-on: ubuntu-latest
     steps:

--- a/provider-ci/providers/cloudamqp/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/cloudamqp/repo/.github/workflows/release.yml
@@ -137,7 +137,7 @@ jobs:
       run: pulumictl create docs-build pulumi-${{ env.PROVIDER }}
         "${GITHUB_REF#refs/tags/}"
   lint:
-    container: golangci/golangci-lint:v1.51
+    container: golangci/golangci-lint:v1.54.1
     name: lint
     runs-on: ubuntu-latest
     steps:

--- a/provider-ci/providers/cloudamqp/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/cloudamqp/repo/.github/workflows/run-acceptance-tests.yml
@@ -144,7 +144,7 @@ jobs:
         repository: ${{ github.event.client_payload.github.payload.repository.full_name }}
         token: ${{ secrets.PULUMI_BOT_TOKEN }}
   lint:
-    container: golangci/golangci-lint:v1.51
+    container: golangci/golangci-lint:v1.54.1
     if: github.event_name == 'repository_dispatch' ||
       github.event.pull_request.head.repo.full_name == github.repository
     name: lint

--- a/provider-ci/providers/cloudflare/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/cloudflare/repo/.github/workflows/main.yml
@@ -178,7 +178,7 @@ jobs:
 
         aws s3 cp "${{ env.COVERAGE_OUTPUT_DIR }}/summary.json" "${s3FullURI}" --acl bucket-owner-full-control
   lint:
-    container: golangci/golangci-lint:v1.51
+    container: golangci/golangci-lint:v1.54.1
     name: lint
     runs-on: ubuntu-latest
     steps:

--- a/provider-ci/providers/cloudflare/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/cloudflare/repo/.github/workflows/master.yml
@@ -178,7 +178,7 @@ jobs:
 
         aws s3 cp "${{ env.COVERAGE_OUTPUT_DIR }}/summary.json" "${s3FullURI}" --acl bucket-owner-full-control
   lint:
-    container: golangci/golangci-lint:v1.51
+    container: golangci/golangci-lint:v1.54.1
     name: lint
     runs-on: ubuntu-latest
     steps:

--- a/provider-ci/providers/cloudflare/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/cloudflare/repo/.github/workflows/prerelease.yml
@@ -125,7 +125,7 @@ jobs:
         - go
         - java
   lint:
-    container: golangci/golangci-lint:v1.51
+    container: golangci/golangci-lint:v1.54.1
     name: lint
     runs-on: ubuntu-latest
     steps:

--- a/provider-ci/providers/cloudflare/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/cloudflare/repo/.github/workflows/release.yml
@@ -138,7 +138,7 @@ jobs:
       run: pulumictl create docs-build pulumi-${{ env.PROVIDER }}
         "${GITHUB_REF#refs/tags/}"
   lint:
-    container: golangci/golangci-lint:v1.51
+    container: golangci/golangci-lint:v1.54.1
     name: lint
     runs-on: ubuntu-latest
     steps:

--- a/provider-ci/providers/cloudflare/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/cloudflare/repo/.github/workflows/run-acceptance-tests.yml
@@ -145,7 +145,7 @@ jobs:
         repository: ${{ github.event.client_payload.github.payload.repository.full_name }}
         token: ${{ secrets.PULUMI_BOT_TOKEN }}
   lint:
-    container: golangci/golangci-lint:v1.51
+    container: golangci/golangci-lint:v1.54.1
     if: github.event_name == 'repository_dispatch' ||
       github.event.pull_request.head.repo.full_name == github.repository
     name: lint

--- a/provider-ci/providers/consul/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/consul/repo/.github/workflows/main.yml
@@ -176,7 +176,7 @@ jobs:
 
         aws s3 cp "${{ env.COVERAGE_OUTPUT_DIR }}/summary.json" "${s3FullURI}" --acl bucket-owner-full-control
   lint:
-    container: golangci/golangci-lint:v1.51
+    container: golangci/golangci-lint:v1.54.1
     name: lint
     runs-on: ubuntu-latest
     steps:

--- a/provider-ci/providers/consul/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/consul/repo/.github/workflows/master.yml
@@ -176,7 +176,7 @@ jobs:
 
         aws s3 cp "${{ env.COVERAGE_OUTPUT_DIR }}/summary.json" "${s3FullURI}" --acl bucket-owner-full-control
   lint:
-    container: golangci/golangci-lint:v1.51
+    container: golangci/golangci-lint:v1.54.1
     name: lint
     runs-on: ubuntu-latest
     steps:

--- a/provider-ci/providers/consul/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/consul/repo/.github/workflows/prerelease.yml
@@ -123,7 +123,7 @@ jobs:
         - go
         - java
   lint:
-    container: golangci/golangci-lint:v1.51
+    container: golangci/golangci-lint:v1.54.1
     name: lint
     runs-on: ubuntu-latest
     steps:

--- a/provider-ci/providers/consul/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/consul/repo/.github/workflows/release.yml
@@ -136,7 +136,7 @@ jobs:
       run: pulumictl create docs-build pulumi-${{ env.PROVIDER }}
         "${GITHUB_REF#refs/tags/}"
   lint:
-    container: golangci/golangci-lint:v1.51
+    container: golangci/golangci-lint:v1.54.1
     name: lint
     runs-on: ubuntu-latest
     steps:

--- a/provider-ci/providers/consul/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/consul/repo/.github/workflows/run-acceptance-tests.yml
@@ -143,7 +143,7 @@ jobs:
         repository: ${{ github.event.client_payload.github.payload.repository.full_name }}
         token: ${{ secrets.PULUMI_BOT_TOKEN }}
   lint:
-    container: golangci/golangci-lint:v1.51
+    container: golangci/golangci-lint:v1.54.1
     if: github.event_name == 'repository_dispatch' ||
       github.event.pull_request.head.repo.full_name == github.repository
     name: lint

--- a/provider-ci/providers/databricks/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/databricks/repo/.github/workflows/main.yml
@@ -180,7 +180,7 @@ jobs:
 
         aws s3 cp "${{ env.COVERAGE_OUTPUT_DIR }}/summary.json" "${s3FullURI}" --acl bucket-owner-full-control
   lint:
-    container: golangci/golangci-lint:v1.51
+    container: golangci/golangci-lint:v1.54.1
     name: lint
     runs-on: ubuntu-latest
     steps:

--- a/provider-ci/providers/databricks/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/databricks/repo/.github/workflows/master.yml
@@ -180,7 +180,7 @@ jobs:
 
         aws s3 cp "${{ env.COVERAGE_OUTPUT_DIR }}/summary.json" "${s3FullURI}" --acl bucket-owner-full-control
   lint:
-    container: golangci/golangci-lint:v1.51
+    container: golangci/golangci-lint:v1.54.1
     name: lint
     runs-on: ubuntu-latest
     steps:

--- a/provider-ci/providers/databricks/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/databricks/repo/.github/workflows/prerelease.yml
@@ -127,7 +127,7 @@ jobs:
         - go
         - java
   lint:
-    container: golangci/golangci-lint:v1.51
+    container: golangci/golangci-lint:v1.54.1
     name: lint
     runs-on: ubuntu-latest
     steps:

--- a/provider-ci/providers/databricks/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/databricks/repo/.github/workflows/release.yml
@@ -140,7 +140,7 @@ jobs:
       run: pulumictl create docs-build pulumi-${{ env.PROVIDER }}
         "${GITHUB_REF#refs/tags/}"
   lint:
-    container: golangci/golangci-lint:v1.51
+    container: golangci/golangci-lint:v1.54.1
     name: lint
     runs-on: ubuntu-latest
     steps:

--- a/provider-ci/providers/databricks/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/databricks/repo/.github/workflows/run-acceptance-tests.yml
@@ -147,7 +147,7 @@ jobs:
         repository: ${{ github.event.client_payload.github.payload.repository.full_name }}
         token: ${{ secrets.PULUMI_BOT_TOKEN }}
   lint:
-    container: golangci/golangci-lint:v1.51
+    container: golangci/golangci-lint:v1.54.1
     if: github.event_name == 'repository_dispatch' ||
       github.event.pull_request.head.repo.full_name == github.repository
     name: lint

--- a/provider-ci/providers/digitalocean/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/digitalocean/repo/.github/workflows/main.yml
@@ -177,7 +177,7 @@ jobs:
 
         aws s3 cp "${{ env.COVERAGE_OUTPUT_DIR }}/summary.json" "${s3FullURI}" --acl bucket-owner-full-control
   lint:
-    container: golangci/golangci-lint:v1.51
+    container: golangci/golangci-lint:v1.54.1
     name: lint
     runs-on: ubuntu-latest
     steps:

--- a/provider-ci/providers/digitalocean/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/digitalocean/repo/.github/workflows/master.yml
@@ -177,7 +177,7 @@ jobs:
 
         aws s3 cp "${{ env.COVERAGE_OUTPUT_DIR }}/summary.json" "${s3FullURI}" --acl bucket-owner-full-control
   lint:
-    container: golangci/golangci-lint:v1.51
+    container: golangci/golangci-lint:v1.54.1
     name: lint
     runs-on: ubuntu-latest
     steps:

--- a/provider-ci/providers/digitalocean/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/digitalocean/repo/.github/workflows/prerelease.yml
@@ -124,7 +124,7 @@ jobs:
         - go
         - java
   lint:
-    container: golangci/golangci-lint:v1.51
+    container: golangci/golangci-lint:v1.54.1
     name: lint
     runs-on: ubuntu-latest
     steps:

--- a/provider-ci/providers/digitalocean/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/digitalocean/repo/.github/workflows/release.yml
@@ -137,7 +137,7 @@ jobs:
       run: pulumictl create docs-build pulumi-${{ env.PROVIDER }}
         "${GITHUB_REF#refs/tags/}"
   lint:
-    container: golangci/golangci-lint:v1.51
+    container: golangci/golangci-lint:v1.54.1
     name: lint
     runs-on: ubuntu-latest
     steps:

--- a/provider-ci/providers/digitalocean/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/digitalocean/repo/.github/workflows/run-acceptance-tests.yml
@@ -144,7 +144,7 @@ jobs:
         repository: ${{ github.event.client_payload.github.payload.repository.full_name }}
         token: ${{ secrets.PULUMI_BOT_TOKEN }}
   lint:
-    container: golangci/golangci-lint:v1.51
+    container: golangci/golangci-lint:v1.54.1
     if: github.event_name == 'repository_dispatch' ||
       github.event.pull_request.head.repo.full_name == github.repository
     name: lint

--- a/provider-ci/providers/dnsimple/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/dnsimple/repo/.github/workflows/main.yml
@@ -178,7 +178,7 @@ jobs:
 
         aws s3 cp "${{ env.COVERAGE_OUTPUT_DIR }}/summary.json" "${s3FullURI}" --acl bucket-owner-full-control
   lint:
-    container: golangci/golangci-lint:v1.51
+    container: golangci/golangci-lint:v1.54.1
     name: lint
     runs-on: ubuntu-latest
     steps:

--- a/provider-ci/providers/dnsimple/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/dnsimple/repo/.github/workflows/master.yml
@@ -178,7 +178,7 @@ jobs:
 
         aws s3 cp "${{ env.COVERAGE_OUTPUT_DIR }}/summary.json" "${s3FullURI}" --acl bucket-owner-full-control
   lint:
-    container: golangci/golangci-lint:v1.51
+    container: golangci/golangci-lint:v1.54.1
     name: lint
     runs-on: ubuntu-latest
     steps:

--- a/provider-ci/providers/dnsimple/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/dnsimple/repo/.github/workflows/prerelease.yml
@@ -125,7 +125,7 @@ jobs:
         - go
         - java
   lint:
-    container: golangci/golangci-lint:v1.51
+    container: golangci/golangci-lint:v1.54.1
     name: lint
     runs-on: ubuntu-latest
     steps:

--- a/provider-ci/providers/dnsimple/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/dnsimple/repo/.github/workflows/release.yml
@@ -138,7 +138,7 @@ jobs:
       run: pulumictl create docs-build pulumi-${{ env.PROVIDER }}
         "${GITHUB_REF#refs/tags/}"
   lint:
-    container: golangci/golangci-lint:v1.51
+    container: golangci/golangci-lint:v1.54.1
     name: lint
     runs-on: ubuntu-latest
     steps:

--- a/provider-ci/providers/dnsimple/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/dnsimple/repo/.github/workflows/run-acceptance-tests.yml
@@ -145,7 +145,7 @@ jobs:
         repository: ${{ github.event.client_payload.github.payload.repository.full_name }}
         token: ${{ secrets.PULUMI_BOT_TOKEN }}
   lint:
-    container: golangci/golangci-lint:v1.51
+    container: golangci/golangci-lint:v1.54.1
     if: github.event_name == 'repository_dispatch' ||
       github.event.pull_request.head.repo.full_name == github.repository
     name: lint

--- a/provider-ci/providers/docker/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/docker/repo/.github/workflows/main.yml
@@ -191,7 +191,7 @@ jobs:
 
         aws s3 cp "${{ env.COVERAGE_OUTPUT_DIR }}/summary.json" "${s3FullURI}" --acl bucket-owner-full-control
   lint:
-    container: golangci/golangci-lint:v1.51
+    container: golangci/golangci-lint:v1.54.1
     name: lint
     runs-on: ubuntu-latest
     steps:

--- a/provider-ci/providers/docker/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/docker/repo/.github/workflows/master.yml
@@ -191,7 +191,7 @@ jobs:
 
         aws s3 cp "${{ env.COVERAGE_OUTPUT_DIR }}/summary.json" "${s3FullURI}" --acl bucket-owner-full-control
   lint:
-    container: golangci/golangci-lint:v1.51
+    container: golangci/golangci-lint:v1.54.1
     name: lint
     runs-on: ubuntu-latest
     steps:

--- a/provider-ci/providers/docker/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/docker/repo/.github/workflows/prerelease.yml
@@ -138,7 +138,7 @@ jobs:
         - go
         - java
   lint:
-    container: golangci/golangci-lint:v1.51
+    container: golangci/golangci-lint:v1.54.1
     name: lint
     runs-on: ubuntu-latest
     steps:

--- a/provider-ci/providers/docker/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/docker/repo/.github/workflows/release.yml
@@ -151,7 +151,7 @@ jobs:
       run: pulumictl create docs-build pulumi-${{ env.PROVIDER }}
         "${GITHUB_REF#refs/tags/}"
   lint:
-    container: golangci/golangci-lint:v1.51
+    container: golangci/golangci-lint:v1.54.1
     name: lint
     runs-on: ubuntu-latest
     steps:

--- a/provider-ci/providers/docker/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/docker/repo/.github/workflows/run-acceptance-tests.yml
@@ -158,7 +158,7 @@ jobs:
         repository: ${{ github.event.client_payload.github.payload.repository.full_name }}
         token: ${{ secrets.PULUMI_BOT_TOKEN }}
   lint:
-    container: golangci/golangci-lint:v1.51
+    container: golangci/golangci-lint:v1.54.1
     if: github.event_name == 'repository_dispatch' ||
       github.event.pull_request.head.repo.full_name == github.repository
     name: lint

--- a/provider-ci/providers/ec/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/ec/repo/.github/workflows/main.yml
@@ -177,7 +177,7 @@ jobs:
 
         aws s3 cp "${{ env.COVERAGE_OUTPUT_DIR }}/summary.json" "${s3FullURI}" --acl bucket-owner-full-control
   lint:
-    container: golangci/golangci-lint:v1.51
+    container: golangci/golangci-lint:v1.54.1
     name: lint
     runs-on: ubuntu-latest
     steps:

--- a/provider-ci/providers/ec/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/ec/repo/.github/workflows/master.yml
@@ -177,7 +177,7 @@ jobs:
 
         aws s3 cp "${{ env.COVERAGE_OUTPUT_DIR }}/summary.json" "${s3FullURI}" --acl bucket-owner-full-control
   lint:
-    container: golangci/golangci-lint:v1.51
+    container: golangci/golangci-lint:v1.54.1
     name: lint
     runs-on: ubuntu-latest
     steps:

--- a/provider-ci/providers/ec/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/ec/repo/.github/workflows/prerelease.yml
@@ -124,7 +124,7 @@ jobs:
         - go
         - java
   lint:
-    container: golangci/golangci-lint:v1.51
+    container: golangci/golangci-lint:v1.54.1
     name: lint
     runs-on: ubuntu-latest
     steps:

--- a/provider-ci/providers/ec/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/ec/repo/.github/workflows/release.yml
@@ -137,7 +137,7 @@ jobs:
       run: pulumictl create docs-build pulumi-${{ env.PROVIDER }}
         "${GITHUB_REF#refs/tags/}"
   lint:
-    container: golangci/golangci-lint:v1.51
+    container: golangci/golangci-lint:v1.54.1
     name: lint
     runs-on: ubuntu-latest
     steps:

--- a/provider-ci/providers/ec/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/ec/repo/.github/workflows/run-acceptance-tests.yml
@@ -144,7 +144,7 @@ jobs:
         repository: ${{ github.event.client_payload.github.payload.repository.full_name }}
         token: ${{ secrets.PULUMI_BOT_TOKEN }}
   lint:
-    container: golangci/golangci-lint:v1.51
+    container: golangci/golangci-lint:v1.54.1
     if: github.event_name == 'repository_dispatch' ||
       github.event.pull_request.head.repo.full_name == github.repository
     name: lint

--- a/provider-ci/providers/f5bigip/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/f5bigip/repo/.github/workflows/main.yml
@@ -180,7 +180,7 @@ jobs:
 
         aws s3 cp "${{ env.COVERAGE_OUTPUT_DIR }}/summary.json" "${s3FullURI}" --acl bucket-owner-full-control
   lint:
-    container: golangci/golangci-lint:v1.51
+    container: golangci/golangci-lint:v1.54.1
     name: lint
     runs-on: ubuntu-latest
     steps:

--- a/provider-ci/providers/f5bigip/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/f5bigip/repo/.github/workflows/master.yml
@@ -180,7 +180,7 @@ jobs:
 
         aws s3 cp "${{ env.COVERAGE_OUTPUT_DIR }}/summary.json" "${s3FullURI}" --acl bucket-owner-full-control
   lint:
-    container: golangci/golangci-lint:v1.51
+    container: golangci/golangci-lint:v1.54.1
     name: lint
     runs-on: ubuntu-latest
     steps:

--- a/provider-ci/providers/f5bigip/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/f5bigip/repo/.github/workflows/prerelease.yml
@@ -127,7 +127,7 @@ jobs:
         - go
         - java
   lint:
-    container: golangci/golangci-lint:v1.51
+    container: golangci/golangci-lint:v1.54.1
     name: lint
     runs-on: ubuntu-latest
     steps:

--- a/provider-ci/providers/f5bigip/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/f5bigip/repo/.github/workflows/release.yml
@@ -140,7 +140,7 @@ jobs:
       run: pulumictl create docs-build pulumi-${{ env.PROVIDER }}
         "${GITHUB_REF#refs/tags/}"
   lint:
-    container: golangci/golangci-lint:v1.51
+    container: golangci/golangci-lint:v1.54.1
     name: lint
     runs-on: ubuntu-latest
     steps:

--- a/provider-ci/providers/f5bigip/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/f5bigip/repo/.github/workflows/run-acceptance-tests.yml
@@ -147,7 +147,7 @@ jobs:
         repository: ${{ github.event.client_payload.github.payload.repository.full_name }}
         token: ${{ secrets.PULUMI_BOT_TOKEN }}
   lint:
-    container: golangci/golangci-lint:v1.51
+    container: golangci/golangci-lint:v1.54.1
     if: github.event_name == 'repository_dispatch' ||
       github.event.pull_request.head.repo.full_name == github.repository
     name: lint

--- a/provider-ci/providers/fastly/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/fastly/repo/.github/workflows/main.yml
@@ -177,7 +177,7 @@ jobs:
 
         aws s3 cp "${{ env.COVERAGE_OUTPUT_DIR }}/summary.json" "${s3FullURI}" --acl bucket-owner-full-control
   lint:
-    container: golangci/golangci-lint:v1.51
+    container: golangci/golangci-lint:v1.54.1
     name: lint
     runs-on: ubuntu-latest
     steps:

--- a/provider-ci/providers/fastly/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/fastly/repo/.github/workflows/master.yml
@@ -177,7 +177,7 @@ jobs:
 
         aws s3 cp "${{ env.COVERAGE_OUTPUT_DIR }}/summary.json" "${s3FullURI}" --acl bucket-owner-full-control
   lint:
-    container: golangci/golangci-lint:v1.51
+    container: golangci/golangci-lint:v1.54.1
     name: lint
     runs-on: ubuntu-latest
     steps:

--- a/provider-ci/providers/fastly/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/fastly/repo/.github/workflows/prerelease.yml
@@ -124,7 +124,7 @@ jobs:
         - go
         - java
   lint:
-    container: golangci/golangci-lint:v1.51
+    container: golangci/golangci-lint:v1.54.1
     name: lint
     runs-on: ubuntu-latest
     steps:

--- a/provider-ci/providers/fastly/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/fastly/repo/.github/workflows/release.yml
@@ -137,7 +137,7 @@ jobs:
       run: pulumictl create docs-build pulumi-${{ env.PROVIDER }}
         "${GITHUB_REF#refs/tags/}"
   lint:
-    container: golangci/golangci-lint:v1.51
+    container: golangci/golangci-lint:v1.54.1
     name: lint
     runs-on: ubuntu-latest
     steps:

--- a/provider-ci/providers/fastly/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/fastly/repo/.github/workflows/run-acceptance-tests.yml
@@ -144,7 +144,7 @@ jobs:
         repository: ${{ github.event.client_payload.github.payload.repository.full_name }}
         token: ${{ secrets.PULUMI_BOT_TOKEN }}
   lint:
-    container: golangci/golangci-lint:v1.51
+    container: golangci/golangci-lint:v1.54.1
     if: github.event_name == 'repository_dispatch' ||
       github.event.pull_request.head.repo.full_name == github.repository
     name: lint

--- a/provider-ci/providers/github/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/github/repo/.github/workflows/main.yml
@@ -178,7 +178,7 @@ jobs:
 
         aws s3 cp "${{ env.COVERAGE_OUTPUT_DIR }}/summary.json" "${s3FullURI}" --acl bucket-owner-full-control
   lint:
-    container: golangci/golangci-lint:v1.51
+    container: golangci/golangci-lint:v1.54.1
     name: lint
     runs-on: ubuntu-latest
     steps:

--- a/provider-ci/providers/github/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/github/repo/.github/workflows/master.yml
@@ -178,7 +178,7 @@ jobs:
 
         aws s3 cp "${{ env.COVERAGE_OUTPUT_DIR }}/summary.json" "${s3FullURI}" --acl bucket-owner-full-control
   lint:
-    container: golangci/golangci-lint:v1.51
+    container: golangci/golangci-lint:v1.54.1
     name: lint
     runs-on: ubuntu-latest
     steps:

--- a/provider-ci/providers/github/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/github/repo/.github/workflows/prerelease.yml
@@ -125,7 +125,7 @@ jobs:
         - go
         - java
   lint:
-    container: golangci/golangci-lint:v1.51
+    container: golangci/golangci-lint:v1.54.1
     name: lint
     runs-on: ubuntu-latest
     steps:

--- a/provider-ci/providers/github/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/github/repo/.github/workflows/release.yml
@@ -138,7 +138,7 @@ jobs:
       run: pulumictl create docs-build pulumi-${{ env.PROVIDER }}
         "${GITHUB_REF#refs/tags/}"
   lint:
-    container: golangci/golangci-lint:v1.51
+    container: golangci/golangci-lint:v1.54.1
     name: lint
     runs-on: ubuntu-latest
     steps:

--- a/provider-ci/providers/github/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/github/repo/.github/workflows/run-acceptance-tests.yml
@@ -145,7 +145,7 @@ jobs:
         repository: ${{ github.event.client_payload.github.payload.repository.full_name }}
         token: ${{ secrets.PULUMI_BOT_TOKEN }}
   lint:
-    container: golangci/golangci-lint:v1.51
+    container: golangci/golangci-lint:v1.54.1
     if: github.event_name == 'repository_dispatch' ||
       github.event.pull_request.head.repo.full_name == github.repository
     name: lint

--- a/provider-ci/providers/gitlab/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/gitlab/repo/.github/workflows/main.yml
@@ -177,7 +177,7 @@ jobs:
 
         aws s3 cp "${{ env.COVERAGE_OUTPUT_DIR }}/summary.json" "${s3FullURI}" --acl bucket-owner-full-control
   lint:
-    container: golangci/golangci-lint:v1.51
+    container: golangci/golangci-lint:v1.54.1
     name: lint
     runs-on: ubuntu-latest
     steps:

--- a/provider-ci/providers/gitlab/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/gitlab/repo/.github/workflows/master.yml
@@ -177,7 +177,7 @@ jobs:
 
         aws s3 cp "${{ env.COVERAGE_OUTPUT_DIR }}/summary.json" "${s3FullURI}" --acl bucket-owner-full-control
   lint:
-    container: golangci/golangci-lint:v1.51
+    container: golangci/golangci-lint:v1.54.1
     name: lint
     runs-on: ubuntu-latest
     steps:

--- a/provider-ci/providers/gitlab/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/gitlab/repo/.github/workflows/prerelease.yml
@@ -124,7 +124,7 @@ jobs:
         - go
         - java
   lint:
-    container: golangci/golangci-lint:v1.51
+    container: golangci/golangci-lint:v1.54.1
     name: lint
     runs-on: ubuntu-latest
     steps:

--- a/provider-ci/providers/gitlab/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/gitlab/repo/.github/workflows/release.yml
@@ -137,7 +137,7 @@ jobs:
       run: pulumictl create docs-build pulumi-${{ env.PROVIDER }}
         "${GITHUB_REF#refs/tags/}"
   lint:
-    container: golangci/golangci-lint:v1.51
+    container: golangci/golangci-lint:v1.54.1
     name: lint
     runs-on: ubuntu-latest
     steps:

--- a/provider-ci/providers/gitlab/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/gitlab/repo/.github/workflows/run-acceptance-tests.yml
@@ -144,7 +144,7 @@ jobs:
         repository: ${{ github.event.client_payload.github.payload.repository.full_name }}
         token: ${{ secrets.PULUMI_BOT_TOKEN }}
   lint:
-    container: golangci/golangci-lint:v1.51
+    container: golangci/golangci-lint:v1.54.1
     if: github.event_name == 'repository_dispatch' ||
       github.event.pull_request.head.repo.full_name == github.repository
     name: lint

--- a/provider-ci/providers/hcloud/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/hcloud/repo/.github/workflows/main.yml
@@ -177,7 +177,7 @@ jobs:
 
         aws s3 cp "${{ env.COVERAGE_OUTPUT_DIR }}/summary.json" "${s3FullURI}" --acl bucket-owner-full-control
   lint:
-    container: golangci/golangci-lint:v1.51
+    container: golangci/golangci-lint:v1.54.1
     name: lint
     runs-on: ubuntu-latest
     steps:

--- a/provider-ci/providers/hcloud/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/hcloud/repo/.github/workflows/master.yml
@@ -177,7 +177,7 @@ jobs:
 
         aws s3 cp "${{ env.COVERAGE_OUTPUT_DIR }}/summary.json" "${s3FullURI}" --acl bucket-owner-full-control
   lint:
-    container: golangci/golangci-lint:v1.51
+    container: golangci/golangci-lint:v1.54.1
     name: lint
     runs-on: ubuntu-latest
     steps:

--- a/provider-ci/providers/hcloud/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/hcloud/repo/.github/workflows/prerelease.yml
@@ -124,7 +124,7 @@ jobs:
         - go
         - java
   lint:
-    container: golangci/golangci-lint:v1.51
+    container: golangci/golangci-lint:v1.54.1
     name: lint
     runs-on: ubuntu-latest
     steps:

--- a/provider-ci/providers/hcloud/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/hcloud/repo/.github/workflows/release.yml
@@ -137,7 +137,7 @@ jobs:
       run: pulumictl create docs-build pulumi-${{ env.PROVIDER }}
         "${GITHUB_REF#refs/tags/}"
   lint:
-    container: golangci/golangci-lint:v1.51
+    container: golangci/golangci-lint:v1.54.1
     name: lint
     runs-on: ubuntu-latest
     steps:

--- a/provider-ci/providers/hcloud/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/hcloud/repo/.github/workflows/run-acceptance-tests.yml
@@ -144,7 +144,7 @@ jobs:
         repository: ${{ github.event.client_payload.github.payload.repository.full_name }}
         token: ${{ secrets.PULUMI_BOT_TOKEN }}
   lint:
-    container: golangci/golangci-lint:v1.51
+    container: golangci/golangci-lint:v1.54.1
     if: github.event_name == 'repository_dispatch' ||
       github.event.pull_request.head.repo.full_name == github.repository
     name: lint

--- a/provider-ci/providers/kafka/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/kafka/repo/.github/workflows/main.yml
@@ -176,7 +176,7 @@ jobs:
 
         aws s3 cp "${{ env.COVERAGE_OUTPUT_DIR }}/summary.json" "${s3FullURI}" --acl bucket-owner-full-control
   lint:
-    container: golangci/golangci-lint:v1.51
+    container: golangci/golangci-lint:v1.54.1
     name: lint
     runs-on: ubuntu-latest
     steps:

--- a/provider-ci/providers/kafka/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/kafka/repo/.github/workflows/master.yml
@@ -176,7 +176,7 @@ jobs:
 
         aws s3 cp "${{ env.COVERAGE_OUTPUT_DIR }}/summary.json" "${s3FullURI}" --acl bucket-owner-full-control
   lint:
-    container: golangci/golangci-lint:v1.51
+    container: golangci/golangci-lint:v1.54.1
     name: lint
     runs-on: ubuntu-latest
     steps:

--- a/provider-ci/providers/kafka/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/kafka/repo/.github/workflows/prerelease.yml
@@ -123,7 +123,7 @@ jobs:
         - go
         - java
   lint:
-    container: golangci/golangci-lint:v1.51
+    container: golangci/golangci-lint:v1.54.1
     name: lint
     runs-on: ubuntu-latest
     steps:

--- a/provider-ci/providers/kafka/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/kafka/repo/.github/workflows/release.yml
@@ -136,7 +136,7 @@ jobs:
       run: pulumictl create docs-build pulumi-${{ env.PROVIDER }}
         "${GITHUB_REF#refs/tags/}"
   lint:
-    container: golangci/golangci-lint:v1.51
+    container: golangci/golangci-lint:v1.54.1
     name: lint
     runs-on: ubuntu-latest
     steps:

--- a/provider-ci/providers/kafka/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/kafka/repo/.github/workflows/run-acceptance-tests.yml
@@ -143,7 +143,7 @@ jobs:
         repository: ${{ github.event.client_payload.github.payload.repository.full_name }}
         token: ${{ secrets.PULUMI_BOT_TOKEN }}
   lint:
-    container: golangci/golangci-lint:v1.51
+    container: golangci/golangci-lint:v1.54.1
     if: github.event_name == 'repository_dispatch' ||
       github.event.pull_request.head.repo.full_name == github.repository
     name: lint

--- a/provider-ci/providers/keycloak/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/keycloak/repo/.github/workflows/main.yml
@@ -181,7 +181,7 @@ jobs:
 
         aws s3 cp "${{ env.COVERAGE_OUTPUT_DIR }}/summary.json" "${s3FullURI}" --acl bucket-owner-full-control
   lint:
-    container: golangci/golangci-lint:v1.51
+    container: golangci/golangci-lint:v1.54.1
     name: lint
     runs-on: ubuntu-latest
     steps:

--- a/provider-ci/providers/keycloak/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/keycloak/repo/.github/workflows/master.yml
@@ -181,7 +181,7 @@ jobs:
 
         aws s3 cp "${{ env.COVERAGE_OUTPUT_DIR }}/summary.json" "${s3FullURI}" --acl bucket-owner-full-control
   lint:
-    container: golangci/golangci-lint:v1.51
+    container: golangci/golangci-lint:v1.54.1
     name: lint
     runs-on: ubuntu-latest
     steps:

--- a/provider-ci/providers/keycloak/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/keycloak/repo/.github/workflows/prerelease.yml
@@ -128,7 +128,7 @@ jobs:
         - go
         - java
   lint:
-    container: golangci/golangci-lint:v1.51
+    container: golangci/golangci-lint:v1.54.1
     name: lint
     runs-on: ubuntu-latest
     steps:

--- a/provider-ci/providers/keycloak/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/keycloak/repo/.github/workflows/release.yml
@@ -141,7 +141,7 @@ jobs:
       run: pulumictl create docs-build pulumi-${{ env.PROVIDER }}
         "${GITHUB_REF#refs/tags/}"
   lint:
-    container: golangci/golangci-lint:v1.51
+    container: golangci/golangci-lint:v1.54.1
     name: lint
     runs-on: ubuntu-latest
     steps:

--- a/provider-ci/providers/keycloak/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/keycloak/repo/.github/workflows/run-acceptance-tests.yml
@@ -148,7 +148,7 @@ jobs:
         repository: ${{ github.event.client_payload.github.payload.repository.full_name }}
         token: ${{ secrets.PULUMI_BOT_TOKEN }}
   lint:
-    container: golangci/golangci-lint:v1.51
+    container: golangci/golangci-lint:v1.54.1
     if: github.event_name == 'repository_dispatch' ||
       github.event.pull_request.head.repo.full_name == github.repository
     name: lint

--- a/provider-ci/providers/kong/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/kong/repo/.github/workflows/main.yml
@@ -176,7 +176,7 @@ jobs:
 
         aws s3 cp "${{ env.COVERAGE_OUTPUT_DIR }}/summary.json" "${s3FullURI}" --acl bucket-owner-full-control
   lint:
-    container: golangci/golangci-lint:v1.51
+    container: golangci/golangci-lint:v1.54.1
     name: lint
     runs-on: ubuntu-latest
     steps:

--- a/provider-ci/providers/kong/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/kong/repo/.github/workflows/master.yml
@@ -176,7 +176,7 @@ jobs:
 
         aws s3 cp "${{ env.COVERAGE_OUTPUT_DIR }}/summary.json" "${s3FullURI}" --acl bucket-owner-full-control
   lint:
-    container: golangci/golangci-lint:v1.51
+    container: golangci/golangci-lint:v1.54.1
     name: lint
     runs-on: ubuntu-latest
     steps:

--- a/provider-ci/providers/kong/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/kong/repo/.github/workflows/prerelease.yml
@@ -123,7 +123,7 @@ jobs:
         - go
         - java
   lint:
-    container: golangci/golangci-lint:v1.51
+    container: golangci/golangci-lint:v1.54.1
     name: lint
     runs-on: ubuntu-latest
     steps:

--- a/provider-ci/providers/kong/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/kong/repo/.github/workflows/release.yml
@@ -136,7 +136,7 @@ jobs:
       run: pulumictl create docs-build pulumi-${{ env.PROVIDER }}
         "${GITHUB_REF#refs/tags/}"
   lint:
-    container: golangci/golangci-lint:v1.51
+    container: golangci/golangci-lint:v1.54.1
     name: lint
     runs-on: ubuntu-latest
     steps:

--- a/provider-ci/providers/kong/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/kong/repo/.github/workflows/run-acceptance-tests.yml
@@ -143,7 +143,7 @@ jobs:
         repository: ${{ github.event.client_payload.github.payload.repository.full_name }}
         token: ${{ secrets.PULUMI_BOT_TOKEN }}
   lint:
-    container: golangci/golangci-lint:v1.51
+    container: golangci/golangci-lint:v1.54.1
     if: github.event_name == 'repository_dispatch' ||
       github.event.pull_request.head.repo.full_name == github.repository
     name: lint

--- a/provider-ci/providers/libvirt/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/libvirt/repo/.github/workflows/main.yml
@@ -177,7 +177,7 @@ jobs:
 
         aws s3 cp "${{ env.COVERAGE_OUTPUT_DIR }}/summary.json" "${s3FullURI}" --acl bucket-owner-full-control
   lint:
-    container: golangci/golangci-lint:v1.51
+    container: golangci/golangci-lint:v1.54.1
     name: lint
     runs-on: ubuntu-latest
     steps:

--- a/provider-ci/providers/libvirt/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/libvirt/repo/.github/workflows/master.yml
@@ -177,7 +177,7 @@ jobs:
 
         aws s3 cp "${{ env.COVERAGE_OUTPUT_DIR }}/summary.json" "${s3FullURI}" --acl bucket-owner-full-control
   lint:
-    container: golangci/golangci-lint:v1.51
+    container: golangci/golangci-lint:v1.54.1
     name: lint
     runs-on: ubuntu-latest
     steps:

--- a/provider-ci/providers/libvirt/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/libvirt/repo/.github/workflows/prerelease.yml
@@ -124,7 +124,7 @@ jobs:
         - go
         - java
   lint:
-    container: golangci/golangci-lint:v1.51
+    container: golangci/golangci-lint:v1.54.1
     name: lint
     runs-on: ubuntu-latest
     steps:

--- a/provider-ci/providers/libvirt/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/libvirt/repo/.github/workflows/release.yml
@@ -137,7 +137,7 @@ jobs:
       run: pulumictl create docs-build pulumi-${{ env.PROVIDER }}
         "${GITHUB_REF#refs/tags/}"
   lint:
-    container: golangci/golangci-lint:v1.51
+    container: golangci/golangci-lint:v1.54.1
     name: lint
     runs-on: ubuntu-latest
     steps:

--- a/provider-ci/providers/libvirt/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/libvirt/repo/.github/workflows/run-acceptance-tests.yml
@@ -144,7 +144,7 @@ jobs:
         repository: ${{ github.event.client_payload.github.payload.repository.full_name }}
         token: ${{ secrets.PULUMI_BOT_TOKEN }}
   lint:
-    container: golangci/golangci-lint:v1.51
+    container: golangci/golangci-lint:v1.54.1
     if: github.event_name == 'repository_dispatch' ||
       github.event.pull_request.head.repo.full_name == github.repository
     name: lint

--- a/provider-ci/providers/linode/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/linode/repo/.github/workflows/main.yml
@@ -177,7 +177,7 @@ jobs:
 
         aws s3 cp "${{ env.COVERAGE_OUTPUT_DIR }}/summary.json" "${s3FullURI}" --acl bucket-owner-full-control
   lint:
-    container: golangci/golangci-lint:v1.51
+    container: golangci/golangci-lint:v1.54.1
     name: lint
     runs-on: ubuntu-latest
     steps:

--- a/provider-ci/providers/linode/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/linode/repo/.github/workflows/master.yml
@@ -177,7 +177,7 @@ jobs:
 
         aws s3 cp "${{ env.COVERAGE_OUTPUT_DIR }}/summary.json" "${s3FullURI}" --acl bucket-owner-full-control
   lint:
-    container: golangci/golangci-lint:v1.51
+    container: golangci/golangci-lint:v1.54.1
     name: lint
     runs-on: ubuntu-latest
     steps:

--- a/provider-ci/providers/linode/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/linode/repo/.github/workflows/prerelease.yml
@@ -124,7 +124,7 @@ jobs:
         - go
         - java
   lint:
-    container: golangci/golangci-lint:v1.51
+    container: golangci/golangci-lint:v1.54.1
     name: lint
     runs-on: ubuntu-latest
     steps:

--- a/provider-ci/providers/linode/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/linode/repo/.github/workflows/release.yml
@@ -137,7 +137,7 @@ jobs:
       run: pulumictl create docs-build pulumi-${{ env.PROVIDER }}
         "${GITHUB_REF#refs/tags/}"
   lint:
-    container: golangci/golangci-lint:v1.51
+    container: golangci/golangci-lint:v1.54.1
     name: lint
     runs-on: ubuntu-latest
     steps:

--- a/provider-ci/providers/linode/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/linode/repo/.github/workflows/run-acceptance-tests.yml
@@ -144,7 +144,7 @@ jobs:
         repository: ${{ github.event.client_payload.github.payload.repository.full_name }}
         token: ${{ secrets.PULUMI_BOT_TOKEN }}
   lint:
-    container: golangci/golangci-lint:v1.51
+    container: golangci/golangci-lint:v1.54.1
     if: github.event_name == 'repository_dispatch' ||
       github.event.pull_request.head.repo.full_name == github.repository
     name: lint

--- a/provider-ci/providers/mailgun/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/mailgun/repo/.github/workflows/main.yml
@@ -177,7 +177,7 @@ jobs:
 
         aws s3 cp "${{ env.COVERAGE_OUTPUT_DIR }}/summary.json" "${s3FullURI}" --acl bucket-owner-full-control
   lint:
-    container: golangci/golangci-lint:v1.51
+    container: golangci/golangci-lint:v1.54.1
     name: lint
     runs-on: ubuntu-latest
     steps:

--- a/provider-ci/providers/mailgun/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/mailgun/repo/.github/workflows/master.yml
@@ -177,7 +177,7 @@ jobs:
 
         aws s3 cp "${{ env.COVERAGE_OUTPUT_DIR }}/summary.json" "${s3FullURI}" --acl bucket-owner-full-control
   lint:
-    container: golangci/golangci-lint:v1.51
+    container: golangci/golangci-lint:v1.54.1
     name: lint
     runs-on: ubuntu-latest
     steps:

--- a/provider-ci/providers/mailgun/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/mailgun/repo/.github/workflows/prerelease.yml
@@ -124,7 +124,7 @@ jobs:
         - go
         - java
   lint:
-    container: golangci/golangci-lint:v1.51
+    container: golangci/golangci-lint:v1.54.1
     name: lint
     runs-on: ubuntu-latest
     steps:

--- a/provider-ci/providers/mailgun/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/mailgun/repo/.github/workflows/release.yml
@@ -137,7 +137,7 @@ jobs:
       run: pulumictl create docs-build pulumi-${{ env.PROVIDER }}
         "${GITHUB_REF#refs/tags/}"
   lint:
-    container: golangci/golangci-lint:v1.51
+    container: golangci/golangci-lint:v1.54.1
     name: lint
     runs-on: ubuntu-latest
     steps:

--- a/provider-ci/providers/mailgun/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/mailgun/repo/.github/workflows/run-acceptance-tests.yml
@@ -144,7 +144,7 @@ jobs:
         repository: ${{ github.event.client_payload.github.payload.repository.full_name }}
         token: ${{ secrets.PULUMI_BOT_TOKEN }}
   lint:
-    container: golangci/golangci-lint:v1.51
+    container: golangci/golangci-lint:v1.54.1
     if: github.event_name == 'repository_dispatch' ||
       github.event.pull_request.head.repo.full_name == github.repository
     name: lint

--- a/provider-ci/providers/minio/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/minio/repo/.github/workflows/main.yml
@@ -180,7 +180,7 @@ jobs:
 
         aws s3 cp "${{ env.COVERAGE_OUTPUT_DIR }}/summary.json" "${s3FullURI}" --acl bucket-owner-full-control
   lint:
-    container: golangci/golangci-lint:v1.51
+    container: golangci/golangci-lint:v1.54.1
     name: lint
     runs-on: ubuntu-latest
     steps:

--- a/provider-ci/providers/minio/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/minio/repo/.github/workflows/master.yml
@@ -180,7 +180,7 @@ jobs:
 
         aws s3 cp "${{ env.COVERAGE_OUTPUT_DIR }}/summary.json" "${s3FullURI}" --acl bucket-owner-full-control
   lint:
-    container: golangci/golangci-lint:v1.51
+    container: golangci/golangci-lint:v1.54.1
     name: lint
     runs-on: ubuntu-latest
     steps:

--- a/provider-ci/providers/minio/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/minio/repo/.github/workflows/prerelease.yml
@@ -127,7 +127,7 @@ jobs:
         - go
         - java
   lint:
-    container: golangci/golangci-lint:v1.51
+    container: golangci/golangci-lint:v1.54.1
     name: lint
     runs-on: ubuntu-latest
     steps:

--- a/provider-ci/providers/minio/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/minio/repo/.github/workflows/release.yml
@@ -140,7 +140,7 @@ jobs:
       run: pulumictl create docs-build pulumi-${{ env.PROVIDER }}
         "${GITHUB_REF#refs/tags/}"
   lint:
-    container: golangci/golangci-lint:v1.51
+    container: golangci/golangci-lint:v1.54.1
     name: lint
     runs-on: ubuntu-latest
     steps:

--- a/provider-ci/providers/minio/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/minio/repo/.github/workflows/run-acceptance-tests.yml
@@ -147,7 +147,7 @@ jobs:
         repository: ${{ github.event.client_payload.github.payload.repository.full_name }}
         token: ${{ secrets.PULUMI_BOT_TOKEN }}
   lint:
-    container: golangci/golangci-lint:v1.51
+    container: golangci/golangci-lint:v1.54.1
     if: github.event_name == 'repository_dispatch' ||
       github.event.pull_request.head.repo.full_name == github.repository
     name: lint

--- a/provider-ci/providers/mongodbatlas/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/mongodbatlas/repo/.github/workflows/main.yml
@@ -179,7 +179,7 @@ jobs:
 
         aws s3 cp "${{ env.COVERAGE_OUTPUT_DIR }}/summary.json" "${s3FullURI}" --acl bucket-owner-full-control
   lint:
-    container: golangci/golangci-lint:v1.51
+    container: golangci/golangci-lint:v1.54.1
     name: lint
     runs-on: ubuntu-latest
     steps:

--- a/provider-ci/providers/mongodbatlas/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/mongodbatlas/repo/.github/workflows/master.yml
@@ -179,7 +179,7 @@ jobs:
 
         aws s3 cp "${{ env.COVERAGE_OUTPUT_DIR }}/summary.json" "${s3FullURI}" --acl bucket-owner-full-control
   lint:
-    container: golangci/golangci-lint:v1.51
+    container: golangci/golangci-lint:v1.54.1
     name: lint
     runs-on: ubuntu-latest
     steps:

--- a/provider-ci/providers/mongodbatlas/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/mongodbatlas/repo/.github/workflows/prerelease.yml
@@ -126,7 +126,7 @@ jobs:
         - go
         - java
   lint:
-    container: golangci/golangci-lint:v1.51
+    container: golangci/golangci-lint:v1.54.1
     name: lint
     runs-on: ubuntu-latest
     steps:

--- a/provider-ci/providers/mongodbatlas/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/mongodbatlas/repo/.github/workflows/release.yml
@@ -139,7 +139,7 @@ jobs:
       run: pulumictl create docs-build pulumi-${{ env.PROVIDER }}
         "${GITHUB_REF#refs/tags/}"
   lint:
-    container: golangci/golangci-lint:v1.51
+    container: golangci/golangci-lint:v1.54.1
     name: lint
     runs-on: ubuntu-latest
     steps:

--- a/provider-ci/providers/mongodbatlas/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/mongodbatlas/repo/.github/workflows/run-acceptance-tests.yml
@@ -146,7 +146,7 @@ jobs:
         repository: ${{ github.event.client_payload.github.payload.repository.full_name }}
         token: ${{ secrets.PULUMI_BOT_TOKEN }}
   lint:
-    container: golangci/golangci-lint:v1.51
+    container: golangci/golangci-lint:v1.54.1
     if: github.event_name == 'repository_dispatch' ||
       github.event.pull_request.head.repo.full_name == github.repository
     name: lint

--- a/provider-ci/providers/mysql/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/mysql/repo/.github/workflows/main.yml
@@ -176,7 +176,7 @@ jobs:
 
         aws s3 cp "${{ env.COVERAGE_OUTPUT_DIR }}/summary.json" "${s3FullURI}" --acl bucket-owner-full-control
   lint:
-    container: golangci/golangci-lint:v1.51
+    container: golangci/golangci-lint:v1.54.1
     name: lint
     runs-on: ubuntu-latest
     steps:

--- a/provider-ci/providers/mysql/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/mysql/repo/.github/workflows/master.yml
@@ -176,7 +176,7 @@ jobs:
 
         aws s3 cp "${{ env.COVERAGE_OUTPUT_DIR }}/summary.json" "${s3FullURI}" --acl bucket-owner-full-control
   lint:
-    container: golangci/golangci-lint:v1.51
+    container: golangci/golangci-lint:v1.54.1
     name: lint
     runs-on: ubuntu-latest
     steps:

--- a/provider-ci/providers/mysql/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/mysql/repo/.github/workflows/prerelease.yml
@@ -123,7 +123,7 @@ jobs:
         - go
         - java
   lint:
-    container: golangci/golangci-lint:v1.51
+    container: golangci/golangci-lint:v1.54.1
     name: lint
     runs-on: ubuntu-latest
     steps:

--- a/provider-ci/providers/mysql/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/mysql/repo/.github/workflows/release.yml
@@ -136,7 +136,7 @@ jobs:
       run: pulumictl create docs-build pulumi-${{ env.PROVIDER }}
         "${GITHUB_REF#refs/tags/}"
   lint:
-    container: golangci/golangci-lint:v1.51
+    container: golangci/golangci-lint:v1.54.1
     name: lint
     runs-on: ubuntu-latest
     steps:

--- a/provider-ci/providers/mysql/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/mysql/repo/.github/workflows/run-acceptance-tests.yml
@@ -143,7 +143,7 @@ jobs:
         repository: ${{ github.event.client_payload.github.payload.repository.full_name }}
         token: ${{ secrets.PULUMI_BOT_TOKEN }}
   lint:
-    container: golangci/golangci-lint:v1.51
+    container: golangci/golangci-lint:v1.54.1
     if: github.event_name == 'repository_dispatch' ||
       github.event.pull_request.head.repo.full_name == github.repository
     name: lint

--- a/provider-ci/providers/newrelic/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/newrelic/repo/.github/workflows/main.yml
@@ -178,7 +178,7 @@ jobs:
 
         aws s3 cp "${{ env.COVERAGE_OUTPUT_DIR }}/summary.json" "${s3FullURI}" --acl bucket-owner-full-control
   lint:
-    container: golangci/golangci-lint:v1.51
+    container: golangci/golangci-lint:v1.54.1
     name: lint
     runs-on: ubuntu-latest
     steps:

--- a/provider-ci/providers/newrelic/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/newrelic/repo/.github/workflows/master.yml
@@ -178,7 +178,7 @@ jobs:
 
         aws s3 cp "${{ env.COVERAGE_OUTPUT_DIR }}/summary.json" "${s3FullURI}" --acl bucket-owner-full-control
   lint:
-    container: golangci/golangci-lint:v1.51
+    container: golangci/golangci-lint:v1.54.1
     name: lint
     runs-on: ubuntu-latest
     steps:

--- a/provider-ci/providers/newrelic/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/newrelic/repo/.github/workflows/prerelease.yml
@@ -125,7 +125,7 @@ jobs:
         - go
         - java
   lint:
-    container: golangci/golangci-lint:v1.51
+    container: golangci/golangci-lint:v1.54.1
     name: lint
     runs-on: ubuntu-latest
     steps:

--- a/provider-ci/providers/newrelic/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/newrelic/repo/.github/workflows/release.yml
@@ -138,7 +138,7 @@ jobs:
       run: pulumictl create docs-build pulumi-${{ env.PROVIDER }}
         "${GITHUB_REF#refs/tags/}"
   lint:
-    container: golangci/golangci-lint:v1.51
+    container: golangci/golangci-lint:v1.54.1
     name: lint
     runs-on: ubuntu-latest
     steps:

--- a/provider-ci/providers/newrelic/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/newrelic/repo/.github/workflows/run-acceptance-tests.yml
@@ -145,7 +145,7 @@ jobs:
         repository: ${{ github.event.client_payload.github.payload.repository.full_name }}
         token: ${{ secrets.PULUMI_BOT_TOKEN }}
   lint:
-    container: golangci/golangci-lint:v1.51
+    container: golangci/golangci-lint:v1.54.1
     if: github.event_name == 'repository_dispatch' ||
       github.event.pull_request.head.repo.full_name == github.repository
     name: lint

--- a/provider-ci/providers/nomad/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/nomad/repo/.github/workflows/main.yml
@@ -177,7 +177,7 @@ jobs:
 
         aws s3 cp "${{ env.COVERAGE_OUTPUT_DIR }}/summary.json" "${s3FullURI}" --acl bucket-owner-full-control
   lint:
-    container: golangci/golangci-lint:v1.51
+    container: golangci/golangci-lint:v1.54.1
     name: lint
     runs-on: ubuntu-latest
     steps:

--- a/provider-ci/providers/nomad/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/nomad/repo/.github/workflows/master.yml
@@ -177,7 +177,7 @@ jobs:
 
         aws s3 cp "${{ env.COVERAGE_OUTPUT_DIR }}/summary.json" "${s3FullURI}" --acl bucket-owner-full-control
   lint:
-    container: golangci/golangci-lint:v1.51
+    container: golangci/golangci-lint:v1.54.1
     name: lint
     runs-on: ubuntu-latest
     steps:

--- a/provider-ci/providers/nomad/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/nomad/repo/.github/workflows/prerelease.yml
@@ -124,7 +124,7 @@ jobs:
         - go
         - java
   lint:
-    container: golangci/golangci-lint:v1.51
+    container: golangci/golangci-lint:v1.54.1
     name: lint
     runs-on: ubuntu-latest
     steps:

--- a/provider-ci/providers/nomad/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/nomad/repo/.github/workflows/release.yml
@@ -137,7 +137,7 @@ jobs:
       run: pulumictl create docs-build pulumi-${{ env.PROVIDER }}
         "${GITHUB_REF#refs/tags/}"
   lint:
-    container: golangci/golangci-lint:v1.51
+    container: golangci/golangci-lint:v1.54.1
     name: lint
     runs-on: ubuntu-latest
     steps:

--- a/provider-ci/providers/nomad/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/nomad/repo/.github/workflows/run-acceptance-tests.yml
@@ -144,7 +144,7 @@ jobs:
         repository: ${{ github.event.client_payload.github.payload.repository.full_name }}
         token: ${{ secrets.PULUMI_BOT_TOKEN }}
   lint:
-    container: golangci/golangci-lint:v1.51
+    container: golangci/golangci-lint:v1.54.1
     if: github.event_name == 'repository_dispatch' ||
       github.event.pull_request.head.repo.full_name == github.repository
     name: lint

--- a/provider-ci/providers/ns1/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/ns1/repo/.github/workflows/main.yml
@@ -177,7 +177,7 @@ jobs:
 
         aws s3 cp "${{ env.COVERAGE_OUTPUT_DIR }}/summary.json" "${s3FullURI}" --acl bucket-owner-full-control
   lint:
-    container: golangci/golangci-lint:v1.51
+    container: golangci/golangci-lint:v1.54.1
     name: lint
     runs-on: ubuntu-latest
     steps:

--- a/provider-ci/providers/ns1/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/ns1/repo/.github/workflows/master.yml
@@ -177,7 +177,7 @@ jobs:
 
         aws s3 cp "${{ env.COVERAGE_OUTPUT_DIR }}/summary.json" "${s3FullURI}" --acl bucket-owner-full-control
   lint:
-    container: golangci/golangci-lint:v1.51
+    container: golangci/golangci-lint:v1.54.1
     name: lint
     runs-on: ubuntu-latest
     steps:

--- a/provider-ci/providers/ns1/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/ns1/repo/.github/workflows/prerelease.yml
@@ -124,7 +124,7 @@ jobs:
         - go
         - java
   lint:
-    container: golangci/golangci-lint:v1.51
+    container: golangci/golangci-lint:v1.54.1
     name: lint
     runs-on: ubuntu-latest
     steps:

--- a/provider-ci/providers/ns1/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/ns1/repo/.github/workflows/release.yml
@@ -137,7 +137,7 @@ jobs:
       run: pulumictl create docs-build pulumi-${{ env.PROVIDER }}
         "${GITHUB_REF#refs/tags/}"
   lint:
-    container: golangci/golangci-lint:v1.51
+    container: golangci/golangci-lint:v1.54.1
     name: lint
     runs-on: ubuntu-latest
     steps:

--- a/provider-ci/providers/ns1/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/ns1/repo/.github/workflows/run-acceptance-tests.yml
@@ -144,7 +144,7 @@ jobs:
         repository: ${{ github.event.client_payload.github.payload.repository.full_name }}
         token: ${{ secrets.PULUMI_BOT_TOKEN }}
   lint:
-    container: golangci/golangci-lint:v1.51
+    container: golangci/golangci-lint:v1.54.1
     if: github.event_name == 'repository_dispatch' ||
       github.event.pull_request.head.repo.full_name == github.repository
     name: lint

--- a/provider-ci/providers/okta/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/okta/repo/.github/workflows/main.yml
@@ -179,7 +179,7 @@ jobs:
 
         aws s3 cp "${{ env.COVERAGE_OUTPUT_DIR }}/summary.json" "${s3FullURI}" --acl bucket-owner-full-control
   lint:
-    container: golangci/golangci-lint:v1.51
+    container: golangci/golangci-lint:v1.54.1
     name: lint
     runs-on: ubuntu-latest
     steps:

--- a/provider-ci/providers/okta/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/okta/repo/.github/workflows/master.yml
@@ -179,7 +179,7 @@ jobs:
 
         aws s3 cp "${{ env.COVERAGE_OUTPUT_DIR }}/summary.json" "${s3FullURI}" --acl bucket-owner-full-control
   lint:
-    container: golangci/golangci-lint:v1.51
+    container: golangci/golangci-lint:v1.54.1
     name: lint
     runs-on: ubuntu-latest
     steps:

--- a/provider-ci/providers/okta/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/okta/repo/.github/workflows/prerelease.yml
@@ -126,7 +126,7 @@ jobs:
         - go
         - java
   lint:
-    container: golangci/golangci-lint:v1.51
+    container: golangci/golangci-lint:v1.54.1
     name: lint
     runs-on: ubuntu-latest
     steps:

--- a/provider-ci/providers/okta/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/okta/repo/.github/workflows/release.yml
@@ -139,7 +139,7 @@ jobs:
       run: pulumictl create docs-build pulumi-${{ env.PROVIDER }}
         "${GITHUB_REF#refs/tags/}"
   lint:
-    container: golangci/golangci-lint:v1.51
+    container: golangci/golangci-lint:v1.54.1
     name: lint
     runs-on: ubuntu-latest
     steps:

--- a/provider-ci/providers/okta/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/okta/repo/.github/workflows/run-acceptance-tests.yml
@@ -146,7 +146,7 @@ jobs:
         repository: ${{ github.event.client_payload.github.payload.repository.full_name }}
         token: ${{ secrets.PULUMI_BOT_TOKEN }}
   lint:
-    container: golangci/golangci-lint:v1.51
+    container: golangci/golangci-lint:v1.54.1
     if: github.event_name == 'repository_dispatch' ||
       github.event.pull_request.head.repo.full_name == github.repository
     name: lint

--- a/provider-ci/providers/onelogin/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/onelogin/repo/.github/workflows/main.yml
@@ -176,7 +176,7 @@ jobs:
 
         aws s3 cp "${{ env.COVERAGE_OUTPUT_DIR }}/summary.json" "${s3FullURI}" --acl bucket-owner-full-control
   lint:
-    container: golangci/golangci-lint:v1.51
+    container: golangci/golangci-lint:v1.54.1
     name: lint
     runs-on: ubuntu-latest
     steps:

--- a/provider-ci/providers/onelogin/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/onelogin/repo/.github/workflows/master.yml
@@ -176,7 +176,7 @@ jobs:
 
         aws s3 cp "${{ env.COVERAGE_OUTPUT_DIR }}/summary.json" "${s3FullURI}" --acl bucket-owner-full-control
   lint:
-    container: golangci/golangci-lint:v1.51
+    container: golangci/golangci-lint:v1.54.1
     name: lint
     runs-on: ubuntu-latest
     steps:

--- a/provider-ci/providers/onelogin/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/onelogin/repo/.github/workflows/prerelease.yml
@@ -123,7 +123,7 @@ jobs:
         - go
         - java
   lint:
-    container: golangci/golangci-lint:v1.51
+    container: golangci/golangci-lint:v1.54.1
     name: lint
     runs-on: ubuntu-latest
     steps:

--- a/provider-ci/providers/onelogin/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/onelogin/repo/.github/workflows/release.yml
@@ -136,7 +136,7 @@ jobs:
       run: pulumictl create docs-build pulumi-${{ env.PROVIDER }}
         "${GITHUB_REF#refs/tags/}"
   lint:
-    container: golangci/golangci-lint:v1.51
+    container: golangci/golangci-lint:v1.54.1
     name: lint
     runs-on: ubuntu-latest
     steps:

--- a/provider-ci/providers/onelogin/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/onelogin/repo/.github/workflows/run-acceptance-tests.yml
@@ -143,7 +143,7 @@ jobs:
         repository: ${{ github.event.client_payload.github.payload.repository.full_name }}
         token: ${{ secrets.PULUMI_BOT_TOKEN }}
   lint:
-    container: golangci/golangci-lint:v1.51
+    container: golangci/golangci-lint:v1.54.1
     if: github.event_name == 'repository_dispatch' ||
       github.event.pull_request.head.repo.full_name == github.repository
     name: lint

--- a/provider-ci/providers/openstack/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/openstack/repo/.github/workflows/main.yml
@@ -185,7 +185,7 @@ jobs:
 
         aws s3 cp "${{ env.COVERAGE_OUTPUT_DIR }}/summary.json" "${s3FullURI}" --acl bucket-owner-full-control
   lint:
-    container: golangci/golangci-lint:v1.51
+    container: golangci/golangci-lint:v1.54.1
     name: lint
     runs-on: ubuntu-latest
     steps:

--- a/provider-ci/providers/openstack/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/openstack/repo/.github/workflows/master.yml
@@ -185,7 +185,7 @@ jobs:
 
         aws s3 cp "${{ env.COVERAGE_OUTPUT_DIR }}/summary.json" "${s3FullURI}" --acl bucket-owner-full-control
   lint:
-    container: golangci/golangci-lint:v1.51
+    container: golangci/golangci-lint:v1.54.1
     name: lint
     runs-on: ubuntu-latest
     steps:

--- a/provider-ci/providers/openstack/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/openstack/repo/.github/workflows/prerelease.yml
@@ -132,7 +132,7 @@ jobs:
         - go
         - java
   lint:
-    container: golangci/golangci-lint:v1.51
+    container: golangci/golangci-lint:v1.54.1
     name: lint
     runs-on: ubuntu-latest
     steps:

--- a/provider-ci/providers/openstack/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/openstack/repo/.github/workflows/release.yml
@@ -145,7 +145,7 @@ jobs:
       run: pulumictl create docs-build pulumi-${{ env.PROVIDER }}
         "${GITHUB_REF#refs/tags/}"
   lint:
-    container: golangci/golangci-lint:v1.51
+    container: golangci/golangci-lint:v1.54.1
     name: lint
     runs-on: ubuntu-latest
     steps:

--- a/provider-ci/providers/openstack/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/openstack/repo/.github/workflows/run-acceptance-tests.yml
@@ -152,7 +152,7 @@ jobs:
         repository: ${{ github.event.client_payload.github.payload.repository.full_name }}
         token: ${{ secrets.PULUMI_BOT_TOKEN }}
   lint:
-    container: golangci/golangci-lint:v1.51
+    container: golangci/golangci-lint:v1.54.1
     if: github.event_name == 'repository_dispatch' ||
       github.event.pull_request.head.repo.full_name == github.repository
     name: lint

--- a/provider-ci/providers/opsgenie/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/opsgenie/repo/.github/workflows/main.yml
@@ -177,7 +177,7 @@ jobs:
 
         aws s3 cp "${{ env.COVERAGE_OUTPUT_DIR }}/summary.json" "${s3FullURI}" --acl bucket-owner-full-control
   lint:
-    container: golangci/golangci-lint:v1.51
+    container: golangci/golangci-lint:v1.54.1
     name: lint
     runs-on: ubuntu-latest
     steps:

--- a/provider-ci/providers/opsgenie/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/opsgenie/repo/.github/workflows/master.yml
@@ -177,7 +177,7 @@ jobs:
 
         aws s3 cp "${{ env.COVERAGE_OUTPUT_DIR }}/summary.json" "${s3FullURI}" --acl bucket-owner-full-control
   lint:
-    container: golangci/golangci-lint:v1.51
+    container: golangci/golangci-lint:v1.54.1
     name: lint
     runs-on: ubuntu-latest
     steps:

--- a/provider-ci/providers/opsgenie/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/opsgenie/repo/.github/workflows/prerelease.yml
@@ -124,7 +124,7 @@ jobs:
         - go
         - java
   lint:
-    container: golangci/golangci-lint:v1.51
+    container: golangci/golangci-lint:v1.54.1
     name: lint
     runs-on: ubuntu-latest
     steps:

--- a/provider-ci/providers/opsgenie/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/opsgenie/repo/.github/workflows/release.yml
@@ -137,7 +137,7 @@ jobs:
       run: pulumictl create docs-build pulumi-${{ env.PROVIDER }}
         "${GITHUB_REF#refs/tags/}"
   lint:
-    container: golangci/golangci-lint:v1.51
+    container: golangci/golangci-lint:v1.54.1
     name: lint
     runs-on: ubuntu-latest
     steps:

--- a/provider-ci/providers/opsgenie/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/opsgenie/repo/.github/workflows/run-acceptance-tests.yml
@@ -144,7 +144,7 @@ jobs:
         repository: ${{ github.event.client_payload.github.payload.repository.full_name }}
         token: ${{ secrets.PULUMI_BOT_TOKEN }}
   lint:
-    container: golangci/golangci-lint:v1.51
+    container: golangci/golangci-lint:v1.54.1
     if: github.event_name == 'repository_dispatch' ||
       github.event.pull_request.head.repo.full_name == github.repository
     name: lint

--- a/provider-ci/providers/pagerduty/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/pagerduty/repo/.github/workflows/main.yml
@@ -177,7 +177,7 @@ jobs:
 
         aws s3 cp "${{ env.COVERAGE_OUTPUT_DIR }}/summary.json" "${s3FullURI}" --acl bucket-owner-full-control
   lint:
-    container: golangci/golangci-lint:v1.51
+    container: golangci/golangci-lint:v1.54.1
     name: lint
     runs-on: ubuntu-latest
     steps:

--- a/provider-ci/providers/pagerduty/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/pagerduty/repo/.github/workflows/master.yml
@@ -177,7 +177,7 @@ jobs:
 
         aws s3 cp "${{ env.COVERAGE_OUTPUT_DIR }}/summary.json" "${s3FullURI}" --acl bucket-owner-full-control
   lint:
-    container: golangci/golangci-lint:v1.51
+    container: golangci/golangci-lint:v1.54.1
     name: lint
     runs-on: ubuntu-latest
     steps:

--- a/provider-ci/providers/pagerduty/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/pagerduty/repo/.github/workflows/prerelease.yml
@@ -124,7 +124,7 @@ jobs:
         - go
         - java
   lint:
-    container: golangci/golangci-lint:v1.51
+    container: golangci/golangci-lint:v1.54.1
     name: lint
     runs-on: ubuntu-latest
     steps:

--- a/provider-ci/providers/pagerduty/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/pagerduty/repo/.github/workflows/release.yml
@@ -137,7 +137,7 @@ jobs:
       run: pulumictl create docs-build pulumi-${{ env.PROVIDER }}
         "${GITHUB_REF#refs/tags/}"
   lint:
-    container: golangci/golangci-lint:v1.51
+    container: golangci/golangci-lint:v1.54.1
     name: lint
     runs-on: ubuntu-latest
     steps:

--- a/provider-ci/providers/pagerduty/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/pagerduty/repo/.github/workflows/run-acceptance-tests.yml
@@ -144,7 +144,7 @@ jobs:
         repository: ${{ github.event.client_payload.github.payload.repository.full_name }}
         token: ${{ secrets.PULUMI_BOT_TOKEN }}
   lint:
-    container: golangci/golangci-lint:v1.51
+    container: golangci/golangci-lint:v1.54.1
     if: github.event_name == 'repository_dispatch' ||
       github.event.pull_request.head.repo.full_name == github.repository
     name: lint

--- a/provider-ci/providers/postgresql/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/postgresql/repo/.github/workflows/main.yml
@@ -176,7 +176,7 @@ jobs:
 
         aws s3 cp "${{ env.COVERAGE_OUTPUT_DIR }}/summary.json" "${s3FullURI}" --acl bucket-owner-full-control
   lint:
-    container: golangci/golangci-lint:v1.51
+    container: golangci/golangci-lint:v1.54.1
     name: lint
     runs-on: ubuntu-latest
     steps:

--- a/provider-ci/providers/postgresql/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/postgresql/repo/.github/workflows/master.yml
@@ -176,7 +176,7 @@ jobs:
 
         aws s3 cp "${{ env.COVERAGE_OUTPUT_DIR }}/summary.json" "${s3FullURI}" --acl bucket-owner-full-control
   lint:
-    container: golangci/golangci-lint:v1.51
+    container: golangci/golangci-lint:v1.54.1
     name: lint
     runs-on: ubuntu-latest
     steps:

--- a/provider-ci/providers/postgresql/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/postgresql/repo/.github/workflows/prerelease.yml
@@ -123,7 +123,7 @@ jobs:
         - go
         - java
   lint:
-    container: golangci/golangci-lint:v1.51
+    container: golangci/golangci-lint:v1.54.1
     name: lint
     runs-on: ubuntu-latest
     steps:

--- a/provider-ci/providers/postgresql/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/postgresql/repo/.github/workflows/release.yml
@@ -136,7 +136,7 @@ jobs:
       run: pulumictl create docs-build pulumi-${{ env.PROVIDER }}
         "${GITHUB_REF#refs/tags/}"
   lint:
-    container: golangci/golangci-lint:v1.51
+    container: golangci/golangci-lint:v1.54.1
     name: lint
     runs-on: ubuntu-latest
     steps:

--- a/provider-ci/providers/postgresql/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/postgresql/repo/.github/workflows/run-acceptance-tests.yml
@@ -143,7 +143,7 @@ jobs:
         repository: ${{ github.event.client_payload.github.payload.repository.full_name }}
         token: ${{ secrets.PULUMI_BOT_TOKEN }}
   lint:
-    container: golangci/golangci-lint:v1.51
+    container: golangci/golangci-lint:v1.54.1
     if: github.event_name == 'repository_dispatch' ||
       github.event.pull_request.head.repo.full_name == github.repository
     name: lint

--- a/provider-ci/providers/rabbitmq/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/rabbitmq/repo/.github/workflows/main.yml
@@ -176,7 +176,7 @@ jobs:
 
         aws s3 cp "${{ env.COVERAGE_OUTPUT_DIR }}/summary.json" "${s3FullURI}" --acl bucket-owner-full-control
   lint:
-    container: golangci/golangci-lint:v1.51
+    container: golangci/golangci-lint:v1.54.1
     name: lint
     runs-on: ubuntu-latest
     steps:

--- a/provider-ci/providers/rabbitmq/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/rabbitmq/repo/.github/workflows/master.yml
@@ -176,7 +176,7 @@ jobs:
 
         aws s3 cp "${{ env.COVERAGE_OUTPUT_DIR }}/summary.json" "${s3FullURI}" --acl bucket-owner-full-control
   lint:
-    container: golangci/golangci-lint:v1.51
+    container: golangci/golangci-lint:v1.54.1
     name: lint
     runs-on: ubuntu-latest
     steps:

--- a/provider-ci/providers/rabbitmq/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/rabbitmq/repo/.github/workflows/prerelease.yml
@@ -123,7 +123,7 @@ jobs:
         - go
         - java
   lint:
-    container: golangci/golangci-lint:v1.51
+    container: golangci/golangci-lint:v1.54.1
     name: lint
     runs-on: ubuntu-latest
     steps:

--- a/provider-ci/providers/rabbitmq/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/rabbitmq/repo/.github/workflows/release.yml
@@ -136,7 +136,7 @@ jobs:
       run: pulumictl create docs-build pulumi-${{ env.PROVIDER }}
         "${GITHUB_REF#refs/tags/}"
   lint:
-    container: golangci/golangci-lint:v1.51
+    container: golangci/golangci-lint:v1.54.1
     name: lint
     runs-on: ubuntu-latest
     steps:

--- a/provider-ci/providers/rabbitmq/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/rabbitmq/repo/.github/workflows/run-acceptance-tests.yml
@@ -143,7 +143,7 @@ jobs:
         repository: ${{ github.event.client_payload.github.payload.repository.full_name }}
         token: ${{ secrets.PULUMI_BOT_TOKEN }}
   lint:
-    container: golangci/golangci-lint:v1.51
+    container: golangci/golangci-lint:v1.54.1
     if: github.event_name == 'repository_dispatch' ||
       github.event.pull_request.head.repo.full_name == github.repository
     name: lint

--- a/provider-ci/providers/random/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/random/repo/.github/workflows/main.yml
@@ -176,7 +176,7 @@ jobs:
 
         aws s3 cp "${{ env.COVERAGE_OUTPUT_DIR }}/summary.json" "${s3FullURI}" --acl bucket-owner-full-control
   lint:
-    container: golangci/golangci-lint:v1.51
+    container: golangci/golangci-lint:v1.54.1
     name: lint
     runs-on: ubuntu-latest
     steps:

--- a/provider-ci/providers/random/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/random/repo/.github/workflows/master.yml
@@ -176,7 +176,7 @@ jobs:
 
         aws s3 cp "${{ env.COVERAGE_OUTPUT_DIR }}/summary.json" "${s3FullURI}" --acl bucket-owner-full-control
   lint:
-    container: golangci/golangci-lint:v1.51
+    container: golangci/golangci-lint:v1.54.1
     name: lint
     runs-on: ubuntu-latest
     steps:

--- a/provider-ci/providers/random/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/random/repo/.github/workflows/prerelease.yml
@@ -123,7 +123,7 @@ jobs:
         - go
         - java
   lint:
-    container: golangci/golangci-lint:v1.51
+    container: golangci/golangci-lint:v1.54.1
     name: lint
     runs-on: ubuntu-latest
     steps:

--- a/provider-ci/providers/random/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/random/repo/.github/workflows/release.yml
@@ -136,7 +136,7 @@ jobs:
       run: pulumictl create docs-build pulumi-${{ env.PROVIDER }}
         "${GITHUB_REF#refs/tags/}"
   lint:
-    container: golangci/golangci-lint:v1.51
+    container: golangci/golangci-lint:v1.54.1
     name: lint
     runs-on: ubuntu-latest
     steps:

--- a/provider-ci/providers/random/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/random/repo/.github/workflows/run-acceptance-tests.yml
@@ -143,7 +143,7 @@ jobs:
         repository: ${{ github.event.client_payload.github.payload.repository.full_name }}
         token: ${{ secrets.PULUMI_BOT_TOKEN }}
   lint:
-    container: golangci/golangci-lint:v1.51
+    container: golangci/golangci-lint:v1.54.1
     if: github.event_name == 'repository_dispatch' ||
       github.event.pull_request.head.repo.full_name == github.repository
     name: lint

--- a/provider-ci/providers/rke/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/rke/repo/.github/workflows/main.yml
@@ -177,7 +177,7 @@ jobs:
 
         aws s3 cp "${{ env.COVERAGE_OUTPUT_DIR }}/summary.json" "${s3FullURI}" --acl bucket-owner-full-control
   lint:
-    container: golangci/golangci-lint:v1.51
+    container: golangci/golangci-lint:v1.54.1
     name: lint
     runs-on: ubuntu-latest
     steps:

--- a/provider-ci/providers/rke/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/rke/repo/.github/workflows/master.yml
@@ -177,7 +177,7 @@ jobs:
 
         aws s3 cp "${{ env.COVERAGE_OUTPUT_DIR }}/summary.json" "${s3FullURI}" --acl bucket-owner-full-control
   lint:
-    container: golangci/golangci-lint:v1.51
+    container: golangci/golangci-lint:v1.54.1
     name: lint
     runs-on: ubuntu-latest
     steps:

--- a/provider-ci/providers/rke/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/rke/repo/.github/workflows/prerelease.yml
@@ -124,7 +124,7 @@ jobs:
         - go
         - java
   lint:
-    container: golangci/golangci-lint:v1.51
+    container: golangci/golangci-lint:v1.54.1
     name: lint
     runs-on: ubuntu-latest
     steps:

--- a/provider-ci/providers/rke/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/rke/repo/.github/workflows/release.yml
@@ -137,7 +137,7 @@ jobs:
       run: pulumictl create docs-build pulumi-${{ env.PROVIDER }}
         "${GITHUB_REF#refs/tags/}"
   lint:
-    container: golangci/golangci-lint:v1.51
+    container: golangci/golangci-lint:v1.54.1
     name: lint
     runs-on: ubuntu-latest
     steps:

--- a/provider-ci/providers/rke/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/rke/repo/.github/workflows/run-acceptance-tests.yml
@@ -144,7 +144,7 @@ jobs:
         repository: ${{ github.event.client_payload.github.payload.repository.full_name }}
         token: ${{ secrets.PULUMI_BOT_TOKEN }}
   lint:
-    container: golangci/golangci-lint:v1.51
+    container: golangci/golangci-lint:v1.54.1
     if: github.event_name == 'repository_dispatch' ||
       github.event.pull_request.head.repo.full_name == github.repository
     name: lint

--- a/provider-ci/providers/signalfx/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/signalfx/repo/.github/workflows/main.yml
@@ -176,7 +176,7 @@ jobs:
 
         aws s3 cp "${{ env.COVERAGE_OUTPUT_DIR }}/summary.json" "${s3FullURI}" --acl bucket-owner-full-control
   lint:
-    container: golangci/golangci-lint:v1.51
+    container: golangci/golangci-lint:v1.54.1
     name: lint
     runs-on: ubuntu-latest
     steps:

--- a/provider-ci/providers/signalfx/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/signalfx/repo/.github/workflows/master.yml
@@ -176,7 +176,7 @@ jobs:
 
         aws s3 cp "${{ env.COVERAGE_OUTPUT_DIR }}/summary.json" "${s3FullURI}" --acl bucket-owner-full-control
   lint:
-    container: golangci/golangci-lint:v1.51
+    container: golangci/golangci-lint:v1.54.1
     name: lint
     runs-on: ubuntu-latest
     steps:

--- a/provider-ci/providers/signalfx/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/signalfx/repo/.github/workflows/prerelease.yml
@@ -123,7 +123,7 @@ jobs:
         - go
         - java
   lint:
-    container: golangci/golangci-lint:v1.51
+    container: golangci/golangci-lint:v1.54.1
     name: lint
     runs-on: ubuntu-latest
     steps:

--- a/provider-ci/providers/signalfx/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/signalfx/repo/.github/workflows/release.yml
@@ -136,7 +136,7 @@ jobs:
       run: pulumictl create docs-build pulumi-${{ env.PROVIDER }}
         "${GITHUB_REF#refs/tags/}"
   lint:
-    container: golangci/golangci-lint:v1.51
+    container: golangci/golangci-lint:v1.54.1
     name: lint
     runs-on: ubuntu-latest
     steps:

--- a/provider-ci/providers/signalfx/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/signalfx/repo/.github/workflows/run-acceptance-tests.yml
@@ -143,7 +143,7 @@ jobs:
         repository: ${{ github.event.client_payload.github.payload.repository.full_name }}
         token: ${{ secrets.PULUMI_BOT_TOKEN }}
   lint:
-    container: golangci/golangci-lint:v1.51
+    container: golangci/golangci-lint:v1.54.1
     if: github.event_name == 'repository_dispatch' ||
       github.event.pull_request.head.repo.full_name == github.repository
     name: lint

--- a/provider-ci/providers/slack/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/slack/repo/.github/workflows/main.yml
@@ -177,7 +177,7 @@ jobs:
 
         aws s3 cp "${{ env.COVERAGE_OUTPUT_DIR }}/summary.json" "${s3FullURI}" --acl bucket-owner-full-control
   lint:
-    container: golangci/golangci-lint:v1.51
+    container: golangci/golangci-lint:v1.54.1
     name: lint
     runs-on: ubuntu-latest
     steps:

--- a/provider-ci/providers/slack/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/slack/repo/.github/workflows/master.yml
@@ -177,7 +177,7 @@ jobs:
 
         aws s3 cp "${{ env.COVERAGE_OUTPUT_DIR }}/summary.json" "${s3FullURI}" --acl bucket-owner-full-control
   lint:
-    container: golangci/golangci-lint:v1.51
+    container: golangci/golangci-lint:v1.54.1
     name: lint
     runs-on: ubuntu-latest
     steps:

--- a/provider-ci/providers/slack/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/slack/repo/.github/workflows/prerelease.yml
@@ -124,7 +124,7 @@ jobs:
         - go
         - java
   lint:
-    container: golangci/golangci-lint:v1.51
+    container: golangci/golangci-lint:v1.54.1
     name: lint
     runs-on: ubuntu-latest
     steps:

--- a/provider-ci/providers/slack/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/slack/repo/.github/workflows/release.yml
@@ -137,7 +137,7 @@ jobs:
       run: pulumictl create docs-build pulumi-${{ env.PROVIDER }}
         "${GITHUB_REF#refs/tags/}"
   lint:
-    container: golangci/golangci-lint:v1.51
+    container: golangci/golangci-lint:v1.54.1
     name: lint
     runs-on: ubuntu-latest
     steps:

--- a/provider-ci/providers/slack/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/slack/repo/.github/workflows/run-acceptance-tests.yml
@@ -144,7 +144,7 @@ jobs:
         repository: ${{ github.event.client_payload.github.payload.repository.full_name }}
         token: ${{ secrets.PULUMI_BOT_TOKEN }}
   lint:
-    container: golangci/golangci-lint:v1.51
+    container: golangci/golangci-lint:v1.54.1
     if: github.event_name == 'repository_dispatch' ||
       github.event.pull_request.head.repo.full_name == github.repository
     name: lint

--- a/provider-ci/providers/snowflake/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/snowflake/repo/.github/workflows/main.yml
@@ -181,7 +181,7 @@ jobs:
 
         aws s3 cp "${{ env.COVERAGE_OUTPUT_DIR }}/summary.json" "${s3FullURI}" --acl bucket-owner-full-control
   lint:
-    container: golangci/golangci-lint:v1.51
+    container: golangci/golangci-lint:v1.54.1
     name: lint
     runs-on: ubuntu-latest
     steps:

--- a/provider-ci/providers/snowflake/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/snowflake/repo/.github/workflows/master.yml
@@ -181,7 +181,7 @@ jobs:
 
         aws s3 cp "${{ env.COVERAGE_OUTPUT_DIR }}/summary.json" "${s3FullURI}" --acl bucket-owner-full-control
   lint:
-    container: golangci/golangci-lint:v1.51
+    container: golangci/golangci-lint:v1.54.1
     name: lint
     runs-on: ubuntu-latest
     steps:

--- a/provider-ci/providers/snowflake/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/snowflake/repo/.github/workflows/prerelease.yml
@@ -128,7 +128,7 @@ jobs:
         - go
         - java
   lint:
-    container: golangci/golangci-lint:v1.51
+    container: golangci/golangci-lint:v1.54.1
     name: lint
     runs-on: ubuntu-latest
     steps:

--- a/provider-ci/providers/snowflake/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/snowflake/repo/.github/workflows/release.yml
@@ -141,7 +141,7 @@ jobs:
       run: pulumictl create docs-build pulumi-${{ env.PROVIDER }}
         "${GITHUB_REF#refs/tags/}"
   lint:
-    container: golangci/golangci-lint:v1.51
+    container: golangci/golangci-lint:v1.54.1
     name: lint
     runs-on: ubuntu-latest
     steps:

--- a/provider-ci/providers/snowflake/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/snowflake/repo/.github/workflows/run-acceptance-tests.yml
@@ -148,7 +148,7 @@ jobs:
         repository: ${{ github.event.client_payload.github.payload.repository.full_name }}
         token: ${{ secrets.PULUMI_BOT_TOKEN }}
   lint:
-    container: golangci/golangci-lint:v1.51
+    container: golangci/golangci-lint:v1.54.1
     if: github.event_name == 'repository_dispatch' ||
       github.event.pull_request.head.repo.full_name == github.repository
     name: lint

--- a/provider-ci/providers/splunk/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/splunk/repo/.github/workflows/main.yml
@@ -179,7 +179,7 @@ jobs:
 
         aws s3 cp "${{ env.COVERAGE_OUTPUT_DIR }}/summary.json" "${s3FullURI}" --acl bucket-owner-full-control
   lint:
-    container: golangci/golangci-lint:v1.51
+    container: golangci/golangci-lint:v1.54.1
     name: lint
     runs-on: ubuntu-latest
     steps:

--- a/provider-ci/providers/splunk/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/splunk/repo/.github/workflows/master.yml
@@ -179,7 +179,7 @@ jobs:
 
         aws s3 cp "${{ env.COVERAGE_OUTPUT_DIR }}/summary.json" "${s3FullURI}" --acl bucket-owner-full-control
   lint:
-    container: golangci/golangci-lint:v1.51
+    container: golangci/golangci-lint:v1.54.1
     name: lint
     runs-on: ubuntu-latest
     steps:

--- a/provider-ci/providers/splunk/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/splunk/repo/.github/workflows/prerelease.yml
@@ -126,7 +126,7 @@ jobs:
         - go
         - java
   lint:
-    container: golangci/golangci-lint:v1.51
+    container: golangci/golangci-lint:v1.54.1
     name: lint
     runs-on: ubuntu-latest
     steps:

--- a/provider-ci/providers/splunk/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/splunk/repo/.github/workflows/release.yml
@@ -139,7 +139,7 @@ jobs:
       run: pulumictl create docs-build pulumi-${{ env.PROVIDER }}
         "${GITHUB_REF#refs/tags/}"
   lint:
-    container: golangci/golangci-lint:v1.51
+    container: golangci/golangci-lint:v1.54.1
     name: lint
     runs-on: ubuntu-latest
     steps:

--- a/provider-ci/providers/splunk/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/splunk/repo/.github/workflows/run-acceptance-tests.yml
@@ -146,7 +146,7 @@ jobs:
         repository: ${{ github.event.client_payload.github.payload.repository.full_name }}
         token: ${{ secrets.PULUMI_BOT_TOKEN }}
   lint:
-    container: golangci/golangci-lint:v1.51
+    container: golangci/golangci-lint:v1.54.1
     if: github.event_name == 'repository_dispatch' ||
       github.event.pull_request.head.repo.full_name == github.repository
     name: lint

--- a/provider-ci/providers/spotinst/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/spotinst/repo/.github/workflows/main.yml
@@ -179,7 +179,7 @@ jobs:
 
         aws s3 cp "${{ env.COVERAGE_OUTPUT_DIR }}/summary.json" "${s3FullURI}" --acl bucket-owner-full-control
   lint:
-    container: golangci/golangci-lint:v1.51
+    container: golangci/golangci-lint:v1.54.1
     name: lint
     runs-on: ubuntu-latest
     steps:

--- a/provider-ci/providers/spotinst/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/spotinst/repo/.github/workflows/master.yml
@@ -179,7 +179,7 @@ jobs:
 
         aws s3 cp "${{ env.COVERAGE_OUTPUT_DIR }}/summary.json" "${s3FullURI}" --acl bucket-owner-full-control
   lint:
-    container: golangci/golangci-lint:v1.51
+    container: golangci/golangci-lint:v1.54.1
     name: lint
     runs-on: ubuntu-latest
     steps:

--- a/provider-ci/providers/spotinst/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/spotinst/repo/.github/workflows/prerelease.yml
@@ -126,7 +126,7 @@ jobs:
         - go
         - java
   lint:
-    container: golangci/golangci-lint:v1.51
+    container: golangci/golangci-lint:v1.54.1
     name: lint
     runs-on: ubuntu-latest
     steps:

--- a/provider-ci/providers/spotinst/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/spotinst/repo/.github/workflows/release.yml
@@ -139,7 +139,7 @@ jobs:
       run: pulumictl create docs-build pulumi-${{ env.PROVIDER }}
         "${GITHUB_REF#refs/tags/}"
   lint:
-    container: golangci/golangci-lint:v1.51
+    container: golangci/golangci-lint:v1.54.1
     name: lint
     runs-on: ubuntu-latest
     steps:

--- a/provider-ci/providers/spotinst/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/spotinst/repo/.github/workflows/run-acceptance-tests.yml
@@ -146,7 +146,7 @@ jobs:
         repository: ${{ github.event.client_payload.github.payload.repository.full_name }}
         token: ${{ secrets.PULUMI_BOT_TOKEN }}
   lint:
-    container: golangci/golangci-lint:v1.51
+    container: golangci/golangci-lint:v1.54.1
     if: github.event_name == 'repository_dispatch' ||
       github.event.pull_request.head.repo.full_name == github.repository
     name: lint

--- a/provider-ci/providers/sumologic/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/sumologic/repo/.github/workflows/main.yml
@@ -179,7 +179,7 @@ jobs:
 
         aws s3 cp "${{ env.COVERAGE_OUTPUT_DIR }}/summary.json" "${s3FullURI}" --acl bucket-owner-full-control
   lint:
-    container: golangci/golangci-lint:v1.51
+    container: golangci/golangci-lint:v1.54.1
     name: lint
     runs-on: ubuntu-latest
     steps:

--- a/provider-ci/providers/sumologic/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/sumologic/repo/.github/workflows/master.yml
@@ -179,7 +179,7 @@ jobs:
 
         aws s3 cp "${{ env.COVERAGE_OUTPUT_DIR }}/summary.json" "${s3FullURI}" --acl bucket-owner-full-control
   lint:
-    container: golangci/golangci-lint:v1.51
+    container: golangci/golangci-lint:v1.54.1
     name: lint
     runs-on: ubuntu-latest
     steps:

--- a/provider-ci/providers/sumologic/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/sumologic/repo/.github/workflows/prerelease.yml
@@ -126,7 +126,7 @@ jobs:
         - go
         - java
   lint:
-    container: golangci/golangci-lint:v1.51
+    container: golangci/golangci-lint:v1.54.1
     name: lint
     runs-on: ubuntu-latest
     steps:

--- a/provider-ci/providers/sumologic/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/sumologic/repo/.github/workflows/release.yml
@@ -139,7 +139,7 @@ jobs:
       run: pulumictl create docs-build pulumi-${{ env.PROVIDER }}
         "${GITHUB_REF#refs/tags/}"
   lint:
-    container: golangci/golangci-lint:v1.51
+    container: golangci/golangci-lint:v1.54.1
     name: lint
     runs-on: ubuntu-latest
     steps:

--- a/provider-ci/providers/sumologic/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/sumologic/repo/.github/workflows/run-acceptance-tests.yml
@@ -146,7 +146,7 @@ jobs:
         repository: ${{ github.event.client_payload.github.payload.repository.full_name }}
         token: ${{ secrets.PULUMI_BOT_TOKEN }}
   lint:
-    container: golangci/golangci-lint:v1.51
+    container: golangci/golangci-lint:v1.54.1
     if: github.event_name == 'repository_dispatch' ||
       github.event.pull_request.head.repo.full_name == github.repository
     name: lint

--- a/provider-ci/providers/tailscale/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/tailscale/repo/.github/workflows/main.yml
@@ -179,7 +179,7 @@ jobs:
 
         aws s3 cp "${{ env.COVERAGE_OUTPUT_DIR }}/summary.json" "${s3FullURI}" --acl bucket-owner-full-control
   lint:
-    container: golangci/golangci-lint:v1.51
+    container: golangci/golangci-lint:v1.54.1
     name: lint
     runs-on: ubuntu-latest
     steps:

--- a/provider-ci/providers/tailscale/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/tailscale/repo/.github/workflows/master.yml
@@ -179,7 +179,7 @@ jobs:
 
         aws s3 cp "${{ env.COVERAGE_OUTPUT_DIR }}/summary.json" "${s3FullURI}" --acl bucket-owner-full-control
   lint:
-    container: golangci/golangci-lint:v1.51
+    container: golangci/golangci-lint:v1.54.1
     name: lint
     runs-on: ubuntu-latest
     steps:

--- a/provider-ci/providers/tailscale/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/tailscale/repo/.github/workflows/prerelease.yml
@@ -126,7 +126,7 @@ jobs:
         - go
         - java
   lint:
-    container: golangci/golangci-lint:v1.51
+    container: golangci/golangci-lint:v1.54.1
     name: lint
     runs-on: ubuntu-latest
     steps:

--- a/provider-ci/providers/tailscale/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/tailscale/repo/.github/workflows/release.yml
@@ -139,7 +139,7 @@ jobs:
       run: pulumictl create docs-build pulumi-${{ env.PROVIDER }}
         "${GITHUB_REF#refs/tags/}"
   lint:
-    container: golangci/golangci-lint:v1.51
+    container: golangci/golangci-lint:v1.54.1
     name: lint
     runs-on: ubuntu-latest
     steps:

--- a/provider-ci/providers/tailscale/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/tailscale/repo/.github/workflows/run-acceptance-tests.yml
@@ -146,7 +146,7 @@ jobs:
         repository: ${{ github.event.client_payload.github.payload.repository.full_name }}
         token: ${{ secrets.PULUMI_BOT_TOKEN }}
   lint:
-    container: golangci/golangci-lint:v1.51
+    container: golangci/golangci-lint:v1.54.1
     if: github.event_name == 'repository_dispatch' ||
       github.event.pull_request.head.repo.full_name == github.repository
     name: lint

--- a/provider-ci/providers/tls/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/tls/repo/.github/workflows/main.yml
@@ -176,7 +176,7 @@ jobs:
 
         aws s3 cp "${{ env.COVERAGE_OUTPUT_DIR }}/summary.json" "${s3FullURI}" --acl bucket-owner-full-control
   lint:
-    container: golangci/golangci-lint:v1.51
+    container: golangci/golangci-lint:v1.54.1
     name: lint
     runs-on: ubuntu-latest
     steps:

--- a/provider-ci/providers/tls/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/tls/repo/.github/workflows/master.yml
@@ -176,7 +176,7 @@ jobs:
 
         aws s3 cp "${{ env.COVERAGE_OUTPUT_DIR }}/summary.json" "${s3FullURI}" --acl bucket-owner-full-control
   lint:
-    container: golangci/golangci-lint:v1.51
+    container: golangci/golangci-lint:v1.54.1
     name: lint
     runs-on: ubuntu-latest
     steps:

--- a/provider-ci/providers/tls/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/tls/repo/.github/workflows/prerelease.yml
@@ -123,7 +123,7 @@ jobs:
         - go
         - java
   lint:
-    container: golangci/golangci-lint:v1.51
+    container: golangci/golangci-lint:v1.54.1
     name: lint
     runs-on: ubuntu-latest
     steps:

--- a/provider-ci/providers/tls/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/tls/repo/.github/workflows/release.yml
@@ -136,7 +136,7 @@ jobs:
       run: pulumictl create docs-build pulumi-${{ env.PROVIDER }}
         "${GITHUB_REF#refs/tags/}"
   lint:
-    container: golangci/golangci-lint:v1.51
+    container: golangci/golangci-lint:v1.54.1
     name: lint
     runs-on: ubuntu-latest
     steps:

--- a/provider-ci/providers/tls/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/tls/repo/.github/workflows/run-acceptance-tests.yml
@@ -143,7 +143,7 @@ jobs:
         repository: ${{ github.event.client_payload.github.payload.repository.full_name }}
         token: ${{ secrets.PULUMI_BOT_TOKEN }}
   lint:
-    container: golangci/golangci-lint:v1.51
+    container: golangci/golangci-lint:v1.54.1
     if: github.event_name == 'repository_dispatch' ||
       github.event.pull_request.head.repo.full_name == github.repository
     name: lint

--- a/provider-ci/providers/vault/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/vault/repo/.github/workflows/main.yml
@@ -176,7 +176,7 @@ jobs:
 
         aws s3 cp "${{ env.COVERAGE_OUTPUT_DIR }}/summary.json" "${s3FullURI}" --acl bucket-owner-full-control
   lint:
-    container: golangci/golangci-lint:v1.51
+    container: golangci/golangci-lint:v1.54.1
     name: lint
     runs-on: ubuntu-latest
     steps:

--- a/provider-ci/providers/vault/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/vault/repo/.github/workflows/master.yml
@@ -176,7 +176,7 @@ jobs:
 
         aws s3 cp "${{ env.COVERAGE_OUTPUT_DIR }}/summary.json" "${s3FullURI}" --acl bucket-owner-full-control
   lint:
-    container: golangci/golangci-lint:v1.51
+    container: golangci/golangci-lint:v1.54.1
     name: lint
     runs-on: ubuntu-latest
     steps:

--- a/provider-ci/providers/vault/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/vault/repo/.github/workflows/prerelease.yml
@@ -123,7 +123,7 @@ jobs:
         - go
         - java
   lint:
-    container: golangci/golangci-lint:v1.51
+    container: golangci/golangci-lint:v1.54.1
     name: lint
     runs-on: ubuntu-latest
     steps:

--- a/provider-ci/providers/vault/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/vault/repo/.github/workflows/release.yml
@@ -136,7 +136,7 @@ jobs:
       run: pulumictl create docs-build pulumi-${{ env.PROVIDER }}
         "${GITHUB_REF#refs/tags/}"
   lint:
-    container: golangci/golangci-lint:v1.51
+    container: golangci/golangci-lint:v1.54.1
     name: lint
     runs-on: ubuntu-latest
     steps:

--- a/provider-ci/providers/vault/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/vault/repo/.github/workflows/run-acceptance-tests.yml
@@ -143,7 +143,7 @@ jobs:
         repository: ${{ github.event.client_payload.github.payload.repository.full_name }}
         token: ${{ secrets.PULUMI_BOT_TOKEN }}
   lint:
-    container: golangci/golangci-lint:v1.51
+    container: golangci/golangci-lint:v1.54.1
     if: github.event_name == 'repository_dispatch' ||
       github.event.pull_request.head.repo.full_name == github.repository
     name: lint

--- a/provider-ci/providers/venafi/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/venafi/repo/.github/workflows/main.yml
@@ -180,7 +180,7 @@ jobs:
 
         aws s3 cp "${{ env.COVERAGE_OUTPUT_DIR }}/summary.json" "${s3FullURI}" --acl bucket-owner-full-control
   lint:
-    container: golangci/golangci-lint:v1.51
+    container: golangci/golangci-lint:v1.54.1
     name: lint
     runs-on: ubuntu-latest
     steps:

--- a/provider-ci/providers/venafi/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/venafi/repo/.github/workflows/master.yml
@@ -180,7 +180,7 @@ jobs:
 
         aws s3 cp "${{ env.COVERAGE_OUTPUT_DIR }}/summary.json" "${s3FullURI}" --acl bucket-owner-full-control
   lint:
-    container: golangci/golangci-lint:v1.51
+    container: golangci/golangci-lint:v1.54.1
     name: lint
     runs-on: ubuntu-latest
     steps:

--- a/provider-ci/providers/venafi/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/venafi/repo/.github/workflows/prerelease.yml
@@ -127,7 +127,7 @@ jobs:
         - go
         - java
   lint:
-    container: golangci/golangci-lint:v1.51
+    container: golangci/golangci-lint:v1.54.1
     name: lint
     runs-on: ubuntu-latest
     steps:

--- a/provider-ci/providers/venafi/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/venafi/repo/.github/workflows/release.yml
@@ -140,7 +140,7 @@ jobs:
       run: pulumictl create docs-build pulumi-${{ env.PROVIDER }}
         "${GITHUB_REF#refs/tags/}"
   lint:
-    container: golangci/golangci-lint:v1.51
+    container: golangci/golangci-lint:v1.54.1
     name: lint
     runs-on: ubuntu-latest
     steps:

--- a/provider-ci/providers/venafi/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/venafi/repo/.github/workflows/run-acceptance-tests.yml
@@ -147,7 +147,7 @@ jobs:
         repository: ${{ github.event.client_payload.github.payload.repository.full_name }}
         token: ${{ secrets.PULUMI_BOT_TOKEN }}
   lint:
-    container: golangci/golangci-lint:v1.51
+    container: golangci/golangci-lint:v1.54.1
     if: github.event_name == 'repository_dispatch' ||
       github.event.pull_request.head.repo.full_name == github.repository
     name: lint

--- a/provider-ci/providers/vsphere/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/vsphere/repo/.github/workflows/main.yml
@@ -176,7 +176,7 @@ jobs:
 
         aws s3 cp "${{ env.COVERAGE_OUTPUT_DIR }}/summary.json" "${s3FullURI}" --acl bucket-owner-full-control
   lint:
-    container: golangci/golangci-lint:v1.51
+    container: golangci/golangci-lint:v1.54.1
     name: lint
     runs-on: ubuntu-latest
     steps:

--- a/provider-ci/providers/vsphere/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/vsphere/repo/.github/workflows/master.yml
@@ -176,7 +176,7 @@ jobs:
 
         aws s3 cp "${{ env.COVERAGE_OUTPUT_DIR }}/summary.json" "${s3FullURI}" --acl bucket-owner-full-control
   lint:
-    container: golangci/golangci-lint:v1.51
+    container: golangci/golangci-lint:v1.54.1
     name: lint
     runs-on: ubuntu-latest
     steps:

--- a/provider-ci/providers/vsphere/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/vsphere/repo/.github/workflows/prerelease.yml
@@ -123,7 +123,7 @@ jobs:
         - go
         - java
   lint:
-    container: golangci/golangci-lint:v1.51
+    container: golangci/golangci-lint:v1.54.1
     name: lint
     runs-on: ubuntu-latest
     steps:

--- a/provider-ci/providers/vsphere/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/vsphere/repo/.github/workflows/release.yml
@@ -136,7 +136,7 @@ jobs:
       run: pulumictl create docs-build pulumi-${{ env.PROVIDER }}
         "${GITHUB_REF#refs/tags/}"
   lint:
-    container: golangci/golangci-lint:v1.51
+    container: golangci/golangci-lint:v1.54.1
     name: lint
     runs-on: ubuntu-latest
     steps:

--- a/provider-ci/providers/vsphere/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/vsphere/repo/.github/workflows/run-acceptance-tests.yml
@@ -143,7 +143,7 @@ jobs:
         repository: ${{ github.event.client_payload.github.payload.repository.full_name }}
         token: ${{ secrets.PULUMI_BOT_TOKEN }}
   lint:
-    container: golangci/golangci-lint:v1.51
+    container: golangci/golangci-lint:v1.54.1
     if: github.event_name == 'repository_dispatch' ||
       github.event.pull_request.head.repo.full_name == github.repository
     name: lint

--- a/provider-ci/providers/wavefront/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/wavefront/repo/.github/workflows/main.yml
@@ -178,7 +178,7 @@ jobs:
 
         aws s3 cp "${{ env.COVERAGE_OUTPUT_DIR }}/summary.json" "${s3FullURI}" --acl bucket-owner-full-control
   lint:
-    container: golangci/golangci-lint:v1.51
+    container: golangci/golangci-lint:v1.54.1
     name: lint
     runs-on: ubuntu-latest
     steps:

--- a/provider-ci/providers/wavefront/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/wavefront/repo/.github/workflows/master.yml
@@ -178,7 +178,7 @@ jobs:
 
         aws s3 cp "${{ env.COVERAGE_OUTPUT_DIR }}/summary.json" "${s3FullURI}" --acl bucket-owner-full-control
   lint:
-    container: golangci/golangci-lint:v1.51
+    container: golangci/golangci-lint:v1.54.1
     name: lint
     runs-on: ubuntu-latest
     steps:

--- a/provider-ci/providers/wavefront/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/wavefront/repo/.github/workflows/prerelease.yml
@@ -125,7 +125,7 @@ jobs:
         - go
         - java
   lint:
-    container: golangci/golangci-lint:v1.51
+    container: golangci/golangci-lint:v1.54.1
     name: lint
     runs-on: ubuntu-latest
     steps:

--- a/provider-ci/providers/wavefront/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/wavefront/repo/.github/workflows/release.yml
@@ -138,7 +138,7 @@ jobs:
       run: pulumictl create docs-build pulumi-${{ env.PROVIDER }}
         "${GITHUB_REF#refs/tags/}"
   lint:
-    container: golangci/golangci-lint:v1.51
+    container: golangci/golangci-lint:v1.54.1
     name: lint
     runs-on: ubuntu-latest
     steps:

--- a/provider-ci/providers/wavefront/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/wavefront/repo/.github/workflows/run-acceptance-tests.yml
@@ -145,7 +145,7 @@ jobs:
         repository: ${{ github.event.client_payload.github.payload.repository.full_name }}
         token: ${{ secrets.PULUMI_BOT_TOKEN }}
   lint:
-    container: golangci/golangci-lint:v1.51
+    container: golangci/golangci-lint:v1.54.1
     if: github.event_name == 'repository_dispatch' ||
       github.event.pull_request.head.repo.full_name == github.repository
     name: lint


### PR DESCRIPTION
`golangci-lint v1.54.1` now supports go 1.21 
Fixes #546 