### PR TITLE
Dependencies: package publisher 0.11

### DIFF
--- a/native-provider-ci/src/action-versions.ts
+++ b/native-provider-ci/src/action-versions.ts
@@ -40,5 +40,5 @@ export const uploadArtifact = "actions/upload-artifact@v3";
 export const githubScript = "actions/github-script@v6";
 export const upgradeProviderAction =
   "pulumi/pulumi-upgrade-provider-action@v0.0.5";
-export const publishProviderSDKs = "pulumi/pulumi-package-publisher@v0.0.7";
+export const publishProviderSDKs = "pulumi/pulumi-package-publisher@v0.0.11";
 export const slackNotification = "rtCamp/action-slack-notify@v2";

--- a/provider-ci/internal/pkg/templates/bridged-provider.config.yaml
+++ b/provider-ci/internal/pkg/templates/bridged-provider.config.yaml
@@ -81,5 +81,5 @@ actionVersions:
   slashCommand: peter-evans/slash-command-dispatch@v2
   uploadArtifact: actions/upload-artifact@v2
   upgradeProviderAction: pulumi/pulumi-upgrade-provider-action@v0.0.6
-  publishProviderSDKs: pulumi/pulumi-package-publisher@v0.0.9
+  publishProviderSDKs: pulumi/pulumi-package-publisher@v0.0.11
   slackNotification: rtCamp/action-slack-notify@v2

--- a/provider-ci/providers/aiven/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/aiven/repo/.github/workflows/main.yml
@@ -302,7 +302,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/aiven/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/aiven/repo/.github/workflows/master.yml
@@ -302,7 +302,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/aiven/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/aiven/repo/.github/workflows/prerelease.yml
@@ -248,7 +248,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/aiven/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/aiven/repo/.github/workflows/release.yml
@@ -260,7 +260,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/akamai/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/akamai/repo/.github/workflows/main.yml
@@ -304,7 +304,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/akamai/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/akamai/repo/.github/workflows/master.yml
@@ -304,7 +304,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/akamai/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/akamai/repo/.github/workflows/prerelease.yml
@@ -250,7 +250,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/akamai/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/akamai/repo/.github/workflows/release.yml
@@ -262,7 +262,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/alicloud/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/alicloud/repo/.github/workflows/main.yml
@@ -303,7 +303,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/alicloud/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/alicloud/repo/.github/workflows/master.yml
@@ -303,7 +303,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/alicloud/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/alicloud/repo/.github/workflows/prerelease.yml
@@ -249,7 +249,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/alicloud/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/alicloud/repo/.github/workflows/release.yml
@@ -261,7 +261,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/archive/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/archive/repo/.github/workflows/main.yml
@@ -301,7 +301,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/archive/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/archive/repo/.github/workflows/master.yml
@@ -301,7 +301,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/archive/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/archive/repo/.github/workflows/prerelease.yml
@@ -247,7 +247,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/archive/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/archive/repo/.github/workflows/release.yml
@@ -245,7 +245,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/artifactory/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/artifactory/repo/.github/workflows/main.yml
@@ -339,7 +339,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/artifactory/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/artifactory/repo/.github/workflows/master.yml
@@ -339,7 +339,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/artifactory/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/artifactory/repo/.github/workflows/prerelease.yml
@@ -285,7 +285,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/artifactory/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/artifactory/repo/.github/workflows/release.yml
@@ -297,7 +297,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/auth0/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/auth0/repo/.github/workflows/main.yml
@@ -339,7 +339,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/auth0/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/auth0/repo/.github/workflows/master.yml
@@ -339,7 +339,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/auth0/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/auth0/repo/.github/workflows/prerelease.yml
@@ -285,7 +285,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/auth0/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/auth0/repo/.github/workflows/release.yml
@@ -297,7 +297,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/aws/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/aws/repo/.github/workflows/main.yml
@@ -320,7 +320,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/aws/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/aws/repo/.github/workflows/master.yml
@@ -320,7 +320,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/aws/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/aws/repo/.github/workflows/prerelease.yml
@@ -271,7 +271,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/aws/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/aws/repo/.github/workflows/release.yml
@@ -274,7 +274,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/azure/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/azure/repo/.github/workflows/main.yml
@@ -307,7 +307,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/azure/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/azure/repo/.github/workflows/master.yml
@@ -307,7 +307,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/azure/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/azure/repo/.github/workflows/prerelease.yml
@@ -253,7 +253,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/azure/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/azure/repo/.github/workflows/release.yml
@@ -265,7 +265,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/azuread/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/azuread/repo/.github/workflows/main.yml
@@ -341,7 +341,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/azuread/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/azuread/repo/.github/workflows/master.yml
@@ -341,7 +341,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/azuread/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/azuread/repo/.github/workflows/prerelease.yml
@@ -287,7 +287,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/azuread/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/azuread/repo/.github/workflows/release.yml
@@ -299,7 +299,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/azuredevops/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/azuredevops/repo/.github/workflows/main.yml
@@ -302,7 +302,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/azuredevops/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/azuredevops/repo/.github/workflows/master.yml
@@ -302,7 +302,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/azuredevops/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/azuredevops/repo/.github/workflows/prerelease.yml
@@ -248,7 +248,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/azuredevops/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/azuredevops/repo/.github/workflows/release.yml
@@ -260,7 +260,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/civo/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/civo/repo/.github/workflows/main.yml
@@ -337,7 +337,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/civo/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/civo/repo/.github/workflows/master.yml
@@ -337,7 +337,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/civo/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/civo/repo/.github/workflows/prerelease.yml
@@ -283,7 +283,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/civo/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/civo/repo/.github/workflows/release.yml
@@ -295,7 +295,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/cloudamqp/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/cloudamqp/repo/.github/workflows/main.yml
@@ -337,7 +337,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/cloudamqp/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/cloudamqp/repo/.github/workflows/master.yml
@@ -337,7 +337,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/cloudamqp/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/cloudamqp/repo/.github/workflows/prerelease.yml
@@ -283,7 +283,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/cloudamqp/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/cloudamqp/repo/.github/workflows/release.yml
@@ -295,7 +295,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/cloudflare/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/cloudflare/repo/.github/workflows/main.yml
@@ -338,7 +338,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/cloudflare/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/cloudflare/repo/.github/workflows/master.yml
@@ -338,7 +338,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/cloudflare/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/cloudflare/repo/.github/workflows/prerelease.yml
@@ -284,7 +284,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/cloudflare/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/cloudflare/repo/.github/workflows/release.yml
@@ -296,7 +296,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/cloudinit/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/cloudinit/repo/.github/workflows/main.yml
@@ -300,7 +300,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/cloudinit/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/cloudinit/repo/.github/workflows/master.yml
@@ -300,7 +300,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/cloudinit/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/cloudinit/repo/.github/workflows/prerelease.yml
@@ -246,7 +246,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/cloudinit/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/cloudinit/repo/.github/workflows/release.yml
@@ -258,7 +258,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/confluentcloud/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/confluentcloud/repo/.github/workflows/main.yml
@@ -302,7 +302,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/confluentcloud/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/confluentcloud/repo/.github/workflows/master.yml
@@ -302,7 +302,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/confluentcloud/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/confluentcloud/repo/.github/workflows/prerelease.yml
@@ -248,7 +248,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/confluentcloud/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/confluentcloud/repo/.github/workflows/release.yml
@@ -260,7 +260,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/consul/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/consul/repo/.github/workflows/main.yml
@@ -336,7 +336,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/consul/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/consul/repo/.github/workflows/master.yml
@@ -336,7 +336,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/consul/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/consul/repo/.github/workflows/prerelease.yml
@@ -282,7 +282,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/consul/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/consul/repo/.github/workflows/release.yml
@@ -294,7 +294,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/databricks/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/databricks/repo/.github/workflows/main.yml
@@ -340,7 +340,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/databricks/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/databricks/repo/.github/workflows/master.yml
@@ -340,7 +340,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/databricks/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/databricks/repo/.github/workflows/prerelease.yml
@@ -286,7 +286,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/databricks/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/databricks/repo/.github/workflows/release.yml
@@ -298,7 +298,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/datadog/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/datadog/repo/.github/workflows/main.yml
@@ -302,7 +302,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/datadog/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/datadog/repo/.github/workflows/master.yml
@@ -302,7 +302,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/datadog/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/datadog/repo/.github/workflows/prerelease.yml
@@ -248,7 +248,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/datadog/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/datadog/repo/.github/workflows/release.yml
@@ -260,7 +260,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/digitalocean/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/digitalocean/repo/.github/workflows/main.yml
@@ -337,7 +337,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/digitalocean/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/digitalocean/repo/.github/workflows/master.yml
@@ -337,7 +337,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/digitalocean/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/digitalocean/repo/.github/workflows/prerelease.yml
@@ -283,7 +283,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/digitalocean/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/digitalocean/repo/.github/workflows/release.yml
@@ -295,7 +295,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/dnsimple/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/dnsimple/repo/.github/workflows/main.yml
@@ -338,7 +338,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/dnsimple/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/dnsimple/repo/.github/workflows/master.yml
@@ -338,7 +338,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/dnsimple/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/dnsimple/repo/.github/workflows/prerelease.yml
@@ -284,7 +284,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/dnsimple/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/dnsimple/repo/.github/workflows/release.yml
@@ -296,7 +296,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/docker/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/docker/repo/.github/workflows/main.yml
@@ -351,7 +351,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/docker/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/docker/repo/.github/workflows/master.yml
@@ -351,7 +351,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/docker/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/docker/repo/.github/workflows/prerelease.yml
@@ -297,7 +297,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/docker/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/docker/repo/.github/workflows/release.yml
@@ -309,7 +309,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/ec/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/ec/repo/.github/workflows/main.yml
@@ -337,7 +337,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/ec/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/ec/repo/.github/workflows/master.yml
@@ -337,7 +337,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/ec/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/ec/repo/.github/workflows/prerelease.yml
@@ -283,7 +283,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/ec/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/ec/repo/.github/workflows/release.yml
@@ -295,7 +295,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/equinix-metal/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/equinix-metal/repo/.github/workflows/main.yml
@@ -301,7 +301,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/equinix-metal/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/equinix-metal/repo/.github/workflows/master.yml
@@ -301,7 +301,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/equinix-metal/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/equinix-metal/repo/.github/workflows/prerelease.yml
@@ -247,7 +247,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/equinix-metal/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/equinix-metal/repo/.github/workflows/release.yml
@@ -259,7 +259,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/external/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/external/repo/.github/workflows/main.yml
@@ -301,7 +301,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/external/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/external/repo/.github/workflows/master.yml
@@ -301,7 +301,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/external/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/external/repo/.github/workflows/prerelease.yml
@@ -247,7 +247,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/external/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/external/repo/.github/workflows/release.yml
@@ -245,7 +245,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/f5bigip/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/f5bigip/repo/.github/workflows/main.yml
@@ -340,7 +340,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/f5bigip/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/f5bigip/repo/.github/workflows/master.yml
@@ -340,7 +340,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/f5bigip/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/f5bigip/repo/.github/workflows/prerelease.yml
@@ -286,7 +286,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/f5bigip/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/f5bigip/repo/.github/workflows/release.yml
@@ -298,7 +298,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/fastly/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/fastly/repo/.github/workflows/main.yml
@@ -337,7 +337,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/fastly/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/fastly/repo/.github/workflows/master.yml
@@ -337,7 +337,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/fastly/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/fastly/repo/.github/workflows/prerelease.yml
@@ -283,7 +283,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/fastly/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/fastly/repo/.github/workflows/release.yml
@@ -295,7 +295,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/gcp/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/gcp/repo/.github/workflows/main.yml
@@ -308,7 +308,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/gcp/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/gcp/repo/.github/workflows/master.yml
@@ -308,7 +308,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/gcp/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/gcp/repo/.github/workflows/prerelease.yml
@@ -254,7 +254,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/gcp/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/gcp/repo/.github/workflows/release.yml
@@ -266,7 +266,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/github/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/github/repo/.github/workflows/main.yml
@@ -338,7 +338,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/github/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/github/repo/.github/workflows/master.yml
@@ -338,7 +338,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/github/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/github/repo/.github/workflows/prerelease.yml
@@ -284,7 +284,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/github/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/github/repo/.github/workflows/release.yml
@@ -296,7 +296,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/gitlab/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/gitlab/repo/.github/workflows/main.yml
@@ -337,7 +337,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/gitlab/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/gitlab/repo/.github/workflows/master.yml
@@ -337,7 +337,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/gitlab/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/gitlab/repo/.github/workflows/prerelease.yml
@@ -283,7 +283,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/gitlab/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/gitlab/repo/.github/workflows/release.yml
@@ -295,7 +295,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/hcloud/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/hcloud/repo/.github/workflows/main.yml
@@ -337,7 +337,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/hcloud/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/hcloud/repo/.github/workflows/master.yml
@@ -337,7 +337,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/hcloud/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/hcloud/repo/.github/workflows/prerelease.yml
@@ -283,7 +283,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/hcloud/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/hcloud/repo/.github/workflows/release.yml
@@ -295,7 +295,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/http/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/http/repo/.github/workflows/main.yml
@@ -301,7 +301,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/http/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/http/repo/.github/workflows/master.yml
@@ -301,7 +301,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/http/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/http/repo/.github/workflows/prerelease.yml
@@ -247,7 +247,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/http/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/http/repo/.github/workflows/release.yml
@@ -245,7 +245,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/kafka/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/kafka/repo/.github/workflows/main.yml
@@ -336,7 +336,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/kafka/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/kafka/repo/.github/workflows/master.yml
@@ -336,7 +336,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/kafka/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/kafka/repo/.github/workflows/prerelease.yml
@@ -282,7 +282,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/kafka/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/kafka/repo/.github/workflows/release.yml
@@ -294,7 +294,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/keycloak/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/keycloak/repo/.github/workflows/main.yml
@@ -341,7 +341,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/keycloak/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/keycloak/repo/.github/workflows/master.yml
@@ -341,7 +341,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/keycloak/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/keycloak/repo/.github/workflows/prerelease.yml
@@ -287,7 +287,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/keycloak/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/keycloak/repo/.github/workflows/release.yml
@@ -299,7 +299,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/kong/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/kong/repo/.github/workflows/main.yml
@@ -336,7 +336,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/kong/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/kong/repo/.github/workflows/master.yml
@@ -336,7 +336,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/kong/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/kong/repo/.github/workflows/prerelease.yml
@@ -282,7 +282,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/kong/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/kong/repo/.github/workflows/release.yml
@@ -294,7 +294,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/libvirt/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/libvirt/repo/.github/workflows/main.yml
@@ -337,7 +337,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/libvirt/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/libvirt/repo/.github/workflows/master.yml
@@ -337,7 +337,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/libvirt/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/libvirt/repo/.github/workflows/prerelease.yml
@@ -283,7 +283,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/libvirt/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/libvirt/repo/.github/workflows/release.yml
@@ -295,7 +295,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/linode/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/linode/repo/.github/workflows/main.yml
@@ -337,7 +337,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/linode/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/linode/repo/.github/workflows/master.yml
@@ -337,7 +337,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/linode/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/linode/repo/.github/workflows/prerelease.yml
@@ -283,7 +283,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/linode/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/linode/repo/.github/workflows/release.yml
@@ -295,7 +295,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/local/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/local/repo/.github/workflows/main.yml
@@ -301,7 +301,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/local/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/local/repo/.github/workflows/master.yml
@@ -301,7 +301,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/local/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/local/repo/.github/workflows/prerelease.yml
@@ -247,7 +247,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/local/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/local/repo/.github/workflows/release.yml
@@ -245,7 +245,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/mailgun/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/mailgun/repo/.github/workflows/main.yml
@@ -337,7 +337,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/mailgun/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/mailgun/repo/.github/workflows/master.yml
@@ -337,7 +337,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/mailgun/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/mailgun/repo/.github/workflows/prerelease.yml
@@ -283,7 +283,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/mailgun/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/mailgun/repo/.github/workflows/release.yml
@@ -295,7 +295,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/minio/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/minio/repo/.github/workflows/main.yml
@@ -340,7 +340,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/minio/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/minio/repo/.github/workflows/master.yml
@@ -340,7 +340,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/minio/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/minio/repo/.github/workflows/prerelease.yml
@@ -286,7 +286,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/minio/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/minio/repo/.github/workflows/release.yml
@@ -298,7 +298,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/mongodbatlas/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/mongodbatlas/repo/.github/workflows/main.yml
@@ -339,7 +339,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/mongodbatlas/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/mongodbatlas/repo/.github/workflows/master.yml
@@ -339,7 +339,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/mongodbatlas/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/mongodbatlas/repo/.github/workflows/prerelease.yml
@@ -285,7 +285,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/mongodbatlas/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/mongodbatlas/repo/.github/workflows/release.yml
@@ -297,7 +297,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/mysql/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/mysql/repo/.github/workflows/main.yml
@@ -336,7 +336,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/mysql/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/mysql/repo/.github/workflows/master.yml
@@ -336,7 +336,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/mysql/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/mysql/repo/.github/workflows/prerelease.yml
@@ -282,7 +282,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/mysql/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/mysql/repo/.github/workflows/release.yml
@@ -294,7 +294,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/newrelic/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/newrelic/repo/.github/workflows/main.yml
@@ -338,7 +338,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/newrelic/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/newrelic/repo/.github/workflows/master.yml
@@ -338,7 +338,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/newrelic/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/newrelic/repo/.github/workflows/prerelease.yml
@@ -284,7 +284,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/newrelic/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/newrelic/repo/.github/workflows/release.yml
@@ -296,7 +296,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/nomad/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/nomad/repo/.github/workflows/main.yml
@@ -337,7 +337,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/nomad/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/nomad/repo/.github/workflows/master.yml
@@ -337,7 +337,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/nomad/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/nomad/repo/.github/workflows/prerelease.yml
@@ -283,7 +283,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/nomad/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/nomad/repo/.github/workflows/release.yml
@@ -295,7 +295,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/ns1/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/ns1/repo/.github/workflows/main.yml
@@ -337,7 +337,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/ns1/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/ns1/repo/.github/workflows/master.yml
@@ -337,7 +337,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/ns1/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/ns1/repo/.github/workflows/prerelease.yml
@@ -283,7 +283,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/ns1/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/ns1/repo/.github/workflows/release.yml
@@ -295,7 +295,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/null/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/null/repo/.github/workflows/main.yml
@@ -301,7 +301,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/null/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/null/repo/.github/workflows/master.yml
@@ -301,7 +301,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/null/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/null/repo/.github/workflows/prerelease.yml
@@ -247,7 +247,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/null/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/null/repo/.github/workflows/release.yml
@@ -245,7 +245,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/oci/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/oci/repo/.github/workflows/main.yml
@@ -304,7 +304,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/oci/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/oci/repo/.github/workflows/master.yml
@@ -304,7 +304,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/oci/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/oci/repo/.github/workflows/prerelease.yml
@@ -250,7 +250,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/oci/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/oci/repo/.github/workflows/release.yml
@@ -262,7 +262,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/okta/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/okta/repo/.github/workflows/main.yml
@@ -339,7 +339,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/okta/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/okta/repo/.github/workflows/master.yml
@@ -339,7 +339,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/okta/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/okta/repo/.github/workflows/prerelease.yml
@@ -285,7 +285,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/okta/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/okta/repo/.github/workflows/release.yml
@@ -297,7 +297,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/onelogin/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/onelogin/repo/.github/workflows/main.yml
@@ -336,7 +336,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/onelogin/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/onelogin/repo/.github/workflows/master.yml
@@ -336,7 +336,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/onelogin/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/onelogin/repo/.github/workflows/prerelease.yml
@@ -282,7 +282,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/onelogin/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/onelogin/repo/.github/workflows/release.yml
@@ -294,7 +294,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/openstack/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/openstack/repo/.github/workflows/main.yml
@@ -345,7 +345,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/openstack/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/openstack/repo/.github/workflows/master.yml
@@ -345,7 +345,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/openstack/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/openstack/repo/.github/workflows/prerelease.yml
@@ -291,7 +291,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/openstack/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/openstack/repo/.github/workflows/release.yml
@@ -303,7 +303,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/opsgenie/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/opsgenie/repo/.github/workflows/main.yml
@@ -337,7 +337,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/opsgenie/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/opsgenie/repo/.github/workflows/master.yml
@@ -337,7 +337,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/opsgenie/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/opsgenie/repo/.github/workflows/prerelease.yml
@@ -283,7 +283,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/opsgenie/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/opsgenie/repo/.github/workflows/release.yml
@@ -295,7 +295,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/pagerduty/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/pagerduty/repo/.github/workflows/main.yml
@@ -337,7 +337,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/pagerduty/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/pagerduty/repo/.github/workflows/master.yml
@@ -337,7 +337,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/pagerduty/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/pagerduty/repo/.github/workflows/prerelease.yml
@@ -283,7 +283,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/pagerduty/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/pagerduty/repo/.github/workflows/release.yml
@@ -295,7 +295,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/postgresql/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/postgresql/repo/.github/workflows/main.yml
@@ -336,7 +336,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/postgresql/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/postgresql/repo/.github/workflows/master.yml
@@ -336,7 +336,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/postgresql/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/postgresql/repo/.github/workflows/prerelease.yml
@@ -282,7 +282,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/postgresql/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/postgresql/repo/.github/workflows/release.yml
@@ -294,7 +294,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/rabbitmq/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/rabbitmq/repo/.github/workflows/main.yml
@@ -336,7 +336,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/rabbitmq/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/rabbitmq/repo/.github/workflows/master.yml
@@ -336,7 +336,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/rabbitmq/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/rabbitmq/repo/.github/workflows/prerelease.yml
@@ -282,7 +282,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/rabbitmq/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/rabbitmq/repo/.github/workflows/release.yml
@@ -294,7 +294,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/rancher2/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/rancher2/repo/.github/workflows/main.yml
@@ -302,7 +302,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/rancher2/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/rancher2/repo/.github/workflows/master.yml
@@ -302,7 +302,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/rancher2/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/rancher2/repo/.github/workflows/prerelease.yml
@@ -248,7 +248,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/rancher2/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/rancher2/repo/.github/workflows/release.yml
@@ -260,7 +260,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/random/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/random/repo/.github/workflows/main.yml
@@ -336,7 +336,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/random/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/random/repo/.github/workflows/master.yml
@@ -336,7 +336,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/random/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/random/repo/.github/workflows/prerelease.yml
@@ -282,7 +282,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/random/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/random/repo/.github/workflows/release.yml
@@ -294,7 +294,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/rke/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/rke/repo/.github/workflows/main.yml
@@ -337,7 +337,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/rke/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/rke/repo/.github/workflows/master.yml
@@ -337,7 +337,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/rke/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/rke/repo/.github/workflows/prerelease.yml
@@ -283,7 +283,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/rke/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/rke/repo/.github/workflows/release.yml
@@ -295,7 +295,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/signalfx/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/signalfx/repo/.github/workflows/main.yml
@@ -336,7 +336,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/signalfx/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/signalfx/repo/.github/workflows/master.yml
@@ -336,7 +336,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/signalfx/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/signalfx/repo/.github/workflows/prerelease.yml
@@ -282,7 +282,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/signalfx/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/signalfx/repo/.github/workflows/release.yml
@@ -294,7 +294,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/slack/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/slack/repo/.github/workflows/main.yml
@@ -337,7 +337,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/slack/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/slack/repo/.github/workflows/master.yml
@@ -337,7 +337,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/slack/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/slack/repo/.github/workflows/prerelease.yml
@@ -283,7 +283,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/slack/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/slack/repo/.github/workflows/release.yml
@@ -295,7 +295,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/snowflake/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/snowflake/repo/.github/workflows/main.yml
@@ -341,7 +341,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/snowflake/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/snowflake/repo/.github/workflows/master.yml
@@ -341,7 +341,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/snowflake/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/snowflake/repo/.github/workflows/prerelease.yml
@@ -287,7 +287,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/snowflake/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/snowflake/repo/.github/workflows/release.yml
@@ -299,7 +299,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/splunk/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/splunk/repo/.github/workflows/main.yml
@@ -339,7 +339,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/splunk/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/splunk/repo/.github/workflows/master.yml
@@ -339,7 +339,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/splunk/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/splunk/repo/.github/workflows/prerelease.yml
@@ -285,7 +285,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/splunk/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/splunk/repo/.github/workflows/release.yml
@@ -297,7 +297,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/spotinst/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/spotinst/repo/.github/workflows/main.yml
@@ -339,7 +339,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/spotinst/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/spotinst/repo/.github/workflows/master.yml
@@ -339,7 +339,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/spotinst/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/spotinst/repo/.github/workflows/prerelease.yml
@@ -285,7 +285,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/spotinst/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/spotinst/repo/.github/workflows/release.yml
@@ -297,7 +297,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/sumologic/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/sumologic/repo/.github/workflows/main.yml
@@ -339,7 +339,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/sumologic/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/sumologic/repo/.github/workflows/master.yml
@@ -339,7 +339,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/sumologic/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/sumologic/repo/.github/workflows/prerelease.yml
@@ -285,7 +285,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/sumologic/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/sumologic/repo/.github/workflows/release.yml
@@ -297,7 +297,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/tailscale/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/tailscale/repo/.github/workflows/main.yml
@@ -339,7 +339,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/tailscale/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/tailscale/repo/.github/workflows/master.yml
@@ -339,7 +339,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/tailscale/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/tailscale/repo/.github/workflows/prerelease.yml
@@ -285,7 +285,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/tailscale/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/tailscale/repo/.github/workflows/release.yml
@@ -297,7 +297,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/tls/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/tls/repo/.github/workflows/main.yml
@@ -336,7 +336,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/tls/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/tls/repo/.github/workflows/master.yml
@@ -336,7 +336,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/tls/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/tls/repo/.github/workflows/prerelease.yml
@@ -282,7 +282,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/tls/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/tls/repo/.github/workflows/release.yml
@@ -294,7 +294,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/vault/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/vault/repo/.github/workflows/main.yml
@@ -337,7 +337,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/vault/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/vault/repo/.github/workflows/master.yml
@@ -337,7 +337,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/vault/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/vault/repo/.github/workflows/prerelease.yml
@@ -283,7 +283,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/vault/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/vault/repo/.github/workflows/release.yml
@@ -295,7 +295,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/venafi/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/venafi/repo/.github/workflows/main.yml
@@ -340,7 +340,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/venafi/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/venafi/repo/.github/workflows/master.yml
@@ -340,7 +340,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/venafi/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/venafi/repo/.github/workflows/prerelease.yml
@@ -286,7 +286,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/venafi/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/venafi/repo/.github/workflows/release.yml
@@ -298,7 +298,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/vsphere/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/vsphere/repo/.github/workflows/main.yml
@@ -336,7 +336,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/vsphere/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/vsphere/repo/.github/workflows/master.yml
@@ -336,7 +336,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/vsphere/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/vsphere/repo/.github/workflows/prerelease.yml
@@ -282,7 +282,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/vsphere/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/vsphere/repo/.github/workflows/release.yml
@@ -294,7 +294,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/wavefront/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/wavefront/repo/.github/workflows/main.yml
@@ -338,7 +338,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/wavefront/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/wavefront/repo/.github/workflows/master.yml
@@ -338,7 +338,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/wavefront/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/wavefront/repo/.github/workflows/prerelease.yml
@@ -284,7 +284,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/wavefront/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/wavefront/repo/.github/workflows/release.yml
@@ -296,7 +296,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"


### PR DESCRIPTION
As far as I know this is safe to roll out. 0.11 unlocks the capability to publish python wheels which I especially care about for bridged providers (AWS, GCP especially). 

LMK if this is good to go or we need a pilot run.

@pulumi/providers 