### PR TITLE
Add script to update commit message settings

### DIFF
--- a/scripts/set-merge-commit-message-to-pr-title-and-body.sh
+++ b/scripts/set-merge-commit-message-to-pr-title-and-body.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+set -euo pipefail
+
+# Check if the 'gh' command-line tool is installed
+if ! command -v gh &> /dev/null; then
+    echo "Error: 'gh' command-line tool is not installed. Please install GitHub CLI (https://cli.github.com/)." >&2
+    exit 1
+fi
+
+# Check if the input file is "-" or if no argument is provided, default to stdin
+input_file="${1:--}"
+if [ "$input_file" = "-" ] ; then
+    input_file="/dev/stdin"
+elif [ ! -f "$input_file" ]; then
+    echo "Error: Input file '$input_file' not found." >&2
+    exit 1
+fi
+
+# Loop through each repository name in the file or from stdin
+while IFS= read -r repo; do
+    echo "setting (squash) merge commit message for \"$repo\""
+    # suppress errors for merge since may repos only support squash
+    gh api "repos/$repo" --silent --method=PATCH \
+        -F merge_commit_message=PR_BODY -F merge_commit_title=PR_TITLE 2>/dev/null || true
+    gh api "repos/$repo" --silent --method=PATCH \
+        -F squash_merge_commit_message=PR_BODY -F squash_merge_commit_title=PR_TITLE || true
+done < "$input_file"


### PR DESCRIPTION
Per our discussion in ideation, I used this script to update the default squash/merge commit message settings to PR title+body. I was able to update most of the repositories we own except for these ones (which I apparently don't have permissions to update):
- pulumi/pulumi-awsx
- pulumi/pulumi-eks
- pulumi/action-test-provider-downstream
- pulumi/arm2pulumi
- pulumi/kube2pulumi
- pulumi/pulumi-aws-apigateway
- pulumi/pulumi-component-provider-py-boilerplate
- pulumi/pulumi-component-provider-ts-boilerplate
- pulumi/pulumi-provider-boilerplate
- pulumi/pulumictl