### PR TITLE
Update provider upgrade slack channel name

### DIFF
--- a/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/main.yml
+++ b/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/main.yml
@@ -315,7 +315,7 @@ jobs:
     - name: Publish SDKs
       uses: #{{ .Config.actionVersions.publishProviderSDKs }}#
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: "Publish failed :x:"

--- a/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/master.yml
+++ b/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/master.yml
@@ -315,7 +315,7 @@ jobs:
     - name: Publish SDKs
       uses: #{{ .Config.actionVersions.publishProviderSDKs }}#
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: "Publish failed :x:"

--- a/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/prerelease.yml
+++ b/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/prerelease.yml
@@ -266,7 +266,7 @@ jobs:
     - name: Publish SDKs
       uses: #{{ .Config.actionVersions.publishProviderSDKs }}#
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: "Publish failed :x:"

--- a/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/release.yml
+++ b/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/release.yml
@@ -277,7 +277,7 @@ jobs:
     - name: Publish SDKs
       uses: #{{ .Config.actionVersions.publishProviderSDKs }}#
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: "Publish failed :x:"

--- a/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/upgrade-bridge.yml
+++ b/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/upgrade-bridge.yml
@@ -13,7 +13,7 @@ jobs:
       with:
         kind: bridge
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#7CFC00"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: >-
@@ -26,7 +26,7 @@ jobs:
       name: Send Upgrade Success To Slack
       uses: #{{ .Config.actionVersions.slackNotification }}#
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: " Upgrade failed :x:"

--- a/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/upgrade-provider.yml
+++ b/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/upgrade-provider.yml
@@ -14,7 +14,7 @@ jobs:
       with:
         kind: all
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#7CFC00"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: >-
@@ -27,7 +27,7 @@ jobs:
       name: Send Upgrade Success To Slack
       uses: #{{ .Config.actionVersions.slackNotification }}#
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: " Upgrade failed :x:"

--- a/provider-ci/providers/aiven/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/aiven/repo/.github/workflows/main.yml
@@ -304,7 +304,7 @@ jobs:
     - name: Publish SDKs
       uses: pulumi/pulumi-package-publisher@v0.0.9
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: "Publish failed :x:"

--- a/provider-ci/providers/aiven/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/aiven/repo/.github/workflows/master.yml
@@ -304,7 +304,7 @@ jobs:
     - name: Publish SDKs
       uses: pulumi/pulumi-package-publisher@v0.0.9
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: "Publish failed :x:"

--- a/provider-ci/providers/aiven/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/aiven/repo/.github/workflows/prerelease.yml
@@ -250,7 +250,7 @@ jobs:
     - name: Publish SDKs
       uses: pulumi/pulumi-package-publisher@v0.0.9
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: "Publish failed :x:"

--- a/provider-ci/providers/aiven/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/aiven/repo/.github/workflows/release.yml
@@ -262,7 +262,7 @@ jobs:
     - name: Publish SDKs
       uses: pulumi/pulumi-package-publisher@v0.0.9
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: "Publish failed :x:"

--- a/provider-ci/providers/aiven/repo/.github/workflows/upgrade-bridge.yml
+++ b/provider-ci/providers/aiven/repo/.github/workflows/upgrade-bridge.yml
@@ -13,7 +13,7 @@ jobs:
       with:
         kind: bridge
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#7CFC00"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: >-
@@ -26,7 +26,7 @@ jobs:
       name: Send Upgrade Success To Slack
       uses: rtCamp/action-slack-notify@v2
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: " Upgrade failed :x:"

--- a/provider-ci/providers/aiven/repo/.github/workflows/upgrade-provider.yml
+++ b/provider-ci/providers/aiven/repo/.github/workflows/upgrade-provider.yml
@@ -14,7 +14,7 @@ jobs:
       with:
         kind: all
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#7CFC00"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: >-
@@ -27,7 +27,7 @@ jobs:
       name: Send Upgrade Success To Slack
       uses: rtCamp/action-slack-notify@v2
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: " Upgrade failed :x:"

--- a/provider-ci/providers/akamai/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/akamai/repo/.github/workflows/main.yml
@@ -306,7 +306,7 @@ jobs:
     - name: Publish SDKs
       uses: pulumi/pulumi-package-publisher@v0.0.9
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: "Publish failed :x:"

--- a/provider-ci/providers/akamai/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/akamai/repo/.github/workflows/master.yml
@@ -306,7 +306,7 @@ jobs:
     - name: Publish SDKs
       uses: pulumi/pulumi-package-publisher@v0.0.9
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: "Publish failed :x:"

--- a/provider-ci/providers/akamai/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/akamai/repo/.github/workflows/prerelease.yml
@@ -252,7 +252,7 @@ jobs:
     - name: Publish SDKs
       uses: pulumi/pulumi-package-publisher@v0.0.9
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: "Publish failed :x:"

--- a/provider-ci/providers/akamai/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/akamai/repo/.github/workflows/release.yml
@@ -264,7 +264,7 @@ jobs:
     - name: Publish SDKs
       uses: pulumi/pulumi-package-publisher@v0.0.9
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: "Publish failed :x:"

--- a/provider-ci/providers/akamai/repo/.github/workflows/upgrade-bridge.yml
+++ b/provider-ci/providers/akamai/repo/.github/workflows/upgrade-bridge.yml
@@ -13,7 +13,7 @@ jobs:
       with:
         kind: bridge
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#7CFC00"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: >-
@@ -26,7 +26,7 @@ jobs:
       name: Send Upgrade Success To Slack
       uses: rtCamp/action-slack-notify@v2
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: " Upgrade failed :x:"

--- a/provider-ci/providers/akamai/repo/.github/workflows/upgrade-provider.yml
+++ b/provider-ci/providers/akamai/repo/.github/workflows/upgrade-provider.yml
@@ -14,7 +14,7 @@ jobs:
       with:
         kind: all
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#7CFC00"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: >-
@@ -27,7 +27,7 @@ jobs:
       name: Send Upgrade Success To Slack
       uses: rtCamp/action-slack-notify@v2
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: " Upgrade failed :x:"

--- a/provider-ci/providers/alicloud/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/alicloud/repo/.github/workflows/main.yml
@@ -305,7 +305,7 @@ jobs:
     - name: Publish SDKs
       uses: pulumi/pulumi-package-publisher@v0.0.9
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: "Publish failed :x:"

--- a/provider-ci/providers/alicloud/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/alicloud/repo/.github/workflows/master.yml
@@ -305,7 +305,7 @@ jobs:
     - name: Publish SDKs
       uses: pulumi/pulumi-package-publisher@v0.0.9
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: "Publish failed :x:"

--- a/provider-ci/providers/alicloud/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/alicloud/repo/.github/workflows/prerelease.yml
@@ -251,7 +251,7 @@ jobs:
     - name: Publish SDKs
       uses: pulumi/pulumi-package-publisher@v0.0.9
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: "Publish failed :x:"

--- a/provider-ci/providers/alicloud/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/alicloud/repo/.github/workflows/release.yml
@@ -263,7 +263,7 @@ jobs:
     - name: Publish SDKs
       uses: pulumi/pulumi-package-publisher@v0.0.9
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: "Publish failed :x:"

--- a/provider-ci/providers/alicloud/repo/.github/workflows/upgrade-bridge.yml
+++ b/provider-ci/providers/alicloud/repo/.github/workflows/upgrade-bridge.yml
@@ -13,7 +13,7 @@ jobs:
       with:
         kind: bridge
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#7CFC00"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: >-
@@ -26,7 +26,7 @@ jobs:
       name: Send Upgrade Success To Slack
       uses: rtCamp/action-slack-notify@v2
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: " Upgrade failed :x:"

--- a/provider-ci/providers/alicloud/repo/.github/workflows/upgrade-provider.yml
+++ b/provider-ci/providers/alicloud/repo/.github/workflows/upgrade-provider.yml
@@ -14,7 +14,7 @@ jobs:
       with:
         kind: all
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#7CFC00"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: >-
@@ -27,7 +27,7 @@ jobs:
       name: Send Upgrade Success To Slack
       uses: rtCamp/action-slack-notify@v2
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: " Upgrade failed :x:"

--- a/provider-ci/providers/archive/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/archive/repo/.github/workflows/main.yml
@@ -303,7 +303,7 @@ jobs:
     - name: Publish SDKs
       uses: pulumi/pulumi-package-publisher@v0.0.9
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: "Publish failed :x:"

--- a/provider-ci/providers/archive/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/archive/repo/.github/workflows/master.yml
@@ -303,7 +303,7 @@ jobs:
     - name: Publish SDKs
       uses: pulumi/pulumi-package-publisher@v0.0.9
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: "Publish failed :x:"

--- a/provider-ci/providers/archive/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/archive/repo/.github/workflows/prerelease.yml
@@ -249,7 +249,7 @@ jobs:
     - name: Publish SDKs
       uses: pulumi/pulumi-package-publisher@v0.0.9
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: "Publish failed :x:"

--- a/provider-ci/providers/archive/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/archive/repo/.github/workflows/release.yml
@@ -247,7 +247,7 @@ jobs:
     - name: Publish SDKs
       uses: pulumi/pulumi-package-publisher@v0.0.9
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: "Publish failed :x:"

--- a/provider-ci/providers/archive/repo/.github/workflows/upgrade-bridge.yml
+++ b/provider-ci/providers/archive/repo/.github/workflows/upgrade-bridge.yml
@@ -13,7 +13,7 @@ jobs:
       with:
         kind: bridge
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#7CFC00"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: >-
@@ -26,7 +26,7 @@ jobs:
       name: Send Upgrade Success To Slack
       uses: rtCamp/action-slack-notify@v2
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: " Upgrade failed :x:"

--- a/provider-ci/providers/archive/repo/.github/workflows/upgrade-provider.yml
+++ b/provider-ci/providers/archive/repo/.github/workflows/upgrade-provider.yml
@@ -14,7 +14,7 @@ jobs:
       with:
         kind: all
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#7CFC00"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: >-
@@ -27,7 +27,7 @@ jobs:
       name: Send Upgrade Success To Slack
       uses: rtCamp/action-slack-notify@v2
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: " Upgrade failed :x:"

--- a/provider-ci/providers/artifactory/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/artifactory/repo/.github/workflows/main.yml
@@ -341,7 +341,7 @@ jobs:
     - name: Publish SDKs
       uses: pulumi/pulumi-package-publisher@v0.0.9
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: "Publish failed :x:"

--- a/provider-ci/providers/artifactory/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/artifactory/repo/.github/workflows/master.yml
@@ -341,7 +341,7 @@ jobs:
     - name: Publish SDKs
       uses: pulumi/pulumi-package-publisher@v0.0.9
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: "Publish failed :x:"

--- a/provider-ci/providers/artifactory/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/artifactory/repo/.github/workflows/prerelease.yml
@@ -287,7 +287,7 @@ jobs:
     - name: Publish SDKs
       uses: pulumi/pulumi-package-publisher@v0.0.9
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: "Publish failed :x:"

--- a/provider-ci/providers/artifactory/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/artifactory/repo/.github/workflows/release.yml
@@ -299,7 +299,7 @@ jobs:
     - name: Publish SDKs
       uses: pulumi/pulumi-package-publisher@v0.0.9
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: "Publish failed :x:"

--- a/provider-ci/providers/artifactory/repo/.github/workflows/upgrade-bridge.yml
+++ b/provider-ci/providers/artifactory/repo/.github/workflows/upgrade-bridge.yml
@@ -13,7 +13,7 @@ jobs:
       with:
         kind: bridge
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#7CFC00"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: >-
@@ -26,7 +26,7 @@ jobs:
       name: Send Upgrade Success To Slack
       uses: rtCamp/action-slack-notify@v2
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: " Upgrade failed :x:"

--- a/provider-ci/providers/artifactory/repo/.github/workflows/upgrade-provider.yml
+++ b/provider-ci/providers/artifactory/repo/.github/workflows/upgrade-provider.yml
@@ -14,7 +14,7 @@ jobs:
       with:
         kind: all
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#7CFC00"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: >-
@@ -27,7 +27,7 @@ jobs:
       name: Send Upgrade Success To Slack
       uses: rtCamp/action-slack-notify@v2
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: " Upgrade failed :x:"

--- a/provider-ci/providers/auth0/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/auth0/repo/.github/workflows/main.yml
@@ -341,7 +341,7 @@ jobs:
     - name: Publish SDKs
       uses: pulumi/pulumi-package-publisher@v0.0.9
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: "Publish failed :x:"

--- a/provider-ci/providers/auth0/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/auth0/repo/.github/workflows/master.yml
@@ -341,7 +341,7 @@ jobs:
     - name: Publish SDKs
       uses: pulumi/pulumi-package-publisher@v0.0.9
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: "Publish failed :x:"

--- a/provider-ci/providers/auth0/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/auth0/repo/.github/workflows/prerelease.yml
@@ -287,7 +287,7 @@ jobs:
     - name: Publish SDKs
       uses: pulumi/pulumi-package-publisher@v0.0.9
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: "Publish failed :x:"

--- a/provider-ci/providers/auth0/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/auth0/repo/.github/workflows/release.yml
@@ -299,7 +299,7 @@ jobs:
     - name: Publish SDKs
       uses: pulumi/pulumi-package-publisher@v0.0.9
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: "Publish failed :x:"

--- a/provider-ci/providers/auth0/repo/.github/workflows/upgrade-bridge.yml
+++ b/provider-ci/providers/auth0/repo/.github/workflows/upgrade-bridge.yml
@@ -13,7 +13,7 @@ jobs:
       with:
         kind: bridge
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#7CFC00"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: >-
@@ -26,7 +26,7 @@ jobs:
       name: Send Upgrade Success To Slack
       uses: rtCamp/action-slack-notify@v2
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: " Upgrade failed :x:"

--- a/provider-ci/providers/auth0/repo/.github/workflows/upgrade-provider.yml
+++ b/provider-ci/providers/auth0/repo/.github/workflows/upgrade-provider.yml
@@ -14,7 +14,7 @@ jobs:
       with:
         kind: all
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#7CFC00"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: >-
@@ -27,7 +27,7 @@ jobs:
       name: Send Upgrade Success To Slack
       uses: rtCamp/action-slack-notify@v2
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: " Upgrade failed :x:"

--- a/provider-ci/providers/aws/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/aws/repo/.github/workflows/main.yml
@@ -322,7 +322,7 @@ jobs:
     - name: Publish SDKs
       uses: pulumi/pulumi-package-publisher@v0.0.9
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: "Publish failed :x:"

--- a/provider-ci/providers/aws/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/aws/repo/.github/workflows/master.yml
@@ -322,7 +322,7 @@ jobs:
     - name: Publish SDKs
       uses: pulumi/pulumi-package-publisher@v0.0.9
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: "Publish failed :x:"

--- a/provider-ci/providers/aws/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/aws/repo/.github/workflows/prerelease.yml
@@ -273,7 +273,7 @@ jobs:
     - name: Publish SDKs
       uses: pulumi/pulumi-package-publisher@v0.0.9
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: "Publish failed :x:"

--- a/provider-ci/providers/aws/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/aws/repo/.github/workflows/release.yml
@@ -276,7 +276,7 @@ jobs:
     - name: Publish SDKs
       uses: pulumi/pulumi-package-publisher@v0.0.9
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: "Publish failed :x:"

--- a/provider-ci/providers/aws/repo/.github/workflows/upgrade-bridge.yml
+++ b/provider-ci/providers/aws/repo/.github/workflows/upgrade-bridge.yml
@@ -13,7 +13,7 @@ jobs:
       with:
         kind: bridge
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#7CFC00"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: >-
@@ -26,7 +26,7 @@ jobs:
       name: Send Upgrade Success To Slack
       uses: rtCamp/action-slack-notify@v2
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: " Upgrade failed :x:"

--- a/provider-ci/providers/aws/repo/.github/workflows/upgrade-provider.yml
+++ b/provider-ci/providers/aws/repo/.github/workflows/upgrade-provider.yml
@@ -14,7 +14,7 @@ jobs:
       with:
         kind: all
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#7CFC00"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: >-
@@ -27,7 +27,7 @@ jobs:
       name: Send Upgrade Success To Slack
       uses: rtCamp/action-slack-notify@v2
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: " Upgrade failed :x:"

--- a/provider-ci/providers/azure/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/azure/repo/.github/workflows/main.yml
@@ -309,7 +309,7 @@ jobs:
     - name: Publish SDKs
       uses: pulumi/pulumi-package-publisher@v0.0.9
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: "Publish failed :x:"

--- a/provider-ci/providers/azure/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/azure/repo/.github/workflows/master.yml
@@ -309,7 +309,7 @@ jobs:
     - name: Publish SDKs
       uses: pulumi/pulumi-package-publisher@v0.0.9
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: "Publish failed :x:"

--- a/provider-ci/providers/azure/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/azure/repo/.github/workflows/prerelease.yml
@@ -255,7 +255,7 @@ jobs:
     - name: Publish SDKs
       uses: pulumi/pulumi-package-publisher@v0.0.9
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: "Publish failed :x:"

--- a/provider-ci/providers/azure/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/azure/repo/.github/workflows/release.yml
@@ -267,7 +267,7 @@ jobs:
     - name: Publish SDKs
       uses: pulumi/pulumi-package-publisher@v0.0.9
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: "Publish failed :x:"

--- a/provider-ci/providers/azure/repo/.github/workflows/upgrade-bridge.yml
+++ b/provider-ci/providers/azure/repo/.github/workflows/upgrade-bridge.yml
@@ -13,7 +13,7 @@ jobs:
       with:
         kind: bridge
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#7CFC00"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: >-
@@ -26,7 +26,7 @@ jobs:
       name: Send Upgrade Success To Slack
       uses: rtCamp/action-slack-notify@v2
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: " Upgrade failed :x:"

--- a/provider-ci/providers/azure/repo/.github/workflows/upgrade-provider.yml
+++ b/provider-ci/providers/azure/repo/.github/workflows/upgrade-provider.yml
@@ -14,7 +14,7 @@ jobs:
       with:
         kind: all
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#7CFC00"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: >-
@@ -27,7 +27,7 @@ jobs:
       name: Send Upgrade Success To Slack
       uses: rtCamp/action-slack-notify@v2
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: " Upgrade failed :x:"

--- a/provider-ci/providers/azuread/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/azuread/repo/.github/workflows/main.yml
@@ -343,7 +343,7 @@ jobs:
     - name: Publish SDKs
       uses: pulumi/pulumi-package-publisher@v0.0.9
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: "Publish failed :x:"

--- a/provider-ci/providers/azuread/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/azuread/repo/.github/workflows/master.yml
@@ -343,7 +343,7 @@ jobs:
     - name: Publish SDKs
       uses: pulumi/pulumi-package-publisher@v0.0.9
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: "Publish failed :x:"

--- a/provider-ci/providers/azuread/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/azuread/repo/.github/workflows/prerelease.yml
@@ -289,7 +289,7 @@ jobs:
     - name: Publish SDKs
       uses: pulumi/pulumi-package-publisher@v0.0.9
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: "Publish failed :x:"

--- a/provider-ci/providers/azuread/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/azuread/repo/.github/workflows/release.yml
@@ -301,7 +301,7 @@ jobs:
     - name: Publish SDKs
       uses: pulumi/pulumi-package-publisher@v0.0.9
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: "Publish failed :x:"

--- a/provider-ci/providers/azuread/repo/.github/workflows/upgrade-bridge.yml
+++ b/provider-ci/providers/azuread/repo/.github/workflows/upgrade-bridge.yml
@@ -13,7 +13,7 @@ jobs:
       with:
         kind: bridge
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#7CFC00"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: >-
@@ -26,7 +26,7 @@ jobs:
       name: Send Upgrade Success To Slack
       uses: rtCamp/action-slack-notify@v2
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: " Upgrade failed :x:"

--- a/provider-ci/providers/azuread/repo/.github/workflows/upgrade-provider.yml
+++ b/provider-ci/providers/azuread/repo/.github/workflows/upgrade-provider.yml
@@ -14,7 +14,7 @@ jobs:
       with:
         kind: all
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#7CFC00"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: >-
@@ -27,7 +27,7 @@ jobs:
       name: Send Upgrade Success To Slack
       uses: rtCamp/action-slack-notify@v2
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: " Upgrade failed :x:"

--- a/provider-ci/providers/azuredevops/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/azuredevops/repo/.github/workflows/main.yml
@@ -304,7 +304,7 @@ jobs:
     - name: Publish SDKs
       uses: pulumi/pulumi-package-publisher@v0.0.9
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: "Publish failed :x:"

--- a/provider-ci/providers/azuredevops/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/azuredevops/repo/.github/workflows/master.yml
@@ -304,7 +304,7 @@ jobs:
     - name: Publish SDKs
       uses: pulumi/pulumi-package-publisher@v0.0.9
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: "Publish failed :x:"

--- a/provider-ci/providers/azuredevops/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/azuredevops/repo/.github/workflows/prerelease.yml
@@ -250,7 +250,7 @@ jobs:
     - name: Publish SDKs
       uses: pulumi/pulumi-package-publisher@v0.0.9
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: "Publish failed :x:"

--- a/provider-ci/providers/azuredevops/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/azuredevops/repo/.github/workflows/release.yml
@@ -262,7 +262,7 @@ jobs:
     - name: Publish SDKs
       uses: pulumi/pulumi-package-publisher@v0.0.9
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: "Publish failed :x:"

--- a/provider-ci/providers/azuredevops/repo/.github/workflows/upgrade-bridge.yml
+++ b/provider-ci/providers/azuredevops/repo/.github/workflows/upgrade-bridge.yml
@@ -13,7 +13,7 @@ jobs:
       with:
         kind: bridge
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#7CFC00"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: >-
@@ -26,7 +26,7 @@ jobs:
       name: Send Upgrade Success To Slack
       uses: rtCamp/action-slack-notify@v2
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: " Upgrade failed :x:"

--- a/provider-ci/providers/azuredevops/repo/.github/workflows/upgrade-provider.yml
+++ b/provider-ci/providers/azuredevops/repo/.github/workflows/upgrade-provider.yml
@@ -14,7 +14,7 @@ jobs:
       with:
         kind: all
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#7CFC00"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: >-
@@ -27,7 +27,7 @@ jobs:
       name: Send Upgrade Success To Slack
       uses: rtCamp/action-slack-notify@v2
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: " Upgrade failed :x:"

--- a/provider-ci/providers/civo/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/civo/repo/.github/workflows/main.yml
@@ -339,7 +339,7 @@ jobs:
     - name: Publish SDKs
       uses: pulumi/pulumi-package-publisher@v0.0.9
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: "Publish failed :x:"

--- a/provider-ci/providers/civo/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/civo/repo/.github/workflows/master.yml
@@ -339,7 +339,7 @@ jobs:
     - name: Publish SDKs
       uses: pulumi/pulumi-package-publisher@v0.0.9
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: "Publish failed :x:"

--- a/provider-ci/providers/civo/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/civo/repo/.github/workflows/prerelease.yml
@@ -285,7 +285,7 @@ jobs:
     - name: Publish SDKs
       uses: pulumi/pulumi-package-publisher@v0.0.9
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: "Publish failed :x:"

--- a/provider-ci/providers/civo/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/civo/repo/.github/workflows/release.yml
@@ -297,7 +297,7 @@ jobs:
     - name: Publish SDKs
       uses: pulumi/pulumi-package-publisher@v0.0.9
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: "Publish failed :x:"

--- a/provider-ci/providers/civo/repo/.github/workflows/upgrade-bridge.yml
+++ b/provider-ci/providers/civo/repo/.github/workflows/upgrade-bridge.yml
@@ -13,7 +13,7 @@ jobs:
       with:
         kind: bridge
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#7CFC00"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: >-
@@ -26,7 +26,7 @@ jobs:
       name: Send Upgrade Success To Slack
       uses: rtCamp/action-slack-notify@v2
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: " Upgrade failed :x:"

--- a/provider-ci/providers/civo/repo/.github/workflows/upgrade-provider.yml
+++ b/provider-ci/providers/civo/repo/.github/workflows/upgrade-provider.yml
@@ -14,7 +14,7 @@ jobs:
       with:
         kind: all
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#7CFC00"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: >-
@@ -27,7 +27,7 @@ jobs:
       name: Send Upgrade Success To Slack
       uses: rtCamp/action-slack-notify@v2
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: " Upgrade failed :x:"

--- a/provider-ci/providers/cloudamqp/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/cloudamqp/repo/.github/workflows/main.yml
@@ -339,7 +339,7 @@ jobs:
     - name: Publish SDKs
       uses: pulumi/pulumi-package-publisher@v0.0.9
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: "Publish failed :x:"

--- a/provider-ci/providers/cloudamqp/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/cloudamqp/repo/.github/workflows/master.yml
@@ -339,7 +339,7 @@ jobs:
     - name: Publish SDKs
       uses: pulumi/pulumi-package-publisher@v0.0.9
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: "Publish failed :x:"

--- a/provider-ci/providers/cloudamqp/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/cloudamqp/repo/.github/workflows/prerelease.yml
@@ -285,7 +285,7 @@ jobs:
     - name: Publish SDKs
       uses: pulumi/pulumi-package-publisher@v0.0.9
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: "Publish failed :x:"

--- a/provider-ci/providers/cloudamqp/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/cloudamqp/repo/.github/workflows/release.yml
@@ -297,7 +297,7 @@ jobs:
     - name: Publish SDKs
       uses: pulumi/pulumi-package-publisher@v0.0.9
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: "Publish failed :x:"

--- a/provider-ci/providers/cloudamqp/repo/.github/workflows/upgrade-bridge.yml
+++ b/provider-ci/providers/cloudamqp/repo/.github/workflows/upgrade-bridge.yml
@@ -13,7 +13,7 @@ jobs:
       with:
         kind: bridge
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#7CFC00"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: >-
@@ -26,7 +26,7 @@ jobs:
       name: Send Upgrade Success To Slack
       uses: rtCamp/action-slack-notify@v2
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: " Upgrade failed :x:"

--- a/provider-ci/providers/cloudamqp/repo/.github/workflows/upgrade-provider.yml
+++ b/provider-ci/providers/cloudamqp/repo/.github/workflows/upgrade-provider.yml
@@ -14,7 +14,7 @@ jobs:
       with:
         kind: all
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#7CFC00"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: >-
@@ -27,7 +27,7 @@ jobs:
       name: Send Upgrade Success To Slack
       uses: rtCamp/action-slack-notify@v2
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: " Upgrade failed :x:"

--- a/provider-ci/providers/cloudflare/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/cloudflare/repo/.github/workflows/main.yml
@@ -340,7 +340,7 @@ jobs:
     - name: Publish SDKs
       uses: pulumi/pulumi-package-publisher@v0.0.9
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: "Publish failed :x:"

--- a/provider-ci/providers/cloudflare/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/cloudflare/repo/.github/workflows/master.yml
@@ -340,7 +340,7 @@ jobs:
     - name: Publish SDKs
       uses: pulumi/pulumi-package-publisher@v0.0.9
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: "Publish failed :x:"

--- a/provider-ci/providers/cloudflare/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/cloudflare/repo/.github/workflows/prerelease.yml
@@ -286,7 +286,7 @@ jobs:
     - name: Publish SDKs
       uses: pulumi/pulumi-package-publisher@v0.0.9
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: "Publish failed :x:"

--- a/provider-ci/providers/cloudflare/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/cloudflare/repo/.github/workflows/release.yml
@@ -298,7 +298,7 @@ jobs:
     - name: Publish SDKs
       uses: pulumi/pulumi-package-publisher@v0.0.9
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: "Publish failed :x:"

--- a/provider-ci/providers/cloudflare/repo/.github/workflows/upgrade-bridge.yml
+++ b/provider-ci/providers/cloudflare/repo/.github/workflows/upgrade-bridge.yml
@@ -13,7 +13,7 @@ jobs:
       with:
         kind: bridge
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#7CFC00"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: >-
@@ -26,7 +26,7 @@ jobs:
       name: Send Upgrade Success To Slack
       uses: rtCamp/action-slack-notify@v2
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: " Upgrade failed :x:"

--- a/provider-ci/providers/cloudflare/repo/.github/workflows/upgrade-provider.yml
+++ b/provider-ci/providers/cloudflare/repo/.github/workflows/upgrade-provider.yml
@@ -14,7 +14,7 @@ jobs:
       with:
         kind: all
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#7CFC00"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: >-
@@ -27,7 +27,7 @@ jobs:
       name: Send Upgrade Success To Slack
       uses: rtCamp/action-slack-notify@v2
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: " Upgrade failed :x:"

--- a/provider-ci/providers/cloudinit/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/cloudinit/repo/.github/workflows/main.yml
@@ -302,7 +302,7 @@ jobs:
     - name: Publish SDKs
       uses: pulumi/pulumi-package-publisher@v0.0.9
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: "Publish failed :x:"

--- a/provider-ci/providers/cloudinit/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/cloudinit/repo/.github/workflows/master.yml
@@ -302,7 +302,7 @@ jobs:
     - name: Publish SDKs
       uses: pulumi/pulumi-package-publisher@v0.0.9
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: "Publish failed :x:"

--- a/provider-ci/providers/cloudinit/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/cloudinit/repo/.github/workflows/prerelease.yml
@@ -248,7 +248,7 @@ jobs:
     - name: Publish SDKs
       uses: pulumi/pulumi-package-publisher@v0.0.9
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: "Publish failed :x:"

--- a/provider-ci/providers/cloudinit/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/cloudinit/repo/.github/workflows/release.yml
@@ -260,7 +260,7 @@ jobs:
     - name: Publish SDKs
       uses: pulumi/pulumi-package-publisher@v0.0.9
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: "Publish failed :x:"

--- a/provider-ci/providers/cloudinit/repo/.github/workflows/upgrade-bridge.yml
+++ b/provider-ci/providers/cloudinit/repo/.github/workflows/upgrade-bridge.yml
@@ -13,7 +13,7 @@ jobs:
       with:
         kind: bridge
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#7CFC00"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: >-
@@ -26,7 +26,7 @@ jobs:
       name: Send Upgrade Success To Slack
       uses: rtCamp/action-slack-notify@v2
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: " Upgrade failed :x:"

--- a/provider-ci/providers/cloudinit/repo/.github/workflows/upgrade-provider.yml
+++ b/provider-ci/providers/cloudinit/repo/.github/workflows/upgrade-provider.yml
@@ -14,7 +14,7 @@ jobs:
       with:
         kind: all
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#7CFC00"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: >-
@@ -27,7 +27,7 @@ jobs:
       name: Send Upgrade Success To Slack
       uses: rtCamp/action-slack-notify@v2
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: " Upgrade failed :x:"

--- a/provider-ci/providers/confluentcloud/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/confluentcloud/repo/.github/workflows/main.yml
@@ -304,7 +304,7 @@ jobs:
     - name: Publish SDKs
       uses: pulumi/pulumi-package-publisher@v0.0.9
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: "Publish failed :x:"

--- a/provider-ci/providers/confluentcloud/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/confluentcloud/repo/.github/workflows/master.yml
@@ -304,7 +304,7 @@ jobs:
     - name: Publish SDKs
       uses: pulumi/pulumi-package-publisher@v0.0.9
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: "Publish failed :x:"

--- a/provider-ci/providers/confluentcloud/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/confluentcloud/repo/.github/workflows/prerelease.yml
@@ -250,7 +250,7 @@ jobs:
     - name: Publish SDKs
       uses: pulumi/pulumi-package-publisher@v0.0.9
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: "Publish failed :x:"

--- a/provider-ci/providers/confluentcloud/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/confluentcloud/repo/.github/workflows/release.yml
@@ -262,7 +262,7 @@ jobs:
     - name: Publish SDKs
       uses: pulumi/pulumi-package-publisher@v0.0.9
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: "Publish failed :x:"

--- a/provider-ci/providers/confluentcloud/repo/.github/workflows/upgrade-bridge.yml
+++ b/provider-ci/providers/confluentcloud/repo/.github/workflows/upgrade-bridge.yml
@@ -13,7 +13,7 @@ jobs:
       with:
         kind: bridge
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#7CFC00"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: >-
@@ -26,7 +26,7 @@ jobs:
       name: Send Upgrade Success To Slack
       uses: rtCamp/action-slack-notify@v2
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: " Upgrade failed :x:"

--- a/provider-ci/providers/confluentcloud/repo/.github/workflows/upgrade-provider.yml
+++ b/provider-ci/providers/confluentcloud/repo/.github/workflows/upgrade-provider.yml
@@ -14,7 +14,7 @@ jobs:
       with:
         kind: all
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#7CFC00"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: >-
@@ -27,7 +27,7 @@ jobs:
       name: Send Upgrade Success To Slack
       uses: rtCamp/action-slack-notify@v2
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: " Upgrade failed :x:"

--- a/provider-ci/providers/consul/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/consul/repo/.github/workflows/main.yml
@@ -338,7 +338,7 @@ jobs:
     - name: Publish SDKs
       uses: pulumi/pulumi-package-publisher@v0.0.9
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: "Publish failed :x:"

--- a/provider-ci/providers/consul/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/consul/repo/.github/workflows/master.yml
@@ -338,7 +338,7 @@ jobs:
     - name: Publish SDKs
       uses: pulumi/pulumi-package-publisher@v0.0.9
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: "Publish failed :x:"

--- a/provider-ci/providers/consul/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/consul/repo/.github/workflows/prerelease.yml
@@ -284,7 +284,7 @@ jobs:
     - name: Publish SDKs
       uses: pulumi/pulumi-package-publisher@v0.0.9
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: "Publish failed :x:"

--- a/provider-ci/providers/consul/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/consul/repo/.github/workflows/release.yml
@@ -296,7 +296,7 @@ jobs:
     - name: Publish SDKs
       uses: pulumi/pulumi-package-publisher@v0.0.9
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: "Publish failed :x:"

--- a/provider-ci/providers/consul/repo/.github/workflows/upgrade-bridge.yml
+++ b/provider-ci/providers/consul/repo/.github/workflows/upgrade-bridge.yml
@@ -13,7 +13,7 @@ jobs:
       with:
         kind: bridge
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#7CFC00"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: >-
@@ -26,7 +26,7 @@ jobs:
       name: Send Upgrade Success To Slack
       uses: rtCamp/action-slack-notify@v2
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: " Upgrade failed :x:"

--- a/provider-ci/providers/consul/repo/.github/workflows/upgrade-provider.yml
+++ b/provider-ci/providers/consul/repo/.github/workflows/upgrade-provider.yml
@@ -14,7 +14,7 @@ jobs:
       with:
         kind: all
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#7CFC00"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: >-
@@ -27,7 +27,7 @@ jobs:
       name: Send Upgrade Success To Slack
       uses: rtCamp/action-slack-notify@v2
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: " Upgrade failed :x:"

--- a/provider-ci/providers/databricks/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/databricks/repo/.github/workflows/main.yml
@@ -342,7 +342,7 @@ jobs:
     - name: Publish SDKs
       uses: pulumi/pulumi-package-publisher@v0.0.9
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: "Publish failed :x:"

--- a/provider-ci/providers/databricks/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/databricks/repo/.github/workflows/master.yml
@@ -342,7 +342,7 @@ jobs:
     - name: Publish SDKs
       uses: pulumi/pulumi-package-publisher@v0.0.9
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: "Publish failed :x:"

--- a/provider-ci/providers/databricks/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/databricks/repo/.github/workflows/prerelease.yml
@@ -288,7 +288,7 @@ jobs:
     - name: Publish SDKs
       uses: pulumi/pulumi-package-publisher@v0.0.9
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: "Publish failed :x:"

--- a/provider-ci/providers/databricks/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/databricks/repo/.github/workflows/release.yml
@@ -300,7 +300,7 @@ jobs:
     - name: Publish SDKs
       uses: pulumi/pulumi-package-publisher@v0.0.9
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: "Publish failed :x:"

--- a/provider-ci/providers/databricks/repo/.github/workflows/upgrade-bridge.yml
+++ b/provider-ci/providers/databricks/repo/.github/workflows/upgrade-bridge.yml
@@ -13,7 +13,7 @@ jobs:
       with:
         kind: bridge
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#7CFC00"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: >-
@@ -26,7 +26,7 @@ jobs:
       name: Send Upgrade Success To Slack
       uses: rtCamp/action-slack-notify@v2
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: " Upgrade failed :x:"

--- a/provider-ci/providers/databricks/repo/.github/workflows/upgrade-provider.yml
+++ b/provider-ci/providers/databricks/repo/.github/workflows/upgrade-provider.yml
@@ -14,7 +14,7 @@ jobs:
       with:
         kind: all
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#7CFC00"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: >-
@@ -27,7 +27,7 @@ jobs:
       name: Send Upgrade Success To Slack
       uses: rtCamp/action-slack-notify@v2
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: " Upgrade failed :x:"

--- a/provider-ci/providers/datadog/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/datadog/repo/.github/workflows/main.yml
@@ -304,7 +304,7 @@ jobs:
     - name: Publish SDKs
       uses: pulumi/pulumi-package-publisher@v0.0.9
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: "Publish failed :x:"

--- a/provider-ci/providers/datadog/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/datadog/repo/.github/workflows/master.yml
@@ -304,7 +304,7 @@ jobs:
     - name: Publish SDKs
       uses: pulumi/pulumi-package-publisher@v0.0.9
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: "Publish failed :x:"

--- a/provider-ci/providers/datadog/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/datadog/repo/.github/workflows/prerelease.yml
@@ -250,7 +250,7 @@ jobs:
     - name: Publish SDKs
       uses: pulumi/pulumi-package-publisher@v0.0.9
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: "Publish failed :x:"

--- a/provider-ci/providers/datadog/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/datadog/repo/.github/workflows/release.yml
@@ -262,7 +262,7 @@ jobs:
     - name: Publish SDKs
       uses: pulumi/pulumi-package-publisher@v0.0.9
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: "Publish failed :x:"

--- a/provider-ci/providers/datadog/repo/.github/workflows/upgrade-bridge.yml
+++ b/provider-ci/providers/datadog/repo/.github/workflows/upgrade-bridge.yml
@@ -13,7 +13,7 @@ jobs:
       with:
         kind: bridge
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#7CFC00"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: >-
@@ -26,7 +26,7 @@ jobs:
       name: Send Upgrade Success To Slack
       uses: rtCamp/action-slack-notify@v2
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: " Upgrade failed :x:"

--- a/provider-ci/providers/datadog/repo/.github/workflows/upgrade-provider.yml
+++ b/provider-ci/providers/datadog/repo/.github/workflows/upgrade-provider.yml
@@ -14,7 +14,7 @@ jobs:
       with:
         kind: all
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#7CFC00"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: >-
@@ -27,7 +27,7 @@ jobs:
       name: Send Upgrade Success To Slack
       uses: rtCamp/action-slack-notify@v2
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: " Upgrade failed :x:"

--- a/provider-ci/providers/digitalocean/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/digitalocean/repo/.github/workflows/main.yml
@@ -339,7 +339,7 @@ jobs:
     - name: Publish SDKs
       uses: pulumi/pulumi-package-publisher@v0.0.9
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: "Publish failed :x:"

--- a/provider-ci/providers/digitalocean/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/digitalocean/repo/.github/workflows/master.yml
@@ -339,7 +339,7 @@ jobs:
     - name: Publish SDKs
       uses: pulumi/pulumi-package-publisher@v0.0.9
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: "Publish failed :x:"

--- a/provider-ci/providers/digitalocean/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/digitalocean/repo/.github/workflows/prerelease.yml
@@ -285,7 +285,7 @@ jobs:
     - name: Publish SDKs
       uses: pulumi/pulumi-package-publisher@v0.0.9
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: "Publish failed :x:"

--- a/provider-ci/providers/digitalocean/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/digitalocean/repo/.github/workflows/release.yml
@@ -297,7 +297,7 @@ jobs:
     - name: Publish SDKs
       uses: pulumi/pulumi-package-publisher@v0.0.9
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: "Publish failed :x:"

--- a/provider-ci/providers/digitalocean/repo/.github/workflows/upgrade-bridge.yml
+++ b/provider-ci/providers/digitalocean/repo/.github/workflows/upgrade-bridge.yml
@@ -13,7 +13,7 @@ jobs:
       with:
         kind: bridge
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#7CFC00"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: >-
@@ -26,7 +26,7 @@ jobs:
       name: Send Upgrade Success To Slack
       uses: rtCamp/action-slack-notify@v2
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: " Upgrade failed :x:"

--- a/provider-ci/providers/digitalocean/repo/.github/workflows/upgrade-provider.yml
+++ b/provider-ci/providers/digitalocean/repo/.github/workflows/upgrade-provider.yml
@@ -14,7 +14,7 @@ jobs:
       with:
         kind: all
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#7CFC00"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: >-
@@ -27,7 +27,7 @@ jobs:
       name: Send Upgrade Success To Slack
       uses: rtCamp/action-slack-notify@v2
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: " Upgrade failed :x:"

--- a/provider-ci/providers/dnsimple/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/dnsimple/repo/.github/workflows/main.yml
@@ -340,7 +340,7 @@ jobs:
     - name: Publish SDKs
       uses: pulumi/pulumi-package-publisher@v0.0.9
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: "Publish failed :x:"

--- a/provider-ci/providers/dnsimple/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/dnsimple/repo/.github/workflows/master.yml
@@ -340,7 +340,7 @@ jobs:
     - name: Publish SDKs
       uses: pulumi/pulumi-package-publisher@v0.0.9
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: "Publish failed :x:"

--- a/provider-ci/providers/dnsimple/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/dnsimple/repo/.github/workflows/prerelease.yml
@@ -286,7 +286,7 @@ jobs:
     - name: Publish SDKs
       uses: pulumi/pulumi-package-publisher@v0.0.9
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: "Publish failed :x:"

--- a/provider-ci/providers/dnsimple/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/dnsimple/repo/.github/workflows/release.yml
@@ -298,7 +298,7 @@ jobs:
     - name: Publish SDKs
       uses: pulumi/pulumi-package-publisher@v0.0.9
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: "Publish failed :x:"

--- a/provider-ci/providers/dnsimple/repo/.github/workflows/upgrade-bridge.yml
+++ b/provider-ci/providers/dnsimple/repo/.github/workflows/upgrade-bridge.yml
@@ -13,7 +13,7 @@ jobs:
       with:
         kind: bridge
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#7CFC00"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: >-
@@ -26,7 +26,7 @@ jobs:
       name: Send Upgrade Success To Slack
       uses: rtCamp/action-slack-notify@v2
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: " Upgrade failed :x:"

--- a/provider-ci/providers/dnsimple/repo/.github/workflows/upgrade-provider.yml
+++ b/provider-ci/providers/dnsimple/repo/.github/workflows/upgrade-provider.yml
@@ -14,7 +14,7 @@ jobs:
       with:
         kind: all
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#7CFC00"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: >-
@@ -27,7 +27,7 @@ jobs:
       name: Send Upgrade Success To Slack
       uses: rtCamp/action-slack-notify@v2
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: " Upgrade failed :x:"

--- a/provider-ci/providers/docker/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/docker/repo/.github/workflows/main.yml
@@ -353,7 +353,7 @@ jobs:
     - name: Publish SDKs
       uses: pulumi/pulumi-package-publisher@v0.0.9
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: "Publish failed :x:"

--- a/provider-ci/providers/docker/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/docker/repo/.github/workflows/master.yml
@@ -353,7 +353,7 @@ jobs:
     - name: Publish SDKs
       uses: pulumi/pulumi-package-publisher@v0.0.9
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: "Publish failed :x:"

--- a/provider-ci/providers/docker/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/docker/repo/.github/workflows/prerelease.yml
@@ -299,7 +299,7 @@ jobs:
     - name: Publish SDKs
       uses: pulumi/pulumi-package-publisher@v0.0.9
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: "Publish failed :x:"

--- a/provider-ci/providers/docker/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/docker/repo/.github/workflows/release.yml
@@ -311,7 +311,7 @@ jobs:
     - name: Publish SDKs
       uses: pulumi/pulumi-package-publisher@v0.0.9
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: "Publish failed :x:"

--- a/provider-ci/providers/docker/repo/.github/workflows/upgrade-bridge.yml
+++ b/provider-ci/providers/docker/repo/.github/workflows/upgrade-bridge.yml
@@ -13,7 +13,7 @@ jobs:
       with:
         kind: bridge
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#7CFC00"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: >-
@@ -26,7 +26,7 @@ jobs:
       name: Send Upgrade Success To Slack
       uses: rtCamp/action-slack-notify@v2
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: " Upgrade failed :x:"

--- a/provider-ci/providers/docker/repo/.github/workflows/upgrade-provider.yml
+++ b/provider-ci/providers/docker/repo/.github/workflows/upgrade-provider.yml
@@ -14,7 +14,7 @@ jobs:
       with:
         kind: all
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#7CFC00"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: >-
@@ -27,7 +27,7 @@ jobs:
       name: Send Upgrade Success To Slack
       uses: rtCamp/action-slack-notify@v2
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: " Upgrade failed :x:"

--- a/provider-ci/providers/ec/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/ec/repo/.github/workflows/main.yml
@@ -339,7 +339,7 @@ jobs:
     - name: Publish SDKs
       uses: pulumi/pulumi-package-publisher@v0.0.9
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: "Publish failed :x:"

--- a/provider-ci/providers/ec/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/ec/repo/.github/workflows/master.yml
@@ -339,7 +339,7 @@ jobs:
     - name: Publish SDKs
       uses: pulumi/pulumi-package-publisher@v0.0.9
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: "Publish failed :x:"

--- a/provider-ci/providers/ec/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/ec/repo/.github/workflows/prerelease.yml
@@ -285,7 +285,7 @@ jobs:
     - name: Publish SDKs
       uses: pulumi/pulumi-package-publisher@v0.0.9
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: "Publish failed :x:"

--- a/provider-ci/providers/ec/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/ec/repo/.github/workflows/release.yml
@@ -297,7 +297,7 @@ jobs:
     - name: Publish SDKs
       uses: pulumi/pulumi-package-publisher@v0.0.9
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: "Publish failed :x:"

--- a/provider-ci/providers/ec/repo/.github/workflows/upgrade-bridge.yml
+++ b/provider-ci/providers/ec/repo/.github/workflows/upgrade-bridge.yml
@@ -13,7 +13,7 @@ jobs:
       with:
         kind: bridge
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#7CFC00"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: >-
@@ -26,7 +26,7 @@ jobs:
       name: Send Upgrade Success To Slack
       uses: rtCamp/action-slack-notify@v2
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: " Upgrade failed :x:"

--- a/provider-ci/providers/ec/repo/.github/workflows/upgrade-provider.yml
+++ b/provider-ci/providers/ec/repo/.github/workflows/upgrade-provider.yml
@@ -14,7 +14,7 @@ jobs:
       with:
         kind: all
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#7CFC00"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: >-
@@ -27,7 +27,7 @@ jobs:
       name: Send Upgrade Success To Slack
       uses: rtCamp/action-slack-notify@v2
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: " Upgrade failed :x:"

--- a/provider-ci/providers/equinix-metal/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/equinix-metal/repo/.github/workflows/main.yml
@@ -303,7 +303,7 @@ jobs:
     - name: Publish SDKs
       uses: pulumi/pulumi-package-publisher@v0.0.9
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: "Publish failed :x:"

--- a/provider-ci/providers/equinix-metal/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/equinix-metal/repo/.github/workflows/master.yml
@@ -303,7 +303,7 @@ jobs:
     - name: Publish SDKs
       uses: pulumi/pulumi-package-publisher@v0.0.9
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: "Publish failed :x:"

--- a/provider-ci/providers/equinix-metal/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/equinix-metal/repo/.github/workflows/prerelease.yml
@@ -249,7 +249,7 @@ jobs:
     - name: Publish SDKs
       uses: pulumi/pulumi-package-publisher@v0.0.9
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: "Publish failed :x:"

--- a/provider-ci/providers/equinix-metal/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/equinix-metal/repo/.github/workflows/release.yml
@@ -261,7 +261,7 @@ jobs:
     - name: Publish SDKs
       uses: pulumi/pulumi-package-publisher@v0.0.9
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: "Publish failed :x:"

--- a/provider-ci/providers/equinix-metal/repo/.github/workflows/upgrade-bridge.yml
+++ b/provider-ci/providers/equinix-metal/repo/.github/workflows/upgrade-bridge.yml
@@ -13,7 +13,7 @@ jobs:
       with:
         kind: bridge
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#7CFC00"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: >-
@@ -26,7 +26,7 @@ jobs:
       name: Send Upgrade Success To Slack
       uses: rtCamp/action-slack-notify@v2
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: " Upgrade failed :x:"

--- a/provider-ci/providers/equinix-metal/repo/.github/workflows/upgrade-provider.yml
+++ b/provider-ci/providers/equinix-metal/repo/.github/workflows/upgrade-provider.yml
@@ -14,7 +14,7 @@ jobs:
       with:
         kind: all
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#7CFC00"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: >-
@@ -27,7 +27,7 @@ jobs:
       name: Send Upgrade Success To Slack
       uses: rtCamp/action-slack-notify@v2
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: " Upgrade failed :x:"

--- a/provider-ci/providers/external/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/external/repo/.github/workflows/main.yml
@@ -303,7 +303,7 @@ jobs:
     - name: Publish SDKs
       uses: pulumi/pulumi-package-publisher@v0.0.9
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: "Publish failed :x:"

--- a/provider-ci/providers/external/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/external/repo/.github/workflows/master.yml
@@ -303,7 +303,7 @@ jobs:
     - name: Publish SDKs
       uses: pulumi/pulumi-package-publisher@v0.0.9
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: "Publish failed :x:"

--- a/provider-ci/providers/external/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/external/repo/.github/workflows/prerelease.yml
@@ -249,7 +249,7 @@ jobs:
     - name: Publish SDKs
       uses: pulumi/pulumi-package-publisher@v0.0.9
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: "Publish failed :x:"

--- a/provider-ci/providers/external/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/external/repo/.github/workflows/release.yml
@@ -247,7 +247,7 @@ jobs:
     - name: Publish SDKs
       uses: pulumi/pulumi-package-publisher@v0.0.9
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: "Publish failed :x:"

--- a/provider-ci/providers/external/repo/.github/workflows/upgrade-bridge.yml
+++ b/provider-ci/providers/external/repo/.github/workflows/upgrade-bridge.yml
@@ -13,7 +13,7 @@ jobs:
       with:
         kind: bridge
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#7CFC00"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: >-
@@ -26,7 +26,7 @@ jobs:
       name: Send Upgrade Success To Slack
       uses: rtCamp/action-slack-notify@v2
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: " Upgrade failed :x:"

--- a/provider-ci/providers/external/repo/.github/workflows/upgrade-provider.yml
+++ b/provider-ci/providers/external/repo/.github/workflows/upgrade-provider.yml
@@ -14,7 +14,7 @@ jobs:
       with:
         kind: all
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#7CFC00"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: >-
@@ -27,7 +27,7 @@ jobs:
       name: Send Upgrade Success To Slack
       uses: rtCamp/action-slack-notify@v2
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: " Upgrade failed :x:"

--- a/provider-ci/providers/f5bigip/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/f5bigip/repo/.github/workflows/main.yml
@@ -342,7 +342,7 @@ jobs:
     - name: Publish SDKs
       uses: pulumi/pulumi-package-publisher@v0.0.9
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: "Publish failed :x:"

--- a/provider-ci/providers/f5bigip/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/f5bigip/repo/.github/workflows/master.yml
@@ -342,7 +342,7 @@ jobs:
     - name: Publish SDKs
       uses: pulumi/pulumi-package-publisher@v0.0.9
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: "Publish failed :x:"

--- a/provider-ci/providers/f5bigip/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/f5bigip/repo/.github/workflows/prerelease.yml
@@ -288,7 +288,7 @@ jobs:
     - name: Publish SDKs
       uses: pulumi/pulumi-package-publisher@v0.0.9
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: "Publish failed :x:"

--- a/provider-ci/providers/f5bigip/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/f5bigip/repo/.github/workflows/release.yml
@@ -300,7 +300,7 @@ jobs:
     - name: Publish SDKs
       uses: pulumi/pulumi-package-publisher@v0.0.9
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: "Publish failed :x:"

--- a/provider-ci/providers/f5bigip/repo/.github/workflows/upgrade-bridge.yml
+++ b/provider-ci/providers/f5bigip/repo/.github/workflows/upgrade-bridge.yml
@@ -13,7 +13,7 @@ jobs:
       with:
         kind: bridge
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#7CFC00"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: >-
@@ -26,7 +26,7 @@ jobs:
       name: Send Upgrade Success To Slack
       uses: rtCamp/action-slack-notify@v2
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: " Upgrade failed :x:"

--- a/provider-ci/providers/f5bigip/repo/.github/workflows/upgrade-provider.yml
+++ b/provider-ci/providers/f5bigip/repo/.github/workflows/upgrade-provider.yml
@@ -14,7 +14,7 @@ jobs:
       with:
         kind: all
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#7CFC00"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: >-
@@ -27,7 +27,7 @@ jobs:
       name: Send Upgrade Success To Slack
       uses: rtCamp/action-slack-notify@v2
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: " Upgrade failed :x:"

--- a/provider-ci/providers/fastly/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/fastly/repo/.github/workflows/main.yml
@@ -339,7 +339,7 @@ jobs:
     - name: Publish SDKs
       uses: pulumi/pulumi-package-publisher@v0.0.9
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: "Publish failed :x:"

--- a/provider-ci/providers/fastly/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/fastly/repo/.github/workflows/master.yml
@@ -339,7 +339,7 @@ jobs:
     - name: Publish SDKs
       uses: pulumi/pulumi-package-publisher@v0.0.9
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: "Publish failed :x:"

--- a/provider-ci/providers/fastly/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/fastly/repo/.github/workflows/prerelease.yml
@@ -285,7 +285,7 @@ jobs:
     - name: Publish SDKs
       uses: pulumi/pulumi-package-publisher@v0.0.9
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: "Publish failed :x:"

--- a/provider-ci/providers/fastly/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/fastly/repo/.github/workflows/release.yml
@@ -297,7 +297,7 @@ jobs:
     - name: Publish SDKs
       uses: pulumi/pulumi-package-publisher@v0.0.9
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: "Publish failed :x:"

--- a/provider-ci/providers/fastly/repo/.github/workflows/upgrade-bridge.yml
+++ b/provider-ci/providers/fastly/repo/.github/workflows/upgrade-bridge.yml
@@ -13,7 +13,7 @@ jobs:
       with:
         kind: bridge
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#7CFC00"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: >-
@@ -26,7 +26,7 @@ jobs:
       name: Send Upgrade Success To Slack
       uses: rtCamp/action-slack-notify@v2
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: " Upgrade failed :x:"

--- a/provider-ci/providers/fastly/repo/.github/workflows/upgrade-provider.yml
+++ b/provider-ci/providers/fastly/repo/.github/workflows/upgrade-provider.yml
@@ -14,7 +14,7 @@ jobs:
       with:
         kind: all
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#7CFC00"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: >-
@@ -27,7 +27,7 @@ jobs:
       name: Send Upgrade Success To Slack
       uses: rtCamp/action-slack-notify@v2
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: " Upgrade failed :x:"

--- a/provider-ci/providers/gcp/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/gcp/repo/.github/workflows/main.yml
@@ -310,7 +310,7 @@ jobs:
     - name: Publish SDKs
       uses: pulumi/pulumi-package-publisher@v0.0.9
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: "Publish failed :x:"

--- a/provider-ci/providers/gcp/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/gcp/repo/.github/workflows/master.yml
@@ -310,7 +310,7 @@ jobs:
     - name: Publish SDKs
       uses: pulumi/pulumi-package-publisher@v0.0.9
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: "Publish failed :x:"

--- a/provider-ci/providers/gcp/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/gcp/repo/.github/workflows/prerelease.yml
@@ -256,7 +256,7 @@ jobs:
     - name: Publish SDKs
       uses: pulumi/pulumi-package-publisher@v0.0.9
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: "Publish failed :x:"

--- a/provider-ci/providers/gcp/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/gcp/repo/.github/workflows/release.yml
@@ -268,7 +268,7 @@ jobs:
     - name: Publish SDKs
       uses: pulumi/pulumi-package-publisher@v0.0.9
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: "Publish failed :x:"

--- a/provider-ci/providers/gcp/repo/.github/workflows/upgrade-bridge.yml
+++ b/provider-ci/providers/gcp/repo/.github/workflows/upgrade-bridge.yml
@@ -13,7 +13,7 @@ jobs:
       with:
         kind: bridge
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#7CFC00"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: >-
@@ -26,7 +26,7 @@ jobs:
       name: Send Upgrade Success To Slack
       uses: rtCamp/action-slack-notify@v2
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: " Upgrade failed :x:"

--- a/provider-ci/providers/gcp/repo/.github/workflows/upgrade-provider.yml
+++ b/provider-ci/providers/gcp/repo/.github/workflows/upgrade-provider.yml
@@ -14,7 +14,7 @@ jobs:
       with:
         kind: all
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#7CFC00"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: >-
@@ -27,7 +27,7 @@ jobs:
       name: Send Upgrade Success To Slack
       uses: rtCamp/action-slack-notify@v2
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: " Upgrade failed :x:"

--- a/provider-ci/providers/github/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/github/repo/.github/workflows/main.yml
@@ -340,7 +340,7 @@ jobs:
     - name: Publish SDKs
       uses: pulumi/pulumi-package-publisher@v0.0.9
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: "Publish failed :x:"

--- a/provider-ci/providers/github/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/github/repo/.github/workflows/master.yml
@@ -340,7 +340,7 @@ jobs:
     - name: Publish SDKs
       uses: pulumi/pulumi-package-publisher@v0.0.9
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: "Publish failed :x:"

--- a/provider-ci/providers/github/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/github/repo/.github/workflows/prerelease.yml
@@ -286,7 +286,7 @@ jobs:
     - name: Publish SDKs
       uses: pulumi/pulumi-package-publisher@v0.0.9
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: "Publish failed :x:"

--- a/provider-ci/providers/github/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/github/repo/.github/workflows/release.yml
@@ -298,7 +298,7 @@ jobs:
     - name: Publish SDKs
       uses: pulumi/pulumi-package-publisher@v0.0.9
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: "Publish failed :x:"

--- a/provider-ci/providers/github/repo/.github/workflows/upgrade-bridge.yml
+++ b/provider-ci/providers/github/repo/.github/workflows/upgrade-bridge.yml
@@ -13,7 +13,7 @@ jobs:
       with:
         kind: bridge
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#7CFC00"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: >-
@@ -26,7 +26,7 @@ jobs:
       name: Send Upgrade Success To Slack
       uses: rtCamp/action-slack-notify@v2
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: " Upgrade failed :x:"

--- a/provider-ci/providers/github/repo/.github/workflows/upgrade-provider.yml
+++ b/provider-ci/providers/github/repo/.github/workflows/upgrade-provider.yml
@@ -14,7 +14,7 @@ jobs:
       with:
         kind: all
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#7CFC00"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: >-
@@ -27,7 +27,7 @@ jobs:
       name: Send Upgrade Success To Slack
       uses: rtCamp/action-slack-notify@v2
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: " Upgrade failed :x:"

--- a/provider-ci/providers/gitlab/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/gitlab/repo/.github/workflows/main.yml
@@ -339,7 +339,7 @@ jobs:
     - name: Publish SDKs
       uses: pulumi/pulumi-package-publisher@v0.0.9
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: "Publish failed :x:"

--- a/provider-ci/providers/gitlab/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/gitlab/repo/.github/workflows/master.yml
@@ -339,7 +339,7 @@ jobs:
     - name: Publish SDKs
       uses: pulumi/pulumi-package-publisher@v0.0.9
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: "Publish failed :x:"

--- a/provider-ci/providers/gitlab/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/gitlab/repo/.github/workflows/prerelease.yml
@@ -285,7 +285,7 @@ jobs:
     - name: Publish SDKs
       uses: pulumi/pulumi-package-publisher@v0.0.9
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: "Publish failed :x:"

--- a/provider-ci/providers/gitlab/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/gitlab/repo/.github/workflows/release.yml
@@ -297,7 +297,7 @@ jobs:
     - name: Publish SDKs
       uses: pulumi/pulumi-package-publisher@v0.0.9
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: "Publish failed :x:"

--- a/provider-ci/providers/gitlab/repo/.github/workflows/upgrade-bridge.yml
+++ b/provider-ci/providers/gitlab/repo/.github/workflows/upgrade-bridge.yml
@@ -13,7 +13,7 @@ jobs:
       with:
         kind: bridge
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#7CFC00"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: >-
@@ -26,7 +26,7 @@ jobs:
       name: Send Upgrade Success To Slack
       uses: rtCamp/action-slack-notify@v2
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: " Upgrade failed :x:"

--- a/provider-ci/providers/gitlab/repo/.github/workflows/upgrade-provider.yml
+++ b/provider-ci/providers/gitlab/repo/.github/workflows/upgrade-provider.yml
@@ -14,7 +14,7 @@ jobs:
       with:
         kind: all
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#7CFC00"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: >-
@@ -27,7 +27,7 @@ jobs:
       name: Send Upgrade Success To Slack
       uses: rtCamp/action-slack-notify@v2
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: " Upgrade failed :x:"

--- a/provider-ci/providers/hcloud/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/hcloud/repo/.github/workflows/main.yml
@@ -339,7 +339,7 @@ jobs:
     - name: Publish SDKs
       uses: pulumi/pulumi-package-publisher@v0.0.9
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: "Publish failed :x:"

--- a/provider-ci/providers/hcloud/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/hcloud/repo/.github/workflows/master.yml
@@ -339,7 +339,7 @@ jobs:
     - name: Publish SDKs
       uses: pulumi/pulumi-package-publisher@v0.0.9
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: "Publish failed :x:"

--- a/provider-ci/providers/hcloud/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/hcloud/repo/.github/workflows/prerelease.yml
@@ -285,7 +285,7 @@ jobs:
     - name: Publish SDKs
       uses: pulumi/pulumi-package-publisher@v0.0.9
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: "Publish failed :x:"

--- a/provider-ci/providers/hcloud/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/hcloud/repo/.github/workflows/release.yml
@@ -297,7 +297,7 @@ jobs:
     - name: Publish SDKs
       uses: pulumi/pulumi-package-publisher@v0.0.9
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: "Publish failed :x:"

--- a/provider-ci/providers/hcloud/repo/.github/workflows/upgrade-bridge.yml
+++ b/provider-ci/providers/hcloud/repo/.github/workflows/upgrade-bridge.yml
@@ -13,7 +13,7 @@ jobs:
       with:
         kind: bridge
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#7CFC00"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: >-
@@ -26,7 +26,7 @@ jobs:
       name: Send Upgrade Success To Slack
       uses: rtCamp/action-slack-notify@v2
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: " Upgrade failed :x:"

--- a/provider-ci/providers/hcloud/repo/.github/workflows/upgrade-provider.yml
+++ b/provider-ci/providers/hcloud/repo/.github/workflows/upgrade-provider.yml
@@ -14,7 +14,7 @@ jobs:
       with:
         kind: all
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#7CFC00"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: >-
@@ -27,7 +27,7 @@ jobs:
       name: Send Upgrade Success To Slack
       uses: rtCamp/action-slack-notify@v2
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: " Upgrade failed :x:"

--- a/provider-ci/providers/http/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/http/repo/.github/workflows/main.yml
@@ -303,7 +303,7 @@ jobs:
     - name: Publish SDKs
       uses: pulumi/pulumi-package-publisher@v0.0.9
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: "Publish failed :x:"

--- a/provider-ci/providers/http/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/http/repo/.github/workflows/master.yml
@@ -303,7 +303,7 @@ jobs:
     - name: Publish SDKs
       uses: pulumi/pulumi-package-publisher@v0.0.9
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: "Publish failed :x:"

--- a/provider-ci/providers/http/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/http/repo/.github/workflows/prerelease.yml
@@ -249,7 +249,7 @@ jobs:
     - name: Publish SDKs
       uses: pulumi/pulumi-package-publisher@v0.0.9
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: "Publish failed :x:"

--- a/provider-ci/providers/http/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/http/repo/.github/workflows/release.yml
@@ -247,7 +247,7 @@ jobs:
     - name: Publish SDKs
       uses: pulumi/pulumi-package-publisher@v0.0.9
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: "Publish failed :x:"

--- a/provider-ci/providers/http/repo/.github/workflows/upgrade-bridge.yml
+++ b/provider-ci/providers/http/repo/.github/workflows/upgrade-bridge.yml
@@ -13,7 +13,7 @@ jobs:
       with:
         kind: bridge
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#7CFC00"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: >-
@@ -26,7 +26,7 @@ jobs:
       name: Send Upgrade Success To Slack
       uses: rtCamp/action-slack-notify@v2
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: " Upgrade failed :x:"

--- a/provider-ci/providers/http/repo/.github/workflows/upgrade-provider.yml
+++ b/provider-ci/providers/http/repo/.github/workflows/upgrade-provider.yml
@@ -14,7 +14,7 @@ jobs:
       with:
         kind: all
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#7CFC00"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: >-
@@ -27,7 +27,7 @@ jobs:
       name: Send Upgrade Success To Slack
       uses: rtCamp/action-slack-notify@v2
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: " Upgrade failed :x:"

--- a/provider-ci/providers/kafka/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/kafka/repo/.github/workflows/main.yml
@@ -338,7 +338,7 @@ jobs:
     - name: Publish SDKs
       uses: pulumi/pulumi-package-publisher@v0.0.9
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: "Publish failed :x:"

--- a/provider-ci/providers/kafka/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/kafka/repo/.github/workflows/master.yml
@@ -338,7 +338,7 @@ jobs:
     - name: Publish SDKs
       uses: pulumi/pulumi-package-publisher@v0.0.9
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: "Publish failed :x:"

--- a/provider-ci/providers/kafka/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/kafka/repo/.github/workflows/prerelease.yml
@@ -284,7 +284,7 @@ jobs:
     - name: Publish SDKs
       uses: pulumi/pulumi-package-publisher@v0.0.9
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: "Publish failed :x:"

--- a/provider-ci/providers/kafka/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/kafka/repo/.github/workflows/release.yml
@@ -296,7 +296,7 @@ jobs:
     - name: Publish SDKs
       uses: pulumi/pulumi-package-publisher@v0.0.9
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: "Publish failed :x:"

--- a/provider-ci/providers/kafka/repo/.github/workflows/upgrade-bridge.yml
+++ b/provider-ci/providers/kafka/repo/.github/workflows/upgrade-bridge.yml
@@ -13,7 +13,7 @@ jobs:
       with:
         kind: bridge
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#7CFC00"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: >-
@@ -26,7 +26,7 @@ jobs:
       name: Send Upgrade Success To Slack
       uses: rtCamp/action-slack-notify@v2
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: " Upgrade failed :x:"

--- a/provider-ci/providers/kafka/repo/.github/workflows/upgrade-provider.yml
+++ b/provider-ci/providers/kafka/repo/.github/workflows/upgrade-provider.yml
@@ -14,7 +14,7 @@ jobs:
       with:
         kind: all
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#7CFC00"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: >-
@@ -27,7 +27,7 @@ jobs:
       name: Send Upgrade Success To Slack
       uses: rtCamp/action-slack-notify@v2
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: " Upgrade failed :x:"

--- a/provider-ci/providers/keycloak/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/keycloak/repo/.github/workflows/main.yml
@@ -343,7 +343,7 @@ jobs:
     - name: Publish SDKs
       uses: pulumi/pulumi-package-publisher@v0.0.9
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: "Publish failed :x:"

--- a/provider-ci/providers/keycloak/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/keycloak/repo/.github/workflows/master.yml
@@ -343,7 +343,7 @@ jobs:
     - name: Publish SDKs
       uses: pulumi/pulumi-package-publisher@v0.0.9
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: "Publish failed :x:"

--- a/provider-ci/providers/keycloak/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/keycloak/repo/.github/workflows/prerelease.yml
@@ -289,7 +289,7 @@ jobs:
     - name: Publish SDKs
       uses: pulumi/pulumi-package-publisher@v0.0.9
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: "Publish failed :x:"

--- a/provider-ci/providers/keycloak/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/keycloak/repo/.github/workflows/release.yml
@@ -301,7 +301,7 @@ jobs:
     - name: Publish SDKs
       uses: pulumi/pulumi-package-publisher@v0.0.9
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: "Publish failed :x:"

--- a/provider-ci/providers/keycloak/repo/.github/workflows/upgrade-bridge.yml
+++ b/provider-ci/providers/keycloak/repo/.github/workflows/upgrade-bridge.yml
@@ -13,7 +13,7 @@ jobs:
       with:
         kind: bridge
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#7CFC00"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: >-
@@ -26,7 +26,7 @@ jobs:
       name: Send Upgrade Success To Slack
       uses: rtCamp/action-slack-notify@v2
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: " Upgrade failed :x:"

--- a/provider-ci/providers/keycloak/repo/.github/workflows/upgrade-provider.yml
+++ b/provider-ci/providers/keycloak/repo/.github/workflows/upgrade-provider.yml
@@ -14,7 +14,7 @@ jobs:
       with:
         kind: all
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#7CFC00"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: >-
@@ -27,7 +27,7 @@ jobs:
       name: Send Upgrade Success To Slack
       uses: rtCamp/action-slack-notify@v2
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: " Upgrade failed :x:"

--- a/provider-ci/providers/kong/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/kong/repo/.github/workflows/main.yml
@@ -338,7 +338,7 @@ jobs:
     - name: Publish SDKs
       uses: pulumi/pulumi-package-publisher@v0.0.9
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: "Publish failed :x:"

--- a/provider-ci/providers/kong/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/kong/repo/.github/workflows/master.yml
@@ -338,7 +338,7 @@ jobs:
     - name: Publish SDKs
       uses: pulumi/pulumi-package-publisher@v0.0.9
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: "Publish failed :x:"

--- a/provider-ci/providers/kong/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/kong/repo/.github/workflows/prerelease.yml
@@ -284,7 +284,7 @@ jobs:
     - name: Publish SDKs
       uses: pulumi/pulumi-package-publisher@v0.0.9
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: "Publish failed :x:"

--- a/provider-ci/providers/kong/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/kong/repo/.github/workflows/release.yml
@@ -296,7 +296,7 @@ jobs:
     - name: Publish SDKs
       uses: pulumi/pulumi-package-publisher@v0.0.9
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: "Publish failed :x:"

--- a/provider-ci/providers/kong/repo/.github/workflows/upgrade-bridge.yml
+++ b/provider-ci/providers/kong/repo/.github/workflows/upgrade-bridge.yml
@@ -13,7 +13,7 @@ jobs:
       with:
         kind: bridge
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#7CFC00"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: >-
@@ -26,7 +26,7 @@ jobs:
       name: Send Upgrade Success To Slack
       uses: rtCamp/action-slack-notify@v2
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: " Upgrade failed :x:"

--- a/provider-ci/providers/kong/repo/.github/workflows/upgrade-provider.yml
+++ b/provider-ci/providers/kong/repo/.github/workflows/upgrade-provider.yml
@@ -14,7 +14,7 @@ jobs:
       with:
         kind: all
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#7CFC00"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: >-
@@ -27,7 +27,7 @@ jobs:
       name: Send Upgrade Success To Slack
       uses: rtCamp/action-slack-notify@v2
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: " Upgrade failed :x:"

--- a/provider-ci/providers/libvirt/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/libvirt/repo/.github/workflows/main.yml
@@ -339,7 +339,7 @@ jobs:
     - name: Publish SDKs
       uses: pulumi/pulumi-package-publisher@v0.0.9
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: "Publish failed :x:"

--- a/provider-ci/providers/libvirt/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/libvirt/repo/.github/workflows/master.yml
@@ -339,7 +339,7 @@ jobs:
     - name: Publish SDKs
       uses: pulumi/pulumi-package-publisher@v0.0.9
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: "Publish failed :x:"

--- a/provider-ci/providers/libvirt/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/libvirt/repo/.github/workflows/prerelease.yml
@@ -285,7 +285,7 @@ jobs:
     - name: Publish SDKs
       uses: pulumi/pulumi-package-publisher@v0.0.9
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: "Publish failed :x:"

--- a/provider-ci/providers/libvirt/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/libvirt/repo/.github/workflows/release.yml
@@ -297,7 +297,7 @@ jobs:
     - name: Publish SDKs
       uses: pulumi/pulumi-package-publisher@v0.0.9
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: "Publish failed :x:"

--- a/provider-ci/providers/libvirt/repo/.github/workflows/upgrade-bridge.yml
+++ b/provider-ci/providers/libvirt/repo/.github/workflows/upgrade-bridge.yml
@@ -13,7 +13,7 @@ jobs:
       with:
         kind: bridge
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#7CFC00"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: >-
@@ -26,7 +26,7 @@ jobs:
       name: Send Upgrade Success To Slack
       uses: rtCamp/action-slack-notify@v2
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: " Upgrade failed :x:"

--- a/provider-ci/providers/libvirt/repo/.github/workflows/upgrade-provider.yml
+++ b/provider-ci/providers/libvirt/repo/.github/workflows/upgrade-provider.yml
@@ -14,7 +14,7 @@ jobs:
       with:
         kind: all
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#7CFC00"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: >-
@@ -27,7 +27,7 @@ jobs:
       name: Send Upgrade Success To Slack
       uses: rtCamp/action-slack-notify@v2
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: " Upgrade failed :x:"

--- a/provider-ci/providers/linode/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/linode/repo/.github/workflows/main.yml
@@ -339,7 +339,7 @@ jobs:
     - name: Publish SDKs
       uses: pulumi/pulumi-package-publisher@v0.0.9
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: "Publish failed :x:"

--- a/provider-ci/providers/linode/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/linode/repo/.github/workflows/master.yml
@@ -339,7 +339,7 @@ jobs:
     - name: Publish SDKs
       uses: pulumi/pulumi-package-publisher@v0.0.9
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: "Publish failed :x:"

--- a/provider-ci/providers/linode/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/linode/repo/.github/workflows/prerelease.yml
@@ -285,7 +285,7 @@ jobs:
     - name: Publish SDKs
       uses: pulumi/pulumi-package-publisher@v0.0.9
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: "Publish failed :x:"

--- a/provider-ci/providers/linode/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/linode/repo/.github/workflows/release.yml
@@ -297,7 +297,7 @@ jobs:
     - name: Publish SDKs
       uses: pulumi/pulumi-package-publisher@v0.0.9
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: "Publish failed :x:"

--- a/provider-ci/providers/linode/repo/.github/workflows/upgrade-bridge.yml
+++ b/provider-ci/providers/linode/repo/.github/workflows/upgrade-bridge.yml
@@ -13,7 +13,7 @@ jobs:
       with:
         kind: bridge
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#7CFC00"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: >-
@@ -26,7 +26,7 @@ jobs:
       name: Send Upgrade Success To Slack
       uses: rtCamp/action-slack-notify@v2
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: " Upgrade failed :x:"

--- a/provider-ci/providers/linode/repo/.github/workflows/upgrade-provider.yml
+++ b/provider-ci/providers/linode/repo/.github/workflows/upgrade-provider.yml
@@ -14,7 +14,7 @@ jobs:
       with:
         kind: all
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#7CFC00"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: >-
@@ -27,7 +27,7 @@ jobs:
       name: Send Upgrade Success To Slack
       uses: rtCamp/action-slack-notify@v2
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: " Upgrade failed :x:"

--- a/provider-ci/providers/local/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/local/repo/.github/workflows/main.yml
@@ -303,7 +303,7 @@ jobs:
     - name: Publish SDKs
       uses: pulumi/pulumi-package-publisher@v0.0.9
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: "Publish failed :x:"

--- a/provider-ci/providers/local/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/local/repo/.github/workflows/master.yml
@@ -303,7 +303,7 @@ jobs:
     - name: Publish SDKs
       uses: pulumi/pulumi-package-publisher@v0.0.9
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: "Publish failed :x:"

--- a/provider-ci/providers/local/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/local/repo/.github/workflows/prerelease.yml
@@ -249,7 +249,7 @@ jobs:
     - name: Publish SDKs
       uses: pulumi/pulumi-package-publisher@v0.0.9
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: "Publish failed :x:"

--- a/provider-ci/providers/local/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/local/repo/.github/workflows/release.yml
@@ -247,7 +247,7 @@ jobs:
     - name: Publish SDKs
       uses: pulumi/pulumi-package-publisher@v0.0.9
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: "Publish failed :x:"

--- a/provider-ci/providers/local/repo/.github/workflows/upgrade-bridge.yml
+++ b/provider-ci/providers/local/repo/.github/workflows/upgrade-bridge.yml
@@ -13,7 +13,7 @@ jobs:
       with:
         kind: bridge
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#7CFC00"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: >-
@@ -26,7 +26,7 @@ jobs:
       name: Send Upgrade Success To Slack
       uses: rtCamp/action-slack-notify@v2
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: " Upgrade failed :x:"

--- a/provider-ci/providers/local/repo/.github/workflows/upgrade-provider.yml
+++ b/provider-ci/providers/local/repo/.github/workflows/upgrade-provider.yml
@@ -14,7 +14,7 @@ jobs:
       with:
         kind: all
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#7CFC00"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: >-
@@ -27,7 +27,7 @@ jobs:
       name: Send Upgrade Success To Slack
       uses: rtCamp/action-slack-notify@v2
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: " Upgrade failed :x:"

--- a/provider-ci/providers/mailgun/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/mailgun/repo/.github/workflows/main.yml
@@ -339,7 +339,7 @@ jobs:
     - name: Publish SDKs
       uses: pulumi/pulumi-package-publisher@v0.0.9
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: "Publish failed :x:"

--- a/provider-ci/providers/mailgun/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/mailgun/repo/.github/workflows/master.yml
@@ -339,7 +339,7 @@ jobs:
     - name: Publish SDKs
       uses: pulumi/pulumi-package-publisher@v0.0.9
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: "Publish failed :x:"

--- a/provider-ci/providers/mailgun/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/mailgun/repo/.github/workflows/prerelease.yml
@@ -285,7 +285,7 @@ jobs:
     - name: Publish SDKs
       uses: pulumi/pulumi-package-publisher@v0.0.9
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: "Publish failed :x:"

--- a/provider-ci/providers/mailgun/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/mailgun/repo/.github/workflows/release.yml
@@ -297,7 +297,7 @@ jobs:
     - name: Publish SDKs
       uses: pulumi/pulumi-package-publisher@v0.0.9
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: "Publish failed :x:"

--- a/provider-ci/providers/mailgun/repo/.github/workflows/upgrade-bridge.yml
+++ b/provider-ci/providers/mailgun/repo/.github/workflows/upgrade-bridge.yml
@@ -13,7 +13,7 @@ jobs:
       with:
         kind: bridge
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#7CFC00"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: >-
@@ -26,7 +26,7 @@ jobs:
       name: Send Upgrade Success To Slack
       uses: rtCamp/action-slack-notify@v2
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: " Upgrade failed :x:"

--- a/provider-ci/providers/mailgun/repo/.github/workflows/upgrade-provider.yml
+++ b/provider-ci/providers/mailgun/repo/.github/workflows/upgrade-provider.yml
@@ -14,7 +14,7 @@ jobs:
       with:
         kind: all
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#7CFC00"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: >-
@@ -27,7 +27,7 @@ jobs:
       name: Send Upgrade Success To Slack
       uses: rtCamp/action-slack-notify@v2
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: " Upgrade failed :x:"

--- a/provider-ci/providers/minio/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/minio/repo/.github/workflows/main.yml
@@ -342,7 +342,7 @@ jobs:
     - name: Publish SDKs
       uses: pulumi/pulumi-package-publisher@v0.0.9
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: "Publish failed :x:"

--- a/provider-ci/providers/minio/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/minio/repo/.github/workflows/master.yml
@@ -342,7 +342,7 @@ jobs:
     - name: Publish SDKs
       uses: pulumi/pulumi-package-publisher@v0.0.9
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: "Publish failed :x:"

--- a/provider-ci/providers/minio/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/minio/repo/.github/workflows/prerelease.yml
@@ -288,7 +288,7 @@ jobs:
     - name: Publish SDKs
       uses: pulumi/pulumi-package-publisher@v0.0.9
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: "Publish failed :x:"

--- a/provider-ci/providers/minio/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/minio/repo/.github/workflows/release.yml
@@ -300,7 +300,7 @@ jobs:
     - name: Publish SDKs
       uses: pulumi/pulumi-package-publisher@v0.0.9
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: "Publish failed :x:"

--- a/provider-ci/providers/minio/repo/.github/workflows/upgrade-bridge.yml
+++ b/provider-ci/providers/minio/repo/.github/workflows/upgrade-bridge.yml
@@ -13,7 +13,7 @@ jobs:
       with:
         kind: bridge
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#7CFC00"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: >-
@@ -26,7 +26,7 @@ jobs:
       name: Send Upgrade Success To Slack
       uses: rtCamp/action-slack-notify@v2
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: " Upgrade failed :x:"

--- a/provider-ci/providers/minio/repo/.github/workflows/upgrade-provider.yml
+++ b/provider-ci/providers/minio/repo/.github/workflows/upgrade-provider.yml
@@ -14,7 +14,7 @@ jobs:
       with:
         kind: all
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#7CFC00"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: >-
@@ -27,7 +27,7 @@ jobs:
       name: Send Upgrade Success To Slack
       uses: rtCamp/action-slack-notify@v2
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: " Upgrade failed :x:"

--- a/provider-ci/providers/mongodbatlas/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/mongodbatlas/repo/.github/workflows/main.yml
@@ -341,7 +341,7 @@ jobs:
     - name: Publish SDKs
       uses: pulumi/pulumi-package-publisher@v0.0.9
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: "Publish failed :x:"

--- a/provider-ci/providers/mongodbatlas/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/mongodbatlas/repo/.github/workflows/master.yml
@@ -341,7 +341,7 @@ jobs:
     - name: Publish SDKs
       uses: pulumi/pulumi-package-publisher@v0.0.9
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: "Publish failed :x:"

--- a/provider-ci/providers/mongodbatlas/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/mongodbatlas/repo/.github/workflows/prerelease.yml
@@ -287,7 +287,7 @@ jobs:
     - name: Publish SDKs
       uses: pulumi/pulumi-package-publisher@v0.0.9
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: "Publish failed :x:"

--- a/provider-ci/providers/mongodbatlas/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/mongodbatlas/repo/.github/workflows/release.yml
@@ -299,7 +299,7 @@ jobs:
     - name: Publish SDKs
       uses: pulumi/pulumi-package-publisher@v0.0.9
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: "Publish failed :x:"

--- a/provider-ci/providers/mongodbatlas/repo/.github/workflows/upgrade-bridge.yml
+++ b/provider-ci/providers/mongodbatlas/repo/.github/workflows/upgrade-bridge.yml
@@ -13,7 +13,7 @@ jobs:
       with:
         kind: bridge
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#7CFC00"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: >-
@@ -26,7 +26,7 @@ jobs:
       name: Send Upgrade Success To Slack
       uses: rtCamp/action-slack-notify@v2
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: " Upgrade failed :x:"

--- a/provider-ci/providers/mongodbatlas/repo/.github/workflows/upgrade-provider.yml
+++ b/provider-ci/providers/mongodbatlas/repo/.github/workflows/upgrade-provider.yml
@@ -14,7 +14,7 @@ jobs:
       with:
         kind: all
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#7CFC00"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: >-
@@ -27,7 +27,7 @@ jobs:
       name: Send Upgrade Success To Slack
       uses: rtCamp/action-slack-notify@v2
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: " Upgrade failed :x:"

--- a/provider-ci/providers/mysql/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/mysql/repo/.github/workflows/main.yml
@@ -338,7 +338,7 @@ jobs:
     - name: Publish SDKs
       uses: pulumi/pulumi-package-publisher@v0.0.9
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: "Publish failed :x:"

--- a/provider-ci/providers/mysql/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/mysql/repo/.github/workflows/master.yml
@@ -338,7 +338,7 @@ jobs:
     - name: Publish SDKs
       uses: pulumi/pulumi-package-publisher@v0.0.9
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: "Publish failed :x:"

--- a/provider-ci/providers/mysql/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/mysql/repo/.github/workflows/prerelease.yml
@@ -284,7 +284,7 @@ jobs:
     - name: Publish SDKs
       uses: pulumi/pulumi-package-publisher@v0.0.9
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: "Publish failed :x:"

--- a/provider-ci/providers/mysql/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/mysql/repo/.github/workflows/release.yml
@@ -296,7 +296,7 @@ jobs:
     - name: Publish SDKs
       uses: pulumi/pulumi-package-publisher@v0.0.9
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: "Publish failed :x:"

--- a/provider-ci/providers/mysql/repo/.github/workflows/upgrade-bridge.yml
+++ b/provider-ci/providers/mysql/repo/.github/workflows/upgrade-bridge.yml
@@ -13,7 +13,7 @@ jobs:
       with:
         kind: bridge
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#7CFC00"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: >-
@@ -26,7 +26,7 @@ jobs:
       name: Send Upgrade Success To Slack
       uses: rtCamp/action-slack-notify@v2
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: " Upgrade failed :x:"

--- a/provider-ci/providers/mysql/repo/.github/workflows/upgrade-provider.yml
+++ b/provider-ci/providers/mysql/repo/.github/workflows/upgrade-provider.yml
@@ -14,7 +14,7 @@ jobs:
       with:
         kind: all
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#7CFC00"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: >-
@@ -27,7 +27,7 @@ jobs:
       name: Send Upgrade Success To Slack
       uses: rtCamp/action-slack-notify@v2
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: " Upgrade failed :x:"

--- a/provider-ci/providers/newrelic/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/newrelic/repo/.github/workflows/main.yml
@@ -340,7 +340,7 @@ jobs:
     - name: Publish SDKs
       uses: pulumi/pulumi-package-publisher@v0.0.9
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: "Publish failed :x:"

--- a/provider-ci/providers/newrelic/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/newrelic/repo/.github/workflows/master.yml
@@ -340,7 +340,7 @@ jobs:
     - name: Publish SDKs
       uses: pulumi/pulumi-package-publisher@v0.0.9
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: "Publish failed :x:"

--- a/provider-ci/providers/newrelic/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/newrelic/repo/.github/workflows/prerelease.yml
@@ -286,7 +286,7 @@ jobs:
     - name: Publish SDKs
       uses: pulumi/pulumi-package-publisher@v0.0.9
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: "Publish failed :x:"

--- a/provider-ci/providers/newrelic/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/newrelic/repo/.github/workflows/release.yml
@@ -298,7 +298,7 @@ jobs:
     - name: Publish SDKs
       uses: pulumi/pulumi-package-publisher@v0.0.9
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: "Publish failed :x:"

--- a/provider-ci/providers/newrelic/repo/.github/workflows/upgrade-bridge.yml
+++ b/provider-ci/providers/newrelic/repo/.github/workflows/upgrade-bridge.yml
@@ -13,7 +13,7 @@ jobs:
       with:
         kind: bridge
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#7CFC00"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: >-
@@ -26,7 +26,7 @@ jobs:
       name: Send Upgrade Success To Slack
       uses: rtCamp/action-slack-notify@v2
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: " Upgrade failed :x:"

--- a/provider-ci/providers/newrelic/repo/.github/workflows/upgrade-provider.yml
+++ b/provider-ci/providers/newrelic/repo/.github/workflows/upgrade-provider.yml
@@ -14,7 +14,7 @@ jobs:
       with:
         kind: all
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#7CFC00"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: >-
@@ -27,7 +27,7 @@ jobs:
       name: Send Upgrade Success To Slack
       uses: rtCamp/action-slack-notify@v2
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: " Upgrade failed :x:"

--- a/provider-ci/providers/nomad/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/nomad/repo/.github/workflows/main.yml
@@ -339,7 +339,7 @@ jobs:
     - name: Publish SDKs
       uses: pulumi/pulumi-package-publisher@v0.0.9
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: "Publish failed :x:"

--- a/provider-ci/providers/nomad/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/nomad/repo/.github/workflows/master.yml
@@ -339,7 +339,7 @@ jobs:
     - name: Publish SDKs
       uses: pulumi/pulumi-package-publisher@v0.0.9
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: "Publish failed :x:"

--- a/provider-ci/providers/nomad/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/nomad/repo/.github/workflows/prerelease.yml
@@ -285,7 +285,7 @@ jobs:
     - name: Publish SDKs
       uses: pulumi/pulumi-package-publisher@v0.0.9
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: "Publish failed :x:"

--- a/provider-ci/providers/nomad/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/nomad/repo/.github/workflows/release.yml
@@ -297,7 +297,7 @@ jobs:
     - name: Publish SDKs
       uses: pulumi/pulumi-package-publisher@v0.0.9
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: "Publish failed :x:"

--- a/provider-ci/providers/nomad/repo/.github/workflows/upgrade-bridge.yml
+++ b/provider-ci/providers/nomad/repo/.github/workflows/upgrade-bridge.yml
@@ -13,7 +13,7 @@ jobs:
       with:
         kind: bridge
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#7CFC00"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: >-
@@ -26,7 +26,7 @@ jobs:
       name: Send Upgrade Success To Slack
       uses: rtCamp/action-slack-notify@v2
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: " Upgrade failed :x:"

--- a/provider-ci/providers/nomad/repo/.github/workflows/upgrade-provider.yml
+++ b/provider-ci/providers/nomad/repo/.github/workflows/upgrade-provider.yml
@@ -14,7 +14,7 @@ jobs:
       with:
         kind: all
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#7CFC00"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: >-
@@ -27,7 +27,7 @@ jobs:
       name: Send Upgrade Success To Slack
       uses: rtCamp/action-slack-notify@v2
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: " Upgrade failed :x:"

--- a/provider-ci/providers/ns1/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/ns1/repo/.github/workflows/main.yml
@@ -339,7 +339,7 @@ jobs:
     - name: Publish SDKs
       uses: pulumi/pulumi-package-publisher@v0.0.9
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: "Publish failed :x:"

--- a/provider-ci/providers/ns1/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/ns1/repo/.github/workflows/master.yml
@@ -339,7 +339,7 @@ jobs:
     - name: Publish SDKs
       uses: pulumi/pulumi-package-publisher@v0.0.9
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: "Publish failed :x:"

--- a/provider-ci/providers/ns1/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/ns1/repo/.github/workflows/prerelease.yml
@@ -285,7 +285,7 @@ jobs:
     - name: Publish SDKs
       uses: pulumi/pulumi-package-publisher@v0.0.9
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: "Publish failed :x:"

--- a/provider-ci/providers/ns1/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/ns1/repo/.github/workflows/release.yml
@@ -297,7 +297,7 @@ jobs:
     - name: Publish SDKs
       uses: pulumi/pulumi-package-publisher@v0.0.9
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: "Publish failed :x:"

--- a/provider-ci/providers/ns1/repo/.github/workflows/upgrade-bridge.yml
+++ b/provider-ci/providers/ns1/repo/.github/workflows/upgrade-bridge.yml
@@ -13,7 +13,7 @@ jobs:
       with:
         kind: bridge
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#7CFC00"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: >-
@@ -26,7 +26,7 @@ jobs:
       name: Send Upgrade Success To Slack
       uses: rtCamp/action-slack-notify@v2
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: " Upgrade failed :x:"

--- a/provider-ci/providers/ns1/repo/.github/workflows/upgrade-provider.yml
+++ b/provider-ci/providers/ns1/repo/.github/workflows/upgrade-provider.yml
@@ -14,7 +14,7 @@ jobs:
       with:
         kind: all
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#7CFC00"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: >-
@@ -27,7 +27,7 @@ jobs:
       name: Send Upgrade Success To Slack
       uses: rtCamp/action-slack-notify@v2
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: " Upgrade failed :x:"

--- a/provider-ci/providers/null/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/null/repo/.github/workflows/main.yml
@@ -303,7 +303,7 @@ jobs:
     - name: Publish SDKs
       uses: pulumi/pulumi-package-publisher@v0.0.9
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: "Publish failed :x:"

--- a/provider-ci/providers/null/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/null/repo/.github/workflows/master.yml
@@ -303,7 +303,7 @@ jobs:
     - name: Publish SDKs
       uses: pulumi/pulumi-package-publisher@v0.0.9
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: "Publish failed :x:"

--- a/provider-ci/providers/null/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/null/repo/.github/workflows/prerelease.yml
@@ -249,7 +249,7 @@ jobs:
     - name: Publish SDKs
       uses: pulumi/pulumi-package-publisher@v0.0.9
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: "Publish failed :x:"

--- a/provider-ci/providers/null/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/null/repo/.github/workflows/release.yml
@@ -247,7 +247,7 @@ jobs:
     - name: Publish SDKs
       uses: pulumi/pulumi-package-publisher@v0.0.9
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: "Publish failed :x:"

--- a/provider-ci/providers/null/repo/.github/workflows/upgrade-bridge.yml
+++ b/provider-ci/providers/null/repo/.github/workflows/upgrade-bridge.yml
@@ -13,7 +13,7 @@ jobs:
       with:
         kind: bridge
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#7CFC00"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: >-
@@ -26,7 +26,7 @@ jobs:
       name: Send Upgrade Success To Slack
       uses: rtCamp/action-slack-notify@v2
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: " Upgrade failed :x:"

--- a/provider-ci/providers/null/repo/.github/workflows/upgrade-provider.yml
+++ b/provider-ci/providers/null/repo/.github/workflows/upgrade-provider.yml
@@ -14,7 +14,7 @@ jobs:
       with:
         kind: all
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#7CFC00"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: >-
@@ -27,7 +27,7 @@ jobs:
       name: Send Upgrade Success To Slack
       uses: rtCamp/action-slack-notify@v2
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: " Upgrade failed :x:"

--- a/provider-ci/providers/oci/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/oci/repo/.github/workflows/main.yml
@@ -306,7 +306,7 @@ jobs:
     - name: Publish SDKs
       uses: pulumi/pulumi-package-publisher@v0.0.9
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: "Publish failed :x:"

--- a/provider-ci/providers/oci/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/oci/repo/.github/workflows/master.yml
@@ -306,7 +306,7 @@ jobs:
     - name: Publish SDKs
       uses: pulumi/pulumi-package-publisher@v0.0.9
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: "Publish failed :x:"

--- a/provider-ci/providers/oci/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/oci/repo/.github/workflows/prerelease.yml
@@ -252,7 +252,7 @@ jobs:
     - name: Publish SDKs
       uses: pulumi/pulumi-package-publisher@v0.0.9
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: "Publish failed :x:"

--- a/provider-ci/providers/oci/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/oci/repo/.github/workflows/release.yml
@@ -264,7 +264,7 @@ jobs:
     - name: Publish SDKs
       uses: pulumi/pulumi-package-publisher@v0.0.9
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: "Publish failed :x:"

--- a/provider-ci/providers/oci/repo/.github/workflows/upgrade-bridge.yml
+++ b/provider-ci/providers/oci/repo/.github/workflows/upgrade-bridge.yml
@@ -13,7 +13,7 @@ jobs:
       with:
         kind: bridge
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#7CFC00"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: >-
@@ -26,7 +26,7 @@ jobs:
       name: Send Upgrade Success To Slack
       uses: rtCamp/action-slack-notify@v2
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: " Upgrade failed :x:"

--- a/provider-ci/providers/oci/repo/.github/workflows/upgrade-provider.yml
+++ b/provider-ci/providers/oci/repo/.github/workflows/upgrade-provider.yml
@@ -14,7 +14,7 @@ jobs:
       with:
         kind: all
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#7CFC00"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: >-
@@ -27,7 +27,7 @@ jobs:
       name: Send Upgrade Success To Slack
       uses: rtCamp/action-slack-notify@v2
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: " Upgrade failed :x:"

--- a/provider-ci/providers/okta/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/okta/repo/.github/workflows/main.yml
@@ -341,7 +341,7 @@ jobs:
     - name: Publish SDKs
       uses: pulumi/pulumi-package-publisher@v0.0.9
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: "Publish failed :x:"

--- a/provider-ci/providers/okta/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/okta/repo/.github/workflows/master.yml
@@ -341,7 +341,7 @@ jobs:
     - name: Publish SDKs
       uses: pulumi/pulumi-package-publisher@v0.0.9
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: "Publish failed :x:"

--- a/provider-ci/providers/okta/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/okta/repo/.github/workflows/prerelease.yml
@@ -287,7 +287,7 @@ jobs:
     - name: Publish SDKs
       uses: pulumi/pulumi-package-publisher@v0.0.9
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: "Publish failed :x:"

--- a/provider-ci/providers/okta/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/okta/repo/.github/workflows/release.yml
@@ -299,7 +299,7 @@ jobs:
     - name: Publish SDKs
       uses: pulumi/pulumi-package-publisher@v0.0.9
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: "Publish failed :x:"

--- a/provider-ci/providers/okta/repo/.github/workflows/upgrade-bridge.yml
+++ b/provider-ci/providers/okta/repo/.github/workflows/upgrade-bridge.yml
@@ -13,7 +13,7 @@ jobs:
       with:
         kind: bridge
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#7CFC00"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: >-
@@ -26,7 +26,7 @@ jobs:
       name: Send Upgrade Success To Slack
       uses: rtCamp/action-slack-notify@v2
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: " Upgrade failed :x:"

--- a/provider-ci/providers/okta/repo/.github/workflows/upgrade-provider.yml
+++ b/provider-ci/providers/okta/repo/.github/workflows/upgrade-provider.yml
@@ -14,7 +14,7 @@ jobs:
       with:
         kind: all
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#7CFC00"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: >-
@@ -27,7 +27,7 @@ jobs:
       name: Send Upgrade Success To Slack
       uses: rtCamp/action-slack-notify@v2
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: " Upgrade failed :x:"

--- a/provider-ci/providers/onelogin/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/onelogin/repo/.github/workflows/main.yml
@@ -338,7 +338,7 @@ jobs:
     - name: Publish SDKs
       uses: pulumi/pulumi-package-publisher@v0.0.9
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: "Publish failed :x:"

--- a/provider-ci/providers/onelogin/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/onelogin/repo/.github/workflows/master.yml
@@ -338,7 +338,7 @@ jobs:
     - name: Publish SDKs
       uses: pulumi/pulumi-package-publisher@v0.0.9
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: "Publish failed :x:"

--- a/provider-ci/providers/onelogin/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/onelogin/repo/.github/workflows/prerelease.yml
@@ -284,7 +284,7 @@ jobs:
     - name: Publish SDKs
       uses: pulumi/pulumi-package-publisher@v0.0.9
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: "Publish failed :x:"

--- a/provider-ci/providers/onelogin/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/onelogin/repo/.github/workflows/release.yml
@@ -296,7 +296,7 @@ jobs:
     - name: Publish SDKs
       uses: pulumi/pulumi-package-publisher@v0.0.9
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: "Publish failed :x:"

--- a/provider-ci/providers/onelogin/repo/.github/workflows/upgrade-bridge.yml
+++ b/provider-ci/providers/onelogin/repo/.github/workflows/upgrade-bridge.yml
@@ -13,7 +13,7 @@ jobs:
       with:
         kind: bridge
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#7CFC00"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: >-
@@ -26,7 +26,7 @@ jobs:
       name: Send Upgrade Success To Slack
       uses: rtCamp/action-slack-notify@v2
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: " Upgrade failed :x:"

--- a/provider-ci/providers/onelogin/repo/.github/workflows/upgrade-provider.yml
+++ b/provider-ci/providers/onelogin/repo/.github/workflows/upgrade-provider.yml
@@ -14,7 +14,7 @@ jobs:
       with:
         kind: all
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#7CFC00"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: >-
@@ -27,7 +27,7 @@ jobs:
       name: Send Upgrade Success To Slack
       uses: rtCamp/action-slack-notify@v2
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: " Upgrade failed :x:"

--- a/provider-ci/providers/openstack/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/openstack/repo/.github/workflows/main.yml
@@ -347,7 +347,7 @@ jobs:
     - name: Publish SDKs
       uses: pulumi/pulumi-package-publisher@v0.0.9
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: "Publish failed :x:"

--- a/provider-ci/providers/openstack/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/openstack/repo/.github/workflows/master.yml
@@ -347,7 +347,7 @@ jobs:
     - name: Publish SDKs
       uses: pulumi/pulumi-package-publisher@v0.0.9
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: "Publish failed :x:"

--- a/provider-ci/providers/openstack/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/openstack/repo/.github/workflows/prerelease.yml
@@ -293,7 +293,7 @@ jobs:
     - name: Publish SDKs
       uses: pulumi/pulumi-package-publisher@v0.0.9
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: "Publish failed :x:"

--- a/provider-ci/providers/openstack/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/openstack/repo/.github/workflows/release.yml
@@ -305,7 +305,7 @@ jobs:
     - name: Publish SDKs
       uses: pulumi/pulumi-package-publisher@v0.0.9
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: "Publish failed :x:"

--- a/provider-ci/providers/openstack/repo/.github/workflows/upgrade-bridge.yml
+++ b/provider-ci/providers/openstack/repo/.github/workflows/upgrade-bridge.yml
@@ -13,7 +13,7 @@ jobs:
       with:
         kind: bridge
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#7CFC00"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: >-
@@ -26,7 +26,7 @@ jobs:
       name: Send Upgrade Success To Slack
       uses: rtCamp/action-slack-notify@v2
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: " Upgrade failed :x:"

--- a/provider-ci/providers/openstack/repo/.github/workflows/upgrade-provider.yml
+++ b/provider-ci/providers/openstack/repo/.github/workflows/upgrade-provider.yml
@@ -14,7 +14,7 @@ jobs:
       with:
         kind: all
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#7CFC00"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: >-
@@ -27,7 +27,7 @@ jobs:
       name: Send Upgrade Success To Slack
       uses: rtCamp/action-slack-notify@v2
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: " Upgrade failed :x:"

--- a/provider-ci/providers/opsgenie/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/opsgenie/repo/.github/workflows/main.yml
@@ -339,7 +339,7 @@ jobs:
     - name: Publish SDKs
       uses: pulumi/pulumi-package-publisher@v0.0.9
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: "Publish failed :x:"

--- a/provider-ci/providers/opsgenie/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/opsgenie/repo/.github/workflows/master.yml
@@ -339,7 +339,7 @@ jobs:
     - name: Publish SDKs
       uses: pulumi/pulumi-package-publisher@v0.0.9
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: "Publish failed :x:"

--- a/provider-ci/providers/opsgenie/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/opsgenie/repo/.github/workflows/prerelease.yml
@@ -285,7 +285,7 @@ jobs:
     - name: Publish SDKs
       uses: pulumi/pulumi-package-publisher@v0.0.9
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: "Publish failed :x:"

--- a/provider-ci/providers/opsgenie/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/opsgenie/repo/.github/workflows/release.yml
@@ -297,7 +297,7 @@ jobs:
     - name: Publish SDKs
       uses: pulumi/pulumi-package-publisher@v0.0.9
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: "Publish failed :x:"

--- a/provider-ci/providers/opsgenie/repo/.github/workflows/upgrade-bridge.yml
+++ b/provider-ci/providers/opsgenie/repo/.github/workflows/upgrade-bridge.yml
@@ -13,7 +13,7 @@ jobs:
       with:
         kind: bridge
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#7CFC00"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: >-
@@ -26,7 +26,7 @@ jobs:
       name: Send Upgrade Success To Slack
       uses: rtCamp/action-slack-notify@v2
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: " Upgrade failed :x:"

--- a/provider-ci/providers/opsgenie/repo/.github/workflows/upgrade-provider.yml
+++ b/provider-ci/providers/opsgenie/repo/.github/workflows/upgrade-provider.yml
@@ -14,7 +14,7 @@ jobs:
       with:
         kind: all
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#7CFC00"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: >-
@@ -27,7 +27,7 @@ jobs:
       name: Send Upgrade Success To Slack
       uses: rtCamp/action-slack-notify@v2
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: " Upgrade failed :x:"

--- a/provider-ci/providers/pagerduty/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/pagerduty/repo/.github/workflows/main.yml
@@ -339,7 +339,7 @@ jobs:
     - name: Publish SDKs
       uses: pulumi/pulumi-package-publisher@v0.0.9
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: "Publish failed :x:"

--- a/provider-ci/providers/pagerduty/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/pagerduty/repo/.github/workflows/master.yml
@@ -339,7 +339,7 @@ jobs:
     - name: Publish SDKs
       uses: pulumi/pulumi-package-publisher@v0.0.9
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: "Publish failed :x:"

--- a/provider-ci/providers/pagerduty/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/pagerduty/repo/.github/workflows/prerelease.yml
@@ -285,7 +285,7 @@ jobs:
     - name: Publish SDKs
       uses: pulumi/pulumi-package-publisher@v0.0.9
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: "Publish failed :x:"

--- a/provider-ci/providers/pagerduty/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/pagerduty/repo/.github/workflows/release.yml
@@ -297,7 +297,7 @@ jobs:
     - name: Publish SDKs
       uses: pulumi/pulumi-package-publisher@v0.0.9
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: "Publish failed :x:"

--- a/provider-ci/providers/pagerduty/repo/.github/workflows/upgrade-bridge.yml
+++ b/provider-ci/providers/pagerduty/repo/.github/workflows/upgrade-bridge.yml
@@ -13,7 +13,7 @@ jobs:
       with:
         kind: bridge
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#7CFC00"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: >-
@@ -26,7 +26,7 @@ jobs:
       name: Send Upgrade Success To Slack
       uses: rtCamp/action-slack-notify@v2
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: " Upgrade failed :x:"

--- a/provider-ci/providers/pagerduty/repo/.github/workflows/upgrade-provider.yml
+++ b/provider-ci/providers/pagerduty/repo/.github/workflows/upgrade-provider.yml
@@ -14,7 +14,7 @@ jobs:
       with:
         kind: all
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#7CFC00"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: >-
@@ -27,7 +27,7 @@ jobs:
       name: Send Upgrade Success To Slack
       uses: rtCamp/action-slack-notify@v2
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: " Upgrade failed :x:"

--- a/provider-ci/providers/postgresql/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/postgresql/repo/.github/workflows/main.yml
@@ -338,7 +338,7 @@ jobs:
     - name: Publish SDKs
       uses: pulumi/pulumi-package-publisher@v0.0.9
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: "Publish failed :x:"

--- a/provider-ci/providers/postgresql/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/postgresql/repo/.github/workflows/master.yml
@@ -338,7 +338,7 @@ jobs:
     - name: Publish SDKs
       uses: pulumi/pulumi-package-publisher@v0.0.9
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: "Publish failed :x:"

--- a/provider-ci/providers/postgresql/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/postgresql/repo/.github/workflows/prerelease.yml
@@ -284,7 +284,7 @@ jobs:
     - name: Publish SDKs
       uses: pulumi/pulumi-package-publisher@v0.0.9
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: "Publish failed :x:"

--- a/provider-ci/providers/postgresql/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/postgresql/repo/.github/workflows/release.yml
@@ -296,7 +296,7 @@ jobs:
     - name: Publish SDKs
       uses: pulumi/pulumi-package-publisher@v0.0.9
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: "Publish failed :x:"

--- a/provider-ci/providers/postgresql/repo/.github/workflows/upgrade-bridge.yml
+++ b/provider-ci/providers/postgresql/repo/.github/workflows/upgrade-bridge.yml
@@ -13,7 +13,7 @@ jobs:
       with:
         kind: bridge
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#7CFC00"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: >-
@@ -26,7 +26,7 @@ jobs:
       name: Send Upgrade Success To Slack
       uses: rtCamp/action-slack-notify@v2
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: " Upgrade failed :x:"

--- a/provider-ci/providers/postgresql/repo/.github/workflows/upgrade-provider.yml
+++ b/provider-ci/providers/postgresql/repo/.github/workflows/upgrade-provider.yml
@@ -14,7 +14,7 @@ jobs:
       with:
         kind: all
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#7CFC00"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: >-
@@ -27,7 +27,7 @@ jobs:
       name: Send Upgrade Success To Slack
       uses: rtCamp/action-slack-notify@v2
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: " Upgrade failed :x:"

--- a/provider-ci/providers/rabbitmq/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/rabbitmq/repo/.github/workflows/main.yml
@@ -338,7 +338,7 @@ jobs:
     - name: Publish SDKs
       uses: pulumi/pulumi-package-publisher@v0.0.9
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: "Publish failed :x:"

--- a/provider-ci/providers/rabbitmq/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/rabbitmq/repo/.github/workflows/master.yml
@@ -338,7 +338,7 @@ jobs:
     - name: Publish SDKs
       uses: pulumi/pulumi-package-publisher@v0.0.9
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: "Publish failed :x:"

--- a/provider-ci/providers/rabbitmq/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/rabbitmq/repo/.github/workflows/prerelease.yml
@@ -284,7 +284,7 @@ jobs:
     - name: Publish SDKs
       uses: pulumi/pulumi-package-publisher@v0.0.9
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: "Publish failed :x:"

--- a/provider-ci/providers/rabbitmq/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/rabbitmq/repo/.github/workflows/release.yml
@@ -296,7 +296,7 @@ jobs:
     - name: Publish SDKs
       uses: pulumi/pulumi-package-publisher@v0.0.9
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: "Publish failed :x:"

--- a/provider-ci/providers/rabbitmq/repo/.github/workflows/upgrade-bridge.yml
+++ b/provider-ci/providers/rabbitmq/repo/.github/workflows/upgrade-bridge.yml
@@ -13,7 +13,7 @@ jobs:
       with:
         kind: bridge
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#7CFC00"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: >-
@@ -26,7 +26,7 @@ jobs:
       name: Send Upgrade Success To Slack
       uses: rtCamp/action-slack-notify@v2
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: " Upgrade failed :x:"

--- a/provider-ci/providers/rabbitmq/repo/.github/workflows/upgrade-provider.yml
+++ b/provider-ci/providers/rabbitmq/repo/.github/workflows/upgrade-provider.yml
@@ -14,7 +14,7 @@ jobs:
       with:
         kind: all
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#7CFC00"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: >-
@@ -27,7 +27,7 @@ jobs:
       name: Send Upgrade Success To Slack
       uses: rtCamp/action-slack-notify@v2
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: " Upgrade failed :x:"

--- a/provider-ci/providers/rancher2/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/rancher2/repo/.github/workflows/main.yml
@@ -304,7 +304,7 @@ jobs:
     - name: Publish SDKs
       uses: pulumi/pulumi-package-publisher@v0.0.9
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: "Publish failed :x:"

--- a/provider-ci/providers/rancher2/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/rancher2/repo/.github/workflows/master.yml
@@ -304,7 +304,7 @@ jobs:
     - name: Publish SDKs
       uses: pulumi/pulumi-package-publisher@v0.0.9
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: "Publish failed :x:"

--- a/provider-ci/providers/rancher2/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/rancher2/repo/.github/workflows/prerelease.yml
@@ -250,7 +250,7 @@ jobs:
     - name: Publish SDKs
       uses: pulumi/pulumi-package-publisher@v0.0.9
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: "Publish failed :x:"

--- a/provider-ci/providers/rancher2/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/rancher2/repo/.github/workflows/release.yml
@@ -262,7 +262,7 @@ jobs:
     - name: Publish SDKs
       uses: pulumi/pulumi-package-publisher@v0.0.9
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: "Publish failed :x:"

--- a/provider-ci/providers/rancher2/repo/.github/workflows/upgrade-bridge.yml
+++ b/provider-ci/providers/rancher2/repo/.github/workflows/upgrade-bridge.yml
@@ -13,7 +13,7 @@ jobs:
       with:
         kind: bridge
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#7CFC00"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: >-
@@ -26,7 +26,7 @@ jobs:
       name: Send Upgrade Success To Slack
       uses: rtCamp/action-slack-notify@v2
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: " Upgrade failed :x:"

--- a/provider-ci/providers/rancher2/repo/.github/workflows/upgrade-provider.yml
+++ b/provider-ci/providers/rancher2/repo/.github/workflows/upgrade-provider.yml
@@ -14,7 +14,7 @@ jobs:
       with:
         kind: all
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#7CFC00"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: >-
@@ -27,7 +27,7 @@ jobs:
       name: Send Upgrade Success To Slack
       uses: rtCamp/action-slack-notify@v2
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: " Upgrade failed :x:"

--- a/provider-ci/providers/random/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/random/repo/.github/workflows/main.yml
@@ -338,7 +338,7 @@ jobs:
     - name: Publish SDKs
       uses: pulumi/pulumi-package-publisher@v0.0.9
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: "Publish failed :x:"

--- a/provider-ci/providers/random/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/random/repo/.github/workflows/master.yml
@@ -338,7 +338,7 @@ jobs:
     - name: Publish SDKs
       uses: pulumi/pulumi-package-publisher@v0.0.9
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: "Publish failed :x:"

--- a/provider-ci/providers/random/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/random/repo/.github/workflows/prerelease.yml
@@ -284,7 +284,7 @@ jobs:
     - name: Publish SDKs
       uses: pulumi/pulumi-package-publisher@v0.0.9
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: "Publish failed :x:"

--- a/provider-ci/providers/random/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/random/repo/.github/workflows/release.yml
@@ -296,7 +296,7 @@ jobs:
     - name: Publish SDKs
       uses: pulumi/pulumi-package-publisher@v0.0.9
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: "Publish failed :x:"

--- a/provider-ci/providers/random/repo/.github/workflows/upgrade-bridge.yml
+++ b/provider-ci/providers/random/repo/.github/workflows/upgrade-bridge.yml
@@ -13,7 +13,7 @@ jobs:
       with:
         kind: bridge
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#7CFC00"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: >-
@@ -26,7 +26,7 @@ jobs:
       name: Send Upgrade Success To Slack
       uses: rtCamp/action-slack-notify@v2
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: " Upgrade failed :x:"

--- a/provider-ci/providers/random/repo/.github/workflows/upgrade-provider.yml
+++ b/provider-ci/providers/random/repo/.github/workflows/upgrade-provider.yml
@@ -14,7 +14,7 @@ jobs:
       with:
         kind: all
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#7CFC00"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: >-
@@ -27,7 +27,7 @@ jobs:
       name: Send Upgrade Success To Slack
       uses: rtCamp/action-slack-notify@v2
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: " Upgrade failed :x:"

--- a/provider-ci/providers/rke/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/rke/repo/.github/workflows/main.yml
@@ -339,7 +339,7 @@ jobs:
     - name: Publish SDKs
       uses: pulumi/pulumi-package-publisher@v0.0.9
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: "Publish failed :x:"

--- a/provider-ci/providers/rke/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/rke/repo/.github/workflows/master.yml
@@ -339,7 +339,7 @@ jobs:
     - name: Publish SDKs
       uses: pulumi/pulumi-package-publisher@v0.0.9
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: "Publish failed :x:"

--- a/provider-ci/providers/rke/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/rke/repo/.github/workflows/prerelease.yml
@@ -285,7 +285,7 @@ jobs:
     - name: Publish SDKs
       uses: pulumi/pulumi-package-publisher@v0.0.9
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: "Publish failed :x:"

--- a/provider-ci/providers/rke/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/rke/repo/.github/workflows/release.yml
@@ -297,7 +297,7 @@ jobs:
     - name: Publish SDKs
       uses: pulumi/pulumi-package-publisher@v0.0.9
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: "Publish failed :x:"

--- a/provider-ci/providers/rke/repo/.github/workflows/upgrade-bridge.yml
+++ b/provider-ci/providers/rke/repo/.github/workflows/upgrade-bridge.yml
@@ -13,7 +13,7 @@ jobs:
       with:
         kind: bridge
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#7CFC00"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: >-
@@ -26,7 +26,7 @@ jobs:
       name: Send Upgrade Success To Slack
       uses: rtCamp/action-slack-notify@v2
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: " Upgrade failed :x:"

--- a/provider-ci/providers/rke/repo/.github/workflows/upgrade-provider.yml
+++ b/provider-ci/providers/rke/repo/.github/workflows/upgrade-provider.yml
@@ -14,7 +14,7 @@ jobs:
       with:
         kind: all
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#7CFC00"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: >-
@@ -27,7 +27,7 @@ jobs:
       name: Send Upgrade Success To Slack
       uses: rtCamp/action-slack-notify@v2
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: " Upgrade failed :x:"

--- a/provider-ci/providers/signalfx/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/signalfx/repo/.github/workflows/main.yml
@@ -338,7 +338,7 @@ jobs:
     - name: Publish SDKs
       uses: pulumi/pulumi-package-publisher@v0.0.9
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: "Publish failed :x:"

--- a/provider-ci/providers/signalfx/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/signalfx/repo/.github/workflows/master.yml
@@ -338,7 +338,7 @@ jobs:
     - name: Publish SDKs
       uses: pulumi/pulumi-package-publisher@v0.0.9
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: "Publish failed :x:"

--- a/provider-ci/providers/signalfx/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/signalfx/repo/.github/workflows/prerelease.yml
@@ -284,7 +284,7 @@ jobs:
     - name: Publish SDKs
       uses: pulumi/pulumi-package-publisher@v0.0.9
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: "Publish failed :x:"

--- a/provider-ci/providers/signalfx/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/signalfx/repo/.github/workflows/release.yml
@@ -296,7 +296,7 @@ jobs:
     - name: Publish SDKs
       uses: pulumi/pulumi-package-publisher@v0.0.9
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: "Publish failed :x:"

--- a/provider-ci/providers/signalfx/repo/.github/workflows/upgrade-bridge.yml
+++ b/provider-ci/providers/signalfx/repo/.github/workflows/upgrade-bridge.yml
@@ -13,7 +13,7 @@ jobs:
       with:
         kind: bridge
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#7CFC00"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: >-
@@ -26,7 +26,7 @@ jobs:
       name: Send Upgrade Success To Slack
       uses: rtCamp/action-slack-notify@v2
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: " Upgrade failed :x:"

--- a/provider-ci/providers/signalfx/repo/.github/workflows/upgrade-provider.yml
+++ b/provider-ci/providers/signalfx/repo/.github/workflows/upgrade-provider.yml
@@ -14,7 +14,7 @@ jobs:
       with:
         kind: all
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#7CFC00"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: >-
@@ -27,7 +27,7 @@ jobs:
       name: Send Upgrade Success To Slack
       uses: rtCamp/action-slack-notify@v2
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: " Upgrade failed :x:"

--- a/provider-ci/providers/slack/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/slack/repo/.github/workflows/main.yml
@@ -339,7 +339,7 @@ jobs:
     - name: Publish SDKs
       uses: pulumi/pulumi-package-publisher@v0.0.9
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: "Publish failed :x:"

--- a/provider-ci/providers/slack/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/slack/repo/.github/workflows/master.yml
@@ -339,7 +339,7 @@ jobs:
     - name: Publish SDKs
       uses: pulumi/pulumi-package-publisher@v0.0.9
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: "Publish failed :x:"

--- a/provider-ci/providers/slack/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/slack/repo/.github/workflows/prerelease.yml
@@ -285,7 +285,7 @@ jobs:
     - name: Publish SDKs
       uses: pulumi/pulumi-package-publisher@v0.0.9
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: "Publish failed :x:"

--- a/provider-ci/providers/slack/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/slack/repo/.github/workflows/release.yml
@@ -297,7 +297,7 @@ jobs:
     - name: Publish SDKs
       uses: pulumi/pulumi-package-publisher@v0.0.9
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: "Publish failed :x:"

--- a/provider-ci/providers/slack/repo/.github/workflows/upgrade-bridge.yml
+++ b/provider-ci/providers/slack/repo/.github/workflows/upgrade-bridge.yml
@@ -13,7 +13,7 @@ jobs:
       with:
         kind: bridge
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#7CFC00"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: >-
@@ -26,7 +26,7 @@ jobs:
       name: Send Upgrade Success To Slack
       uses: rtCamp/action-slack-notify@v2
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: " Upgrade failed :x:"

--- a/provider-ci/providers/slack/repo/.github/workflows/upgrade-provider.yml
+++ b/provider-ci/providers/slack/repo/.github/workflows/upgrade-provider.yml
@@ -14,7 +14,7 @@ jobs:
       with:
         kind: all
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#7CFC00"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: >-
@@ -27,7 +27,7 @@ jobs:
       name: Send Upgrade Success To Slack
       uses: rtCamp/action-slack-notify@v2
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: " Upgrade failed :x:"

--- a/provider-ci/providers/snowflake/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/snowflake/repo/.github/workflows/main.yml
@@ -343,7 +343,7 @@ jobs:
     - name: Publish SDKs
       uses: pulumi/pulumi-package-publisher@v0.0.9
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: "Publish failed :x:"

--- a/provider-ci/providers/snowflake/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/snowflake/repo/.github/workflows/master.yml
@@ -343,7 +343,7 @@ jobs:
     - name: Publish SDKs
       uses: pulumi/pulumi-package-publisher@v0.0.9
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: "Publish failed :x:"

--- a/provider-ci/providers/snowflake/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/snowflake/repo/.github/workflows/prerelease.yml
@@ -289,7 +289,7 @@ jobs:
     - name: Publish SDKs
       uses: pulumi/pulumi-package-publisher@v0.0.9
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: "Publish failed :x:"

--- a/provider-ci/providers/snowflake/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/snowflake/repo/.github/workflows/release.yml
@@ -301,7 +301,7 @@ jobs:
     - name: Publish SDKs
       uses: pulumi/pulumi-package-publisher@v0.0.9
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: "Publish failed :x:"

--- a/provider-ci/providers/snowflake/repo/.github/workflows/upgrade-bridge.yml
+++ b/provider-ci/providers/snowflake/repo/.github/workflows/upgrade-bridge.yml
@@ -13,7 +13,7 @@ jobs:
       with:
         kind: bridge
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#7CFC00"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: >-
@@ -26,7 +26,7 @@ jobs:
       name: Send Upgrade Success To Slack
       uses: rtCamp/action-slack-notify@v2
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: " Upgrade failed :x:"

--- a/provider-ci/providers/snowflake/repo/.github/workflows/upgrade-provider.yml
+++ b/provider-ci/providers/snowflake/repo/.github/workflows/upgrade-provider.yml
@@ -14,7 +14,7 @@ jobs:
       with:
         kind: all
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#7CFC00"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: >-
@@ -27,7 +27,7 @@ jobs:
       name: Send Upgrade Success To Slack
       uses: rtCamp/action-slack-notify@v2
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: " Upgrade failed :x:"

--- a/provider-ci/providers/splunk/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/splunk/repo/.github/workflows/main.yml
@@ -341,7 +341,7 @@ jobs:
     - name: Publish SDKs
       uses: pulumi/pulumi-package-publisher@v0.0.9
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: "Publish failed :x:"

--- a/provider-ci/providers/splunk/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/splunk/repo/.github/workflows/master.yml
@@ -341,7 +341,7 @@ jobs:
     - name: Publish SDKs
       uses: pulumi/pulumi-package-publisher@v0.0.9
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: "Publish failed :x:"

--- a/provider-ci/providers/splunk/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/splunk/repo/.github/workflows/prerelease.yml
@@ -287,7 +287,7 @@ jobs:
     - name: Publish SDKs
       uses: pulumi/pulumi-package-publisher@v0.0.9
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: "Publish failed :x:"

--- a/provider-ci/providers/splunk/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/splunk/repo/.github/workflows/release.yml
@@ -299,7 +299,7 @@ jobs:
     - name: Publish SDKs
       uses: pulumi/pulumi-package-publisher@v0.0.9
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: "Publish failed :x:"

--- a/provider-ci/providers/splunk/repo/.github/workflows/upgrade-bridge.yml
+++ b/provider-ci/providers/splunk/repo/.github/workflows/upgrade-bridge.yml
@@ -13,7 +13,7 @@ jobs:
       with:
         kind: bridge
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#7CFC00"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: >-
@@ -26,7 +26,7 @@ jobs:
       name: Send Upgrade Success To Slack
       uses: rtCamp/action-slack-notify@v2
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: " Upgrade failed :x:"

--- a/provider-ci/providers/splunk/repo/.github/workflows/upgrade-provider.yml
+++ b/provider-ci/providers/splunk/repo/.github/workflows/upgrade-provider.yml
@@ -14,7 +14,7 @@ jobs:
       with:
         kind: all
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#7CFC00"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: >-
@@ -27,7 +27,7 @@ jobs:
       name: Send Upgrade Success To Slack
       uses: rtCamp/action-slack-notify@v2
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: " Upgrade failed :x:"

--- a/provider-ci/providers/spotinst/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/spotinst/repo/.github/workflows/main.yml
@@ -341,7 +341,7 @@ jobs:
     - name: Publish SDKs
       uses: pulumi/pulumi-package-publisher@v0.0.9
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: "Publish failed :x:"

--- a/provider-ci/providers/spotinst/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/spotinst/repo/.github/workflows/master.yml
@@ -341,7 +341,7 @@ jobs:
     - name: Publish SDKs
       uses: pulumi/pulumi-package-publisher@v0.0.9
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: "Publish failed :x:"

--- a/provider-ci/providers/spotinst/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/spotinst/repo/.github/workflows/prerelease.yml
@@ -287,7 +287,7 @@ jobs:
     - name: Publish SDKs
       uses: pulumi/pulumi-package-publisher@v0.0.9
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: "Publish failed :x:"

--- a/provider-ci/providers/spotinst/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/spotinst/repo/.github/workflows/release.yml
@@ -299,7 +299,7 @@ jobs:
     - name: Publish SDKs
       uses: pulumi/pulumi-package-publisher@v0.0.9
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: "Publish failed :x:"

--- a/provider-ci/providers/spotinst/repo/.github/workflows/upgrade-bridge.yml
+++ b/provider-ci/providers/spotinst/repo/.github/workflows/upgrade-bridge.yml
@@ -13,7 +13,7 @@ jobs:
       with:
         kind: bridge
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#7CFC00"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: >-
@@ -26,7 +26,7 @@ jobs:
       name: Send Upgrade Success To Slack
       uses: rtCamp/action-slack-notify@v2
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: " Upgrade failed :x:"

--- a/provider-ci/providers/spotinst/repo/.github/workflows/upgrade-provider.yml
+++ b/provider-ci/providers/spotinst/repo/.github/workflows/upgrade-provider.yml
@@ -14,7 +14,7 @@ jobs:
       with:
         kind: all
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#7CFC00"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: >-
@@ -27,7 +27,7 @@ jobs:
       name: Send Upgrade Success To Slack
       uses: rtCamp/action-slack-notify@v2
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: " Upgrade failed :x:"

--- a/provider-ci/providers/sumologic/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/sumologic/repo/.github/workflows/main.yml
@@ -341,7 +341,7 @@ jobs:
     - name: Publish SDKs
       uses: pulumi/pulumi-package-publisher@v0.0.9
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: "Publish failed :x:"

--- a/provider-ci/providers/sumologic/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/sumologic/repo/.github/workflows/master.yml
@@ -341,7 +341,7 @@ jobs:
     - name: Publish SDKs
       uses: pulumi/pulumi-package-publisher@v0.0.9
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: "Publish failed :x:"

--- a/provider-ci/providers/sumologic/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/sumologic/repo/.github/workflows/prerelease.yml
@@ -287,7 +287,7 @@ jobs:
     - name: Publish SDKs
       uses: pulumi/pulumi-package-publisher@v0.0.9
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: "Publish failed :x:"

--- a/provider-ci/providers/sumologic/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/sumologic/repo/.github/workflows/release.yml
@@ -299,7 +299,7 @@ jobs:
     - name: Publish SDKs
       uses: pulumi/pulumi-package-publisher@v0.0.9
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: "Publish failed :x:"

--- a/provider-ci/providers/sumologic/repo/.github/workflows/upgrade-bridge.yml
+++ b/provider-ci/providers/sumologic/repo/.github/workflows/upgrade-bridge.yml
@@ -13,7 +13,7 @@ jobs:
       with:
         kind: bridge
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#7CFC00"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: >-
@@ -26,7 +26,7 @@ jobs:
       name: Send Upgrade Success To Slack
       uses: rtCamp/action-slack-notify@v2
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: " Upgrade failed :x:"

--- a/provider-ci/providers/sumologic/repo/.github/workflows/upgrade-provider.yml
+++ b/provider-ci/providers/sumologic/repo/.github/workflows/upgrade-provider.yml
@@ -14,7 +14,7 @@ jobs:
       with:
         kind: all
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#7CFC00"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: >-
@@ -27,7 +27,7 @@ jobs:
       name: Send Upgrade Success To Slack
       uses: rtCamp/action-slack-notify@v2
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: " Upgrade failed :x:"

--- a/provider-ci/providers/tailscale/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/tailscale/repo/.github/workflows/main.yml
@@ -341,7 +341,7 @@ jobs:
     - name: Publish SDKs
       uses: pulumi/pulumi-package-publisher@v0.0.9
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: "Publish failed :x:"

--- a/provider-ci/providers/tailscale/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/tailscale/repo/.github/workflows/master.yml
@@ -341,7 +341,7 @@ jobs:
     - name: Publish SDKs
       uses: pulumi/pulumi-package-publisher@v0.0.9
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: "Publish failed :x:"

--- a/provider-ci/providers/tailscale/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/tailscale/repo/.github/workflows/prerelease.yml
@@ -287,7 +287,7 @@ jobs:
     - name: Publish SDKs
       uses: pulumi/pulumi-package-publisher@v0.0.9
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: "Publish failed :x:"

--- a/provider-ci/providers/tailscale/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/tailscale/repo/.github/workflows/release.yml
@@ -299,7 +299,7 @@ jobs:
     - name: Publish SDKs
       uses: pulumi/pulumi-package-publisher@v0.0.9
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: "Publish failed :x:"

--- a/provider-ci/providers/tailscale/repo/.github/workflows/upgrade-bridge.yml
+++ b/provider-ci/providers/tailscale/repo/.github/workflows/upgrade-bridge.yml
@@ -13,7 +13,7 @@ jobs:
       with:
         kind: bridge
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#7CFC00"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: >-
@@ -26,7 +26,7 @@ jobs:
       name: Send Upgrade Success To Slack
       uses: rtCamp/action-slack-notify@v2
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: " Upgrade failed :x:"

--- a/provider-ci/providers/tailscale/repo/.github/workflows/upgrade-provider.yml
+++ b/provider-ci/providers/tailscale/repo/.github/workflows/upgrade-provider.yml
@@ -14,7 +14,7 @@ jobs:
       with:
         kind: all
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#7CFC00"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: >-
@@ -27,7 +27,7 @@ jobs:
       name: Send Upgrade Success To Slack
       uses: rtCamp/action-slack-notify@v2
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: " Upgrade failed :x:"

--- a/provider-ci/providers/tls/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/tls/repo/.github/workflows/main.yml
@@ -338,7 +338,7 @@ jobs:
     - name: Publish SDKs
       uses: pulumi/pulumi-package-publisher@v0.0.9
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: "Publish failed :x:"

--- a/provider-ci/providers/tls/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/tls/repo/.github/workflows/master.yml
@@ -338,7 +338,7 @@ jobs:
     - name: Publish SDKs
       uses: pulumi/pulumi-package-publisher@v0.0.9
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: "Publish failed :x:"

--- a/provider-ci/providers/tls/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/tls/repo/.github/workflows/prerelease.yml
@@ -284,7 +284,7 @@ jobs:
     - name: Publish SDKs
       uses: pulumi/pulumi-package-publisher@v0.0.9
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: "Publish failed :x:"

--- a/provider-ci/providers/tls/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/tls/repo/.github/workflows/release.yml
@@ -296,7 +296,7 @@ jobs:
     - name: Publish SDKs
       uses: pulumi/pulumi-package-publisher@v0.0.9
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: "Publish failed :x:"

--- a/provider-ci/providers/tls/repo/.github/workflows/upgrade-bridge.yml
+++ b/provider-ci/providers/tls/repo/.github/workflows/upgrade-bridge.yml
@@ -13,7 +13,7 @@ jobs:
       with:
         kind: bridge
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#7CFC00"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: >-
@@ -26,7 +26,7 @@ jobs:
       name: Send Upgrade Success To Slack
       uses: rtCamp/action-slack-notify@v2
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: " Upgrade failed :x:"

--- a/provider-ci/providers/tls/repo/.github/workflows/upgrade-provider.yml
+++ b/provider-ci/providers/tls/repo/.github/workflows/upgrade-provider.yml
@@ -14,7 +14,7 @@ jobs:
       with:
         kind: all
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#7CFC00"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: >-
@@ -27,7 +27,7 @@ jobs:
       name: Send Upgrade Success To Slack
       uses: rtCamp/action-slack-notify@v2
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: " Upgrade failed :x:"

--- a/provider-ci/providers/vault/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/vault/repo/.github/workflows/main.yml
@@ -339,7 +339,7 @@ jobs:
     - name: Publish SDKs
       uses: pulumi/pulumi-package-publisher@v0.0.9
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: "Publish failed :x:"

--- a/provider-ci/providers/vault/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/vault/repo/.github/workflows/master.yml
@@ -339,7 +339,7 @@ jobs:
     - name: Publish SDKs
       uses: pulumi/pulumi-package-publisher@v0.0.9
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: "Publish failed :x:"

--- a/provider-ci/providers/vault/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/vault/repo/.github/workflows/prerelease.yml
@@ -285,7 +285,7 @@ jobs:
     - name: Publish SDKs
       uses: pulumi/pulumi-package-publisher@v0.0.9
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: "Publish failed :x:"

--- a/provider-ci/providers/vault/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/vault/repo/.github/workflows/release.yml
@@ -297,7 +297,7 @@ jobs:
     - name: Publish SDKs
       uses: pulumi/pulumi-package-publisher@v0.0.9
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: "Publish failed :x:"

--- a/provider-ci/providers/vault/repo/.github/workflows/upgrade-bridge.yml
+++ b/provider-ci/providers/vault/repo/.github/workflows/upgrade-bridge.yml
@@ -13,7 +13,7 @@ jobs:
       with:
         kind: bridge
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#7CFC00"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: >-
@@ -26,7 +26,7 @@ jobs:
       name: Send Upgrade Success To Slack
       uses: rtCamp/action-slack-notify@v2
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: " Upgrade failed :x:"

--- a/provider-ci/providers/vault/repo/.github/workflows/upgrade-provider.yml
+++ b/provider-ci/providers/vault/repo/.github/workflows/upgrade-provider.yml
@@ -14,7 +14,7 @@ jobs:
       with:
         kind: all
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#7CFC00"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: >-
@@ -27,7 +27,7 @@ jobs:
       name: Send Upgrade Success To Slack
       uses: rtCamp/action-slack-notify@v2
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: " Upgrade failed :x:"

--- a/provider-ci/providers/venafi/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/venafi/repo/.github/workflows/main.yml
@@ -342,7 +342,7 @@ jobs:
     - name: Publish SDKs
       uses: pulumi/pulumi-package-publisher@v0.0.9
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: "Publish failed :x:"

--- a/provider-ci/providers/venafi/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/venafi/repo/.github/workflows/master.yml
@@ -342,7 +342,7 @@ jobs:
     - name: Publish SDKs
       uses: pulumi/pulumi-package-publisher@v0.0.9
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: "Publish failed :x:"

--- a/provider-ci/providers/venafi/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/venafi/repo/.github/workflows/prerelease.yml
@@ -288,7 +288,7 @@ jobs:
     - name: Publish SDKs
       uses: pulumi/pulumi-package-publisher@v0.0.9
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: "Publish failed :x:"

--- a/provider-ci/providers/venafi/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/venafi/repo/.github/workflows/release.yml
@@ -300,7 +300,7 @@ jobs:
     - name: Publish SDKs
       uses: pulumi/pulumi-package-publisher@v0.0.9
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: "Publish failed :x:"

--- a/provider-ci/providers/venafi/repo/.github/workflows/upgrade-bridge.yml
+++ b/provider-ci/providers/venafi/repo/.github/workflows/upgrade-bridge.yml
@@ -13,7 +13,7 @@ jobs:
       with:
         kind: bridge
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#7CFC00"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: >-
@@ -26,7 +26,7 @@ jobs:
       name: Send Upgrade Success To Slack
       uses: rtCamp/action-slack-notify@v2
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: " Upgrade failed :x:"

--- a/provider-ci/providers/venafi/repo/.github/workflows/upgrade-provider.yml
+++ b/provider-ci/providers/venafi/repo/.github/workflows/upgrade-provider.yml
@@ -14,7 +14,7 @@ jobs:
       with:
         kind: all
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#7CFC00"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: >-
@@ -27,7 +27,7 @@ jobs:
       name: Send Upgrade Success To Slack
       uses: rtCamp/action-slack-notify@v2
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: " Upgrade failed :x:"

--- a/provider-ci/providers/vsphere/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/vsphere/repo/.github/workflows/main.yml
@@ -338,7 +338,7 @@ jobs:
     - name: Publish SDKs
       uses: pulumi/pulumi-package-publisher@v0.0.9
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: "Publish failed :x:"

--- a/provider-ci/providers/vsphere/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/vsphere/repo/.github/workflows/master.yml
@@ -338,7 +338,7 @@ jobs:
     - name: Publish SDKs
       uses: pulumi/pulumi-package-publisher@v0.0.9
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: "Publish failed :x:"

--- a/provider-ci/providers/vsphere/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/vsphere/repo/.github/workflows/prerelease.yml
@@ -284,7 +284,7 @@ jobs:
     - name: Publish SDKs
       uses: pulumi/pulumi-package-publisher@v0.0.9
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: "Publish failed :x:"

--- a/provider-ci/providers/vsphere/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/vsphere/repo/.github/workflows/release.yml
@@ -296,7 +296,7 @@ jobs:
     - name: Publish SDKs
       uses: pulumi/pulumi-package-publisher@v0.0.9
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: "Publish failed :x:"

--- a/provider-ci/providers/vsphere/repo/.github/workflows/upgrade-bridge.yml
+++ b/provider-ci/providers/vsphere/repo/.github/workflows/upgrade-bridge.yml
@@ -13,7 +13,7 @@ jobs:
       with:
         kind: bridge
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#7CFC00"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: >-
@@ -26,7 +26,7 @@ jobs:
       name: Send Upgrade Success To Slack
       uses: rtCamp/action-slack-notify@v2
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: " Upgrade failed :x:"

--- a/provider-ci/providers/vsphere/repo/.github/workflows/upgrade-provider.yml
+++ b/provider-ci/providers/vsphere/repo/.github/workflows/upgrade-provider.yml
@@ -14,7 +14,7 @@ jobs:
       with:
         kind: all
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#7CFC00"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: >-
@@ -27,7 +27,7 @@ jobs:
       name: Send Upgrade Success To Slack
       uses: rtCamp/action-slack-notify@v2
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: " Upgrade failed :x:"

--- a/provider-ci/providers/wavefront/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/wavefront/repo/.github/workflows/main.yml
@@ -340,7 +340,7 @@ jobs:
     - name: Publish SDKs
       uses: pulumi/pulumi-package-publisher@v0.0.9
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: "Publish failed :x:"

--- a/provider-ci/providers/wavefront/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/wavefront/repo/.github/workflows/master.yml
@@ -340,7 +340,7 @@ jobs:
     - name: Publish SDKs
       uses: pulumi/pulumi-package-publisher@v0.0.9
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: "Publish failed :x:"

--- a/provider-ci/providers/wavefront/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/wavefront/repo/.github/workflows/prerelease.yml
@@ -286,7 +286,7 @@ jobs:
     - name: Publish SDKs
       uses: pulumi/pulumi-package-publisher@v0.0.9
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: "Publish failed :x:"

--- a/provider-ci/providers/wavefront/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/wavefront/repo/.github/workflows/release.yml
@@ -298,7 +298,7 @@ jobs:
     - name: Publish SDKs
       uses: pulumi/pulumi-package-publisher@v0.0.9
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: "Publish failed :x:"

--- a/provider-ci/providers/wavefront/repo/.github/workflows/upgrade-bridge.yml
+++ b/provider-ci/providers/wavefront/repo/.github/workflows/upgrade-bridge.yml
@@ -13,7 +13,7 @@ jobs:
       with:
         kind: bridge
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#7CFC00"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: >-
@@ -26,7 +26,7 @@ jobs:
       name: Send Upgrade Success To Slack
       uses: rtCamp/action-slack-notify@v2
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: " Upgrade failed :x:"

--- a/provider-ci/providers/wavefront/repo/.github/workflows/upgrade-provider.yml
+++ b/provider-ci/providers/wavefront/repo/.github/workflows/upgrade-provider.yml
@@ -14,7 +14,7 @@ jobs:
       with:
         kind: all
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#7CFC00"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: >-
@@ -27,7 +27,7 @@ jobs:
       name: Send Upgrade Success To Slack
       uses: rtCamp/action-slack-notify@v2
     - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
+        SLACK_CHANNEL: provider-upgrade-status
         SLACK_COLOR: "#FF0000"
         SLACK_ICON_EMOJI: ":taco:"
         SLACK_MESSAGE: " Upgrade failed :x:"


### PR DESCRIPTION
The slack channel was renamed/ simplified from `provider-upgrade-publish-status` to `provider-upgrade-status`.  