### PR TITLE
Build sdks on larger runner

### DIFF
--- a/native-provider-ci/providers/aws-native/repo/.github/workflows/build.yml
+++ b/native-provider-ci/providers/aws-native/repo/.github/workflows/build.yml
@@ -132,7 +132,7 @@ jobs:
         status: ${{ job.status }}
   build_sdks:
     needs: prerequisites
-    runs-on: ubuntu-latest
+    runs-on: pulumi-ubuntu-8core
     strategy:
       fail-fast: true
       matrix:

--- a/native-provider-ci/providers/aws-native/repo/.github/workflows/prerelease.yml
+++ b/native-provider-ci/providers/aws-native/repo/.github/workflows/prerelease.yml
@@ -124,7 +124,7 @@ jobs:
         status: ${{ job.status }}
   build_sdks:
     needs: prerequisites
-    runs-on: ubuntu-latest
+    runs-on: pulumi-ubuntu-8core
     strategy:
       fail-fast: true
       matrix:

--- a/native-provider-ci/providers/aws-native/repo/.github/workflows/release.yml
+++ b/native-provider-ci/providers/aws-native/repo/.github/workflows/release.yml
@@ -124,7 +124,7 @@ jobs:
         status: ${{ job.status }}
   build_sdks:
     needs: prerequisites
-    runs-on: ubuntu-latest
+    runs-on: pulumi-ubuntu-8core
     strategy:
       fail-fast: true
       matrix:

--- a/native-provider-ci/providers/aws-native/repo/.github/workflows/run-acceptance-tests.yml
+++ b/native-provider-ci/providers/aws-native/repo/.github/workflows/run-acceptance-tests.yml
@@ -150,7 +150,7 @@ jobs:
       github.event.pull_request.head.repo.full_name == github.repository
   build_sdks:
     needs: prerequisites
-    runs-on: ubuntu-latest
+    runs-on: pulumi-ubuntu-8core
     strategy:
       fail-fast: true
       matrix:

--- a/native-provider-ci/providers/command/repo/.github/workflows/build.yml
+++ b/native-provider-ci/providers/command/repo/.github/workflows/build.yml
@@ -97,7 +97,7 @@ jobs:
         status: ${{ job.status }}
   build_sdks:
     needs: prerequisites
-    runs-on: ubuntu-latest
+    runs-on: pulumi-ubuntu-8core
     strategy:
       fail-fast: true
       matrix:

--- a/native-provider-ci/providers/command/repo/.github/workflows/prerelease.yml
+++ b/native-provider-ci/providers/command/repo/.github/workflows/prerelease.yml
@@ -89,7 +89,7 @@ jobs:
         status: ${{ job.status }}
   build_sdks:
     needs: prerequisites
-    runs-on: ubuntu-latest
+    runs-on: pulumi-ubuntu-8core
     strategy:
       fail-fast: true
       matrix:

--- a/native-provider-ci/providers/command/repo/.github/workflows/release.yml
+++ b/native-provider-ci/providers/command/repo/.github/workflows/release.yml
@@ -89,7 +89,7 @@ jobs:
         status: ${{ job.status }}
   build_sdks:
     needs: prerequisites
-    runs-on: ubuntu-latest
+    runs-on: pulumi-ubuntu-8core
     strategy:
       fail-fast: true
       matrix:

--- a/native-provider-ci/providers/command/repo/.github/workflows/run-acceptance-tests.yml
+++ b/native-provider-ci/providers/command/repo/.github/workflows/run-acceptance-tests.yml
@@ -115,7 +115,7 @@ jobs:
       github.event.pull_request.head.repo.full_name == github.repository
   build_sdks:
     needs: prerequisites
-    runs-on: ubuntu-latest
+    runs-on: pulumi-ubuntu-8core
     strategy:
       fail-fast: true
       matrix:

--- a/native-provider-ci/providers/google-native/repo/.github/workflows/build.yml
+++ b/native-provider-ci/providers/google-native/repo/.github/workflows/build.yml
@@ -138,7 +138,7 @@ jobs:
         status: ${{ job.status }}
   build_sdks:
     needs: prerequisites
-    runs-on: ubuntu-latest
+    runs-on: pulumi-ubuntu-8core
     strategy:
       fail-fast: true
       matrix:

--- a/native-provider-ci/providers/google-native/repo/.github/workflows/prerelease.yml
+++ b/native-provider-ci/providers/google-native/repo/.github/workflows/prerelease.yml
@@ -130,7 +130,7 @@ jobs:
         status: ${{ job.status }}
   build_sdks:
     needs: prerequisites
-    runs-on: ubuntu-latest
+    runs-on: pulumi-ubuntu-8core
     strategy:
       fail-fast: true
       matrix:

--- a/native-provider-ci/providers/google-native/repo/.github/workflows/release.yml
+++ b/native-provider-ci/providers/google-native/repo/.github/workflows/release.yml
@@ -130,7 +130,7 @@ jobs:
         status: ${{ job.status }}
   build_sdks:
     needs: prerequisites
-    runs-on: ubuntu-latest
+    runs-on: pulumi-ubuntu-8core
     strategy:
       fail-fast: true
       matrix:

--- a/native-provider-ci/providers/google-native/repo/.github/workflows/run-acceptance-tests.yml
+++ b/native-provider-ci/providers/google-native/repo/.github/workflows/run-acceptance-tests.yml
@@ -156,7 +156,7 @@ jobs:
       github.event.pull_request.head.repo.full_name == github.repository
   build_sdks:
     needs: prerequisites
-    runs-on: ubuntu-latest
+    runs-on: pulumi-ubuntu-8core
     strategy:
       fail-fast: true
       matrix:

--- a/native-provider-ci/providers/kubernetes/repo/.github/workflows/build.yml
+++ b/native-provider-ci/providers/kubernetes/repo/.github/workflows/build.yml
@@ -138,7 +138,7 @@ jobs:
         status: ${{ job.status }}
   build_sdks:
     needs: prerequisites
-    runs-on: ubuntu-latest
+    runs-on: pulumi-ubuntu-8core
     strategy:
       fail-fast: true
       matrix:

--- a/native-provider-ci/providers/kubernetes/repo/.github/workflows/prerelease.yml
+++ b/native-provider-ci/providers/kubernetes/repo/.github/workflows/prerelease.yml
@@ -130,7 +130,7 @@ jobs:
         status: ${{ job.status }}
   build_sdks:
     needs: prerequisites
-    runs-on: ubuntu-latest
+    runs-on: pulumi-ubuntu-8core
     strategy:
       fail-fast: true
       matrix:

--- a/native-provider-ci/providers/kubernetes/repo/.github/workflows/release.yml
+++ b/native-provider-ci/providers/kubernetes/repo/.github/workflows/release.yml
@@ -130,7 +130,7 @@ jobs:
         status: ${{ job.status }}
   build_sdks:
     needs: prerequisites
-    runs-on: ubuntu-latest
+    runs-on: pulumi-ubuntu-8core
     strategy:
       fail-fast: true
       matrix:

--- a/native-provider-ci/providers/kubernetes/repo/.github/workflows/run-acceptance-tests.yml
+++ b/native-provider-ci/providers/kubernetes/repo/.github/workflows/run-acceptance-tests.yml
@@ -157,7 +157,7 @@ jobs:
       github.event.pull_request.head.repo.full_name == github.repository
   build_sdks:
     needs: prerequisites
-    runs-on: ubuntu-latest
+    runs-on: pulumi-ubuntu-8core
     strategy:
       fail-fast: true
       matrix:

--- a/native-provider-ci/src/workflows.ts
+++ b/native-provider-ci/src/workflows.ts
@@ -432,9 +432,9 @@ export function Arm2PulumiReleaseWorkflow(
 
 export class BuildSdkJob implements NormalJob {
   needs = "prerequisites";
-   
+
   "runs-on" = "pulumi-ubuntu-8core"; // insufficient resources to run Go builds on ubuntu-latest
-    
+
   strategy = {
     "fail-fast": true,
     matrix: {

--- a/native-provider-ci/src/workflows.ts
+++ b/native-provider-ci/src/workflows.ts
@@ -432,7 +432,9 @@ export function Arm2PulumiReleaseWorkflow(
 
 export class BuildSdkJob implements NormalJob {
   needs = "prerequisites";
-  "runs-on" = "ubuntu-latest";
+   
+  "runs-on" = "pulumi-ubuntu-8core"; // insufficient resources to run Go builds on ubuntu-latest
+    
   strategy = {
     "fail-fast": true,
     matrix: {


### PR DESCRIPTION
Workaround https://github.com/pulumi/ci-mgmt/issues/554 fallout for native providers. Some of these have drifted from ci-mgmt but I notice that pulumi-aws-native is very close so it could definitely benefit it.