### PR TITLE
Simplify the lint job

### DIFF
--- a/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/main.yml
+++ b/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/main.yml
@@ -150,7 +150,6 @@ jobs:
         aws s3 cp "${{ env.COVERAGE_OUTPUT_DIR }}/summary.json" "${s3FullURI}" --acl bucket-owner-full-control
   #{{ if .Config.lint -}}#
   lint:
-    container: golangci/golangci-lint:v1.54.1
     name: lint
     runs-on: #{{ .Config.runner.default }}#
     steps:
@@ -160,22 +159,15 @@ jobs:
       with:
         submodules: #{{ .Config.checkoutSubmodules }}#
 #{{- end }}#
-    - name: Checkout Scripts Repo
-      uses: #{{ .Config.actionVersions.checkout }}#
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Mark repo as safe directory
-      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER }}/pulumi-${{ env.PROVIDER }}
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
 #{{ .Config.actions.setupGo | toYaml | indent 4 }}#
-    - name: Install pulumictl
-      uses: #{{ .Config.actionVersions.installGhRelease }}#
+    - name: disarm go:embed directives to enable lint
+      run: |
+        git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: golangci-lint
+      uses: golangci/golangci-lint-action@v3
       with:
-        repo: pulumi/pulumictl
-#{{ .Config.actions.setupPulumi | toYaml | indent 4 }}#
-    - run: make lint_provider
+        version: v1.54.1
+        working-directory: provider
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: #{{ .Config.actionVersions.notifySlack }}#

--- a/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/main.yml
+++ b/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/main.yml
@@ -163,6 +163,9 @@ jobs:
     - name: disarm go:embed directives to enable lint
       run: |
         git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: prepare upstream
+      continue-on-error: true
+      run: make upstream
     - name: golangci-lint
       uses: golangci/golangci-lint-action@v3
       with:

--- a/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/master.yml
+++ b/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/master.yml
@@ -150,7 +150,6 @@ jobs:
         aws s3 cp "${{ env.COVERAGE_OUTPUT_DIR }}/summary.json" "${s3FullURI}" --acl bucket-owner-full-control
   #{{ if .Config.lint -}}#
   lint:
-    container: golangci/golangci-lint:v1.54.1
     name: lint
     runs-on: #{{ .Config.runner.default }}#
     steps:
@@ -160,22 +159,15 @@ jobs:
       with:
         submodules: #{{ .Config.checkoutSubmodules }}#
 #{{- end }}#
-    - name: Checkout Scripts Repo
-      uses: #{{ .Config.actionVersions.checkout }}#
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Mark repo as safe directory
-      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER }}/pulumi-${{ env.PROVIDER }}
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
 #{{ .Config.actions.setupGo | toYaml | indent 4 }}#
-    - name: Install pulumictl
-      uses: #{{ .Config.actionVersions.installGhRelease }}#
+    - name: disarm go:embed directives to enable lint
+      run: |
+        git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: golangci-lint
+      uses: golangci/golangci-lint-action@v3
       with:
-        repo: pulumi/pulumictl
-#{{ .Config.actions.setupPulumi | toYaml | indent 4 }}#
-    - run: make lint_provider
+        version: v1.54.1
+        working-directory: provider
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: #{{ .Config.actionVersions.notifySlack }}#

--- a/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/master.yml
+++ b/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/master.yml
@@ -163,6 +163,9 @@ jobs:
     - name: disarm go:embed directives to enable lint
       run: |
         git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: prepare upstream
+      continue-on-error: true
+      run: make upstream
     - name: golangci-lint
       uses: golangci/golangci-lint-action@v3
       with:

--- a/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/prerelease.yml
+++ b/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/prerelease.yml
@@ -99,7 +99,6 @@ jobs:
         - java
   #{{ if .Config.lint -}}#
   lint:
-    container: golangci/golangci-lint:v1.54.1
     name: lint
     runs-on: #{{ .Config.runner.default }}#
     steps:
@@ -109,22 +108,15 @@ jobs:
       with:
         submodules: #{{ .Config.checkoutSubmodules }}#
 #{{- end }}#
-    - name: Checkout Scripts Repo
-      uses: #{{ .Config.actionVersions.checkout }}#
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Mark repo as safe directory
-      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER }}/pulumi-${{ env.PROVIDER }}
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
 #{{ .Config.actions.setupGo | toYaml | indent 4 }}#
-    - name: Install pulumictl
-      uses: #{{ .Config.actionVersions.installGhRelease }}#
+    - name: disarm go:embed directives to enable lint
+      run: |
+        git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: golangci-lint
+      uses: golangci/golangci-lint-action@v3
       with:
-        repo: pulumi/pulumictl
-#{{ .Config.actions.setupPulumi | toYaml | indent 4 }}#
-    - run: make lint_provider
+        version: v1.54.1
+        working-directory: provider
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: #{{ .Config.actionVersions.notifySlack }}#

--- a/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/prerelease.yml
+++ b/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/prerelease.yml
@@ -112,6 +112,9 @@ jobs:
     - name: disarm go:embed directives to enable lint
       run: |
         git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: prepare upstream
+      continue-on-error: true
+      run: make upstream
     - name: golangci-lint
       uses: golangci/golangci-lint-action@v3
       with:

--- a/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/release.yml
+++ b/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/release.yml
@@ -114,7 +114,6 @@ jobs:
   #{{ end -}}#
   #{{ if .Config.lint -}}#
   lint:
-    container: golangci/golangci-lint:v1.54.1
     name: lint
     runs-on: #{{ .Config.runner.default }}#
     steps:
@@ -124,22 +123,15 @@ jobs:
       with:
         submodules: #{{ .Config.checkoutSubmodules }}#
 #{{- end }}#
-    - name: Checkout Scripts Repo
-      uses: #{{ .Config.actionVersions.checkout }}#
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Mark repo as safe directory
-      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER }}/pulumi-${{ env.PROVIDER }}
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
 #{{ .Config.actions.setupGo | toYaml | indent 4 }}#
-    - name: Install pulumictl
-      uses: #{{ .Config.actionVersions.installGhRelease }}#
+    - name: disarm go:embed directives to enable lint
+      run: |
+        git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: golangci-lint
+      uses: golangci/golangci-lint-action@v3
       with:
-        repo: pulumi/pulumictl
-#{{ .Config.actions.setupPulumi | toYaml | indent 4 }}#
-    - run: make lint_provider
+        version: v1.54.1
+        working-directory: provider
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: #{{ .Config.actionVersions.notifySlack }}#

--- a/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/release.yml
+++ b/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/release.yml
@@ -127,6 +127,9 @@ jobs:
     - name: disarm go:embed directives to enable lint
       run: |
         git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: prepare upstream
+      continue-on-error: true
+      run: make upstream
     - name: golangci-lint
       uses: golangci/golangci-lint-action@v3
       with:

--- a/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/run-acceptance-tests.yml
@@ -118,7 +118,6 @@ jobs:
         token: ${{ secrets.PULUMI_BOT_TOKEN }}
   #{{ if .Config.lint -}}#
   lint:
-    container: golangci/golangci-lint:v1.54.1
     if: github.event_name == 'repository_dispatch' ||
       github.event.pull_request.head.repo.full_name == github.repository
     name: lint
@@ -131,22 +130,15 @@ jobs:
         #{{- if .Config.checkoutSubmodules }}#
         submodules: #{{ .Config.checkoutSubmodules }}#
         #{{- end }}#
-    - name: Checkout Scripts Repo
-      uses: #{{ .Config.actionVersions.checkout }}#
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Mark repo as safe directory
-      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER }}/pulumi-${{ env.PROVIDER }}
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
 #{{ .Config.actions.setupGo | toYaml | indent 4 }}#
-    - name: Install pulumictl
-      uses: #{{ .Config.actionVersions.installGhRelease }}#
+    - name: disarm go:embed directives to enable lint
+      run: |
+        git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: golangci-lint
+      uses: golangci/golangci-lint-action@v3
       with:
-        repo: pulumi/pulumictl
-#{{ .Config.actions.setupPulumi | toYaml | indent 4 }}#
-    - run: make lint_provider
+        version: v1.54.1
+        working-directory: provider
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: #{{ .Config.actionVersions.notifySlack }}#

--- a/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/run-acceptance-tests.yml
@@ -130,10 +130,16 @@ jobs:
         #{{- if .Config.checkoutSubmodules }}#
         submodules: #{{ .Config.checkoutSubmodules }}#
         #{{- end }}#
-#{{ .Config.actions.setupGo | toYaml | indent 4 }}#
     - name: disarm go:embed directives to enable lint
       run: |
         git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: Install go
+      uses: actions/setup-go@v4
+      with:
+        # The versions of golangci-lint and setup-go here cross-depend and need to update together.
+        go-version: 1.21
+        # Either this action or golangci-lint needs to disable the cache
+        cache: false
     - name: golangci-lint
       uses: golangci/golangci-lint-action@v3
       with:

--- a/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/run-acceptance-tests.yml
@@ -133,6 +133,9 @@ jobs:
     - name: disarm go:embed directives to enable lint
       run: |
         git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: prepare upstream
+      continue-on-error: true
+      run: make upstream
     - name: Install go
       uses: actions/setup-go@v4
       with:

--- a/provider-ci/providers/artifactory/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/artifactory/repo/.github/workflows/main.yml
@@ -179,34 +179,25 @@ jobs:
 
         aws s3 cp "${{ env.COVERAGE_OUTPUT_DIR }}/summary.json" "${s3FullURI}" --acl bucket-owner-full-control
   lint:
-    container: golangci/golangci-lint:v1.54.1
     name: lint
     runs-on: ubuntu-latest
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Mark repo as safe directory
-      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER }}/pulumi-${{ env.PROVIDER }}
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
     - name: Install Go
       uses: actions/setup-go@v4
       with:
         cache-dependency-path: |
             sdk/go.sum
         go-version: 1.21.x
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
+    - name: disarm go:embed directives to enable lint
+      run: |
+        git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: golangci-lint
+      uses: golangci/golangci-lint-action@v3
       with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - run: make lint_provider
+        version: v1.54.1
+        working-directory: provider
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3

--- a/provider-ci/providers/artifactory/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/artifactory/repo/.github/workflows/main.yml
@@ -193,6 +193,9 @@ jobs:
     - name: disarm go:embed directives to enable lint
       run: |
         git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: prepare upstream
+      continue-on-error: true
+      run: make upstream
     - name: golangci-lint
       uses: golangci/golangci-lint-action@v3
       with:

--- a/provider-ci/providers/artifactory/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/artifactory/repo/.github/workflows/master.yml
@@ -179,34 +179,25 @@ jobs:
 
         aws s3 cp "${{ env.COVERAGE_OUTPUT_DIR }}/summary.json" "${s3FullURI}" --acl bucket-owner-full-control
   lint:
-    container: golangci/golangci-lint:v1.54.1
     name: lint
     runs-on: ubuntu-latest
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Mark repo as safe directory
-      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER }}/pulumi-${{ env.PROVIDER }}
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
     - name: Install Go
       uses: actions/setup-go@v4
       with:
         cache-dependency-path: |
             sdk/go.sum
         go-version: 1.21.x
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
+    - name: disarm go:embed directives to enable lint
+      run: |
+        git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: golangci-lint
+      uses: golangci/golangci-lint-action@v3
       with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - run: make lint_provider
+        version: v1.54.1
+        working-directory: provider
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3

--- a/provider-ci/providers/artifactory/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/artifactory/repo/.github/workflows/master.yml
@@ -193,6 +193,9 @@ jobs:
     - name: disarm go:embed directives to enable lint
       run: |
         git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: prepare upstream
+      continue-on-error: true
+      run: make upstream
     - name: golangci-lint
       uses: golangci/golangci-lint-action@v3
       with:

--- a/provider-ci/providers/artifactory/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/artifactory/repo/.github/workflows/prerelease.yml
@@ -140,6 +140,9 @@ jobs:
     - name: disarm go:embed directives to enable lint
       run: |
         git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: prepare upstream
+      continue-on-error: true
+      run: make upstream
     - name: golangci-lint
       uses: golangci/golangci-lint-action@v3
       with:

--- a/provider-ci/providers/artifactory/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/artifactory/repo/.github/workflows/prerelease.yml
@@ -126,34 +126,25 @@ jobs:
         - go
         - java
   lint:
-    container: golangci/golangci-lint:v1.54.1
     name: lint
     runs-on: ubuntu-latest
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Mark repo as safe directory
-      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER }}/pulumi-${{ env.PROVIDER }}
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
     - name: Install Go
       uses: actions/setup-go@v4
       with:
         cache-dependency-path: |
             sdk/go.sum
         go-version: 1.21.x
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
+    - name: disarm go:embed directives to enable lint
+      run: |
+        git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: golangci-lint
+      uses: golangci/golangci-lint-action@v3
       with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - run: make lint_provider
+        version: v1.54.1
+        working-directory: provider
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3

--- a/provider-ci/providers/artifactory/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/artifactory/repo/.github/workflows/release.yml
@@ -153,6 +153,9 @@ jobs:
     - name: disarm go:embed directives to enable lint
       run: |
         git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: prepare upstream
+      continue-on-error: true
+      run: make upstream
     - name: golangci-lint
       uses: golangci/golangci-lint-action@v3
       with:

--- a/provider-ci/providers/artifactory/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/artifactory/repo/.github/workflows/release.yml
@@ -139,34 +139,25 @@ jobs:
       run: pulumictl create docs-build pulumi-${{ env.PROVIDER }}
         "${GITHUB_REF#refs/tags/}"
   lint:
-    container: golangci/golangci-lint:v1.54.1
     name: lint
     runs-on: ubuntu-latest
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Mark repo as safe directory
-      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER }}/pulumi-${{ env.PROVIDER }}
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
     - name: Install Go
       uses: actions/setup-go@v4
       with:
         cache-dependency-path: |
             sdk/go.sum
         go-version: 1.21.x
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
+    - name: disarm go:embed directives to enable lint
+      run: |
+        git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: golangci-lint
+      uses: golangci/golangci-lint-action@v3
       with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - run: make lint_provider
+        version: v1.54.1
+        working-directory: provider
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3

--- a/provider-ci/providers/artifactory/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/artifactory/repo/.github/workflows/run-acceptance-tests.yml
@@ -146,7 +146,6 @@ jobs:
         repository: ${{ github.event.client_payload.github.payload.repository.full_name }}
         token: ${{ secrets.PULUMI_BOT_TOKEN }}
   lint:
-    container: golangci/golangci-lint:v1.54.1
     if: github.event_name == 'repository_dispatch' ||
       github.event.pull_request.head.repo.full_name == github.repository
     name: lint
@@ -156,28 +155,20 @@ jobs:
       uses: actions/checkout@v3
       with:
         ref: ${{ env.PR_COMMIT_SHA }}
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Mark repo as safe directory
-      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER }}/pulumi-${{ env.PROVIDER }}
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
     - name: Install Go
       uses: actions/setup-go@v4
       with:
         cache-dependency-path: |
             sdk/go.sum
         go-version: 1.21.x
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
+    - name: disarm go:embed directives to enable lint
+      run: |
+        git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: golangci-lint
+      uses: golangci/golangci-lint-action@v3
       with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - run: make lint_provider
+        version: v1.54.1
+        working-directory: provider
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3

--- a/provider-ci/providers/artifactory/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/artifactory/repo/.github/workflows/run-acceptance-tests.yml
@@ -158,6 +158,9 @@ jobs:
     - name: disarm go:embed directives to enable lint
       run: |
         git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: prepare upstream
+      continue-on-error: true
+      run: make upstream
     - name: Install go
       uses: actions/setup-go@v4
       with:

--- a/provider-ci/providers/artifactory/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/artifactory/repo/.github/workflows/run-acceptance-tests.yml
@@ -155,15 +155,16 @@ jobs:
       uses: actions/checkout@v3
       with:
         ref: ${{ env.PR_COMMIT_SHA }}
-    - name: Install Go
-      uses: actions/setup-go@v4
-      with:
-        cache-dependency-path: |
-            sdk/go.sum
-        go-version: 1.21.x
     - name: disarm go:embed directives to enable lint
       run: |
         git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: Install go
+      uses: actions/setup-go@v4
+      with:
+        # The versions of golangci-lint and setup-go here cross-depend and need to update together.
+        go-version: 1.21
+        # Either this action or golangci-lint needs to disable the cache
+        cache: false
     - name: golangci-lint
       uses: golangci/golangci-lint-action@v3
       with:

--- a/provider-ci/providers/auth0/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/auth0/repo/.github/workflows/main.yml
@@ -179,34 +179,25 @@ jobs:
 
         aws s3 cp "${{ env.COVERAGE_OUTPUT_DIR }}/summary.json" "${s3FullURI}" --acl bucket-owner-full-control
   lint:
-    container: golangci/golangci-lint:v1.54.1
     name: lint
     runs-on: ubuntu-latest
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Mark repo as safe directory
-      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER }}/pulumi-${{ env.PROVIDER }}
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
     - name: Install Go
       uses: actions/setup-go@v4
       with:
         cache-dependency-path: |
             sdk/go.sum
         go-version: 1.21.x
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
+    - name: disarm go:embed directives to enable lint
+      run: |
+        git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: golangci-lint
+      uses: golangci/golangci-lint-action@v3
       with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - run: make lint_provider
+        version: v1.54.1
+        working-directory: provider
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3

--- a/provider-ci/providers/auth0/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/auth0/repo/.github/workflows/main.yml
@@ -193,6 +193,9 @@ jobs:
     - name: disarm go:embed directives to enable lint
       run: |
         git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: prepare upstream
+      continue-on-error: true
+      run: make upstream
     - name: golangci-lint
       uses: golangci/golangci-lint-action@v3
       with:

--- a/provider-ci/providers/auth0/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/auth0/repo/.github/workflows/master.yml
@@ -179,34 +179,25 @@ jobs:
 
         aws s3 cp "${{ env.COVERAGE_OUTPUT_DIR }}/summary.json" "${s3FullURI}" --acl bucket-owner-full-control
   lint:
-    container: golangci/golangci-lint:v1.54.1
     name: lint
     runs-on: ubuntu-latest
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Mark repo as safe directory
-      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER }}/pulumi-${{ env.PROVIDER }}
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
     - name: Install Go
       uses: actions/setup-go@v4
       with:
         cache-dependency-path: |
             sdk/go.sum
         go-version: 1.21.x
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
+    - name: disarm go:embed directives to enable lint
+      run: |
+        git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: golangci-lint
+      uses: golangci/golangci-lint-action@v3
       with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - run: make lint_provider
+        version: v1.54.1
+        working-directory: provider
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3

--- a/provider-ci/providers/auth0/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/auth0/repo/.github/workflows/master.yml
@@ -193,6 +193,9 @@ jobs:
     - name: disarm go:embed directives to enable lint
       run: |
         git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: prepare upstream
+      continue-on-error: true
+      run: make upstream
     - name: golangci-lint
       uses: golangci/golangci-lint-action@v3
       with:

--- a/provider-ci/providers/auth0/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/auth0/repo/.github/workflows/prerelease.yml
@@ -140,6 +140,9 @@ jobs:
     - name: disarm go:embed directives to enable lint
       run: |
         git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: prepare upstream
+      continue-on-error: true
+      run: make upstream
     - name: golangci-lint
       uses: golangci/golangci-lint-action@v3
       with:

--- a/provider-ci/providers/auth0/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/auth0/repo/.github/workflows/prerelease.yml
@@ -126,34 +126,25 @@ jobs:
         - go
         - java
   lint:
-    container: golangci/golangci-lint:v1.54.1
     name: lint
     runs-on: ubuntu-latest
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Mark repo as safe directory
-      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER }}/pulumi-${{ env.PROVIDER }}
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
     - name: Install Go
       uses: actions/setup-go@v4
       with:
         cache-dependency-path: |
             sdk/go.sum
         go-version: 1.21.x
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
+    - name: disarm go:embed directives to enable lint
+      run: |
+        git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: golangci-lint
+      uses: golangci/golangci-lint-action@v3
       with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - run: make lint_provider
+        version: v1.54.1
+        working-directory: provider
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3

--- a/provider-ci/providers/auth0/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/auth0/repo/.github/workflows/release.yml
@@ -153,6 +153,9 @@ jobs:
     - name: disarm go:embed directives to enable lint
       run: |
         git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: prepare upstream
+      continue-on-error: true
+      run: make upstream
     - name: golangci-lint
       uses: golangci/golangci-lint-action@v3
       with:

--- a/provider-ci/providers/auth0/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/auth0/repo/.github/workflows/release.yml
@@ -139,34 +139,25 @@ jobs:
       run: pulumictl create docs-build pulumi-${{ env.PROVIDER }}
         "${GITHUB_REF#refs/tags/}"
   lint:
-    container: golangci/golangci-lint:v1.54.1
     name: lint
     runs-on: ubuntu-latest
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Mark repo as safe directory
-      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER }}/pulumi-${{ env.PROVIDER }}
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
     - name: Install Go
       uses: actions/setup-go@v4
       with:
         cache-dependency-path: |
             sdk/go.sum
         go-version: 1.21.x
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
+    - name: disarm go:embed directives to enable lint
+      run: |
+        git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: golangci-lint
+      uses: golangci/golangci-lint-action@v3
       with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - run: make lint_provider
+        version: v1.54.1
+        working-directory: provider
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3

--- a/provider-ci/providers/auth0/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/auth0/repo/.github/workflows/run-acceptance-tests.yml
@@ -146,7 +146,6 @@ jobs:
         repository: ${{ github.event.client_payload.github.payload.repository.full_name }}
         token: ${{ secrets.PULUMI_BOT_TOKEN }}
   lint:
-    container: golangci/golangci-lint:v1.54.1
     if: github.event_name == 'repository_dispatch' ||
       github.event.pull_request.head.repo.full_name == github.repository
     name: lint
@@ -156,28 +155,20 @@ jobs:
       uses: actions/checkout@v3
       with:
         ref: ${{ env.PR_COMMIT_SHA }}
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Mark repo as safe directory
-      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER }}/pulumi-${{ env.PROVIDER }}
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
     - name: Install Go
       uses: actions/setup-go@v4
       with:
         cache-dependency-path: |
             sdk/go.sum
         go-version: 1.21.x
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
+    - name: disarm go:embed directives to enable lint
+      run: |
+        git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: golangci-lint
+      uses: golangci/golangci-lint-action@v3
       with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - run: make lint_provider
+        version: v1.54.1
+        working-directory: provider
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3

--- a/provider-ci/providers/auth0/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/auth0/repo/.github/workflows/run-acceptance-tests.yml
@@ -158,6 +158,9 @@ jobs:
     - name: disarm go:embed directives to enable lint
       run: |
         git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: prepare upstream
+      continue-on-error: true
+      run: make upstream
     - name: Install go
       uses: actions/setup-go@v4
       with:

--- a/provider-ci/providers/auth0/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/auth0/repo/.github/workflows/run-acceptance-tests.yml
@@ -155,15 +155,16 @@ jobs:
       uses: actions/checkout@v3
       with:
         ref: ${{ env.PR_COMMIT_SHA }}
-    - name: Install Go
-      uses: actions/setup-go@v4
-      with:
-        cache-dependency-path: |
-            sdk/go.sum
-        go-version: 1.21.x
     - name: disarm go:embed directives to enable lint
       run: |
         git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: Install go
+      uses: actions/setup-go@v4
+      with:
+        # The versions of golangci-lint and setup-go here cross-depend and need to update together.
+        go-version: 1.21
+        # Either this action or golangci-lint needs to disable the cache
+        cache: false
     - name: golangci-lint
       uses: golangci/golangci-lint-action@v3
       with:

--- a/provider-ci/providers/azuread/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/azuread/repo/.github/workflows/main.yml
@@ -181,34 +181,25 @@ jobs:
 
         aws s3 cp "${{ env.COVERAGE_OUTPUT_DIR }}/summary.json" "${s3FullURI}" --acl bucket-owner-full-control
   lint:
-    container: golangci/golangci-lint:v1.54.1
     name: lint
     runs-on: ubuntu-latest
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Mark repo as safe directory
-      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER }}/pulumi-${{ env.PROVIDER }}
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
     - name: Install Go
       uses: actions/setup-go@v4
       with:
         cache-dependency-path: |
             sdk/go.sum
         go-version: 1.21.x
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
+    - name: disarm go:embed directives to enable lint
+      run: |
+        git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: golangci-lint
+      uses: golangci/golangci-lint-action@v3
       with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - run: make lint_provider
+        version: v1.54.1
+        working-directory: provider
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3

--- a/provider-ci/providers/azuread/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/azuread/repo/.github/workflows/main.yml
@@ -195,6 +195,9 @@ jobs:
     - name: disarm go:embed directives to enable lint
       run: |
         git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: prepare upstream
+      continue-on-error: true
+      run: make upstream
     - name: golangci-lint
       uses: golangci/golangci-lint-action@v3
       with:

--- a/provider-ci/providers/azuread/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/azuread/repo/.github/workflows/master.yml
@@ -181,34 +181,25 @@ jobs:
 
         aws s3 cp "${{ env.COVERAGE_OUTPUT_DIR }}/summary.json" "${s3FullURI}" --acl bucket-owner-full-control
   lint:
-    container: golangci/golangci-lint:v1.54.1
     name: lint
     runs-on: ubuntu-latest
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Mark repo as safe directory
-      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER }}/pulumi-${{ env.PROVIDER }}
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
     - name: Install Go
       uses: actions/setup-go@v4
       with:
         cache-dependency-path: |
             sdk/go.sum
         go-version: 1.21.x
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
+    - name: disarm go:embed directives to enable lint
+      run: |
+        git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: golangci-lint
+      uses: golangci/golangci-lint-action@v3
       with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - run: make lint_provider
+        version: v1.54.1
+        working-directory: provider
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3

--- a/provider-ci/providers/azuread/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/azuread/repo/.github/workflows/master.yml
@@ -195,6 +195,9 @@ jobs:
     - name: disarm go:embed directives to enable lint
       run: |
         git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: prepare upstream
+      continue-on-error: true
+      run: make upstream
     - name: golangci-lint
       uses: golangci/golangci-lint-action@v3
       with:

--- a/provider-ci/providers/azuread/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/azuread/repo/.github/workflows/prerelease.yml
@@ -142,6 +142,9 @@ jobs:
     - name: disarm go:embed directives to enable lint
       run: |
         git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: prepare upstream
+      continue-on-error: true
+      run: make upstream
     - name: golangci-lint
       uses: golangci/golangci-lint-action@v3
       with:

--- a/provider-ci/providers/azuread/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/azuread/repo/.github/workflows/prerelease.yml
@@ -128,34 +128,25 @@ jobs:
         - go
         - java
   lint:
-    container: golangci/golangci-lint:v1.54.1
     name: lint
     runs-on: ubuntu-latest
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Mark repo as safe directory
-      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER }}/pulumi-${{ env.PROVIDER }}
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
     - name: Install Go
       uses: actions/setup-go@v4
       with:
         cache-dependency-path: |
             sdk/go.sum
         go-version: 1.21.x
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
+    - name: disarm go:embed directives to enable lint
+      run: |
+        git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: golangci-lint
+      uses: golangci/golangci-lint-action@v3
       with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - run: make lint_provider
+        version: v1.54.1
+        working-directory: provider
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3

--- a/provider-ci/providers/azuread/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/azuread/repo/.github/workflows/release.yml
@@ -155,6 +155,9 @@ jobs:
     - name: disarm go:embed directives to enable lint
       run: |
         git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: prepare upstream
+      continue-on-error: true
+      run: make upstream
     - name: golangci-lint
       uses: golangci/golangci-lint-action@v3
       with:

--- a/provider-ci/providers/azuread/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/azuread/repo/.github/workflows/release.yml
@@ -141,34 +141,25 @@ jobs:
       run: pulumictl create docs-build pulumi-${{ env.PROVIDER }}
         "${GITHUB_REF#refs/tags/}"
   lint:
-    container: golangci/golangci-lint:v1.54.1
     name: lint
     runs-on: ubuntu-latest
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Mark repo as safe directory
-      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER }}/pulumi-${{ env.PROVIDER }}
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
     - name: Install Go
       uses: actions/setup-go@v4
       with:
         cache-dependency-path: |
             sdk/go.sum
         go-version: 1.21.x
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
+    - name: disarm go:embed directives to enable lint
+      run: |
+        git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: golangci-lint
+      uses: golangci/golangci-lint-action@v3
       with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - run: make lint_provider
+        version: v1.54.1
+        working-directory: provider
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3

--- a/provider-ci/providers/azuread/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/azuread/repo/.github/workflows/run-acceptance-tests.yml
@@ -157,15 +157,16 @@ jobs:
       uses: actions/checkout@v3
       with:
         ref: ${{ env.PR_COMMIT_SHA }}
-    - name: Install Go
-      uses: actions/setup-go@v4
-      with:
-        cache-dependency-path: |
-            sdk/go.sum
-        go-version: 1.21.x
     - name: disarm go:embed directives to enable lint
       run: |
         git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: Install go
+      uses: actions/setup-go@v4
+      with:
+        # The versions of golangci-lint and setup-go here cross-depend and need to update together.
+        go-version: 1.21
+        # Either this action or golangci-lint needs to disable the cache
+        cache: false
     - name: golangci-lint
       uses: golangci/golangci-lint-action@v3
       with:

--- a/provider-ci/providers/azuread/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/azuread/repo/.github/workflows/run-acceptance-tests.yml
@@ -160,6 +160,9 @@ jobs:
     - name: disarm go:embed directives to enable lint
       run: |
         git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: prepare upstream
+      continue-on-error: true
+      run: make upstream
     - name: Install go
       uses: actions/setup-go@v4
       with:

--- a/provider-ci/providers/azuread/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/azuread/repo/.github/workflows/run-acceptance-tests.yml
@@ -148,7 +148,6 @@ jobs:
         repository: ${{ github.event.client_payload.github.payload.repository.full_name }}
         token: ${{ secrets.PULUMI_BOT_TOKEN }}
   lint:
-    container: golangci/golangci-lint:v1.54.1
     if: github.event_name == 'repository_dispatch' ||
       github.event.pull_request.head.repo.full_name == github.repository
     name: lint
@@ -158,28 +157,20 @@ jobs:
       uses: actions/checkout@v3
       with:
         ref: ${{ env.PR_COMMIT_SHA }}
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Mark repo as safe directory
-      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER }}/pulumi-${{ env.PROVIDER }}
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
     - name: Install Go
       uses: actions/setup-go@v4
       with:
         cache-dependency-path: |
             sdk/go.sum
         go-version: 1.21.x
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
+    - name: disarm go:embed directives to enable lint
+      run: |
+        git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: golangci-lint
+      uses: golangci/golangci-lint-action@v3
       with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - run: make lint_provider
+        version: v1.54.1
+        working-directory: provider
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3

--- a/provider-ci/providers/civo/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/civo/repo/.github/workflows/main.yml
@@ -191,6 +191,9 @@ jobs:
     - name: disarm go:embed directives to enable lint
       run: |
         git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: prepare upstream
+      continue-on-error: true
+      run: make upstream
     - name: golangci-lint
       uses: golangci/golangci-lint-action@v3
       with:

--- a/provider-ci/providers/civo/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/civo/repo/.github/workflows/main.yml
@@ -177,34 +177,25 @@ jobs:
 
         aws s3 cp "${{ env.COVERAGE_OUTPUT_DIR }}/summary.json" "${s3FullURI}" --acl bucket-owner-full-control
   lint:
-    container: golangci/golangci-lint:v1.54.1
     name: lint
     runs-on: ubuntu-latest
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Mark repo as safe directory
-      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER }}/pulumi-${{ env.PROVIDER }}
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
     - name: Install Go
       uses: actions/setup-go@v4
       with:
         cache-dependency-path: |
             sdk/go.sum
         go-version: 1.21.x
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
+    - name: disarm go:embed directives to enable lint
+      run: |
+        git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: golangci-lint
+      uses: golangci/golangci-lint-action@v3
       with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - run: make lint_provider
+        version: v1.54.1
+        working-directory: provider
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3

--- a/provider-ci/providers/civo/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/civo/repo/.github/workflows/master.yml
@@ -191,6 +191,9 @@ jobs:
     - name: disarm go:embed directives to enable lint
       run: |
         git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: prepare upstream
+      continue-on-error: true
+      run: make upstream
     - name: golangci-lint
       uses: golangci/golangci-lint-action@v3
       with:

--- a/provider-ci/providers/civo/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/civo/repo/.github/workflows/master.yml
@@ -177,34 +177,25 @@ jobs:
 
         aws s3 cp "${{ env.COVERAGE_OUTPUT_DIR }}/summary.json" "${s3FullURI}" --acl bucket-owner-full-control
   lint:
-    container: golangci/golangci-lint:v1.54.1
     name: lint
     runs-on: ubuntu-latest
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Mark repo as safe directory
-      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER }}/pulumi-${{ env.PROVIDER }}
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
     - name: Install Go
       uses: actions/setup-go@v4
       with:
         cache-dependency-path: |
             sdk/go.sum
         go-version: 1.21.x
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
+    - name: disarm go:embed directives to enable lint
+      run: |
+        git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: golangci-lint
+      uses: golangci/golangci-lint-action@v3
       with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - run: make lint_provider
+        version: v1.54.1
+        working-directory: provider
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3

--- a/provider-ci/providers/civo/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/civo/repo/.github/workflows/prerelease.yml
@@ -124,34 +124,25 @@ jobs:
         - go
         - java
   lint:
-    container: golangci/golangci-lint:v1.54.1
     name: lint
     runs-on: ubuntu-latest
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Mark repo as safe directory
-      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER }}/pulumi-${{ env.PROVIDER }}
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
     - name: Install Go
       uses: actions/setup-go@v4
       with:
         cache-dependency-path: |
             sdk/go.sum
         go-version: 1.21.x
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
+    - name: disarm go:embed directives to enable lint
+      run: |
+        git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: golangci-lint
+      uses: golangci/golangci-lint-action@v3
       with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - run: make lint_provider
+        version: v1.54.1
+        working-directory: provider
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3

--- a/provider-ci/providers/civo/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/civo/repo/.github/workflows/prerelease.yml
@@ -138,6 +138,9 @@ jobs:
     - name: disarm go:embed directives to enable lint
       run: |
         git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: prepare upstream
+      continue-on-error: true
+      run: make upstream
     - name: golangci-lint
       uses: golangci/golangci-lint-action@v3
       with:

--- a/provider-ci/providers/civo/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/civo/repo/.github/workflows/release.yml
@@ -151,6 +151,9 @@ jobs:
     - name: disarm go:embed directives to enable lint
       run: |
         git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: prepare upstream
+      continue-on-error: true
+      run: make upstream
     - name: golangci-lint
       uses: golangci/golangci-lint-action@v3
       with:

--- a/provider-ci/providers/civo/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/civo/repo/.github/workflows/release.yml
@@ -137,34 +137,25 @@ jobs:
       run: pulumictl create docs-build pulumi-${{ env.PROVIDER }}
         "${GITHUB_REF#refs/tags/}"
   lint:
-    container: golangci/golangci-lint:v1.54.1
     name: lint
     runs-on: ubuntu-latest
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Mark repo as safe directory
-      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER }}/pulumi-${{ env.PROVIDER }}
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
     - name: Install Go
       uses: actions/setup-go@v4
       with:
         cache-dependency-path: |
             sdk/go.sum
         go-version: 1.21.x
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
+    - name: disarm go:embed directives to enable lint
+      run: |
+        git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: golangci-lint
+      uses: golangci/golangci-lint-action@v3
       with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - run: make lint_provider
+        version: v1.54.1
+        working-directory: provider
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3

--- a/provider-ci/providers/civo/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/civo/repo/.github/workflows/run-acceptance-tests.yml
@@ -153,15 +153,16 @@ jobs:
       uses: actions/checkout@v3
       with:
         ref: ${{ env.PR_COMMIT_SHA }}
-    - name: Install Go
-      uses: actions/setup-go@v4
-      with:
-        cache-dependency-path: |
-            sdk/go.sum
-        go-version: 1.21.x
     - name: disarm go:embed directives to enable lint
       run: |
         git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: Install go
+      uses: actions/setup-go@v4
+      with:
+        # The versions of golangci-lint and setup-go here cross-depend and need to update together.
+        go-version: 1.21
+        # Either this action or golangci-lint needs to disable the cache
+        cache: false
     - name: golangci-lint
       uses: golangci/golangci-lint-action@v3
       with:

--- a/provider-ci/providers/civo/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/civo/repo/.github/workflows/run-acceptance-tests.yml
@@ -144,7 +144,6 @@ jobs:
         repository: ${{ github.event.client_payload.github.payload.repository.full_name }}
         token: ${{ secrets.PULUMI_BOT_TOKEN }}
   lint:
-    container: golangci/golangci-lint:v1.54.1
     if: github.event_name == 'repository_dispatch' ||
       github.event.pull_request.head.repo.full_name == github.repository
     name: lint
@@ -154,28 +153,20 @@ jobs:
       uses: actions/checkout@v3
       with:
         ref: ${{ env.PR_COMMIT_SHA }}
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Mark repo as safe directory
-      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER }}/pulumi-${{ env.PROVIDER }}
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
     - name: Install Go
       uses: actions/setup-go@v4
       with:
         cache-dependency-path: |
             sdk/go.sum
         go-version: 1.21.x
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
+    - name: disarm go:embed directives to enable lint
+      run: |
+        git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: golangci-lint
+      uses: golangci/golangci-lint-action@v3
       with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - run: make lint_provider
+        version: v1.54.1
+        working-directory: provider
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3

--- a/provider-ci/providers/civo/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/civo/repo/.github/workflows/run-acceptance-tests.yml
@@ -156,6 +156,9 @@ jobs:
     - name: disarm go:embed directives to enable lint
       run: |
         git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: prepare upstream
+      continue-on-error: true
+      run: make upstream
     - name: Install go
       uses: actions/setup-go@v4
       with:

--- a/provider-ci/providers/cloudamqp/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/cloudamqp/repo/.github/workflows/main.yml
@@ -191,6 +191,9 @@ jobs:
     - name: disarm go:embed directives to enable lint
       run: |
         git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: prepare upstream
+      continue-on-error: true
+      run: make upstream
     - name: golangci-lint
       uses: golangci/golangci-lint-action@v3
       with:

--- a/provider-ci/providers/cloudamqp/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/cloudamqp/repo/.github/workflows/main.yml
@@ -177,34 +177,25 @@ jobs:
 
         aws s3 cp "${{ env.COVERAGE_OUTPUT_DIR }}/summary.json" "${s3FullURI}" --acl bucket-owner-full-control
   lint:
-    container: golangci/golangci-lint:v1.54.1
     name: lint
     runs-on: ubuntu-latest
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Mark repo as safe directory
-      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER }}/pulumi-${{ env.PROVIDER }}
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
     - name: Install Go
       uses: actions/setup-go@v4
       with:
         cache-dependency-path: |
             sdk/go.sum
         go-version: 1.21.x
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
+    - name: disarm go:embed directives to enable lint
+      run: |
+        git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: golangci-lint
+      uses: golangci/golangci-lint-action@v3
       with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - run: make lint_provider
+        version: v1.54.1
+        working-directory: provider
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3

--- a/provider-ci/providers/cloudamqp/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/cloudamqp/repo/.github/workflows/master.yml
@@ -191,6 +191,9 @@ jobs:
     - name: disarm go:embed directives to enable lint
       run: |
         git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: prepare upstream
+      continue-on-error: true
+      run: make upstream
     - name: golangci-lint
       uses: golangci/golangci-lint-action@v3
       with:

--- a/provider-ci/providers/cloudamqp/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/cloudamqp/repo/.github/workflows/master.yml
@@ -177,34 +177,25 @@ jobs:
 
         aws s3 cp "${{ env.COVERAGE_OUTPUT_DIR }}/summary.json" "${s3FullURI}" --acl bucket-owner-full-control
   lint:
-    container: golangci/golangci-lint:v1.54.1
     name: lint
     runs-on: ubuntu-latest
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Mark repo as safe directory
-      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER }}/pulumi-${{ env.PROVIDER }}
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
     - name: Install Go
       uses: actions/setup-go@v4
       with:
         cache-dependency-path: |
             sdk/go.sum
         go-version: 1.21.x
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
+    - name: disarm go:embed directives to enable lint
+      run: |
+        git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: golangci-lint
+      uses: golangci/golangci-lint-action@v3
       with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - run: make lint_provider
+        version: v1.54.1
+        working-directory: provider
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3

--- a/provider-ci/providers/cloudamqp/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/cloudamqp/repo/.github/workflows/prerelease.yml
@@ -124,34 +124,25 @@ jobs:
         - go
         - java
   lint:
-    container: golangci/golangci-lint:v1.54.1
     name: lint
     runs-on: ubuntu-latest
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Mark repo as safe directory
-      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER }}/pulumi-${{ env.PROVIDER }}
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
     - name: Install Go
       uses: actions/setup-go@v4
       with:
         cache-dependency-path: |
             sdk/go.sum
         go-version: 1.21.x
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
+    - name: disarm go:embed directives to enable lint
+      run: |
+        git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: golangci-lint
+      uses: golangci/golangci-lint-action@v3
       with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - run: make lint_provider
+        version: v1.54.1
+        working-directory: provider
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3

--- a/provider-ci/providers/cloudamqp/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/cloudamqp/repo/.github/workflows/prerelease.yml
@@ -138,6 +138,9 @@ jobs:
     - name: disarm go:embed directives to enable lint
       run: |
         git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: prepare upstream
+      continue-on-error: true
+      run: make upstream
     - name: golangci-lint
       uses: golangci/golangci-lint-action@v3
       with:

--- a/provider-ci/providers/cloudamqp/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/cloudamqp/repo/.github/workflows/release.yml
@@ -151,6 +151,9 @@ jobs:
     - name: disarm go:embed directives to enable lint
       run: |
         git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: prepare upstream
+      continue-on-error: true
+      run: make upstream
     - name: golangci-lint
       uses: golangci/golangci-lint-action@v3
       with:

--- a/provider-ci/providers/cloudamqp/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/cloudamqp/repo/.github/workflows/release.yml
@@ -137,34 +137,25 @@ jobs:
       run: pulumictl create docs-build pulumi-${{ env.PROVIDER }}
         "${GITHUB_REF#refs/tags/}"
   lint:
-    container: golangci/golangci-lint:v1.54.1
     name: lint
     runs-on: ubuntu-latest
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Mark repo as safe directory
-      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER }}/pulumi-${{ env.PROVIDER }}
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
     - name: Install Go
       uses: actions/setup-go@v4
       with:
         cache-dependency-path: |
             sdk/go.sum
         go-version: 1.21.x
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
+    - name: disarm go:embed directives to enable lint
+      run: |
+        git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: golangci-lint
+      uses: golangci/golangci-lint-action@v3
       with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - run: make lint_provider
+        version: v1.54.1
+        working-directory: provider
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3

--- a/provider-ci/providers/cloudamqp/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/cloudamqp/repo/.github/workflows/run-acceptance-tests.yml
@@ -153,15 +153,16 @@ jobs:
       uses: actions/checkout@v3
       with:
         ref: ${{ env.PR_COMMIT_SHA }}
-    - name: Install Go
-      uses: actions/setup-go@v4
-      with:
-        cache-dependency-path: |
-            sdk/go.sum
-        go-version: 1.21.x
     - name: disarm go:embed directives to enable lint
       run: |
         git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: Install go
+      uses: actions/setup-go@v4
+      with:
+        # The versions of golangci-lint and setup-go here cross-depend and need to update together.
+        go-version: 1.21
+        # Either this action or golangci-lint needs to disable the cache
+        cache: false
     - name: golangci-lint
       uses: golangci/golangci-lint-action@v3
       with:

--- a/provider-ci/providers/cloudamqp/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/cloudamqp/repo/.github/workflows/run-acceptance-tests.yml
@@ -144,7 +144,6 @@ jobs:
         repository: ${{ github.event.client_payload.github.payload.repository.full_name }}
         token: ${{ secrets.PULUMI_BOT_TOKEN }}
   lint:
-    container: golangci/golangci-lint:v1.54.1
     if: github.event_name == 'repository_dispatch' ||
       github.event.pull_request.head.repo.full_name == github.repository
     name: lint
@@ -154,28 +153,20 @@ jobs:
       uses: actions/checkout@v3
       with:
         ref: ${{ env.PR_COMMIT_SHA }}
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Mark repo as safe directory
-      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER }}/pulumi-${{ env.PROVIDER }}
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
     - name: Install Go
       uses: actions/setup-go@v4
       with:
         cache-dependency-path: |
             sdk/go.sum
         go-version: 1.21.x
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
+    - name: disarm go:embed directives to enable lint
+      run: |
+        git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: golangci-lint
+      uses: golangci/golangci-lint-action@v3
       with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - run: make lint_provider
+        version: v1.54.1
+        working-directory: provider
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3

--- a/provider-ci/providers/cloudamqp/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/cloudamqp/repo/.github/workflows/run-acceptance-tests.yml
@@ -156,6 +156,9 @@ jobs:
     - name: disarm go:embed directives to enable lint
       run: |
         git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: prepare upstream
+      continue-on-error: true
+      run: make upstream
     - name: Install go
       uses: actions/setup-go@v4
       with:

--- a/provider-ci/providers/cloudflare/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/cloudflare/repo/.github/workflows/main.yml
@@ -178,34 +178,25 @@ jobs:
 
         aws s3 cp "${{ env.COVERAGE_OUTPUT_DIR }}/summary.json" "${s3FullURI}" --acl bucket-owner-full-control
   lint:
-    container: golangci/golangci-lint:v1.54.1
     name: lint
     runs-on: ubuntu-latest
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Mark repo as safe directory
-      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER }}/pulumi-${{ env.PROVIDER }}
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
     - name: Install Go
       uses: actions/setup-go@v4
       with:
         cache-dependency-path: |
             sdk/go.sum
         go-version: 1.21.x
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
+    - name: disarm go:embed directives to enable lint
+      run: |
+        git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: golangci-lint
+      uses: golangci/golangci-lint-action@v3
       with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - run: make lint_provider
+        version: v1.54.1
+        working-directory: provider
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3

--- a/provider-ci/providers/cloudflare/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/cloudflare/repo/.github/workflows/main.yml
@@ -192,6 +192,9 @@ jobs:
     - name: disarm go:embed directives to enable lint
       run: |
         git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: prepare upstream
+      continue-on-error: true
+      run: make upstream
     - name: golangci-lint
       uses: golangci/golangci-lint-action@v3
       with:

--- a/provider-ci/providers/cloudflare/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/cloudflare/repo/.github/workflows/master.yml
@@ -178,34 +178,25 @@ jobs:
 
         aws s3 cp "${{ env.COVERAGE_OUTPUT_DIR }}/summary.json" "${s3FullURI}" --acl bucket-owner-full-control
   lint:
-    container: golangci/golangci-lint:v1.54.1
     name: lint
     runs-on: ubuntu-latest
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Mark repo as safe directory
-      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER }}/pulumi-${{ env.PROVIDER }}
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
     - name: Install Go
       uses: actions/setup-go@v4
       with:
         cache-dependency-path: |
             sdk/go.sum
         go-version: 1.21.x
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
+    - name: disarm go:embed directives to enable lint
+      run: |
+        git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: golangci-lint
+      uses: golangci/golangci-lint-action@v3
       with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - run: make lint_provider
+        version: v1.54.1
+        working-directory: provider
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3

--- a/provider-ci/providers/cloudflare/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/cloudflare/repo/.github/workflows/master.yml
@@ -192,6 +192,9 @@ jobs:
     - name: disarm go:embed directives to enable lint
       run: |
         git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: prepare upstream
+      continue-on-error: true
+      run: make upstream
     - name: golangci-lint
       uses: golangci/golangci-lint-action@v3
       with:

--- a/provider-ci/providers/cloudflare/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/cloudflare/repo/.github/workflows/prerelease.yml
@@ -125,34 +125,25 @@ jobs:
         - go
         - java
   lint:
-    container: golangci/golangci-lint:v1.54.1
     name: lint
     runs-on: ubuntu-latest
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Mark repo as safe directory
-      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER }}/pulumi-${{ env.PROVIDER }}
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
     - name: Install Go
       uses: actions/setup-go@v4
       with:
         cache-dependency-path: |
             sdk/go.sum
         go-version: 1.21.x
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
+    - name: disarm go:embed directives to enable lint
+      run: |
+        git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: golangci-lint
+      uses: golangci/golangci-lint-action@v3
       with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - run: make lint_provider
+        version: v1.54.1
+        working-directory: provider
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3

--- a/provider-ci/providers/cloudflare/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/cloudflare/repo/.github/workflows/prerelease.yml
@@ -139,6 +139,9 @@ jobs:
     - name: disarm go:embed directives to enable lint
       run: |
         git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: prepare upstream
+      continue-on-error: true
+      run: make upstream
     - name: golangci-lint
       uses: golangci/golangci-lint-action@v3
       with:

--- a/provider-ci/providers/cloudflare/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/cloudflare/repo/.github/workflows/release.yml
@@ -152,6 +152,9 @@ jobs:
     - name: disarm go:embed directives to enable lint
       run: |
         git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: prepare upstream
+      continue-on-error: true
+      run: make upstream
     - name: golangci-lint
       uses: golangci/golangci-lint-action@v3
       with:

--- a/provider-ci/providers/cloudflare/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/cloudflare/repo/.github/workflows/release.yml
@@ -138,34 +138,25 @@ jobs:
       run: pulumictl create docs-build pulumi-${{ env.PROVIDER }}
         "${GITHUB_REF#refs/tags/}"
   lint:
-    container: golangci/golangci-lint:v1.54.1
     name: lint
     runs-on: ubuntu-latest
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Mark repo as safe directory
-      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER }}/pulumi-${{ env.PROVIDER }}
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
     - name: Install Go
       uses: actions/setup-go@v4
       with:
         cache-dependency-path: |
             sdk/go.sum
         go-version: 1.21.x
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
+    - name: disarm go:embed directives to enable lint
+      run: |
+        git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: golangci-lint
+      uses: golangci/golangci-lint-action@v3
       with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - run: make lint_provider
+        version: v1.54.1
+        working-directory: provider
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3

--- a/provider-ci/providers/cloudflare/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/cloudflare/repo/.github/workflows/run-acceptance-tests.yml
@@ -157,6 +157,9 @@ jobs:
     - name: disarm go:embed directives to enable lint
       run: |
         git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: prepare upstream
+      continue-on-error: true
+      run: make upstream
     - name: Install go
       uses: actions/setup-go@v4
       with:

--- a/provider-ci/providers/cloudflare/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/cloudflare/repo/.github/workflows/run-acceptance-tests.yml
@@ -145,7 +145,6 @@ jobs:
         repository: ${{ github.event.client_payload.github.payload.repository.full_name }}
         token: ${{ secrets.PULUMI_BOT_TOKEN }}
   lint:
-    container: golangci/golangci-lint:v1.54.1
     if: github.event_name == 'repository_dispatch' ||
       github.event.pull_request.head.repo.full_name == github.repository
     name: lint
@@ -155,28 +154,20 @@ jobs:
       uses: actions/checkout@v3
       with:
         ref: ${{ env.PR_COMMIT_SHA }}
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Mark repo as safe directory
-      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER }}/pulumi-${{ env.PROVIDER }}
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
     - name: Install Go
       uses: actions/setup-go@v4
       with:
         cache-dependency-path: |
             sdk/go.sum
         go-version: 1.21.x
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
+    - name: disarm go:embed directives to enable lint
+      run: |
+        git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: golangci-lint
+      uses: golangci/golangci-lint-action@v3
       with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - run: make lint_provider
+        version: v1.54.1
+        working-directory: provider
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3

--- a/provider-ci/providers/cloudflare/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/cloudflare/repo/.github/workflows/run-acceptance-tests.yml
@@ -154,15 +154,16 @@ jobs:
       uses: actions/checkout@v3
       with:
         ref: ${{ env.PR_COMMIT_SHA }}
-    - name: Install Go
-      uses: actions/setup-go@v4
-      with:
-        cache-dependency-path: |
-            sdk/go.sum
-        go-version: 1.21.x
     - name: disarm go:embed directives to enable lint
       run: |
         git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: Install go
+      uses: actions/setup-go@v4
+      with:
+        # The versions of golangci-lint and setup-go here cross-depend and need to update together.
+        go-version: 1.21
+        # Either this action or golangci-lint needs to disable the cache
+        cache: false
     - name: golangci-lint
       uses: golangci/golangci-lint-action@v3
       with:

--- a/provider-ci/providers/consul/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/consul/repo/.github/workflows/main.yml
@@ -176,34 +176,25 @@ jobs:
 
         aws s3 cp "${{ env.COVERAGE_OUTPUT_DIR }}/summary.json" "${s3FullURI}" --acl bucket-owner-full-control
   lint:
-    container: golangci/golangci-lint:v1.54.1
     name: lint
     runs-on: ubuntu-latest
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Mark repo as safe directory
-      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER }}/pulumi-${{ env.PROVIDER }}
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
     - name: Install Go
       uses: actions/setup-go@v4
       with:
         cache-dependency-path: |
             sdk/go.sum
         go-version: 1.21.x
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
+    - name: disarm go:embed directives to enable lint
+      run: |
+        git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: golangci-lint
+      uses: golangci/golangci-lint-action@v3
       with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - run: make lint_provider
+        version: v1.54.1
+        working-directory: provider
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3

--- a/provider-ci/providers/consul/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/consul/repo/.github/workflows/main.yml
@@ -190,6 +190,9 @@ jobs:
     - name: disarm go:embed directives to enable lint
       run: |
         git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: prepare upstream
+      continue-on-error: true
+      run: make upstream
     - name: golangci-lint
       uses: golangci/golangci-lint-action@v3
       with:

--- a/provider-ci/providers/consul/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/consul/repo/.github/workflows/master.yml
@@ -176,34 +176,25 @@ jobs:
 
         aws s3 cp "${{ env.COVERAGE_OUTPUT_DIR }}/summary.json" "${s3FullURI}" --acl bucket-owner-full-control
   lint:
-    container: golangci/golangci-lint:v1.54.1
     name: lint
     runs-on: ubuntu-latest
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Mark repo as safe directory
-      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER }}/pulumi-${{ env.PROVIDER }}
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
     - name: Install Go
       uses: actions/setup-go@v4
       with:
         cache-dependency-path: |
             sdk/go.sum
         go-version: 1.21.x
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
+    - name: disarm go:embed directives to enable lint
+      run: |
+        git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: golangci-lint
+      uses: golangci/golangci-lint-action@v3
       with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - run: make lint_provider
+        version: v1.54.1
+        working-directory: provider
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3

--- a/provider-ci/providers/consul/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/consul/repo/.github/workflows/master.yml
@@ -190,6 +190,9 @@ jobs:
     - name: disarm go:embed directives to enable lint
       run: |
         git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: prepare upstream
+      continue-on-error: true
+      run: make upstream
     - name: golangci-lint
       uses: golangci/golangci-lint-action@v3
       with:

--- a/provider-ci/providers/consul/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/consul/repo/.github/workflows/prerelease.yml
@@ -123,34 +123,25 @@ jobs:
         - go
         - java
   lint:
-    container: golangci/golangci-lint:v1.54.1
     name: lint
     runs-on: ubuntu-latest
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Mark repo as safe directory
-      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER }}/pulumi-${{ env.PROVIDER }}
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
     - name: Install Go
       uses: actions/setup-go@v4
       with:
         cache-dependency-path: |
             sdk/go.sum
         go-version: 1.21.x
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
+    - name: disarm go:embed directives to enable lint
+      run: |
+        git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: golangci-lint
+      uses: golangci/golangci-lint-action@v3
       with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - run: make lint_provider
+        version: v1.54.1
+        working-directory: provider
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3

--- a/provider-ci/providers/consul/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/consul/repo/.github/workflows/prerelease.yml
@@ -137,6 +137,9 @@ jobs:
     - name: disarm go:embed directives to enable lint
       run: |
         git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: prepare upstream
+      continue-on-error: true
+      run: make upstream
     - name: golangci-lint
       uses: golangci/golangci-lint-action@v3
       with:

--- a/provider-ci/providers/consul/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/consul/repo/.github/workflows/release.yml
@@ -136,34 +136,25 @@ jobs:
       run: pulumictl create docs-build pulumi-${{ env.PROVIDER }}
         "${GITHUB_REF#refs/tags/}"
   lint:
-    container: golangci/golangci-lint:v1.54.1
     name: lint
     runs-on: ubuntu-latest
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Mark repo as safe directory
-      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER }}/pulumi-${{ env.PROVIDER }}
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
     - name: Install Go
       uses: actions/setup-go@v4
       with:
         cache-dependency-path: |
             sdk/go.sum
         go-version: 1.21.x
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
+    - name: disarm go:embed directives to enable lint
+      run: |
+        git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: golangci-lint
+      uses: golangci/golangci-lint-action@v3
       with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - run: make lint_provider
+        version: v1.54.1
+        working-directory: provider
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3

--- a/provider-ci/providers/consul/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/consul/repo/.github/workflows/release.yml
@@ -150,6 +150,9 @@ jobs:
     - name: disarm go:embed directives to enable lint
       run: |
         git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: prepare upstream
+      continue-on-error: true
+      run: make upstream
     - name: golangci-lint
       uses: golangci/golangci-lint-action@v3
       with:

--- a/provider-ci/providers/consul/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/consul/repo/.github/workflows/run-acceptance-tests.yml
@@ -143,7 +143,6 @@ jobs:
         repository: ${{ github.event.client_payload.github.payload.repository.full_name }}
         token: ${{ secrets.PULUMI_BOT_TOKEN }}
   lint:
-    container: golangci/golangci-lint:v1.54.1
     if: github.event_name == 'repository_dispatch' ||
       github.event.pull_request.head.repo.full_name == github.repository
     name: lint
@@ -153,28 +152,20 @@ jobs:
       uses: actions/checkout@v3
       with:
         ref: ${{ env.PR_COMMIT_SHA }}
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Mark repo as safe directory
-      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER }}/pulumi-${{ env.PROVIDER }}
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
     - name: Install Go
       uses: actions/setup-go@v4
       with:
         cache-dependency-path: |
             sdk/go.sum
         go-version: 1.21.x
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
+    - name: disarm go:embed directives to enable lint
+      run: |
+        git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: golangci-lint
+      uses: golangci/golangci-lint-action@v3
       with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - run: make lint_provider
+        version: v1.54.1
+        working-directory: provider
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3

--- a/provider-ci/providers/consul/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/consul/repo/.github/workflows/run-acceptance-tests.yml
@@ -155,6 +155,9 @@ jobs:
     - name: disarm go:embed directives to enable lint
       run: |
         git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: prepare upstream
+      continue-on-error: true
+      run: make upstream
     - name: Install go
       uses: actions/setup-go@v4
       with:

--- a/provider-ci/providers/consul/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/consul/repo/.github/workflows/run-acceptance-tests.yml
@@ -152,15 +152,16 @@ jobs:
       uses: actions/checkout@v3
       with:
         ref: ${{ env.PR_COMMIT_SHA }}
-    - name: Install Go
-      uses: actions/setup-go@v4
-      with:
-        cache-dependency-path: |
-            sdk/go.sum
-        go-version: 1.21.x
     - name: disarm go:embed directives to enable lint
       run: |
         git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: Install go
+      uses: actions/setup-go@v4
+      with:
+        # The versions of golangci-lint and setup-go here cross-depend and need to update together.
+        go-version: 1.21
+        # Either this action or golangci-lint needs to disable the cache
+        cache: false
     - name: golangci-lint
       uses: golangci/golangci-lint-action@v3
       with:

--- a/provider-ci/providers/databricks/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/databricks/repo/.github/workflows/main.yml
@@ -194,6 +194,9 @@ jobs:
     - name: disarm go:embed directives to enable lint
       run: |
         git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: prepare upstream
+      continue-on-error: true
+      run: make upstream
     - name: golangci-lint
       uses: golangci/golangci-lint-action@v3
       with:

--- a/provider-ci/providers/databricks/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/databricks/repo/.github/workflows/main.yml
@@ -180,34 +180,25 @@ jobs:
 
         aws s3 cp "${{ env.COVERAGE_OUTPUT_DIR }}/summary.json" "${s3FullURI}" --acl bucket-owner-full-control
   lint:
-    container: golangci/golangci-lint:v1.54.1
     name: lint
     runs-on: ubuntu-latest
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Mark repo as safe directory
-      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER }}/pulumi-${{ env.PROVIDER }}
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
     - name: Install Go
       uses: actions/setup-go@v4
       with:
         cache-dependency-path: |
             sdk/go.sum
         go-version: 1.21.x
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
+    - name: disarm go:embed directives to enable lint
+      run: |
+        git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: golangci-lint
+      uses: golangci/golangci-lint-action@v3
       with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - run: make lint_provider
+        version: v1.54.1
+        working-directory: provider
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3

--- a/provider-ci/providers/databricks/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/databricks/repo/.github/workflows/master.yml
@@ -194,6 +194,9 @@ jobs:
     - name: disarm go:embed directives to enable lint
       run: |
         git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: prepare upstream
+      continue-on-error: true
+      run: make upstream
     - name: golangci-lint
       uses: golangci/golangci-lint-action@v3
       with:

--- a/provider-ci/providers/databricks/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/databricks/repo/.github/workflows/master.yml
@@ -180,34 +180,25 @@ jobs:
 
         aws s3 cp "${{ env.COVERAGE_OUTPUT_DIR }}/summary.json" "${s3FullURI}" --acl bucket-owner-full-control
   lint:
-    container: golangci/golangci-lint:v1.54.1
     name: lint
     runs-on: ubuntu-latest
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Mark repo as safe directory
-      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER }}/pulumi-${{ env.PROVIDER }}
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
     - name: Install Go
       uses: actions/setup-go@v4
       with:
         cache-dependency-path: |
             sdk/go.sum
         go-version: 1.21.x
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
+    - name: disarm go:embed directives to enable lint
+      run: |
+        git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: golangci-lint
+      uses: golangci/golangci-lint-action@v3
       with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - run: make lint_provider
+        version: v1.54.1
+        working-directory: provider
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3

--- a/provider-ci/providers/databricks/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/databricks/repo/.github/workflows/prerelease.yml
@@ -127,34 +127,25 @@ jobs:
         - go
         - java
   lint:
-    container: golangci/golangci-lint:v1.54.1
     name: lint
     runs-on: ubuntu-latest
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Mark repo as safe directory
-      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER }}/pulumi-${{ env.PROVIDER }}
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
     - name: Install Go
       uses: actions/setup-go@v4
       with:
         cache-dependency-path: |
             sdk/go.sum
         go-version: 1.21.x
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
+    - name: disarm go:embed directives to enable lint
+      run: |
+        git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: golangci-lint
+      uses: golangci/golangci-lint-action@v3
       with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - run: make lint_provider
+        version: v1.54.1
+        working-directory: provider
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3

--- a/provider-ci/providers/databricks/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/databricks/repo/.github/workflows/prerelease.yml
@@ -141,6 +141,9 @@ jobs:
     - name: disarm go:embed directives to enable lint
       run: |
         git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: prepare upstream
+      continue-on-error: true
+      run: make upstream
     - name: golangci-lint
       uses: golangci/golangci-lint-action@v3
       with:

--- a/provider-ci/providers/databricks/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/databricks/repo/.github/workflows/release.yml
@@ -140,34 +140,25 @@ jobs:
       run: pulumictl create docs-build pulumi-${{ env.PROVIDER }}
         "${GITHUB_REF#refs/tags/}"
   lint:
-    container: golangci/golangci-lint:v1.54.1
     name: lint
     runs-on: ubuntu-latest
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Mark repo as safe directory
-      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER }}/pulumi-${{ env.PROVIDER }}
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
     - name: Install Go
       uses: actions/setup-go@v4
       with:
         cache-dependency-path: |
             sdk/go.sum
         go-version: 1.21.x
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
+    - name: disarm go:embed directives to enable lint
+      run: |
+        git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: golangci-lint
+      uses: golangci/golangci-lint-action@v3
       with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - run: make lint_provider
+        version: v1.54.1
+        working-directory: provider
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3

--- a/provider-ci/providers/databricks/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/databricks/repo/.github/workflows/release.yml
@@ -154,6 +154,9 @@ jobs:
     - name: disarm go:embed directives to enable lint
       run: |
         git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: prepare upstream
+      continue-on-error: true
+      run: make upstream
     - name: golangci-lint
       uses: golangci/golangci-lint-action@v3
       with:

--- a/provider-ci/providers/databricks/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/databricks/repo/.github/workflows/run-acceptance-tests.yml
@@ -159,6 +159,9 @@ jobs:
     - name: disarm go:embed directives to enable lint
       run: |
         git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: prepare upstream
+      continue-on-error: true
+      run: make upstream
     - name: Install go
       uses: actions/setup-go@v4
       with:

--- a/provider-ci/providers/databricks/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/databricks/repo/.github/workflows/run-acceptance-tests.yml
@@ -147,7 +147,6 @@ jobs:
         repository: ${{ github.event.client_payload.github.payload.repository.full_name }}
         token: ${{ secrets.PULUMI_BOT_TOKEN }}
   lint:
-    container: golangci/golangci-lint:v1.54.1
     if: github.event_name == 'repository_dispatch' ||
       github.event.pull_request.head.repo.full_name == github.repository
     name: lint
@@ -157,28 +156,20 @@ jobs:
       uses: actions/checkout@v3
       with:
         ref: ${{ env.PR_COMMIT_SHA }}
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Mark repo as safe directory
-      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER }}/pulumi-${{ env.PROVIDER }}
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
     - name: Install Go
       uses: actions/setup-go@v4
       with:
         cache-dependency-path: |
             sdk/go.sum
         go-version: 1.21.x
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
+    - name: disarm go:embed directives to enable lint
+      run: |
+        git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: golangci-lint
+      uses: golangci/golangci-lint-action@v3
       with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - run: make lint_provider
+        version: v1.54.1
+        working-directory: provider
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3

--- a/provider-ci/providers/databricks/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/databricks/repo/.github/workflows/run-acceptance-tests.yml
@@ -156,15 +156,16 @@ jobs:
       uses: actions/checkout@v3
       with:
         ref: ${{ env.PR_COMMIT_SHA }}
-    - name: Install Go
-      uses: actions/setup-go@v4
-      with:
-        cache-dependency-path: |
-            sdk/go.sum
-        go-version: 1.21.x
     - name: disarm go:embed directives to enable lint
       run: |
         git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: Install go
+      uses: actions/setup-go@v4
+      with:
+        # The versions of golangci-lint and setup-go here cross-depend and need to update together.
+        go-version: 1.21
+        # Either this action or golangci-lint needs to disable the cache
+        cache: false
     - name: golangci-lint
       uses: golangci/golangci-lint-action@v3
       with:

--- a/provider-ci/providers/digitalocean/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/digitalocean/repo/.github/workflows/main.yml
@@ -191,6 +191,9 @@ jobs:
     - name: disarm go:embed directives to enable lint
       run: |
         git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: prepare upstream
+      continue-on-error: true
+      run: make upstream
     - name: golangci-lint
       uses: golangci/golangci-lint-action@v3
       with:

--- a/provider-ci/providers/digitalocean/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/digitalocean/repo/.github/workflows/main.yml
@@ -177,34 +177,25 @@ jobs:
 
         aws s3 cp "${{ env.COVERAGE_OUTPUT_DIR }}/summary.json" "${s3FullURI}" --acl bucket-owner-full-control
   lint:
-    container: golangci/golangci-lint:v1.54.1
     name: lint
     runs-on: ubuntu-latest
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Mark repo as safe directory
-      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER }}/pulumi-${{ env.PROVIDER }}
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
     - name: Install Go
       uses: actions/setup-go@v4
       with:
         cache-dependency-path: |
             sdk/go.sum
         go-version: 1.21.x
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
+    - name: disarm go:embed directives to enable lint
+      run: |
+        git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: golangci-lint
+      uses: golangci/golangci-lint-action@v3
       with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - run: make lint_provider
+        version: v1.54.1
+        working-directory: provider
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3

--- a/provider-ci/providers/digitalocean/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/digitalocean/repo/.github/workflows/master.yml
@@ -191,6 +191,9 @@ jobs:
     - name: disarm go:embed directives to enable lint
       run: |
         git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: prepare upstream
+      continue-on-error: true
+      run: make upstream
     - name: golangci-lint
       uses: golangci/golangci-lint-action@v3
       with:

--- a/provider-ci/providers/digitalocean/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/digitalocean/repo/.github/workflows/master.yml
@@ -177,34 +177,25 @@ jobs:
 
         aws s3 cp "${{ env.COVERAGE_OUTPUT_DIR }}/summary.json" "${s3FullURI}" --acl bucket-owner-full-control
   lint:
-    container: golangci/golangci-lint:v1.54.1
     name: lint
     runs-on: ubuntu-latest
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Mark repo as safe directory
-      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER }}/pulumi-${{ env.PROVIDER }}
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
     - name: Install Go
       uses: actions/setup-go@v4
       with:
         cache-dependency-path: |
             sdk/go.sum
         go-version: 1.21.x
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
+    - name: disarm go:embed directives to enable lint
+      run: |
+        git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: golangci-lint
+      uses: golangci/golangci-lint-action@v3
       with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - run: make lint_provider
+        version: v1.54.1
+        working-directory: provider
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3

--- a/provider-ci/providers/digitalocean/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/digitalocean/repo/.github/workflows/prerelease.yml
@@ -124,34 +124,25 @@ jobs:
         - go
         - java
   lint:
-    container: golangci/golangci-lint:v1.54.1
     name: lint
     runs-on: ubuntu-latest
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Mark repo as safe directory
-      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER }}/pulumi-${{ env.PROVIDER }}
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
     - name: Install Go
       uses: actions/setup-go@v4
       with:
         cache-dependency-path: |
             sdk/go.sum
         go-version: 1.21.x
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
+    - name: disarm go:embed directives to enable lint
+      run: |
+        git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: golangci-lint
+      uses: golangci/golangci-lint-action@v3
       with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - run: make lint_provider
+        version: v1.54.1
+        working-directory: provider
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3

--- a/provider-ci/providers/digitalocean/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/digitalocean/repo/.github/workflows/prerelease.yml
@@ -138,6 +138,9 @@ jobs:
     - name: disarm go:embed directives to enable lint
       run: |
         git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: prepare upstream
+      continue-on-error: true
+      run: make upstream
     - name: golangci-lint
       uses: golangci/golangci-lint-action@v3
       with:

--- a/provider-ci/providers/digitalocean/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/digitalocean/repo/.github/workflows/release.yml
@@ -151,6 +151,9 @@ jobs:
     - name: disarm go:embed directives to enable lint
       run: |
         git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: prepare upstream
+      continue-on-error: true
+      run: make upstream
     - name: golangci-lint
       uses: golangci/golangci-lint-action@v3
       with:

--- a/provider-ci/providers/digitalocean/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/digitalocean/repo/.github/workflows/release.yml
@@ -137,34 +137,25 @@ jobs:
       run: pulumictl create docs-build pulumi-${{ env.PROVIDER }}
         "${GITHUB_REF#refs/tags/}"
   lint:
-    container: golangci/golangci-lint:v1.54.1
     name: lint
     runs-on: ubuntu-latest
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Mark repo as safe directory
-      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER }}/pulumi-${{ env.PROVIDER }}
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
     - name: Install Go
       uses: actions/setup-go@v4
       with:
         cache-dependency-path: |
             sdk/go.sum
         go-version: 1.21.x
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
+    - name: disarm go:embed directives to enable lint
+      run: |
+        git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: golangci-lint
+      uses: golangci/golangci-lint-action@v3
       with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - run: make lint_provider
+        version: v1.54.1
+        working-directory: provider
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3

--- a/provider-ci/providers/digitalocean/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/digitalocean/repo/.github/workflows/run-acceptance-tests.yml
@@ -153,15 +153,16 @@ jobs:
       uses: actions/checkout@v3
       with:
         ref: ${{ env.PR_COMMIT_SHA }}
-    - name: Install Go
-      uses: actions/setup-go@v4
-      with:
-        cache-dependency-path: |
-            sdk/go.sum
-        go-version: 1.21.x
     - name: disarm go:embed directives to enable lint
       run: |
         git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: Install go
+      uses: actions/setup-go@v4
+      with:
+        # The versions of golangci-lint and setup-go here cross-depend and need to update together.
+        go-version: 1.21
+        # Either this action or golangci-lint needs to disable the cache
+        cache: false
     - name: golangci-lint
       uses: golangci/golangci-lint-action@v3
       with:

--- a/provider-ci/providers/digitalocean/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/digitalocean/repo/.github/workflows/run-acceptance-tests.yml
@@ -144,7 +144,6 @@ jobs:
         repository: ${{ github.event.client_payload.github.payload.repository.full_name }}
         token: ${{ secrets.PULUMI_BOT_TOKEN }}
   lint:
-    container: golangci/golangci-lint:v1.54.1
     if: github.event_name == 'repository_dispatch' ||
       github.event.pull_request.head.repo.full_name == github.repository
     name: lint
@@ -154,28 +153,20 @@ jobs:
       uses: actions/checkout@v3
       with:
         ref: ${{ env.PR_COMMIT_SHA }}
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Mark repo as safe directory
-      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER }}/pulumi-${{ env.PROVIDER }}
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
     - name: Install Go
       uses: actions/setup-go@v4
       with:
         cache-dependency-path: |
             sdk/go.sum
         go-version: 1.21.x
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
+    - name: disarm go:embed directives to enable lint
+      run: |
+        git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: golangci-lint
+      uses: golangci/golangci-lint-action@v3
       with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - run: make lint_provider
+        version: v1.54.1
+        working-directory: provider
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3

--- a/provider-ci/providers/digitalocean/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/digitalocean/repo/.github/workflows/run-acceptance-tests.yml
@@ -156,6 +156,9 @@ jobs:
     - name: disarm go:embed directives to enable lint
       run: |
         git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: prepare upstream
+      continue-on-error: true
+      run: make upstream
     - name: Install go
       uses: actions/setup-go@v4
       with:

--- a/provider-ci/providers/dnsimple/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/dnsimple/repo/.github/workflows/main.yml
@@ -178,34 +178,25 @@ jobs:
 
         aws s3 cp "${{ env.COVERAGE_OUTPUT_DIR }}/summary.json" "${s3FullURI}" --acl bucket-owner-full-control
   lint:
-    container: golangci/golangci-lint:v1.54.1
     name: lint
     runs-on: ubuntu-latest
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Mark repo as safe directory
-      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER }}/pulumi-${{ env.PROVIDER }}
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
     - name: Install Go
       uses: actions/setup-go@v4
       with:
         cache-dependency-path: |
             sdk/go.sum
         go-version: 1.21.x
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
+    - name: disarm go:embed directives to enable lint
+      run: |
+        git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: golangci-lint
+      uses: golangci/golangci-lint-action@v3
       with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - run: make lint_provider
+        version: v1.54.1
+        working-directory: provider
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3

--- a/provider-ci/providers/dnsimple/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/dnsimple/repo/.github/workflows/main.yml
@@ -192,6 +192,9 @@ jobs:
     - name: disarm go:embed directives to enable lint
       run: |
         git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: prepare upstream
+      continue-on-error: true
+      run: make upstream
     - name: golangci-lint
       uses: golangci/golangci-lint-action@v3
       with:

--- a/provider-ci/providers/dnsimple/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/dnsimple/repo/.github/workflows/master.yml
@@ -178,34 +178,25 @@ jobs:
 
         aws s3 cp "${{ env.COVERAGE_OUTPUT_DIR }}/summary.json" "${s3FullURI}" --acl bucket-owner-full-control
   lint:
-    container: golangci/golangci-lint:v1.54.1
     name: lint
     runs-on: ubuntu-latest
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Mark repo as safe directory
-      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER }}/pulumi-${{ env.PROVIDER }}
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
     - name: Install Go
       uses: actions/setup-go@v4
       with:
         cache-dependency-path: |
             sdk/go.sum
         go-version: 1.21.x
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
+    - name: disarm go:embed directives to enable lint
+      run: |
+        git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: golangci-lint
+      uses: golangci/golangci-lint-action@v3
       with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - run: make lint_provider
+        version: v1.54.1
+        working-directory: provider
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3

--- a/provider-ci/providers/dnsimple/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/dnsimple/repo/.github/workflows/master.yml
@@ -192,6 +192,9 @@ jobs:
     - name: disarm go:embed directives to enable lint
       run: |
         git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: prepare upstream
+      continue-on-error: true
+      run: make upstream
     - name: golangci-lint
       uses: golangci/golangci-lint-action@v3
       with:

--- a/provider-ci/providers/dnsimple/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/dnsimple/repo/.github/workflows/prerelease.yml
@@ -125,34 +125,25 @@ jobs:
         - go
         - java
   lint:
-    container: golangci/golangci-lint:v1.54.1
     name: lint
     runs-on: ubuntu-latest
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Mark repo as safe directory
-      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER }}/pulumi-${{ env.PROVIDER }}
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
     - name: Install Go
       uses: actions/setup-go@v4
       with:
         cache-dependency-path: |
             sdk/go.sum
         go-version: 1.21.x
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
+    - name: disarm go:embed directives to enable lint
+      run: |
+        git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: golangci-lint
+      uses: golangci/golangci-lint-action@v3
       with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - run: make lint_provider
+        version: v1.54.1
+        working-directory: provider
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3

--- a/provider-ci/providers/dnsimple/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/dnsimple/repo/.github/workflows/prerelease.yml
@@ -139,6 +139,9 @@ jobs:
     - name: disarm go:embed directives to enable lint
       run: |
         git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: prepare upstream
+      continue-on-error: true
+      run: make upstream
     - name: golangci-lint
       uses: golangci/golangci-lint-action@v3
       with:

--- a/provider-ci/providers/dnsimple/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/dnsimple/repo/.github/workflows/release.yml
@@ -152,6 +152,9 @@ jobs:
     - name: disarm go:embed directives to enable lint
       run: |
         git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: prepare upstream
+      continue-on-error: true
+      run: make upstream
     - name: golangci-lint
       uses: golangci/golangci-lint-action@v3
       with:

--- a/provider-ci/providers/dnsimple/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/dnsimple/repo/.github/workflows/release.yml
@@ -138,34 +138,25 @@ jobs:
       run: pulumictl create docs-build pulumi-${{ env.PROVIDER }}
         "${GITHUB_REF#refs/tags/}"
   lint:
-    container: golangci/golangci-lint:v1.54.1
     name: lint
     runs-on: ubuntu-latest
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Mark repo as safe directory
-      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER }}/pulumi-${{ env.PROVIDER }}
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
     - name: Install Go
       uses: actions/setup-go@v4
       with:
         cache-dependency-path: |
             sdk/go.sum
         go-version: 1.21.x
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
+    - name: disarm go:embed directives to enable lint
+      run: |
+        git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: golangci-lint
+      uses: golangci/golangci-lint-action@v3
       with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - run: make lint_provider
+        version: v1.54.1
+        working-directory: provider
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3

--- a/provider-ci/providers/dnsimple/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/dnsimple/repo/.github/workflows/run-acceptance-tests.yml
@@ -157,6 +157,9 @@ jobs:
     - name: disarm go:embed directives to enable lint
       run: |
         git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: prepare upstream
+      continue-on-error: true
+      run: make upstream
     - name: Install go
       uses: actions/setup-go@v4
       with:

--- a/provider-ci/providers/dnsimple/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/dnsimple/repo/.github/workflows/run-acceptance-tests.yml
@@ -145,7 +145,6 @@ jobs:
         repository: ${{ github.event.client_payload.github.payload.repository.full_name }}
         token: ${{ secrets.PULUMI_BOT_TOKEN }}
   lint:
-    container: golangci/golangci-lint:v1.54.1
     if: github.event_name == 'repository_dispatch' ||
       github.event.pull_request.head.repo.full_name == github.repository
     name: lint
@@ -155,28 +154,20 @@ jobs:
       uses: actions/checkout@v3
       with:
         ref: ${{ env.PR_COMMIT_SHA }}
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Mark repo as safe directory
-      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER }}/pulumi-${{ env.PROVIDER }}
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
     - name: Install Go
       uses: actions/setup-go@v4
       with:
         cache-dependency-path: |
             sdk/go.sum
         go-version: 1.21.x
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
+    - name: disarm go:embed directives to enable lint
+      run: |
+        git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: golangci-lint
+      uses: golangci/golangci-lint-action@v3
       with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - run: make lint_provider
+        version: v1.54.1
+        working-directory: provider
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3

--- a/provider-ci/providers/dnsimple/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/dnsimple/repo/.github/workflows/run-acceptance-tests.yml
@@ -154,15 +154,16 @@ jobs:
       uses: actions/checkout@v3
       with:
         ref: ${{ env.PR_COMMIT_SHA }}
-    - name: Install Go
-      uses: actions/setup-go@v4
-      with:
-        cache-dependency-path: |
-            sdk/go.sum
-        go-version: 1.21.x
     - name: disarm go:embed directives to enable lint
       run: |
         git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: Install go
+      uses: actions/setup-go@v4
+      with:
+        # The versions of golangci-lint and setup-go here cross-depend and need to update together.
+        go-version: 1.21
+        # Either this action or golangci-lint needs to disable the cache
+        cache: false
     - name: golangci-lint
       uses: golangci/golangci-lint-action@v3
       with:

--- a/provider-ci/providers/docker/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/docker/repo/.github/workflows/main.yml
@@ -191,34 +191,25 @@ jobs:
 
         aws s3 cp "${{ env.COVERAGE_OUTPUT_DIR }}/summary.json" "${s3FullURI}" --acl bucket-owner-full-control
   lint:
-    container: golangci/golangci-lint:v1.54.1
     name: lint
     runs-on: ubuntu-latest
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Mark repo as safe directory
-      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER }}/pulumi-${{ env.PROVIDER }}
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
     - name: Install Go
       uses: actions/setup-go@v4
       with:
         cache-dependency-path: |
             sdk/go.sum
         go-version: 1.21.x
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
+    - name: disarm go:embed directives to enable lint
+      run: |
+        git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: golangci-lint
+      uses: golangci/golangci-lint-action@v3
       with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - run: make lint_provider
+        version: v1.54.1
+        working-directory: provider
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3

--- a/provider-ci/providers/docker/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/docker/repo/.github/workflows/main.yml
@@ -205,6 +205,9 @@ jobs:
     - name: disarm go:embed directives to enable lint
       run: |
         git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: prepare upstream
+      continue-on-error: true
+      run: make upstream
     - name: golangci-lint
       uses: golangci/golangci-lint-action@v3
       with:

--- a/provider-ci/providers/docker/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/docker/repo/.github/workflows/master.yml
@@ -191,34 +191,25 @@ jobs:
 
         aws s3 cp "${{ env.COVERAGE_OUTPUT_DIR }}/summary.json" "${s3FullURI}" --acl bucket-owner-full-control
   lint:
-    container: golangci/golangci-lint:v1.54.1
     name: lint
     runs-on: ubuntu-latest
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Mark repo as safe directory
-      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER }}/pulumi-${{ env.PROVIDER }}
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
     - name: Install Go
       uses: actions/setup-go@v4
       with:
         cache-dependency-path: |
             sdk/go.sum
         go-version: 1.21.x
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
+    - name: disarm go:embed directives to enable lint
+      run: |
+        git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: golangci-lint
+      uses: golangci/golangci-lint-action@v3
       with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - run: make lint_provider
+        version: v1.54.1
+        working-directory: provider
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3

--- a/provider-ci/providers/docker/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/docker/repo/.github/workflows/master.yml
@@ -205,6 +205,9 @@ jobs:
     - name: disarm go:embed directives to enable lint
       run: |
         git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: prepare upstream
+      continue-on-error: true
+      run: make upstream
     - name: golangci-lint
       uses: golangci/golangci-lint-action@v3
       with:

--- a/provider-ci/providers/docker/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/docker/repo/.github/workflows/prerelease.yml
@@ -152,6 +152,9 @@ jobs:
     - name: disarm go:embed directives to enable lint
       run: |
         git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: prepare upstream
+      continue-on-error: true
+      run: make upstream
     - name: golangci-lint
       uses: golangci/golangci-lint-action@v3
       with:

--- a/provider-ci/providers/docker/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/docker/repo/.github/workflows/prerelease.yml
@@ -138,34 +138,25 @@ jobs:
         - go
         - java
   lint:
-    container: golangci/golangci-lint:v1.54.1
     name: lint
     runs-on: ubuntu-latest
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Mark repo as safe directory
-      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER }}/pulumi-${{ env.PROVIDER }}
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
     - name: Install Go
       uses: actions/setup-go@v4
       with:
         cache-dependency-path: |
             sdk/go.sum
         go-version: 1.21.x
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
+    - name: disarm go:embed directives to enable lint
+      run: |
+        git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: golangci-lint
+      uses: golangci/golangci-lint-action@v3
       with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - run: make lint_provider
+        version: v1.54.1
+        working-directory: provider
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3

--- a/provider-ci/providers/docker/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/docker/repo/.github/workflows/release.yml
@@ -165,6 +165,9 @@ jobs:
     - name: disarm go:embed directives to enable lint
       run: |
         git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: prepare upstream
+      continue-on-error: true
+      run: make upstream
     - name: golangci-lint
       uses: golangci/golangci-lint-action@v3
       with:

--- a/provider-ci/providers/docker/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/docker/repo/.github/workflows/release.yml
@@ -151,34 +151,25 @@ jobs:
       run: pulumictl create docs-build pulumi-${{ env.PROVIDER }}
         "${GITHUB_REF#refs/tags/}"
   lint:
-    container: golangci/golangci-lint:v1.54.1
     name: lint
     runs-on: ubuntu-latest
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Mark repo as safe directory
-      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER }}/pulumi-${{ env.PROVIDER }}
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
     - name: Install Go
       uses: actions/setup-go@v4
       with:
         cache-dependency-path: |
             sdk/go.sum
         go-version: 1.21.x
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
+    - name: disarm go:embed directives to enable lint
+      run: |
+        git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: golangci-lint
+      uses: golangci/golangci-lint-action@v3
       with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - run: make lint_provider
+        version: v1.54.1
+        working-directory: provider
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3

--- a/provider-ci/providers/docker/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/docker/repo/.github/workflows/run-acceptance-tests.yml
@@ -170,6 +170,9 @@ jobs:
     - name: disarm go:embed directives to enable lint
       run: |
         git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: prepare upstream
+      continue-on-error: true
+      run: make upstream
     - name: Install go
       uses: actions/setup-go@v4
       with:

--- a/provider-ci/providers/docker/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/docker/repo/.github/workflows/run-acceptance-tests.yml
@@ -158,7 +158,6 @@ jobs:
         repository: ${{ github.event.client_payload.github.payload.repository.full_name }}
         token: ${{ secrets.PULUMI_BOT_TOKEN }}
   lint:
-    container: golangci/golangci-lint:v1.54.1
     if: github.event_name == 'repository_dispatch' ||
       github.event.pull_request.head.repo.full_name == github.repository
     name: lint
@@ -168,28 +167,20 @@ jobs:
       uses: actions/checkout@v3
       with:
         ref: ${{ env.PR_COMMIT_SHA }}
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Mark repo as safe directory
-      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER }}/pulumi-${{ env.PROVIDER }}
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
     - name: Install Go
       uses: actions/setup-go@v4
       with:
         cache-dependency-path: |
             sdk/go.sum
         go-version: 1.21.x
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
+    - name: disarm go:embed directives to enable lint
+      run: |
+        git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: golangci-lint
+      uses: golangci/golangci-lint-action@v3
       with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - run: make lint_provider
+        version: v1.54.1
+        working-directory: provider
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3

--- a/provider-ci/providers/docker/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/docker/repo/.github/workflows/run-acceptance-tests.yml
@@ -167,15 +167,16 @@ jobs:
       uses: actions/checkout@v3
       with:
         ref: ${{ env.PR_COMMIT_SHA }}
-    - name: Install Go
-      uses: actions/setup-go@v4
-      with:
-        cache-dependency-path: |
-            sdk/go.sum
-        go-version: 1.21.x
     - name: disarm go:embed directives to enable lint
       run: |
         git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: Install go
+      uses: actions/setup-go@v4
+      with:
+        # The versions of golangci-lint and setup-go here cross-depend and need to update together.
+        go-version: 1.21
+        # Either this action or golangci-lint needs to disable the cache
+        cache: false
     - name: golangci-lint
       uses: golangci/golangci-lint-action@v3
       with:

--- a/provider-ci/providers/ec/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/ec/repo/.github/workflows/main.yml
@@ -191,6 +191,9 @@ jobs:
     - name: disarm go:embed directives to enable lint
       run: |
         git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: prepare upstream
+      continue-on-error: true
+      run: make upstream
     - name: golangci-lint
       uses: golangci/golangci-lint-action@v3
       with:

--- a/provider-ci/providers/ec/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/ec/repo/.github/workflows/main.yml
@@ -177,34 +177,25 @@ jobs:
 
         aws s3 cp "${{ env.COVERAGE_OUTPUT_DIR }}/summary.json" "${s3FullURI}" --acl bucket-owner-full-control
   lint:
-    container: golangci/golangci-lint:v1.54.1
     name: lint
     runs-on: ubuntu-latest
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Mark repo as safe directory
-      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER }}/pulumi-${{ env.PROVIDER }}
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
     - name: Install Go
       uses: actions/setup-go@v4
       with:
         cache-dependency-path: |
             sdk/go.sum
         go-version: 1.21.x
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
+    - name: disarm go:embed directives to enable lint
+      run: |
+        git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: golangci-lint
+      uses: golangci/golangci-lint-action@v3
       with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - run: make lint_provider
+        version: v1.54.1
+        working-directory: provider
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3

--- a/provider-ci/providers/ec/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/ec/repo/.github/workflows/master.yml
@@ -191,6 +191,9 @@ jobs:
     - name: disarm go:embed directives to enable lint
       run: |
         git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: prepare upstream
+      continue-on-error: true
+      run: make upstream
     - name: golangci-lint
       uses: golangci/golangci-lint-action@v3
       with:

--- a/provider-ci/providers/ec/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/ec/repo/.github/workflows/master.yml
@@ -177,34 +177,25 @@ jobs:
 
         aws s3 cp "${{ env.COVERAGE_OUTPUT_DIR }}/summary.json" "${s3FullURI}" --acl bucket-owner-full-control
   lint:
-    container: golangci/golangci-lint:v1.54.1
     name: lint
     runs-on: ubuntu-latest
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Mark repo as safe directory
-      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER }}/pulumi-${{ env.PROVIDER }}
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
     - name: Install Go
       uses: actions/setup-go@v4
       with:
         cache-dependency-path: |
             sdk/go.sum
         go-version: 1.21.x
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
+    - name: disarm go:embed directives to enable lint
+      run: |
+        git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: golangci-lint
+      uses: golangci/golangci-lint-action@v3
       with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - run: make lint_provider
+        version: v1.54.1
+        working-directory: provider
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3

--- a/provider-ci/providers/ec/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/ec/repo/.github/workflows/prerelease.yml
@@ -124,34 +124,25 @@ jobs:
         - go
         - java
   lint:
-    container: golangci/golangci-lint:v1.54.1
     name: lint
     runs-on: ubuntu-latest
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Mark repo as safe directory
-      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER }}/pulumi-${{ env.PROVIDER }}
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
     - name: Install Go
       uses: actions/setup-go@v4
       with:
         cache-dependency-path: |
             sdk/go.sum
         go-version: 1.21.x
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
+    - name: disarm go:embed directives to enable lint
+      run: |
+        git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: golangci-lint
+      uses: golangci/golangci-lint-action@v3
       with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - run: make lint_provider
+        version: v1.54.1
+        working-directory: provider
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3

--- a/provider-ci/providers/ec/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/ec/repo/.github/workflows/prerelease.yml
@@ -138,6 +138,9 @@ jobs:
     - name: disarm go:embed directives to enable lint
       run: |
         git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: prepare upstream
+      continue-on-error: true
+      run: make upstream
     - name: golangci-lint
       uses: golangci/golangci-lint-action@v3
       with:

--- a/provider-ci/providers/ec/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/ec/repo/.github/workflows/release.yml
@@ -151,6 +151,9 @@ jobs:
     - name: disarm go:embed directives to enable lint
       run: |
         git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: prepare upstream
+      continue-on-error: true
+      run: make upstream
     - name: golangci-lint
       uses: golangci/golangci-lint-action@v3
       with:

--- a/provider-ci/providers/ec/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/ec/repo/.github/workflows/release.yml
@@ -137,34 +137,25 @@ jobs:
       run: pulumictl create docs-build pulumi-${{ env.PROVIDER }}
         "${GITHUB_REF#refs/tags/}"
   lint:
-    container: golangci/golangci-lint:v1.54.1
     name: lint
     runs-on: ubuntu-latest
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Mark repo as safe directory
-      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER }}/pulumi-${{ env.PROVIDER }}
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
     - name: Install Go
       uses: actions/setup-go@v4
       with:
         cache-dependency-path: |
             sdk/go.sum
         go-version: 1.21.x
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
+    - name: disarm go:embed directives to enable lint
+      run: |
+        git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: golangci-lint
+      uses: golangci/golangci-lint-action@v3
       with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - run: make lint_provider
+        version: v1.54.1
+        working-directory: provider
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3

--- a/provider-ci/providers/ec/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/ec/repo/.github/workflows/run-acceptance-tests.yml
@@ -153,15 +153,16 @@ jobs:
       uses: actions/checkout@v3
       with:
         ref: ${{ env.PR_COMMIT_SHA }}
-    - name: Install Go
-      uses: actions/setup-go@v4
-      with:
-        cache-dependency-path: |
-            sdk/go.sum
-        go-version: 1.21.x
     - name: disarm go:embed directives to enable lint
       run: |
         git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: Install go
+      uses: actions/setup-go@v4
+      with:
+        # The versions of golangci-lint and setup-go here cross-depend and need to update together.
+        go-version: 1.21
+        # Either this action or golangci-lint needs to disable the cache
+        cache: false
     - name: golangci-lint
       uses: golangci/golangci-lint-action@v3
       with:

--- a/provider-ci/providers/ec/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/ec/repo/.github/workflows/run-acceptance-tests.yml
@@ -144,7 +144,6 @@ jobs:
         repository: ${{ github.event.client_payload.github.payload.repository.full_name }}
         token: ${{ secrets.PULUMI_BOT_TOKEN }}
   lint:
-    container: golangci/golangci-lint:v1.54.1
     if: github.event_name == 'repository_dispatch' ||
       github.event.pull_request.head.repo.full_name == github.repository
     name: lint
@@ -154,28 +153,20 @@ jobs:
       uses: actions/checkout@v3
       with:
         ref: ${{ env.PR_COMMIT_SHA }}
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Mark repo as safe directory
-      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER }}/pulumi-${{ env.PROVIDER }}
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
     - name: Install Go
       uses: actions/setup-go@v4
       with:
         cache-dependency-path: |
             sdk/go.sum
         go-version: 1.21.x
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
+    - name: disarm go:embed directives to enable lint
+      run: |
+        git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: golangci-lint
+      uses: golangci/golangci-lint-action@v3
       with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - run: make lint_provider
+        version: v1.54.1
+        working-directory: provider
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3

--- a/provider-ci/providers/ec/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/ec/repo/.github/workflows/run-acceptance-tests.yml
@@ -156,6 +156,9 @@ jobs:
     - name: disarm go:embed directives to enable lint
       run: |
         git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: prepare upstream
+      continue-on-error: true
+      run: make upstream
     - name: Install go
       uses: actions/setup-go@v4
       with:

--- a/provider-ci/providers/f5bigip/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/f5bigip/repo/.github/workflows/main.yml
@@ -194,6 +194,9 @@ jobs:
     - name: disarm go:embed directives to enable lint
       run: |
         git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: prepare upstream
+      continue-on-error: true
+      run: make upstream
     - name: golangci-lint
       uses: golangci/golangci-lint-action@v3
       with:

--- a/provider-ci/providers/f5bigip/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/f5bigip/repo/.github/workflows/main.yml
@@ -180,34 +180,25 @@ jobs:
 
         aws s3 cp "${{ env.COVERAGE_OUTPUT_DIR }}/summary.json" "${s3FullURI}" --acl bucket-owner-full-control
   lint:
-    container: golangci/golangci-lint:v1.54.1
     name: lint
     runs-on: ubuntu-latest
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Mark repo as safe directory
-      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER }}/pulumi-${{ env.PROVIDER }}
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
     - name: Install Go
       uses: actions/setup-go@v4
       with:
         cache-dependency-path: |
             sdk/go.sum
         go-version: 1.21.x
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
+    - name: disarm go:embed directives to enable lint
+      run: |
+        git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: golangci-lint
+      uses: golangci/golangci-lint-action@v3
       with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - run: make lint_provider
+        version: v1.54.1
+        working-directory: provider
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3

--- a/provider-ci/providers/f5bigip/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/f5bigip/repo/.github/workflows/master.yml
@@ -194,6 +194,9 @@ jobs:
     - name: disarm go:embed directives to enable lint
       run: |
         git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: prepare upstream
+      continue-on-error: true
+      run: make upstream
     - name: golangci-lint
       uses: golangci/golangci-lint-action@v3
       with:

--- a/provider-ci/providers/f5bigip/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/f5bigip/repo/.github/workflows/master.yml
@@ -180,34 +180,25 @@ jobs:
 
         aws s3 cp "${{ env.COVERAGE_OUTPUT_DIR }}/summary.json" "${s3FullURI}" --acl bucket-owner-full-control
   lint:
-    container: golangci/golangci-lint:v1.54.1
     name: lint
     runs-on: ubuntu-latest
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Mark repo as safe directory
-      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER }}/pulumi-${{ env.PROVIDER }}
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
     - name: Install Go
       uses: actions/setup-go@v4
       with:
         cache-dependency-path: |
             sdk/go.sum
         go-version: 1.21.x
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
+    - name: disarm go:embed directives to enable lint
+      run: |
+        git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: golangci-lint
+      uses: golangci/golangci-lint-action@v3
       with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - run: make lint_provider
+        version: v1.54.1
+        working-directory: provider
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3

--- a/provider-ci/providers/f5bigip/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/f5bigip/repo/.github/workflows/prerelease.yml
@@ -127,34 +127,25 @@ jobs:
         - go
         - java
   lint:
-    container: golangci/golangci-lint:v1.54.1
     name: lint
     runs-on: ubuntu-latest
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Mark repo as safe directory
-      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER }}/pulumi-${{ env.PROVIDER }}
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
     - name: Install Go
       uses: actions/setup-go@v4
       with:
         cache-dependency-path: |
             sdk/go.sum
         go-version: 1.21.x
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
+    - name: disarm go:embed directives to enable lint
+      run: |
+        git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: golangci-lint
+      uses: golangci/golangci-lint-action@v3
       with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - run: make lint_provider
+        version: v1.54.1
+        working-directory: provider
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3

--- a/provider-ci/providers/f5bigip/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/f5bigip/repo/.github/workflows/prerelease.yml
@@ -141,6 +141,9 @@ jobs:
     - name: disarm go:embed directives to enable lint
       run: |
         git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: prepare upstream
+      continue-on-error: true
+      run: make upstream
     - name: golangci-lint
       uses: golangci/golangci-lint-action@v3
       with:

--- a/provider-ci/providers/f5bigip/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/f5bigip/repo/.github/workflows/release.yml
@@ -140,34 +140,25 @@ jobs:
       run: pulumictl create docs-build pulumi-${{ env.PROVIDER }}
         "${GITHUB_REF#refs/tags/}"
   lint:
-    container: golangci/golangci-lint:v1.54.1
     name: lint
     runs-on: ubuntu-latest
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Mark repo as safe directory
-      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER }}/pulumi-${{ env.PROVIDER }}
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
     - name: Install Go
       uses: actions/setup-go@v4
       with:
         cache-dependency-path: |
             sdk/go.sum
         go-version: 1.21.x
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
+    - name: disarm go:embed directives to enable lint
+      run: |
+        git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: golangci-lint
+      uses: golangci/golangci-lint-action@v3
       with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - run: make lint_provider
+        version: v1.54.1
+        working-directory: provider
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3

--- a/provider-ci/providers/f5bigip/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/f5bigip/repo/.github/workflows/release.yml
@@ -154,6 +154,9 @@ jobs:
     - name: disarm go:embed directives to enable lint
       run: |
         git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: prepare upstream
+      continue-on-error: true
+      run: make upstream
     - name: golangci-lint
       uses: golangci/golangci-lint-action@v3
       with:

--- a/provider-ci/providers/f5bigip/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/f5bigip/repo/.github/workflows/run-acceptance-tests.yml
@@ -159,6 +159,9 @@ jobs:
     - name: disarm go:embed directives to enable lint
       run: |
         git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: prepare upstream
+      continue-on-error: true
+      run: make upstream
     - name: Install go
       uses: actions/setup-go@v4
       with:

--- a/provider-ci/providers/f5bigip/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/f5bigip/repo/.github/workflows/run-acceptance-tests.yml
@@ -147,7 +147,6 @@ jobs:
         repository: ${{ github.event.client_payload.github.payload.repository.full_name }}
         token: ${{ secrets.PULUMI_BOT_TOKEN }}
   lint:
-    container: golangci/golangci-lint:v1.54.1
     if: github.event_name == 'repository_dispatch' ||
       github.event.pull_request.head.repo.full_name == github.repository
     name: lint
@@ -157,28 +156,20 @@ jobs:
       uses: actions/checkout@v3
       with:
         ref: ${{ env.PR_COMMIT_SHA }}
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Mark repo as safe directory
-      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER }}/pulumi-${{ env.PROVIDER }}
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
     - name: Install Go
       uses: actions/setup-go@v4
       with:
         cache-dependency-path: |
             sdk/go.sum
         go-version: 1.21.x
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
+    - name: disarm go:embed directives to enable lint
+      run: |
+        git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: golangci-lint
+      uses: golangci/golangci-lint-action@v3
       with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - run: make lint_provider
+        version: v1.54.1
+        working-directory: provider
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3

--- a/provider-ci/providers/f5bigip/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/f5bigip/repo/.github/workflows/run-acceptance-tests.yml
@@ -156,15 +156,16 @@ jobs:
       uses: actions/checkout@v3
       with:
         ref: ${{ env.PR_COMMIT_SHA }}
-    - name: Install Go
-      uses: actions/setup-go@v4
-      with:
-        cache-dependency-path: |
-            sdk/go.sum
-        go-version: 1.21.x
     - name: disarm go:embed directives to enable lint
       run: |
         git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: Install go
+      uses: actions/setup-go@v4
+      with:
+        # The versions of golangci-lint and setup-go here cross-depend and need to update together.
+        go-version: 1.21
+        # Either this action or golangci-lint needs to disable the cache
+        cache: false
     - name: golangci-lint
       uses: golangci/golangci-lint-action@v3
       with:

--- a/provider-ci/providers/fastly/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/fastly/repo/.github/workflows/main.yml
@@ -191,6 +191,9 @@ jobs:
     - name: disarm go:embed directives to enable lint
       run: |
         git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: prepare upstream
+      continue-on-error: true
+      run: make upstream
     - name: golangci-lint
       uses: golangci/golangci-lint-action@v3
       with:

--- a/provider-ci/providers/fastly/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/fastly/repo/.github/workflows/main.yml
@@ -177,34 +177,25 @@ jobs:
 
         aws s3 cp "${{ env.COVERAGE_OUTPUT_DIR }}/summary.json" "${s3FullURI}" --acl bucket-owner-full-control
   lint:
-    container: golangci/golangci-lint:v1.54.1
     name: lint
     runs-on: ubuntu-latest
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Mark repo as safe directory
-      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER }}/pulumi-${{ env.PROVIDER }}
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
     - name: Install Go
       uses: actions/setup-go@v4
       with:
         cache-dependency-path: |
             sdk/go.sum
         go-version: 1.21.x
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
+    - name: disarm go:embed directives to enable lint
+      run: |
+        git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: golangci-lint
+      uses: golangci/golangci-lint-action@v3
       with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - run: make lint_provider
+        version: v1.54.1
+        working-directory: provider
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3

--- a/provider-ci/providers/fastly/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/fastly/repo/.github/workflows/master.yml
@@ -191,6 +191,9 @@ jobs:
     - name: disarm go:embed directives to enable lint
       run: |
         git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: prepare upstream
+      continue-on-error: true
+      run: make upstream
     - name: golangci-lint
       uses: golangci/golangci-lint-action@v3
       with:

--- a/provider-ci/providers/fastly/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/fastly/repo/.github/workflows/master.yml
@@ -177,34 +177,25 @@ jobs:
 
         aws s3 cp "${{ env.COVERAGE_OUTPUT_DIR }}/summary.json" "${s3FullURI}" --acl bucket-owner-full-control
   lint:
-    container: golangci/golangci-lint:v1.54.1
     name: lint
     runs-on: ubuntu-latest
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Mark repo as safe directory
-      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER }}/pulumi-${{ env.PROVIDER }}
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
     - name: Install Go
       uses: actions/setup-go@v4
       with:
         cache-dependency-path: |
             sdk/go.sum
         go-version: 1.21.x
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
+    - name: disarm go:embed directives to enable lint
+      run: |
+        git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: golangci-lint
+      uses: golangci/golangci-lint-action@v3
       with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - run: make lint_provider
+        version: v1.54.1
+        working-directory: provider
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3

--- a/provider-ci/providers/fastly/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/fastly/repo/.github/workflows/prerelease.yml
@@ -124,34 +124,25 @@ jobs:
         - go
         - java
   lint:
-    container: golangci/golangci-lint:v1.54.1
     name: lint
     runs-on: ubuntu-latest
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Mark repo as safe directory
-      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER }}/pulumi-${{ env.PROVIDER }}
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
     - name: Install Go
       uses: actions/setup-go@v4
       with:
         cache-dependency-path: |
             sdk/go.sum
         go-version: 1.21.x
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
+    - name: disarm go:embed directives to enable lint
+      run: |
+        git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: golangci-lint
+      uses: golangci/golangci-lint-action@v3
       with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - run: make lint_provider
+        version: v1.54.1
+        working-directory: provider
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3

--- a/provider-ci/providers/fastly/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/fastly/repo/.github/workflows/prerelease.yml
@@ -138,6 +138,9 @@ jobs:
     - name: disarm go:embed directives to enable lint
       run: |
         git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: prepare upstream
+      continue-on-error: true
+      run: make upstream
     - name: golangci-lint
       uses: golangci/golangci-lint-action@v3
       with:

--- a/provider-ci/providers/fastly/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/fastly/repo/.github/workflows/release.yml
@@ -151,6 +151,9 @@ jobs:
     - name: disarm go:embed directives to enable lint
       run: |
         git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: prepare upstream
+      continue-on-error: true
+      run: make upstream
     - name: golangci-lint
       uses: golangci/golangci-lint-action@v3
       with:

--- a/provider-ci/providers/fastly/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/fastly/repo/.github/workflows/release.yml
@@ -137,34 +137,25 @@ jobs:
       run: pulumictl create docs-build pulumi-${{ env.PROVIDER }}
         "${GITHUB_REF#refs/tags/}"
   lint:
-    container: golangci/golangci-lint:v1.54.1
     name: lint
     runs-on: ubuntu-latest
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Mark repo as safe directory
-      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER }}/pulumi-${{ env.PROVIDER }}
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
     - name: Install Go
       uses: actions/setup-go@v4
       with:
         cache-dependency-path: |
             sdk/go.sum
         go-version: 1.21.x
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
+    - name: disarm go:embed directives to enable lint
+      run: |
+        git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: golangci-lint
+      uses: golangci/golangci-lint-action@v3
       with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - run: make lint_provider
+        version: v1.54.1
+        working-directory: provider
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3

--- a/provider-ci/providers/fastly/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/fastly/repo/.github/workflows/run-acceptance-tests.yml
@@ -153,15 +153,16 @@ jobs:
       uses: actions/checkout@v3
       with:
         ref: ${{ env.PR_COMMIT_SHA }}
-    - name: Install Go
-      uses: actions/setup-go@v4
-      with:
-        cache-dependency-path: |
-            sdk/go.sum
-        go-version: 1.21.x
     - name: disarm go:embed directives to enable lint
       run: |
         git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: Install go
+      uses: actions/setup-go@v4
+      with:
+        # The versions of golangci-lint and setup-go here cross-depend and need to update together.
+        go-version: 1.21
+        # Either this action or golangci-lint needs to disable the cache
+        cache: false
     - name: golangci-lint
       uses: golangci/golangci-lint-action@v3
       with:

--- a/provider-ci/providers/fastly/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/fastly/repo/.github/workflows/run-acceptance-tests.yml
@@ -144,7 +144,6 @@ jobs:
         repository: ${{ github.event.client_payload.github.payload.repository.full_name }}
         token: ${{ secrets.PULUMI_BOT_TOKEN }}
   lint:
-    container: golangci/golangci-lint:v1.54.1
     if: github.event_name == 'repository_dispatch' ||
       github.event.pull_request.head.repo.full_name == github.repository
     name: lint
@@ -154,28 +153,20 @@ jobs:
       uses: actions/checkout@v3
       with:
         ref: ${{ env.PR_COMMIT_SHA }}
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Mark repo as safe directory
-      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER }}/pulumi-${{ env.PROVIDER }}
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
     - name: Install Go
       uses: actions/setup-go@v4
       with:
         cache-dependency-path: |
             sdk/go.sum
         go-version: 1.21.x
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
+    - name: disarm go:embed directives to enable lint
+      run: |
+        git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: golangci-lint
+      uses: golangci/golangci-lint-action@v3
       with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - run: make lint_provider
+        version: v1.54.1
+        working-directory: provider
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3

--- a/provider-ci/providers/fastly/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/fastly/repo/.github/workflows/run-acceptance-tests.yml
@@ -156,6 +156,9 @@ jobs:
     - name: disarm go:embed directives to enable lint
       run: |
         git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: prepare upstream
+      continue-on-error: true
+      run: make upstream
     - name: Install go
       uses: actions/setup-go@v4
       with:

--- a/provider-ci/providers/github/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/github/repo/.github/workflows/main.yml
@@ -178,34 +178,25 @@ jobs:
 
         aws s3 cp "${{ env.COVERAGE_OUTPUT_DIR }}/summary.json" "${s3FullURI}" --acl bucket-owner-full-control
   lint:
-    container: golangci/golangci-lint:v1.54.1
     name: lint
     runs-on: ubuntu-latest
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Mark repo as safe directory
-      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER }}/pulumi-${{ env.PROVIDER }}
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
     - name: Install Go
       uses: actions/setup-go@v4
       with:
         cache-dependency-path: |
             sdk/go.sum
         go-version: 1.21.x
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
+    - name: disarm go:embed directives to enable lint
+      run: |
+        git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: golangci-lint
+      uses: golangci/golangci-lint-action@v3
       with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - run: make lint_provider
+        version: v1.54.1
+        working-directory: provider
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3

--- a/provider-ci/providers/github/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/github/repo/.github/workflows/main.yml
@@ -192,6 +192,9 @@ jobs:
     - name: disarm go:embed directives to enable lint
       run: |
         git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: prepare upstream
+      continue-on-error: true
+      run: make upstream
     - name: golangci-lint
       uses: golangci/golangci-lint-action@v3
       with:

--- a/provider-ci/providers/github/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/github/repo/.github/workflows/master.yml
@@ -178,34 +178,25 @@ jobs:
 
         aws s3 cp "${{ env.COVERAGE_OUTPUT_DIR }}/summary.json" "${s3FullURI}" --acl bucket-owner-full-control
   lint:
-    container: golangci/golangci-lint:v1.54.1
     name: lint
     runs-on: ubuntu-latest
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Mark repo as safe directory
-      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER }}/pulumi-${{ env.PROVIDER }}
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
     - name: Install Go
       uses: actions/setup-go@v4
       with:
         cache-dependency-path: |
             sdk/go.sum
         go-version: 1.21.x
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
+    - name: disarm go:embed directives to enable lint
+      run: |
+        git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: golangci-lint
+      uses: golangci/golangci-lint-action@v3
       with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - run: make lint_provider
+        version: v1.54.1
+        working-directory: provider
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3

--- a/provider-ci/providers/github/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/github/repo/.github/workflows/master.yml
@@ -192,6 +192,9 @@ jobs:
     - name: disarm go:embed directives to enable lint
       run: |
         git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: prepare upstream
+      continue-on-error: true
+      run: make upstream
     - name: golangci-lint
       uses: golangci/golangci-lint-action@v3
       with:

--- a/provider-ci/providers/github/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/github/repo/.github/workflows/prerelease.yml
@@ -125,34 +125,25 @@ jobs:
         - go
         - java
   lint:
-    container: golangci/golangci-lint:v1.54.1
     name: lint
     runs-on: ubuntu-latest
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Mark repo as safe directory
-      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER }}/pulumi-${{ env.PROVIDER }}
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
     - name: Install Go
       uses: actions/setup-go@v4
       with:
         cache-dependency-path: |
             sdk/go.sum
         go-version: 1.21.x
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
+    - name: disarm go:embed directives to enable lint
+      run: |
+        git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: golangci-lint
+      uses: golangci/golangci-lint-action@v3
       with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - run: make lint_provider
+        version: v1.54.1
+        working-directory: provider
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3

--- a/provider-ci/providers/github/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/github/repo/.github/workflows/prerelease.yml
@@ -139,6 +139,9 @@ jobs:
     - name: disarm go:embed directives to enable lint
       run: |
         git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: prepare upstream
+      continue-on-error: true
+      run: make upstream
     - name: golangci-lint
       uses: golangci/golangci-lint-action@v3
       with:

--- a/provider-ci/providers/github/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/github/repo/.github/workflows/release.yml
@@ -152,6 +152,9 @@ jobs:
     - name: disarm go:embed directives to enable lint
       run: |
         git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: prepare upstream
+      continue-on-error: true
+      run: make upstream
     - name: golangci-lint
       uses: golangci/golangci-lint-action@v3
       with:

--- a/provider-ci/providers/github/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/github/repo/.github/workflows/release.yml
@@ -138,34 +138,25 @@ jobs:
       run: pulumictl create docs-build pulumi-${{ env.PROVIDER }}
         "${GITHUB_REF#refs/tags/}"
   lint:
-    container: golangci/golangci-lint:v1.54.1
     name: lint
     runs-on: ubuntu-latest
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Mark repo as safe directory
-      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER }}/pulumi-${{ env.PROVIDER }}
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
     - name: Install Go
       uses: actions/setup-go@v4
       with:
         cache-dependency-path: |
             sdk/go.sum
         go-version: 1.21.x
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
+    - name: disarm go:embed directives to enable lint
+      run: |
+        git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: golangci-lint
+      uses: golangci/golangci-lint-action@v3
       with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - run: make lint_provider
+        version: v1.54.1
+        working-directory: provider
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3

--- a/provider-ci/providers/github/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/github/repo/.github/workflows/run-acceptance-tests.yml
@@ -157,6 +157,9 @@ jobs:
     - name: disarm go:embed directives to enable lint
       run: |
         git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: prepare upstream
+      continue-on-error: true
+      run: make upstream
     - name: Install go
       uses: actions/setup-go@v4
       with:

--- a/provider-ci/providers/github/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/github/repo/.github/workflows/run-acceptance-tests.yml
@@ -145,7 +145,6 @@ jobs:
         repository: ${{ github.event.client_payload.github.payload.repository.full_name }}
         token: ${{ secrets.PULUMI_BOT_TOKEN }}
   lint:
-    container: golangci/golangci-lint:v1.54.1
     if: github.event_name == 'repository_dispatch' ||
       github.event.pull_request.head.repo.full_name == github.repository
     name: lint
@@ -155,28 +154,20 @@ jobs:
       uses: actions/checkout@v3
       with:
         ref: ${{ env.PR_COMMIT_SHA }}
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Mark repo as safe directory
-      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER }}/pulumi-${{ env.PROVIDER }}
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
     - name: Install Go
       uses: actions/setup-go@v4
       with:
         cache-dependency-path: |
             sdk/go.sum
         go-version: 1.21.x
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
+    - name: disarm go:embed directives to enable lint
+      run: |
+        git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: golangci-lint
+      uses: golangci/golangci-lint-action@v3
       with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - run: make lint_provider
+        version: v1.54.1
+        working-directory: provider
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3

--- a/provider-ci/providers/github/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/github/repo/.github/workflows/run-acceptance-tests.yml
@@ -154,15 +154,16 @@ jobs:
       uses: actions/checkout@v3
       with:
         ref: ${{ env.PR_COMMIT_SHA }}
-    - name: Install Go
-      uses: actions/setup-go@v4
-      with:
-        cache-dependency-path: |
-            sdk/go.sum
-        go-version: 1.21.x
     - name: disarm go:embed directives to enable lint
       run: |
         git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: Install go
+      uses: actions/setup-go@v4
+      with:
+        # The versions of golangci-lint and setup-go here cross-depend and need to update together.
+        go-version: 1.21
+        # Either this action or golangci-lint needs to disable the cache
+        cache: false
     - name: golangci-lint
       uses: golangci/golangci-lint-action@v3
       with:

--- a/provider-ci/providers/gitlab/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/gitlab/repo/.github/workflows/main.yml
@@ -191,6 +191,9 @@ jobs:
     - name: disarm go:embed directives to enable lint
       run: |
         git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: prepare upstream
+      continue-on-error: true
+      run: make upstream
     - name: golangci-lint
       uses: golangci/golangci-lint-action@v3
       with:

--- a/provider-ci/providers/gitlab/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/gitlab/repo/.github/workflows/main.yml
@@ -177,34 +177,25 @@ jobs:
 
         aws s3 cp "${{ env.COVERAGE_OUTPUT_DIR }}/summary.json" "${s3FullURI}" --acl bucket-owner-full-control
   lint:
-    container: golangci/golangci-lint:v1.54.1
     name: lint
     runs-on: ubuntu-latest
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Mark repo as safe directory
-      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER }}/pulumi-${{ env.PROVIDER }}
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
     - name: Install Go
       uses: actions/setup-go@v4
       with:
         cache-dependency-path: |
             sdk/go.sum
         go-version: 1.21.x
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
+    - name: disarm go:embed directives to enable lint
+      run: |
+        git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: golangci-lint
+      uses: golangci/golangci-lint-action@v3
       with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - run: make lint_provider
+        version: v1.54.1
+        working-directory: provider
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3

--- a/provider-ci/providers/gitlab/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/gitlab/repo/.github/workflows/master.yml
@@ -191,6 +191,9 @@ jobs:
     - name: disarm go:embed directives to enable lint
       run: |
         git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: prepare upstream
+      continue-on-error: true
+      run: make upstream
     - name: golangci-lint
       uses: golangci/golangci-lint-action@v3
       with:

--- a/provider-ci/providers/gitlab/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/gitlab/repo/.github/workflows/master.yml
@@ -177,34 +177,25 @@ jobs:
 
         aws s3 cp "${{ env.COVERAGE_OUTPUT_DIR }}/summary.json" "${s3FullURI}" --acl bucket-owner-full-control
   lint:
-    container: golangci/golangci-lint:v1.54.1
     name: lint
     runs-on: ubuntu-latest
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Mark repo as safe directory
-      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER }}/pulumi-${{ env.PROVIDER }}
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
     - name: Install Go
       uses: actions/setup-go@v4
       with:
         cache-dependency-path: |
             sdk/go.sum
         go-version: 1.21.x
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
+    - name: disarm go:embed directives to enable lint
+      run: |
+        git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: golangci-lint
+      uses: golangci/golangci-lint-action@v3
       with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - run: make lint_provider
+        version: v1.54.1
+        working-directory: provider
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3

--- a/provider-ci/providers/gitlab/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/gitlab/repo/.github/workflows/prerelease.yml
@@ -124,34 +124,25 @@ jobs:
         - go
         - java
   lint:
-    container: golangci/golangci-lint:v1.54.1
     name: lint
     runs-on: ubuntu-latest
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Mark repo as safe directory
-      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER }}/pulumi-${{ env.PROVIDER }}
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
     - name: Install Go
       uses: actions/setup-go@v4
       with:
         cache-dependency-path: |
             sdk/go.sum
         go-version: 1.21.x
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
+    - name: disarm go:embed directives to enable lint
+      run: |
+        git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: golangci-lint
+      uses: golangci/golangci-lint-action@v3
       with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - run: make lint_provider
+        version: v1.54.1
+        working-directory: provider
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3

--- a/provider-ci/providers/gitlab/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/gitlab/repo/.github/workflows/prerelease.yml
@@ -138,6 +138,9 @@ jobs:
     - name: disarm go:embed directives to enable lint
       run: |
         git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: prepare upstream
+      continue-on-error: true
+      run: make upstream
     - name: golangci-lint
       uses: golangci/golangci-lint-action@v3
       with:

--- a/provider-ci/providers/gitlab/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/gitlab/repo/.github/workflows/release.yml
@@ -151,6 +151,9 @@ jobs:
     - name: disarm go:embed directives to enable lint
       run: |
         git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: prepare upstream
+      continue-on-error: true
+      run: make upstream
     - name: golangci-lint
       uses: golangci/golangci-lint-action@v3
       with:

--- a/provider-ci/providers/gitlab/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/gitlab/repo/.github/workflows/release.yml
@@ -137,34 +137,25 @@ jobs:
       run: pulumictl create docs-build pulumi-${{ env.PROVIDER }}
         "${GITHUB_REF#refs/tags/}"
   lint:
-    container: golangci/golangci-lint:v1.54.1
     name: lint
     runs-on: ubuntu-latest
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Mark repo as safe directory
-      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER }}/pulumi-${{ env.PROVIDER }}
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
     - name: Install Go
       uses: actions/setup-go@v4
       with:
         cache-dependency-path: |
             sdk/go.sum
         go-version: 1.21.x
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
+    - name: disarm go:embed directives to enable lint
+      run: |
+        git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: golangci-lint
+      uses: golangci/golangci-lint-action@v3
       with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - run: make lint_provider
+        version: v1.54.1
+        working-directory: provider
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3

--- a/provider-ci/providers/gitlab/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/gitlab/repo/.github/workflows/run-acceptance-tests.yml
@@ -153,15 +153,16 @@ jobs:
       uses: actions/checkout@v3
       with:
         ref: ${{ env.PR_COMMIT_SHA }}
-    - name: Install Go
-      uses: actions/setup-go@v4
-      with:
-        cache-dependency-path: |
-            sdk/go.sum
-        go-version: 1.21.x
     - name: disarm go:embed directives to enable lint
       run: |
         git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: Install go
+      uses: actions/setup-go@v4
+      with:
+        # The versions of golangci-lint and setup-go here cross-depend and need to update together.
+        go-version: 1.21
+        # Either this action or golangci-lint needs to disable the cache
+        cache: false
     - name: golangci-lint
       uses: golangci/golangci-lint-action@v3
       with:

--- a/provider-ci/providers/gitlab/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/gitlab/repo/.github/workflows/run-acceptance-tests.yml
@@ -144,7 +144,6 @@ jobs:
         repository: ${{ github.event.client_payload.github.payload.repository.full_name }}
         token: ${{ secrets.PULUMI_BOT_TOKEN }}
   lint:
-    container: golangci/golangci-lint:v1.54.1
     if: github.event_name == 'repository_dispatch' ||
       github.event.pull_request.head.repo.full_name == github.repository
     name: lint
@@ -154,28 +153,20 @@ jobs:
       uses: actions/checkout@v3
       with:
         ref: ${{ env.PR_COMMIT_SHA }}
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Mark repo as safe directory
-      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER }}/pulumi-${{ env.PROVIDER }}
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
     - name: Install Go
       uses: actions/setup-go@v4
       with:
         cache-dependency-path: |
             sdk/go.sum
         go-version: 1.21.x
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
+    - name: disarm go:embed directives to enable lint
+      run: |
+        git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: golangci-lint
+      uses: golangci/golangci-lint-action@v3
       with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - run: make lint_provider
+        version: v1.54.1
+        working-directory: provider
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3

--- a/provider-ci/providers/gitlab/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/gitlab/repo/.github/workflows/run-acceptance-tests.yml
@@ -156,6 +156,9 @@ jobs:
     - name: disarm go:embed directives to enable lint
       run: |
         git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: prepare upstream
+      continue-on-error: true
+      run: make upstream
     - name: Install go
       uses: actions/setup-go@v4
       with:

--- a/provider-ci/providers/hcloud/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/hcloud/repo/.github/workflows/main.yml
@@ -191,6 +191,9 @@ jobs:
     - name: disarm go:embed directives to enable lint
       run: |
         git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: prepare upstream
+      continue-on-error: true
+      run: make upstream
     - name: golangci-lint
       uses: golangci/golangci-lint-action@v3
       with:

--- a/provider-ci/providers/hcloud/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/hcloud/repo/.github/workflows/main.yml
@@ -177,34 +177,25 @@ jobs:
 
         aws s3 cp "${{ env.COVERAGE_OUTPUT_DIR }}/summary.json" "${s3FullURI}" --acl bucket-owner-full-control
   lint:
-    container: golangci/golangci-lint:v1.54.1
     name: lint
     runs-on: ubuntu-latest
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Mark repo as safe directory
-      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER }}/pulumi-${{ env.PROVIDER }}
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
     - name: Install Go
       uses: actions/setup-go@v4
       with:
         cache-dependency-path: |
             sdk/go.sum
         go-version: 1.21.x
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
+    - name: disarm go:embed directives to enable lint
+      run: |
+        git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: golangci-lint
+      uses: golangci/golangci-lint-action@v3
       with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - run: make lint_provider
+        version: v1.54.1
+        working-directory: provider
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3

--- a/provider-ci/providers/hcloud/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/hcloud/repo/.github/workflows/master.yml
@@ -191,6 +191,9 @@ jobs:
     - name: disarm go:embed directives to enable lint
       run: |
         git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: prepare upstream
+      continue-on-error: true
+      run: make upstream
     - name: golangci-lint
       uses: golangci/golangci-lint-action@v3
       with:

--- a/provider-ci/providers/hcloud/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/hcloud/repo/.github/workflows/master.yml
@@ -177,34 +177,25 @@ jobs:
 
         aws s3 cp "${{ env.COVERAGE_OUTPUT_DIR }}/summary.json" "${s3FullURI}" --acl bucket-owner-full-control
   lint:
-    container: golangci/golangci-lint:v1.54.1
     name: lint
     runs-on: ubuntu-latest
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Mark repo as safe directory
-      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER }}/pulumi-${{ env.PROVIDER }}
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
     - name: Install Go
       uses: actions/setup-go@v4
       with:
         cache-dependency-path: |
             sdk/go.sum
         go-version: 1.21.x
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
+    - name: disarm go:embed directives to enable lint
+      run: |
+        git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: golangci-lint
+      uses: golangci/golangci-lint-action@v3
       with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - run: make lint_provider
+        version: v1.54.1
+        working-directory: provider
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3

--- a/provider-ci/providers/hcloud/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/hcloud/repo/.github/workflows/prerelease.yml
@@ -124,34 +124,25 @@ jobs:
         - go
         - java
   lint:
-    container: golangci/golangci-lint:v1.54.1
     name: lint
     runs-on: ubuntu-latest
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Mark repo as safe directory
-      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER }}/pulumi-${{ env.PROVIDER }}
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
     - name: Install Go
       uses: actions/setup-go@v4
       with:
         cache-dependency-path: |
             sdk/go.sum
         go-version: 1.21.x
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
+    - name: disarm go:embed directives to enable lint
+      run: |
+        git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: golangci-lint
+      uses: golangci/golangci-lint-action@v3
       with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - run: make lint_provider
+        version: v1.54.1
+        working-directory: provider
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3

--- a/provider-ci/providers/hcloud/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/hcloud/repo/.github/workflows/prerelease.yml
@@ -138,6 +138,9 @@ jobs:
     - name: disarm go:embed directives to enable lint
       run: |
         git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: prepare upstream
+      continue-on-error: true
+      run: make upstream
     - name: golangci-lint
       uses: golangci/golangci-lint-action@v3
       with:

--- a/provider-ci/providers/hcloud/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/hcloud/repo/.github/workflows/release.yml
@@ -151,6 +151,9 @@ jobs:
     - name: disarm go:embed directives to enable lint
       run: |
         git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: prepare upstream
+      continue-on-error: true
+      run: make upstream
     - name: golangci-lint
       uses: golangci/golangci-lint-action@v3
       with:

--- a/provider-ci/providers/hcloud/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/hcloud/repo/.github/workflows/release.yml
@@ -137,34 +137,25 @@ jobs:
       run: pulumictl create docs-build pulumi-${{ env.PROVIDER }}
         "${GITHUB_REF#refs/tags/}"
   lint:
-    container: golangci/golangci-lint:v1.54.1
     name: lint
     runs-on: ubuntu-latest
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Mark repo as safe directory
-      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER }}/pulumi-${{ env.PROVIDER }}
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
     - name: Install Go
       uses: actions/setup-go@v4
       with:
         cache-dependency-path: |
             sdk/go.sum
         go-version: 1.21.x
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
+    - name: disarm go:embed directives to enable lint
+      run: |
+        git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: golangci-lint
+      uses: golangci/golangci-lint-action@v3
       with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - run: make lint_provider
+        version: v1.54.1
+        working-directory: provider
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3

--- a/provider-ci/providers/hcloud/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/hcloud/repo/.github/workflows/run-acceptance-tests.yml
@@ -153,15 +153,16 @@ jobs:
       uses: actions/checkout@v3
       with:
         ref: ${{ env.PR_COMMIT_SHA }}
-    - name: Install Go
-      uses: actions/setup-go@v4
-      with:
-        cache-dependency-path: |
-            sdk/go.sum
-        go-version: 1.21.x
     - name: disarm go:embed directives to enable lint
       run: |
         git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: Install go
+      uses: actions/setup-go@v4
+      with:
+        # The versions of golangci-lint and setup-go here cross-depend and need to update together.
+        go-version: 1.21
+        # Either this action or golangci-lint needs to disable the cache
+        cache: false
     - name: golangci-lint
       uses: golangci/golangci-lint-action@v3
       with:

--- a/provider-ci/providers/hcloud/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/hcloud/repo/.github/workflows/run-acceptance-tests.yml
@@ -144,7 +144,6 @@ jobs:
         repository: ${{ github.event.client_payload.github.payload.repository.full_name }}
         token: ${{ secrets.PULUMI_BOT_TOKEN }}
   lint:
-    container: golangci/golangci-lint:v1.54.1
     if: github.event_name == 'repository_dispatch' ||
       github.event.pull_request.head.repo.full_name == github.repository
     name: lint
@@ -154,28 +153,20 @@ jobs:
       uses: actions/checkout@v3
       with:
         ref: ${{ env.PR_COMMIT_SHA }}
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Mark repo as safe directory
-      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER }}/pulumi-${{ env.PROVIDER }}
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
     - name: Install Go
       uses: actions/setup-go@v4
       with:
         cache-dependency-path: |
             sdk/go.sum
         go-version: 1.21.x
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
+    - name: disarm go:embed directives to enable lint
+      run: |
+        git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: golangci-lint
+      uses: golangci/golangci-lint-action@v3
       with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - run: make lint_provider
+        version: v1.54.1
+        working-directory: provider
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3

--- a/provider-ci/providers/hcloud/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/hcloud/repo/.github/workflows/run-acceptance-tests.yml
@@ -156,6 +156,9 @@ jobs:
     - name: disarm go:embed directives to enable lint
       run: |
         git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: prepare upstream
+      continue-on-error: true
+      run: make upstream
     - name: Install go
       uses: actions/setup-go@v4
       with:

--- a/provider-ci/providers/kafka/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/kafka/repo/.github/workflows/main.yml
@@ -176,34 +176,25 @@ jobs:
 
         aws s3 cp "${{ env.COVERAGE_OUTPUT_DIR }}/summary.json" "${s3FullURI}" --acl bucket-owner-full-control
   lint:
-    container: golangci/golangci-lint:v1.54.1
     name: lint
     runs-on: ubuntu-latest
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Mark repo as safe directory
-      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER }}/pulumi-${{ env.PROVIDER }}
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
     - name: Install Go
       uses: actions/setup-go@v4
       with:
         cache-dependency-path: |
             sdk/go.sum
         go-version: 1.21.x
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
+    - name: disarm go:embed directives to enable lint
+      run: |
+        git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: golangci-lint
+      uses: golangci/golangci-lint-action@v3
       with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - run: make lint_provider
+        version: v1.54.1
+        working-directory: provider
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3

--- a/provider-ci/providers/kafka/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/kafka/repo/.github/workflows/main.yml
@@ -190,6 +190,9 @@ jobs:
     - name: disarm go:embed directives to enable lint
       run: |
         git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: prepare upstream
+      continue-on-error: true
+      run: make upstream
     - name: golangci-lint
       uses: golangci/golangci-lint-action@v3
       with:

--- a/provider-ci/providers/kafka/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/kafka/repo/.github/workflows/master.yml
@@ -176,34 +176,25 @@ jobs:
 
         aws s3 cp "${{ env.COVERAGE_OUTPUT_DIR }}/summary.json" "${s3FullURI}" --acl bucket-owner-full-control
   lint:
-    container: golangci/golangci-lint:v1.54.1
     name: lint
     runs-on: ubuntu-latest
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Mark repo as safe directory
-      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER }}/pulumi-${{ env.PROVIDER }}
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
     - name: Install Go
       uses: actions/setup-go@v4
       with:
         cache-dependency-path: |
             sdk/go.sum
         go-version: 1.21.x
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
+    - name: disarm go:embed directives to enable lint
+      run: |
+        git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: golangci-lint
+      uses: golangci/golangci-lint-action@v3
       with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - run: make lint_provider
+        version: v1.54.1
+        working-directory: provider
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3

--- a/provider-ci/providers/kafka/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/kafka/repo/.github/workflows/master.yml
@@ -190,6 +190,9 @@ jobs:
     - name: disarm go:embed directives to enable lint
       run: |
         git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: prepare upstream
+      continue-on-error: true
+      run: make upstream
     - name: golangci-lint
       uses: golangci/golangci-lint-action@v3
       with:

--- a/provider-ci/providers/kafka/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/kafka/repo/.github/workflows/prerelease.yml
@@ -123,34 +123,25 @@ jobs:
         - go
         - java
   lint:
-    container: golangci/golangci-lint:v1.54.1
     name: lint
     runs-on: ubuntu-latest
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Mark repo as safe directory
-      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER }}/pulumi-${{ env.PROVIDER }}
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
     - name: Install Go
       uses: actions/setup-go@v4
       with:
         cache-dependency-path: |
             sdk/go.sum
         go-version: 1.21.x
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
+    - name: disarm go:embed directives to enable lint
+      run: |
+        git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: golangci-lint
+      uses: golangci/golangci-lint-action@v3
       with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - run: make lint_provider
+        version: v1.54.1
+        working-directory: provider
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3

--- a/provider-ci/providers/kafka/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/kafka/repo/.github/workflows/prerelease.yml
@@ -137,6 +137,9 @@ jobs:
     - name: disarm go:embed directives to enable lint
       run: |
         git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: prepare upstream
+      continue-on-error: true
+      run: make upstream
     - name: golangci-lint
       uses: golangci/golangci-lint-action@v3
       with:

--- a/provider-ci/providers/kafka/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/kafka/repo/.github/workflows/release.yml
@@ -136,34 +136,25 @@ jobs:
       run: pulumictl create docs-build pulumi-${{ env.PROVIDER }}
         "${GITHUB_REF#refs/tags/}"
   lint:
-    container: golangci/golangci-lint:v1.54.1
     name: lint
     runs-on: ubuntu-latest
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Mark repo as safe directory
-      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER }}/pulumi-${{ env.PROVIDER }}
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
     - name: Install Go
       uses: actions/setup-go@v4
       with:
         cache-dependency-path: |
             sdk/go.sum
         go-version: 1.21.x
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
+    - name: disarm go:embed directives to enable lint
+      run: |
+        git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: golangci-lint
+      uses: golangci/golangci-lint-action@v3
       with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - run: make lint_provider
+        version: v1.54.1
+        working-directory: provider
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3

--- a/provider-ci/providers/kafka/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/kafka/repo/.github/workflows/release.yml
@@ -150,6 +150,9 @@ jobs:
     - name: disarm go:embed directives to enable lint
       run: |
         git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: prepare upstream
+      continue-on-error: true
+      run: make upstream
     - name: golangci-lint
       uses: golangci/golangci-lint-action@v3
       with:

--- a/provider-ci/providers/kafka/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/kafka/repo/.github/workflows/run-acceptance-tests.yml
@@ -143,7 +143,6 @@ jobs:
         repository: ${{ github.event.client_payload.github.payload.repository.full_name }}
         token: ${{ secrets.PULUMI_BOT_TOKEN }}
   lint:
-    container: golangci/golangci-lint:v1.54.1
     if: github.event_name == 'repository_dispatch' ||
       github.event.pull_request.head.repo.full_name == github.repository
     name: lint
@@ -153,28 +152,20 @@ jobs:
       uses: actions/checkout@v3
       with:
         ref: ${{ env.PR_COMMIT_SHA }}
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Mark repo as safe directory
-      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER }}/pulumi-${{ env.PROVIDER }}
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
     - name: Install Go
       uses: actions/setup-go@v4
       with:
         cache-dependency-path: |
             sdk/go.sum
         go-version: 1.21.x
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
+    - name: disarm go:embed directives to enable lint
+      run: |
+        git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: golangci-lint
+      uses: golangci/golangci-lint-action@v3
       with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - run: make lint_provider
+        version: v1.54.1
+        working-directory: provider
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3

--- a/provider-ci/providers/kafka/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/kafka/repo/.github/workflows/run-acceptance-tests.yml
@@ -155,6 +155,9 @@ jobs:
     - name: disarm go:embed directives to enable lint
       run: |
         git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: prepare upstream
+      continue-on-error: true
+      run: make upstream
     - name: Install go
       uses: actions/setup-go@v4
       with:

--- a/provider-ci/providers/kafka/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/kafka/repo/.github/workflows/run-acceptance-tests.yml
@@ -152,15 +152,16 @@ jobs:
       uses: actions/checkout@v3
       with:
         ref: ${{ env.PR_COMMIT_SHA }}
-    - name: Install Go
-      uses: actions/setup-go@v4
-      with:
-        cache-dependency-path: |
-            sdk/go.sum
-        go-version: 1.21.x
     - name: disarm go:embed directives to enable lint
       run: |
         git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: Install go
+      uses: actions/setup-go@v4
+      with:
+        # The versions of golangci-lint and setup-go here cross-depend and need to update together.
+        go-version: 1.21
+        # Either this action or golangci-lint needs to disable the cache
+        cache: false
     - name: golangci-lint
       uses: golangci/golangci-lint-action@v3
       with:

--- a/provider-ci/providers/keycloak/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/keycloak/repo/.github/workflows/main.yml
@@ -181,34 +181,25 @@ jobs:
 
         aws s3 cp "${{ env.COVERAGE_OUTPUT_DIR }}/summary.json" "${s3FullURI}" --acl bucket-owner-full-control
   lint:
-    container: golangci/golangci-lint:v1.54.1
     name: lint
     runs-on: ubuntu-latest
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Mark repo as safe directory
-      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER }}/pulumi-${{ env.PROVIDER }}
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
     - name: Install Go
       uses: actions/setup-go@v4
       with:
         cache-dependency-path: |
             sdk/go.sum
         go-version: 1.21.x
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
+    - name: disarm go:embed directives to enable lint
+      run: |
+        git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: golangci-lint
+      uses: golangci/golangci-lint-action@v3
       with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - run: make lint_provider
+        version: v1.54.1
+        working-directory: provider
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3

--- a/provider-ci/providers/keycloak/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/keycloak/repo/.github/workflows/main.yml
@@ -195,6 +195,9 @@ jobs:
     - name: disarm go:embed directives to enable lint
       run: |
         git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: prepare upstream
+      continue-on-error: true
+      run: make upstream
     - name: golangci-lint
       uses: golangci/golangci-lint-action@v3
       with:

--- a/provider-ci/providers/keycloak/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/keycloak/repo/.github/workflows/master.yml
@@ -181,34 +181,25 @@ jobs:
 
         aws s3 cp "${{ env.COVERAGE_OUTPUT_DIR }}/summary.json" "${s3FullURI}" --acl bucket-owner-full-control
   lint:
-    container: golangci/golangci-lint:v1.54.1
     name: lint
     runs-on: ubuntu-latest
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Mark repo as safe directory
-      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER }}/pulumi-${{ env.PROVIDER }}
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
     - name: Install Go
       uses: actions/setup-go@v4
       with:
         cache-dependency-path: |
             sdk/go.sum
         go-version: 1.21.x
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
+    - name: disarm go:embed directives to enable lint
+      run: |
+        git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: golangci-lint
+      uses: golangci/golangci-lint-action@v3
       with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - run: make lint_provider
+        version: v1.54.1
+        working-directory: provider
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3

--- a/provider-ci/providers/keycloak/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/keycloak/repo/.github/workflows/master.yml
@@ -195,6 +195,9 @@ jobs:
     - name: disarm go:embed directives to enable lint
       run: |
         git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: prepare upstream
+      continue-on-error: true
+      run: make upstream
     - name: golangci-lint
       uses: golangci/golangci-lint-action@v3
       with:

--- a/provider-ci/providers/keycloak/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/keycloak/repo/.github/workflows/prerelease.yml
@@ -142,6 +142,9 @@ jobs:
     - name: disarm go:embed directives to enable lint
       run: |
         git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: prepare upstream
+      continue-on-error: true
+      run: make upstream
     - name: golangci-lint
       uses: golangci/golangci-lint-action@v3
       with:

--- a/provider-ci/providers/keycloak/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/keycloak/repo/.github/workflows/prerelease.yml
@@ -128,34 +128,25 @@ jobs:
         - go
         - java
   lint:
-    container: golangci/golangci-lint:v1.54.1
     name: lint
     runs-on: ubuntu-latest
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Mark repo as safe directory
-      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER }}/pulumi-${{ env.PROVIDER }}
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
     - name: Install Go
       uses: actions/setup-go@v4
       with:
         cache-dependency-path: |
             sdk/go.sum
         go-version: 1.21.x
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
+    - name: disarm go:embed directives to enable lint
+      run: |
+        git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: golangci-lint
+      uses: golangci/golangci-lint-action@v3
       with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - run: make lint_provider
+        version: v1.54.1
+        working-directory: provider
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3

--- a/provider-ci/providers/keycloak/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/keycloak/repo/.github/workflows/release.yml
@@ -155,6 +155,9 @@ jobs:
     - name: disarm go:embed directives to enable lint
       run: |
         git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: prepare upstream
+      continue-on-error: true
+      run: make upstream
     - name: golangci-lint
       uses: golangci/golangci-lint-action@v3
       with:

--- a/provider-ci/providers/keycloak/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/keycloak/repo/.github/workflows/release.yml
@@ -141,34 +141,25 @@ jobs:
       run: pulumictl create docs-build pulumi-${{ env.PROVIDER }}
         "${GITHUB_REF#refs/tags/}"
   lint:
-    container: golangci/golangci-lint:v1.54.1
     name: lint
     runs-on: ubuntu-latest
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Mark repo as safe directory
-      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER }}/pulumi-${{ env.PROVIDER }}
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
     - name: Install Go
       uses: actions/setup-go@v4
       with:
         cache-dependency-path: |
             sdk/go.sum
         go-version: 1.21.x
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
+    - name: disarm go:embed directives to enable lint
+      run: |
+        git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: golangci-lint
+      uses: golangci/golangci-lint-action@v3
       with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - run: make lint_provider
+        version: v1.54.1
+        working-directory: provider
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3

--- a/provider-ci/providers/keycloak/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/keycloak/repo/.github/workflows/run-acceptance-tests.yml
@@ -157,15 +157,16 @@ jobs:
       uses: actions/checkout@v3
       with:
         ref: ${{ env.PR_COMMIT_SHA }}
-    - name: Install Go
-      uses: actions/setup-go@v4
-      with:
-        cache-dependency-path: |
-            sdk/go.sum
-        go-version: 1.21.x
     - name: disarm go:embed directives to enable lint
       run: |
         git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: Install go
+      uses: actions/setup-go@v4
+      with:
+        # The versions of golangci-lint and setup-go here cross-depend and need to update together.
+        go-version: 1.21
+        # Either this action or golangci-lint needs to disable the cache
+        cache: false
     - name: golangci-lint
       uses: golangci/golangci-lint-action@v3
       with:

--- a/provider-ci/providers/keycloak/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/keycloak/repo/.github/workflows/run-acceptance-tests.yml
@@ -160,6 +160,9 @@ jobs:
     - name: disarm go:embed directives to enable lint
       run: |
         git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: prepare upstream
+      continue-on-error: true
+      run: make upstream
     - name: Install go
       uses: actions/setup-go@v4
       with:

--- a/provider-ci/providers/keycloak/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/keycloak/repo/.github/workflows/run-acceptance-tests.yml
@@ -148,7 +148,6 @@ jobs:
         repository: ${{ github.event.client_payload.github.payload.repository.full_name }}
         token: ${{ secrets.PULUMI_BOT_TOKEN }}
   lint:
-    container: golangci/golangci-lint:v1.54.1
     if: github.event_name == 'repository_dispatch' ||
       github.event.pull_request.head.repo.full_name == github.repository
     name: lint
@@ -158,28 +157,20 @@ jobs:
       uses: actions/checkout@v3
       with:
         ref: ${{ env.PR_COMMIT_SHA }}
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Mark repo as safe directory
-      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER }}/pulumi-${{ env.PROVIDER }}
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
     - name: Install Go
       uses: actions/setup-go@v4
       with:
         cache-dependency-path: |
             sdk/go.sum
         go-version: 1.21.x
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
+    - name: disarm go:embed directives to enable lint
+      run: |
+        git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: golangci-lint
+      uses: golangci/golangci-lint-action@v3
       with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - run: make lint_provider
+        version: v1.54.1
+        working-directory: provider
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3

--- a/provider-ci/providers/kong/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/kong/repo/.github/workflows/main.yml
@@ -176,34 +176,25 @@ jobs:
 
         aws s3 cp "${{ env.COVERAGE_OUTPUT_DIR }}/summary.json" "${s3FullURI}" --acl bucket-owner-full-control
   lint:
-    container: golangci/golangci-lint:v1.54.1
     name: lint
     runs-on: ubuntu-latest
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Mark repo as safe directory
-      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER }}/pulumi-${{ env.PROVIDER }}
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
     - name: Install Go
       uses: actions/setup-go@v4
       with:
         cache-dependency-path: |
             sdk/go.sum
         go-version: 1.21.x
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
+    - name: disarm go:embed directives to enable lint
+      run: |
+        git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: golangci-lint
+      uses: golangci/golangci-lint-action@v3
       with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - run: make lint_provider
+        version: v1.54.1
+        working-directory: provider
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3

--- a/provider-ci/providers/kong/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/kong/repo/.github/workflows/main.yml
@@ -190,6 +190,9 @@ jobs:
     - name: disarm go:embed directives to enable lint
       run: |
         git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: prepare upstream
+      continue-on-error: true
+      run: make upstream
     - name: golangci-lint
       uses: golangci/golangci-lint-action@v3
       with:

--- a/provider-ci/providers/kong/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/kong/repo/.github/workflows/master.yml
@@ -176,34 +176,25 @@ jobs:
 
         aws s3 cp "${{ env.COVERAGE_OUTPUT_DIR }}/summary.json" "${s3FullURI}" --acl bucket-owner-full-control
   lint:
-    container: golangci/golangci-lint:v1.54.1
     name: lint
     runs-on: ubuntu-latest
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Mark repo as safe directory
-      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER }}/pulumi-${{ env.PROVIDER }}
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
     - name: Install Go
       uses: actions/setup-go@v4
       with:
         cache-dependency-path: |
             sdk/go.sum
         go-version: 1.21.x
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
+    - name: disarm go:embed directives to enable lint
+      run: |
+        git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: golangci-lint
+      uses: golangci/golangci-lint-action@v3
       with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - run: make lint_provider
+        version: v1.54.1
+        working-directory: provider
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3

--- a/provider-ci/providers/kong/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/kong/repo/.github/workflows/master.yml
@@ -190,6 +190,9 @@ jobs:
     - name: disarm go:embed directives to enable lint
       run: |
         git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: prepare upstream
+      continue-on-error: true
+      run: make upstream
     - name: golangci-lint
       uses: golangci/golangci-lint-action@v3
       with:

--- a/provider-ci/providers/kong/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/kong/repo/.github/workflows/prerelease.yml
@@ -123,34 +123,25 @@ jobs:
         - go
         - java
   lint:
-    container: golangci/golangci-lint:v1.54.1
     name: lint
     runs-on: ubuntu-latest
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Mark repo as safe directory
-      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER }}/pulumi-${{ env.PROVIDER }}
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
     - name: Install Go
       uses: actions/setup-go@v4
       with:
         cache-dependency-path: |
             sdk/go.sum
         go-version: 1.21.x
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
+    - name: disarm go:embed directives to enable lint
+      run: |
+        git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: golangci-lint
+      uses: golangci/golangci-lint-action@v3
       with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - run: make lint_provider
+        version: v1.54.1
+        working-directory: provider
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3

--- a/provider-ci/providers/kong/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/kong/repo/.github/workflows/prerelease.yml
@@ -137,6 +137,9 @@ jobs:
     - name: disarm go:embed directives to enable lint
       run: |
         git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: prepare upstream
+      continue-on-error: true
+      run: make upstream
     - name: golangci-lint
       uses: golangci/golangci-lint-action@v3
       with:

--- a/provider-ci/providers/kong/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/kong/repo/.github/workflows/release.yml
@@ -136,34 +136,25 @@ jobs:
       run: pulumictl create docs-build pulumi-${{ env.PROVIDER }}
         "${GITHUB_REF#refs/tags/}"
   lint:
-    container: golangci/golangci-lint:v1.54.1
     name: lint
     runs-on: ubuntu-latest
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Mark repo as safe directory
-      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER }}/pulumi-${{ env.PROVIDER }}
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
     - name: Install Go
       uses: actions/setup-go@v4
       with:
         cache-dependency-path: |
             sdk/go.sum
         go-version: 1.21.x
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
+    - name: disarm go:embed directives to enable lint
+      run: |
+        git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: golangci-lint
+      uses: golangci/golangci-lint-action@v3
       with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - run: make lint_provider
+        version: v1.54.1
+        working-directory: provider
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3

--- a/provider-ci/providers/kong/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/kong/repo/.github/workflows/release.yml
@@ -150,6 +150,9 @@ jobs:
     - name: disarm go:embed directives to enable lint
       run: |
         git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: prepare upstream
+      continue-on-error: true
+      run: make upstream
     - name: golangci-lint
       uses: golangci/golangci-lint-action@v3
       with:

--- a/provider-ci/providers/kong/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/kong/repo/.github/workflows/run-acceptance-tests.yml
@@ -143,7 +143,6 @@ jobs:
         repository: ${{ github.event.client_payload.github.payload.repository.full_name }}
         token: ${{ secrets.PULUMI_BOT_TOKEN }}
   lint:
-    container: golangci/golangci-lint:v1.54.1
     if: github.event_name == 'repository_dispatch' ||
       github.event.pull_request.head.repo.full_name == github.repository
     name: lint
@@ -153,28 +152,20 @@ jobs:
       uses: actions/checkout@v3
       with:
         ref: ${{ env.PR_COMMIT_SHA }}
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Mark repo as safe directory
-      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER }}/pulumi-${{ env.PROVIDER }}
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
     - name: Install Go
       uses: actions/setup-go@v4
       with:
         cache-dependency-path: |
             sdk/go.sum
         go-version: 1.21.x
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
+    - name: disarm go:embed directives to enable lint
+      run: |
+        git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: golangci-lint
+      uses: golangci/golangci-lint-action@v3
       with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - run: make lint_provider
+        version: v1.54.1
+        working-directory: provider
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3

--- a/provider-ci/providers/kong/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/kong/repo/.github/workflows/run-acceptance-tests.yml
@@ -155,6 +155,9 @@ jobs:
     - name: disarm go:embed directives to enable lint
       run: |
         git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: prepare upstream
+      continue-on-error: true
+      run: make upstream
     - name: Install go
       uses: actions/setup-go@v4
       with:

--- a/provider-ci/providers/kong/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/kong/repo/.github/workflows/run-acceptance-tests.yml
@@ -152,15 +152,16 @@ jobs:
       uses: actions/checkout@v3
       with:
         ref: ${{ env.PR_COMMIT_SHA }}
-    - name: Install Go
-      uses: actions/setup-go@v4
-      with:
-        cache-dependency-path: |
-            sdk/go.sum
-        go-version: 1.21.x
     - name: disarm go:embed directives to enable lint
       run: |
         git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: Install go
+      uses: actions/setup-go@v4
+      with:
+        # The versions of golangci-lint and setup-go here cross-depend and need to update together.
+        go-version: 1.21
+        # Either this action or golangci-lint needs to disable the cache
+        cache: false
     - name: golangci-lint
       uses: golangci/golangci-lint-action@v3
       with:

--- a/provider-ci/providers/libvirt/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/libvirt/repo/.github/workflows/main.yml
@@ -191,6 +191,9 @@ jobs:
     - name: disarm go:embed directives to enable lint
       run: |
         git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: prepare upstream
+      continue-on-error: true
+      run: make upstream
     - name: golangci-lint
       uses: golangci/golangci-lint-action@v3
       with:

--- a/provider-ci/providers/libvirt/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/libvirt/repo/.github/workflows/main.yml
@@ -177,34 +177,25 @@ jobs:
 
         aws s3 cp "${{ env.COVERAGE_OUTPUT_DIR }}/summary.json" "${s3FullURI}" --acl bucket-owner-full-control
   lint:
-    container: golangci/golangci-lint:v1.54.1
     name: lint
     runs-on: ubuntu-latest
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Mark repo as safe directory
-      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER }}/pulumi-${{ env.PROVIDER }}
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
     - name: Install Go
       uses: actions/setup-go@v4
       with:
         cache-dependency-path: |
             sdk/go.sum
         go-version: 1.21.x
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
+    - name: disarm go:embed directives to enable lint
+      run: |
+        git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: golangci-lint
+      uses: golangci/golangci-lint-action@v3
       with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - run: make lint_provider
+        version: v1.54.1
+        working-directory: provider
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3

--- a/provider-ci/providers/libvirt/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/libvirt/repo/.github/workflows/master.yml
@@ -191,6 +191,9 @@ jobs:
     - name: disarm go:embed directives to enable lint
       run: |
         git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: prepare upstream
+      continue-on-error: true
+      run: make upstream
     - name: golangci-lint
       uses: golangci/golangci-lint-action@v3
       with:

--- a/provider-ci/providers/libvirt/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/libvirt/repo/.github/workflows/master.yml
@@ -177,34 +177,25 @@ jobs:
 
         aws s3 cp "${{ env.COVERAGE_OUTPUT_DIR }}/summary.json" "${s3FullURI}" --acl bucket-owner-full-control
   lint:
-    container: golangci/golangci-lint:v1.54.1
     name: lint
     runs-on: ubuntu-latest
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Mark repo as safe directory
-      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER }}/pulumi-${{ env.PROVIDER }}
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
     - name: Install Go
       uses: actions/setup-go@v4
       with:
         cache-dependency-path: |
             sdk/go.sum
         go-version: 1.21.x
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
+    - name: disarm go:embed directives to enable lint
+      run: |
+        git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: golangci-lint
+      uses: golangci/golangci-lint-action@v3
       with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - run: make lint_provider
+        version: v1.54.1
+        working-directory: provider
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3

--- a/provider-ci/providers/libvirt/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/libvirt/repo/.github/workflows/prerelease.yml
@@ -124,34 +124,25 @@ jobs:
         - go
         - java
   lint:
-    container: golangci/golangci-lint:v1.54.1
     name: lint
     runs-on: ubuntu-latest
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Mark repo as safe directory
-      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER }}/pulumi-${{ env.PROVIDER }}
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
     - name: Install Go
       uses: actions/setup-go@v4
       with:
         cache-dependency-path: |
             sdk/go.sum
         go-version: 1.21.x
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
+    - name: disarm go:embed directives to enable lint
+      run: |
+        git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: golangci-lint
+      uses: golangci/golangci-lint-action@v3
       with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - run: make lint_provider
+        version: v1.54.1
+        working-directory: provider
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3

--- a/provider-ci/providers/libvirt/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/libvirt/repo/.github/workflows/prerelease.yml
@@ -138,6 +138,9 @@ jobs:
     - name: disarm go:embed directives to enable lint
       run: |
         git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: prepare upstream
+      continue-on-error: true
+      run: make upstream
     - name: golangci-lint
       uses: golangci/golangci-lint-action@v3
       with:

--- a/provider-ci/providers/libvirt/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/libvirt/repo/.github/workflows/release.yml
@@ -151,6 +151,9 @@ jobs:
     - name: disarm go:embed directives to enable lint
       run: |
         git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: prepare upstream
+      continue-on-error: true
+      run: make upstream
     - name: golangci-lint
       uses: golangci/golangci-lint-action@v3
       with:

--- a/provider-ci/providers/libvirt/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/libvirt/repo/.github/workflows/release.yml
@@ -137,34 +137,25 @@ jobs:
       run: pulumictl create docs-build pulumi-${{ env.PROVIDER }}
         "${GITHUB_REF#refs/tags/}"
   lint:
-    container: golangci/golangci-lint:v1.54.1
     name: lint
     runs-on: ubuntu-latest
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Mark repo as safe directory
-      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER }}/pulumi-${{ env.PROVIDER }}
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
     - name: Install Go
       uses: actions/setup-go@v4
       with:
         cache-dependency-path: |
             sdk/go.sum
         go-version: 1.21.x
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
+    - name: disarm go:embed directives to enable lint
+      run: |
+        git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: golangci-lint
+      uses: golangci/golangci-lint-action@v3
       with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - run: make lint_provider
+        version: v1.54.1
+        working-directory: provider
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3

--- a/provider-ci/providers/libvirt/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/libvirt/repo/.github/workflows/run-acceptance-tests.yml
@@ -153,15 +153,16 @@ jobs:
       uses: actions/checkout@v3
       with:
         ref: ${{ env.PR_COMMIT_SHA }}
-    - name: Install Go
-      uses: actions/setup-go@v4
-      with:
-        cache-dependency-path: |
-            sdk/go.sum
-        go-version: 1.21.x
     - name: disarm go:embed directives to enable lint
       run: |
         git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: Install go
+      uses: actions/setup-go@v4
+      with:
+        # The versions of golangci-lint and setup-go here cross-depend and need to update together.
+        go-version: 1.21
+        # Either this action or golangci-lint needs to disable the cache
+        cache: false
     - name: golangci-lint
       uses: golangci/golangci-lint-action@v3
       with:

--- a/provider-ci/providers/libvirt/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/libvirt/repo/.github/workflows/run-acceptance-tests.yml
@@ -144,7 +144,6 @@ jobs:
         repository: ${{ github.event.client_payload.github.payload.repository.full_name }}
         token: ${{ secrets.PULUMI_BOT_TOKEN }}
   lint:
-    container: golangci/golangci-lint:v1.54.1
     if: github.event_name == 'repository_dispatch' ||
       github.event.pull_request.head.repo.full_name == github.repository
     name: lint
@@ -154,28 +153,20 @@ jobs:
       uses: actions/checkout@v3
       with:
         ref: ${{ env.PR_COMMIT_SHA }}
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Mark repo as safe directory
-      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER }}/pulumi-${{ env.PROVIDER }}
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
     - name: Install Go
       uses: actions/setup-go@v4
       with:
         cache-dependency-path: |
             sdk/go.sum
         go-version: 1.21.x
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
+    - name: disarm go:embed directives to enable lint
+      run: |
+        git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: golangci-lint
+      uses: golangci/golangci-lint-action@v3
       with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - run: make lint_provider
+        version: v1.54.1
+        working-directory: provider
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3

--- a/provider-ci/providers/libvirt/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/libvirt/repo/.github/workflows/run-acceptance-tests.yml
@@ -156,6 +156,9 @@ jobs:
     - name: disarm go:embed directives to enable lint
       run: |
         git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: prepare upstream
+      continue-on-error: true
+      run: make upstream
     - name: Install go
       uses: actions/setup-go@v4
       with:

--- a/provider-ci/providers/linode/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/linode/repo/.github/workflows/main.yml
@@ -191,6 +191,9 @@ jobs:
     - name: disarm go:embed directives to enable lint
       run: |
         git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: prepare upstream
+      continue-on-error: true
+      run: make upstream
     - name: golangci-lint
       uses: golangci/golangci-lint-action@v3
       with:

--- a/provider-ci/providers/linode/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/linode/repo/.github/workflows/main.yml
@@ -177,34 +177,25 @@ jobs:
 
         aws s3 cp "${{ env.COVERAGE_OUTPUT_DIR }}/summary.json" "${s3FullURI}" --acl bucket-owner-full-control
   lint:
-    container: golangci/golangci-lint:v1.54.1
     name: lint
     runs-on: ubuntu-latest
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Mark repo as safe directory
-      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER }}/pulumi-${{ env.PROVIDER }}
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
     - name: Install Go
       uses: actions/setup-go@v4
       with:
         cache-dependency-path: |
             sdk/go.sum
         go-version: 1.21.x
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
+    - name: disarm go:embed directives to enable lint
+      run: |
+        git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: golangci-lint
+      uses: golangci/golangci-lint-action@v3
       with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - run: make lint_provider
+        version: v1.54.1
+        working-directory: provider
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3

--- a/provider-ci/providers/linode/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/linode/repo/.github/workflows/master.yml
@@ -191,6 +191,9 @@ jobs:
     - name: disarm go:embed directives to enable lint
       run: |
         git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: prepare upstream
+      continue-on-error: true
+      run: make upstream
     - name: golangci-lint
       uses: golangci/golangci-lint-action@v3
       with:

--- a/provider-ci/providers/linode/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/linode/repo/.github/workflows/master.yml
@@ -177,34 +177,25 @@ jobs:
 
         aws s3 cp "${{ env.COVERAGE_OUTPUT_DIR }}/summary.json" "${s3FullURI}" --acl bucket-owner-full-control
   lint:
-    container: golangci/golangci-lint:v1.54.1
     name: lint
     runs-on: ubuntu-latest
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Mark repo as safe directory
-      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER }}/pulumi-${{ env.PROVIDER }}
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
     - name: Install Go
       uses: actions/setup-go@v4
       with:
         cache-dependency-path: |
             sdk/go.sum
         go-version: 1.21.x
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
+    - name: disarm go:embed directives to enable lint
+      run: |
+        git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: golangci-lint
+      uses: golangci/golangci-lint-action@v3
       with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - run: make lint_provider
+        version: v1.54.1
+        working-directory: provider
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3

--- a/provider-ci/providers/linode/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/linode/repo/.github/workflows/prerelease.yml
@@ -124,34 +124,25 @@ jobs:
         - go
         - java
   lint:
-    container: golangci/golangci-lint:v1.54.1
     name: lint
     runs-on: ubuntu-latest
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Mark repo as safe directory
-      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER }}/pulumi-${{ env.PROVIDER }}
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
     - name: Install Go
       uses: actions/setup-go@v4
       with:
         cache-dependency-path: |
             sdk/go.sum
         go-version: 1.21.x
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
+    - name: disarm go:embed directives to enable lint
+      run: |
+        git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: golangci-lint
+      uses: golangci/golangci-lint-action@v3
       with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - run: make lint_provider
+        version: v1.54.1
+        working-directory: provider
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3

--- a/provider-ci/providers/linode/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/linode/repo/.github/workflows/prerelease.yml
@@ -138,6 +138,9 @@ jobs:
     - name: disarm go:embed directives to enable lint
       run: |
         git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: prepare upstream
+      continue-on-error: true
+      run: make upstream
     - name: golangci-lint
       uses: golangci/golangci-lint-action@v3
       with:

--- a/provider-ci/providers/linode/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/linode/repo/.github/workflows/release.yml
@@ -151,6 +151,9 @@ jobs:
     - name: disarm go:embed directives to enable lint
       run: |
         git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: prepare upstream
+      continue-on-error: true
+      run: make upstream
     - name: golangci-lint
       uses: golangci/golangci-lint-action@v3
       with:

--- a/provider-ci/providers/linode/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/linode/repo/.github/workflows/release.yml
@@ -137,34 +137,25 @@ jobs:
       run: pulumictl create docs-build pulumi-${{ env.PROVIDER }}
         "${GITHUB_REF#refs/tags/}"
   lint:
-    container: golangci/golangci-lint:v1.54.1
     name: lint
     runs-on: ubuntu-latest
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Mark repo as safe directory
-      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER }}/pulumi-${{ env.PROVIDER }}
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
     - name: Install Go
       uses: actions/setup-go@v4
       with:
         cache-dependency-path: |
             sdk/go.sum
         go-version: 1.21.x
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
+    - name: disarm go:embed directives to enable lint
+      run: |
+        git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: golangci-lint
+      uses: golangci/golangci-lint-action@v3
       with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - run: make lint_provider
+        version: v1.54.1
+        working-directory: provider
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3

--- a/provider-ci/providers/linode/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/linode/repo/.github/workflows/run-acceptance-tests.yml
@@ -153,15 +153,16 @@ jobs:
       uses: actions/checkout@v3
       with:
         ref: ${{ env.PR_COMMIT_SHA }}
-    - name: Install Go
-      uses: actions/setup-go@v4
-      with:
-        cache-dependency-path: |
-            sdk/go.sum
-        go-version: 1.21.x
     - name: disarm go:embed directives to enable lint
       run: |
         git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: Install go
+      uses: actions/setup-go@v4
+      with:
+        # The versions of golangci-lint and setup-go here cross-depend and need to update together.
+        go-version: 1.21
+        # Either this action or golangci-lint needs to disable the cache
+        cache: false
     - name: golangci-lint
       uses: golangci/golangci-lint-action@v3
       with:

--- a/provider-ci/providers/linode/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/linode/repo/.github/workflows/run-acceptance-tests.yml
@@ -144,7 +144,6 @@ jobs:
         repository: ${{ github.event.client_payload.github.payload.repository.full_name }}
         token: ${{ secrets.PULUMI_BOT_TOKEN }}
   lint:
-    container: golangci/golangci-lint:v1.54.1
     if: github.event_name == 'repository_dispatch' ||
       github.event.pull_request.head.repo.full_name == github.repository
     name: lint
@@ -154,28 +153,20 @@ jobs:
       uses: actions/checkout@v3
       with:
         ref: ${{ env.PR_COMMIT_SHA }}
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Mark repo as safe directory
-      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER }}/pulumi-${{ env.PROVIDER }}
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
     - name: Install Go
       uses: actions/setup-go@v4
       with:
         cache-dependency-path: |
             sdk/go.sum
         go-version: 1.21.x
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
+    - name: disarm go:embed directives to enable lint
+      run: |
+        git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: golangci-lint
+      uses: golangci/golangci-lint-action@v3
       with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - run: make lint_provider
+        version: v1.54.1
+        working-directory: provider
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3

--- a/provider-ci/providers/linode/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/linode/repo/.github/workflows/run-acceptance-tests.yml
@@ -156,6 +156,9 @@ jobs:
     - name: disarm go:embed directives to enable lint
       run: |
         git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: prepare upstream
+      continue-on-error: true
+      run: make upstream
     - name: Install go
       uses: actions/setup-go@v4
       with:

--- a/provider-ci/providers/mailgun/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/mailgun/repo/.github/workflows/main.yml
@@ -191,6 +191,9 @@ jobs:
     - name: disarm go:embed directives to enable lint
       run: |
         git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: prepare upstream
+      continue-on-error: true
+      run: make upstream
     - name: golangci-lint
       uses: golangci/golangci-lint-action@v3
       with:

--- a/provider-ci/providers/mailgun/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/mailgun/repo/.github/workflows/main.yml
@@ -177,34 +177,25 @@ jobs:
 
         aws s3 cp "${{ env.COVERAGE_OUTPUT_DIR }}/summary.json" "${s3FullURI}" --acl bucket-owner-full-control
   lint:
-    container: golangci/golangci-lint:v1.54.1
     name: lint
     runs-on: ubuntu-latest
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Mark repo as safe directory
-      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER }}/pulumi-${{ env.PROVIDER }}
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
     - name: Install Go
       uses: actions/setup-go@v4
       with:
         cache-dependency-path: |
             sdk/go.sum
         go-version: 1.21.x
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
+    - name: disarm go:embed directives to enable lint
+      run: |
+        git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: golangci-lint
+      uses: golangci/golangci-lint-action@v3
       with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - run: make lint_provider
+        version: v1.54.1
+        working-directory: provider
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3

--- a/provider-ci/providers/mailgun/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/mailgun/repo/.github/workflows/master.yml
@@ -191,6 +191,9 @@ jobs:
     - name: disarm go:embed directives to enable lint
       run: |
         git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: prepare upstream
+      continue-on-error: true
+      run: make upstream
     - name: golangci-lint
       uses: golangci/golangci-lint-action@v3
       with:

--- a/provider-ci/providers/mailgun/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/mailgun/repo/.github/workflows/master.yml
@@ -177,34 +177,25 @@ jobs:
 
         aws s3 cp "${{ env.COVERAGE_OUTPUT_DIR }}/summary.json" "${s3FullURI}" --acl bucket-owner-full-control
   lint:
-    container: golangci/golangci-lint:v1.54.1
     name: lint
     runs-on: ubuntu-latest
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Mark repo as safe directory
-      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER }}/pulumi-${{ env.PROVIDER }}
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
     - name: Install Go
       uses: actions/setup-go@v4
       with:
         cache-dependency-path: |
             sdk/go.sum
         go-version: 1.21.x
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
+    - name: disarm go:embed directives to enable lint
+      run: |
+        git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: golangci-lint
+      uses: golangci/golangci-lint-action@v3
       with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - run: make lint_provider
+        version: v1.54.1
+        working-directory: provider
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3

--- a/provider-ci/providers/mailgun/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/mailgun/repo/.github/workflows/prerelease.yml
@@ -124,34 +124,25 @@ jobs:
         - go
         - java
   lint:
-    container: golangci/golangci-lint:v1.54.1
     name: lint
     runs-on: ubuntu-latest
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Mark repo as safe directory
-      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER }}/pulumi-${{ env.PROVIDER }}
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
     - name: Install Go
       uses: actions/setup-go@v4
       with:
         cache-dependency-path: |
             sdk/go.sum
         go-version: 1.21.x
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
+    - name: disarm go:embed directives to enable lint
+      run: |
+        git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: golangci-lint
+      uses: golangci/golangci-lint-action@v3
       with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - run: make lint_provider
+        version: v1.54.1
+        working-directory: provider
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3

--- a/provider-ci/providers/mailgun/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/mailgun/repo/.github/workflows/prerelease.yml
@@ -138,6 +138,9 @@ jobs:
     - name: disarm go:embed directives to enable lint
       run: |
         git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: prepare upstream
+      continue-on-error: true
+      run: make upstream
     - name: golangci-lint
       uses: golangci/golangci-lint-action@v3
       with:

--- a/provider-ci/providers/mailgun/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/mailgun/repo/.github/workflows/release.yml
@@ -151,6 +151,9 @@ jobs:
     - name: disarm go:embed directives to enable lint
       run: |
         git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: prepare upstream
+      continue-on-error: true
+      run: make upstream
     - name: golangci-lint
       uses: golangci/golangci-lint-action@v3
       with:

--- a/provider-ci/providers/mailgun/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/mailgun/repo/.github/workflows/release.yml
@@ -137,34 +137,25 @@ jobs:
       run: pulumictl create docs-build pulumi-${{ env.PROVIDER }}
         "${GITHUB_REF#refs/tags/}"
   lint:
-    container: golangci/golangci-lint:v1.54.1
     name: lint
     runs-on: ubuntu-latest
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Mark repo as safe directory
-      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER }}/pulumi-${{ env.PROVIDER }}
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
     - name: Install Go
       uses: actions/setup-go@v4
       with:
         cache-dependency-path: |
             sdk/go.sum
         go-version: 1.21.x
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
+    - name: disarm go:embed directives to enable lint
+      run: |
+        git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: golangci-lint
+      uses: golangci/golangci-lint-action@v3
       with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - run: make lint_provider
+        version: v1.54.1
+        working-directory: provider
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3

--- a/provider-ci/providers/mailgun/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/mailgun/repo/.github/workflows/run-acceptance-tests.yml
@@ -153,15 +153,16 @@ jobs:
       uses: actions/checkout@v3
       with:
         ref: ${{ env.PR_COMMIT_SHA }}
-    - name: Install Go
-      uses: actions/setup-go@v4
-      with:
-        cache-dependency-path: |
-            sdk/go.sum
-        go-version: 1.21.x
     - name: disarm go:embed directives to enable lint
       run: |
         git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: Install go
+      uses: actions/setup-go@v4
+      with:
+        # The versions of golangci-lint and setup-go here cross-depend and need to update together.
+        go-version: 1.21
+        # Either this action or golangci-lint needs to disable the cache
+        cache: false
     - name: golangci-lint
       uses: golangci/golangci-lint-action@v3
       with:

--- a/provider-ci/providers/mailgun/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/mailgun/repo/.github/workflows/run-acceptance-tests.yml
@@ -144,7 +144,6 @@ jobs:
         repository: ${{ github.event.client_payload.github.payload.repository.full_name }}
         token: ${{ secrets.PULUMI_BOT_TOKEN }}
   lint:
-    container: golangci/golangci-lint:v1.54.1
     if: github.event_name == 'repository_dispatch' ||
       github.event.pull_request.head.repo.full_name == github.repository
     name: lint
@@ -154,28 +153,20 @@ jobs:
       uses: actions/checkout@v3
       with:
         ref: ${{ env.PR_COMMIT_SHA }}
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Mark repo as safe directory
-      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER }}/pulumi-${{ env.PROVIDER }}
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
     - name: Install Go
       uses: actions/setup-go@v4
       with:
         cache-dependency-path: |
             sdk/go.sum
         go-version: 1.21.x
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
+    - name: disarm go:embed directives to enable lint
+      run: |
+        git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: golangci-lint
+      uses: golangci/golangci-lint-action@v3
       with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - run: make lint_provider
+        version: v1.54.1
+        working-directory: provider
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3

--- a/provider-ci/providers/mailgun/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/mailgun/repo/.github/workflows/run-acceptance-tests.yml
@@ -156,6 +156,9 @@ jobs:
     - name: disarm go:embed directives to enable lint
       run: |
         git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: prepare upstream
+      continue-on-error: true
+      run: make upstream
     - name: Install go
       uses: actions/setup-go@v4
       with:

--- a/provider-ci/providers/minio/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/minio/repo/.github/workflows/main.yml
@@ -194,6 +194,9 @@ jobs:
     - name: disarm go:embed directives to enable lint
       run: |
         git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: prepare upstream
+      continue-on-error: true
+      run: make upstream
     - name: golangci-lint
       uses: golangci/golangci-lint-action@v3
       with:

--- a/provider-ci/providers/minio/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/minio/repo/.github/workflows/main.yml
@@ -180,34 +180,25 @@ jobs:
 
         aws s3 cp "${{ env.COVERAGE_OUTPUT_DIR }}/summary.json" "${s3FullURI}" --acl bucket-owner-full-control
   lint:
-    container: golangci/golangci-lint:v1.54.1
     name: lint
     runs-on: ubuntu-latest
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Mark repo as safe directory
-      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER }}/pulumi-${{ env.PROVIDER }}
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
     - name: Install Go
       uses: actions/setup-go@v4
       with:
         cache-dependency-path: |
             sdk/go.sum
         go-version: 1.21.x
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
+    - name: disarm go:embed directives to enable lint
+      run: |
+        git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: golangci-lint
+      uses: golangci/golangci-lint-action@v3
       with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - run: make lint_provider
+        version: v1.54.1
+        working-directory: provider
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3

--- a/provider-ci/providers/minio/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/minio/repo/.github/workflows/master.yml
@@ -194,6 +194,9 @@ jobs:
     - name: disarm go:embed directives to enable lint
       run: |
         git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: prepare upstream
+      continue-on-error: true
+      run: make upstream
     - name: golangci-lint
       uses: golangci/golangci-lint-action@v3
       with:

--- a/provider-ci/providers/minio/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/minio/repo/.github/workflows/master.yml
@@ -180,34 +180,25 @@ jobs:
 
         aws s3 cp "${{ env.COVERAGE_OUTPUT_DIR }}/summary.json" "${s3FullURI}" --acl bucket-owner-full-control
   lint:
-    container: golangci/golangci-lint:v1.54.1
     name: lint
     runs-on: ubuntu-latest
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Mark repo as safe directory
-      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER }}/pulumi-${{ env.PROVIDER }}
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
     - name: Install Go
       uses: actions/setup-go@v4
       with:
         cache-dependency-path: |
             sdk/go.sum
         go-version: 1.21.x
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
+    - name: disarm go:embed directives to enable lint
+      run: |
+        git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: golangci-lint
+      uses: golangci/golangci-lint-action@v3
       with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - run: make lint_provider
+        version: v1.54.1
+        working-directory: provider
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3

--- a/provider-ci/providers/minio/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/minio/repo/.github/workflows/prerelease.yml
@@ -127,34 +127,25 @@ jobs:
         - go
         - java
   lint:
-    container: golangci/golangci-lint:v1.54.1
     name: lint
     runs-on: ubuntu-latest
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Mark repo as safe directory
-      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER }}/pulumi-${{ env.PROVIDER }}
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
     - name: Install Go
       uses: actions/setup-go@v4
       with:
         cache-dependency-path: |
             sdk/go.sum
         go-version: 1.21.x
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
+    - name: disarm go:embed directives to enable lint
+      run: |
+        git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: golangci-lint
+      uses: golangci/golangci-lint-action@v3
       with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - run: make lint_provider
+        version: v1.54.1
+        working-directory: provider
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3

--- a/provider-ci/providers/minio/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/minio/repo/.github/workflows/prerelease.yml
@@ -141,6 +141,9 @@ jobs:
     - name: disarm go:embed directives to enable lint
       run: |
         git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: prepare upstream
+      continue-on-error: true
+      run: make upstream
     - name: golangci-lint
       uses: golangci/golangci-lint-action@v3
       with:

--- a/provider-ci/providers/minio/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/minio/repo/.github/workflows/release.yml
@@ -140,34 +140,25 @@ jobs:
       run: pulumictl create docs-build pulumi-${{ env.PROVIDER }}
         "${GITHUB_REF#refs/tags/}"
   lint:
-    container: golangci/golangci-lint:v1.54.1
     name: lint
     runs-on: ubuntu-latest
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Mark repo as safe directory
-      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER }}/pulumi-${{ env.PROVIDER }}
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
     - name: Install Go
       uses: actions/setup-go@v4
       with:
         cache-dependency-path: |
             sdk/go.sum
         go-version: 1.21.x
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
+    - name: disarm go:embed directives to enable lint
+      run: |
+        git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: golangci-lint
+      uses: golangci/golangci-lint-action@v3
       with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - run: make lint_provider
+        version: v1.54.1
+        working-directory: provider
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3

--- a/provider-ci/providers/minio/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/minio/repo/.github/workflows/release.yml
@@ -154,6 +154,9 @@ jobs:
     - name: disarm go:embed directives to enable lint
       run: |
         git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: prepare upstream
+      continue-on-error: true
+      run: make upstream
     - name: golangci-lint
       uses: golangci/golangci-lint-action@v3
       with:

--- a/provider-ci/providers/minio/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/minio/repo/.github/workflows/run-acceptance-tests.yml
@@ -159,6 +159,9 @@ jobs:
     - name: disarm go:embed directives to enable lint
       run: |
         git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: prepare upstream
+      continue-on-error: true
+      run: make upstream
     - name: Install go
       uses: actions/setup-go@v4
       with:

--- a/provider-ci/providers/minio/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/minio/repo/.github/workflows/run-acceptance-tests.yml
@@ -147,7 +147,6 @@ jobs:
         repository: ${{ github.event.client_payload.github.payload.repository.full_name }}
         token: ${{ secrets.PULUMI_BOT_TOKEN }}
   lint:
-    container: golangci/golangci-lint:v1.54.1
     if: github.event_name == 'repository_dispatch' ||
       github.event.pull_request.head.repo.full_name == github.repository
     name: lint
@@ -157,28 +156,20 @@ jobs:
       uses: actions/checkout@v3
       with:
         ref: ${{ env.PR_COMMIT_SHA }}
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Mark repo as safe directory
-      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER }}/pulumi-${{ env.PROVIDER }}
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
     - name: Install Go
       uses: actions/setup-go@v4
       with:
         cache-dependency-path: |
             sdk/go.sum
         go-version: 1.21.x
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
+    - name: disarm go:embed directives to enable lint
+      run: |
+        git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: golangci-lint
+      uses: golangci/golangci-lint-action@v3
       with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - run: make lint_provider
+        version: v1.54.1
+        working-directory: provider
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3

--- a/provider-ci/providers/minio/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/minio/repo/.github/workflows/run-acceptance-tests.yml
@@ -156,15 +156,16 @@ jobs:
       uses: actions/checkout@v3
       with:
         ref: ${{ env.PR_COMMIT_SHA }}
-    - name: Install Go
-      uses: actions/setup-go@v4
-      with:
-        cache-dependency-path: |
-            sdk/go.sum
-        go-version: 1.21.x
     - name: disarm go:embed directives to enable lint
       run: |
         git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: Install go
+      uses: actions/setup-go@v4
+      with:
+        # The versions of golangci-lint and setup-go here cross-depend and need to update together.
+        go-version: 1.21
+        # Either this action or golangci-lint needs to disable the cache
+        cache: false
     - name: golangci-lint
       uses: golangci/golangci-lint-action@v3
       with:

--- a/provider-ci/providers/mongodbatlas/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/mongodbatlas/repo/.github/workflows/main.yml
@@ -179,34 +179,25 @@ jobs:
 
         aws s3 cp "${{ env.COVERAGE_OUTPUT_DIR }}/summary.json" "${s3FullURI}" --acl bucket-owner-full-control
   lint:
-    container: golangci/golangci-lint:v1.54.1
     name: lint
     runs-on: ubuntu-latest
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Mark repo as safe directory
-      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER }}/pulumi-${{ env.PROVIDER }}
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
     - name: Install Go
       uses: actions/setup-go@v4
       with:
         cache-dependency-path: |
             sdk/go.sum
         go-version: 1.21.x
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
+    - name: disarm go:embed directives to enable lint
+      run: |
+        git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: golangci-lint
+      uses: golangci/golangci-lint-action@v3
       with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - run: make lint_provider
+        version: v1.54.1
+        working-directory: provider
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3

--- a/provider-ci/providers/mongodbatlas/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/mongodbatlas/repo/.github/workflows/main.yml
@@ -193,6 +193,9 @@ jobs:
     - name: disarm go:embed directives to enable lint
       run: |
         git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: prepare upstream
+      continue-on-error: true
+      run: make upstream
     - name: golangci-lint
       uses: golangci/golangci-lint-action@v3
       with:

--- a/provider-ci/providers/mongodbatlas/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/mongodbatlas/repo/.github/workflows/master.yml
@@ -179,34 +179,25 @@ jobs:
 
         aws s3 cp "${{ env.COVERAGE_OUTPUT_DIR }}/summary.json" "${s3FullURI}" --acl bucket-owner-full-control
   lint:
-    container: golangci/golangci-lint:v1.54.1
     name: lint
     runs-on: ubuntu-latest
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Mark repo as safe directory
-      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER }}/pulumi-${{ env.PROVIDER }}
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
     - name: Install Go
       uses: actions/setup-go@v4
       with:
         cache-dependency-path: |
             sdk/go.sum
         go-version: 1.21.x
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
+    - name: disarm go:embed directives to enable lint
+      run: |
+        git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: golangci-lint
+      uses: golangci/golangci-lint-action@v3
       with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - run: make lint_provider
+        version: v1.54.1
+        working-directory: provider
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3

--- a/provider-ci/providers/mongodbatlas/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/mongodbatlas/repo/.github/workflows/master.yml
@@ -193,6 +193,9 @@ jobs:
     - name: disarm go:embed directives to enable lint
       run: |
         git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: prepare upstream
+      continue-on-error: true
+      run: make upstream
     - name: golangci-lint
       uses: golangci/golangci-lint-action@v3
       with:

--- a/provider-ci/providers/mongodbatlas/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/mongodbatlas/repo/.github/workflows/prerelease.yml
@@ -140,6 +140,9 @@ jobs:
     - name: disarm go:embed directives to enable lint
       run: |
         git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: prepare upstream
+      continue-on-error: true
+      run: make upstream
     - name: golangci-lint
       uses: golangci/golangci-lint-action@v3
       with:

--- a/provider-ci/providers/mongodbatlas/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/mongodbatlas/repo/.github/workflows/prerelease.yml
@@ -126,34 +126,25 @@ jobs:
         - go
         - java
   lint:
-    container: golangci/golangci-lint:v1.54.1
     name: lint
     runs-on: ubuntu-latest
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Mark repo as safe directory
-      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER }}/pulumi-${{ env.PROVIDER }}
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
     - name: Install Go
       uses: actions/setup-go@v4
       with:
         cache-dependency-path: |
             sdk/go.sum
         go-version: 1.21.x
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
+    - name: disarm go:embed directives to enable lint
+      run: |
+        git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: golangci-lint
+      uses: golangci/golangci-lint-action@v3
       with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - run: make lint_provider
+        version: v1.54.1
+        working-directory: provider
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3

--- a/provider-ci/providers/mongodbatlas/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/mongodbatlas/repo/.github/workflows/release.yml
@@ -153,6 +153,9 @@ jobs:
     - name: disarm go:embed directives to enable lint
       run: |
         git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: prepare upstream
+      continue-on-error: true
+      run: make upstream
     - name: golangci-lint
       uses: golangci/golangci-lint-action@v3
       with:

--- a/provider-ci/providers/mongodbatlas/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/mongodbatlas/repo/.github/workflows/release.yml
@@ -139,34 +139,25 @@ jobs:
       run: pulumictl create docs-build pulumi-${{ env.PROVIDER }}
         "${GITHUB_REF#refs/tags/}"
   lint:
-    container: golangci/golangci-lint:v1.54.1
     name: lint
     runs-on: ubuntu-latest
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Mark repo as safe directory
-      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER }}/pulumi-${{ env.PROVIDER }}
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
     - name: Install Go
       uses: actions/setup-go@v4
       with:
         cache-dependency-path: |
             sdk/go.sum
         go-version: 1.21.x
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
+    - name: disarm go:embed directives to enable lint
+      run: |
+        git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: golangci-lint
+      uses: golangci/golangci-lint-action@v3
       with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - run: make lint_provider
+        version: v1.54.1
+        working-directory: provider
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3

--- a/provider-ci/providers/mongodbatlas/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/mongodbatlas/repo/.github/workflows/run-acceptance-tests.yml
@@ -146,7 +146,6 @@ jobs:
         repository: ${{ github.event.client_payload.github.payload.repository.full_name }}
         token: ${{ secrets.PULUMI_BOT_TOKEN }}
   lint:
-    container: golangci/golangci-lint:v1.54.1
     if: github.event_name == 'repository_dispatch' ||
       github.event.pull_request.head.repo.full_name == github.repository
     name: lint
@@ -156,28 +155,20 @@ jobs:
       uses: actions/checkout@v3
       with:
         ref: ${{ env.PR_COMMIT_SHA }}
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Mark repo as safe directory
-      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER }}/pulumi-${{ env.PROVIDER }}
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
     - name: Install Go
       uses: actions/setup-go@v4
       with:
         cache-dependency-path: |
             sdk/go.sum
         go-version: 1.21.x
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
+    - name: disarm go:embed directives to enable lint
+      run: |
+        git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: golangci-lint
+      uses: golangci/golangci-lint-action@v3
       with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - run: make lint_provider
+        version: v1.54.1
+        working-directory: provider
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3

--- a/provider-ci/providers/mongodbatlas/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/mongodbatlas/repo/.github/workflows/run-acceptance-tests.yml
@@ -158,6 +158,9 @@ jobs:
     - name: disarm go:embed directives to enable lint
       run: |
         git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: prepare upstream
+      continue-on-error: true
+      run: make upstream
     - name: Install go
       uses: actions/setup-go@v4
       with:

--- a/provider-ci/providers/mongodbatlas/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/mongodbatlas/repo/.github/workflows/run-acceptance-tests.yml
@@ -155,15 +155,16 @@ jobs:
       uses: actions/checkout@v3
       with:
         ref: ${{ env.PR_COMMIT_SHA }}
-    - name: Install Go
-      uses: actions/setup-go@v4
-      with:
-        cache-dependency-path: |
-            sdk/go.sum
-        go-version: 1.21.x
     - name: disarm go:embed directives to enable lint
       run: |
         git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: Install go
+      uses: actions/setup-go@v4
+      with:
+        # The versions of golangci-lint and setup-go here cross-depend and need to update together.
+        go-version: 1.21
+        # Either this action or golangci-lint needs to disable the cache
+        cache: false
     - name: golangci-lint
       uses: golangci/golangci-lint-action@v3
       with:

--- a/provider-ci/providers/mysql/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/mysql/repo/.github/workflows/main.yml
@@ -176,34 +176,25 @@ jobs:
 
         aws s3 cp "${{ env.COVERAGE_OUTPUT_DIR }}/summary.json" "${s3FullURI}" --acl bucket-owner-full-control
   lint:
-    container: golangci/golangci-lint:v1.54.1
     name: lint
     runs-on: ubuntu-latest
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Mark repo as safe directory
-      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER }}/pulumi-${{ env.PROVIDER }}
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
     - name: Install Go
       uses: actions/setup-go@v4
       with:
         cache-dependency-path: |
             sdk/go.sum
         go-version: 1.21.x
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
+    - name: disarm go:embed directives to enable lint
+      run: |
+        git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: golangci-lint
+      uses: golangci/golangci-lint-action@v3
       with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - run: make lint_provider
+        version: v1.54.1
+        working-directory: provider
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3

--- a/provider-ci/providers/mysql/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/mysql/repo/.github/workflows/main.yml
@@ -190,6 +190,9 @@ jobs:
     - name: disarm go:embed directives to enable lint
       run: |
         git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: prepare upstream
+      continue-on-error: true
+      run: make upstream
     - name: golangci-lint
       uses: golangci/golangci-lint-action@v3
       with:

--- a/provider-ci/providers/mysql/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/mysql/repo/.github/workflows/master.yml
@@ -176,34 +176,25 @@ jobs:
 
         aws s3 cp "${{ env.COVERAGE_OUTPUT_DIR }}/summary.json" "${s3FullURI}" --acl bucket-owner-full-control
   lint:
-    container: golangci/golangci-lint:v1.54.1
     name: lint
     runs-on: ubuntu-latest
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Mark repo as safe directory
-      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER }}/pulumi-${{ env.PROVIDER }}
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
     - name: Install Go
       uses: actions/setup-go@v4
       with:
         cache-dependency-path: |
             sdk/go.sum
         go-version: 1.21.x
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
+    - name: disarm go:embed directives to enable lint
+      run: |
+        git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: golangci-lint
+      uses: golangci/golangci-lint-action@v3
       with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - run: make lint_provider
+        version: v1.54.1
+        working-directory: provider
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3

--- a/provider-ci/providers/mysql/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/mysql/repo/.github/workflows/master.yml
@@ -190,6 +190,9 @@ jobs:
     - name: disarm go:embed directives to enable lint
       run: |
         git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: prepare upstream
+      continue-on-error: true
+      run: make upstream
     - name: golangci-lint
       uses: golangci/golangci-lint-action@v3
       with:

--- a/provider-ci/providers/mysql/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/mysql/repo/.github/workflows/prerelease.yml
@@ -123,34 +123,25 @@ jobs:
         - go
         - java
   lint:
-    container: golangci/golangci-lint:v1.54.1
     name: lint
     runs-on: ubuntu-latest
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Mark repo as safe directory
-      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER }}/pulumi-${{ env.PROVIDER }}
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
     - name: Install Go
       uses: actions/setup-go@v4
       with:
         cache-dependency-path: |
             sdk/go.sum
         go-version: 1.21.x
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
+    - name: disarm go:embed directives to enable lint
+      run: |
+        git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: golangci-lint
+      uses: golangci/golangci-lint-action@v3
       with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - run: make lint_provider
+        version: v1.54.1
+        working-directory: provider
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3

--- a/provider-ci/providers/mysql/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/mysql/repo/.github/workflows/prerelease.yml
@@ -137,6 +137,9 @@ jobs:
     - name: disarm go:embed directives to enable lint
       run: |
         git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: prepare upstream
+      continue-on-error: true
+      run: make upstream
     - name: golangci-lint
       uses: golangci/golangci-lint-action@v3
       with:

--- a/provider-ci/providers/mysql/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/mysql/repo/.github/workflows/release.yml
@@ -136,34 +136,25 @@ jobs:
       run: pulumictl create docs-build pulumi-${{ env.PROVIDER }}
         "${GITHUB_REF#refs/tags/}"
   lint:
-    container: golangci/golangci-lint:v1.54.1
     name: lint
     runs-on: ubuntu-latest
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Mark repo as safe directory
-      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER }}/pulumi-${{ env.PROVIDER }}
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
     - name: Install Go
       uses: actions/setup-go@v4
       with:
         cache-dependency-path: |
             sdk/go.sum
         go-version: 1.21.x
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
+    - name: disarm go:embed directives to enable lint
+      run: |
+        git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: golangci-lint
+      uses: golangci/golangci-lint-action@v3
       with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - run: make lint_provider
+        version: v1.54.1
+        working-directory: provider
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3

--- a/provider-ci/providers/mysql/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/mysql/repo/.github/workflows/release.yml
@@ -150,6 +150,9 @@ jobs:
     - name: disarm go:embed directives to enable lint
       run: |
         git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: prepare upstream
+      continue-on-error: true
+      run: make upstream
     - name: golangci-lint
       uses: golangci/golangci-lint-action@v3
       with:

--- a/provider-ci/providers/mysql/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/mysql/repo/.github/workflows/run-acceptance-tests.yml
@@ -143,7 +143,6 @@ jobs:
         repository: ${{ github.event.client_payload.github.payload.repository.full_name }}
         token: ${{ secrets.PULUMI_BOT_TOKEN }}
   lint:
-    container: golangci/golangci-lint:v1.54.1
     if: github.event_name == 'repository_dispatch' ||
       github.event.pull_request.head.repo.full_name == github.repository
     name: lint
@@ -153,28 +152,20 @@ jobs:
       uses: actions/checkout@v3
       with:
         ref: ${{ env.PR_COMMIT_SHA }}
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Mark repo as safe directory
-      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER }}/pulumi-${{ env.PROVIDER }}
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
     - name: Install Go
       uses: actions/setup-go@v4
       with:
         cache-dependency-path: |
             sdk/go.sum
         go-version: 1.21.x
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
+    - name: disarm go:embed directives to enable lint
+      run: |
+        git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: golangci-lint
+      uses: golangci/golangci-lint-action@v3
       with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - run: make lint_provider
+        version: v1.54.1
+        working-directory: provider
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3

--- a/provider-ci/providers/mysql/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/mysql/repo/.github/workflows/run-acceptance-tests.yml
@@ -155,6 +155,9 @@ jobs:
     - name: disarm go:embed directives to enable lint
       run: |
         git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: prepare upstream
+      continue-on-error: true
+      run: make upstream
     - name: Install go
       uses: actions/setup-go@v4
       with:

--- a/provider-ci/providers/mysql/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/mysql/repo/.github/workflows/run-acceptance-tests.yml
@@ -152,15 +152,16 @@ jobs:
       uses: actions/checkout@v3
       with:
         ref: ${{ env.PR_COMMIT_SHA }}
-    - name: Install Go
-      uses: actions/setup-go@v4
-      with:
-        cache-dependency-path: |
-            sdk/go.sum
-        go-version: 1.21.x
     - name: disarm go:embed directives to enable lint
       run: |
         git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: Install go
+      uses: actions/setup-go@v4
+      with:
+        # The versions of golangci-lint and setup-go here cross-depend and need to update together.
+        go-version: 1.21
+        # Either this action or golangci-lint needs to disable the cache
+        cache: false
     - name: golangci-lint
       uses: golangci/golangci-lint-action@v3
       with:

--- a/provider-ci/providers/newrelic/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/newrelic/repo/.github/workflows/main.yml
@@ -178,34 +178,25 @@ jobs:
 
         aws s3 cp "${{ env.COVERAGE_OUTPUT_DIR }}/summary.json" "${s3FullURI}" --acl bucket-owner-full-control
   lint:
-    container: golangci/golangci-lint:v1.54.1
     name: lint
     runs-on: ubuntu-latest
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Mark repo as safe directory
-      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER }}/pulumi-${{ env.PROVIDER }}
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
     - name: Install Go
       uses: actions/setup-go@v4
       with:
         cache-dependency-path: |
             sdk/go.sum
         go-version: 1.21.x
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
+    - name: disarm go:embed directives to enable lint
+      run: |
+        git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: golangci-lint
+      uses: golangci/golangci-lint-action@v3
       with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - run: make lint_provider
+        version: v1.54.1
+        working-directory: provider
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3

--- a/provider-ci/providers/newrelic/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/newrelic/repo/.github/workflows/main.yml
@@ -192,6 +192,9 @@ jobs:
     - name: disarm go:embed directives to enable lint
       run: |
         git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: prepare upstream
+      continue-on-error: true
+      run: make upstream
     - name: golangci-lint
       uses: golangci/golangci-lint-action@v3
       with:

--- a/provider-ci/providers/newrelic/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/newrelic/repo/.github/workflows/master.yml
@@ -178,34 +178,25 @@ jobs:
 
         aws s3 cp "${{ env.COVERAGE_OUTPUT_DIR }}/summary.json" "${s3FullURI}" --acl bucket-owner-full-control
   lint:
-    container: golangci/golangci-lint:v1.54.1
     name: lint
     runs-on: ubuntu-latest
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Mark repo as safe directory
-      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER }}/pulumi-${{ env.PROVIDER }}
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
     - name: Install Go
       uses: actions/setup-go@v4
       with:
         cache-dependency-path: |
             sdk/go.sum
         go-version: 1.21.x
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
+    - name: disarm go:embed directives to enable lint
+      run: |
+        git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: golangci-lint
+      uses: golangci/golangci-lint-action@v3
       with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - run: make lint_provider
+        version: v1.54.1
+        working-directory: provider
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3

--- a/provider-ci/providers/newrelic/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/newrelic/repo/.github/workflows/master.yml
@@ -192,6 +192,9 @@ jobs:
     - name: disarm go:embed directives to enable lint
       run: |
         git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: prepare upstream
+      continue-on-error: true
+      run: make upstream
     - name: golangci-lint
       uses: golangci/golangci-lint-action@v3
       with:

--- a/provider-ci/providers/newrelic/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/newrelic/repo/.github/workflows/prerelease.yml
@@ -125,34 +125,25 @@ jobs:
         - go
         - java
   lint:
-    container: golangci/golangci-lint:v1.54.1
     name: lint
     runs-on: ubuntu-latest
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Mark repo as safe directory
-      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER }}/pulumi-${{ env.PROVIDER }}
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
     - name: Install Go
       uses: actions/setup-go@v4
       with:
         cache-dependency-path: |
             sdk/go.sum
         go-version: 1.21.x
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
+    - name: disarm go:embed directives to enable lint
+      run: |
+        git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: golangci-lint
+      uses: golangci/golangci-lint-action@v3
       with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - run: make lint_provider
+        version: v1.54.1
+        working-directory: provider
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3

--- a/provider-ci/providers/newrelic/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/newrelic/repo/.github/workflows/prerelease.yml
@@ -139,6 +139,9 @@ jobs:
     - name: disarm go:embed directives to enable lint
       run: |
         git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: prepare upstream
+      continue-on-error: true
+      run: make upstream
     - name: golangci-lint
       uses: golangci/golangci-lint-action@v3
       with:

--- a/provider-ci/providers/newrelic/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/newrelic/repo/.github/workflows/release.yml
@@ -152,6 +152,9 @@ jobs:
     - name: disarm go:embed directives to enable lint
       run: |
         git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: prepare upstream
+      continue-on-error: true
+      run: make upstream
     - name: golangci-lint
       uses: golangci/golangci-lint-action@v3
       with:

--- a/provider-ci/providers/newrelic/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/newrelic/repo/.github/workflows/release.yml
@@ -138,34 +138,25 @@ jobs:
       run: pulumictl create docs-build pulumi-${{ env.PROVIDER }}
         "${GITHUB_REF#refs/tags/}"
   lint:
-    container: golangci/golangci-lint:v1.54.1
     name: lint
     runs-on: ubuntu-latest
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Mark repo as safe directory
-      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER }}/pulumi-${{ env.PROVIDER }}
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
     - name: Install Go
       uses: actions/setup-go@v4
       with:
         cache-dependency-path: |
             sdk/go.sum
         go-version: 1.21.x
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
+    - name: disarm go:embed directives to enable lint
+      run: |
+        git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: golangci-lint
+      uses: golangci/golangci-lint-action@v3
       with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - run: make lint_provider
+        version: v1.54.1
+        working-directory: provider
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3

--- a/provider-ci/providers/newrelic/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/newrelic/repo/.github/workflows/run-acceptance-tests.yml
@@ -157,6 +157,9 @@ jobs:
     - name: disarm go:embed directives to enable lint
       run: |
         git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: prepare upstream
+      continue-on-error: true
+      run: make upstream
     - name: Install go
       uses: actions/setup-go@v4
       with:

--- a/provider-ci/providers/newrelic/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/newrelic/repo/.github/workflows/run-acceptance-tests.yml
@@ -145,7 +145,6 @@ jobs:
         repository: ${{ github.event.client_payload.github.payload.repository.full_name }}
         token: ${{ secrets.PULUMI_BOT_TOKEN }}
   lint:
-    container: golangci/golangci-lint:v1.54.1
     if: github.event_name == 'repository_dispatch' ||
       github.event.pull_request.head.repo.full_name == github.repository
     name: lint
@@ -155,28 +154,20 @@ jobs:
       uses: actions/checkout@v3
       with:
         ref: ${{ env.PR_COMMIT_SHA }}
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Mark repo as safe directory
-      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER }}/pulumi-${{ env.PROVIDER }}
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
     - name: Install Go
       uses: actions/setup-go@v4
       with:
         cache-dependency-path: |
             sdk/go.sum
         go-version: 1.21.x
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
+    - name: disarm go:embed directives to enable lint
+      run: |
+        git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: golangci-lint
+      uses: golangci/golangci-lint-action@v3
       with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - run: make lint_provider
+        version: v1.54.1
+        working-directory: provider
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3

--- a/provider-ci/providers/newrelic/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/newrelic/repo/.github/workflows/run-acceptance-tests.yml
@@ -154,15 +154,16 @@ jobs:
       uses: actions/checkout@v3
       with:
         ref: ${{ env.PR_COMMIT_SHA }}
-    - name: Install Go
-      uses: actions/setup-go@v4
-      with:
-        cache-dependency-path: |
-            sdk/go.sum
-        go-version: 1.21.x
     - name: disarm go:embed directives to enable lint
       run: |
         git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: Install go
+      uses: actions/setup-go@v4
+      with:
+        # The versions of golangci-lint and setup-go here cross-depend and need to update together.
+        go-version: 1.21
+        # Either this action or golangci-lint needs to disable the cache
+        cache: false
     - name: golangci-lint
       uses: golangci/golangci-lint-action@v3
       with:

--- a/provider-ci/providers/nomad/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/nomad/repo/.github/workflows/main.yml
@@ -191,6 +191,9 @@ jobs:
     - name: disarm go:embed directives to enable lint
       run: |
         git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: prepare upstream
+      continue-on-error: true
+      run: make upstream
     - name: golangci-lint
       uses: golangci/golangci-lint-action@v3
       with:

--- a/provider-ci/providers/nomad/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/nomad/repo/.github/workflows/main.yml
@@ -177,34 +177,25 @@ jobs:
 
         aws s3 cp "${{ env.COVERAGE_OUTPUT_DIR }}/summary.json" "${s3FullURI}" --acl bucket-owner-full-control
   lint:
-    container: golangci/golangci-lint:v1.54.1
     name: lint
     runs-on: ubuntu-latest
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Mark repo as safe directory
-      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER }}/pulumi-${{ env.PROVIDER }}
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
     - name: Install Go
       uses: actions/setup-go@v4
       with:
         cache-dependency-path: |
             sdk/go.sum
         go-version: 1.21.x
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
+    - name: disarm go:embed directives to enable lint
+      run: |
+        git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: golangci-lint
+      uses: golangci/golangci-lint-action@v3
       with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - run: make lint_provider
+        version: v1.54.1
+        working-directory: provider
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3

--- a/provider-ci/providers/nomad/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/nomad/repo/.github/workflows/master.yml
@@ -191,6 +191,9 @@ jobs:
     - name: disarm go:embed directives to enable lint
       run: |
         git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: prepare upstream
+      continue-on-error: true
+      run: make upstream
     - name: golangci-lint
       uses: golangci/golangci-lint-action@v3
       with:

--- a/provider-ci/providers/nomad/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/nomad/repo/.github/workflows/master.yml
@@ -177,34 +177,25 @@ jobs:
 
         aws s3 cp "${{ env.COVERAGE_OUTPUT_DIR }}/summary.json" "${s3FullURI}" --acl bucket-owner-full-control
   lint:
-    container: golangci/golangci-lint:v1.54.1
     name: lint
     runs-on: ubuntu-latest
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Mark repo as safe directory
-      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER }}/pulumi-${{ env.PROVIDER }}
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
     - name: Install Go
       uses: actions/setup-go@v4
       with:
         cache-dependency-path: |
             sdk/go.sum
         go-version: 1.21.x
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
+    - name: disarm go:embed directives to enable lint
+      run: |
+        git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: golangci-lint
+      uses: golangci/golangci-lint-action@v3
       with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - run: make lint_provider
+        version: v1.54.1
+        working-directory: provider
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3

--- a/provider-ci/providers/nomad/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/nomad/repo/.github/workflows/prerelease.yml
@@ -124,34 +124,25 @@ jobs:
         - go
         - java
   lint:
-    container: golangci/golangci-lint:v1.54.1
     name: lint
     runs-on: ubuntu-latest
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Mark repo as safe directory
-      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER }}/pulumi-${{ env.PROVIDER }}
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
     - name: Install Go
       uses: actions/setup-go@v4
       with:
         cache-dependency-path: |
             sdk/go.sum
         go-version: 1.21.x
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
+    - name: disarm go:embed directives to enable lint
+      run: |
+        git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: golangci-lint
+      uses: golangci/golangci-lint-action@v3
       with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - run: make lint_provider
+        version: v1.54.1
+        working-directory: provider
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3

--- a/provider-ci/providers/nomad/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/nomad/repo/.github/workflows/prerelease.yml
@@ -138,6 +138,9 @@ jobs:
     - name: disarm go:embed directives to enable lint
       run: |
         git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: prepare upstream
+      continue-on-error: true
+      run: make upstream
     - name: golangci-lint
       uses: golangci/golangci-lint-action@v3
       with:

--- a/provider-ci/providers/nomad/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/nomad/repo/.github/workflows/release.yml
@@ -151,6 +151,9 @@ jobs:
     - name: disarm go:embed directives to enable lint
       run: |
         git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: prepare upstream
+      continue-on-error: true
+      run: make upstream
     - name: golangci-lint
       uses: golangci/golangci-lint-action@v3
       with:

--- a/provider-ci/providers/nomad/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/nomad/repo/.github/workflows/release.yml
@@ -137,34 +137,25 @@ jobs:
       run: pulumictl create docs-build pulumi-${{ env.PROVIDER }}
         "${GITHUB_REF#refs/tags/}"
   lint:
-    container: golangci/golangci-lint:v1.54.1
     name: lint
     runs-on: ubuntu-latest
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Mark repo as safe directory
-      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER }}/pulumi-${{ env.PROVIDER }}
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
     - name: Install Go
       uses: actions/setup-go@v4
       with:
         cache-dependency-path: |
             sdk/go.sum
         go-version: 1.21.x
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
+    - name: disarm go:embed directives to enable lint
+      run: |
+        git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: golangci-lint
+      uses: golangci/golangci-lint-action@v3
       with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - run: make lint_provider
+        version: v1.54.1
+        working-directory: provider
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3

--- a/provider-ci/providers/nomad/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/nomad/repo/.github/workflows/run-acceptance-tests.yml
@@ -153,15 +153,16 @@ jobs:
       uses: actions/checkout@v3
       with:
         ref: ${{ env.PR_COMMIT_SHA }}
-    - name: Install Go
-      uses: actions/setup-go@v4
-      with:
-        cache-dependency-path: |
-            sdk/go.sum
-        go-version: 1.21.x
     - name: disarm go:embed directives to enable lint
       run: |
         git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: Install go
+      uses: actions/setup-go@v4
+      with:
+        # The versions of golangci-lint and setup-go here cross-depend and need to update together.
+        go-version: 1.21
+        # Either this action or golangci-lint needs to disable the cache
+        cache: false
     - name: golangci-lint
       uses: golangci/golangci-lint-action@v3
       with:

--- a/provider-ci/providers/nomad/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/nomad/repo/.github/workflows/run-acceptance-tests.yml
@@ -144,7 +144,6 @@ jobs:
         repository: ${{ github.event.client_payload.github.payload.repository.full_name }}
         token: ${{ secrets.PULUMI_BOT_TOKEN }}
   lint:
-    container: golangci/golangci-lint:v1.54.1
     if: github.event_name == 'repository_dispatch' ||
       github.event.pull_request.head.repo.full_name == github.repository
     name: lint
@@ -154,28 +153,20 @@ jobs:
       uses: actions/checkout@v3
       with:
         ref: ${{ env.PR_COMMIT_SHA }}
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Mark repo as safe directory
-      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER }}/pulumi-${{ env.PROVIDER }}
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
     - name: Install Go
       uses: actions/setup-go@v4
       with:
         cache-dependency-path: |
             sdk/go.sum
         go-version: 1.21.x
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
+    - name: disarm go:embed directives to enable lint
+      run: |
+        git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: golangci-lint
+      uses: golangci/golangci-lint-action@v3
       with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - run: make lint_provider
+        version: v1.54.1
+        working-directory: provider
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3

--- a/provider-ci/providers/nomad/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/nomad/repo/.github/workflows/run-acceptance-tests.yml
@@ -156,6 +156,9 @@ jobs:
     - name: disarm go:embed directives to enable lint
       run: |
         git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: prepare upstream
+      continue-on-error: true
+      run: make upstream
     - name: Install go
       uses: actions/setup-go@v4
       with:

--- a/provider-ci/providers/ns1/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/ns1/repo/.github/workflows/main.yml
@@ -191,6 +191,9 @@ jobs:
     - name: disarm go:embed directives to enable lint
       run: |
         git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: prepare upstream
+      continue-on-error: true
+      run: make upstream
     - name: golangci-lint
       uses: golangci/golangci-lint-action@v3
       with:

--- a/provider-ci/providers/ns1/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/ns1/repo/.github/workflows/main.yml
@@ -177,34 +177,25 @@ jobs:
 
         aws s3 cp "${{ env.COVERAGE_OUTPUT_DIR }}/summary.json" "${s3FullURI}" --acl bucket-owner-full-control
   lint:
-    container: golangci/golangci-lint:v1.54.1
     name: lint
     runs-on: ubuntu-latest
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Mark repo as safe directory
-      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER }}/pulumi-${{ env.PROVIDER }}
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
     - name: Install Go
       uses: actions/setup-go@v4
       with:
         cache-dependency-path: |
             sdk/go.sum
         go-version: 1.21.x
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
+    - name: disarm go:embed directives to enable lint
+      run: |
+        git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: golangci-lint
+      uses: golangci/golangci-lint-action@v3
       with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - run: make lint_provider
+        version: v1.54.1
+        working-directory: provider
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3

--- a/provider-ci/providers/ns1/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/ns1/repo/.github/workflows/master.yml
@@ -191,6 +191,9 @@ jobs:
     - name: disarm go:embed directives to enable lint
       run: |
         git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: prepare upstream
+      continue-on-error: true
+      run: make upstream
     - name: golangci-lint
       uses: golangci/golangci-lint-action@v3
       with:

--- a/provider-ci/providers/ns1/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/ns1/repo/.github/workflows/master.yml
@@ -177,34 +177,25 @@ jobs:
 
         aws s3 cp "${{ env.COVERAGE_OUTPUT_DIR }}/summary.json" "${s3FullURI}" --acl bucket-owner-full-control
   lint:
-    container: golangci/golangci-lint:v1.54.1
     name: lint
     runs-on: ubuntu-latest
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Mark repo as safe directory
-      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER }}/pulumi-${{ env.PROVIDER }}
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
     - name: Install Go
       uses: actions/setup-go@v4
       with:
         cache-dependency-path: |
             sdk/go.sum
         go-version: 1.21.x
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
+    - name: disarm go:embed directives to enable lint
+      run: |
+        git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: golangci-lint
+      uses: golangci/golangci-lint-action@v3
       with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - run: make lint_provider
+        version: v1.54.1
+        working-directory: provider
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3

--- a/provider-ci/providers/ns1/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/ns1/repo/.github/workflows/prerelease.yml
@@ -124,34 +124,25 @@ jobs:
         - go
         - java
   lint:
-    container: golangci/golangci-lint:v1.54.1
     name: lint
     runs-on: ubuntu-latest
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Mark repo as safe directory
-      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER }}/pulumi-${{ env.PROVIDER }}
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
     - name: Install Go
       uses: actions/setup-go@v4
       with:
         cache-dependency-path: |
             sdk/go.sum
         go-version: 1.21.x
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
+    - name: disarm go:embed directives to enable lint
+      run: |
+        git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: golangci-lint
+      uses: golangci/golangci-lint-action@v3
       with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - run: make lint_provider
+        version: v1.54.1
+        working-directory: provider
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3

--- a/provider-ci/providers/ns1/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/ns1/repo/.github/workflows/prerelease.yml
@@ -138,6 +138,9 @@ jobs:
     - name: disarm go:embed directives to enable lint
       run: |
         git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: prepare upstream
+      continue-on-error: true
+      run: make upstream
     - name: golangci-lint
       uses: golangci/golangci-lint-action@v3
       with:

--- a/provider-ci/providers/ns1/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/ns1/repo/.github/workflows/release.yml
@@ -151,6 +151,9 @@ jobs:
     - name: disarm go:embed directives to enable lint
       run: |
         git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: prepare upstream
+      continue-on-error: true
+      run: make upstream
     - name: golangci-lint
       uses: golangci/golangci-lint-action@v3
       with:

--- a/provider-ci/providers/ns1/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/ns1/repo/.github/workflows/release.yml
@@ -137,34 +137,25 @@ jobs:
       run: pulumictl create docs-build pulumi-${{ env.PROVIDER }}
         "${GITHUB_REF#refs/tags/}"
   lint:
-    container: golangci/golangci-lint:v1.54.1
     name: lint
     runs-on: ubuntu-latest
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Mark repo as safe directory
-      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER }}/pulumi-${{ env.PROVIDER }}
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
     - name: Install Go
       uses: actions/setup-go@v4
       with:
         cache-dependency-path: |
             sdk/go.sum
         go-version: 1.21.x
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
+    - name: disarm go:embed directives to enable lint
+      run: |
+        git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: golangci-lint
+      uses: golangci/golangci-lint-action@v3
       with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - run: make lint_provider
+        version: v1.54.1
+        working-directory: provider
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3

--- a/provider-ci/providers/ns1/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/ns1/repo/.github/workflows/run-acceptance-tests.yml
@@ -153,15 +153,16 @@ jobs:
       uses: actions/checkout@v3
       with:
         ref: ${{ env.PR_COMMIT_SHA }}
-    - name: Install Go
-      uses: actions/setup-go@v4
-      with:
-        cache-dependency-path: |
-            sdk/go.sum
-        go-version: 1.21.x
     - name: disarm go:embed directives to enable lint
       run: |
         git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: Install go
+      uses: actions/setup-go@v4
+      with:
+        # The versions of golangci-lint and setup-go here cross-depend and need to update together.
+        go-version: 1.21
+        # Either this action or golangci-lint needs to disable the cache
+        cache: false
     - name: golangci-lint
       uses: golangci/golangci-lint-action@v3
       with:

--- a/provider-ci/providers/ns1/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/ns1/repo/.github/workflows/run-acceptance-tests.yml
@@ -144,7 +144,6 @@ jobs:
         repository: ${{ github.event.client_payload.github.payload.repository.full_name }}
         token: ${{ secrets.PULUMI_BOT_TOKEN }}
   lint:
-    container: golangci/golangci-lint:v1.54.1
     if: github.event_name == 'repository_dispatch' ||
       github.event.pull_request.head.repo.full_name == github.repository
     name: lint
@@ -154,28 +153,20 @@ jobs:
       uses: actions/checkout@v3
       with:
         ref: ${{ env.PR_COMMIT_SHA }}
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Mark repo as safe directory
-      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER }}/pulumi-${{ env.PROVIDER }}
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
     - name: Install Go
       uses: actions/setup-go@v4
       with:
         cache-dependency-path: |
             sdk/go.sum
         go-version: 1.21.x
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
+    - name: disarm go:embed directives to enable lint
+      run: |
+        git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: golangci-lint
+      uses: golangci/golangci-lint-action@v3
       with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - run: make lint_provider
+        version: v1.54.1
+        working-directory: provider
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3

--- a/provider-ci/providers/ns1/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/ns1/repo/.github/workflows/run-acceptance-tests.yml
@@ -156,6 +156,9 @@ jobs:
     - name: disarm go:embed directives to enable lint
       run: |
         git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: prepare upstream
+      continue-on-error: true
+      run: make upstream
     - name: Install go
       uses: actions/setup-go@v4
       with:

--- a/provider-ci/providers/okta/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/okta/repo/.github/workflows/main.yml
@@ -179,34 +179,25 @@ jobs:
 
         aws s3 cp "${{ env.COVERAGE_OUTPUT_DIR }}/summary.json" "${s3FullURI}" --acl bucket-owner-full-control
   lint:
-    container: golangci/golangci-lint:v1.54.1
     name: lint
     runs-on: ubuntu-latest
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Mark repo as safe directory
-      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER }}/pulumi-${{ env.PROVIDER }}
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
     - name: Install Go
       uses: actions/setup-go@v4
       with:
         cache-dependency-path: |
             sdk/go.sum
         go-version: 1.21.x
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
+    - name: disarm go:embed directives to enable lint
+      run: |
+        git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: golangci-lint
+      uses: golangci/golangci-lint-action@v3
       with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - run: make lint_provider
+        version: v1.54.1
+        working-directory: provider
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3

--- a/provider-ci/providers/okta/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/okta/repo/.github/workflows/main.yml
@@ -193,6 +193,9 @@ jobs:
     - name: disarm go:embed directives to enable lint
       run: |
         git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: prepare upstream
+      continue-on-error: true
+      run: make upstream
     - name: golangci-lint
       uses: golangci/golangci-lint-action@v3
       with:

--- a/provider-ci/providers/okta/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/okta/repo/.github/workflows/master.yml
@@ -179,34 +179,25 @@ jobs:
 
         aws s3 cp "${{ env.COVERAGE_OUTPUT_DIR }}/summary.json" "${s3FullURI}" --acl bucket-owner-full-control
   lint:
-    container: golangci/golangci-lint:v1.54.1
     name: lint
     runs-on: ubuntu-latest
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Mark repo as safe directory
-      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER }}/pulumi-${{ env.PROVIDER }}
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
     - name: Install Go
       uses: actions/setup-go@v4
       with:
         cache-dependency-path: |
             sdk/go.sum
         go-version: 1.21.x
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
+    - name: disarm go:embed directives to enable lint
+      run: |
+        git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: golangci-lint
+      uses: golangci/golangci-lint-action@v3
       with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - run: make lint_provider
+        version: v1.54.1
+        working-directory: provider
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3

--- a/provider-ci/providers/okta/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/okta/repo/.github/workflows/master.yml
@@ -193,6 +193,9 @@ jobs:
     - name: disarm go:embed directives to enable lint
       run: |
         git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: prepare upstream
+      continue-on-error: true
+      run: make upstream
     - name: golangci-lint
       uses: golangci/golangci-lint-action@v3
       with:

--- a/provider-ci/providers/okta/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/okta/repo/.github/workflows/prerelease.yml
@@ -140,6 +140,9 @@ jobs:
     - name: disarm go:embed directives to enable lint
       run: |
         git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: prepare upstream
+      continue-on-error: true
+      run: make upstream
     - name: golangci-lint
       uses: golangci/golangci-lint-action@v3
       with:

--- a/provider-ci/providers/okta/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/okta/repo/.github/workflows/prerelease.yml
@@ -126,34 +126,25 @@ jobs:
         - go
         - java
   lint:
-    container: golangci/golangci-lint:v1.54.1
     name: lint
     runs-on: ubuntu-latest
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Mark repo as safe directory
-      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER }}/pulumi-${{ env.PROVIDER }}
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
     - name: Install Go
       uses: actions/setup-go@v4
       with:
         cache-dependency-path: |
             sdk/go.sum
         go-version: 1.21.x
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
+    - name: disarm go:embed directives to enable lint
+      run: |
+        git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: golangci-lint
+      uses: golangci/golangci-lint-action@v3
       with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - run: make lint_provider
+        version: v1.54.1
+        working-directory: provider
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3

--- a/provider-ci/providers/okta/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/okta/repo/.github/workflows/release.yml
@@ -153,6 +153,9 @@ jobs:
     - name: disarm go:embed directives to enable lint
       run: |
         git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: prepare upstream
+      continue-on-error: true
+      run: make upstream
     - name: golangci-lint
       uses: golangci/golangci-lint-action@v3
       with:

--- a/provider-ci/providers/okta/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/okta/repo/.github/workflows/release.yml
@@ -139,34 +139,25 @@ jobs:
       run: pulumictl create docs-build pulumi-${{ env.PROVIDER }}
         "${GITHUB_REF#refs/tags/}"
   lint:
-    container: golangci/golangci-lint:v1.54.1
     name: lint
     runs-on: ubuntu-latest
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Mark repo as safe directory
-      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER }}/pulumi-${{ env.PROVIDER }}
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
     - name: Install Go
       uses: actions/setup-go@v4
       with:
         cache-dependency-path: |
             sdk/go.sum
         go-version: 1.21.x
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
+    - name: disarm go:embed directives to enable lint
+      run: |
+        git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: golangci-lint
+      uses: golangci/golangci-lint-action@v3
       with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - run: make lint_provider
+        version: v1.54.1
+        working-directory: provider
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3

--- a/provider-ci/providers/okta/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/okta/repo/.github/workflows/run-acceptance-tests.yml
@@ -146,7 +146,6 @@ jobs:
         repository: ${{ github.event.client_payload.github.payload.repository.full_name }}
         token: ${{ secrets.PULUMI_BOT_TOKEN }}
   lint:
-    container: golangci/golangci-lint:v1.54.1
     if: github.event_name == 'repository_dispatch' ||
       github.event.pull_request.head.repo.full_name == github.repository
     name: lint
@@ -156,28 +155,20 @@ jobs:
       uses: actions/checkout@v3
       with:
         ref: ${{ env.PR_COMMIT_SHA }}
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Mark repo as safe directory
-      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER }}/pulumi-${{ env.PROVIDER }}
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
     - name: Install Go
       uses: actions/setup-go@v4
       with:
         cache-dependency-path: |
             sdk/go.sum
         go-version: 1.21.x
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
+    - name: disarm go:embed directives to enable lint
+      run: |
+        git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: golangci-lint
+      uses: golangci/golangci-lint-action@v3
       with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - run: make lint_provider
+        version: v1.54.1
+        working-directory: provider
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3

--- a/provider-ci/providers/okta/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/okta/repo/.github/workflows/run-acceptance-tests.yml
@@ -158,6 +158,9 @@ jobs:
     - name: disarm go:embed directives to enable lint
       run: |
         git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: prepare upstream
+      continue-on-error: true
+      run: make upstream
     - name: Install go
       uses: actions/setup-go@v4
       with:

--- a/provider-ci/providers/okta/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/okta/repo/.github/workflows/run-acceptance-tests.yml
@@ -155,15 +155,16 @@ jobs:
       uses: actions/checkout@v3
       with:
         ref: ${{ env.PR_COMMIT_SHA }}
-    - name: Install Go
-      uses: actions/setup-go@v4
-      with:
-        cache-dependency-path: |
-            sdk/go.sum
-        go-version: 1.21.x
     - name: disarm go:embed directives to enable lint
       run: |
         git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: Install go
+      uses: actions/setup-go@v4
+      with:
+        # The versions of golangci-lint and setup-go here cross-depend and need to update together.
+        go-version: 1.21
+        # Either this action or golangci-lint needs to disable the cache
+        cache: false
     - name: golangci-lint
       uses: golangci/golangci-lint-action@v3
       with:

--- a/provider-ci/providers/onelogin/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/onelogin/repo/.github/workflows/main.yml
@@ -176,34 +176,25 @@ jobs:
 
         aws s3 cp "${{ env.COVERAGE_OUTPUT_DIR }}/summary.json" "${s3FullURI}" --acl bucket-owner-full-control
   lint:
-    container: golangci/golangci-lint:v1.54.1
     name: lint
     runs-on: ubuntu-latest
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Mark repo as safe directory
-      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER }}/pulumi-${{ env.PROVIDER }}
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
     - name: Install Go
       uses: actions/setup-go@v4
       with:
         cache-dependency-path: |
             sdk/go.sum
         go-version: 1.21.x
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
+    - name: disarm go:embed directives to enable lint
+      run: |
+        git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: golangci-lint
+      uses: golangci/golangci-lint-action@v3
       with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - run: make lint_provider
+        version: v1.54.1
+        working-directory: provider
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3

--- a/provider-ci/providers/onelogin/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/onelogin/repo/.github/workflows/main.yml
@@ -190,6 +190,9 @@ jobs:
     - name: disarm go:embed directives to enable lint
       run: |
         git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: prepare upstream
+      continue-on-error: true
+      run: make upstream
     - name: golangci-lint
       uses: golangci/golangci-lint-action@v3
       with:

--- a/provider-ci/providers/onelogin/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/onelogin/repo/.github/workflows/master.yml
@@ -176,34 +176,25 @@ jobs:
 
         aws s3 cp "${{ env.COVERAGE_OUTPUT_DIR }}/summary.json" "${s3FullURI}" --acl bucket-owner-full-control
   lint:
-    container: golangci/golangci-lint:v1.54.1
     name: lint
     runs-on: ubuntu-latest
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Mark repo as safe directory
-      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER }}/pulumi-${{ env.PROVIDER }}
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
     - name: Install Go
       uses: actions/setup-go@v4
       with:
         cache-dependency-path: |
             sdk/go.sum
         go-version: 1.21.x
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
+    - name: disarm go:embed directives to enable lint
+      run: |
+        git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: golangci-lint
+      uses: golangci/golangci-lint-action@v3
       with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - run: make lint_provider
+        version: v1.54.1
+        working-directory: provider
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3

--- a/provider-ci/providers/onelogin/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/onelogin/repo/.github/workflows/master.yml
@@ -190,6 +190,9 @@ jobs:
     - name: disarm go:embed directives to enable lint
       run: |
         git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: prepare upstream
+      continue-on-error: true
+      run: make upstream
     - name: golangci-lint
       uses: golangci/golangci-lint-action@v3
       with:

--- a/provider-ci/providers/onelogin/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/onelogin/repo/.github/workflows/prerelease.yml
@@ -123,34 +123,25 @@ jobs:
         - go
         - java
   lint:
-    container: golangci/golangci-lint:v1.54.1
     name: lint
     runs-on: ubuntu-latest
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Mark repo as safe directory
-      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER }}/pulumi-${{ env.PROVIDER }}
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
     - name: Install Go
       uses: actions/setup-go@v4
       with:
         cache-dependency-path: |
             sdk/go.sum
         go-version: 1.21.x
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
+    - name: disarm go:embed directives to enable lint
+      run: |
+        git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: golangci-lint
+      uses: golangci/golangci-lint-action@v3
       with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - run: make lint_provider
+        version: v1.54.1
+        working-directory: provider
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3

--- a/provider-ci/providers/onelogin/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/onelogin/repo/.github/workflows/prerelease.yml
@@ -137,6 +137,9 @@ jobs:
     - name: disarm go:embed directives to enable lint
       run: |
         git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: prepare upstream
+      continue-on-error: true
+      run: make upstream
     - name: golangci-lint
       uses: golangci/golangci-lint-action@v3
       with:

--- a/provider-ci/providers/onelogin/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/onelogin/repo/.github/workflows/release.yml
@@ -136,34 +136,25 @@ jobs:
       run: pulumictl create docs-build pulumi-${{ env.PROVIDER }}
         "${GITHUB_REF#refs/tags/}"
   lint:
-    container: golangci/golangci-lint:v1.54.1
     name: lint
     runs-on: ubuntu-latest
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Mark repo as safe directory
-      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER }}/pulumi-${{ env.PROVIDER }}
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
     - name: Install Go
       uses: actions/setup-go@v4
       with:
         cache-dependency-path: |
             sdk/go.sum
         go-version: 1.21.x
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
+    - name: disarm go:embed directives to enable lint
+      run: |
+        git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: golangci-lint
+      uses: golangci/golangci-lint-action@v3
       with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - run: make lint_provider
+        version: v1.54.1
+        working-directory: provider
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3

--- a/provider-ci/providers/onelogin/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/onelogin/repo/.github/workflows/release.yml
@@ -150,6 +150,9 @@ jobs:
     - name: disarm go:embed directives to enable lint
       run: |
         git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: prepare upstream
+      continue-on-error: true
+      run: make upstream
     - name: golangci-lint
       uses: golangci/golangci-lint-action@v3
       with:

--- a/provider-ci/providers/onelogin/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/onelogin/repo/.github/workflows/run-acceptance-tests.yml
@@ -143,7 +143,6 @@ jobs:
         repository: ${{ github.event.client_payload.github.payload.repository.full_name }}
         token: ${{ secrets.PULUMI_BOT_TOKEN }}
   lint:
-    container: golangci/golangci-lint:v1.54.1
     if: github.event_name == 'repository_dispatch' ||
       github.event.pull_request.head.repo.full_name == github.repository
     name: lint
@@ -153,28 +152,20 @@ jobs:
       uses: actions/checkout@v3
       with:
         ref: ${{ env.PR_COMMIT_SHA }}
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Mark repo as safe directory
-      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER }}/pulumi-${{ env.PROVIDER }}
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
     - name: Install Go
       uses: actions/setup-go@v4
       with:
         cache-dependency-path: |
             sdk/go.sum
         go-version: 1.21.x
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
+    - name: disarm go:embed directives to enable lint
+      run: |
+        git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: golangci-lint
+      uses: golangci/golangci-lint-action@v3
       with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - run: make lint_provider
+        version: v1.54.1
+        working-directory: provider
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3

--- a/provider-ci/providers/onelogin/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/onelogin/repo/.github/workflows/run-acceptance-tests.yml
@@ -155,6 +155,9 @@ jobs:
     - name: disarm go:embed directives to enable lint
       run: |
         git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: prepare upstream
+      continue-on-error: true
+      run: make upstream
     - name: Install go
       uses: actions/setup-go@v4
       with:

--- a/provider-ci/providers/onelogin/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/onelogin/repo/.github/workflows/run-acceptance-tests.yml
@@ -152,15 +152,16 @@ jobs:
       uses: actions/checkout@v3
       with:
         ref: ${{ env.PR_COMMIT_SHA }}
-    - name: Install Go
-      uses: actions/setup-go@v4
-      with:
-        cache-dependency-path: |
-            sdk/go.sum
-        go-version: 1.21.x
     - name: disarm go:embed directives to enable lint
       run: |
         git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: Install go
+      uses: actions/setup-go@v4
+      with:
+        # The versions of golangci-lint and setup-go here cross-depend and need to update together.
+        go-version: 1.21
+        # Either this action or golangci-lint needs to disable the cache
+        cache: false
     - name: golangci-lint
       uses: golangci/golangci-lint-action@v3
       with:

--- a/provider-ci/providers/openstack/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/openstack/repo/.github/workflows/main.yml
@@ -185,34 +185,25 @@ jobs:
 
         aws s3 cp "${{ env.COVERAGE_OUTPUT_DIR }}/summary.json" "${s3FullURI}" --acl bucket-owner-full-control
   lint:
-    container: golangci/golangci-lint:v1.54.1
     name: lint
     runs-on: ubuntu-latest
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Mark repo as safe directory
-      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER }}/pulumi-${{ env.PROVIDER }}
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
     - name: Install Go
       uses: actions/setup-go@v4
       with:
         cache-dependency-path: |
             sdk/go.sum
         go-version: 1.21.x
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
+    - name: disarm go:embed directives to enable lint
+      run: |
+        git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: golangci-lint
+      uses: golangci/golangci-lint-action@v3
       with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - run: make lint_provider
+        version: v1.54.1
+        working-directory: provider
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3

--- a/provider-ci/providers/openstack/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/openstack/repo/.github/workflows/main.yml
@@ -199,6 +199,9 @@ jobs:
     - name: disarm go:embed directives to enable lint
       run: |
         git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: prepare upstream
+      continue-on-error: true
+      run: make upstream
     - name: golangci-lint
       uses: golangci/golangci-lint-action@v3
       with:

--- a/provider-ci/providers/openstack/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/openstack/repo/.github/workflows/master.yml
@@ -185,34 +185,25 @@ jobs:
 
         aws s3 cp "${{ env.COVERAGE_OUTPUT_DIR }}/summary.json" "${s3FullURI}" --acl bucket-owner-full-control
   lint:
-    container: golangci/golangci-lint:v1.54.1
     name: lint
     runs-on: ubuntu-latest
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Mark repo as safe directory
-      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER }}/pulumi-${{ env.PROVIDER }}
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
     - name: Install Go
       uses: actions/setup-go@v4
       with:
         cache-dependency-path: |
             sdk/go.sum
         go-version: 1.21.x
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
+    - name: disarm go:embed directives to enable lint
+      run: |
+        git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: golangci-lint
+      uses: golangci/golangci-lint-action@v3
       with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - run: make lint_provider
+        version: v1.54.1
+        working-directory: provider
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3

--- a/provider-ci/providers/openstack/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/openstack/repo/.github/workflows/master.yml
@@ -199,6 +199,9 @@ jobs:
     - name: disarm go:embed directives to enable lint
       run: |
         git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: prepare upstream
+      continue-on-error: true
+      run: make upstream
     - name: golangci-lint
       uses: golangci/golangci-lint-action@v3
       with:

--- a/provider-ci/providers/openstack/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/openstack/repo/.github/workflows/prerelease.yml
@@ -146,6 +146,9 @@ jobs:
     - name: disarm go:embed directives to enable lint
       run: |
         git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: prepare upstream
+      continue-on-error: true
+      run: make upstream
     - name: golangci-lint
       uses: golangci/golangci-lint-action@v3
       with:

--- a/provider-ci/providers/openstack/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/openstack/repo/.github/workflows/prerelease.yml
@@ -132,34 +132,25 @@ jobs:
         - go
         - java
   lint:
-    container: golangci/golangci-lint:v1.54.1
     name: lint
     runs-on: ubuntu-latest
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Mark repo as safe directory
-      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER }}/pulumi-${{ env.PROVIDER }}
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
     - name: Install Go
       uses: actions/setup-go@v4
       with:
         cache-dependency-path: |
             sdk/go.sum
         go-version: 1.21.x
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
+    - name: disarm go:embed directives to enable lint
+      run: |
+        git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: golangci-lint
+      uses: golangci/golangci-lint-action@v3
       with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - run: make lint_provider
+        version: v1.54.1
+        working-directory: provider
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3

--- a/provider-ci/providers/openstack/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/openstack/repo/.github/workflows/release.yml
@@ -145,34 +145,25 @@ jobs:
       run: pulumictl create docs-build pulumi-${{ env.PROVIDER }}
         "${GITHUB_REF#refs/tags/}"
   lint:
-    container: golangci/golangci-lint:v1.54.1
     name: lint
     runs-on: ubuntu-latest
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Mark repo as safe directory
-      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER }}/pulumi-${{ env.PROVIDER }}
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
     - name: Install Go
       uses: actions/setup-go@v4
       with:
         cache-dependency-path: |
             sdk/go.sum
         go-version: 1.21.x
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
+    - name: disarm go:embed directives to enable lint
+      run: |
+        git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: golangci-lint
+      uses: golangci/golangci-lint-action@v3
       with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - run: make lint_provider
+        version: v1.54.1
+        working-directory: provider
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3

--- a/provider-ci/providers/openstack/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/openstack/repo/.github/workflows/release.yml
@@ -159,6 +159,9 @@ jobs:
     - name: disarm go:embed directives to enable lint
       run: |
         git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: prepare upstream
+      continue-on-error: true
+      run: make upstream
     - name: golangci-lint
       uses: golangci/golangci-lint-action@v3
       with:

--- a/provider-ci/providers/openstack/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/openstack/repo/.github/workflows/run-acceptance-tests.yml
@@ -164,6 +164,9 @@ jobs:
     - name: disarm go:embed directives to enable lint
       run: |
         git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: prepare upstream
+      continue-on-error: true
+      run: make upstream
     - name: Install go
       uses: actions/setup-go@v4
       with:

--- a/provider-ci/providers/openstack/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/openstack/repo/.github/workflows/run-acceptance-tests.yml
@@ -152,7 +152,6 @@ jobs:
         repository: ${{ github.event.client_payload.github.payload.repository.full_name }}
         token: ${{ secrets.PULUMI_BOT_TOKEN }}
   lint:
-    container: golangci/golangci-lint:v1.54.1
     if: github.event_name == 'repository_dispatch' ||
       github.event.pull_request.head.repo.full_name == github.repository
     name: lint
@@ -162,28 +161,20 @@ jobs:
       uses: actions/checkout@v3
       with:
         ref: ${{ env.PR_COMMIT_SHA }}
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Mark repo as safe directory
-      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER }}/pulumi-${{ env.PROVIDER }}
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
     - name: Install Go
       uses: actions/setup-go@v4
       with:
         cache-dependency-path: |
             sdk/go.sum
         go-version: 1.21.x
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
+    - name: disarm go:embed directives to enable lint
+      run: |
+        git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: golangci-lint
+      uses: golangci/golangci-lint-action@v3
       with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - run: make lint_provider
+        version: v1.54.1
+        working-directory: provider
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3

--- a/provider-ci/providers/openstack/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/openstack/repo/.github/workflows/run-acceptance-tests.yml
@@ -161,15 +161,16 @@ jobs:
       uses: actions/checkout@v3
       with:
         ref: ${{ env.PR_COMMIT_SHA }}
-    - name: Install Go
-      uses: actions/setup-go@v4
-      with:
-        cache-dependency-path: |
-            sdk/go.sum
-        go-version: 1.21.x
     - name: disarm go:embed directives to enable lint
       run: |
         git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: Install go
+      uses: actions/setup-go@v4
+      with:
+        # The versions of golangci-lint and setup-go here cross-depend and need to update together.
+        go-version: 1.21
+        # Either this action or golangci-lint needs to disable the cache
+        cache: false
     - name: golangci-lint
       uses: golangci/golangci-lint-action@v3
       with:

--- a/provider-ci/providers/opsgenie/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/opsgenie/repo/.github/workflows/main.yml
@@ -191,6 +191,9 @@ jobs:
     - name: disarm go:embed directives to enable lint
       run: |
         git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: prepare upstream
+      continue-on-error: true
+      run: make upstream
     - name: golangci-lint
       uses: golangci/golangci-lint-action@v3
       with:

--- a/provider-ci/providers/opsgenie/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/opsgenie/repo/.github/workflows/main.yml
@@ -177,34 +177,25 @@ jobs:
 
         aws s3 cp "${{ env.COVERAGE_OUTPUT_DIR }}/summary.json" "${s3FullURI}" --acl bucket-owner-full-control
   lint:
-    container: golangci/golangci-lint:v1.54.1
     name: lint
     runs-on: ubuntu-latest
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Mark repo as safe directory
-      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER }}/pulumi-${{ env.PROVIDER }}
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
     - name: Install Go
       uses: actions/setup-go@v4
       with:
         cache-dependency-path: |
             sdk/go.sum
         go-version: 1.21.x
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
+    - name: disarm go:embed directives to enable lint
+      run: |
+        git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: golangci-lint
+      uses: golangci/golangci-lint-action@v3
       with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - run: make lint_provider
+        version: v1.54.1
+        working-directory: provider
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3

--- a/provider-ci/providers/opsgenie/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/opsgenie/repo/.github/workflows/master.yml
@@ -191,6 +191,9 @@ jobs:
     - name: disarm go:embed directives to enable lint
       run: |
         git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: prepare upstream
+      continue-on-error: true
+      run: make upstream
     - name: golangci-lint
       uses: golangci/golangci-lint-action@v3
       with:

--- a/provider-ci/providers/opsgenie/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/opsgenie/repo/.github/workflows/master.yml
@@ -177,34 +177,25 @@ jobs:
 
         aws s3 cp "${{ env.COVERAGE_OUTPUT_DIR }}/summary.json" "${s3FullURI}" --acl bucket-owner-full-control
   lint:
-    container: golangci/golangci-lint:v1.54.1
     name: lint
     runs-on: ubuntu-latest
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Mark repo as safe directory
-      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER }}/pulumi-${{ env.PROVIDER }}
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
     - name: Install Go
       uses: actions/setup-go@v4
       with:
         cache-dependency-path: |
             sdk/go.sum
         go-version: 1.21.x
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
+    - name: disarm go:embed directives to enable lint
+      run: |
+        git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: golangci-lint
+      uses: golangci/golangci-lint-action@v3
       with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - run: make lint_provider
+        version: v1.54.1
+        working-directory: provider
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3

--- a/provider-ci/providers/opsgenie/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/opsgenie/repo/.github/workflows/prerelease.yml
@@ -124,34 +124,25 @@ jobs:
         - go
         - java
   lint:
-    container: golangci/golangci-lint:v1.54.1
     name: lint
     runs-on: ubuntu-latest
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Mark repo as safe directory
-      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER }}/pulumi-${{ env.PROVIDER }}
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
     - name: Install Go
       uses: actions/setup-go@v4
       with:
         cache-dependency-path: |
             sdk/go.sum
         go-version: 1.21.x
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
+    - name: disarm go:embed directives to enable lint
+      run: |
+        git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: golangci-lint
+      uses: golangci/golangci-lint-action@v3
       with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - run: make lint_provider
+        version: v1.54.1
+        working-directory: provider
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3

--- a/provider-ci/providers/opsgenie/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/opsgenie/repo/.github/workflows/prerelease.yml
@@ -138,6 +138,9 @@ jobs:
     - name: disarm go:embed directives to enable lint
       run: |
         git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: prepare upstream
+      continue-on-error: true
+      run: make upstream
     - name: golangci-lint
       uses: golangci/golangci-lint-action@v3
       with:

--- a/provider-ci/providers/opsgenie/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/opsgenie/repo/.github/workflows/release.yml
@@ -151,6 +151,9 @@ jobs:
     - name: disarm go:embed directives to enable lint
       run: |
         git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: prepare upstream
+      continue-on-error: true
+      run: make upstream
     - name: golangci-lint
       uses: golangci/golangci-lint-action@v3
       with:

--- a/provider-ci/providers/opsgenie/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/opsgenie/repo/.github/workflows/release.yml
@@ -137,34 +137,25 @@ jobs:
       run: pulumictl create docs-build pulumi-${{ env.PROVIDER }}
         "${GITHUB_REF#refs/tags/}"
   lint:
-    container: golangci/golangci-lint:v1.54.1
     name: lint
     runs-on: ubuntu-latest
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Mark repo as safe directory
-      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER }}/pulumi-${{ env.PROVIDER }}
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
     - name: Install Go
       uses: actions/setup-go@v4
       with:
         cache-dependency-path: |
             sdk/go.sum
         go-version: 1.21.x
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
+    - name: disarm go:embed directives to enable lint
+      run: |
+        git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: golangci-lint
+      uses: golangci/golangci-lint-action@v3
       with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - run: make lint_provider
+        version: v1.54.1
+        working-directory: provider
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3

--- a/provider-ci/providers/opsgenie/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/opsgenie/repo/.github/workflows/run-acceptance-tests.yml
@@ -153,15 +153,16 @@ jobs:
       uses: actions/checkout@v3
       with:
         ref: ${{ env.PR_COMMIT_SHA }}
-    - name: Install Go
-      uses: actions/setup-go@v4
-      with:
-        cache-dependency-path: |
-            sdk/go.sum
-        go-version: 1.21.x
     - name: disarm go:embed directives to enable lint
       run: |
         git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: Install go
+      uses: actions/setup-go@v4
+      with:
+        # The versions of golangci-lint and setup-go here cross-depend and need to update together.
+        go-version: 1.21
+        # Either this action or golangci-lint needs to disable the cache
+        cache: false
     - name: golangci-lint
       uses: golangci/golangci-lint-action@v3
       with:

--- a/provider-ci/providers/opsgenie/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/opsgenie/repo/.github/workflows/run-acceptance-tests.yml
@@ -144,7 +144,6 @@ jobs:
         repository: ${{ github.event.client_payload.github.payload.repository.full_name }}
         token: ${{ secrets.PULUMI_BOT_TOKEN }}
   lint:
-    container: golangci/golangci-lint:v1.54.1
     if: github.event_name == 'repository_dispatch' ||
       github.event.pull_request.head.repo.full_name == github.repository
     name: lint
@@ -154,28 +153,20 @@ jobs:
       uses: actions/checkout@v3
       with:
         ref: ${{ env.PR_COMMIT_SHA }}
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Mark repo as safe directory
-      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER }}/pulumi-${{ env.PROVIDER }}
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
     - name: Install Go
       uses: actions/setup-go@v4
       with:
         cache-dependency-path: |
             sdk/go.sum
         go-version: 1.21.x
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
+    - name: disarm go:embed directives to enable lint
+      run: |
+        git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: golangci-lint
+      uses: golangci/golangci-lint-action@v3
       with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - run: make lint_provider
+        version: v1.54.1
+        working-directory: provider
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3

--- a/provider-ci/providers/opsgenie/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/opsgenie/repo/.github/workflows/run-acceptance-tests.yml
@@ -156,6 +156,9 @@ jobs:
     - name: disarm go:embed directives to enable lint
       run: |
         git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: prepare upstream
+      continue-on-error: true
+      run: make upstream
     - name: Install go
       uses: actions/setup-go@v4
       with:

--- a/provider-ci/providers/pagerduty/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/pagerduty/repo/.github/workflows/main.yml
@@ -191,6 +191,9 @@ jobs:
     - name: disarm go:embed directives to enable lint
       run: |
         git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: prepare upstream
+      continue-on-error: true
+      run: make upstream
     - name: golangci-lint
       uses: golangci/golangci-lint-action@v3
       with:

--- a/provider-ci/providers/pagerduty/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/pagerduty/repo/.github/workflows/main.yml
@@ -177,34 +177,25 @@ jobs:
 
         aws s3 cp "${{ env.COVERAGE_OUTPUT_DIR }}/summary.json" "${s3FullURI}" --acl bucket-owner-full-control
   lint:
-    container: golangci/golangci-lint:v1.54.1
     name: lint
     runs-on: ubuntu-latest
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Mark repo as safe directory
-      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER }}/pulumi-${{ env.PROVIDER }}
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
     - name: Install Go
       uses: actions/setup-go@v4
       with:
         cache-dependency-path: |
             sdk/go.sum
         go-version: 1.21.x
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
+    - name: disarm go:embed directives to enable lint
+      run: |
+        git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: golangci-lint
+      uses: golangci/golangci-lint-action@v3
       with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - run: make lint_provider
+        version: v1.54.1
+        working-directory: provider
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3

--- a/provider-ci/providers/pagerduty/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/pagerduty/repo/.github/workflows/master.yml
@@ -191,6 +191,9 @@ jobs:
     - name: disarm go:embed directives to enable lint
       run: |
         git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: prepare upstream
+      continue-on-error: true
+      run: make upstream
     - name: golangci-lint
       uses: golangci/golangci-lint-action@v3
       with:

--- a/provider-ci/providers/pagerduty/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/pagerduty/repo/.github/workflows/master.yml
@@ -177,34 +177,25 @@ jobs:
 
         aws s3 cp "${{ env.COVERAGE_OUTPUT_DIR }}/summary.json" "${s3FullURI}" --acl bucket-owner-full-control
   lint:
-    container: golangci/golangci-lint:v1.54.1
     name: lint
     runs-on: ubuntu-latest
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Mark repo as safe directory
-      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER }}/pulumi-${{ env.PROVIDER }}
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
     - name: Install Go
       uses: actions/setup-go@v4
       with:
         cache-dependency-path: |
             sdk/go.sum
         go-version: 1.21.x
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
+    - name: disarm go:embed directives to enable lint
+      run: |
+        git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: golangci-lint
+      uses: golangci/golangci-lint-action@v3
       with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - run: make lint_provider
+        version: v1.54.1
+        working-directory: provider
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3

--- a/provider-ci/providers/pagerduty/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/pagerduty/repo/.github/workflows/prerelease.yml
@@ -124,34 +124,25 @@ jobs:
         - go
         - java
   lint:
-    container: golangci/golangci-lint:v1.54.1
     name: lint
     runs-on: ubuntu-latest
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Mark repo as safe directory
-      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER }}/pulumi-${{ env.PROVIDER }}
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
     - name: Install Go
       uses: actions/setup-go@v4
       with:
         cache-dependency-path: |
             sdk/go.sum
         go-version: 1.21.x
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
+    - name: disarm go:embed directives to enable lint
+      run: |
+        git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: golangci-lint
+      uses: golangci/golangci-lint-action@v3
       with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - run: make lint_provider
+        version: v1.54.1
+        working-directory: provider
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3

--- a/provider-ci/providers/pagerduty/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/pagerduty/repo/.github/workflows/prerelease.yml
@@ -138,6 +138,9 @@ jobs:
     - name: disarm go:embed directives to enable lint
       run: |
         git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: prepare upstream
+      continue-on-error: true
+      run: make upstream
     - name: golangci-lint
       uses: golangci/golangci-lint-action@v3
       with:

--- a/provider-ci/providers/pagerduty/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/pagerduty/repo/.github/workflows/release.yml
@@ -151,6 +151,9 @@ jobs:
     - name: disarm go:embed directives to enable lint
       run: |
         git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: prepare upstream
+      continue-on-error: true
+      run: make upstream
     - name: golangci-lint
       uses: golangci/golangci-lint-action@v3
       with:

--- a/provider-ci/providers/pagerduty/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/pagerduty/repo/.github/workflows/release.yml
@@ -137,34 +137,25 @@ jobs:
       run: pulumictl create docs-build pulumi-${{ env.PROVIDER }}
         "${GITHUB_REF#refs/tags/}"
   lint:
-    container: golangci/golangci-lint:v1.54.1
     name: lint
     runs-on: ubuntu-latest
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Mark repo as safe directory
-      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER }}/pulumi-${{ env.PROVIDER }}
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
     - name: Install Go
       uses: actions/setup-go@v4
       with:
         cache-dependency-path: |
             sdk/go.sum
         go-version: 1.21.x
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
+    - name: disarm go:embed directives to enable lint
+      run: |
+        git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: golangci-lint
+      uses: golangci/golangci-lint-action@v3
       with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - run: make lint_provider
+        version: v1.54.1
+        working-directory: provider
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3

--- a/provider-ci/providers/pagerduty/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/pagerduty/repo/.github/workflows/run-acceptance-tests.yml
@@ -153,15 +153,16 @@ jobs:
       uses: actions/checkout@v3
       with:
         ref: ${{ env.PR_COMMIT_SHA }}
-    - name: Install Go
-      uses: actions/setup-go@v4
-      with:
-        cache-dependency-path: |
-            sdk/go.sum
-        go-version: 1.21.x
     - name: disarm go:embed directives to enable lint
       run: |
         git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: Install go
+      uses: actions/setup-go@v4
+      with:
+        # The versions of golangci-lint and setup-go here cross-depend and need to update together.
+        go-version: 1.21
+        # Either this action or golangci-lint needs to disable the cache
+        cache: false
     - name: golangci-lint
       uses: golangci/golangci-lint-action@v3
       with:

--- a/provider-ci/providers/pagerduty/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/pagerduty/repo/.github/workflows/run-acceptance-tests.yml
@@ -144,7 +144,6 @@ jobs:
         repository: ${{ github.event.client_payload.github.payload.repository.full_name }}
         token: ${{ secrets.PULUMI_BOT_TOKEN }}
   lint:
-    container: golangci/golangci-lint:v1.54.1
     if: github.event_name == 'repository_dispatch' ||
       github.event.pull_request.head.repo.full_name == github.repository
     name: lint
@@ -154,28 +153,20 @@ jobs:
       uses: actions/checkout@v3
       with:
         ref: ${{ env.PR_COMMIT_SHA }}
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Mark repo as safe directory
-      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER }}/pulumi-${{ env.PROVIDER }}
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
     - name: Install Go
       uses: actions/setup-go@v4
       with:
         cache-dependency-path: |
             sdk/go.sum
         go-version: 1.21.x
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
+    - name: disarm go:embed directives to enable lint
+      run: |
+        git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: golangci-lint
+      uses: golangci/golangci-lint-action@v3
       with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - run: make lint_provider
+        version: v1.54.1
+        working-directory: provider
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3

--- a/provider-ci/providers/pagerduty/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/pagerduty/repo/.github/workflows/run-acceptance-tests.yml
@@ -156,6 +156,9 @@ jobs:
     - name: disarm go:embed directives to enable lint
       run: |
         git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: prepare upstream
+      continue-on-error: true
+      run: make upstream
     - name: Install go
       uses: actions/setup-go@v4
       with:

--- a/provider-ci/providers/postgresql/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/postgresql/repo/.github/workflows/main.yml
@@ -176,34 +176,25 @@ jobs:
 
         aws s3 cp "${{ env.COVERAGE_OUTPUT_DIR }}/summary.json" "${s3FullURI}" --acl bucket-owner-full-control
   lint:
-    container: golangci/golangci-lint:v1.54.1
     name: lint
     runs-on: ubuntu-latest
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Mark repo as safe directory
-      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER }}/pulumi-${{ env.PROVIDER }}
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
     - name: Install Go
       uses: actions/setup-go@v4
       with:
         cache-dependency-path: |
             sdk/go.sum
         go-version: 1.21.x
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
+    - name: disarm go:embed directives to enable lint
+      run: |
+        git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: golangci-lint
+      uses: golangci/golangci-lint-action@v3
       with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - run: make lint_provider
+        version: v1.54.1
+        working-directory: provider
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3

--- a/provider-ci/providers/postgresql/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/postgresql/repo/.github/workflows/main.yml
@@ -190,6 +190,9 @@ jobs:
     - name: disarm go:embed directives to enable lint
       run: |
         git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: prepare upstream
+      continue-on-error: true
+      run: make upstream
     - name: golangci-lint
       uses: golangci/golangci-lint-action@v3
       with:

--- a/provider-ci/providers/postgresql/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/postgresql/repo/.github/workflows/master.yml
@@ -176,34 +176,25 @@ jobs:
 
         aws s3 cp "${{ env.COVERAGE_OUTPUT_DIR }}/summary.json" "${s3FullURI}" --acl bucket-owner-full-control
   lint:
-    container: golangci/golangci-lint:v1.54.1
     name: lint
     runs-on: ubuntu-latest
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Mark repo as safe directory
-      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER }}/pulumi-${{ env.PROVIDER }}
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
     - name: Install Go
       uses: actions/setup-go@v4
       with:
         cache-dependency-path: |
             sdk/go.sum
         go-version: 1.21.x
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
+    - name: disarm go:embed directives to enable lint
+      run: |
+        git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: golangci-lint
+      uses: golangci/golangci-lint-action@v3
       with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - run: make lint_provider
+        version: v1.54.1
+        working-directory: provider
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3

--- a/provider-ci/providers/postgresql/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/postgresql/repo/.github/workflows/master.yml
@@ -190,6 +190,9 @@ jobs:
     - name: disarm go:embed directives to enable lint
       run: |
         git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: prepare upstream
+      continue-on-error: true
+      run: make upstream
     - name: golangci-lint
       uses: golangci/golangci-lint-action@v3
       with:

--- a/provider-ci/providers/postgresql/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/postgresql/repo/.github/workflows/prerelease.yml
@@ -123,34 +123,25 @@ jobs:
         - go
         - java
   lint:
-    container: golangci/golangci-lint:v1.54.1
     name: lint
     runs-on: ubuntu-latest
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Mark repo as safe directory
-      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER }}/pulumi-${{ env.PROVIDER }}
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
     - name: Install Go
       uses: actions/setup-go@v4
       with:
         cache-dependency-path: |
             sdk/go.sum
         go-version: 1.21.x
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
+    - name: disarm go:embed directives to enable lint
+      run: |
+        git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: golangci-lint
+      uses: golangci/golangci-lint-action@v3
       with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - run: make lint_provider
+        version: v1.54.1
+        working-directory: provider
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3

--- a/provider-ci/providers/postgresql/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/postgresql/repo/.github/workflows/prerelease.yml
@@ -137,6 +137,9 @@ jobs:
     - name: disarm go:embed directives to enable lint
       run: |
         git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: prepare upstream
+      continue-on-error: true
+      run: make upstream
     - name: golangci-lint
       uses: golangci/golangci-lint-action@v3
       with:

--- a/provider-ci/providers/postgresql/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/postgresql/repo/.github/workflows/release.yml
@@ -136,34 +136,25 @@ jobs:
       run: pulumictl create docs-build pulumi-${{ env.PROVIDER }}
         "${GITHUB_REF#refs/tags/}"
   lint:
-    container: golangci/golangci-lint:v1.54.1
     name: lint
     runs-on: ubuntu-latest
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Mark repo as safe directory
-      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER }}/pulumi-${{ env.PROVIDER }}
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
     - name: Install Go
       uses: actions/setup-go@v4
       with:
         cache-dependency-path: |
             sdk/go.sum
         go-version: 1.21.x
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
+    - name: disarm go:embed directives to enable lint
+      run: |
+        git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: golangci-lint
+      uses: golangci/golangci-lint-action@v3
       with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - run: make lint_provider
+        version: v1.54.1
+        working-directory: provider
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3

--- a/provider-ci/providers/postgresql/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/postgresql/repo/.github/workflows/release.yml
@@ -150,6 +150,9 @@ jobs:
     - name: disarm go:embed directives to enable lint
       run: |
         git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: prepare upstream
+      continue-on-error: true
+      run: make upstream
     - name: golangci-lint
       uses: golangci/golangci-lint-action@v3
       with:

--- a/provider-ci/providers/postgresql/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/postgresql/repo/.github/workflows/run-acceptance-tests.yml
@@ -143,7 +143,6 @@ jobs:
         repository: ${{ github.event.client_payload.github.payload.repository.full_name }}
         token: ${{ secrets.PULUMI_BOT_TOKEN }}
   lint:
-    container: golangci/golangci-lint:v1.54.1
     if: github.event_name == 'repository_dispatch' ||
       github.event.pull_request.head.repo.full_name == github.repository
     name: lint
@@ -153,28 +152,20 @@ jobs:
       uses: actions/checkout@v3
       with:
         ref: ${{ env.PR_COMMIT_SHA }}
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Mark repo as safe directory
-      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER }}/pulumi-${{ env.PROVIDER }}
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
     - name: Install Go
       uses: actions/setup-go@v4
       with:
         cache-dependency-path: |
             sdk/go.sum
         go-version: 1.21.x
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
+    - name: disarm go:embed directives to enable lint
+      run: |
+        git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: golangci-lint
+      uses: golangci/golangci-lint-action@v3
       with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - run: make lint_provider
+        version: v1.54.1
+        working-directory: provider
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3

--- a/provider-ci/providers/postgresql/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/postgresql/repo/.github/workflows/run-acceptance-tests.yml
@@ -155,6 +155,9 @@ jobs:
     - name: disarm go:embed directives to enable lint
       run: |
         git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: prepare upstream
+      continue-on-error: true
+      run: make upstream
     - name: Install go
       uses: actions/setup-go@v4
       with:

--- a/provider-ci/providers/postgresql/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/postgresql/repo/.github/workflows/run-acceptance-tests.yml
@@ -152,15 +152,16 @@ jobs:
       uses: actions/checkout@v3
       with:
         ref: ${{ env.PR_COMMIT_SHA }}
-    - name: Install Go
-      uses: actions/setup-go@v4
-      with:
-        cache-dependency-path: |
-            sdk/go.sum
-        go-version: 1.21.x
     - name: disarm go:embed directives to enable lint
       run: |
         git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: Install go
+      uses: actions/setup-go@v4
+      with:
+        # The versions of golangci-lint and setup-go here cross-depend and need to update together.
+        go-version: 1.21
+        # Either this action or golangci-lint needs to disable the cache
+        cache: false
     - name: golangci-lint
       uses: golangci/golangci-lint-action@v3
       with:

--- a/provider-ci/providers/rabbitmq/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/rabbitmq/repo/.github/workflows/main.yml
@@ -176,34 +176,25 @@ jobs:
 
         aws s3 cp "${{ env.COVERAGE_OUTPUT_DIR }}/summary.json" "${s3FullURI}" --acl bucket-owner-full-control
   lint:
-    container: golangci/golangci-lint:v1.54.1
     name: lint
     runs-on: ubuntu-latest
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Mark repo as safe directory
-      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER }}/pulumi-${{ env.PROVIDER }}
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
     - name: Install Go
       uses: actions/setup-go@v4
       with:
         cache-dependency-path: |
             sdk/go.sum
         go-version: 1.21.x
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
+    - name: disarm go:embed directives to enable lint
+      run: |
+        git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: golangci-lint
+      uses: golangci/golangci-lint-action@v3
       with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - run: make lint_provider
+        version: v1.54.1
+        working-directory: provider
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3

--- a/provider-ci/providers/rabbitmq/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/rabbitmq/repo/.github/workflows/main.yml
@@ -190,6 +190,9 @@ jobs:
     - name: disarm go:embed directives to enable lint
       run: |
         git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: prepare upstream
+      continue-on-error: true
+      run: make upstream
     - name: golangci-lint
       uses: golangci/golangci-lint-action@v3
       with:

--- a/provider-ci/providers/rabbitmq/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/rabbitmq/repo/.github/workflows/master.yml
@@ -176,34 +176,25 @@ jobs:
 
         aws s3 cp "${{ env.COVERAGE_OUTPUT_DIR }}/summary.json" "${s3FullURI}" --acl bucket-owner-full-control
   lint:
-    container: golangci/golangci-lint:v1.54.1
     name: lint
     runs-on: ubuntu-latest
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Mark repo as safe directory
-      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER }}/pulumi-${{ env.PROVIDER }}
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
     - name: Install Go
       uses: actions/setup-go@v4
       with:
         cache-dependency-path: |
             sdk/go.sum
         go-version: 1.21.x
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
+    - name: disarm go:embed directives to enable lint
+      run: |
+        git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: golangci-lint
+      uses: golangci/golangci-lint-action@v3
       with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - run: make lint_provider
+        version: v1.54.1
+        working-directory: provider
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3

--- a/provider-ci/providers/rabbitmq/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/rabbitmq/repo/.github/workflows/master.yml
@@ -190,6 +190,9 @@ jobs:
     - name: disarm go:embed directives to enable lint
       run: |
         git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: prepare upstream
+      continue-on-error: true
+      run: make upstream
     - name: golangci-lint
       uses: golangci/golangci-lint-action@v3
       with:

--- a/provider-ci/providers/rabbitmq/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/rabbitmq/repo/.github/workflows/prerelease.yml
@@ -123,34 +123,25 @@ jobs:
         - go
         - java
   lint:
-    container: golangci/golangci-lint:v1.54.1
     name: lint
     runs-on: ubuntu-latest
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Mark repo as safe directory
-      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER }}/pulumi-${{ env.PROVIDER }}
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
     - name: Install Go
       uses: actions/setup-go@v4
       with:
         cache-dependency-path: |
             sdk/go.sum
         go-version: 1.21.x
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
+    - name: disarm go:embed directives to enable lint
+      run: |
+        git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: golangci-lint
+      uses: golangci/golangci-lint-action@v3
       with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - run: make lint_provider
+        version: v1.54.1
+        working-directory: provider
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3

--- a/provider-ci/providers/rabbitmq/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/rabbitmq/repo/.github/workflows/prerelease.yml
@@ -137,6 +137,9 @@ jobs:
     - name: disarm go:embed directives to enable lint
       run: |
         git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: prepare upstream
+      continue-on-error: true
+      run: make upstream
     - name: golangci-lint
       uses: golangci/golangci-lint-action@v3
       with:

--- a/provider-ci/providers/rabbitmq/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/rabbitmq/repo/.github/workflows/release.yml
@@ -136,34 +136,25 @@ jobs:
       run: pulumictl create docs-build pulumi-${{ env.PROVIDER }}
         "${GITHUB_REF#refs/tags/}"
   lint:
-    container: golangci/golangci-lint:v1.54.1
     name: lint
     runs-on: ubuntu-latest
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Mark repo as safe directory
-      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER }}/pulumi-${{ env.PROVIDER }}
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
     - name: Install Go
       uses: actions/setup-go@v4
       with:
         cache-dependency-path: |
             sdk/go.sum
         go-version: 1.21.x
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
+    - name: disarm go:embed directives to enable lint
+      run: |
+        git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: golangci-lint
+      uses: golangci/golangci-lint-action@v3
       with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - run: make lint_provider
+        version: v1.54.1
+        working-directory: provider
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3

--- a/provider-ci/providers/rabbitmq/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/rabbitmq/repo/.github/workflows/release.yml
@@ -150,6 +150,9 @@ jobs:
     - name: disarm go:embed directives to enable lint
       run: |
         git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: prepare upstream
+      continue-on-error: true
+      run: make upstream
     - name: golangci-lint
       uses: golangci/golangci-lint-action@v3
       with:

--- a/provider-ci/providers/rabbitmq/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/rabbitmq/repo/.github/workflows/run-acceptance-tests.yml
@@ -143,7 +143,6 @@ jobs:
         repository: ${{ github.event.client_payload.github.payload.repository.full_name }}
         token: ${{ secrets.PULUMI_BOT_TOKEN }}
   lint:
-    container: golangci/golangci-lint:v1.54.1
     if: github.event_name == 'repository_dispatch' ||
       github.event.pull_request.head.repo.full_name == github.repository
     name: lint
@@ -153,28 +152,20 @@ jobs:
       uses: actions/checkout@v3
       with:
         ref: ${{ env.PR_COMMIT_SHA }}
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Mark repo as safe directory
-      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER }}/pulumi-${{ env.PROVIDER }}
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
     - name: Install Go
       uses: actions/setup-go@v4
       with:
         cache-dependency-path: |
             sdk/go.sum
         go-version: 1.21.x
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
+    - name: disarm go:embed directives to enable lint
+      run: |
+        git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: golangci-lint
+      uses: golangci/golangci-lint-action@v3
       with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - run: make lint_provider
+        version: v1.54.1
+        working-directory: provider
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3

--- a/provider-ci/providers/rabbitmq/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/rabbitmq/repo/.github/workflows/run-acceptance-tests.yml
@@ -155,6 +155,9 @@ jobs:
     - name: disarm go:embed directives to enable lint
       run: |
         git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: prepare upstream
+      continue-on-error: true
+      run: make upstream
     - name: Install go
       uses: actions/setup-go@v4
       with:

--- a/provider-ci/providers/rabbitmq/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/rabbitmq/repo/.github/workflows/run-acceptance-tests.yml
@@ -152,15 +152,16 @@ jobs:
       uses: actions/checkout@v3
       with:
         ref: ${{ env.PR_COMMIT_SHA }}
-    - name: Install Go
-      uses: actions/setup-go@v4
-      with:
-        cache-dependency-path: |
-            sdk/go.sum
-        go-version: 1.21.x
     - name: disarm go:embed directives to enable lint
       run: |
         git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: Install go
+      uses: actions/setup-go@v4
+      with:
+        # The versions of golangci-lint and setup-go here cross-depend and need to update together.
+        go-version: 1.21
+        # Either this action or golangci-lint needs to disable the cache
+        cache: false
     - name: golangci-lint
       uses: golangci/golangci-lint-action@v3
       with:

--- a/provider-ci/providers/random/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/random/repo/.github/workflows/main.yml
@@ -176,34 +176,25 @@ jobs:
 
         aws s3 cp "${{ env.COVERAGE_OUTPUT_DIR }}/summary.json" "${s3FullURI}" --acl bucket-owner-full-control
   lint:
-    container: golangci/golangci-lint:v1.54.1
     name: lint
     runs-on: ubuntu-latest
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Mark repo as safe directory
-      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER }}/pulumi-${{ env.PROVIDER }}
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
     - name: Install Go
       uses: actions/setup-go@v4
       with:
         cache-dependency-path: |
             sdk/go.sum
         go-version: 1.21.x
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
+    - name: disarm go:embed directives to enable lint
+      run: |
+        git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: golangci-lint
+      uses: golangci/golangci-lint-action@v3
       with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - run: make lint_provider
+        version: v1.54.1
+        working-directory: provider
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3

--- a/provider-ci/providers/random/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/random/repo/.github/workflows/main.yml
@@ -190,6 +190,9 @@ jobs:
     - name: disarm go:embed directives to enable lint
       run: |
         git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: prepare upstream
+      continue-on-error: true
+      run: make upstream
     - name: golangci-lint
       uses: golangci/golangci-lint-action@v3
       with:

--- a/provider-ci/providers/random/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/random/repo/.github/workflows/master.yml
@@ -176,34 +176,25 @@ jobs:
 
         aws s3 cp "${{ env.COVERAGE_OUTPUT_DIR }}/summary.json" "${s3FullURI}" --acl bucket-owner-full-control
   lint:
-    container: golangci/golangci-lint:v1.54.1
     name: lint
     runs-on: ubuntu-latest
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Mark repo as safe directory
-      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER }}/pulumi-${{ env.PROVIDER }}
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
     - name: Install Go
       uses: actions/setup-go@v4
       with:
         cache-dependency-path: |
             sdk/go.sum
         go-version: 1.21.x
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
+    - name: disarm go:embed directives to enable lint
+      run: |
+        git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: golangci-lint
+      uses: golangci/golangci-lint-action@v3
       with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - run: make lint_provider
+        version: v1.54.1
+        working-directory: provider
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3

--- a/provider-ci/providers/random/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/random/repo/.github/workflows/master.yml
@@ -190,6 +190,9 @@ jobs:
     - name: disarm go:embed directives to enable lint
       run: |
         git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: prepare upstream
+      continue-on-error: true
+      run: make upstream
     - name: golangci-lint
       uses: golangci/golangci-lint-action@v3
       with:

--- a/provider-ci/providers/random/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/random/repo/.github/workflows/prerelease.yml
@@ -123,34 +123,25 @@ jobs:
         - go
         - java
   lint:
-    container: golangci/golangci-lint:v1.54.1
     name: lint
     runs-on: ubuntu-latest
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Mark repo as safe directory
-      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER }}/pulumi-${{ env.PROVIDER }}
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
     - name: Install Go
       uses: actions/setup-go@v4
       with:
         cache-dependency-path: |
             sdk/go.sum
         go-version: 1.21.x
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
+    - name: disarm go:embed directives to enable lint
+      run: |
+        git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: golangci-lint
+      uses: golangci/golangci-lint-action@v3
       with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - run: make lint_provider
+        version: v1.54.1
+        working-directory: provider
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3

--- a/provider-ci/providers/random/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/random/repo/.github/workflows/prerelease.yml
@@ -137,6 +137,9 @@ jobs:
     - name: disarm go:embed directives to enable lint
       run: |
         git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: prepare upstream
+      continue-on-error: true
+      run: make upstream
     - name: golangci-lint
       uses: golangci/golangci-lint-action@v3
       with:

--- a/provider-ci/providers/random/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/random/repo/.github/workflows/release.yml
@@ -136,34 +136,25 @@ jobs:
       run: pulumictl create docs-build pulumi-${{ env.PROVIDER }}
         "${GITHUB_REF#refs/tags/}"
   lint:
-    container: golangci/golangci-lint:v1.54.1
     name: lint
     runs-on: ubuntu-latest
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Mark repo as safe directory
-      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER }}/pulumi-${{ env.PROVIDER }}
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
     - name: Install Go
       uses: actions/setup-go@v4
       with:
         cache-dependency-path: |
             sdk/go.sum
         go-version: 1.21.x
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
+    - name: disarm go:embed directives to enable lint
+      run: |
+        git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: golangci-lint
+      uses: golangci/golangci-lint-action@v3
       with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - run: make lint_provider
+        version: v1.54.1
+        working-directory: provider
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3

--- a/provider-ci/providers/random/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/random/repo/.github/workflows/release.yml
@@ -150,6 +150,9 @@ jobs:
     - name: disarm go:embed directives to enable lint
       run: |
         git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: prepare upstream
+      continue-on-error: true
+      run: make upstream
     - name: golangci-lint
       uses: golangci/golangci-lint-action@v3
       with:

--- a/provider-ci/providers/random/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/random/repo/.github/workflows/run-acceptance-tests.yml
@@ -143,7 +143,6 @@ jobs:
         repository: ${{ github.event.client_payload.github.payload.repository.full_name }}
         token: ${{ secrets.PULUMI_BOT_TOKEN }}
   lint:
-    container: golangci/golangci-lint:v1.54.1
     if: github.event_name == 'repository_dispatch' ||
       github.event.pull_request.head.repo.full_name == github.repository
     name: lint
@@ -153,28 +152,20 @@ jobs:
       uses: actions/checkout@v3
       with:
         ref: ${{ env.PR_COMMIT_SHA }}
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Mark repo as safe directory
-      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER }}/pulumi-${{ env.PROVIDER }}
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
     - name: Install Go
       uses: actions/setup-go@v4
       with:
         cache-dependency-path: |
             sdk/go.sum
         go-version: 1.21.x
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
+    - name: disarm go:embed directives to enable lint
+      run: |
+        git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: golangci-lint
+      uses: golangci/golangci-lint-action@v3
       with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - run: make lint_provider
+        version: v1.54.1
+        working-directory: provider
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3

--- a/provider-ci/providers/random/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/random/repo/.github/workflows/run-acceptance-tests.yml
@@ -155,6 +155,9 @@ jobs:
     - name: disarm go:embed directives to enable lint
       run: |
         git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: prepare upstream
+      continue-on-error: true
+      run: make upstream
     - name: Install go
       uses: actions/setup-go@v4
       with:

--- a/provider-ci/providers/random/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/random/repo/.github/workflows/run-acceptance-tests.yml
@@ -152,15 +152,16 @@ jobs:
       uses: actions/checkout@v3
       with:
         ref: ${{ env.PR_COMMIT_SHA }}
-    - name: Install Go
-      uses: actions/setup-go@v4
-      with:
-        cache-dependency-path: |
-            sdk/go.sum
-        go-version: 1.21.x
     - name: disarm go:embed directives to enable lint
       run: |
         git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: Install go
+      uses: actions/setup-go@v4
+      with:
+        # The versions of golangci-lint and setup-go here cross-depend and need to update together.
+        go-version: 1.21
+        # Either this action or golangci-lint needs to disable the cache
+        cache: false
     - name: golangci-lint
       uses: golangci/golangci-lint-action@v3
       with:

--- a/provider-ci/providers/rke/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/rke/repo/.github/workflows/main.yml
@@ -191,6 +191,9 @@ jobs:
     - name: disarm go:embed directives to enable lint
       run: |
         git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: prepare upstream
+      continue-on-error: true
+      run: make upstream
     - name: golangci-lint
       uses: golangci/golangci-lint-action@v3
       with:

--- a/provider-ci/providers/rke/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/rke/repo/.github/workflows/main.yml
@@ -177,34 +177,25 @@ jobs:
 
         aws s3 cp "${{ env.COVERAGE_OUTPUT_DIR }}/summary.json" "${s3FullURI}" --acl bucket-owner-full-control
   lint:
-    container: golangci/golangci-lint:v1.54.1
     name: lint
     runs-on: ubuntu-latest
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Mark repo as safe directory
-      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER }}/pulumi-${{ env.PROVIDER }}
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
     - name: Install Go
       uses: actions/setup-go@v4
       with:
         cache-dependency-path: |
             sdk/go.sum
         go-version: 1.21.x
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
+    - name: disarm go:embed directives to enable lint
+      run: |
+        git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: golangci-lint
+      uses: golangci/golangci-lint-action@v3
       with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - run: make lint_provider
+        version: v1.54.1
+        working-directory: provider
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3

--- a/provider-ci/providers/rke/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/rke/repo/.github/workflows/master.yml
@@ -191,6 +191,9 @@ jobs:
     - name: disarm go:embed directives to enable lint
       run: |
         git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: prepare upstream
+      continue-on-error: true
+      run: make upstream
     - name: golangci-lint
       uses: golangci/golangci-lint-action@v3
       with:

--- a/provider-ci/providers/rke/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/rke/repo/.github/workflows/master.yml
@@ -177,34 +177,25 @@ jobs:
 
         aws s3 cp "${{ env.COVERAGE_OUTPUT_DIR }}/summary.json" "${s3FullURI}" --acl bucket-owner-full-control
   lint:
-    container: golangci/golangci-lint:v1.54.1
     name: lint
     runs-on: ubuntu-latest
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Mark repo as safe directory
-      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER }}/pulumi-${{ env.PROVIDER }}
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
     - name: Install Go
       uses: actions/setup-go@v4
       with:
         cache-dependency-path: |
             sdk/go.sum
         go-version: 1.21.x
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
+    - name: disarm go:embed directives to enable lint
+      run: |
+        git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: golangci-lint
+      uses: golangci/golangci-lint-action@v3
       with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - run: make lint_provider
+        version: v1.54.1
+        working-directory: provider
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3

--- a/provider-ci/providers/rke/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/rke/repo/.github/workflows/prerelease.yml
@@ -124,34 +124,25 @@ jobs:
         - go
         - java
   lint:
-    container: golangci/golangci-lint:v1.54.1
     name: lint
     runs-on: ubuntu-latest
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Mark repo as safe directory
-      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER }}/pulumi-${{ env.PROVIDER }}
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
     - name: Install Go
       uses: actions/setup-go@v4
       with:
         cache-dependency-path: |
             sdk/go.sum
         go-version: 1.21.x
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
+    - name: disarm go:embed directives to enable lint
+      run: |
+        git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: golangci-lint
+      uses: golangci/golangci-lint-action@v3
       with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - run: make lint_provider
+        version: v1.54.1
+        working-directory: provider
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3

--- a/provider-ci/providers/rke/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/rke/repo/.github/workflows/prerelease.yml
@@ -138,6 +138,9 @@ jobs:
     - name: disarm go:embed directives to enable lint
       run: |
         git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: prepare upstream
+      continue-on-error: true
+      run: make upstream
     - name: golangci-lint
       uses: golangci/golangci-lint-action@v3
       with:

--- a/provider-ci/providers/rke/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/rke/repo/.github/workflows/release.yml
@@ -151,6 +151,9 @@ jobs:
     - name: disarm go:embed directives to enable lint
       run: |
         git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: prepare upstream
+      continue-on-error: true
+      run: make upstream
     - name: golangci-lint
       uses: golangci/golangci-lint-action@v3
       with:

--- a/provider-ci/providers/rke/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/rke/repo/.github/workflows/release.yml
@@ -137,34 +137,25 @@ jobs:
       run: pulumictl create docs-build pulumi-${{ env.PROVIDER }}
         "${GITHUB_REF#refs/tags/}"
   lint:
-    container: golangci/golangci-lint:v1.54.1
     name: lint
     runs-on: ubuntu-latest
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Mark repo as safe directory
-      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER }}/pulumi-${{ env.PROVIDER }}
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
     - name: Install Go
       uses: actions/setup-go@v4
       with:
         cache-dependency-path: |
             sdk/go.sum
         go-version: 1.21.x
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
+    - name: disarm go:embed directives to enable lint
+      run: |
+        git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: golangci-lint
+      uses: golangci/golangci-lint-action@v3
       with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - run: make lint_provider
+        version: v1.54.1
+        working-directory: provider
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3

--- a/provider-ci/providers/rke/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/rke/repo/.github/workflows/run-acceptance-tests.yml
@@ -153,15 +153,16 @@ jobs:
       uses: actions/checkout@v3
       with:
         ref: ${{ env.PR_COMMIT_SHA }}
-    - name: Install Go
-      uses: actions/setup-go@v4
-      with:
-        cache-dependency-path: |
-            sdk/go.sum
-        go-version: 1.21.x
     - name: disarm go:embed directives to enable lint
       run: |
         git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: Install go
+      uses: actions/setup-go@v4
+      with:
+        # The versions of golangci-lint and setup-go here cross-depend and need to update together.
+        go-version: 1.21
+        # Either this action or golangci-lint needs to disable the cache
+        cache: false
     - name: golangci-lint
       uses: golangci/golangci-lint-action@v3
       with:

--- a/provider-ci/providers/rke/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/rke/repo/.github/workflows/run-acceptance-tests.yml
@@ -144,7 +144,6 @@ jobs:
         repository: ${{ github.event.client_payload.github.payload.repository.full_name }}
         token: ${{ secrets.PULUMI_BOT_TOKEN }}
   lint:
-    container: golangci/golangci-lint:v1.54.1
     if: github.event_name == 'repository_dispatch' ||
       github.event.pull_request.head.repo.full_name == github.repository
     name: lint
@@ -154,28 +153,20 @@ jobs:
       uses: actions/checkout@v3
       with:
         ref: ${{ env.PR_COMMIT_SHA }}
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Mark repo as safe directory
-      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER }}/pulumi-${{ env.PROVIDER }}
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
     - name: Install Go
       uses: actions/setup-go@v4
       with:
         cache-dependency-path: |
             sdk/go.sum
         go-version: 1.21.x
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
+    - name: disarm go:embed directives to enable lint
+      run: |
+        git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: golangci-lint
+      uses: golangci/golangci-lint-action@v3
       with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - run: make lint_provider
+        version: v1.54.1
+        working-directory: provider
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3

--- a/provider-ci/providers/rke/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/rke/repo/.github/workflows/run-acceptance-tests.yml
@@ -156,6 +156,9 @@ jobs:
     - name: disarm go:embed directives to enable lint
       run: |
         git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: prepare upstream
+      continue-on-error: true
+      run: make upstream
     - name: Install go
       uses: actions/setup-go@v4
       with:

--- a/provider-ci/providers/signalfx/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/signalfx/repo/.github/workflows/main.yml
@@ -176,34 +176,25 @@ jobs:
 
         aws s3 cp "${{ env.COVERAGE_OUTPUT_DIR }}/summary.json" "${s3FullURI}" --acl bucket-owner-full-control
   lint:
-    container: golangci/golangci-lint:v1.54.1
     name: lint
     runs-on: ubuntu-latest
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Mark repo as safe directory
-      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER }}/pulumi-${{ env.PROVIDER }}
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
     - name: Install Go
       uses: actions/setup-go@v4
       with:
         cache-dependency-path: |
             sdk/go.sum
         go-version: 1.21.x
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
+    - name: disarm go:embed directives to enable lint
+      run: |
+        git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: golangci-lint
+      uses: golangci/golangci-lint-action@v3
       with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - run: make lint_provider
+        version: v1.54.1
+        working-directory: provider
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3

--- a/provider-ci/providers/signalfx/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/signalfx/repo/.github/workflows/main.yml
@@ -190,6 +190,9 @@ jobs:
     - name: disarm go:embed directives to enable lint
       run: |
         git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: prepare upstream
+      continue-on-error: true
+      run: make upstream
     - name: golangci-lint
       uses: golangci/golangci-lint-action@v3
       with:

--- a/provider-ci/providers/signalfx/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/signalfx/repo/.github/workflows/master.yml
@@ -176,34 +176,25 @@ jobs:
 
         aws s3 cp "${{ env.COVERAGE_OUTPUT_DIR }}/summary.json" "${s3FullURI}" --acl bucket-owner-full-control
   lint:
-    container: golangci/golangci-lint:v1.54.1
     name: lint
     runs-on: ubuntu-latest
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Mark repo as safe directory
-      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER }}/pulumi-${{ env.PROVIDER }}
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
     - name: Install Go
       uses: actions/setup-go@v4
       with:
         cache-dependency-path: |
             sdk/go.sum
         go-version: 1.21.x
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
+    - name: disarm go:embed directives to enable lint
+      run: |
+        git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: golangci-lint
+      uses: golangci/golangci-lint-action@v3
       with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - run: make lint_provider
+        version: v1.54.1
+        working-directory: provider
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3

--- a/provider-ci/providers/signalfx/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/signalfx/repo/.github/workflows/master.yml
@@ -190,6 +190,9 @@ jobs:
     - name: disarm go:embed directives to enable lint
       run: |
         git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: prepare upstream
+      continue-on-error: true
+      run: make upstream
     - name: golangci-lint
       uses: golangci/golangci-lint-action@v3
       with:

--- a/provider-ci/providers/signalfx/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/signalfx/repo/.github/workflows/prerelease.yml
@@ -123,34 +123,25 @@ jobs:
         - go
         - java
   lint:
-    container: golangci/golangci-lint:v1.54.1
     name: lint
     runs-on: ubuntu-latest
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Mark repo as safe directory
-      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER }}/pulumi-${{ env.PROVIDER }}
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
     - name: Install Go
       uses: actions/setup-go@v4
       with:
         cache-dependency-path: |
             sdk/go.sum
         go-version: 1.21.x
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
+    - name: disarm go:embed directives to enable lint
+      run: |
+        git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: golangci-lint
+      uses: golangci/golangci-lint-action@v3
       with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - run: make lint_provider
+        version: v1.54.1
+        working-directory: provider
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3

--- a/provider-ci/providers/signalfx/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/signalfx/repo/.github/workflows/prerelease.yml
@@ -137,6 +137,9 @@ jobs:
     - name: disarm go:embed directives to enable lint
       run: |
         git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: prepare upstream
+      continue-on-error: true
+      run: make upstream
     - name: golangci-lint
       uses: golangci/golangci-lint-action@v3
       with:

--- a/provider-ci/providers/signalfx/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/signalfx/repo/.github/workflows/release.yml
@@ -136,34 +136,25 @@ jobs:
       run: pulumictl create docs-build pulumi-${{ env.PROVIDER }}
         "${GITHUB_REF#refs/tags/}"
   lint:
-    container: golangci/golangci-lint:v1.54.1
     name: lint
     runs-on: ubuntu-latest
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Mark repo as safe directory
-      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER }}/pulumi-${{ env.PROVIDER }}
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
     - name: Install Go
       uses: actions/setup-go@v4
       with:
         cache-dependency-path: |
             sdk/go.sum
         go-version: 1.21.x
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
+    - name: disarm go:embed directives to enable lint
+      run: |
+        git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: golangci-lint
+      uses: golangci/golangci-lint-action@v3
       with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - run: make lint_provider
+        version: v1.54.1
+        working-directory: provider
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3

--- a/provider-ci/providers/signalfx/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/signalfx/repo/.github/workflows/release.yml
@@ -150,6 +150,9 @@ jobs:
     - name: disarm go:embed directives to enable lint
       run: |
         git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: prepare upstream
+      continue-on-error: true
+      run: make upstream
     - name: golangci-lint
       uses: golangci/golangci-lint-action@v3
       with:

--- a/provider-ci/providers/signalfx/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/signalfx/repo/.github/workflows/run-acceptance-tests.yml
@@ -143,7 +143,6 @@ jobs:
         repository: ${{ github.event.client_payload.github.payload.repository.full_name }}
         token: ${{ secrets.PULUMI_BOT_TOKEN }}
   lint:
-    container: golangci/golangci-lint:v1.54.1
     if: github.event_name == 'repository_dispatch' ||
       github.event.pull_request.head.repo.full_name == github.repository
     name: lint
@@ -153,28 +152,20 @@ jobs:
       uses: actions/checkout@v3
       with:
         ref: ${{ env.PR_COMMIT_SHA }}
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Mark repo as safe directory
-      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER }}/pulumi-${{ env.PROVIDER }}
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
     - name: Install Go
       uses: actions/setup-go@v4
       with:
         cache-dependency-path: |
             sdk/go.sum
         go-version: 1.21.x
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
+    - name: disarm go:embed directives to enable lint
+      run: |
+        git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: golangci-lint
+      uses: golangci/golangci-lint-action@v3
       with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - run: make lint_provider
+        version: v1.54.1
+        working-directory: provider
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3

--- a/provider-ci/providers/signalfx/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/signalfx/repo/.github/workflows/run-acceptance-tests.yml
@@ -155,6 +155,9 @@ jobs:
     - name: disarm go:embed directives to enable lint
       run: |
         git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: prepare upstream
+      continue-on-error: true
+      run: make upstream
     - name: Install go
       uses: actions/setup-go@v4
       with:

--- a/provider-ci/providers/signalfx/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/signalfx/repo/.github/workflows/run-acceptance-tests.yml
@@ -152,15 +152,16 @@ jobs:
       uses: actions/checkout@v3
       with:
         ref: ${{ env.PR_COMMIT_SHA }}
-    - name: Install Go
-      uses: actions/setup-go@v4
-      with:
-        cache-dependency-path: |
-            sdk/go.sum
-        go-version: 1.21.x
     - name: disarm go:embed directives to enable lint
       run: |
         git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: Install go
+      uses: actions/setup-go@v4
+      with:
+        # The versions of golangci-lint and setup-go here cross-depend and need to update together.
+        go-version: 1.21
+        # Either this action or golangci-lint needs to disable the cache
+        cache: false
     - name: golangci-lint
       uses: golangci/golangci-lint-action@v3
       with:

--- a/provider-ci/providers/slack/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/slack/repo/.github/workflows/main.yml
@@ -191,6 +191,9 @@ jobs:
     - name: disarm go:embed directives to enable lint
       run: |
         git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: prepare upstream
+      continue-on-error: true
+      run: make upstream
     - name: golangci-lint
       uses: golangci/golangci-lint-action@v3
       with:

--- a/provider-ci/providers/slack/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/slack/repo/.github/workflows/main.yml
@@ -177,34 +177,25 @@ jobs:
 
         aws s3 cp "${{ env.COVERAGE_OUTPUT_DIR }}/summary.json" "${s3FullURI}" --acl bucket-owner-full-control
   lint:
-    container: golangci/golangci-lint:v1.54.1
     name: lint
     runs-on: ubuntu-latest
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Mark repo as safe directory
-      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER }}/pulumi-${{ env.PROVIDER }}
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
     - name: Install Go
       uses: actions/setup-go@v4
       with:
         cache-dependency-path: |
             sdk/go.sum
         go-version: 1.21.x
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
+    - name: disarm go:embed directives to enable lint
+      run: |
+        git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: golangci-lint
+      uses: golangci/golangci-lint-action@v3
       with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - run: make lint_provider
+        version: v1.54.1
+        working-directory: provider
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3

--- a/provider-ci/providers/slack/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/slack/repo/.github/workflows/master.yml
@@ -191,6 +191,9 @@ jobs:
     - name: disarm go:embed directives to enable lint
       run: |
         git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: prepare upstream
+      continue-on-error: true
+      run: make upstream
     - name: golangci-lint
       uses: golangci/golangci-lint-action@v3
       with:

--- a/provider-ci/providers/slack/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/slack/repo/.github/workflows/master.yml
@@ -177,34 +177,25 @@ jobs:
 
         aws s3 cp "${{ env.COVERAGE_OUTPUT_DIR }}/summary.json" "${s3FullURI}" --acl bucket-owner-full-control
   lint:
-    container: golangci/golangci-lint:v1.54.1
     name: lint
     runs-on: ubuntu-latest
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Mark repo as safe directory
-      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER }}/pulumi-${{ env.PROVIDER }}
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
     - name: Install Go
       uses: actions/setup-go@v4
       with:
         cache-dependency-path: |
             sdk/go.sum
         go-version: 1.21.x
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
+    - name: disarm go:embed directives to enable lint
+      run: |
+        git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: golangci-lint
+      uses: golangci/golangci-lint-action@v3
       with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - run: make lint_provider
+        version: v1.54.1
+        working-directory: provider
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3

--- a/provider-ci/providers/slack/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/slack/repo/.github/workflows/prerelease.yml
@@ -124,34 +124,25 @@ jobs:
         - go
         - java
   lint:
-    container: golangci/golangci-lint:v1.54.1
     name: lint
     runs-on: ubuntu-latest
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Mark repo as safe directory
-      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER }}/pulumi-${{ env.PROVIDER }}
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
     - name: Install Go
       uses: actions/setup-go@v4
       with:
         cache-dependency-path: |
             sdk/go.sum
         go-version: 1.21.x
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
+    - name: disarm go:embed directives to enable lint
+      run: |
+        git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: golangci-lint
+      uses: golangci/golangci-lint-action@v3
       with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - run: make lint_provider
+        version: v1.54.1
+        working-directory: provider
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3

--- a/provider-ci/providers/slack/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/slack/repo/.github/workflows/prerelease.yml
@@ -138,6 +138,9 @@ jobs:
     - name: disarm go:embed directives to enable lint
       run: |
         git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: prepare upstream
+      continue-on-error: true
+      run: make upstream
     - name: golangci-lint
       uses: golangci/golangci-lint-action@v3
       with:

--- a/provider-ci/providers/slack/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/slack/repo/.github/workflows/release.yml
@@ -151,6 +151,9 @@ jobs:
     - name: disarm go:embed directives to enable lint
       run: |
         git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: prepare upstream
+      continue-on-error: true
+      run: make upstream
     - name: golangci-lint
       uses: golangci/golangci-lint-action@v3
       with:

--- a/provider-ci/providers/slack/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/slack/repo/.github/workflows/release.yml
@@ -137,34 +137,25 @@ jobs:
       run: pulumictl create docs-build pulumi-${{ env.PROVIDER }}
         "${GITHUB_REF#refs/tags/}"
   lint:
-    container: golangci/golangci-lint:v1.54.1
     name: lint
     runs-on: ubuntu-latest
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Mark repo as safe directory
-      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER }}/pulumi-${{ env.PROVIDER }}
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
     - name: Install Go
       uses: actions/setup-go@v4
       with:
         cache-dependency-path: |
             sdk/go.sum
         go-version: 1.21.x
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
+    - name: disarm go:embed directives to enable lint
+      run: |
+        git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: golangci-lint
+      uses: golangci/golangci-lint-action@v3
       with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - run: make lint_provider
+        version: v1.54.1
+        working-directory: provider
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3

--- a/provider-ci/providers/slack/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/slack/repo/.github/workflows/run-acceptance-tests.yml
@@ -153,15 +153,16 @@ jobs:
       uses: actions/checkout@v3
       with:
         ref: ${{ env.PR_COMMIT_SHA }}
-    - name: Install Go
-      uses: actions/setup-go@v4
-      with:
-        cache-dependency-path: |
-            sdk/go.sum
-        go-version: 1.21.x
     - name: disarm go:embed directives to enable lint
       run: |
         git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: Install go
+      uses: actions/setup-go@v4
+      with:
+        # The versions of golangci-lint and setup-go here cross-depend and need to update together.
+        go-version: 1.21
+        # Either this action or golangci-lint needs to disable the cache
+        cache: false
     - name: golangci-lint
       uses: golangci/golangci-lint-action@v3
       with:

--- a/provider-ci/providers/slack/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/slack/repo/.github/workflows/run-acceptance-tests.yml
@@ -144,7 +144,6 @@ jobs:
         repository: ${{ github.event.client_payload.github.payload.repository.full_name }}
         token: ${{ secrets.PULUMI_BOT_TOKEN }}
   lint:
-    container: golangci/golangci-lint:v1.54.1
     if: github.event_name == 'repository_dispatch' ||
       github.event.pull_request.head.repo.full_name == github.repository
     name: lint
@@ -154,28 +153,20 @@ jobs:
       uses: actions/checkout@v3
       with:
         ref: ${{ env.PR_COMMIT_SHA }}
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Mark repo as safe directory
-      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER }}/pulumi-${{ env.PROVIDER }}
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
     - name: Install Go
       uses: actions/setup-go@v4
       with:
         cache-dependency-path: |
             sdk/go.sum
         go-version: 1.21.x
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
+    - name: disarm go:embed directives to enable lint
+      run: |
+        git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: golangci-lint
+      uses: golangci/golangci-lint-action@v3
       with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - run: make lint_provider
+        version: v1.54.1
+        working-directory: provider
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3

--- a/provider-ci/providers/slack/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/slack/repo/.github/workflows/run-acceptance-tests.yml
@@ -156,6 +156,9 @@ jobs:
     - name: disarm go:embed directives to enable lint
       run: |
         git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: prepare upstream
+      continue-on-error: true
+      run: make upstream
     - name: Install go
       uses: actions/setup-go@v4
       with:

--- a/provider-ci/providers/snowflake/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/snowflake/repo/.github/workflows/main.yml
@@ -181,34 +181,25 @@ jobs:
 
         aws s3 cp "${{ env.COVERAGE_OUTPUT_DIR }}/summary.json" "${s3FullURI}" --acl bucket-owner-full-control
   lint:
-    container: golangci/golangci-lint:v1.54.1
     name: lint
     runs-on: ubuntu-latest
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Mark repo as safe directory
-      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER }}/pulumi-${{ env.PROVIDER }}
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
     - name: Install Go
       uses: actions/setup-go@v4
       with:
         cache-dependency-path: |
             sdk/go.sum
         go-version: 1.21.x
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
+    - name: disarm go:embed directives to enable lint
+      run: |
+        git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: golangci-lint
+      uses: golangci/golangci-lint-action@v3
       with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - run: make lint_provider
+        version: v1.54.1
+        working-directory: provider
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3

--- a/provider-ci/providers/snowflake/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/snowflake/repo/.github/workflows/main.yml
@@ -195,6 +195,9 @@ jobs:
     - name: disarm go:embed directives to enable lint
       run: |
         git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: prepare upstream
+      continue-on-error: true
+      run: make upstream
     - name: golangci-lint
       uses: golangci/golangci-lint-action@v3
       with:

--- a/provider-ci/providers/snowflake/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/snowflake/repo/.github/workflows/master.yml
@@ -181,34 +181,25 @@ jobs:
 
         aws s3 cp "${{ env.COVERAGE_OUTPUT_DIR }}/summary.json" "${s3FullURI}" --acl bucket-owner-full-control
   lint:
-    container: golangci/golangci-lint:v1.54.1
     name: lint
     runs-on: ubuntu-latest
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Mark repo as safe directory
-      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER }}/pulumi-${{ env.PROVIDER }}
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
     - name: Install Go
       uses: actions/setup-go@v4
       with:
         cache-dependency-path: |
             sdk/go.sum
         go-version: 1.21.x
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
+    - name: disarm go:embed directives to enable lint
+      run: |
+        git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: golangci-lint
+      uses: golangci/golangci-lint-action@v3
       with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - run: make lint_provider
+        version: v1.54.1
+        working-directory: provider
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3

--- a/provider-ci/providers/snowflake/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/snowflake/repo/.github/workflows/master.yml
@@ -195,6 +195,9 @@ jobs:
     - name: disarm go:embed directives to enable lint
       run: |
         git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: prepare upstream
+      continue-on-error: true
+      run: make upstream
     - name: golangci-lint
       uses: golangci/golangci-lint-action@v3
       with:

--- a/provider-ci/providers/snowflake/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/snowflake/repo/.github/workflows/prerelease.yml
@@ -142,6 +142,9 @@ jobs:
     - name: disarm go:embed directives to enable lint
       run: |
         git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: prepare upstream
+      continue-on-error: true
+      run: make upstream
     - name: golangci-lint
       uses: golangci/golangci-lint-action@v3
       with:

--- a/provider-ci/providers/snowflake/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/snowflake/repo/.github/workflows/prerelease.yml
@@ -128,34 +128,25 @@ jobs:
         - go
         - java
   lint:
-    container: golangci/golangci-lint:v1.54.1
     name: lint
     runs-on: ubuntu-latest
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Mark repo as safe directory
-      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER }}/pulumi-${{ env.PROVIDER }}
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
     - name: Install Go
       uses: actions/setup-go@v4
       with:
         cache-dependency-path: |
             sdk/go.sum
         go-version: 1.21.x
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
+    - name: disarm go:embed directives to enable lint
+      run: |
+        git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: golangci-lint
+      uses: golangci/golangci-lint-action@v3
       with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - run: make lint_provider
+        version: v1.54.1
+        working-directory: provider
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3

--- a/provider-ci/providers/snowflake/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/snowflake/repo/.github/workflows/release.yml
@@ -155,6 +155,9 @@ jobs:
     - name: disarm go:embed directives to enable lint
       run: |
         git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: prepare upstream
+      continue-on-error: true
+      run: make upstream
     - name: golangci-lint
       uses: golangci/golangci-lint-action@v3
       with:

--- a/provider-ci/providers/snowflake/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/snowflake/repo/.github/workflows/release.yml
@@ -141,34 +141,25 @@ jobs:
       run: pulumictl create docs-build pulumi-${{ env.PROVIDER }}
         "${GITHUB_REF#refs/tags/}"
   lint:
-    container: golangci/golangci-lint:v1.54.1
     name: lint
     runs-on: ubuntu-latest
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Mark repo as safe directory
-      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER }}/pulumi-${{ env.PROVIDER }}
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
     - name: Install Go
       uses: actions/setup-go@v4
       with:
         cache-dependency-path: |
             sdk/go.sum
         go-version: 1.21.x
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
+    - name: disarm go:embed directives to enable lint
+      run: |
+        git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: golangci-lint
+      uses: golangci/golangci-lint-action@v3
       with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - run: make lint_provider
+        version: v1.54.1
+        working-directory: provider
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3

--- a/provider-ci/providers/snowflake/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/snowflake/repo/.github/workflows/run-acceptance-tests.yml
@@ -157,15 +157,16 @@ jobs:
       uses: actions/checkout@v3
       with:
         ref: ${{ env.PR_COMMIT_SHA }}
-    - name: Install Go
-      uses: actions/setup-go@v4
-      with:
-        cache-dependency-path: |
-            sdk/go.sum
-        go-version: 1.21.x
     - name: disarm go:embed directives to enable lint
       run: |
         git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: Install go
+      uses: actions/setup-go@v4
+      with:
+        # The versions of golangci-lint and setup-go here cross-depend and need to update together.
+        go-version: 1.21
+        # Either this action or golangci-lint needs to disable the cache
+        cache: false
     - name: golangci-lint
       uses: golangci/golangci-lint-action@v3
       with:

--- a/provider-ci/providers/snowflake/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/snowflake/repo/.github/workflows/run-acceptance-tests.yml
@@ -160,6 +160,9 @@ jobs:
     - name: disarm go:embed directives to enable lint
       run: |
         git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: prepare upstream
+      continue-on-error: true
+      run: make upstream
     - name: Install go
       uses: actions/setup-go@v4
       with:

--- a/provider-ci/providers/snowflake/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/snowflake/repo/.github/workflows/run-acceptance-tests.yml
@@ -148,7 +148,6 @@ jobs:
         repository: ${{ github.event.client_payload.github.payload.repository.full_name }}
         token: ${{ secrets.PULUMI_BOT_TOKEN }}
   lint:
-    container: golangci/golangci-lint:v1.54.1
     if: github.event_name == 'repository_dispatch' ||
       github.event.pull_request.head.repo.full_name == github.repository
     name: lint
@@ -158,28 +157,20 @@ jobs:
       uses: actions/checkout@v3
       with:
         ref: ${{ env.PR_COMMIT_SHA }}
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Mark repo as safe directory
-      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER }}/pulumi-${{ env.PROVIDER }}
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
     - name: Install Go
       uses: actions/setup-go@v4
       with:
         cache-dependency-path: |
             sdk/go.sum
         go-version: 1.21.x
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
+    - name: disarm go:embed directives to enable lint
+      run: |
+        git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: golangci-lint
+      uses: golangci/golangci-lint-action@v3
       with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - run: make lint_provider
+        version: v1.54.1
+        working-directory: provider
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3

--- a/provider-ci/providers/splunk/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/splunk/repo/.github/workflows/main.yml
@@ -179,34 +179,25 @@ jobs:
 
         aws s3 cp "${{ env.COVERAGE_OUTPUT_DIR }}/summary.json" "${s3FullURI}" --acl bucket-owner-full-control
   lint:
-    container: golangci/golangci-lint:v1.54.1
     name: lint
     runs-on: ubuntu-latest
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Mark repo as safe directory
-      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER }}/pulumi-${{ env.PROVIDER }}
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
     - name: Install Go
       uses: actions/setup-go@v4
       with:
         cache-dependency-path: |
             sdk/go.sum
         go-version: 1.21.x
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
+    - name: disarm go:embed directives to enable lint
+      run: |
+        git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: golangci-lint
+      uses: golangci/golangci-lint-action@v3
       with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - run: make lint_provider
+        version: v1.54.1
+        working-directory: provider
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3

--- a/provider-ci/providers/splunk/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/splunk/repo/.github/workflows/main.yml
@@ -193,6 +193,9 @@ jobs:
     - name: disarm go:embed directives to enable lint
       run: |
         git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: prepare upstream
+      continue-on-error: true
+      run: make upstream
     - name: golangci-lint
       uses: golangci/golangci-lint-action@v3
       with:

--- a/provider-ci/providers/splunk/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/splunk/repo/.github/workflows/master.yml
@@ -179,34 +179,25 @@ jobs:
 
         aws s3 cp "${{ env.COVERAGE_OUTPUT_DIR }}/summary.json" "${s3FullURI}" --acl bucket-owner-full-control
   lint:
-    container: golangci/golangci-lint:v1.54.1
     name: lint
     runs-on: ubuntu-latest
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Mark repo as safe directory
-      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER }}/pulumi-${{ env.PROVIDER }}
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
     - name: Install Go
       uses: actions/setup-go@v4
       with:
         cache-dependency-path: |
             sdk/go.sum
         go-version: 1.21.x
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
+    - name: disarm go:embed directives to enable lint
+      run: |
+        git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: golangci-lint
+      uses: golangci/golangci-lint-action@v3
       with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - run: make lint_provider
+        version: v1.54.1
+        working-directory: provider
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3

--- a/provider-ci/providers/splunk/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/splunk/repo/.github/workflows/master.yml
@@ -193,6 +193,9 @@ jobs:
     - name: disarm go:embed directives to enable lint
       run: |
         git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: prepare upstream
+      continue-on-error: true
+      run: make upstream
     - name: golangci-lint
       uses: golangci/golangci-lint-action@v3
       with:

--- a/provider-ci/providers/splunk/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/splunk/repo/.github/workflows/prerelease.yml
@@ -140,6 +140,9 @@ jobs:
     - name: disarm go:embed directives to enable lint
       run: |
         git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: prepare upstream
+      continue-on-error: true
+      run: make upstream
     - name: golangci-lint
       uses: golangci/golangci-lint-action@v3
       with:

--- a/provider-ci/providers/splunk/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/splunk/repo/.github/workflows/prerelease.yml
@@ -126,34 +126,25 @@ jobs:
         - go
         - java
   lint:
-    container: golangci/golangci-lint:v1.54.1
     name: lint
     runs-on: ubuntu-latest
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Mark repo as safe directory
-      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER }}/pulumi-${{ env.PROVIDER }}
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
     - name: Install Go
       uses: actions/setup-go@v4
       with:
         cache-dependency-path: |
             sdk/go.sum
         go-version: 1.21.x
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
+    - name: disarm go:embed directives to enable lint
+      run: |
+        git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: golangci-lint
+      uses: golangci/golangci-lint-action@v3
       with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - run: make lint_provider
+        version: v1.54.1
+        working-directory: provider
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3

--- a/provider-ci/providers/splunk/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/splunk/repo/.github/workflows/release.yml
@@ -153,6 +153,9 @@ jobs:
     - name: disarm go:embed directives to enable lint
       run: |
         git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: prepare upstream
+      continue-on-error: true
+      run: make upstream
     - name: golangci-lint
       uses: golangci/golangci-lint-action@v3
       with:

--- a/provider-ci/providers/splunk/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/splunk/repo/.github/workflows/release.yml
@@ -139,34 +139,25 @@ jobs:
       run: pulumictl create docs-build pulumi-${{ env.PROVIDER }}
         "${GITHUB_REF#refs/tags/}"
   lint:
-    container: golangci/golangci-lint:v1.54.1
     name: lint
     runs-on: ubuntu-latest
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Mark repo as safe directory
-      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER }}/pulumi-${{ env.PROVIDER }}
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
     - name: Install Go
       uses: actions/setup-go@v4
       with:
         cache-dependency-path: |
             sdk/go.sum
         go-version: 1.21.x
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
+    - name: disarm go:embed directives to enable lint
+      run: |
+        git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: golangci-lint
+      uses: golangci/golangci-lint-action@v3
       with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - run: make lint_provider
+        version: v1.54.1
+        working-directory: provider
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3

--- a/provider-ci/providers/splunk/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/splunk/repo/.github/workflows/run-acceptance-tests.yml
@@ -146,7 +146,6 @@ jobs:
         repository: ${{ github.event.client_payload.github.payload.repository.full_name }}
         token: ${{ secrets.PULUMI_BOT_TOKEN }}
   lint:
-    container: golangci/golangci-lint:v1.54.1
     if: github.event_name == 'repository_dispatch' ||
       github.event.pull_request.head.repo.full_name == github.repository
     name: lint
@@ -156,28 +155,20 @@ jobs:
       uses: actions/checkout@v3
       with:
         ref: ${{ env.PR_COMMIT_SHA }}
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Mark repo as safe directory
-      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER }}/pulumi-${{ env.PROVIDER }}
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
     - name: Install Go
       uses: actions/setup-go@v4
       with:
         cache-dependency-path: |
             sdk/go.sum
         go-version: 1.21.x
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
+    - name: disarm go:embed directives to enable lint
+      run: |
+        git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: golangci-lint
+      uses: golangci/golangci-lint-action@v3
       with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - run: make lint_provider
+        version: v1.54.1
+        working-directory: provider
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3

--- a/provider-ci/providers/splunk/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/splunk/repo/.github/workflows/run-acceptance-tests.yml
@@ -158,6 +158,9 @@ jobs:
     - name: disarm go:embed directives to enable lint
       run: |
         git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: prepare upstream
+      continue-on-error: true
+      run: make upstream
     - name: Install go
       uses: actions/setup-go@v4
       with:

--- a/provider-ci/providers/splunk/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/splunk/repo/.github/workflows/run-acceptance-tests.yml
@@ -155,15 +155,16 @@ jobs:
       uses: actions/checkout@v3
       with:
         ref: ${{ env.PR_COMMIT_SHA }}
-    - name: Install Go
-      uses: actions/setup-go@v4
-      with:
-        cache-dependency-path: |
-            sdk/go.sum
-        go-version: 1.21.x
     - name: disarm go:embed directives to enable lint
       run: |
         git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: Install go
+      uses: actions/setup-go@v4
+      with:
+        # The versions of golangci-lint and setup-go here cross-depend and need to update together.
+        go-version: 1.21
+        # Either this action or golangci-lint needs to disable the cache
+        cache: false
     - name: golangci-lint
       uses: golangci/golangci-lint-action@v3
       with:

--- a/provider-ci/providers/spotinst/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/spotinst/repo/.github/workflows/main.yml
@@ -179,34 +179,25 @@ jobs:
 
         aws s3 cp "${{ env.COVERAGE_OUTPUT_DIR }}/summary.json" "${s3FullURI}" --acl bucket-owner-full-control
   lint:
-    container: golangci/golangci-lint:v1.54.1
     name: lint
     runs-on: ubuntu-latest
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Mark repo as safe directory
-      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER }}/pulumi-${{ env.PROVIDER }}
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
     - name: Install Go
       uses: actions/setup-go@v4
       with:
         cache-dependency-path: |
             sdk/go.sum
         go-version: 1.21.x
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
+    - name: disarm go:embed directives to enable lint
+      run: |
+        git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: golangci-lint
+      uses: golangci/golangci-lint-action@v3
       with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - run: make lint_provider
+        version: v1.54.1
+        working-directory: provider
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3

--- a/provider-ci/providers/spotinst/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/spotinst/repo/.github/workflows/main.yml
@@ -193,6 +193,9 @@ jobs:
     - name: disarm go:embed directives to enable lint
       run: |
         git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: prepare upstream
+      continue-on-error: true
+      run: make upstream
     - name: golangci-lint
       uses: golangci/golangci-lint-action@v3
       with:

--- a/provider-ci/providers/spotinst/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/spotinst/repo/.github/workflows/master.yml
@@ -179,34 +179,25 @@ jobs:
 
         aws s3 cp "${{ env.COVERAGE_OUTPUT_DIR }}/summary.json" "${s3FullURI}" --acl bucket-owner-full-control
   lint:
-    container: golangci/golangci-lint:v1.54.1
     name: lint
     runs-on: ubuntu-latest
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Mark repo as safe directory
-      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER }}/pulumi-${{ env.PROVIDER }}
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
     - name: Install Go
       uses: actions/setup-go@v4
       with:
         cache-dependency-path: |
             sdk/go.sum
         go-version: 1.21.x
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
+    - name: disarm go:embed directives to enable lint
+      run: |
+        git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: golangci-lint
+      uses: golangci/golangci-lint-action@v3
       with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - run: make lint_provider
+        version: v1.54.1
+        working-directory: provider
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3

--- a/provider-ci/providers/spotinst/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/spotinst/repo/.github/workflows/master.yml
@@ -193,6 +193,9 @@ jobs:
     - name: disarm go:embed directives to enable lint
       run: |
         git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: prepare upstream
+      continue-on-error: true
+      run: make upstream
     - name: golangci-lint
       uses: golangci/golangci-lint-action@v3
       with:

--- a/provider-ci/providers/spotinst/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/spotinst/repo/.github/workflows/prerelease.yml
@@ -140,6 +140,9 @@ jobs:
     - name: disarm go:embed directives to enable lint
       run: |
         git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: prepare upstream
+      continue-on-error: true
+      run: make upstream
     - name: golangci-lint
       uses: golangci/golangci-lint-action@v3
       with:

--- a/provider-ci/providers/spotinst/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/spotinst/repo/.github/workflows/prerelease.yml
@@ -126,34 +126,25 @@ jobs:
         - go
         - java
   lint:
-    container: golangci/golangci-lint:v1.54.1
     name: lint
     runs-on: ubuntu-latest
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Mark repo as safe directory
-      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER }}/pulumi-${{ env.PROVIDER }}
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
     - name: Install Go
       uses: actions/setup-go@v4
       with:
         cache-dependency-path: |
             sdk/go.sum
         go-version: 1.21.x
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
+    - name: disarm go:embed directives to enable lint
+      run: |
+        git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: golangci-lint
+      uses: golangci/golangci-lint-action@v3
       with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - run: make lint_provider
+        version: v1.54.1
+        working-directory: provider
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3

--- a/provider-ci/providers/spotinst/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/spotinst/repo/.github/workflows/release.yml
@@ -153,6 +153,9 @@ jobs:
     - name: disarm go:embed directives to enable lint
       run: |
         git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: prepare upstream
+      continue-on-error: true
+      run: make upstream
     - name: golangci-lint
       uses: golangci/golangci-lint-action@v3
       with:

--- a/provider-ci/providers/spotinst/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/spotinst/repo/.github/workflows/release.yml
@@ -139,34 +139,25 @@ jobs:
       run: pulumictl create docs-build pulumi-${{ env.PROVIDER }}
         "${GITHUB_REF#refs/tags/}"
   lint:
-    container: golangci/golangci-lint:v1.54.1
     name: lint
     runs-on: ubuntu-latest
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Mark repo as safe directory
-      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER }}/pulumi-${{ env.PROVIDER }}
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
     - name: Install Go
       uses: actions/setup-go@v4
       with:
         cache-dependency-path: |
             sdk/go.sum
         go-version: 1.21.x
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
+    - name: disarm go:embed directives to enable lint
+      run: |
+        git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: golangci-lint
+      uses: golangci/golangci-lint-action@v3
       with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - run: make lint_provider
+        version: v1.54.1
+        working-directory: provider
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3

--- a/provider-ci/providers/spotinst/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/spotinst/repo/.github/workflows/run-acceptance-tests.yml
@@ -146,7 +146,6 @@ jobs:
         repository: ${{ github.event.client_payload.github.payload.repository.full_name }}
         token: ${{ secrets.PULUMI_BOT_TOKEN }}
   lint:
-    container: golangci/golangci-lint:v1.54.1
     if: github.event_name == 'repository_dispatch' ||
       github.event.pull_request.head.repo.full_name == github.repository
     name: lint
@@ -156,28 +155,20 @@ jobs:
       uses: actions/checkout@v3
       with:
         ref: ${{ env.PR_COMMIT_SHA }}
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Mark repo as safe directory
-      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER }}/pulumi-${{ env.PROVIDER }}
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
     - name: Install Go
       uses: actions/setup-go@v4
       with:
         cache-dependency-path: |
             sdk/go.sum
         go-version: 1.21.x
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
+    - name: disarm go:embed directives to enable lint
+      run: |
+        git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: golangci-lint
+      uses: golangci/golangci-lint-action@v3
       with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - run: make lint_provider
+        version: v1.54.1
+        working-directory: provider
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3

--- a/provider-ci/providers/spotinst/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/spotinst/repo/.github/workflows/run-acceptance-tests.yml
@@ -158,6 +158,9 @@ jobs:
     - name: disarm go:embed directives to enable lint
       run: |
         git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: prepare upstream
+      continue-on-error: true
+      run: make upstream
     - name: Install go
       uses: actions/setup-go@v4
       with:

--- a/provider-ci/providers/spotinst/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/spotinst/repo/.github/workflows/run-acceptance-tests.yml
@@ -155,15 +155,16 @@ jobs:
       uses: actions/checkout@v3
       with:
         ref: ${{ env.PR_COMMIT_SHA }}
-    - name: Install Go
-      uses: actions/setup-go@v4
-      with:
-        cache-dependency-path: |
-            sdk/go.sum
-        go-version: 1.21.x
     - name: disarm go:embed directives to enable lint
       run: |
         git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: Install go
+      uses: actions/setup-go@v4
+      with:
+        # The versions of golangci-lint and setup-go here cross-depend and need to update together.
+        go-version: 1.21
+        # Either this action or golangci-lint needs to disable the cache
+        cache: false
     - name: golangci-lint
       uses: golangci/golangci-lint-action@v3
       with:

--- a/provider-ci/providers/sumologic/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/sumologic/repo/.github/workflows/main.yml
@@ -179,34 +179,25 @@ jobs:
 
         aws s3 cp "${{ env.COVERAGE_OUTPUT_DIR }}/summary.json" "${s3FullURI}" --acl bucket-owner-full-control
   lint:
-    container: golangci/golangci-lint:v1.54.1
     name: lint
     runs-on: ubuntu-latest
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Mark repo as safe directory
-      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER }}/pulumi-${{ env.PROVIDER }}
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
     - name: Install Go
       uses: actions/setup-go@v4
       with:
         cache-dependency-path: |
             sdk/go.sum
         go-version: 1.21.x
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
+    - name: disarm go:embed directives to enable lint
+      run: |
+        git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: golangci-lint
+      uses: golangci/golangci-lint-action@v3
       with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - run: make lint_provider
+        version: v1.54.1
+        working-directory: provider
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3

--- a/provider-ci/providers/sumologic/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/sumologic/repo/.github/workflows/main.yml
@@ -193,6 +193,9 @@ jobs:
     - name: disarm go:embed directives to enable lint
       run: |
         git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: prepare upstream
+      continue-on-error: true
+      run: make upstream
     - name: golangci-lint
       uses: golangci/golangci-lint-action@v3
       with:

--- a/provider-ci/providers/sumologic/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/sumologic/repo/.github/workflows/master.yml
@@ -179,34 +179,25 @@ jobs:
 
         aws s3 cp "${{ env.COVERAGE_OUTPUT_DIR }}/summary.json" "${s3FullURI}" --acl bucket-owner-full-control
   lint:
-    container: golangci/golangci-lint:v1.54.1
     name: lint
     runs-on: ubuntu-latest
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Mark repo as safe directory
-      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER }}/pulumi-${{ env.PROVIDER }}
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
     - name: Install Go
       uses: actions/setup-go@v4
       with:
         cache-dependency-path: |
             sdk/go.sum
         go-version: 1.21.x
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
+    - name: disarm go:embed directives to enable lint
+      run: |
+        git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: golangci-lint
+      uses: golangci/golangci-lint-action@v3
       with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - run: make lint_provider
+        version: v1.54.1
+        working-directory: provider
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3

--- a/provider-ci/providers/sumologic/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/sumologic/repo/.github/workflows/master.yml
@@ -193,6 +193,9 @@ jobs:
     - name: disarm go:embed directives to enable lint
       run: |
         git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: prepare upstream
+      continue-on-error: true
+      run: make upstream
     - name: golangci-lint
       uses: golangci/golangci-lint-action@v3
       with:

--- a/provider-ci/providers/sumologic/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/sumologic/repo/.github/workflows/prerelease.yml
@@ -140,6 +140,9 @@ jobs:
     - name: disarm go:embed directives to enable lint
       run: |
         git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: prepare upstream
+      continue-on-error: true
+      run: make upstream
     - name: golangci-lint
       uses: golangci/golangci-lint-action@v3
       with:

--- a/provider-ci/providers/sumologic/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/sumologic/repo/.github/workflows/prerelease.yml
@@ -126,34 +126,25 @@ jobs:
         - go
         - java
   lint:
-    container: golangci/golangci-lint:v1.54.1
     name: lint
     runs-on: ubuntu-latest
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Mark repo as safe directory
-      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER }}/pulumi-${{ env.PROVIDER }}
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
     - name: Install Go
       uses: actions/setup-go@v4
       with:
         cache-dependency-path: |
             sdk/go.sum
         go-version: 1.21.x
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
+    - name: disarm go:embed directives to enable lint
+      run: |
+        git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: golangci-lint
+      uses: golangci/golangci-lint-action@v3
       with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - run: make lint_provider
+        version: v1.54.1
+        working-directory: provider
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3

--- a/provider-ci/providers/sumologic/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/sumologic/repo/.github/workflows/release.yml
@@ -153,6 +153,9 @@ jobs:
     - name: disarm go:embed directives to enable lint
       run: |
         git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: prepare upstream
+      continue-on-error: true
+      run: make upstream
     - name: golangci-lint
       uses: golangci/golangci-lint-action@v3
       with:

--- a/provider-ci/providers/sumologic/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/sumologic/repo/.github/workflows/release.yml
@@ -139,34 +139,25 @@ jobs:
       run: pulumictl create docs-build pulumi-${{ env.PROVIDER }}
         "${GITHUB_REF#refs/tags/}"
   lint:
-    container: golangci/golangci-lint:v1.54.1
     name: lint
     runs-on: ubuntu-latest
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Mark repo as safe directory
-      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER }}/pulumi-${{ env.PROVIDER }}
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
     - name: Install Go
       uses: actions/setup-go@v4
       with:
         cache-dependency-path: |
             sdk/go.sum
         go-version: 1.21.x
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
+    - name: disarm go:embed directives to enable lint
+      run: |
+        git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: golangci-lint
+      uses: golangci/golangci-lint-action@v3
       with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - run: make lint_provider
+        version: v1.54.1
+        working-directory: provider
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3

--- a/provider-ci/providers/sumologic/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/sumologic/repo/.github/workflows/run-acceptance-tests.yml
@@ -146,7 +146,6 @@ jobs:
         repository: ${{ github.event.client_payload.github.payload.repository.full_name }}
         token: ${{ secrets.PULUMI_BOT_TOKEN }}
   lint:
-    container: golangci/golangci-lint:v1.54.1
     if: github.event_name == 'repository_dispatch' ||
       github.event.pull_request.head.repo.full_name == github.repository
     name: lint
@@ -156,28 +155,20 @@ jobs:
       uses: actions/checkout@v3
       with:
         ref: ${{ env.PR_COMMIT_SHA }}
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Mark repo as safe directory
-      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER }}/pulumi-${{ env.PROVIDER }}
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
     - name: Install Go
       uses: actions/setup-go@v4
       with:
         cache-dependency-path: |
             sdk/go.sum
         go-version: 1.21.x
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
+    - name: disarm go:embed directives to enable lint
+      run: |
+        git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: golangci-lint
+      uses: golangci/golangci-lint-action@v3
       with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - run: make lint_provider
+        version: v1.54.1
+        working-directory: provider
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3

--- a/provider-ci/providers/sumologic/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/sumologic/repo/.github/workflows/run-acceptance-tests.yml
@@ -158,6 +158,9 @@ jobs:
     - name: disarm go:embed directives to enable lint
       run: |
         git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: prepare upstream
+      continue-on-error: true
+      run: make upstream
     - name: Install go
       uses: actions/setup-go@v4
       with:

--- a/provider-ci/providers/sumologic/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/sumologic/repo/.github/workflows/run-acceptance-tests.yml
@@ -155,15 +155,16 @@ jobs:
       uses: actions/checkout@v3
       with:
         ref: ${{ env.PR_COMMIT_SHA }}
-    - name: Install Go
-      uses: actions/setup-go@v4
-      with:
-        cache-dependency-path: |
-            sdk/go.sum
-        go-version: 1.21.x
     - name: disarm go:embed directives to enable lint
       run: |
         git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: Install go
+      uses: actions/setup-go@v4
+      with:
+        # The versions of golangci-lint and setup-go here cross-depend and need to update together.
+        go-version: 1.21
+        # Either this action or golangci-lint needs to disable the cache
+        cache: false
     - name: golangci-lint
       uses: golangci/golangci-lint-action@v3
       with:

--- a/provider-ci/providers/tailscale/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/tailscale/repo/.github/workflows/main.yml
@@ -179,34 +179,25 @@ jobs:
 
         aws s3 cp "${{ env.COVERAGE_OUTPUT_DIR }}/summary.json" "${s3FullURI}" --acl bucket-owner-full-control
   lint:
-    container: golangci/golangci-lint:v1.54.1
     name: lint
     runs-on: ubuntu-latest
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Mark repo as safe directory
-      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER }}/pulumi-${{ env.PROVIDER }}
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
     - name: Install Go
       uses: actions/setup-go@v4
       with:
         cache-dependency-path: |
             sdk/go.sum
         go-version: 1.21.x
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
+    - name: disarm go:embed directives to enable lint
+      run: |
+        git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: golangci-lint
+      uses: golangci/golangci-lint-action@v3
       with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - run: make lint_provider
+        version: v1.54.1
+        working-directory: provider
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3

--- a/provider-ci/providers/tailscale/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/tailscale/repo/.github/workflows/main.yml
@@ -193,6 +193,9 @@ jobs:
     - name: disarm go:embed directives to enable lint
       run: |
         git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: prepare upstream
+      continue-on-error: true
+      run: make upstream
     - name: golangci-lint
       uses: golangci/golangci-lint-action@v3
       with:

--- a/provider-ci/providers/tailscale/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/tailscale/repo/.github/workflows/master.yml
@@ -179,34 +179,25 @@ jobs:
 
         aws s3 cp "${{ env.COVERAGE_OUTPUT_DIR }}/summary.json" "${s3FullURI}" --acl bucket-owner-full-control
   lint:
-    container: golangci/golangci-lint:v1.54.1
     name: lint
     runs-on: ubuntu-latest
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Mark repo as safe directory
-      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER }}/pulumi-${{ env.PROVIDER }}
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
     - name: Install Go
       uses: actions/setup-go@v4
       with:
         cache-dependency-path: |
             sdk/go.sum
         go-version: 1.21.x
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
+    - name: disarm go:embed directives to enable lint
+      run: |
+        git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: golangci-lint
+      uses: golangci/golangci-lint-action@v3
       with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - run: make lint_provider
+        version: v1.54.1
+        working-directory: provider
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3

--- a/provider-ci/providers/tailscale/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/tailscale/repo/.github/workflows/master.yml
@@ -193,6 +193,9 @@ jobs:
     - name: disarm go:embed directives to enable lint
       run: |
         git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: prepare upstream
+      continue-on-error: true
+      run: make upstream
     - name: golangci-lint
       uses: golangci/golangci-lint-action@v3
       with:

--- a/provider-ci/providers/tailscale/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/tailscale/repo/.github/workflows/prerelease.yml
@@ -140,6 +140,9 @@ jobs:
     - name: disarm go:embed directives to enable lint
       run: |
         git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: prepare upstream
+      continue-on-error: true
+      run: make upstream
     - name: golangci-lint
       uses: golangci/golangci-lint-action@v3
       with:

--- a/provider-ci/providers/tailscale/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/tailscale/repo/.github/workflows/prerelease.yml
@@ -126,34 +126,25 @@ jobs:
         - go
         - java
   lint:
-    container: golangci/golangci-lint:v1.54.1
     name: lint
     runs-on: ubuntu-latest
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Mark repo as safe directory
-      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER }}/pulumi-${{ env.PROVIDER }}
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
     - name: Install Go
       uses: actions/setup-go@v4
       with:
         cache-dependency-path: |
             sdk/go.sum
         go-version: 1.21.x
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
+    - name: disarm go:embed directives to enable lint
+      run: |
+        git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: golangci-lint
+      uses: golangci/golangci-lint-action@v3
       with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - run: make lint_provider
+        version: v1.54.1
+        working-directory: provider
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3

--- a/provider-ci/providers/tailscale/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/tailscale/repo/.github/workflows/release.yml
@@ -153,6 +153,9 @@ jobs:
     - name: disarm go:embed directives to enable lint
       run: |
         git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: prepare upstream
+      continue-on-error: true
+      run: make upstream
     - name: golangci-lint
       uses: golangci/golangci-lint-action@v3
       with:

--- a/provider-ci/providers/tailscale/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/tailscale/repo/.github/workflows/release.yml
@@ -139,34 +139,25 @@ jobs:
       run: pulumictl create docs-build pulumi-${{ env.PROVIDER }}
         "${GITHUB_REF#refs/tags/}"
   lint:
-    container: golangci/golangci-lint:v1.54.1
     name: lint
     runs-on: ubuntu-latest
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Mark repo as safe directory
-      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER }}/pulumi-${{ env.PROVIDER }}
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
     - name: Install Go
       uses: actions/setup-go@v4
       with:
         cache-dependency-path: |
             sdk/go.sum
         go-version: 1.21.x
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
+    - name: disarm go:embed directives to enable lint
+      run: |
+        git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: golangci-lint
+      uses: golangci/golangci-lint-action@v3
       with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - run: make lint_provider
+        version: v1.54.1
+        working-directory: provider
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3

--- a/provider-ci/providers/tailscale/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/tailscale/repo/.github/workflows/run-acceptance-tests.yml
@@ -146,7 +146,6 @@ jobs:
         repository: ${{ github.event.client_payload.github.payload.repository.full_name }}
         token: ${{ secrets.PULUMI_BOT_TOKEN }}
   lint:
-    container: golangci/golangci-lint:v1.54.1
     if: github.event_name == 'repository_dispatch' ||
       github.event.pull_request.head.repo.full_name == github.repository
     name: lint
@@ -156,28 +155,20 @@ jobs:
       uses: actions/checkout@v3
       with:
         ref: ${{ env.PR_COMMIT_SHA }}
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Mark repo as safe directory
-      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER }}/pulumi-${{ env.PROVIDER }}
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
     - name: Install Go
       uses: actions/setup-go@v4
       with:
         cache-dependency-path: |
             sdk/go.sum
         go-version: 1.21.x
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
+    - name: disarm go:embed directives to enable lint
+      run: |
+        git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: golangci-lint
+      uses: golangci/golangci-lint-action@v3
       with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - run: make lint_provider
+        version: v1.54.1
+        working-directory: provider
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3

--- a/provider-ci/providers/tailscale/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/tailscale/repo/.github/workflows/run-acceptance-tests.yml
@@ -158,6 +158,9 @@ jobs:
     - name: disarm go:embed directives to enable lint
       run: |
         git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: prepare upstream
+      continue-on-error: true
+      run: make upstream
     - name: Install go
       uses: actions/setup-go@v4
       with:

--- a/provider-ci/providers/tailscale/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/tailscale/repo/.github/workflows/run-acceptance-tests.yml
@@ -155,15 +155,16 @@ jobs:
       uses: actions/checkout@v3
       with:
         ref: ${{ env.PR_COMMIT_SHA }}
-    - name: Install Go
-      uses: actions/setup-go@v4
-      with:
-        cache-dependency-path: |
-            sdk/go.sum
-        go-version: 1.21.x
     - name: disarm go:embed directives to enable lint
       run: |
         git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: Install go
+      uses: actions/setup-go@v4
+      with:
+        # The versions of golangci-lint and setup-go here cross-depend and need to update together.
+        go-version: 1.21
+        # Either this action or golangci-lint needs to disable the cache
+        cache: false
     - name: golangci-lint
       uses: golangci/golangci-lint-action@v3
       with:

--- a/provider-ci/providers/tls/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/tls/repo/.github/workflows/main.yml
@@ -176,34 +176,25 @@ jobs:
 
         aws s3 cp "${{ env.COVERAGE_OUTPUT_DIR }}/summary.json" "${s3FullURI}" --acl bucket-owner-full-control
   lint:
-    container: golangci/golangci-lint:v1.54.1
     name: lint
     runs-on: ubuntu-latest
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Mark repo as safe directory
-      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER }}/pulumi-${{ env.PROVIDER }}
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
     - name: Install Go
       uses: actions/setup-go@v4
       with:
         cache-dependency-path: |
             sdk/go.sum
         go-version: 1.21.x
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
+    - name: disarm go:embed directives to enable lint
+      run: |
+        git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: golangci-lint
+      uses: golangci/golangci-lint-action@v3
       with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - run: make lint_provider
+        version: v1.54.1
+        working-directory: provider
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3

--- a/provider-ci/providers/tls/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/tls/repo/.github/workflows/main.yml
@@ -190,6 +190,9 @@ jobs:
     - name: disarm go:embed directives to enable lint
       run: |
         git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: prepare upstream
+      continue-on-error: true
+      run: make upstream
     - name: golangci-lint
       uses: golangci/golangci-lint-action@v3
       with:

--- a/provider-ci/providers/tls/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/tls/repo/.github/workflows/master.yml
@@ -176,34 +176,25 @@ jobs:
 
         aws s3 cp "${{ env.COVERAGE_OUTPUT_DIR }}/summary.json" "${s3FullURI}" --acl bucket-owner-full-control
   lint:
-    container: golangci/golangci-lint:v1.54.1
     name: lint
     runs-on: ubuntu-latest
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Mark repo as safe directory
-      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER }}/pulumi-${{ env.PROVIDER }}
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
     - name: Install Go
       uses: actions/setup-go@v4
       with:
         cache-dependency-path: |
             sdk/go.sum
         go-version: 1.21.x
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
+    - name: disarm go:embed directives to enable lint
+      run: |
+        git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: golangci-lint
+      uses: golangci/golangci-lint-action@v3
       with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - run: make lint_provider
+        version: v1.54.1
+        working-directory: provider
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3

--- a/provider-ci/providers/tls/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/tls/repo/.github/workflows/master.yml
@@ -190,6 +190,9 @@ jobs:
     - name: disarm go:embed directives to enable lint
       run: |
         git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: prepare upstream
+      continue-on-error: true
+      run: make upstream
     - name: golangci-lint
       uses: golangci/golangci-lint-action@v3
       with:

--- a/provider-ci/providers/tls/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/tls/repo/.github/workflows/prerelease.yml
@@ -123,34 +123,25 @@ jobs:
         - go
         - java
   lint:
-    container: golangci/golangci-lint:v1.54.1
     name: lint
     runs-on: ubuntu-latest
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Mark repo as safe directory
-      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER }}/pulumi-${{ env.PROVIDER }}
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
     - name: Install Go
       uses: actions/setup-go@v4
       with:
         cache-dependency-path: |
             sdk/go.sum
         go-version: 1.21.x
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
+    - name: disarm go:embed directives to enable lint
+      run: |
+        git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: golangci-lint
+      uses: golangci/golangci-lint-action@v3
       with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - run: make lint_provider
+        version: v1.54.1
+        working-directory: provider
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3

--- a/provider-ci/providers/tls/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/tls/repo/.github/workflows/prerelease.yml
@@ -137,6 +137,9 @@ jobs:
     - name: disarm go:embed directives to enable lint
       run: |
         git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: prepare upstream
+      continue-on-error: true
+      run: make upstream
     - name: golangci-lint
       uses: golangci/golangci-lint-action@v3
       with:

--- a/provider-ci/providers/tls/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/tls/repo/.github/workflows/release.yml
@@ -136,34 +136,25 @@ jobs:
       run: pulumictl create docs-build pulumi-${{ env.PROVIDER }}
         "${GITHUB_REF#refs/tags/}"
   lint:
-    container: golangci/golangci-lint:v1.54.1
     name: lint
     runs-on: ubuntu-latest
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Mark repo as safe directory
-      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER }}/pulumi-${{ env.PROVIDER }}
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
     - name: Install Go
       uses: actions/setup-go@v4
       with:
         cache-dependency-path: |
             sdk/go.sum
         go-version: 1.21.x
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
+    - name: disarm go:embed directives to enable lint
+      run: |
+        git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: golangci-lint
+      uses: golangci/golangci-lint-action@v3
       with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - run: make lint_provider
+        version: v1.54.1
+        working-directory: provider
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3

--- a/provider-ci/providers/tls/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/tls/repo/.github/workflows/release.yml
@@ -150,6 +150,9 @@ jobs:
     - name: disarm go:embed directives to enable lint
       run: |
         git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: prepare upstream
+      continue-on-error: true
+      run: make upstream
     - name: golangci-lint
       uses: golangci/golangci-lint-action@v3
       with:

--- a/provider-ci/providers/tls/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/tls/repo/.github/workflows/run-acceptance-tests.yml
@@ -143,7 +143,6 @@ jobs:
         repository: ${{ github.event.client_payload.github.payload.repository.full_name }}
         token: ${{ secrets.PULUMI_BOT_TOKEN }}
   lint:
-    container: golangci/golangci-lint:v1.54.1
     if: github.event_name == 'repository_dispatch' ||
       github.event.pull_request.head.repo.full_name == github.repository
     name: lint
@@ -153,28 +152,20 @@ jobs:
       uses: actions/checkout@v3
       with:
         ref: ${{ env.PR_COMMIT_SHA }}
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Mark repo as safe directory
-      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER }}/pulumi-${{ env.PROVIDER }}
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
     - name: Install Go
       uses: actions/setup-go@v4
       with:
         cache-dependency-path: |
             sdk/go.sum
         go-version: 1.21.x
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
+    - name: disarm go:embed directives to enable lint
+      run: |
+        git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: golangci-lint
+      uses: golangci/golangci-lint-action@v3
       with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - run: make lint_provider
+        version: v1.54.1
+        working-directory: provider
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3

--- a/provider-ci/providers/tls/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/tls/repo/.github/workflows/run-acceptance-tests.yml
@@ -155,6 +155,9 @@ jobs:
     - name: disarm go:embed directives to enable lint
       run: |
         git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: prepare upstream
+      continue-on-error: true
+      run: make upstream
     - name: Install go
       uses: actions/setup-go@v4
       with:

--- a/provider-ci/providers/tls/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/tls/repo/.github/workflows/run-acceptance-tests.yml
@@ -152,15 +152,16 @@ jobs:
       uses: actions/checkout@v3
       with:
         ref: ${{ env.PR_COMMIT_SHA }}
-    - name: Install Go
-      uses: actions/setup-go@v4
-      with:
-        cache-dependency-path: |
-            sdk/go.sum
-        go-version: 1.21.x
     - name: disarm go:embed directives to enable lint
       run: |
         git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: Install go
+      uses: actions/setup-go@v4
+      with:
+        # The versions of golangci-lint and setup-go here cross-depend and need to update together.
+        go-version: 1.21
+        # Either this action or golangci-lint needs to disable the cache
+        cache: false
     - name: golangci-lint
       uses: golangci/golangci-lint-action@v3
       with:

--- a/provider-ci/providers/vault/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/vault/repo/.github/workflows/main.yml
@@ -191,6 +191,9 @@ jobs:
     - name: disarm go:embed directives to enable lint
       run: |
         git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: prepare upstream
+      continue-on-error: true
+      run: make upstream
     - name: golangci-lint
       uses: golangci/golangci-lint-action@v3
       with:

--- a/provider-ci/providers/vault/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/vault/repo/.github/workflows/main.yml
@@ -177,34 +177,25 @@ jobs:
 
         aws s3 cp "${{ env.COVERAGE_OUTPUT_DIR }}/summary.json" "${s3FullURI}" --acl bucket-owner-full-control
   lint:
-    container: golangci/golangci-lint:v1.54.1
     name: lint
     runs-on: ubuntu-latest
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Mark repo as safe directory
-      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER }}/pulumi-${{ env.PROVIDER }}
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
     - name: Install Go
       uses: actions/setup-go@v4
       with:
         cache-dependency-path: |
             sdk/go.sum
         go-version: 1.21.x
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
+    - name: disarm go:embed directives to enable lint
+      run: |
+        git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: golangci-lint
+      uses: golangci/golangci-lint-action@v3
       with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - run: make lint_provider
+        version: v1.54.1
+        working-directory: provider
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3

--- a/provider-ci/providers/vault/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/vault/repo/.github/workflows/master.yml
@@ -191,6 +191,9 @@ jobs:
     - name: disarm go:embed directives to enable lint
       run: |
         git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: prepare upstream
+      continue-on-error: true
+      run: make upstream
     - name: golangci-lint
       uses: golangci/golangci-lint-action@v3
       with:

--- a/provider-ci/providers/vault/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/vault/repo/.github/workflows/master.yml
@@ -177,34 +177,25 @@ jobs:
 
         aws s3 cp "${{ env.COVERAGE_OUTPUT_DIR }}/summary.json" "${s3FullURI}" --acl bucket-owner-full-control
   lint:
-    container: golangci/golangci-lint:v1.54.1
     name: lint
     runs-on: ubuntu-latest
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Mark repo as safe directory
-      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER }}/pulumi-${{ env.PROVIDER }}
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
     - name: Install Go
       uses: actions/setup-go@v4
       with:
         cache-dependency-path: |
             sdk/go.sum
         go-version: 1.21.x
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
+    - name: disarm go:embed directives to enable lint
+      run: |
+        git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: golangci-lint
+      uses: golangci/golangci-lint-action@v3
       with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - run: make lint_provider
+        version: v1.54.1
+        working-directory: provider
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3

--- a/provider-ci/providers/vault/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/vault/repo/.github/workflows/prerelease.yml
@@ -124,34 +124,25 @@ jobs:
         - go
         - java
   lint:
-    container: golangci/golangci-lint:v1.54.1
     name: lint
     runs-on: ubuntu-latest
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Mark repo as safe directory
-      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER }}/pulumi-${{ env.PROVIDER }}
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
     - name: Install Go
       uses: actions/setup-go@v4
       with:
         cache-dependency-path: |
             sdk/go.sum
         go-version: 1.21.x
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
+    - name: disarm go:embed directives to enable lint
+      run: |
+        git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: golangci-lint
+      uses: golangci/golangci-lint-action@v3
       with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - run: make lint_provider
+        version: v1.54.1
+        working-directory: provider
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3

--- a/provider-ci/providers/vault/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/vault/repo/.github/workflows/prerelease.yml
@@ -138,6 +138,9 @@ jobs:
     - name: disarm go:embed directives to enable lint
       run: |
         git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: prepare upstream
+      continue-on-error: true
+      run: make upstream
     - name: golangci-lint
       uses: golangci/golangci-lint-action@v3
       with:

--- a/provider-ci/providers/vault/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/vault/repo/.github/workflows/release.yml
@@ -151,6 +151,9 @@ jobs:
     - name: disarm go:embed directives to enable lint
       run: |
         git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: prepare upstream
+      continue-on-error: true
+      run: make upstream
     - name: golangci-lint
       uses: golangci/golangci-lint-action@v3
       with:

--- a/provider-ci/providers/vault/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/vault/repo/.github/workflows/release.yml
@@ -137,34 +137,25 @@ jobs:
       run: pulumictl create docs-build pulumi-${{ env.PROVIDER }}
         "${GITHUB_REF#refs/tags/}"
   lint:
-    container: golangci/golangci-lint:v1.54.1
     name: lint
     runs-on: ubuntu-latest
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Mark repo as safe directory
-      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER }}/pulumi-${{ env.PROVIDER }}
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
     - name: Install Go
       uses: actions/setup-go@v4
       with:
         cache-dependency-path: |
             sdk/go.sum
         go-version: 1.21.x
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
+    - name: disarm go:embed directives to enable lint
+      run: |
+        git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: golangci-lint
+      uses: golangci/golangci-lint-action@v3
       with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - run: make lint_provider
+        version: v1.54.1
+        working-directory: provider
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3

--- a/provider-ci/providers/vault/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/vault/repo/.github/workflows/run-acceptance-tests.yml
@@ -153,15 +153,16 @@ jobs:
       uses: actions/checkout@v3
       with:
         ref: ${{ env.PR_COMMIT_SHA }}
-    - name: Install Go
-      uses: actions/setup-go@v4
-      with:
-        cache-dependency-path: |
-            sdk/go.sum
-        go-version: 1.21.x
     - name: disarm go:embed directives to enable lint
       run: |
         git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: Install go
+      uses: actions/setup-go@v4
+      with:
+        # The versions of golangci-lint and setup-go here cross-depend and need to update together.
+        go-version: 1.21
+        # Either this action or golangci-lint needs to disable the cache
+        cache: false
     - name: golangci-lint
       uses: golangci/golangci-lint-action@v3
       with:

--- a/provider-ci/providers/vault/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/vault/repo/.github/workflows/run-acceptance-tests.yml
@@ -144,7 +144,6 @@ jobs:
         repository: ${{ github.event.client_payload.github.payload.repository.full_name }}
         token: ${{ secrets.PULUMI_BOT_TOKEN }}
   lint:
-    container: golangci/golangci-lint:v1.54.1
     if: github.event_name == 'repository_dispatch' ||
       github.event.pull_request.head.repo.full_name == github.repository
     name: lint
@@ -154,28 +153,20 @@ jobs:
       uses: actions/checkout@v3
       with:
         ref: ${{ env.PR_COMMIT_SHA }}
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Mark repo as safe directory
-      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER }}/pulumi-${{ env.PROVIDER }}
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
     - name: Install Go
       uses: actions/setup-go@v4
       with:
         cache-dependency-path: |
             sdk/go.sum
         go-version: 1.21.x
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
+    - name: disarm go:embed directives to enable lint
+      run: |
+        git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: golangci-lint
+      uses: golangci/golangci-lint-action@v3
       with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - run: make lint_provider
+        version: v1.54.1
+        working-directory: provider
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3

--- a/provider-ci/providers/vault/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/vault/repo/.github/workflows/run-acceptance-tests.yml
@@ -156,6 +156,9 @@ jobs:
     - name: disarm go:embed directives to enable lint
       run: |
         git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: prepare upstream
+      continue-on-error: true
+      run: make upstream
     - name: Install go
       uses: actions/setup-go@v4
       with:

--- a/provider-ci/providers/venafi/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/venafi/repo/.github/workflows/main.yml
@@ -194,6 +194,9 @@ jobs:
     - name: disarm go:embed directives to enable lint
       run: |
         git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: prepare upstream
+      continue-on-error: true
+      run: make upstream
     - name: golangci-lint
       uses: golangci/golangci-lint-action@v3
       with:

--- a/provider-ci/providers/venafi/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/venafi/repo/.github/workflows/main.yml
@@ -180,34 +180,25 @@ jobs:
 
         aws s3 cp "${{ env.COVERAGE_OUTPUT_DIR }}/summary.json" "${s3FullURI}" --acl bucket-owner-full-control
   lint:
-    container: golangci/golangci-lint:v1.54.1
     name: lint
     runs-on: ubuntu-latest
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Mark repo as safe directory
-      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER }}/pulumi-${{ env.PROVIDER }}
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
     - name: Install Go
       uses: actions/setup-go@v4
       with:
         cache-dependency-path: |
             sdk/go.sum
         go-version: 1.21.x
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
+    - name: disarm go:embed directives to enable lint
+      run: |
+        git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: golangci-lint
+      uses: golangci/golangci-lint-action@v3
       with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - run: make lint_provider
+        version: v1.54.1
+        working-directory: provider
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3

--- a/provider-ci/providers/venafi/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/venafi/repo/.github/workflows/master.yml
@@ -194,6 +194,9 @@ jobs:
     - name: disarm go:embed directives to enable lint
       run: |
         git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: prepare upstream
+      continue-on-error: true
+      run: make upstream
     - name: golangci-lint
       uses: golangci/golangci-lint-action@v3
       with:

--- a/provider-ci/providers/venafi/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/venafi/repo/.github/workflows/master.yml
@@ -180,34 +180,25 @@ jobs:
 
         aws s3 cp "${{ env.COVERAGE_OUTPUT_DIR }}/summary.json" "${s3FullURI}" --acl bucket-owner-full-control
   lint:
-    container: golangci/golangci-lint:v1.54.1
     name: lint
     runs-on: ubuntu-latest
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Mark repo as safe directory
-      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER }}/pulumi-${{ env.PROVIDER }}
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
     - name: Install Go
       uses: actions/setup-go@v4
       with:
         cache-dependency-path: |
             sdk/go.sum
         go-version: 1.21.x
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
+    - name: disarm go:embed directives to enable lint
+      run: |
+        git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: golangci-lint
+      uses: golangci/golangci-lint-action@v3
       with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - run: make lint_provider
+        version: v1.54.1
+        working-directory: provider
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3

--- a/provider-ci/providers/venafi/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/venafi/repo/.github/workflows/prerelease.yml
@@ -127,34 +127,25 @@ jobs:
         - go
         - java
   lint:
-    container: golangci/golangci-lint:v1.54.1
     name: lint
     runs-on: ubuntu-latest
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Mark repo as safe directory
-      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER }}/pulumi-${{ env.PROVIDER }}
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
     - name: Install Go
       uses: actions/setup-go@v4
       with:
         cache-dependency-path: |
             sdk/go.sum
         go-version: 1.21.x
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
+    - name: disarm go:embed directives to enable lint
+      run: |
+        git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: golangci-lint
+      uses: golangci/golangci-lint-action@v3
       with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - run: make lint_provider
+        version: v1.54.1
+        working-directory: provider
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3

--- a/provider-ci/providers/venafi/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/venafi/repo/.github/workflows/prerelease.yml
@@ -141,6 +141,9 @@ jobs:
     - name: disarm go:embed directives to enable lint
       run: |
         git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: prepare upstream
+      continue-on-error: true
+      run: make upstream
     - name: golangci-lint
       uses: golangci/golangci-lint-action@v3
       with:

--- a/provider-ci/providers/venafi/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/venafi/repo/.github/workflows/release.yml
@@ -140,34 +140,25 @@ jobs:
       run: pulumictl create docs-build pulumi-${{ env.PROVIDER }}
         "${GITHUB_REF#refs/tags/}"
   lint:
-    container: golangci/golangci-lint:v1.54.1
     name: lint
     runs-on: ubuntu-latest
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Mark repo as safe directory
-      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER }}/pulumi-${{ env.PROVIDER }}
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
     - name: Install Go
       uses: actions/setup-go@v4
       with:
         cache-dependency-path: |
             sdk/go.sum
         go-version: 1.21.x
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
+    - name: disarm go:embed directives to enable lint
+      run: |
+        git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: golangci-lint
+      uses: golangci/golangci-lint-action@v3
       with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - run: make lint_provider
+        version: v1.54.1
+        working-directory: provider
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3

--- a/provider-ci/providers/venafi/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/venafi/repo/.github/workflows/release.yml
@@ -154,6 +154,9 @@ jobs:
     - name: disarm go:embed directives to enable lint
       run: |
         git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: prepare upstream
+      continue-on-error: true
+      run: make upstream
     - name: golangci-lint
       uses: golangci/golangci-lint-action@v3
       with:

--- a/provider-ci/providers/venafi/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/venafi/repo/.github/workflows/run-acceptance-tests.yml
@@ -159,6 +159,9 @@ jobs:
     - name: disarm go:embed directives to enable lint
       run: |
         git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: prepare upstream
+      continue-on-error: true
+      run: make upstream
     - name: Install go
       uses: actions/setup-go@v4
       with:

--- a/provider-ci/providers/venafi/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/venafi/repo/.github/workflows/run-acceptance-tests.yml
@@ -147,7 +147,6 @@ jobs:
         repository: ${{ github.event.client_payload.github.payload.repository.full_name }}
         token: ${{ secrets.PULUMI_BOT_TOKEN }}
   lint:
-    container: golangci/golangci-lint:v1.54.1
     if: github.event_name == 'repository_dispatch' ||
       github.event.pull_request.head.repo.full_name == github.repository
     name: lint
@@ -157,28 +156,20 @@ jobs:
       uses: actions/checkout@v3
       with:
         ref: ${{ env.PR_COMMIT_SHA }}
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Mark repo as safe directory
-      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER }}/pulumi-${{ env.PROVIDER }}
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
     - name: Install Go
       uses: actions/setup-go@v4
       with:
         cache-dependency-path: |
             sdk/go.sum
         go-version: 1.21.x
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
+    - name: disarm go:embed directives to enable lint
+      run: |
+        git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: golangci-lint
+      uses: golangci/golangci-lint-action@v3
       with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - run: make lint_provider
+        version: v1.54.1
+        working-directory: provider
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3

--- a/provider-ci/providers/venafi/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/venafi/repo/.github/workflows/run-acceptance-tests.yml
@@ -156,15 +156,16 @@ jobs:
       uses: actions/checkout@v3
       with:
         ref: ${{ env.PR_COMMIT_SHA }}
-    - name: Install Go
-      uses: actions/setup-go@v4
-      with:
-        cache-dependency-path: |
-            sdk/go.sum
-        go-version: 1.21.x
     - name: disarm go:embed directives to enable lint
       run: |
         git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: Install go
+      uses: actions/setup-go@v4
+      with:
+        # The versions of golangci-lint and setup-go here cross-depend and need to update together.
+        go-version: 1.21
+        # Either this action or golangci-lint needs to disable the cache
+        cache: false
     - name: golangci-lint
       uses: golangci/golangci-lint-action@v3
       with:

--- a/provider-ci/providers/vsphere/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/vsphere/repo/.github/workflows/main.yml
@@ -176,34 +176,25 @@ jobs:
 
         aws s3 cp "${{ env.COVERAGE_OUTPUT_DIR }}/summary.json" "${s3FullURI}" --acl bucket-owner-full-control
   lint:
-    container: golangci/golangci-lint:v1.54.1
     name: lint
     runs-on: ubuntu-latest
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Mark repo as safe directory
-      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER }}/pulumi-${{ env.PROVIDER }}
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
     - name: Install Go
       uses: actions/setup-go@v4
       with:
         cache-dependency-path: |
             sdk/go.sum
         go-version: 1.21.x
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
+    - name: disarm go:embed directives to enable lint
+      run: |
+        git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: golangci-lint
+      uses: golangci/golangci-lint-action@v3
       with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - run: make lint_provider
+        version: v1.54.1
+        working-directory: provider
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3

--- a/provider-ci/providers/vsphere/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/vsphere/repo/.github/workflows/main.yml
@@ -190,6 +190,9 @@ jobs:
     - name: disarm go:embed directives to enable lint
       run: |
         git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: prepare upstream
+      continue-on-error: true
+      run: make upstream
     - name: golangci-lint
       uses: golangci/golangci-lint-action@v3
       with:

--- a/provider-ci/providers/vsphere/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/vsphere/repo/.github/workflows/master.yml
@@ -176,34 +176,25 @@ jobs:
 
         aws s3 cp "${{ env.COVERAGE_OUTPUT_DIR }}/summary.json" "${s3FullURI}" --acl bucket-owner-full-control
   lint:
-    container: golangci/golangci-lint:v1.54.1
     name: lint
     runs-on: ubuntu-latest
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Mark repo as safe directory
-      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER }}/pulumi-${{ env.PROVIDER }}
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
     - name: Install Go
       uses: actions/setup-go@v4
       with:
         cache-dependency-path: |
             sdk/go.sum
         go-version: 1.21.x
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
+    - name: disarm go:embed directives to enable lint
+      run: |
+        git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: golangci-lint
+      uses: golangci/golangci-lint-action@v3
       with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - run: make lint_provider
+        version: v1.54.1
+        working-directory: provider
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3

--- a/provider-ci/providers/vsphere/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/vsphere/repo/.github/workflows/master.yml
@@ -190,6 +190,9 @@ jobs:
     - name: disarm go:embed directives to enable lint
       run: |
         git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: prepare upstream
+      continue-on-error: true
+      run: make upstream
     - name: golangci-lint
       uses: golangci/golangci-lint-action@v3
       with:

--- a/provider-ci/providers/vsphere/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/vsphere/repo/.github/workflows/prerelease.yml
@@ -123,34 +123,25 @@ jobs:
         - go
         - java
   lint:
-    container: golangci/golangci-lint:v1.54.1
     name: lint
     runs-on: ubuntu-latest
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Mark repo as safe directory
-      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER }}/pulumi-${{ env.PROVIDER }}
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
     - name: Install Go
       uses: actions/setup-go@v4
       with:
         cache-dependency-path: |
             sdk/go.sum
         go-version: 1.21.x
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
+    - name: disarm go:embed directives to enable lint
+      run: |
+        git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: golangci-lint
+      uses: golangci/golangci-lint-action@v3
       with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - run: make lint_provider
+        version: v1.54.1
+        working-directory: provider
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3

--- a/provider-ci/providers/vsphere/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/vsphere/repo/.github/workflows/prerelease.yml
@@ -137,6 +137,9 @@ jobs:
     - name: disarm go:embed directives to enable lint
       run: |
         git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: prepare upstream
+      continue-on-error: true
+      run: make upstream
     - name: golangci-lint
       uses: golangci/golangci-lint-action@v3
       with:

--- a/provider-ci/providers/vsphere/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/vsphere/repo/.github/workflows/release.yml
@@ -136,34 +136,25 @@ jobs:
       run: pulumictl create docs-build pulumi-${{ env.PROVIDER }}
         "${GITHUB_REF#refs/tags/}"
   lint:
-    container: golangci/golangci-lint:v1.54.1
     name: lint
     runs-on: ubuntu-latest
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Mark repo as safe directory
-      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER }}/pulumi-${{ env.PROVIDER }}
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
     - name: Install Go
       uses: actions/setup-go@v4
       with:
         cache-dependency-path: |
             sdk/go.sum
         go-version: 1.21.x
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
+    - name: disarm go:embed directives to enable lint
+      run: |
+        git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: golangci-lint
+      uses: golangci/golangci-lint-action@v3
       with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - run: make lint_provider
+        version: v1.54.1
+        working-directory: provider
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3

--- a/provider-ci/providers/vsphere/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/vsphere/repo/.github/workflows/release.yml
@@ -150,6 +150,9 @@ jobs:
     - name: disarm go:embed directives to enable lint
       run: |
         git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: prepare upstream
+      continue-on-error: true
+      run: make upstream
     - name: golangci-lint
       uses: golangci/golangci-lint-action@v3
       with:

--- a/provider-ci/providers/vsphere/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/vsphere/repo/.github/workflows/run-acceptance-tests.yml
@@ -143,7 +143,6 @@ jobs:
         repository: ${{ github.event.client_payload.github.payload.repository.full_name }}
         token: ${{ secrets.PULUMI_BOT_TOKEN }}
   lint:
-    container: golangci/golangci-lint:v1.54.1
     if: github.event_name == 'repository_dispatch' ||
       github.event.pull_request.head.repo.full_name == github.repository
     name: lint
@@ -153,28 +152,20 @@ jobs:
       uses: actions/checkout@v3
       with:
         ref: ${{ env.PR_COMMIT_SHA }}
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Mark repo as safe directory
-      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER }}/pulumi-${{ env.PROVIDER }}
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
     - name: Install Go
       uses: actions/setup-go@v4
       with:
         cache-dependency-path: |
             sdk/go.sum
         go-version: 1.21.x
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
+    - name: disarm go:embed directives to enable lint
+      run: |
+        git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: golangci-lint
+      uses: golangci/golangci-lint-action@v3
       with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - run: make lint_provider
+        version: v1.54.1
+        working-directory: provider
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3

--- a/provider-ci/providers/vsphere/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/vsphere/repo/.github/workflows/run-acceptance-tests.yml
@@ -155,6 +155,9 @@ jobs:
     - name: disarm go:embed directives to enable lint
       run: |
         git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: prepare upstream
+      continue-on-error: true
+      run: make upstream
     - name: Install go
       uses: actions/setup-go@v4
       with:

--- a/provider-ci/providers/vsphere/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/vsphere/repo/.github/workflows/run-acceptance-tests.yml
@@ -152,15 +152,16 @@ jobs:
       uses: actions/checkout@v3
       with:
         ref: ${{ env.PR_COMMIT_SHA }}
-    - name: Install Go
-      uses: actions/setup-go@v4
-      with:
-        cache-dependency-path: |
-            sdk/go.sum
-        go-version: 1.21.x
     - name: disarm go:embed directives to enable lint
       run: |
         git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: Install go
+      uses: actions/setup-go@v4
+      with:
+        # The versions of golangci-lint and setup-go here cross-depend and need to update together.
+        go-version: 1.21
+        # Either this action or golangci-lint needs to disable the cache
+        cache: false
     - name: golangci-lint
       uses: golangci/golangci-lint-action@v3
       with:

--- a/provider-ci/providers/wavefront/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/wavefront/repo/.github/workflows/main.yml
@@ -178,34 +178,25 @@ jobs:
 
         aws s3 cp "${{ env.COVERAGE_OUTPUT_DIR }}/summary.json" "${s3FullURI}" --acl bucket-owner-full-control
   lint:
-    container: golangci/golangci-lint:v1.54.1
     name: lint
     runs-on: ubuntu-latest
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Mark repo as safe directory
-      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER }}/pulumi-${{ env.PROVIDER }}
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
     - name: Install Go
       uses: actions/setup-go@v4
       with:
         cache-dependency-path: |
             sdk/go.sum
         go-version: 1.21.x
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
+    - name: disarm go:embed directives to enable lint
+      run: |
+        git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: golangci-lint
+      uses: golangci/golangci-lint-action@v3
       with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - run: make lint_provider
+        version: v1.54.1
+        working-directory: provider
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3

--- a/provider-ci/providers/wavefront/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/wavefront/repo/.github/workflows/main.yml
@@ -192,6 +192,9 @@ jobs:
     - name: disarm go:embed directives to enable lint
       run: |
         git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: prepare upstream
+      continue-on-error: true
+      run: make upstream
     - name: golangci-lint
       uses: golangci/golangci-lint-action@v3
       with:

--- a/provider-ci/providers/wavefront/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/wavefront/repo/.github/workflows/master.yml
@@ -178,34 +178,25 @@ jobs:
 
         aws s3 cp "${{ env.COVERAGE_OUTPUT_DIR }}/summary.json" "${s3FullURI}" --acl bucket-owner-full-control
   lint:
-    container: golangci/golangci-lint:v1.54.1
     name: lint
     runs-on: ubuntu-latest
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Mark repo as safe directory
-      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER }}/pulumi-${{ env.PROVIDER }}
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
     - name: Install Go
       uses: actions/setup-go@v4
       with:
         cache-dependency-path: |
             sdk/go.sum
         go-version: 1.21.x
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
+    - name: disarm go:embed directives to enable lint
+      run: |
+        git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: golangci-lint
+      uses: golangci/golangci-lint-action@v3
       with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - run: make lint_provider
+        version: v1.54.1
+        working-directory: provider
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3

--- a/provider-ci/providers/wavefront/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/wavefront/repo/.github/workflows/master.yml
@@ -192,6 +192,9 @@ jobs:
     - name: disarm go:embed directives to enable lint
       run: |
         git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: prepare upstream
+      continue-on-error: true
+      run: make upstream
     - name: golangci-lint
       uses: golangci/golangci-lint-action@v3
       with:

--- a/provider-ci/providers/wavefront/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/wavefront/repo/.github/workflows/prerelease.yml
@@ -125,34 +125,25 @@ jobs:
         - go
         - java
   lint:
-    container: golangci/golangci-lint:v1.54.1
     name: lint
     runs-on: ubuntu-latest
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Mark repo as safe directory
-      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER }}/pulumi-${{ env.PROVIDER }}
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
     - name: Install Go
       uses: actions/setup-go@v4
       with:
         cache-dependency-path: |
             sdk/go.sum
         go-version: 1.21.x
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
+    - name: disarm go:embed directives to enable lint
+      run: |
+        git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: golangci-lint
+      uses: golangci/golangci-lint-action@v3
       with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - run: make lint_provider
+        version: v1.54.1
+        working-directory: provider
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3

--- a/provider-ci/providers/wavefront/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/wavefront/repo/.github/workflows/prerelease.yml
@@ -139,6 +139,9 @@ jobs:
     - name: disarm go:embed directives to enable lint
       run: |
         git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: prepare upstream
+      continue-on-error: true
+      run: make upstream
     - name: golangci-lint
       uses: golangci/golangci-lint-action@v3
       with:

--- a/provider-ci/providers/wavefront/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/wavefront/repo/.github/workflows/release.yml
@@ -152,6 +152,9 @@ jobs:
     - name: disarm go:embed directives to enable lint
       run: |
         git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: prepare upstream
+      continue-on-error: true
+      run: make upstream
     - name: golangci-lint
       uses: golangci/golangci-lint-action@v3
       with:

--- a/provider-ci/providers/wavefront/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/wavefront/repo/.github/workflows/release.yml
@@ -138,34 +138,25 @@ jobs:
       run: pulumictl create docs-build pulumi-${{ env.PROVIDER }}
         "${GITHUB_REF#refs/tags/}"
   lint:
-    container: golangci/golangci-lint:v1.54.1
     name: lint
     runs-on: ubuntu-latest
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v3
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Mark repo as safe directory
-      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER }}/pulumi-${{ env.PROVIDER }}
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
     - name: Install Go
       uses: actions/setup-go@v4
       with:
         cache-dependency-path: |
             sdk/go.sum
         go-version: 1.21.x
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
+    - name: disarm go:embed directives to enable lint
+      run: |
+        git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: golangci-lint
+      uses: golangci/golangci-lint-action@v3
       with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - run: make lint_provider
+        version: v1.54.1
+        working-directory: provider
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3

--- a/provider-ci/providers/wavefront/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/wavefront/repo/.github/workflows/run-acceptance-tests.yml
@@ -157,6 +157,9 @@ jobs:
     - name: disarm go:embed directives to enable lint
       run: |
         git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: prepare upstream
+      continue-on-error: true
+      run: make upstream
     - name: Install go
       uses: actions/setup-go@v4
       with:

--- a/provider-ci/providers/wavefront/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/wavefront/repo/.github/workflows/run-acceptance-tests.yml
@@ -145,7 +145,6 @@ jobs:
         repository: ${{ github.event.client_payload.github.payload.repository.full_name }}
         token: ${{ secrets.PULUMI_BOT_TOKEN }}
   lint:
-    container: golangci/golangci-lint:v1.54.1
     if: github.event_name == 'repository_dispatch' ||
       github.event.pull_request.head.repo.full_name == github.repository
     name: lint
@@ -155,28 +154,20 @@ jobs:
       uses: actions/checkout@v3
       with:
         ref: ${{ env.PR_COMMIT_SHA }}
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - name: Mark repo as safe directory
-      run: git config --global --add safe.directory /__w/pulumi-${{ env.PROVIDER }}/pulumi-${{ env.PROVIDER }}
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
     - name: Install Go
       uses: actions/setup-go@v4
       with:
         cache-dependency-path: |
             sdk/go.sum
         go-version: 1.21.x
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
+    - name: disarm go:embed directives to enable lint
+      run: |
+        git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: golangci-lint
+      uses: golangci/golangci-lint-action@v3
       with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
-    - run: make lint_provider
+        version: v1.54.1
+        working-directory: provider
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3

--- a/provider-ci/providers/wavefront/repo/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/providers/wavefront/repo/.github/workflows/run-acceptance-tests.yml
@@ -154,15 +154,16 @@ jobs:
       uses: actions/checkout@v3
       with:
         ref: ${{ env.PR_COMMIT_SHA }}
-    - name: Install Go
-      uses: actions/setup-go@v4
-      with:
-        cache-dependency-path: |
-            sdk/go.sum
-        go-version: 1.21.x
     - name: disarm go:embed directives to enable lint
       run: |
         git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
+    - name: Install go
+      uses: actions/setup-go@v4
+      with:
+        # The versions of golangci-lint and setup-go here cross-depend and need to update together.
+        go-version: 1.21
+        # Either this action or golangci-lint needs to disable the cache
+        cache: false
     - name: golangci-lint
       uses: golangci/golangci-lint-action@v3
       with:


### PR DESCRIPTION
Fixes https://github.com/pulumi/ci-mgmt/issues/574

I think the root cause is some version mismatch between Go tooling and golint version. I found the job really strange though so took the time to make it more in line with the docs on golangci-lint itself and how we lint the bridge.

Use official golangci/golangci-lint-action@v3 action

Pro: caches
Con: drift from Makefile to CI

Do not build the provider in the lint job.

Pro: faster, fewer things to install
Con: need to disarm go:embed directives; the linter checks if the embedded files are not present, which they will not be before a lot of computation 

Do not containerize the lint job.

Pro: use same ubuntu-latest runtime environment as the rest of the jobs.