### PR TITLE
Update for nomad major version bump

### DIFF
--- a/provider-ci/providers/nomad/config.yaml
+++ b/provider-ci/providers/nomad/config.yaml
@@ -1,10 +1,10 @@
 provider: nomad
-major-version: 1
+major-version: 2
 setup-script: "testing/setup.sh"
 env:
   VAULT_ADDR: "http://127.0.0.1:4646"
 makeTemplate: bridged
 plugins:
-  - name: random 
+  - name: random
     version: "4.2.0"
 team: ecosystem

--- a/provider-ci/providers/nomad/repo/.goreleaser.prerelease.yml
+++ b/provider-ci/providers/nomad/repo/.goreleaser.prerelease.yml
@@ -32,7 +32,7 @@ builds:
     - env GOOS={{ .Os }} GOARCH={{ .Arch }} go clean -modcache
   ignore: []
   ldflags:
-  - -X github.com/pulumi/pulumi-nomad/provider/pkg/version.Version={{.Tag}}
+  - -X github.com/pulumi/pulumi-nomad/provider/v2/pkg/version.Version={{.Tag}}
   main: ./cmd/pulumi-resource-nomad/
 changelog:
   skip: true

--- a/provider-ci/providers/nomad/repo/.goreleaser.yml
+++ b/provider-ci/providers/nomad/repo/.goreleaser.yml
@@ -32,7 +32,7 @@ builds:
     - env GOOS={{ .Os }} GOARCH={{ .Arch }} go clean -modcache
   ignore: []
   ldflags:
-  - -X github.com/pulumi/pulumi-nomad/provider/pkg/version.Version={{.Tag}}
+  - -X github.com/pulumi/pulumi-nomad/provider/v2/pkg/version.Version={{.Tag}}
   main: ./cmd/pulumi-resource-nomad/
 changelog:
   filters:

--- a/provider-ci/providers/nomad/repo/Makefile
+++ b/provider-ci/providers/nomad/repo/Makefile
@@ -3,7 +3,7 @@
 PACK := nomad
 ORG := pulumi
 PROJECT := github.com/$(ORG)/pulumi-$(PACK)
-PROVIDER_PATH := provider
+PROVIDER_PATH := provider/v2
 VERSION_PATH := $(PROVIDER_PATH)/pkg/version.Version
 TFGEN := pulumi-tfgen-$(PACK)
 PROVIDER := pulumi-resource-$(PACK)


### PR DESCRIPTION
Major version was bumped in https://github.com/pulumi/pulumi-nomad/pull/113. This brings the ci-mgmt files in line with the new version.