### PR TITLE
Bump upgrade provider action to v0.0.6

### DIFF
--- a/provider-ci/internal/pkg/templates/bridged-provider.config.yaml
+++ b/provider-ci/internal/pkg/templates/bridged-provider.config.yaml
@@ -79,6 +79,6 @@ actionVersions:
   prComment: thollander/actions-comment-pull-request@v2
   slashCommand: peter-evans/slash-command-dispatch@v2
   uploadArtifact: actions/upload-artifact@v2
-  upgradeProviderAction: pulumi/pulumi-upgrade-provider-action@v0.0.5
+  upgradeProviderAction: pulumi/pulumi-upgrade-provider-action@v0.0.6
   publishProviderSDKs: pulumi/pulumi-package-publisher@v0.0.9
   slackNotification: rtCamp/action-slack-notify@v2

--- a/provider-ci/providers/aiven/repo/.github/workflows/upgrade-bridge.yml
+++ b/provider-ci/providers/aiven/repo/.github/workflows/upgrade-bridge.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Call upgrade provider action
-      uses: pulumi/pulumi-upgrade-provider-action@v0.0.5
+      uses: pulumi/pulumi-upgrade-provider-action@v0.0.6
       with:
         kind: bridge
     - env:

--- a/provider-ci/providers/aiven/repo/.github/workflows/upgrade-provider.yml
+++ b/provider-ci/providers/aiven/repo/.github/workflows/upgrade-provider.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Call upgrade provider action
-      uses: pulumi/pulumi-upgrade-provider-action@v0.0.5
+      uses: pulumi/pulumi-upgrade-provider-action@v0.0.6
       with:
         kind: all
     - env:

--- a/provider-ci/providers/akamai/repo/.github/workflows/upgrade-bridge.yml
+++ b/provider-ci/providers/akamai/repo/.github/workflows/upgrade-bridge.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Call upgrade provider action
-      uses: pulumi/pulumi-upgrade-provider-action@v0.0.5
+      uses: pulumi/pulumi-upgrade-provider-action@v0.0.6
       with:
         kind: bridge
     - env:

--- a/provider-ci/providers/akamai/repo/.github/workflows/upgrade-provider.yml
+++ b/provider-ci/providers/akamai/repo/.github/workflows/upgrade-provider.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Call upgrade provider action
-      uses: pulumi/pulumi-upgrade-provider-action@v0.0.5
+      uses: pulumi/pulumi-upgrade-provider-action@v0.0.6
       with:
         kind: all
     - env:

--- a/provider-ci/providers/alicloud/repo/.github/workflows/upgrade-bridge.yml
+++ b/provider-ci/providers/alicloud/repo/.github/workflows/upgrade-bridge.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Call upgrade provider action
-      uses: pulumi/pulumi-upgrade-provider-action@v0.0.5
+      uses: pulumi/pulumi-upgrade-provider-action@v0.0.6
       with:
         kind: bridge
     - env:

--- a/provider-ci/providers/alicloud/repo/.github/workflows/upgrade-provider.yml
+++ b/provider-ci/providers/alicloud/repo/.github/workflows/upgrade-provider.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Call upgrade provider action
-      uses: pulumi/pulumi-upgrade-provider-action@v0.0.5
+      uses: pulumi/pulumi-upgrade-provider-action@v0.0.6
       with:
         kind: all
     - env:

--- a/provider-ci/providers/archive/repo/.github/workflows/upgrade-bridge.yml
+++ b/provider-ci/providers/archive/repo/.github/workflows/upgrade-bridge.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Call upgrade provider action
-      uses: pulumi/pulumi-upgrade-provider-action@v0.0.5
+      uses: pulumi/pulumi-upgrade-provider-action@v0.0.6
       with:
         kind: bridge
     - env:

--- a/provider-ci/providers/archive/repo/.github/workflows/upgrade-provider.yml
+++ b/provider-ci/providers/archive/repo/.github/workflows/upgrade-provider.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Call upgrade provider action
-      uses: pulumi/pulumi-upgrade-provider-action@v0.0.5
+      uses: pulumi/pulumi-upgrade-provider-action@v0.0.6
       with:
         kind: all
     - env:

--- a/provider-ci/providers/artifactory/repo/.github/workflows/upgrade-bridge.yml
+++ b/provider-ci/providers/artifactory/repo/.github/workflows/upgrade-bridge.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Call upgrade provider action
-      uses: pulumi/pulumi-upgrade-provider-action@v0.0.5
+      uses: pulumi/pulumi-upgrade-provider-action@v0.0.6
       with:
         kind: bridge
     - env:

--- a/provider-ci/providers/artifactory/repo/.github/workflows/upgrade-provider.yml
+++ b/provider-ci/providers/artifactory/repo/.github/workflows/upgrade-provider.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Call upgrade provider action
-      uses: pulumi/pulumi-upgrade-provider-action@v0.0.5
+      uses: pulumi/pulumi-upgrade-provider-action@v0.0.6
       with:
         kind: all
     - env:

--- a/provider-ci/providers/auth0/repo/.github/workflows/upgrade-bridge.yml
+++ b/provider-ci/providers/auth0/repo/.github/workflows/upgrade-bridge.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Call upgrade provider action
-      uses: pulumi/pulumi-upgrade-provider-action@v0.0.5
+      uses: pulumi/pulumi-upgrade-provider-action@v0.0.6
       with:
         kind: bridge
     - env:

--- a/provider-ci/providers/auth0/repo/.github/workflows/upgrade-provider.yml
+++ b/provider-ci/providers/auth0/repo/.github/workflows/upgrade-provider.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Call upgrade provider action
-      uses: pulumi/pulumi-upgrade-provider-action@v0.0.5
+      uses: pulumi/pulumi-upgrade-provider-action@v0.0.6
       with:
         kind: all
     - env:

--- a/provider-ci/providers/aws/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/aws/repo/.github/workflows/main.yml
@@ -465,7 +465,11 @@ jobs:
           - name: go test
             run: |
               cd provider/shim
-              go test -v .
+              go test -v -coverprofile="coverage.txt" .
+          - env:
+              CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+            name: Upload coverage reports to Codecov
+            uses: codecov/codecov-action@v3
       timeout-minutes: 60
 
 name: main

--- a/provider-ci/providers/aws/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/aws/repo/.github/workflows/master.yml
@@ -465,7 +465,11 @@ jobs:
           - name: go test
             run: |
               cd provider/shim
-              go test -v .
+              go test -v -coverprofile="coverage.txt" .
+          - env:
+              CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+            name: Upload coverage reports to Codecov
+            uses: codecov/codecov-action@v3
       timeout-minutes: 60
 
 name: master

--- a/provider-ci/providers/aws/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/aws/repo/.github/workflows/prerelease.yml
@@ -416,7 +416,11 @@ jobs:
           - name: go test
             run: |
               cd provider/shim
-              go test -v .
+              go test -v -coverprofile="coverage.txt" .
+          - env:
+              CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+            name: Upload coverage reports to Codecov
+            uses: codecov/codecov-action@v3
       timeout-minutes: 60
 
 name: prerelease

--- a/provider-ci/providers/aws/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/aws/repo/.github/workflows/release.yml
@@ -435,7 +435,11 @@ jobs:
           - name: go test
             run: |
               cd provider/shim
-              go test -v .
+              go test -v -coverprofile="coverage.txt" .
+          - env:
+              CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+            name: Upload coverage reports to Codecov
+            uses: codecov/codecov-action@v3
       timeout-minutes: 60
 
 name: release

--- a/provider-ci/providers/aws/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/aws/repo/.github/workflows/run-acceptance-tests.yml
@@ -410,7 +410,11 @@ jobs:
           - name: go test
             run: |
               cd provider/shim
-              go test -v .
+              go test -v -coverprofile="coverage.txt" .
+          - env:
+              CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+            name: Upload coverage reports to Codecov
+            uses: codecov/codecov-action@v3
       timeout-minutes: 60
 
 name: run-acceptance-tests

--- a/provider-ci/providers/aws/repo/.github/workflows/upgrade-bridge.yml
+++ b/provider-ci/providers/aws/repo/.github/workflows/upgrade-bridge.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Call upgrade provider action
-      uses: pulumi/pulumi-upgrade-provider-action@v0.0.5
+      uses: pulumi/pulumi-upgrade-provider-action@v0.0.6
       with:
         kind: bridge
     - env:

--- a/provider-ci/providers/aws/repo/.github/workflows/upgrade-provider.yml
+++ b/provider-ci/providers/aws/repo/.github/workflows/upgrade-provider.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Call upgrade provider action
-      uses: pulumi/pulumi-upgrade-provider-action@v0.0.5
+      uses: pulumi/pulumi-upgrade-provider-action@v0.0.6
       with:
         kind: all
     - env:

--- a/provider-ci/providers/azure/repo/.github/workflows/upgrade-bridge.yml
+++ b/provider-ci/providers/azure/repo/.github/workflows/upgrade-bridge.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Call upgrade provider action
-      uses: pulumi/pulumi-upgrade-provider-action@v0.0.5
+      uses: pulumi/pulumi-upgrade-provider-action@v0.0.6
       with:
         kind: bridge
     - env:

--- a/provider-ci/providers/azure/repo/.github/workflows/upgrade-provider.yml
+++ b/provider-ci/providers/azure/repo/.github/workflows/upgrade-provider.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Call upgrade provider action
-      uses: pulumi/pulumi-upgrade-provider-action@v0.0.5
+      uses: pulumi/pulumi-upgrade-provider-action@v0.0.6
       with:
         kind: all
     - env:

--- a/provider-ci/providers/azuread/repo/.github/workflows/upgrade-bridge.yml
+++ b/provider-ci/providers/azuread/repo/.github/workflows/upgrade-bridge.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Call upgrade provider action
-      uses: pulumi/pulumi-upgrade-provider-action@v0.0.5
+      uses: pulumi/pulumi-upgrade-provider-action@v0.0.6
       with:
         kind: bridge
     - env:

--- a/provider-ci/providers/azuread/repo/.github/workflows/upgrade-provider.yml
+++ b/provider-ci/providers/azuread/repo/.github/workflows/upgrade-provider.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Call upgrade provider action
-      uses: pulumi/pulumi-upgrade-provider-action@v0.0.5
+      uses: pulumi/pulumi-upgrade-provider-action@v0.0.6
       with:
         kind: all
     - env:

--- a/provider-ci/providers/azuredevops/repo/.github/workflows/upgrade-bridge.yml
+++ b/provider-ci/providers/azuredevops/repo/.github/workflows/upgrade-bridge.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Call upgrade provider action
-      uses: pulumi/pulumi-upgrade-provider-action@v0.0.5
+      uses: pulumi/pulumi-upgrade-provider-action@v0.0.6
       with:
         kind: bridge
     - env:

--- a/provider-ci/providers/azuredevops/repo/.github/workflows/upgrade-provider.yml
+++ b/provider-ci/providers/azuredevops/repo/.github/workflows/upgrade-provider.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Call upgrade provider action
-      uses: pulumi/pulumi-upgrade-provider-action@v0.0.5
+      uses: pulumi/pulumi-upgrade-provider-action@v0.0.6
       with:
         kind: all
     - env:

--- a/provider-ci/providers/civo/repo/.github/workflows/upgrade-bridge.yml
+++ b/provider-ci/providers/civo/repo/.github/workflows/upgrade-bridge.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Call upgrade provider action
-      uses: pulumi/pulumi-upgrade-provider-action@v0.0.5
+      uses: pulumi/pulumi-upgrade-provider-action@v0.0.6
       with:
         kind: bridge
     - env:

--- a/provider-ci/providers/civo/repo/.github/workflows/upgrade-provider.yml
+++ b/provider-ci/providers/civo/repo/.github/workflows/upgrade-provider.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Call upgrade provider action
-      uses: pulumi/pulumi-upgrade-provider-action@v0.0.5
+      uses: pulumi/pulumi-upgrade-provider-action@v0.0.6
       with:
         kind: all
     - env:

--- a/provider-ci/providers/cloudamqp/repo/.github/workflows/upgrade-bridge.yml
+++ b/provider-ci/providers/cloudamqp/repo/.github/workflows/upgrade-bridge.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Call upgrade provider action
-      uses: pulumi/pulumi-upgrade-provider-action@v0.0.5
+      uses: pulumi/pulumi-upgrade-provider-action@v0.0.6
       with:
         kind: bridge
     - env:

--- a/provider-ci/providers/cloudamqp/repo/.github/workflows/upgrade-provider.yml
+++ b/provider-ci/providers/cloudamqp/repo/.github/workflows/upgrade-provider.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Call upgrade provider action
-      uses: pulumi/pulumi-upgrade-provider-action@v0.0.5
+      uses: pulumi/pulumi-upgrade-provider-action@v0.0.6
       with:
         kind: all
     - env:

--- a/provider-ci/providers/cloudflare/repo/.github/workflows/upgrade-bridge.yml
+++ b/provider-ci/providers/cloudflare/repo/.github/workflows/upgrade-bridge.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Call upgrade provider action
-      uses: pulumi/pulumi-upgrade-provider-action@v0.0.5
+      uses: pulumi/pulumi-upgrade-provider-action@v0.0.6
       with:
         kind: bridge
     - env:

--- a/provider-ci/providers/cloudflare/repo/.github/workflows/upgrade-provider.yml
+++ b/provider-ci/providers/cloudflare/repo/.github/workflows/upgrade-provider.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Call upgrade provider action
-      uses: pulumi/pulumi-upgrade-provider-action@v0.0.5
+      uses: pulumi/pulumi-upgrade-provider-action@v0.0.6
       with:
         kind: all
     - env:

--- a/provider-ci/providers/cloudinit/repo/.github/workflows/upgrade-bridge.yml
+++ b/provider-ci/providers/cloudinit/repo/.github/workflows/upgrade-bridge.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Call upgrade provider action
-      uses: pulumi/pulumi-upgrade-provider-action@v0.0.5
+      uses: pulumi/pulumi-upgrade-provider-action@v0.0.6
       with:
         kind: bridge
     - env:

--- a/provider-ci/providers/cloudinit/repo/.github/workflows/upgrade-provider.yml
+++ b/provider-ci/providers/cloudinit/repo/.github/workflows/upgrade-provider.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Call upgrade provider action
-      uses: pulumi/pulumi-upgrade-provider-action@v0.0.5
+      uses: pulumi/pulumi-upgrade-provider-action@v0.0.6
       with:
         kind: all
     - env:

--- a/provider-ci/providers/confluentcloud/repo/.github/workflows/upgrade-bridge.yml
+++ b/provider-ci/providers/confluentcloud/repo/.github/workflows/upgrade-bridge.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Call upgrade provider action
-      uses: pulumi/pulumi-upgrade-provider-action@v0.0.5
+      uses: pulumi/pulumi-upgrade-provider-action@v0.0.6
       with:
         kind: bridge
     - env:

--- a/provider-ci/providers/confluentcloud/repo/.github/workflows/upgrade-provider.yml
+++ b/provider-ci/providers/confluentcloud/repo/.github/workflows/upgrade-provider.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Call upgrade provider action
-      uses: pulumi/pulumi-upgrade-provider-action@v0.0.5
+      uses: pulumi/pulumi-upgrade-provider-action@v0.0.6
       with:
         kind: all
     - env:

--- a/provider-ci/providers/consul/repo/.github/workflows/upgrade-bridge.yml
+++ b/provider-ci/providers/consul/repo/.github/workflows/upgrade-bridge.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Call upgrade provider action
-      uses: pulumi/pulumi-upgrade-provider-action@v0.0.5
+      uses: pulumi/pulumi-upgrade-provider-action@v0.0.6
       with:
         kind: bridge
     - env:

--- a/provider-ci/providers/consul/repo/.github/workflows/upgrade-provider.yml
+++ b/provider-ci/providers/consul/repo/.github/workflows/upgrade-provider.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Call upgrade provider action
-      uses: pulumi/pulumi-upgrade-provider-action@v0.0.5
+      uses: pulumi/pulumi-upgrade-provider-action@v0.0.6
       with:
         kind: all
     - env:

--- a/provider-ci/providers/databricks/repo/.github/workflows/upgrade-bridge.yml
+++ b/provider-ci/providers/databricks/repo/.github/workflows/upgrade-bridge.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Call upgrade provider action
-      uses: pulumi/pulumi-upgrade-provider-action@v0.0.5
+      uses: pulumi/pulumi-upgrade-provider-action@v0.0.6
       with:
         kind: bridge
     - env:

--- a/provider-ci/providers/databricks/repo/.github/workflows/upgrade-provider.yml
+++ b/provider-ci/providers/databricks/repo/.github/workflows/upgrade-provider.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Call upgrade provider action
-      uses: pulumi/pulumi-upgrade-provider-action@v0.0.5
+      uses: pulumi/pulumi-upgrade-provider-action@v0.0.6
       with:
         kind: all
     - env:

--- a/provider-ci/providers/datadog/repo/.github/workflows/upgrade-bridge.yml
+++ b/provider-ci/providers/datadog/repo/.github/workflows/upgrade-bridge.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Call upgrade provider action
-      uses: pulumi/pulumi-upgrade-provider-action@v0.0.5
+      uses: pulumi/pulumi-upgrade-provider-action@v0.0.6
       with:
         kind: bridge
     - env:

--- a/provider-ci/providers/datadog/repo/.github/workflows/upgrade-provider.yml
+++ b/provider-ci/providers/datadog/repo/.github/workflows/upgrade-provider.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Call upgrade provider action
-      uses: pulumi/pulumi-upgrade-provider-action@v0.0.5
+      uses: pulumi/pulumi-upgrade-provider-action@v0.0.6
       with:
         kind: all
     - env:

--- a/provider-ci/providers/digitalocean/repo/.github/workflows/upgrade-bridge.yml
+++ b/provider-ci/providers/digitalocean/repo/.github/workflows/upgrade-bridge.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Call upgrade provider action
-      uses: pulumi/pulumi-upgrade-provider-action@v0.0.5
+      uses: pulumi/pulumi-upgrade-provider-action@v0.0.6
       with:
         kind: bridge
     - env:

--- a/provider-ci/providers/digitalocean/repo/.github/workflows/upgrade-provider.yml
+++ b/provider-ci/providers/digitalocean/repo/.github/workflows/upgrade-provider.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Call upgrade provider action
-      uses: pulumi/pulumi-upgrade-provider-action@v0.0.5
+      uses: pulumi/pulumi-upgrade-provider-action@v0.0.6
       with:
         kind: all
     - env:

--- a/provider-ci/providers/dnsimple/repo/.github/workflows/upgrade-bridge.yml
+++ b/provider-ci/providers/dnsimple/repo/.github/workflows/upgrade-bridge.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Call upgrade provider action
-      uses: pulumi/pulumi-upgrade-provider-action@v0.0.5
+      uses: pulumi/pulumi-upgrade-provider-action@v0.0.6
       with:
         kind: bridge
     - env:

--- a/provider-ci/providers/dnsimple/repo/.github/workflows/upgrade-provider.yml
+++ b/provider-ci/providers/dnsimple/repo/.github/workflows/upgrade-provider.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Call upgrade provider action
-      uses: pulumi/pulumi-upgrade-provider-action@v0.0.5
+      uses: pulumi/pulumi-upgrade-provider-action@v0.0.6
       with:
         kind: all
     - env:

--- a/provider-ci/providers/docker/repo/.github/workflows/upgrade-bridge.yml
+++ b/provider-ci/providers/docker/repo/.github/workflows/upgrade-bridge.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Call upgrade provider action
-      uses: pulumi/pulumi-upgrade-provider-action@v0.0.5
+      uses: pulumi/pulumi-upgrade-provider-action@v0.0.6
       with:
         kind: bridge
     - env:

--- a/provider-ci/providers/docker/repo/.github/workflows/upgrade-provider.yml
+++ b/provider-ci/providers/docker/repo/.github/workflows/upgrade-provider.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Call upgrade provider action
-      uses: pulumi/pulumi-upgrade-provider-action@v0.0.5
+      uses: pulumi/pulumi-upgrade-provider-action@v0.0.6
       with:
         kind: all
     - env:

--- a/provider-ci/providers/ec/repo/.github/workflows/upgrade-bridge.yml
+++ b/provider-ci/providers/ec/repo/.github/workflows/upgrade-bridge.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Call upgrade provider action
-      uses: pulumi/pulumi-upgrade-provider-action@v0.0.5
+      uses: pulumi/pulumi-upgrade-provider-action@v0.0.6
       with:
         kind: bridge
     - env:

--- a/provider-ci/providers/ec/repo/.github/workflows/upgrade-provider.yml
+++ b/provider-ci/providers/ec/repo/.github/workflows/upgrade-provider.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Call upgrade provider action
-      uses: pulumi/pulumi-upgrade-provider-action@v0.0.5
+      uses: pulumi/pulumi-upgrade-provider-action@v0.0.6
       with:
         kind: all
     - env:

--- a/provider-ci/providers/equinix-metal/repo/.github/workflows/upgrade-bridge.yml
+++ b/provider-ci/providers/equinix-metal/repo/.github/workflows/upgrade-bridge.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Call upgrade provider action
-      uses: pulumi/pulumi-upgrade-provider-action@v0.0.5
+      uses: pulumi/pulumi-upgrade-provider-action@v0.0.6
       with:
         kind: bridge
     - env:

--- a/provider-ci/providers/equinix-metal/repo/.github/workflows/upgrade-provider.yml
+++ b/provider-ci/providers/equinix-metal/repo/.github/workflows/upgrade-provider.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Call upgrade provider action
-      uses: pulumi/pulumi-upgrade-provider-action@v0.0.5
+      uses: pulumi/pulumi-upgrade-provider-action@v0.0.6
       with:
         kind: all
     - env:

--- a/provider-ci/providers/external/repo/.github/workflows/upgrade-bridge.yml
+++ b/provider-ci/providers/external/repo/.github/workflows/upgrade-bridge.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Call upgrade provider action
-      uses: pulumi/pulumi-upgrade-provider-action@v0.0.5
+      uses: pulumi/pulumi-upgrade-provider-action@v0.0.6
       with:
         kind: bridge
     - env:

--- a/provider-ci/providers/external/repo/.github/workflows/upgrade-provider.yml
+++ b/provider-ci/providers/external/repo/.github/workflows/upgrade-provider.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Call upgrade provider action
-      uses: pulumi/pulumi-upgrade-provider-action@v0.0.5
+      uses: pulumi/pulumi-upgrade-provider-action@v0.0.6
       with:
         kind: all
     - env:

--- a/provider-ci/providers/f5bigip/repo/.github/workflows/upgrade-bridge.yml
+++ b/provider-ci/providers/f5bigip/repo/.github/workflows/upgrade-bridge.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Call upgrade provider action
-      uses: pulumi/pulumi-upgrade-provider-action@v0.0.5
+      uses: pulumi/pulumi-upgrade-provider-action@v0.0.6
       with:
         kind: bridge
     - env:

--- a/provider-ci/providers/f5bigip/repo/.github/workflows/upgrade-provider.yml
+++ b/provider-ci/providers/f5bigip/repo/.github/workflows/upgrade-provider.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Call upgrade provider action
-      uses: pulumi/pulumi-upgrade-provider-action@v0.0.5
+      uses: pulumi/pulumi-upgrade-provider-action@v0.0.6
       with:
         kind: all
     - env:

--- a/provider-ci/providers/fastly/repo/.github/workflows/upgrade-bridge.yml
+++ b/provider-ci/providers/fastly/repo/.github/workflows/upgrade-bridge.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Call upgrade provider action
-      uses: pulumi/pulumi-upgrade-provider-action@v0.0.5
+      uses: pulumi/pulumi-upgrade-provider-action@v0.0.6
       with:
         kind: bridge
     - env:

--- a/provider-ci/providers/fastly/repo/.github/workflows/upgrade-provider.yml
+++ b/provider-ci/providers/fastly/repo/.github/workflows/upgrade-provider.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Call upgrade provider action
-      uses: pulumi/pulumi-upgrade-provider-action@v0.0.5
+      uses: pulumi/pulumi-upgrade-provider-action@v0.0.6
       with:
         kind: all
     - env:

--- a/provider-ci/providers/gcp/repo/.github/workflows/upgrade-bridge.yml
+++ b/provider-ci/providers/gcp/repo/.github/workflows/upgrade-bridge.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Call upgrade provider action
-      uses: pulumi/pulumi-upgrade-provider-action@v0.0.5
+      uses: pulumi/pulumi-upgrade-provider-action@v0.0.6
       with:
         kind: bridge
     - env:

--- a/provider-ci/providers/gcp/repo/.github/workflows/upgrade-provider.yml
+++ b/provider-ci/providers/gcp/repo/.github/workflows/upgrade-provider.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Call upgrade provider action
-      uses: pulumi/pulumi-upgrade-provider-action@v0.0.5
+      uses: pulumi/pulumi-upgrade-provider-action@v0.0.6
       with:
         kind: all
     - env:

--- a/provider-ci/providers/github/repo/.github/workflows/upgrade-bridge.yml
+++ b/provider-ci/providers/github/repo/.github/workflows/upgrade-bridge.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Call upgrade provider action
-      uses: pulumi/pulumi-upgrade-provider-action@v0.0.5
+      uses: pulumi/pulumi-upgrade-provider-action@v0.0.6
       with:
         kind: bridge
     - env:

--- a/provider-ci/providers/github/repo/.github/workflows/upgrade-provider.yml
+++ b/provider-ci/providers/github/repo/.github/workflows/upgrade-provider.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Call upgrade provider action
-      uses: pulumi/pulumi-upgrade-provider-action@v0.0.5
+      uses: pulumi/pulumi-upgrade-provider-action@v0.0.6
       with:
         kind: all
     - env:

--- a/provider-ci/providers/gitlab/repo/.github/workflows/upgrade-bridge.yml
+++ b/provider-ci/providers/gitlab/repo/.github/workflows/upgrade-bridge.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Call upgrade provider action
-      uses: pulumi/pulumi-upgrade-provider-action@v0.0.5
+      uses: pulumi/pulumi-upgrade-provider-action@v0.0.6
       with:
         kind: bridge
     - env:

--- a/provider-ci/providers/gitlab/repo/.github/workflows/upgrade-provider.yml
+++ b/provider-ci/providers/gitlab/repo/.github/workflows/upgrade-provider.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Call upgrade provider action
-      uses: pulumi/pulumi-upgrade-provider-action@v0.0.5
+      uses: pulumi/pulumi-upgrade-provider-action@v0.0.6
       with:
         kind: all
     - env:

--- a/provider-ci/providers/hcloud/repo/.github/workflows/upgrade-bridge.yml
+++ b/provider-ci/providers/hcloud/repo/.github/workflows/upgrade-bridge.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Call upgrade provider action
-      uses: pulumi/pulumi-upgrade-provider-action@v0.0.5
+      uses: pulumi/pulumi-upgrade-provider-action@v0.0.6
       with:
         kind: bridge
     - env:

--- a/provider-ci/providers/hcloud/repo/.github/workflows/upgrade-provider.yml
+++ b/provider-ci/providers/hcloud/repo/.github/workflows/upgrade-provider.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Call upgrade provider action
-      uses: pulumi/pulumi-upgrade-provider-action@v0.0.5
+      uses: pulumi/pulumi-upgrade-provider-action@v0.0.6
       with:
         kind: all
     - env:

--- a/provider-ci/providers/http/repo/.github/workflows/upgrade-bridge.yml
+++ b/provider-ci/providers/http/repo/.github/workflows/upgrade-bridge.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Call upgrade provider action
-      uses: pulumi/pulumi-upgrade-provider-action@v0.0.5
+      uses: pulumi/pulumi-upgrade-provider-action@v0.0.6
       with:
         kind: bridge
     - env:

--- a/provider-ci/providers/http/repo/.github/workflows/upgrade-provider.yml
+++ b/provider-ci/providers/http/repo/.github/workflows/upgrade-provider.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Call upgrade provider action
-      uses: pulumi/pulumi-upgrade-provider-action@v0.0.5
+      uses: pulumi/pulumi-upgrade-provider-action@v0.0.6
       with:
         kind: all
     - env:

--- a/provider-ci/providers/kafka/repo/.github/workflows/upgrade-bridge.yml
+++ b/provider-ci/providers/kafka/repo/.github/workflows/upgrade-bridge.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Call upgrade provider action
-      uses: pulumi/pulumi-upgrade-provider-action@v0.0.5
+      uses: pulumi/pulumi-upgrade-provider-action@v0.0.6
       with:
         kind: bridge
     - env:

--- a/provider-ci/providers/kafka/repo/.github/workflows/upgrade-provider.yml
+++ b/provider-ci/providers/kafka/repo/.github/workflows/upgrade-provider.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Call upgrade provider action
-      uses: pulumi/pulumi-upgrade-provider-action@v0.0.5
+      uses: pulumi/pulumi-upgrade-provider-action@v0.0.6
       with:
         kind: all
     - env:

--- a/provider-ci/providers/keycloak/repo/.github/workflows/upgrade-bridge.yml
+++ b/provider-ci/providers/keycloak/repo/.github/workflows/upgrade-bridge.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Call upgrade provider action
-      uses: pulumi/pulumi-upgrade-provider-action@v0.0.5
+      uses: pulumi/pulumi-upgrade-provider-action@v0.0.6
       with:
         kind: bridge
     - env:

--- a/provider-ci/providers/keycloak/repo/.github/workflows/upgrade-provider.yml
+++ b/provider-ci/providers/keycloak/repo/.github/workflows/upgrade-provider.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Call upgrade provider action
-      uses: pulumi/pulumi-upgrade-provider-action@v0.0.5
+      uses: pulumi/pulumi-upgrade-provider-action@v0.0.6
       with:
         kind: all
     - env:

--- a/provider-ci/providers/kong/repo/.github/workflows/upgrade-bridge.yml
+++ b/provider-ci/providers/kong/repo/.github/workflows/upgrade-bridge.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Call upgrade provider action
-      uses: pulumi/pulumi-upgrade-provider-action@v0.0.5
+      uses: pulumi/pulumi-upgrade-provider-action@v0.0.6
       with:
         kind: bridge
     - env:

--- a/provider-ci/providers/kong/repo/.github/workflows/upgrade-provider.yml
+++ b/provider-ci/providers/kong/repo/.github/workflows/upgrade-provider.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Call upgrade provider action
-      uses: pulumi/pulumi-upgrade-provider-action@v0.0.5
+      uses: pulumi/pulumi-upgrade-provider-action@v0.0.6
       with:
         kind: all
     - env:

--- a/provider-ci/providers/libvirt/repo/.github/workflows/upgrade-bridge.yml
+++ b/provider-ci/providers/libvirt/repo/.github/workflows/upgrade-bridge.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Call upgrade provider action
-      uses: pulumi/pulumi-upgrade-provider-action@v0.0.5
+      uses: pulumi/pulumi-upgrade-provider-action@v0.0.6
       with:
         kind: bridge
     - env:

--- a/provider-ci/providers/libvirt/repo/.github/workflows/upgrade-provider.yml
+++ b/provider-ci/providers/libvirt/repo/.github/workflows/upgrade-provider.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Call upgrade provider action
-      uses: pulumi/pulumi-upgrade-provider-action@v0.0.5
+      uses: pulumi/pulumi-upgrade-provider-action@v0.0.6
       with:
         kind: all
     - env:

--- a/provider-ci/providers/linode/repo/.github/workflows/upgrade-bridge.yml
+++ b/provider-ci/providers/linode/repo/.github/workflows/upgrade-bridge.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Call upgrade provider action
-      uses: pulumi/pulumi-upgrade-provider-action@v0.0.5
+      uses: pulumi/pulumi-upgrade-provider-action@v0.0.6
       with:
         kind: bridge
     - env:

--- a/provider-ci/providers/linode/repo/.github/workflows/upgrade-provider.yml
+++ b/provider-ci/providers/linode/repo/.github/workflows/upgrade-provider.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Call upgrade provider action
-      uses: pulumi/pulumi-upgrade-provider-action@v0.0.5
+      uses: pulumi/pulumi-upgrade-provider-action@v0.0.6
       with:
         kind: all
     - env:

--- a/provider-ci/providers/local/repo/.github/workflows/upgrade-bridge.yml
+++ b/provider-ci/providers/local/repo/.github/workflows/upgrade-bridge.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Call upgrade provider action
-      uses: pulumi/pulumi-upgrade-provider-action@v0.0.5
+      uses: pulumi/pulumi-upgrade-provider-action@v0.0.6
       with:
         kind: bridge
     - env:

--- a/provider-ci/providers/local/repo/.github/workflows/upgrade-provider.yml
+++ b/provider-ci/providers/local/repo/.github/workflows/upgrade-provider.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Call upgrade provider action
-      uses: pulumi/pulumi-upgrade-provider-action@v0.0.5
+      uses: pulumi/pulumi-upgrade-provider-action@v0.0.6
       with:
         kind: all
     - env:

--- a/provider-ci/providers/mailgun/repo/.github/workflows/upgrade-bridge.yml
+++ b/provider-ci/providers/mailgun/repo/.github/workflows/upgrade-bridge.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Call upgrade provider action
-      uses: pulumi/pulumi-upgrade-provider-action@v0.0.5
+      uses: pulumi/pulumi-upgrade-provider-action@v0.0.6
       with:
         kind: bridge
     - env:

--- a/provider-ci/providers/mailgun/repo/.github/workflows/upgrade-provider.yml
+++ b/provider-ci/providers/mailgun/repo/.github/workflows/upgrade-provider.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Call upgrade provider action
-      uses: pulumi/pulumi-upgrade-provider-action@v0.0.5
+      uses: pulumi/pulumi-upgrade-provider-action@v0.0.6
       with:
         kind: all
     - env:

--- a/provider-ci/providers/minio/repo/.github/workflows/upgrade-bridge.yml
+++ b/provider-ci/providers/minio/repo/.github/workflows/upgrade-bridge.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Call upgrade provider action
-      uses: pulumi/pulumi-upgrade-provider-action@v0.0.5
+      uses: pulumi/pulumi-upgrade-provider-action@v0.0.6
       with:
         kind: bridge
     - env:

--- a/provider-ci/providers/minio/repo/.github/workflows/upgrade-provider.yml
+++ b/provider-ci/providers/minio/repo/.github/workflows/upgrade-provider.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Call upgrade provider action
-      uses: pulumi/pulumi-upgrade-provider-action@v0.0.5
+      uses: pulumi/pulumi-upgrade-provider-action@v0.0.6
       with:
         kind: all
     - env:

--- a/provider-ci/providers/mongodbatlas/repo/.github/workflows/upgrade-bridge.yml
+++ b/provider-ci/providers/mongodbatlas/repo/.github/workflows/upgrade-bridge.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Call upgrade provider action
-      uses: pulumi/pulumi-upgrade-provider-action@v0.0.5
+      uses: pulumi/pulumi-upgrade-provider-action@v0.0.6
       with:
         kind: bridge
     - env:

--- a/provider-ci/providers/mongodbatlas/repo/.github/workflows/upgrade-provider.yml
+++ b/provider-ci/providers/mongodbatlas/repo/.github/workflows/upgrade-provider.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Call upgrade provider action
-      uses: pulumi/pulumi-upgrade-provider-action@v0.0.5
+      uses: pulumi/pulumi-upgrade-provider-action@v0.0.6
       with:
         kind: all
     - env:

--- a/provider-ci/providers/mysql/repo/.github/workflows/upgrade-bridge.yml
+++ b/provider-ci/providers/mysql/repo/.github/workflows/upgrade-bridge.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Call upgrade provider action
-      uses: pulumi/pulumi-upgrade-provider-action@v0.0.5
+      uses: pulumi/pulumi-upgrade-provider-action@v0.0.6
       with:
         kind: bridge
     - env:

--- a/provider-ci/providers/mysql/repo/.github/workflows/upgrade-provider.yml
+++ b/provider-ci/providers/mysql/repo/.github/workflows/upgrade-provider.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Call upgrade provider action
-      uses: pulumi/pulumi-upgrade-provider-action@v0.0.5
+      uses: pulumi/pulumi-upgrade-provider-action@v0.0.6
       with:
         kind: all
     - env:

--- a/provider-ci/providers/newrelic/repo/.github/workflows/upgrade-bridge.yml
+++ b/provider-ci/providers/newrelic/repo/.github/workflows/upgrade-bridge.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Call upgrade provider action
-      uses: pulumi/pulumi-upgrade-provider-action@v0.0.5
+      uses: pulumi/pulumi-upgrade-provider-action@v0.0.6
       with:
         kind: bridge
     - env:

--- a/provider-ci/providers/newrelic/repo/.github/workflows/upgrade-provider.yml
+++ b/provider-ci/providers/newrelic/repo/.github/workflows/upgrade-provider.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Call upgrade provider action
-      uses: pulumi/pulumi-upgrade-provider-action@v0.0.5
+      uses: pulumi/pulumi-upgrade-provider-action@v0.0.6
       with:
         kind: all
     - env:

--- a/provider-ci/providers/nomad/repo/.github/workflows/upgrade-bridge.yml
+++ b/provider-ci/providers/nomad/repo/.github/workflows/upgrade-bridge.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Call upgrade provider action
-      uses: pulumi/pulumi-upgrade-provider-action@v0.0.5
+      uses: pulumi/pulumi-upgrade-provider-action@v0.0.6
       with:
         kind: bridge
     - env:

--- a/provider-ci/providers/nomad/repo/.github/workflows/upgrade-provider.yml
+++ b/provider-ci/providers/nomad/repo/.github/workflows/upgrade-provider.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Call upgrade provider action
-      uses: pulumi/pulumi-upgrade-provider-action@v0.0.5
+      uses: pulumi/pulumi-upgrade-provider-action@v0.0.6
       with:
         kind: all
     - env:

--- a/provider-ci/providers/ns1/repo/.github/workflows/upgrade-bridge.yml
+++ b/provider-ci/providers/ns1/repo/.github/workflows/upgrade-bridge.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Call upgrade provider action
-      uses: pulumi/pulumi-upgrade-provider-action@v0.0.5
+      uses: pulumi/pulumi-upgrade-provider-action@v0.0.6
       with:
         kind: bridge
     - env:

--- a/provider-ci/providers/ns1/repo/.github/workflows/upgrade-provider.yml
+++ b/provider-ci/providers/ns1/repo/.github/workflows/upgrade-provider.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Call upgrade provider action
-      uses: pulumi/pulumi-upgrade-provider-action@v0.0.5
+      uses: pulumi/pulumi-upgrade-provider-action@v0.0.6
       with:
         kind: all
     - env:

--- a/provider-ci/providers/null/repo/.github/workflows/upgrade-bridge.yml
+++ b/provider-ci/providers/null/repo/.github/workflows/upgrade-bridge.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Call upgrade provider action
-      uses: pulumi/pulumi-upgrade-provider-action@v0.0.5
+      uses: pulumi/pulumi-upgrade-provider-action@v0.0.6
       with:
         kind: bridge
     - env:

--- a/provider-ci/providers/null/repo/.github/workflows/upgrade-provider.yml
+++ b/provider-ci/providers/null/repo/.github/workflows/upgrade-provider.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Call upgrade provider action
-      uses: pulumi/pulumi-upgrade-provider-action@v0.0.5
+      uses: pulumi/pulumi-upgrade-provider-action@v0.0.6
       with:
         kind: all
     - env:

--- a/provider-ci/providers/oci/repo/.github/workflows/upgrade-bridge.yml
+++ b/provider-ci/providers/oci/repo/.github/workflows/upgrade-bridge.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Call upgrade provider action
-      uses: pulumi/pulumi-upgrade-provider-action@v0.0.5
+      uses: pulumi/pulumi-upgrade-provider-action@v0.0.6
       with:
         kind: bridge
     - env:

--- a/provider-ci/providers/oci/repo/.github/workflows/upgrade-provider.yml
+++ b/provider-ci/providers/oci/repo/.github/workflows/upgrade-provider.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Call upgrade provider action
-      uses: pulumi/pulumi-upgrade-provider-action@v0.0.5
+      uses: pulumi/pulumi-upgrade-provider-action@v0.0.6
       with:
         kind: all
     - env:

--- a/provider-ci/providers/okta/repo/.github/workflows/upgrade-bridge.yml
+++ b/provider-ci/providers/okta/repo/.github/workflows/upgrade-bridge.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Call upgrade provider action
-      uses: pulumi/pulumi-upgrade-provider-action@v0.0.5
+      uses: pulumi/pulumi-upgrade-provider-action@v0.0.6
       with:
         kind: bridge
     - env:

--- a/provider-ci/providers/okta/repo/.github/workflows/upgrade-provider.yml
+++ b/provider-ci/providers/okta/repo/.github/workflows/upgrade-provider.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Call upgrade provider action
-      uses: pulumi/pulumi-upgrade-provider-action@v0.0.5
+      uses: pulumi/pulumi-upgrade-provider-action@v0.0.6
       with:
         kind: all
     - env:

--- a/provider-ci/providers/onelogin/repo/.github/workflows/upgrade-bridge.yml
+++ b/provider-ci/providers/onelogin/repo/.github/workflows/upgrade-bridge.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Call upgrade provider action
-      uses: pulumi/pulumi-upgrade-provider-action@v0.0.5
+      uses: pulumi/pulumi-upgrade-provider-action@v0.0.6
       with:
         kind: bridge
     - env:

--- a/provider-ci/providers/onelogin/repo/.github/workflows/upgrade-provider.yml
+++ b/provider-ci/providers/onelogin/repo/.github/workflows/upgrade-provider.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Call upgrade provider action
-      uses: pulumi/pulumi-upgrade-provider-action@v0.0.5
+      uses: pulumi/pulumi-upgrade-provider-action@v0.0.6
       with:
         kind: all
     - env:

--- a/provider-ci/providers/openstack/repo/.github/workflows/upgrade-bridge.yml
+++ b/provider-ci/providers/openstack/repo/.github/workflows/upgrade-bridge.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Call upgrade provider action
-      uses: pulumi/pulumi-upgrade-provider-action@v0.0.5
+      uses: pulumi/pulumi-upgrade-provider-action@v0.0.6
       with:
         kind: bridge
     - env:

--- a/provider-ci/providers/openstack/repo/.github/workflows/upgrade-provider.yml
+++ b/provider-ci/providers/openstack/repo/.github/workflows/upgrade-provider.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Call upgrade provider action
-      uses: pulumi/pulumi-upgrade-provider-action@v0.0.5
+      uses: pulumi/pulumi-upgrade-provider-action@v0.0.6
       with:
         kind: all
     - env:

--- a/provider-ci/providers/opsgenie/repo/.github/workflows/upgrade-bridge.yml
+++ b/provider-ci/providers/opsgenie/repo/.github/workflows/upgrade-bridge.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Call upgrade provider action
-      uses: pulumi/pulumi-upgrade-provider-action@v0.0.5
+      uses: pulumi/pulumi-upgrade-provider-action@v0.0.6
       with:
         kind: bridge
     - env:

--- a/provider-ci/providers/opsgenie/repo/.github/workflows/upgrade-provider.yml
+++ b/provider-ci/providers/opsgenie/repo/.github/workflows/upgrade-provider.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Call upgrade provider action
-      uses: pulumi/pulumi-upgrade-provider-action@v0.0.5
+      uses: pulumi/pulumi-upgrade-provider-action@v0.0.6
       with:
         kind: all
     - env:

--- a/provider-ci/providers/pagerduty/repo/.github/workflows/upgrade-bridge.yml
+++ b/provider-ci/providers/pagerduty/repo/.github/workflows/upgrade-bridge.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Call upgrade provider action
-      uses: pulumi/pulumi-upgrade-provider-action@v0.0.5
+      uses: pulumi/pulumi-upgrade-provider-action@v0.0.6
       with:
         kind: bridge
     - env:

--- a/provider-ci/providers/pagerduty/repo/.github/workflows/upgrade-provider.yml
+++ b/provider-ci/providers/pagerduty/repo/.github/workflows/upgrade-provider.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Call upgrade provider action
-      uses: pulumi/pulumi-upgrade-provider-action@v0.0.5
+      uses: pulumi/pulumi-upgrade-provider-action@v0.0.6
       with:
         kind: all
     - env:

--- a/provider-ci/providers/postgresql/repo/.github/workflows/upgrade-bridge.yml
+++ b/provider-ci/providers/postgresql/repo/.github/workflows/upgrade-bridge.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Call upgrade provider action
-      uses: pulumi/pulumi-upgrade-provider-action@v0.0.5
+      uses: pulumi/pulumi-upgrade-provider-action@v0.0.6
       with:
         kind: bridge
     - env:

--- a/provider-ci/providers/postgresql/repo/.github/workflows/upgrade-provider.yml
+++ b/provider-ci/providers/postgresql/repo/.github/workflows/upgrade-provider.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Call upgrade provider action
-      uses: pulumi/pulumi-upgrade-provider-action@v0.0.5
+      uses: pulumi/pulumi-upgrade-provider-action@v0.0.6
       with:
         kind: all
     - env:

--- a/provider-ci/providers/rabbitmq/repo/.github/workflows/upgrade-bridge.yml
+++ b/provider-ci/providers/rabbitmq/repo/.github/workflows/upgrade-bridge.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Call upgrade provider action
-      uses: pulumi/pulumi-upgrade-provider-action@v0.0.5
+      uses: pulumi/pulumi-upgrade-provider-action@v0.0.6
       with:
         kind: bridge
     - env:

--- a/provider-ci/providers/rabbitmq/repo/.github/workflows/upgrade-provider.yml
+++ b/provider-ci/providers/rabbitmq/repo/.github/workflows/upgrade-provider.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Call upgrade provider action
-      uses: pulumi/pulumi-upgrade-provider-action@v0.0.5
+      uses: pulumi/pulumi-upgrade-provider-action@v0.0.6
       with:
         kind: all
     - env:

--- a/provider-ci/providers/rancher2/repo/.github/workflows/upgrade-bridge.yml
+++ b/provider-ci/providers/rancher2/repo/.github/workflows/upgrade-bridge.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Call upgrade provider action
-      uses: pulumi/pulumi-upgrade-provider-action@v0.0.5
+      uses: pulumi/pulumi-upgrade-provider-action@v0.0.6
       with:
         kind: bridge
     - env:

--- a/provider-ci/providers/rancher2/repo/.github/workflows/upgrade-provider.yml
+++ b/provider-ci/providers/rancher2/repo/.github/workflows/upgrade-provider.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Call upgrade provider action
-      uses: pulumi/pulumi-upgrade-provider-action@v0.0.5
+      uses: pulumi/pulumi-upgrade-provider-action@v0.0.6
       with:
         kind: all
     - env:

--- a/provider-ci/providers/random/repo/.github/workflows/upgrade-bridge.yml
+++ b/provider-ci/providers/random/repo/.github/workflows/upgrade-bridge.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Call upgrade provider action
-      uses: pulumi/pulumi-upgrade-provider-action@v0.0.5
+      uses: pulumi/pulumi-upgrade-provider-action@v0.0.6
       with:
         kind: bridge
     - env:

--- a/provider-ci/providers/random/repo/.github/workflows/upgrade-provider.yml
+++ b/provider-ci/providers/random/repo/.github/workflows/upgrade-provider.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Call upgrade provider action
-      uses: pulumi/pulumi-upgrade-provider-action@v0.0.5
+      uses: pulumi/pulumi-upgrade-provider-action@v0.0.6
       with:
         kind: all
     - env:

--- a/provider-ci/providers/rke/repo/.github/workflows/upgrade-bridge.yml
+++ b/provider-ci/providers/rke/repo/.github/workflows/upgrade-bridge.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Call upgrade provider action
-      uses: pulumi/pulumi-upgrade-provider-action@v0.0.5
+      uses: pulumi/pulumi-upgrade-provider-action@v0.0.6
       with:
         kind: bridge
     - env:

--- a/provider-ci/providers/rke/repo/.github/workflows/upgrade-provider.yml
+++ b/provider-ci/providers/rke/repo/.github/workflows/upgrade-provider.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Call upgrade provider action
-      uses: pulumi/pulumi-upgrade-provider-action@v0.0.5
+      uses: pulumi/pulumi-upgrade-provider-action@v0.0.6
       with:
         kind: all
     - env:

--- a/provider-ci/providers/signalfx/repo/.github/workflows/upgrade-bridge.yml
+++ b/provider-ci/providers/signalfx/repo/.github/workflows/upgrade-bridge.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Call upgrade provider action
-      uses: pulumi/pulumi-upgrade-provider-action@v0.0.5
+      uses: pulumi/pulumi-upgrade-provider-action@v0.0.6
       with:
         kind: bridge
     - env:

--- a/provider-ci/providers/signalfx/repo/.github/workflows/upgrade-provider.yml
+++ b/provider-ci/providers/signalfx/repo/.github/workflows/upgrade-provider.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Call upgrade provider action
-      uses: pulumi/pulumi-upgrade-provider-action@v0.0.5
+      uses: pulumi/pulumi-upgrade-provider-action@v0.0.6
       with:
         kind: all
     - env:

--- a/provider-ci/providers/slack/repo/.github/workflows/upgrade-bridge.yml
+++ b/provider-ci/providers/slack/repo/.github/workflows/upgrade-bridge.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Call upgrade provider action
-      uses: pulumi/pulumi-upgrade-provider-action@v0.0.5
+      uses: pulumi/pulumi-upgrade-provider-action@v0.0.6
       with:
         kind: bridge
     - env:

--- a/provider-ci/providers/slack/repo/.github/workflows/upgrade-provider.yml
+++ b/provider-ci/providers/slack/repo/.github/workflows/upgrade-provider.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Call upgrade provider action
-      uses: pulumi/pulumi-upgrade-provider-action@v0.0.5
+      uses: pulumi/pulumi-upgrade-provider-action@v0.0.6
       with:
         kind: all
     - env:

--- a/provider-ci/providers/snowflake/repo/.github/workflows/upgrade-bridge.yml
+++ b/provider-ci/providers/snowflake/repo/.github/workflows/upgrade-bridge.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Call upgrade provider action
-      uses: pulumi/pulumi-upgrade-provider-action@v0.0.5
+      uses: pulumi/pulumi-upgrade-provider-action@v0.0.6
       with:
         kind: bridge
     - env:

--- a/provider-ci/providers/snowflake/repo/.github/workflows/upgrade-provider.yml
+++ b/provider-ci/providers/snowflake/repo/.github/workflows/upgrade-provider.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Call upgrade provider action
-      uses: pulumi/pulumi-upgrade-provider-action@v0.0.5
+      uses: pulumi/pulumi-upgrade-provider-action@v0.0.6
       with:
         kind: all
     - env:

--- a/provider-ci/providers/splunk/repo/.github/workflows/upgrade-bridge.yml
+++ b/provider-ci/providers/splunk/repo/.github/workflows/upgrade-bridge.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Call upgrade provider action
-      uses: pulumi/pulumi-upgrade-provider-action@v0.0.5
+      uses: pulumi/pulumi-upgrade-provider-action@v0.0.6
       with:
         kind: bridge
     - env:

--- a/provider-ci/providers/splunk/repo/.github/workflows/upgrade-provider.yml
+++ b/provider-ci/providers/splunk/repo/.github/workflows/upgrade-provider.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Call upgrade provider action
-      uses: pulumi/pulumi-upgrade-provider-action@v0.0.5
+      uses: pulumi/pulumi-upgrade-provider-action@v0.0.6
       with:
         kind: all
     - env:

--- a/provider-ci/providers/spotinst/repo/.github/workflows/upgrade-bridge.yml
+++ b/provider-ci/providers/spotinst/repo/.github/workflows/upgrade-bridge.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Call upgrade provider action
-      uses: pulumi/pulumi-upgrade-provider-action@v0.0.5
+      uses: pulumi/pulumi-upgrade-provider-action@v0.0.6
       with:
         kind: bridge
     - env:

--- a/provider-ci/providers/spotinst/repo/.github/workflows/upgrade-provider.yml
+++ b/provider-ci/providers/spotinst/repo/.github/workflows/upgrade-provider.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Call upgrade provider action
-      uses: pulumi/pulumi-upgrade-provider-action@v0.0.5
+      uses: pulumi/pulumi-upgrade-provider-action@v0.0.6
       with:
         kind: all
     - env:

--- a/provider-ci/providers/sumologic/repo/.github/workflows/upgrade-bridge.yml
+++ b/provider-ci/providers/sumologic/repo/.github/workflows/upgrade-bridge.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Call upgrade provider action
-      uses: pulumi/pulumi-upgrade-provider-action@v0.0.5
+      uses: pulumi/pulumi-upgrade-provider-action@v0.0.6
       with:
         kind: bridge
     - env:

--- a/provider-ci/providers/sumologic/repo/.github/workflows/upgrade-provider.yml
+++ b/provider-ci/providers/sumologic/repo/.github/workflows/upgrade-provider.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Call upgrade provider action
-      uses: pulumi/pulumi-upgrade-provider-action@v0.0.5
+      uses: pulumi/pulumi-upgrade-provider-action@v0.0.6
       with:
         kind: all
     - env:

--- a/provider-ci/providers/tailscale/repo/.github/workflows/upgrade-bridge.yml
+++ b/provider-ci/providers/tailscale/repo/.github/workflows/upgrade-bridge.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Call upgrade provider action
-      uses: pulumi/pulumi-upgrade-provider-action@v0.0.5
+      uses: pulumi/pulumi-upgrade-provider-action@v0.0.6
       with:
         kind: bridge
     - env:

--- a/provider-ci/providers/tailscale/repo/.github/workflows/upgrade-provider.yml
+++ b/provider-ci/providers/tailscale/repo/.github/workflows/upgrade-provider.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Call upgrade provider action
-      uses: pulumi/pulumi-upgrade-provider-action@v0.0.5
+      uses: pulumi/pulumi-upgrade-provider-action@v0.0.6
       with:
         kind: all
     - env:

--- a/provider-ci/providers/tls/repo/.github/workflows/upgrade-bridge.yml
+++ b/provider-ci/providers/tls/repo/.github/workflows/upgrade-bridge.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Call upgrade provider action
-      uses: pulumi/pulumi-upgrade-provider-action@v0.0.5
+      uses: pulumi/pulumi-upgrade-provider-action@v0.0.6
       with:
         kind: bridge
     - env:

--- a/provider-ci/providers/tls/repo/.github/workflows/upgrade-provider.yml
+++ b/provider-ci/providers/tls/repo/.github/workflows/upgrade-provider.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Call upgrade provider action
-      uses: pulumi/pulumi-upgrade-provider-action@v0.0.5
+      uses: pulumi/pulumi-upgrade-provider-action@v0.0.6
       with:
         kind: all
     - env:

--- a/provider-ci/providers/vault/repo/.github/workflows/upgrade-bridge.yml
+++ b/provider-ci/providers/vault/repo/.github/workflows/upgrade-bridge.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Call upgrade provider action
-      uses: pulumi/pulumi-upgrade-provider-action@v0.0.5
+      uses: pulumi/pulumi-upgrade-provider-action@v0.0.6
       with:
         kind: bridge
     - env:

--- a/provider-ci/providers/vault/repo/.github/workflows/upgrade-provider.yml
+++ b/provider-ci/providers/vault/repo/.github/workflows/upgrade-provider.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Call upgrade provider action
-      uses: pulumi/pulumi-upgrade-provider-action@v0.0.5
+      uses: pulumi/pulumi-upgrade-provider-action@v0.0.6
       with:
         kind: all
     - env:

--- a/provider-ci/providers/venafi/repo/.github/workflows/upgrade-bridge.yml
+++ b/provider-ci/providers/venafi/repo/.github/workflows/upgrade-bridge.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Call upgrade provider action
-      uses: pulumi/pulumi-upgrade-provider-action@v0.0.5
+      uses: pulumi/pulumi-upgrade-provider-action@v0.0.6
       with:
         kind: bridge
     - env:

--- a/provider-ci/providers/venafi/repo/.github/workflows/upgrade-provider.yml
+++ b/provider-ci/providers/venafi/repo/.github/workflows/upgrade-provider.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Call upgrade provider action
-      uses: pulumi/pulumi-upgrade-provider-action@v0.0.5
+      uses: pulumi/pulumi-upgrade-provider-action@v0.0.6
       with:
         kind: all
     - env:

--- a/provider-ci/providers/vsphere/repo/.github/workflows/upgrade-bridge.yml
+++ b/provider-ci/providers/vsphere/repo/.github/workflows/upgrade-bridge.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Call upgrade provider action
-      uses: pulumi/pulumi-upgrade-provider-action@v0.0.5
+      uses: pulumi/pulumi-upgrade-provider-action@v0.0.6
       with:
         kind: bridge
     - env:

--- a/provider-ci/providers/vsphere/repo/.github/workflows/upgrade-provider.yml
+++ b/provider-ci/providers/vsphere/repo/.github/workflows/upgrade-provider.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Call upgrade provider action
-      uses: pulumi/pulumi-upgrade-provider-action@v0.0.5
+      uses: pulumi/pulumi-upgrade-provider-action@v0.0.6
       with:
         kind: all
     - env:

--- a/provider-ci/providers/wavefront/repo/.github/workflows/upgrade-bridge.yml
+++ b/provider-ci/providers/wavefront/repo/.github/workflows/upgrade-bridge.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Call upgrade provider action
-      uses: pulumi/pulumi-upgrade-provider-action@v0.0.5
+      uses: pulumi/pulumi-upgrade-provider-action@v0.0.6
       with:
         kind: bridge
     - env:

--- a/provider-ci/providers/wavefront/repo/.github/workflows/upgrade-provider.yml
+++ b/provider-ci/providers/wavefront/repo/.github/workflows/upgrade-provider.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Call upgrade provider action
-      uses: pulumi/pulumi-upgrade-provider-action@v0.0.5
+      uses: pulumi/pulumi-upgrade-provider-action@v0.0.6
       with:
         kind: all
     - env:


### PR DESCRIPTION
Resolves ci failures such as https://github.com/pulumi/pulumi-auth0/actions/runs/6086452637/job/16512853682, https://github.com/pulumi/pulumi-linode/actions/runs/6039131983/job/16387080694