### PR TITLE
Disable GoReleaser posthooks for GCP

### DIFF
--- a/provider-ci/internal/pkg/templates/bridged-provider/.goreleaser.prerelease.yml
+++ b/provider-ci/internal/pkg/templates/bridged-provider/.goreleaser.prerelease.yml
@@ -26,10 +26,13 @@ builds:
   - darwin
   - windows
   - linux
+  #{{- if .Config.skipGoReleaserHooks }}#
+  #{{- else }}#
   hooks:
     post:
     - env GOOS={{ .Os }} GOARCH={{ .Arch }} go clean -cache
     - env GOOS={{ .Os }} GOARCH={{ .Arch }} go clean -modcache
+  #{{- end }}#
   #{{- if .Config.skipWindowsArmBuild }}#
   ignore:
   - goarch: arm64

--- a/provider-ci/internal/pkg/templates/bridged-provider/.goreleaser.yml
+++ b/provider-ci/internal/pkg/templates/bridged-provider/.goreleaser.yml
@@ -26,10 +26,13 @@ builds:
   - darwin
   - windows
   - linux
+  #{{- if .Config.skipGoReleaserHooks }}#
+  #{{- else }}#
   hooks:
     post:
     - env GOOS={{ .Os }} GOARCH={{ .Arch }} go clean -cache
     - env GOOS={{ .Os }} GOARCH={{ .Arch }} go clean -modcache
+  #{{- end }}#
   #{{- if .Config.skipWindowsArmBuild }}#
   ignore:
   - goarch: arm64

--- a/provider-ci/providers/gcp/config.yaml
+++ b/provider-ci/providers/gcp/config.yaml
@@ -29,3 +29,4 @@ plugins:
     version: "0.0.15"
 team: ecosystem
 goBuildParallelism: 2
+skipGoReleaserHooks: true

--- a/provider-ci/providers/gcp/repo/.goreleaser.prerelease.yml
+++ b/provider-ci/providers/gcp/repo/.goreleaser.prerelease.yml
@@ -26,10 +26,6 @@ builds:
   - darwin
   - windows
   - linux
-  hooks:
-    post:
-    - env GOOS={{ .Os }} GOARCH={{ .Arch }} go clean -cache
-    - env GOOS={{ .Os }} GOARCH={{ .Arch }} go clean -modcache
   ignore: []
   ldflags:
   - -X github.com/pulumi/pulumi-gcp/provider/v6/pkg/version.Version={{.Tag}}

--- a/provider-ci/providers/gcp/repo/.goreleaser.yml
+++ b/provider-ci/providers/gcp/repo/.goreleaser.yml
@@ -26,10 +26,6 @@ builds:
   - darwin
   - windows
   - linux
-  hooks:
-    post:
-    - env GOOS={{ .Os }} GOARCH={{ .Arch }} go clean -cache
-    - env GOOS={{ .Os }} GOARCH={{ .Arch }} go clean -modcache
   ignore: []
   ldflags:
   - -X github.com/pulumi/pulumi-gcp/provider/v6/pkg/version.Version={{.Tag}}


### PR DESCRIPTION
Fixes: https://github.com/pulumi/pulumi-gcp/issues/1161 via ci-mgmt so changes to the config files persist.

This is done by adding a new config to our goreleaser templates.