### PR TITLE
Permit custom self-hosted runner

### DIFF
--- a/provider-ci/Makefile
+++ b/provider-ci/Makefile
@@ -41,7 +41,7 @@ providers/%/repo: bin/provider-ci providers/%/config.yaml
 
 lint-providers/%/repo: $(ACTIONLINT) providers/%/repo
 	@echo Linting $*
-	$(ACTIONLINT) providers/$*/repo/.github/workflows/*
+	$(ACTIONLINT) -config-file actionlint.yml providers/$*/repo/.github/workflows/*
 	@scripts/shellcheck.sh providers/$*/repo
 
 LINT_RULES := $(addprefix lint-, $(PROVIDER_REPOS))

--- a/provider-ci/actionlint.yml
+++ b/provider-ci/actionlint.yml
@@ -1,0 +1,4 @@
+self-hosted-runner:
+  # Labels of self-hosted runner in array of string
+  labels:
+    - pulumi-ubuntu-8core


### PR DESCRIPTION
Without this runner listed as a possibility in the Makefile the actions no longer pass actionlint. 