### PR TITLE
Fix default branch logic for Workflow dispatch of bridge upgrade

### DIFF
--- a/.github/workflows/update-bridge-ecosystem-providers.yml
+++ b/.github/workflows/update-bridge-ecosystem-providers.yml
@@ -50,7 +50,7 @@ jobs:
             ref: main
       - name: pulumi-${{ matrix.provider }} master
         id: upgrade-on-master
-        if: steps.upgrade-on-master.outcome != 'success'
+        if: steps.upgrade-on-main.outcome != 'success'
         uses: benc-uk/workflow-dispatch@v1.2.2
         with:
             workflow: upgrade-bridge.yml

--- a/.github/workflows/update-bridge-ecosystem-providers.yml
+++ b/.github/workflows/update-bridge-ecosystem-providers.yml
@@ -50,7 +50,7 @@ jobs:
             ref: main
       - name: pulumi-${{ matrix.provider }} master
         id: upgrade-on-master
-        if: steps.upgrade-on-main.outcome != 'success'
+        if: steps.upgrade-on-main.outcome == failure
         uses: benc-uk/workflow-dispatch@v1.2.2
         with:
             workflow: upgrade-bridge.yml

--- a/.github/workflows/update-bridge-single-ecosystem-provider.yml
+++ b/.github/workflows/update-bridge-single-ecosystem-provider.yml
@@ -1,0 +1,43 @@
+# Performs a workflow_dispatch to run the upgrade-bridge workflow in a specified
+# provider.
+# Note that this workflow does not generate any files - workflows must already be generated and committed to this repo
+# when this workflow is run.
+name: Update bridge, single ecosystem provider
+on:
+  workflow_dispatch:
+    inputs:
+      automerge:
+        description: Mark created PRs for auto-merging?
+        required: true
+        type: boolean
+        default: false
+      provider:
+        description: The name of the provider to update - do not include the pulumi prefix in the name.
+        required: true
+        type: string
+
+env:
+  GITHUB_TOKEN: ${{ secrets.PULUMI_BOT_TOKEN }}
+jobs:
+  update-bridge:
+    runs-on: ubuntu-latest
+    steps:
+      - name: pulumi-${{ github.event.inputs.provider }} main
+        id: upgrade-on-main
+        uses: benc-uk/workflow-dispatch@v1.2.2
+        continue-on-error: true
+        with:
+          workflow: upgrade-bridge.yml
+          token: ${{ secrets.PULUMI_BOT_TOKEN }}
+          repo: pulumi/pulumi-${{ github.event.inputs.provider }}
+          ref: main
+      - name: pulumi-${{ github.event.inputs.provider }} master
+        id: upgrade-on-master
+        if: steps.upgrade-on-main.outcome != 'success'
+        uses: benc-uk/workflow-dispatch@v1.2.2
+        with:
+          workflow: upgrade-bridge.yml
+          token: ${{ secrets.PULUMI_BOT_TOKEN }}
+          repo: pulumi/pulumi-${{ github.event.inputs.provider }}
+          ref: master
+

--- a/.github/workflows/update-bridge-single-ecosystem-provider.yml
+++ b/.github/workflows/update-bridge-single-ecosystem-provider.yml
@@ -33,7 +33,7 @@ jobs:
           ref: main
       - name: pulumi-${{ github.event.inputs.provider }} master
         id: upgrade-on-master
-        if: steps.upgrade-on-main.outcome != 'success'
+        if: steps.upgrade-on-main.outcome == failure
         uses: benc-uk/workflow-dispatch@v1.2.2
         with:
           workflow: upgrade-bridge.yml


### PR DESCRIPTION
Previous to this change, when the `upgrade-on-main` step failed, we would call `upgrade-on-master` every time, because the `if` condition on that step never made sense. 
But for providers where default branch is set to `main`, this would result in an overall failure, because `upgrade-on-master` does not specify `continue-on-error: true`. 
With this change, the `upgrade-on-master` step should no longer run at all for providers whose default branch is `main`. 

Note that using `github.event.repository.default_branch` is not available to us here, as that would detect the originating repo's (ci-mgmt's) default branch.

Furthermore, this PR adds a Workflow to update a single ecosystem provider, so we can optionally do gradual/test rollouts of updates.

Final note: There are a lot of "bridge updates" in this folder, and some are stale. To keep the scope tight, this is tracked in https://github.com/pulumi/ci-mgmt/issues/579.

Closes #566.
Closes #593.
- fix success logic on triggering against master ref
- Add option to upgrade a single provider's bridge version
