### PR TITLE
More power to test runners

### DIFF
--- a/native-provider-ci/providers/aws-native/repo/.github/workflows/build.yml
+++ b/native-provider-ci/providers/aws-native/repo/.github/workflows/build.yml
@@ -224,7 +224,7 @@ jobs:
         fields: repo,commit,author,action
         status: ${{ job.status }}
   test:
-    runs-on: ubuntu-latest
+    runs-on: pulumi-ubuntu-8core
     needs:
     - build_sdks
     strategy:

--- a/native-provider-ci/providers/aws-native/repo/.github/workflows/prerelease.yml
+++ b/native-provider-ci/providers/aws-native/repo/.github/workflows/prerelease.yml
@@ -215,7 +215,7 @@ jobs:
         fields: repo,commit,author,action
         status: ${{ job.status }}
   test:
-    runs-on: ubuntu-latest
+    runs-on: pulumi-ubuntu-8core
     needs:
     - build_sdks
     strategy:

--- a/native-provider-ci/providers/aws-native/repo/.github/workflows/release.yml
+++ b/native-provider-ci/providers/aws-native/repo/.github/workflows/release.yml
@@ -215,7 +215,7 @@ jobs:
         fields: repo,commit,author,action
         status: ${{ job.status }}
   test:
-    runs-on: ubuntu-latest
+    runs-on: pulumi-ubuntu-8core
     needs:
     - build_sdks
     strategy:

--- a/native-provider-ci/providers/aws-native/repo/.github/workflows/run-acceptance-tests.yml
+++ b/native-provider-ci/providers/aws-native/repo/.github/workflows/run-acceptance-tests.yml
@@ -245,7 +245,7 @@ jobs:
     if: github.event_name == 'repository_dispatch' ||
       github.event.pull_request.head.repo.full_name == github.repository
   test:
-    runs-on: ubuntu-latest
+    runs-on: pulumi-ubuntu-8core
     needs:
     - build_sdks
     strategy:

--- a/native-provider-ci/providers/azure-native/repo/.github/workflows/build.yml
+++ b/native-provider-ci/providers/azure-native/repo/.github/workflows/build.yml
@@ -236,7 +236,7 @@ jobs:
         fields: repo,commit,author,action
         status: ${{ job.status }}
   test:
-    runs-on: ubuntu-latest
+    runs-on: pulumi-ubuntu-8core
     needs:
     - build_sdks
     strategy:

--- a/native-provider-ci/providers/azure-native/repo/.github/workflows/prerelease.yml
+++ b/native-provider-ci/providers/azure-native/repo/.github/workflows/prerelease.yml
@@ -227,7 +227,7 @@ jobs:
         fields: repo,commit,author,action
         status: ${{ job.status }}
   test:
-    runs-on: ubuntu-latest
+    runs-on: pulumi-ubuntu-8core
     needs:
     - build_sdks
     strategy:

--- a/native-provider-ci/providers/azure-native/repo/.github/workflows/release.yml
+++ b/native-provider-ci/providers/azure-native/repo/.github/workflows/release.yml
@@ -227,7 +227,7 @@ jobs:
         fields: repo,commit,author,action
         status: ${{ job.status }}
   test:
-    runs-on: ubuntu-latest
+    runs-on: pulumi-ubuntu-8core
     needs:
     - build_sdks
     strategy:

--- a/native-provider-ci/providers/azure-native/repo/.github/workflows/run-acceptance-tests.yml
+++ b/native-provider-ci/providers/azure-native/repo/.github/workflows/run-acceptance-tests.yml
@@ -257,7 +257,7 @@ jobs:
     if: github.event_name == 'repository_dispatch' ||
       github.event.pull_request.head.repo.full_name == github.repository
   test:
-    runs-on: ubuntu-latest
+    runs-on: pulumi-ubuntu-8core
     needs:
     - build_sdks
     strategy:

--- a/native-provider-ci/providers/command/repo/.github/workflows/build.yml
+++ b/native-provider-ci/providers/command/repo/.github/workflows/build.yml
@@ -185,7 +185,7 @@ jobs:
         fields: repo,commit,author,action
         status: ${{ job.status }}
   test:
-    runs-on: ubuntu-latest
+    runs-on: pulumi-ubuntu-8core
     needs:
     - build_sdks
     strategy:

--- a/native-provider-ci/providers/command/repo/.github/workflows/prerelease.yml
+++ b/native-provider-ci/providers/command/repo/.github/workflows/prerelease.yml
@@ -176,7 +176,7 @@ jobs:
         fields: repo,commit,author,action
         status: ${{ job.status }}
   test:
-    runs-on: ubuntu-latest
+    runs-on: pulumi-ubuntu-8core
     needs:
     - build_sdks
     strategy:

--- a/native-provider-ci/providers/command/repo/.github/workflows/release.yml
+++ b/native-provider-ci/providers/command/repo/.github/workflows/release.yml
@@ -176,7 +176,7 @@ jobs:
         fields: repo,commit,author,action
         status: ${{ job.status }}
   test:
-    runs-on: ubuntu-latest
+    runs-on: pulumi-ubuntu-8core
     needs:
     - build_sdks
     strategy:

--- a/native-provider-ci/providers/command/repo/.github/workflows/run-acceptance-tests.yml
+++ b/native-provider-ci/providers/command/repo/.github/workflows/run-acceptance-tests.yml
@@ -206,7 +206,7 @@ jobs:
     if: github.event_name == 'repository_dispatch' ||
       github.event.pull_request.head.repo.full_name == github.repository
   test:
-    runs-on: ubuntu-latest
+    runs-on: pulumi-ubuntu-8core
     needs:
     - build_sdks
     strategy:

--- a/native-provider-ci/providers/google-native/repo/.github/workflows/build.yml
+++ b/native-provider-ci/providers/google-native/repo/.github/workflows/build.yml
@@ -230,7 +230,7 @@ jobs:
         fields: repo,commit,author,action
         status: ${{ job.status }}
   test:
-    runs-on: ubuntu-latest
+    runs-on: pulumi-ubuntu-8core
     needs:
     - build_sdks
     strategy:

--- a/native-provider-ci/providers/google-native/repo/.github/workflows/prerelease.yml
+++ b/native-provider-ci/providers/google-native/repo/.github/workflows/prerelease.yml
@@ -221,7 +221,7 @@ jobs:
         fields: repo,commit,author,action
         status: ${{ job.status }}
   test:
-    runs-on: ubuntu-latest
+    runs-on: pulumi-ubuntu-8core
     needs:
     - build_sdks
     strategy:

--- a/native-provider-ci/providers/google-native/repo/.github/workflows/release.yml
+++ b/native-provider-ci/providers/google-native/repo/.github/workflows/release.yml
@@ -221,7 +221,7 @@ jobs:
         fields: repo,commit,author,action
         status: ${{ job.status }}
   test:
-    runs-on: ubuntu-latest
+    runs-on: pulumi-ubuntu-8core
     needs:
     - build_sdks
     strategy:

--- a/native-provider-ci/providers/google-native/repo/.github/workflows/run-acceptance-tests.yml
+++ b/native-provider-ci/providers/google-native/repo/.github/workflows/run-acceptance-tests.yml
@@ -251,7 +251,7 @@ jobs:
     if: github.event_name == 'repository_dispatch' ||
       github.event.pull_request.head.repo.full_name == github.repository
   test:
-    runs-on: ubuntu-latest
+    runs-on: pulumi-ubuntu-8core
     needs:
     - build_sdks
     strategy:

--- a/native-provider-ci/providers/kubernetes/repo/.github/workflows/build.yml
+++ b/native-provider-ci/providers/kubernetes/repo/.github/workflows/build.yml
@@ -226,7 +226,7 @@ jobs:
         fields: repo,commit,author,action
         status: ${{ job.status }}
   test:
-    runs-on: ubuntu-latest
+    runs-on: pulumi-ubuntu-8core
     needs:
     - build_sdks
     - build-test-cluster

--- a/native-provider-ci/providers/kubernetes/repo/.github/workflows/prerelease.yml
+++ b/native-provider-ci/providers/kubernetes/repo/.github/workflows/prerelease.yml
@@ -217,7 +217,7 @@ jobs:
         fields: repo,commit,author,action
         status: ${{ job.status }}
   test:
-    runs-on: ubuntu-latest
+    runs-on: pulumi-ubuntu-8core
     needs:
     - build_sdks
     - build-test-cluster

--- a/native-provider-ci/providers/kubernetes/repo/.github/workflows/release.yml
+++ b/native-provider-ci/providers/kubernetes/repo/.github/workflows/release.yml
@@ -217,7 +217,7 @@ jobs:
         fields: repo,commit,author,action
         status: ${{ job.status }}
   test:
-    runs-on: ubuntu-latest
+    runs-on: pulumi-ubuntu-8core
     needs:
     - build_sdks
     - build-test-cluster

--- a/native-provider-ci/providers/kubernetes/repo/.github/workflows/run-acceptance-tests.yml
+++ b/native-provider-ci/providers/kubernetes/repo/.github/workflows/run-acceptance-tests.yml
@@ -248,7 +248,7 @@ jobs:
     if: github.event_name == 'repository_dispatch' ||
       github.event.pull_request.head.repo.full_name == github.repository
   test:
-    runs-on: ubuntu-latest
+    runs-on: pulumi-ubuntu-8core
     needs:
     - build_sdks
     - build-test-cluster

--- a/native-provider-ci/src/workflows.ts
+++ b/native-provider-ci/src/workflows.ts
@@ -549,7 +549,8 @@ export class PrerequisitesJob implements NormalJob {
 }
 
 export class TestsJob implements NormalJob {
-  "runs-on" = "ubuntu-latest";
+  "runs-on" = "pulumi-ubuntu-8core"; // insufficient resources to run Go builds on ubuntu-latest, specifically for K8S
+
   needs = ["build_sdks"];
   strategy = {
     "fail-fast": true,


### PR DESCRIPTION
Working with K8S repo we can't pass the tests on the normal runner.

```
free: 231G
$ install stuff
free: 226G (-5G)
$ go test -run COMPILEONLY
free: 218G (-8G)
$ go test
free: 213G (-5G)
```

We run just a bit short. Moving everything to the larger worker while it is available.