### PR TITLE
We now have TLS going back to 4.x

### DIFF
--- a/provider-ci/providers/tls/config.yaml
+++ b/provider-ci/providers/tls/config.yaml
@@ -1,5 +1,5 @@
 provider: tls
-major-version: 5
+major-version: 4
 makeTemplate: bridged
 # TODO: Enable this once our tls provider is updated with framework support
 # generate-nightly-test-workflow: true

--- a/provider-ci/providers/tls/config.yaml
+++ b/provider-ci/providers/tls/config.yaml
@@ -6,4 +6,5 @@ makeTemplate: bridged
 plugins:
   - name: aws
     version: "4.26.0"
+javaGenVersion: "v0.9.7"
 team: ecosystem

--- a/provider-ci/providers/tls/repo/.goreleaser.prerelease.yml
+++ b/provider-ci/providers/tls/repo/.goreleaser.prerelease.yml
@@ -32,7 +32,7 @@ builds:
     - env GOOS={{ .Os }} GOARCH={{ .Arch }} go clean -modcache
   ignore: []
   ldflags:
-  - -X github.com/pulumi/pulumi-tls/provider/v5/pkg/version.Version={{.Tag}}
+  - -X github.com/pulumi/pulumi-tls/provider/v4/pkg/version.Version={{.Tag}}
   main: ./cmd/pulumi-resource-tls/
 changelog:
   skip: true

--- a/provider-ci/providers/tls/repo/.goreleaser.yml
+++ b/provider-ci/providers/tls/repo/.goreleaser.yml
@@ -32,7 +32,7 @@ builds:
     - env GOOS={{ .Os }} GOARCH={{ .Arch }} go clean -modcache
   ignore: []
   ldflags:
-  - -X github.com/pulumi/pulumi-tls/provider/v5/pkg/version.Version={{.Tag}}
+  - -X github.com/pulumi/pulumi-tls/provider/v4/pkg/version.Version={{.Tag}}
   main: ./cmd/pulumi-resource-tls/
 changelog:
   filters:

--- a/provider-ci/providers/tls/repo/Makefile
+++ b/provider-ci/providers/tls/repo/Makefile
@@ -9,7 +9,7 @@ TFGEN := pulumi-tfgen-$(PACK)
 PROVIDER := pulumi-resource-$(PACK)
 VERSION := $(shell pulumictl get version)
 JAVA_GEN := pulumi-java-gen
-JAVA_GEN_VERSION := v0.5.4
+JAVA_GEN_VERSION := v0.9.7
 TESTPARALLELISM := 10
 WORKING_DIR := $(shell pwd)
 

--- a/provider-ci/providers/tls/repo/Makefile
+++ b/provider-ci/providers/tls/repo/Makefile
@@ -3,7 +3,7 @@
 PACK := tls
 ORG := pulumi
 PROJECT := github.com/$(ORG)/pulumi-$(PACK)
-PROVIDER_PATH := provider/v5
+PROVIDER_PATH := provider/v4
 VERSION_PATH := $(PROVIDER_PATH)/pkg/version.Version
 TFGEN := pulumi-tfgen-$(PACK)
 PROVIDER := pulumi-resource-$(PACK)


### PR DESCRIPTION
This reflects changes done to pulumi-tls repo today. These need to be in ci-mgmt so that nightly job does not roll them back.
