### PR TITLE
Update pulumi-package-publisher to v0.0.11

### DIFF
--- a/provider-ci/internal/pkg/templates/bridged-provider.config.yaml
+++ b/provider-ci/internal/pkg/templates/bridged-provider.config.yaml
@@ -81,5 +81,5 @@ actionVersions:
   slashCommand: peter-evans/slash-command-dispatch@v2
   uploadArtifact: actions/upload-artifact@v2
   upgradeProviderAction: pulumi/pulumi-upgrade-provider-action@v0.0.6
-  publishProviderSDKs: pulumi/pulumi-package-publisher@v0.0.9
+  publishProviderSDKs: pulumi/pulumi-package-publisher@v0.0.11
   slackNotification: rtCamp/action-slack-notify@v2

--- a/provider-ci/internal/pkg/templates/bridged-provider/Makefile
+++ b/provider-ci/internal/pkg/templates/bridged-provider/Makefile
@@ -66,8 +66,6 @@ build_nodejs:#{{ if eq .Config.team "ecosystem" }}# upstream#{{ end }}#
 		cp ../../README.md ../../LICENSE* package.json yarn.lock ./bin/ && \
 		sed -i.bak -e "s/\$${VERSION}/$(VERSION)/g" ./bin/package.json
 
-#{{- if .Config.wheels }}#
-
 build_python: PYPI_VERSION := $(shell pulumictl get version --language python)
 build_python:#{{ if eq .Config.team "ecosystem" }}# upstream#{{ end }}#
 	rm -rf sdk/python/
@@ -82,20 +80,6 @@ build_python:#{{ if eq .Config.team "ecosystem" }}# upstream#{{ end }}#
 		./venv/bin/python -m pip install build && \
 		cd ./bin && \
 		../venv/bin/python -m build .
-#{{- else }}#
-
-build_python: PYPI_VERSION := $(shell pulumictl get version --language python)
-build_python:#{{ if eq .Config.team "ecosystem" }}# upstream#{{ end }}#
-	$(WORKING_DIR)/bin/$(TFGEN) python --out sdk/python/
-	cd sdk/python/ && \
-		printf "module fake_python_module // Exclude this directory from Go tools\n\ngo 1.17\n" > go.mod && \
-		cp ../../README.md . && \
-		python3 setup.py clean --all 2>/dev/null && \
-		rm -rf ./bin/ ../python.bin/ && cp -R . ../python.bin && mv ../python.bin ./bin && \
-		sed -i.bak -e 's/^VERSION = .*/VERSION = "$(PYPI_VERSION)"/g' -e 's/^PLUGIN_VERSION = .*/PLUGIN_VERSION = "$(VERSION)"/g' ./bin/setup.py && \
-		rm ./bin/setup.py.bak && rm ./bin/go.mod && \
-		cd ./bin && python3 setup.py build sdist
-#{{- end }}#
 
 clean:
 	rm -rf sdk/{dotnet,nodejs,go,python}

--- a/provider-ci/providers/aiven/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/aiven/repo/.github/workflows/main.yml
@@ -302,7 +302,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/aiven/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/aiven/repo/.github/workflows/master.yml
@@ -302,7 +302,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/aiven/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/aiven/repo/.github/workflows/prerelease.yml
@@ -248,7 +248,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/aiven/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/aiven/repo/.github/workflows/release.yml
@@ -260,7 +260,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/aiven/repo/Makefile
+++ b/provider-ci/providers/aiven/repo/Makefile
@@ -61,15 +61,18 @@ build_nodejs: upstream
 
 build_python: PYPI_VERSION := $(shell pulumictl get version --language python)
 build_python: upstream
+	rm -rf sdk/python/
 	$(WORKING_DIR)/bin/$(TFGEN) python --out sdk/python/
 	cd sdk/python/ && \
 		printf "module fake_python_module // Exclude this directory from Go tools\n\ngo 1.17\n" > go.mod && \
 		cp ../../README.md . && \
-		python3 setup.py clean --all 2>/dev/null && \
 		rm -rf ./bin/ ../python.bin/ && cp -R . ../python.bin && mv ../python.bin ./bin && \
-		sed -i.bak -e 's/^VERSION = .*/VERSION = "$(PYPI_VERSION)"/g' -e 's/^PLUGIN_VERSION = .*/PLUGIN_VERSION = "$(VERSION)"/g' ./bin/setup.py && \
-		rm ./bin/setup.py.bak && rm ./bin/go.mod && \
-		cd ./bin && python3 setup.py build sdist
+		sed -i.bak -e 's/^  version = .*/  version = "$(PYPI_VERSION)"/g' ./bin/pyproject.toml && \
+		rm ./bin/pyproject.toml.bak && rm ./bin/go.mod && \
+		python3 -m venv venv && \
+		./venv/bin/python -m pip install build && \
+		cd ./bin && \
+		../venv/bin/python -m build .
 
 clean:
 	rm -rf sdk/{dotnet,nodejs,go,python}

--- a/provider-ci/providers/akamai/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/akamai/repo/.github/workflows/main.yml
@@ -304,7 +304,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/akamai/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/akamai/repo/.github/workflows/master.yml
@@ -304,7 +304,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/akamai/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/akamai/repo/.github/workflows/prerelease.yml
@@ -250,7 +250,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/akamai/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/akamai/repo/.github/workflows/release.yml
@@ -262,7 +262,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/akamai/repo/Makefile
+++ b/provider-ci/providers/akamai/repo/Makefile
@@ -61,15 +61,18 @@ build_nodejs: upstream
 
 build_python: PYPI_VERSION := $(shell pulumictl get version --language python)
 build_python: upstream
+	rm -rf sdk/python/
 	$(WORKING_DIR)/bin/$(TFGEN) python --out sdk/python/
 	cd sdk/python/ && \
 		printf "module fake_python_module // Exclude this directory from Go tools\n\ngo 1.17\n" > go.mod && \
 		cp ../../README.md . && \
-		python3 setup.py clean --all 2>/dev/null && \
 		rm -rf ./bin/ ../python.bin/ && cp -R . ../python.bin && mv ../python.bin ./bin && \
-		sed -i.bak -e 's/^VERSION = .*/VERSION = "$(PYPI_VERSION)"/g' -e 's/^PLUGIN_VERSION = .*/PLUGIN_VERSION = "$(VERSION)"/g' ./bin/setup.py && \
-		rm ./bin/setup.py.bak && rm ./bin/go.mod && \
-		cd ./bin && python3 setup.py build sdist
+		sed -i.bak -e 's/^  version = .*/  version = "$(PYPI_VERSION)"/g' ./bin/pyproject.toml && \
+		rm ./bin/pyproject.toml.bak && rm ./bin/go.mod && \
+		python3 -m venv venv && \
+		./venv/bin/python -m pip install build && \
+		cd ./bin && \
+		../venv/bin/python -m build .
 
 clean:
 	rm -rf sdk/{dotnet,nodejs,go,python}

--- a/provider-ci/providers/alicloud/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/alicloud/repo/.github/workflows/main.yml
@@ -303,7 +303,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/alicloud/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/alicloud/repo/.github/workflows/master.yml
@@ -303,7 +303,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/alicloud/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/alicloud/repo/.github/workflows/prerelease.yml
@@ -249,7 +249,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/alicloud/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/alicloud/repo/.github/workflows/release.yml
@@ -261,7 +261,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/alicloud/repo/Makefile
+++ b/provider-ci/providers/alicloud/repo/Makefile
@@ -61,15 +61,18 @@ build_nodejs: upstream
 
 build_python: PYPI_VERSION := $(shell pulumictl get version --language python)
 build_python: upstream
+	rm -rf sdk/python/
 	$(WORKING_DIR)/bin/$(TFGEN) python --out sdk/python/
 	cd sdk/python/ && \
 		printf "module fake_python_module // Exclude this directory from Go tools\n\ngo 1.17\n" > go.mod && \
 		cp ../../README.md . && \
-		python3 setup.py clean --all 2>/dev/null && \
 		rm -rf ./bin/ ../python.bin/ && cp -R . ../python.bin && mv ../python.bin ./bin && \
-		sed -i.bak -e 's/^VERSION = .*/VERSION = "$(PYPI_VERSION)"/g' -e 's/^PLUGIN_VERSION = .*/PLUGIN_VERSION = "$(VERSION)"/g' ./bin/setup.py && \
-		rm ./bin/setup.py.bak && rm ./bin/go.mod && \
-		cd ./bin && python3 setup.py build sdist
+		sed -i.bak -e 's/^  version = .*/  version = "$(PYPI_VERSION)"/g' ./bin/pyproject.toml && \
+		rm ./bin/pyproject.toml.bak && rm ./bin/go.mod && \
+		python3 -m venv venv && \
+		./venv/bin/python -m pip install build && \
+		cd ./bin && \
+		../venv/bin/python -m build .
 
 clean:
 	rm -rf sdk/{dotnet,nodejs,go,python}

--- a/provider-ci/providers/archive/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/archive/repo/.github/workflows/main.yml
@@ -301,7 +301,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/archive/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/archive/repo/.github/workflows/master.yml
@@ -301,7 +301,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/archive/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/archive/repo/.github/workflows/prerelease.yml
@@ -247,7 +247,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/archive/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/archive/repo/.github/workflows/release.yml
@@ -245,7 +245,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/archive/repo/Makefile
+++ b/provider-ci/providers/archive/repo/Makefile
@@ -61,15 +61,18 @@ build_nodejs: upstream
 
 build_python: PYPI_VERSION := $(shell pulumictl get version --language python)
 build_python: upstream
+	rm -rf sdk/python/
 	$(WORKING_DIR)/bin/$(TFGEN) python --out sdk/python/
 	cd sdk/python/ && \
 		printf "module fake_python_module // Exclude this directory from Go tools\n\ngo 1.17\n" > go.mod && \
 		cp ../../README.md . && \
-		python3 setup.py clean --all 2>/dev/null && \
 		rm -rf ./bin/ ../python.bin/ && cp -R . ../python.bin && mv ../python.bin ./bin && \
-		sed -i.bak -e 's/^VERSION = .*/VERSION = "$(PYPI_VERSION)"/g' -e 's/^PLUGIN_VERSION = .*/PLUGIN_VERSION = "$(VERSION)"/g' ./bin/setup.py && \
-		rm ./bin/setup.py.bak && rm ./bin/go.mod && \
-		cd ./bin && python3 setup.py build sdist
+		sed -i.bak -e 's/^  version = .*/  version = "$(PYPI_VERSION)"/g' ./bin/pyproject.toml && \
+		rm ./bin/pyproject.toml.bak && rm ./bin/go.mod && \
+		python3 -m venv venv && \
+		./venv/bin/python -m pip install build && \
+		cd ./bin && \
+		../venv/bin/python -m build .
 
 clean:
 	rm -rf sdk/{dotnet,nodejs,go,python}

--- a/provider-ci/providers/artifactory/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/artifactory/repo/.github/workflows/main.yml
@@ -333,7 +333,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/artifactory/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/artifactory/repo/.github/workflows/master.yml
@@ -333,7 +333,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/artifactory/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/artifactory/repo/.github/workflows/prerelease.yml
@@ -279,7 +279,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/artifactory/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/artifactory/repo/.github/workflows/release.yml
@@ -291,7 +291,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/artifactory/repo/Makefile
+++ b/provider-ci/providers/artifactory/repo/Makefile
@@ -61,15 +61,18 @@ build_nodejs: upstream
 
 build_python: PYPI_VERSION := $(shell pulumictl get version --language python)
 build_python: upstream
+	rm -rf sdk/python/
 	$(WORKING_DIR)/bin/$(TFGEN) python --out sdk/python/
 	cd sdk/python/ && \
 		printf "module fake_python_module // Exclude this directory from Go tools\n\ngo 1.17\n" > go.mod && \
 		cp ../../README.md . && \
-		python3 setup.py clean --all 2>/dev/null && \
 		rm -rf ./bin/ ../python.bin/ && cp -R . ../python.bin && mv ../python.bin ./bin && \
-		sed -i.bak -e 's/^VERSION = .*/VERSION = "$(PYPI_VERSION)"/g' -e 's/^PLUGIN_VERSION = .*/PLUGIN_VERSION = "$(VERSION)"/g' ./bin/setup.py && \
-		rm ./bin/setup.py.bak && rm ./bin/go.mod && \
-		cd ./bin && python3 setup.py build sdist
+		sed -i.bak -e 's/^  version = .*/  version = "$(PYPI_VERSION)"/g' ./bin/pyproject.toml && \
+		rm ./bin/pyproject.toml.bak && rm ./bin/go.mod && \
+		python3 -m venv venv && \
+		./venv/bin/python -m pip install build && \
+		cd ./bin && \
+		../venv/bin/python -m build .
 
 clean:
 	rm -rf sdk/{dotnet,nodejs,go,python}

--- a/provider-ci/providers/auth0/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/auth0/repo/.github/workflows/main.yml
@@ -333,7 +333,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/auth0/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/auth0/repo/.github/workflows/master.yml
@@ -333,7 +333,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/auth0/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/auth0/repo/.github/workflows/prerelease.yml
@@ -279,7 +279,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/auth0/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/auth0/repo/.github/workflows/release.yml
@@ -291,7 +291,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/auth0/repo/Makefile
+++ b/provider-ci/providers/auth0/repo/Makefile
@@ -61,15 +61,18 @@ build_nodejs: upstream
 
 build_python: PYPI_VERSION := $(shell pulumictl get version --language python)
 build_python: upstream
+	rm -rf sdk/python/
 	$(WORKING_DIR)/bin/$(TFGEN) python --out sdk/python/
 	cd sdk/python/ && \
 		printf "module fake_python_module // Exclude this directory from Go tools\n\ngo 1.17\n" > go.mod && \
 		cp ../../README.md . && \
-		python3 setup.py clean --all 2>/dev/null && \
 		rm -rf ./bin/ ../python.bin/ && cp -R . ../python.bin && mv ../python.bin ./bin && \
-		sed -i.bak -e 's/^VERSION = .*/VERSION = "$(PYPI_VERSION)"/g' -e 's/^PLUGIN_VERSION = .*/PLUGIN_VERSION = "$(VERSION)"/g' ./bin/setup.py && \
-		rm ./bin/setup.py.bak && rm ./bin/go.mod && \
-		cd ./bin && python3 setup.py build sdist
+		sed -i.bak -e 's/^  version = .*/  version = "$(PYPI_VERSION)"/g' ./bin/pyproject.toml && \
+		rm ./bin/pyproject.toml.bak && rm ./bin/go.mod && \
+		python3 -m venv venv && \
+		./venv/bin/python -m pip install build && \
+		cd ./bin && \
+		../venv/bin/python -m build .
 
 clean:
 	rm -rf sdk/{dotnet,nodejs,go,python}

--- a/provider-ci/providers/aws/config.yaml
+++ b/provider-ci/providers/aws/config.yaml
@@ -29,7 +29,6 @@ plugins:
 team: ecosystem
 goBuildParallelism: 2
 javaGenVersion: "v0.9.5"
-wheels: true
 runner:
   publish: pulumi-ubuntu-8core
   buildSdk: pulumi-ubuntu-8core
@@ -67,8 +66,6 @@ actions:
         # http://azure.archive.ubuntu.com/ubuntu/pool/universe/d/dotnet7/aspnetcore-targeting-pack-7.0_7.0.105-0ubuntu1%7e22.04.1_amd64.deb
         # 404 Not Found [IP: 40.81.13.82 80]
         large-packages: false
-actionVersions:
-   publishProviderSDKs: pulumi/pulumi-package-publisher@v0.0.11
 extraTests:
   go_test_shim:
     name: Run test of provider shim

--- a/provider-ci/providers/azure/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/azure/repo/.github/workflows/main.yml
@@ -307,7 +307,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/azure/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/azure/repo/.github/workflows/master.yml
@@ -307,7 +307,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/azure/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/azure/repo/.github/workflows/prerelease.yml
@@ -253,7 +253,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/azure/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/azure/repo/.github/workflows/release.yml
@@ -265,7 +265,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/azure/repo/Makefile
+++ b/provider-ci/providers/azure/repo/Makefile
@@ -62,15 +62,18 @@ build_nodejs: upstream
 
 build_python: PYPI_VERSION := $(shell pulumictl get version --language python)
 build_python: upstream
+	rm -rf sdk/python/
 	$(WORKING_DIR)/bin/$(TFGEN) python --out sdk/python/
 	cd sdk/python/ && \
 		printf "module fake_python_module // Exclude this directory from Go tools\n\ngo 1.17\n" > go.mod && \
 		cp ../../README.md . && \
-		python3 setup.py clean --all 2>/dev/null && \
 		rm -rf ./bin/ ../python.bin/ && cp -R . ../python.bin && mv ../python.bin ./bin && \
-		sed -i.bak -e 's/^VERSION = .*/VERSION = "$(PYPI_VERSION)"/g' -e 's/^PLUGIN_VERSION = .*/PLUGIN_VERSION = "$(VERSION)"/g' ./bin/setup.py && \
-		rm ./bin/setup.py.bak && rm ./bin/go.mod && \
-		cd ./bin && python3 setup.py build sdist
+		sed -i.bak -e 's/^  version = .*/  version = "$(PYPI_VERSION)"/g' ./bin/pyproject.toml && \
+		rm ./bin/pyproject.toml.bak && rm ./bin/go.mod && \
+		python3 -m venv venv && \
+		./venv/bin/python -m pip install build && \
+		cd ./bin && \
+		../venv/bin/python -m build .
 
 clean:
 	rm -rf sdk/{dotnet,nodejs,go,python}

--- a/provider-ci/providers/azuread/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/azuread/repo/.github/workflows/main.yml
@@ -335,7 +335,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/azuread/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/azuread/repo/.github/workflows/master.yml
@@ -335,7 +335,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/azuread/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/azuread/repo/.github/workflows/prerelease.yml
@@ -281,7 +281,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/azuread/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/azuread/repo/.github/workflows/release.yml
@@ -293,7 +293,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/azuread/repo/Makefile
+++ b/provider-ci/providers/azuread/repo/Makefile
@@ -61,15 +61,18 @@ build_nodejs: upstream
 
 build_python: PYPI_VERSION := $(shell pulumictl get version --language python)
 build_python: upstream
+	rm -rf sdk/python/
 	$(WORKING_DIR)/bin/$(TFGEN) python --out sdk/python/
 	cd sdk/python/ && \
 		printf "module fake_python_module // Exclude this directory from Go tools\n\ngo 1.17\n" > go.mod && \
 		cp ../../README.md . && \
-		python3 setup.py clean --all 2>/dev/null && \
 		rm -rf ./bin/ ../python.bin/ && cp -R . ../python.bin && mv ../python.bin ./bin && \
-		sed -i.bak -e 's/^VERSION = .*/VERSION = "$(PYPI_VERSION)"/g' -e 's/^PLUGIN_VERSION = .*/PLUGIN_VERSION = "$(VERSION)"/g' ./bin/setup.py && \
-		rm ./bin/setup.py.bak && rm ./bin/go.mod && \
-		cd ./bin && python3 setup.py build sdist
+		sed -i.bak -e 's/^  version = .*/  version = "$(PYPI_VERSION)"/g' ./bin/pyproject.toml && \
+		rm ./bin/pyproject.toml.bak && rm ./bin/go.mod && \
+		python3 -m venv venv && \
+		./venv/bin/python -m pip install build && \
+		cd ./bin && \
+		../venv/bin/python -m build .
 
 clean:
 	rm -rf sdk/{dotnet,nodejs,go,python}

--- a/provider-ci/providers/azuredevops/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/azuredevops/repo/.github/workflows/main.yml
@@ -302,7 +302,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/azuredevops/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/azuredevops/repo/.github/workflows/master.yml
@@ -302,7 +302,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/azuredevops/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/azuredevops/repo/.github/workflows/prerelease.yml
@@ -248,7 +248,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/azuredevops/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/azuredevops/repo/.github/workflows/release.yml
@@ -260,7 +260,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/azuredevops/repo/Makefile
+++ b/provider-ci/providers/azuredevops/repo/Makefile
@@ -61,15 +61,18 @@ build_nodejs:
 
 build_python: PYPI_VERSION := $(shell pulumictl get version --language python)
 build_python:
+	rm -rf sdk/python/
 	$(WORKING_DIR)/bin/$(TFGEN) python --out sdk/python/
 	cd sdk/python/ && \
 		printf "module fake_python_module // Exclude this directory from Go tools\n\ngo 1.17\n" > go.mod && \
 		cp ../../README.md . && \
-		python3 setup.py clean --all 2>/dev/null && \
 		rm -rf ./bin/ ../python.bin/ && cp -R . ../python.bin && mv ../python.bin ./bin && \
-		sed -i.bak -e 's/^VERSION = .*/VERSION = "$(PYPI_VERSION)"/g' -e 's/^PLUGIN_VERSION = .*/PLUGIN_VERSION = "$(VERSION)"/g' ./bin/setup.py && \
-		rm ./bin/setup.py.bak && rm ./bin/go.mod && \
-		cd ./bin && python3 setup.py build sdist
+		sed -i.bak -e 's/^  version = .*/  version = "$(PYPI_VERSION)"/g' ./bin/pyproject.toml && \
+		rm ./bin/pyproject.toml.bak && rm ./bin/go.mod && \
+		python3 -m venv venv && \
+		./venv/bin/python -m pip install build && \
+		cd ./bin && \
+		../venv/bin/python -m build .
 
 clean:
 	rm -rf sdk/{dotnet,nodejs,go,python}

--- a/provider-ci/providers/civo/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/civo/repo/.github/workflows/main.yml
@@ -331,7 +331,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/civo/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/civo/repo/.github/workflows/master.yml
@@ -331,7 +331,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/civo/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/civo/repo/.github/workflows/prerelease.yml
@@ -277,7 +277,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/civo/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/civo/repo/.github/workflows/release.yml
@@ -289,7 +289,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/civo/repo/Makefile
+++ b/provider-ci/providers/civo/repo/Makefile
@@ -61,15 +61,18 @@ build_nodejs: upstream
 
 build_python: PYPI_VERSION := $(shell pulumictl get version --language python)
 build_python: upstream
+	rm -rf sdk/python/
 	$(WORKING_DIR)/bin/$(TFGEN) python --out sdk/python/
 	cd sdk/python/ && \
 		printf "module fake_python_module // Exclude this directory from Go tools\n\ngo 1.17\n" > go.mod && \
 		cp ../../README.md . && \
-		python3 setup.py clean --all 2>/dev/null && \
 		rm -rf ./bin/ ../python.bin/ && cp -R . ../python.bin && mv ../python.bin ./bin && \
-		sed -i.bak -e 's/^VERSION = .*/VERSION = "$(PYPI_VERSION)"/g' -e 's/^PLUGIN_VERSION = .*/PLUGIN_VERSION = "$(VERSION)"/g' ./bin/setup.py && \
-		rm ./bin/setup.py.bak && rm ./bin/go.mod && \
-		cd ./bin && python3 setup.py build sdist
+		sed -i.bak -e 's/^  version = .*/  version = "$(PYPI_VERSION)"/g' ./bin/pyproject.toml && \
+		rm ./bin/pyproject.toml.bak && rm ./bin/go.mod && \
+		python3 -m venv venv && \
+		./venv/bin/python -m pip install build && \
+		cd ./bin && \
+		../venv/bin/python -m build .
 
 clean:
 	rm -rf sdk/{dotnet,nodejs,go,python}

--- a/provider-ci/providers/cloudamqp/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/cloudamqp/repo/.github/workflows/main.yml
@@ -331,7 +331,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/cloudamqp/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/cloudamqp/repo/.github/workflows/master.yml
@@ -331,7 +331,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/cloudamqp/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/cloudamqp/repo/.github/workflows/prerelease.yml
@@ -277,7 +277,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/cloudamqp/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/cloudamqp/repo/.github/workflows/release.yml
@@ -289,7 +289,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/cloudamqp/repo/Makefile
+++ b/provider-ci/providers/cloudamqp/repo/Makefile
@@ -61,15 +61,18 @@ build_nodejs: upstream
 
 build_python: PYPI_VERSION := $(shell pulumictl get version --language python)
 build_python: upstream
+	rm -rf sdk/python/
 	$(WORKING_DIR)/bin/$(TFGEN) python --out sdk/python/
 	cd sdk/python/ && \
 		printf "module fake_python_module // Exclude this directory from Go tools\n\ngo 1.17\n" > go.mod && \
 		cp ../../README.md . && \
-		python3 setup.py clean --all 2>/dev/null && \
 		rm -rf ./bin/ ../python.bin/ && cp -R . ../python.bin && mv ../python.bin ./bin && \
-		sed -i.bak -e 's/^VERSION = .*/VERSION = "$(PYPI_VERSION)"/g' -e 's/^PLUGIN_VERSION = .*/PLUGIN_VERSION = "$(VERSION)"/g' ./bin/setup.py && \
-		rm ./bin/setup.py.bak && rm ./bin/go.mod && \
-		cd ./bin && python3 setup.py build sdist
+		sed -i.bak -e 's/^  version = .*/  version = "$(PYPI_VERSION)"/g' ./bin/pyproject.toml && \
+		rm ./bin/pyproject.toml.bak && rm ./bin/go.mod && \
+		python3 -m venv venv && \
+		./venv/bin/python -m pip install build && \
+		cd ./bin && \
+		../venv/bin/python -m build .
 
 clean:
 	rm -rf sdk/{dotnet,nodejs,go,python}

--- a/provider-ci/providers/cloudflare/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/cloudflare/repo/.github/workflows/main.yml
@@ -332,7 +332,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/cloudflare/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/cloudflare/repo/.github/workflows/master.yml
@@ -332,7 +332,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/cloudflare/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/cloudflare/repo/.github/workflows/prerelease.yml
@@ -278,7 +278,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/cloudflare/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/cloudflare/repo/.github/workflows/release.yml
@@ -290,7 +290,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/cloudflare/repo/Makefile
+++ b/provider-ci/providers/cloudflare/repo/Makefile
@@ -61,15 +61,18 @@ build_nodejs: upstream
 
 build_python: PYPI_VERSION := $(shell pulumictl get version --language python)
 build_python: upstream
+	rm -rf sdk/python/
 	$(WORKING_DIR)/bin/$(TFGEN) python --out sdk/python/
 	cd sdk/python/ && \
 		printf "module fake_python_module // Exclude this directory from Go tools\n\ngo 1.17\n" > go.mod && \
 		cp ../../README.md . && \
-		python3 setup.py clean --all 2>/dev/null && \
 		rm -rf ./bin/ ../python.bin/ && cp -R . ../python.bin && mv ../python.bin ./bin && \
-		sed -i.bak -e 's/^VERSION = .*/VERSION = "$(PYPI_VERSION)"/g' -e 's/^PLUGIN_VERSION = .*/PLUGIN_VERSION = "$(VERSION)"/g' ./bin/setup.py && \
-		rm ./bin/setup.py.bak && rm ./bin/go.mod && \
-		cd ./bin && python3 setup.py build sdist
+		sed -i.bak -e 's/^  version = .*/  version = "$(PYPI_VERSION)"/g' ./bin/pyproject.toml && \
+		rm ./bin/pyproject.toml.bak && rm ./bin/go.mod && \
+		python3 -m venv venv && \
+		./venv/bin/python -m pip install build && \
+		cd ./bin && \
+		../venv/bin/python -m build .
 
 clean:
 	rm -rf sdk/{dotnet,nodejs,go,python}

--- a/provider-ci/providers/cloudinit/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/cloudinit/repo/.github/workflows/main.yml
@@ -300,7 +300,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/cloudinit/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/cloudinit/repo/.github/workflows/master.yml
@@ -300,7 +300,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/cloudinit/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/cloudinit/repo/.github/workflows/prerelease.yml
@@ -246,7 +246,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/cloudinit/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/cloudinit/repo/.github/workflows/release.yml
@@ -258,7 +258,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/cloudinit/repo/Makefile
+++ b/provider-ci/providers/cloudinit/repo/Makefile
@@ -61,15 +61,18 @@ build_nodejs: upstream
 
 build_python: PYPI_VERSION := $(shell pulumictl get version --language python)
 build_python: upstream
+	rm -rf sdk/python/
 	$(WORKING_DIR)/bin/$(TFGEN) python --out sdk/python/
 	cd sdk/python/ && \
 		printf "module fake_python_module // Exclude this directory from Go tools\n\ngo 1.17\n" > go.mod && \
 		cp ../../README.md . && \
-		python3 setup.py clean --all 2>/dev/null && \
 		rm -rf ./bin/ ../python.bin/ && cp -R . ../python.bin && mv ../python.bin ./bin && \
-		sed -i.bak -e 's/^VERSION = .*/VERSION = "$(PYPI_VERSION)"/g' -e 's/^PLUGIN_VERSION = .*/PLUGIN_VERSION = "$(VERSION)"/g' ./bin/setup.py && \
-		rm ./bin/setup.py.bak && rm ./bin/go.mod && \
-		cd ./bin && python3 setup.py build sdist
+		sed -i.bak -e 's/^  version = .*/  version = "$(PYPI_VERSION)"/g' ./bin/pyproject.toml && \
+		rm ./bin/pyproject.toml.bak && rm ./bin/go.mod && \
+		python3 -m venv venv && \
+		./venv/bin/python -m pip install build && \
+		cd ./bin && \
+		../venv/bin/python -m build .
 
 clean:
 	rm -rf sdk/{dotnet,nodejs,go,python}

--- a/provider-ci/providers/confluentcloud/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/confluentcloud/repo/.github/workflows/main.yml
@@ -302,7 +302,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/confluentcloud/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/confluentcloud/repo/.github/workflows/master.yml
@@ -302,7 +302,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/confluentcloud/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/confluentcloud/repo/.github/workflows/prerelease.yml
@@ -248,7 +248,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/confluentcloud/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/confluentcloud/repo/.github/workflows/release.yml
@@ -260,7 +260,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/confluentcloud/repo/Makefile
+++ b/provider-ci/providers/confluentcloud/repo/Makefile
@@ -61,15 +61,18 @@ build_nodejs: upstream
 
 build_python: PYPI_VERSION := $(shell pulumictl get version --language python)
 build_python: upstream
+	rm -rf sdk/python/
 	$(WORKING_DIR)/bin/$(TFGEN) python --out sdk/python/
 	cd sdk/python/ && \
 		printf "module fake_python_module // Exclude this directory from Go tools\n\ngo 1.17\n" > go.mod && \
 		cp ../../README.md . && \
-		python3 setup.py clean --all 2>/dev/null && \
 		rm -rf ./bin/ ../python.bin/ && cp -R . ../python.bin && mv ../python.bin ./bin && \
-		sed -i.bak -e 's/^VERSION = .*/VERSION = "$(PYPI_VERSION)"/g' -e 's/^PLUGIN_VERSION = .*/PLUGIN_VERSION = "$(VERSION)"/g' ./bin/setup.py && \
-		rm ./bin/setup.py.bak && rm ./bin/go.mod && \
-		cd ./bin && python3 setup.py build sdist
+		sed -i.bak -e 's/^  version = .*/  version = "$(PYPI_VERSION)"/g' ./bin/pyproject.toml && \
+		rm ./bin/pyproject.toml.bak && rm ./bin/go.mod && \
+		python3 -m venv venv && \
+		./venv/bin/python -m pip install build && \
+		cd ./bin && \
+		../venv/bin/python -m build .
 
 clean:
 	rm -rf sdk/{dotnet,nodejs,go,python}

--- a/provider-ci/providers/consul/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/consul/repo/.github/workflows/main.yml
@@ -330,7 +330,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/consul/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/consul/repo/.github/workflows/master.yml
@@ -330,7 +330,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/consul/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/consul/repo/.github/workflows/prerelease.yml
@@ -276,7 +276,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/consul/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/consul/repo/.github/workflows/release.yml
@@ -288,7 +288,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/consul/repo/Makefile
+++ b/provider-ci/providers/consul/repo/Makefile
@@ -61,15 +61,18 @@ build_nodejs: upstream
 
 build_python: PYPI_VERSION := $(shell pulumictl get version --language python)
 build_python: upstream
+	rm -rf sdk/python/
 	$(WORKING_DIR)/bin/$(TFGEN) python --out sdk/python/
 	cd sdk/python/ && \
 		printf "module fake_python_module // Exclude this directory from Go tools\n\ngo 1.17\n" > go.mod && \
 		cp ../../README.md . && \
-		python3 setup.py clean --all 2>/dev/null && \
 		rm -rf ./bin/ ../python.bin/ && cp -R . ../python.bin && mv ../python.bin ./bin && \
-		sed -i.bak -e 's/^VERSION = .*/VERSION = "$(PYPI_VERSION)"/g' -e 's/^PLUGIN_VERSION = .*/PLUGIN_VERSION = "$(VERSION)"/g' ./bin/setup.py && \
-		rm ./bin/setup.py.bak && rm ./bin/go.mod && \
-		cd ./bin && python3 setup.py build sdist
+		sed -i.bak -e 's/^  version = .*/  version = "$(PYPI_VERSION)"/g' ./bin/pyproject.toml && \
+		rm ./bin/pyproject.toml.bak && rm ./bin/go.mod && \
+		python3 -m venv venv && \
+		./venv/bin/python -m pip install build && \
+		cd ./bin && \
+		../venv/bin/python -m build .
 
 clean:
 	rm -rf sdk/{dotnet,nodejs,go,python}

--- a/provider-ci/providers/databricks/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/databricks/repo/.github/workflows/main.yml
@@ -334,7 +334,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/databricks/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/databricks/repo/.github/workflows/master.yml
@@ -334,7 +334,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/databricks/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/databricks/repo/.github/workflows/prerelease.yml
@@ -280,7 +280,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/databricks/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/databricks/repo/.github/workflows/release.yml
@@ -292,7 +292,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/databricks/repo/Makefile
+++ b/provider-ci/providers/databricks/repo/Makefile
@@ -61,15 +61,18 @@ build_nodejs: upstream
 
 build_python: PYPI_VERSION := $(shell pulumictl get version --language python)
 build_python: upstream
+	rm -rf sdk/python/
 	$(WORKING_DIR)/bin/$(TFGEN) python --out sdk/python/
 	cd sdk/python/ && \
 		printf "module fake_python_module // Exclude this directory from Go tools\n\ngo 1.17\n" > go.mod && \
 		cp ../../README.md . && \
-		python3 setup.py clean --all 2>/dev/null && \
 		rm -rf ./bin/ ../python.bin/ && cp -R . ../python.bin && mv ../python.bin ./bin && \
-		sed -i.bak -e 's/^VERSION = .*/VERSION = "$(PYPI_VERSION)"/g' -e 's/^PLUGIN_VERSION = .*/PLUGIN_VERSION = "$(VERSION)"/g' ./bin/setup.py && \
-		rm ./bin/setup.py.bak && rm ./bin/go.mod && \
-		cd ./bin && python3 setup.py build sdist
+		sed -i.bak -e 's/^  version = .*/  version = "$(PYPI_VERSION)"/g' ./bin/pyproject.toml && \
+		rm ./bin/pyproject.toml.bak && rm ./bin/go.mod && \
+		python3 -m venv venv && \
+		./venv/bin/python -m pip install build && \
+		cd ./bin && \
+		../venv/bin/python -m build .
 
 clean:
 	rm -rf sdk/{dotnet,nodejs,go,python}

--- a/provider-ci/providers/datadog/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/datadog/repo/.github/workflows/main.yml
@@ -302,7 +302,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/datadog/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/datadog/repo/.github/workflows/master.yml
@@ -302,7 +302,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/datadog/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/datadog/repo/.github/workflows/prerelease.yml
@@ -248,7 +248,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/datadog/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/datadog/repo/.github/workflows/release.yml
@@ -260,7 +260,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/datadog/repo/Makefile
+++ b/provider-ci/providers/datadog/repo/Makefile
@@ -61,15 +61,18 @@ build_nodejs: upstream
 
 build_python: PYPI_VERSION := $(shell pulumictl get version --language python)
 build_python: upstream
+	rm -rf sdk/python/
 	$(WORKING_DIR)/bin/$(TFGEN) python --out sdk/python/
 	cd sdk/python/ && \
 		printf "module fake_python_module // Exclude this directory from Go tools\n\ngo 1.17\n" > go.mod && \
 		cp ../../README.md . && \
-		python3 setup.py clean --all 2>/dev/null && \
 		rm -rf ./bin/ ../python.bin/ && cp -R . ../python.bin && mv ../python.bin ./bin && \
-		sed -i.bak -e 's/^VERSION = .*/VERSION = "$(PYPI_VERSION)"/g' -e 's/^PLUGIN_VERSION = .*/PLUGIN_VERSION = "$(VERSION)"/g' ./bin/setup.py && \
-		rm ./bin/setup.py.bak && rm ./bin/go.mod && \
-		cd ./bin && python3 setup.py build sdist
+		sed -i.bak -e 's/^  version = .*/  version = "$(PYPI_VERSION)"/g' ./bin/pyproject.toml && \
+		rm ./bin/pyproject.toml.bak && rm ./bin/go.mod && \
+		python3 -m venv venv && \
+		./venv/bin/python -m pip install build && \
+		cd ./bin && \
+		../venv/bin/python -m build .
 
 clean:
 	rm -rf sdk/{dotnet,nodejs,go,python}

--- a/provider-ci/providers/digitalocean/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/digitalocean/repo/.github/workflows/main.yml
@@ -331,7 +331,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/digitalocean/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/digitalocean/repo/.github/workflows/master.yml
@@ -331,7 +331,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/digitalocean/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/digitalocean/repo/.github/workflows/prerelease.yml
@@ -277,7 +277,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/digitalocean/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/digitalocean/repo/.github/workflows/release.yml
@@ -289,7 +289,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/digitalocean/repo/Makefile
+++ b/provider-ci/providers/digitalocean/repo/Makefile
@@ -61,15 +61,18 @@ build_nodejs: upstream
 
 build_python: PYPI_VERSION := $(shell pulumictl get version --language python)
 build_python: upstream
+	rm -rf sdk/python/
 	$(WORKING_DIR)/bin/$(TFGEN) python --out sdk/python/
 	cd sdk/python/ && \
 		printf "module fake_python_module // Exclude this directory from Go tools\n\ngo 1.17\n" > go.mod && \
 		cp ../../README.md . && \
-		python3 setup.py clean --all 2>/dev/null && \
 		rm -rf ./bin/ ../python.bin/ && cp -R . ../python.bin && mv ../python.bin ./bin && \
-		sed -i.bak -e 's/^VERSION = .*/VERSION = "$(PYPI_VERSION)"/g' -e 's/^PLUGIN_VERSION = .*/PLUGIN_VERSION = "$(VERSION)"/g' ./bin/setup.py && \
-		rm ./bin/setup.py.bak && rm ./bin/go.mod && \
-		cd ./bin && python3 setup.py build sdist
+		sed -i.bak -e 's/^  version = .*/  version = "$(PYPI_VERSION)"/g' ./bin/pyproject.toml && \
+		rm ./bin/pyproject.toml.bak && rm ./bin/go.mod && \
+		python3 -m venv venv && \
+		./venv/bin/python -m pip install build && \
+		cd ./bin && \
+		../venv/bin/python -m build .
 
 clean:
 	rm -rf sdk/{dotnet,nodejs,go,python}

--- a/provider-ci/providers/dnsimple/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/dnsimple/repo/.github/workflows/main.yml
@@ -332,7 +332,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/dnsimple/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/dnsimple/repo/.github/workflows/master.yml
@@ -332,7 +332,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/dnsimple/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/dnsimple/repo/.github/workflows/prerelease.yml
@@ -278,7 +278,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/dnsimple/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/dnsimple/repo/.github/workflows/release.yml
@@ -290,7 +290,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/dnsimple/repo/Makefile
+++ b/provider-ci/providers/dnsimple/repo/Makefile
@@ -61,15 +61,18 @@ build_nodejs: upstream
 
 build_python: PYPI_VERSION := $(shell pulumictl get version --language python)
 build_python: upstream
+	rm -rf sdk/python/
 	$(WORKING_DIR)/bin/$(TFGEN) python --out sdk/python/
 	cd sdk/python/ && \
 		printf "module fake_python_module // Exclude this directory from Go tools\n\ngo 1.17\n" > go.mod && \
 		cp ../../README.md . && \
-		python3 setup.py clean --all 2>/dev/null && \
 		rm -rf ./bin/ ../python.bin/ && cp -R . ../python.bin && mv ../python.bin ./bin && \
-		sed -i.bak -e 's/^VERSION = .*/VERSION = "$(PYPI_VERSION)"/g' -e 's/^PLUGIN_VERSION = .*/PLUGIN_VERSION = "$(VERSION)"/g' ./bin/setup.py && \
-		rm ./bin/setup.py.bak && rm ./bin/go.mod && \
-		cd ./bin && python3 setup.py build sdist
+		sed -i.bak -e 's/^  version = .*/  version = "$(PYPI_VERSION)"/g' ./bin/pyproject.toml && \
+		rm ./bin/pyproject.toml.bak && rm ./bin/go.mod && \
+		python3 -m venv venv && \
+		./venv/bin/python -m pip install build && \
+		cd ./bin && \
+		../venv/bin/python -m build .
 
 clean:
 	rm -rf sdk/{dotnet,nodejs,go,python}

--- a/provider-ci/providers/docker/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/docker/repo/.github/workflows/main.yml
@@ -345,7 +345,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/docker/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/docker/repo/.github/workflows/master.yml
@@ -345,7 +345,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/docker/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/docker/repo/.github/workflows/prerelease.yml
@@ -291,7 +291,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/docker/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/docker/repo/.github/workflows/release.yml
@@ -303,7 +303,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/docker/repo/Makefile
+++ b/provider-ci/providers/docker/repo/Makefile
@@ -61,15 +61,18 @@ build_nodejs: upstream
 
 build_python: PYPI_VERSION := $(shell pulumictl get version --language python)
 build_python: upstream
+	rm -rf sdk/python/
 	$(WORKING_DIR)/bin/$(TFGEN) python --out sdk/python/
 	cd sdk/python/ && \
 		printf "module fake_python_module // Exclude this directory from Go tools\n\ngo 1.17\n" > go.mod && \
 		cp ../../README.md . && \
-		python3 setup.py clean --all 2>/dev/null && \
 		rm -rf ./bin/ ../python.bin/ && cp -R . ../python.bin && mv ../python.bin ./bin && \
-		sed -i.bak -e 's/^VERSION = .*/VERSION = "$(PYPI_VERSION)"/g' -e 's/^PLUGIN_VERSION = .*/PLUGIN_VERSION = "$(VERSION)"/g' ./bin/setup.py && \
-		rm ./bin/setup.py.bak && rm ./bin/go.mod && \
-		cd ./bin && python3 setup.py build sdist
+		sed -i.bak -e 's/^  version = .*/  version = "$(PYPI_VERSION)"/g' ./bin/pyproject.toml && \
+		rm ./bin/pyproject.toml.bak && rm ./bin/go.mod && \
+		python3 -m venv venv && \
+		./venv/bin/python -m pip install build && \
+		cd ./bin && \
+		../venv/bin/python -m build .
 
 clean:
 	rm -rf sdk/{dotnet,nodejs,go,python}

--- a/provider-ci/providers/ec/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/ec/repo/.github/workflows/main.yml
@@ -331,7 +331,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/ec/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/ec/repo/.github/workflows/master.yml
@@ -331,7 +331,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/ec/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/ec/repo/.github/workflows/prerelease.yml
@@ -277,7 +277,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/ec/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/ec/repo/.github/workflows/release.yml
@@ -289,7 +289,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/ec/repo/Makefile
+++ b/provider-ci/providers/ec/repo/Makefile
@@ -61,15 +61,18 @@ build_nodejs: upstream
 
 build_python: PYPI_VERSION := $(shell pulumictl get version --language python)
 build_python: upstream
+	rm -rf sdk/python/
 	$(WORKING_DIR)/bin/$(TFGEN) python --out sdk/python/
 	cd sdk/python/ && \
 		printf "module fake_python_module // Exclude this directory from Go tools\n\ngo 1.17\n" > go.mod && \
 		cp ../../README.md . && \
-		python3 setup.py clean --all 2>/dev/null && \
 		rm -rf ./bin/ ../python.bin/ && cp -R . ../python.bin && mv ../python.bin ./bin && \
-		sed -i.bak -e 's/^VERSION = .*/VERSION = "$(PYPI_VERSION)"/g' -e 's/^PLUGIN_VERSION = .*/PLUGIN_VERSION = "$(VERSION)"/g' ./bin/setup.py && \
-		rm ./bin/setup.py.bak && rm ./bin/go.mod && \
-		cd ./bin && python3 setup.py build sdist
+		sed -i.bak -e 's/^  version = .*/  version = "$(PYPI_VERSION)"/g' ./bin/pyproject.toml && \
+		rm ./bin/pyproject.toml.bak && rm ./bin/go.mod && \
+		python3 -m venv venv && \
+		./venv/bin/python -m pip install build && \
+		cd ./bin && \
+		../venv/bin/python -m build .
 
 clean:
 	rm -rf sdk/{dotnet,nodejs,go,python}

--- a/provider-ci/providers/equinix-metal/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/equinix-metal/repo/.github/workflows/main.yml
@@ -301,7 +301,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/equinix-metal/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/equinix-metal/repo/.github/workflows/master.yml
@@ -301,7 +301,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/equinix-metal/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/equinix-metal/repo/.github/workflows/prerelease.yml
@@ -247,7 +247,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/equinix-metal/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/equinix-metal/repo/.github/workflows/release.yml
@@ -259,7 +259,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/equinix-metal/repo/Makefile
+++ b/provider-ci/providers/equinix-metal/repo/Makefile
@@ -61,15 +61,18 @@ build_nodejs: upstream
 
 build_python: PYPI_VERSION := $(shell pulumictl get version --language python)
 build_python: upstream
+	rm -rf sdk/python/
 	$(WORKING_DIR)/bin/$(TFGEN) python --out sdk/python/
 	cd sdk/python/ && \
 		printf "module fake_python_module // Exclude this directory from Go tools\n\ngo 1.17\n" > go.mod && \
 		cp ../../README.md . && \
-		python3 setup.py clean --all 2>/dev/null && \
 		rm -rf ./bin/ ../python.bin/ && cp -R . ../python.bin && mv ../python.bin ./bin && \
-		sed -i.bak -e 's/^VERSION = .*/VERSION = "$(PYPI_VERSION)"/g' -e 's/^PLUGIN_VERSION = .*/PLUGIN_VERSION = "$(VERSION)"/g' ./bin/setup.py && \
-		rm ./bin/setup.py.bak && rm ./bin/go.mod && \
-		cd ./bin && python3 setup.py build sdist
+		sed -i.bak -e 's/^  version = .*/  version = "$(PYPI_VERSION)"/g' ./bin/pyproject.toml && \
+		rm ./bin/pyproject.toml.bak && rm ./bin/go.mod && \
+		python3 -m venv venv && \
+		./venv/bin/python -m pip install build && \
+		cd ./bin && \
+		../venv/bin/python -m build .
 
 clean:
 	rm -rf sdk/{dotnet,nodejs,go,python}

--- a/provider-ci/providers/external/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/external/repo/.github/workflows/main.yml
@@ -301,7 +301,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/external/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/external/repo/.github/workflows/master.yml
@@ -301,7 +301,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/external/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/external/repo/.github/workflows/prerelease.yml
@@ -247,7 +247,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/external/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/external/repo/.github/workflows/release.yml
@@ -245,7 +245,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/external/repo/Makefile
+++ b/provider-ci/providers/external/repo/Makefile
@@ -61,15 +61,18 @@ build_nodejs: upstream
 
 build_python: PYPI_VERSION := $(shell pulumictl get version --language python)
 build_python: upstream
+	rm -rf sdk/python/
 	$(WORKING_DIR)/bin/$(TFGEN) python --out sdk/python/
 	cd sdk/python/ && \
 		printf "module fake_python_module // Exclude this directory from Go tools\n\ngo 1.17\n" > go.mod && \
 		cp ../../README.md . && \
-		python3 setup.py clean --all 2>/dev/null && \
 		rm -rf ./bin/ ../python.bin/ && cp -R . ../python.bin && mv ../python.bin ./bin && \
-		sed -i.bak -e 's/^VERSION = .*/VERSION = "$(PYPI_VERSION)"/g' -e 's/^PLUGIN_VERSION = .*/PLUGIN_VERSION = "$(VERSION)"/g' ./bin/setup.py && \
-		rm ./bin/setup.py.bak && rm ./bin/go.mod && \
-		cd ./bin && python3 setup.py build sdist
+		sed -i.bak -e 's/^  version = .*/  version = "$(PYPI_VERSION)"/g' ./bin/pyproject.toml && \
+		rm ./bin/pyproject.toml.bak && rm ./bin/go.mod && \
+		python3 -m venv venv && \
+		./venv/bin/python -m pip install build && \
+		cd ./bin && \
+		../venv/bin/python -m build .
 
 clean:
 	rm -rf sdk/{dotnet,nodejs,go,python}

--- a/provider-ci/providers/f5bigip/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/f5bigip/repo/.github/workflows/main.yml
@@ -334,7 +334,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/f5bigip/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/f5bigip/repo/.github/workflows/master.yml
@@ -334,7 +334,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/f5bigip/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/f5bigip/repo/.github/workflows/prerelease.yml
@@ -280,7 +280,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/f5bigip/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/f5bigip/repo/.github/workflows/release.yml
@@ -292,7 +292,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/f5bigip/repo/Makefile
+++ b/provider-ci/providers/f5bigip/repo/Makefile
@@ -61,15 +61,18 @@ build_nodejs: upstream
 
 build_python: PYPI_VERSION := $(shell pulumictl get version --language python)
 build_python: upstream
+	rm -rf sdk/python/
 	$(WORKING_DIR)/bin/$(TFGEN) python --out sdk/python/
 	cd sdk/python/ && \
 		printf "module fake_python_module // Exclude this directory from Go tools\n\ngo 1.17\n" > go.mod && \
 		cp ../../README.md . && \
-		python3 setup.py clean --all 2>/dev/null && \
 		rm -rf ./bin/ ../python.bin/ && cp -R . ../python.bin && mv ../python.bin ./bin && \
-		sed -i.bak -e 's/^VERSION = .*/VERSION = "$(PYPI_VERSION)"/g' -e 's/^PLUGIN_VERSION = .*/PLUGIN_VERSION = "$(VERSION)"/g' ./bin/setup.py && \
-		rm ./bin/setup.py.bak && rm ./bin/go.mod && \
-		cd ./bin && python3 setup.py build sdist
+		sed -i.bak -e 's/^  version = .*/  version = "$(PYPI_VERSION)"/g' ./bin/pyproject.toml && \
+		rm ./bin/pyproject.toml.bak && rm ./bin/go.mod && \
+		python3 -m venv venv && \
+		./venv/bin/python -m pip install build && \
+		cd ./bin && \
+		../venv/bin/python -m build .
 
 clean:
 	rm -rf sdk/{dotnet,nodejs,go,python}

--- a/provider-ci/providers/fastly/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/fastly/repo/.github/workflows/main.yml
@@ -331,7 +331,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/fastly/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/fastly/repo/.github/workflows/master.yml
@@ -331,7 +331,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/fastly/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/fastly/repo/.github/workflows/prerelease.yml
@@ -277,7 +277,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/fastly/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/fastly/repo/.github/workflows/release.yml
@@ -289,7 +289,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/fastly/repo/Makefile
+++ b/provider-ci/providers/fastly/repo/Makefile
@@ -61,15 +61,18 @@ build_nodejs: upstream
 
 build_python: PYPI_VERSION := $(shell pulumictl get version --language python)
 build_python: upstream
+	rm -rf sdk/python/
 	$(WORKING_DIR)/bin/$(TFGEN) python --out sdk/python/
 	cd sdk/python/ && \
 		printf "module fake_python_module // Exclude this directory from Go tools\n\ngo 1.17\n" > go.mod && \
 		cp ../../README.md . && \
-		python3 setup.py clean --all 2>/dev/null && \
 		rm -rf ./bin/ ../python.bin/ && cp -R . ../python.bin && mv ../python.bin ./bin && \
-		sed -i.bak -e 's/^VERSION = .*/VERSION = "$(PYPI_VERSION)"/g' -e 's/^PLUGIN_VERSION = .*/PLUGIN_VERSION = "$(VERSION)"/g' ./bin/setup.py && \
-		rm ./bin/setup.py.bak && rm ./bin/go.mod && \
-		cd ./bin && python3 setup.py build sdist
+		sed -i.bak -e 's/^  version = .*/  version = "$(PYPI_VERSION)"/g' ./bin/pyproject.toml && \
+		rm ./bin/pyproject.toml.bak && rm ./bin/go.mod && \
+		python3 -m venv venv && \
+		./venv/bin/python -m pip install build && \
+		cd ./bin && \
+		../venv/bin/python -m build .
 
 clean:
 	rm -rf sdk/{dotnet,nodejs,go,python}

--- a/provider-ci/providers/gcp/config.yaml
+++ b/provider-ci/providers/gcp/config.yaml
@@ -31,9 +31,6 @@ team: ecosystem
 goBuildParallelism: 2
 skipGoReleaserHooks: true
 javaGenVersion: v0.9.7
-wheels: true
-actionVersions:
-   publishProviderSDKs: pulumi/pulumi-package-publisher@v0.0.11
 runner:
   publish: pulumi-ubuntu-8core
   buildSdk: pulumi-ubuntu-8core

--- a/provider-ci/providers/github/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/github/repo/.github/workflows/main.yml
@@ -332,7 +332,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/github/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/github/repo/.github/workflows/master.yml
@@ -332,7 +332,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/github/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/github/repo/.github/workflows/prerelease.yml
@@ -278,7 +278,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/github/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/github/repo/.github/workflows/release.yml
@@ -290,7 +290,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/github/repo/Makefile
+++ b/provider-ci/providers/github/repo/Makefile
@@ -61,15 +61,18 @@ build_nodejs: upstream
 
 build_python: PYPI_VERSION := $(shell pulumictl get version --language python)
 build_python: upstream
+	rm -rf sdk/python/
 	$(WORKING_DIR)/bin/$(TFGEN) python --out sdk/python/
 	cd sdk/python/ && \
 		printf "module fake_python_module // Exclude this directory from Go tools\n\ngo 1.17\n" > go.mod && \
 		cp ../../README.md . && \
-		python3 setup.py clean --all 2>/dev/null && \
 		rm -rf ./bin/ ../python.bin/ && cp -R . ../python.bin && mv ../python.bin ./bin && \
-		sed -i.bak -e 's/^VERSION = .*/VERSION = "$(PYPI_VERSION)"/g' -e 's/^PLUGIN_VERSION = .*/PLUGIN_VERSION = "$(VERSION)"/g' ./bin/setup.py && \
-		rm ./bin/setup.py.bak && rm ./bin/go.mod && \
-		cd ./bin && python3 setup.py build sdist
+		sed -i.bak -e 's/^  version = .*/  version = "$(PYPI_VERSION)"/g' ./bin/pyproject.toml && \
+		rm ./bin/pyproject.toml.bak && rm ./bin/go.mod && \
+		python3 -m venv venv && \
+		./venv/bin/python -m pip install build && \
+		cd ./bin && \
+		../venv/bin/python -m build .
 
 clean:
 	rm -rf sdk/{dotnet,nodejs,go,python}

--- a/provider-ci/providers/gitlab/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/gitlab/repo/.github/workflows/main.yml
@@ -331,7 +331,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/gitlab/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/gitlab/repo/.github/workflows/master.yml
@@ -331,7 +331,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/gitlab/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/gitlab/repo/.github/workflows/prerelease.yml
@@ -277,7 +277,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/gitlab/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/gitlab/repo/.github/workflows/release.yml
@@ -289,7 +289,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/gitlab/repo/Makefile
+++ b/provider-ci/providers/gitlab/repo/Makefile
@@ -61,15 +61,18 @@ build_nodejs: upstream
 
 build_python: PYPI_VERSION := $(shell pulumictl get version --language python)
 build_python: upstream
+	rm -rf sdk/python/
 	$(WORKING_DIR)/bin/$(TFGEN) python --out sdk/python/
 	cd sdk/python/ && \
 		printf "module fake_python_module // Exclude this directory from Go tools\n\ngo 1.17\n" > go.mod && \
 		cp ../../README.md . && \
-		python3 setup.py clean --all 2>/dev/null && \
 		rm -rf ./bin/ ../python.bin/ && cp -R . ../python.bin && mv ../python.bin ./bin && \
-		sed -i.bak -e 's/^VERSION = .*/VERSION = "$(PYPI_VERSION)"/g' -e 's/^PLUGIN_VERSION = .*/PLUGIN_VERSION = "$(VERSION)"/g' ./bin/setup.py && \
-		rm ./bin/setup.py.bak && rm ./bin/go.mod && \
-		cd ./bin && python3 setup.py build sdist
+		sed -i.bak -e 's/^  version = .*/  version = "$(PYPI_VERSION)"/g' ./bin/pyproject.toml && \
+		rm ./bin/pyproject.toml.bak && rm ./bin/go.mod && \
+		python3 -m venv venv && \
+		./venv/bin/python -m pip install build && \
+		cd ./bin && \
+		../venv/bin/python -m build .
 
 clean:
 	rm -rf sdk/{dotnet,nodejs,go,python}

--- a/provider-ci/providers/hcloud/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/hcloud/repo/.github/workflows/main.yml
@@ -331,7 +331,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/hcloud/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/hcloud/repo/.github/workflows/master.yml
@@ -331,7 +331,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/hcloud/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/hcloud/repo/.github/workflows/prerelease.yml
@@ -277,7 +277,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/hcloud/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/hcloud/repo/.github/workflows/release.yml
@@ -289,7 +289,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/hcloud/repo/Makefile
+++ b/provider-ci/providers/hcloud/repo/Makefile
@@ -61,15 +61,18 @@ build_nodejs: upstream
 
 build_python: PYPI_VERSION := $(shell pulumictl get version --language python)
 build_python: upstream
+	rm -rf sdk/python/
 	$(WORKING_DIR)/bin/$(TFGEN) python --out sdk/python/
 	cd sdk/python/ && \
 		printf "module fake_python_module // Exclude this directory from Go tools\n\ngo 1.17\n" > go.mod && \
 		cp ../../README.md . && \
-		python3 setup.py clean --all 2>/dev/null && \
 		rm -rf ./bin/ ../python.bin/ && cp -R . ../python.bin && mv ../python.bin ./bin && \
-		sed -i.bak -e 's/^VERSION = .*/VERSION = "$(PYPI_VERSION)"/g' -e 's/^PLUGIN_VERSION = .*/PLUGIN_VERSION = "$(VERSION)"/g' ./bin/setup.py && \
-		rm ./bin/setup.py.bak && rm ./bin/go.mod && \
-		cd ./bin && python3 setup.py build sdist
+		sed -i.bak -e 's/^  version = .*/  version = "$(PYPI_VERSION)"/g' ./bin/pyproject.toml && \
+		rm ./bin/pyproject.toml.bak && rm ./bin/go.mod && \
+		python3 -m venv venv && \
+		./venv/bin/python -m pip install build && \
+		cd ./bin && \
+		../venv/bin/python -m build .
 
 clean:
 	rm -rf sdk/{dotnet,nodejs,go,python}

--- a/provider-ci/providers/http/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/http/repo/.github/workflows/main.yml
@@ -301,7 +301,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/http/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/http/repo/.github/workflows/master.yml
@@ -301,7 +301,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/http/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/http/repo/.github/workflows/prerelease.yml
@@ -247,7 +247,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/http/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/http/repo/.github/workflows/release.yml
@@ -245,7 +245,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/http/repo/Makefile
+++ b/provider-ci/providers/http/repo/Makefile
@@ -61,15 +61,18 @@ build_nodejs: upstream
 
 build_python: PYPI_VERSION := $(shell pulumictl get version --language python)
 build_python: upstream
+	rm -rf sdk/python/
 	$(WORKING_DIR)/bin/$(TFGEN) python --out sdk/python/
 	cd sdk/python/ && \
 		printf "module fake_python_module // Exclude this directory from Go tools\n\ngo 1.17\n" > go.mod && \
 		cp ../../README.md . && \
-		python3 setup.py clean --all 2>/dev/null && \
 		rm -rf ./bin/ ../python.bin/ && cp -R . ../python.bin && mv ../python.bin ./bin && \
-		sed -i.bak -e 's/^VERSION = .*/VERSION = "$(PYPI_VERSION)"/g' -e 's/^PLUGIN_VERSION = .*/PLUGIN_VERSION = "$(VERSION)"/g' ./bin/setup.py && \
-		rm ./bin/setup.py.bak && rm ./bin/go.mod && \
-		cd ./bin && python3 setup.py build sdist
+		sed -i.bak -e 's/^  version = .*/  version = "$(PYPI_VERSION)"/g' ./bin/pyproject.toml && \
+		rm ./bin/pyproject.toml.bak && rm ./bin/go.mod && \
+		python3 -m venv venv && \
+		./venv/bin/python -m pip install build && \
+		cd ./bin && \
+		../venv/bin/python -m build .
 
 clean:
 	rm -rf sdk/{dotnet,nodejs,go,python}

--- a/provider-ci/providers/kafka/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/kafka/repo/.github/workflows/main.yml
@@ -330,7 +330,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/kafka/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/kafka/repo/.github/workflows/master.yml
@@ -330,7 +330,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/kafka/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/kafka/repo/.github/workflows/prerelease.yml
@@ -276,7 +276,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/kafka/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/kafka/repo/.github/workflows/release.yml
@@ -288,7 +288,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/kafka/repo/Makefile
+++ b/provider-ci/providers/kafka/repo/Makefile
@@ -61,15 +61,18 @@ build_nodejs: upstream
 
 build_python: PYPI_VERSION := $(shell pulumictl get version --language python)
 build_python: upstream
+	rm -rf sdk/python/
 	$(WORKING_DIR)/bin/$(TFGEN) python --out sdk/python/
 	cd sdk/python/ && \
 		printf "module fake_python_module // Exclude this directory from Go tools\n\ngo 1.17\n" > go.mod && \
 		cp ../../README.md . && \
-		python3 setup.py clean --all 2>/dev/null && \
 		rm -rf ./bin/ ../python.bin/ && cp -R . ../python.bin && mv ../python.bin ./bin && \
-		sed -i.bak -e 's/^VERSION = .*/VERSION = "$(PYPI_VERSION)"/g' -e 's/^PLUGIN_VERSION = .*/PLUGIN_VERSION = "$(VERSION)"/g' ./bin/setup.py && \
-		rm ./bin/setup.py.bak && rm ./bin/go.mod && \
-		cd ./bin && python3 setup.py build sdist
+		sed -i.bak -e 's/^  version = .*/  version = "$(PYPI_VERSION)"/g' ./bin/pyproject.toml && \
+		rm ./bin/pyproject.toml.bak && rm ./bin/go.mod && \
+		python3 -m venv venv && \
+		./venv/bin/python -m pip install build && \
+		cd ./bin && \
+		../venv/bin/python -m build .
 
 clean:
 	rm -rf sdk/{dotnet,nodejs,go,python}

--- a/provider-ci/providers/keycloak/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/keycloak/repo/.github/workflows/main.yml
@@ -335,7 +335,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/keycloak/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/keycloak/repo/.github/workflows/master.yml
@@ -335,7 +335,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/keycloak/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/keycloak/repo/.github/workflows/prerelease.yml
@@ -281,7 +281,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/keycloak/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/keycloak/repo/.github/workflows/release.yml
@@ -293,7 +293,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/keycloak/repo/Makefile
+++ b/provider-ci/providers/keycloak/repo/Makefile
@@ -61,15 +61,18 @@ build_nodejs: upstream
 
 build_python: PYPI_VERSION := $(shell pulumictl get version --language python)
 build_python: upstream
+	rm -rf sdk/python/
 	$(WORKING_DIR)/bin/$(TFGEN) python --out sdk/python/
 	cd sdk/python/ && \
 		printf "module fake_python_module // Exclude this directory from Go tools\n\ngo 1.17\n" > go.mod && \
 		cp ../../README.md . && \
-		python3 setup.py clean --all 2>/dev/null && \
 		rm -rf ./bin/ ../python.bin/ && cp -R . ../python.bin && mv ../python.bin ./bin && \
-		sed -i.bak -e 's/^VERSION = .*/VERSION = "$(PYPI_VERSION)"/g' -e 's/^PLUGIN_VERSION = .*/PLUGIN_VERSION = "$(VERSION)"/g' ./bin/setup.py && \
-		rm ./bin/setup.py.bak && rm ./bin/go.mod && \
-		cd ./bin && python3 setup.py build sdist
+		sed -i.bak -e 's/^  version = .*/  version = "$(PYPI_VERSION)"/g' ./bin/pyproject.toml && \
+		rm ./bin/pyproject.toml.bak && rm ./bin/go.mod && \
+		python3 -m venv venv && \
+		./venv/bin/python -m pip install build && \
+		cd ./bin && \
+		../venv/bin/python -m build .
 
 clean:
 	rm -rf sdk/{dotnet,nodejs,go,python}

--- a/provider-ci/providers/kong/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/kong/repo/.github/workflows/main.yml
@@ -330,7 +330,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/kong/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/kong/repo/.github/workflows/master.yml
@@ -330,7 +330,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/kong/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/kong/repo/.github/workflows/prerelease.yml
@@ -276,7 +276,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/kong/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/kong/repo/.github/workflows/release.yml
@@ -288,7 +288,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/kong/repo/Makefile
+++ b/provider-ci/providers/kong/repo/Makefile
@@ -61,15 +61,18 @@ build_nodejs: upstream
 
 build_python: PYPI_VERSION := $(shell pulumictl get version --language python)
 build_python: upstream
+	rm -rf sdk/python/
 	$(WORKING_DIR)/bin/$(TFGEN) python --out sdk/python/
 	cd sdk/python/ && \
 		printf "module fake_python_module // Exclude this directory from Go tools\n\ngo 1.17\n" > go.mod && \
 		cp ../../README.md . && \
-		python3 setup.py clean --all 2>/dev/null && \
 		rm -rf ./bin/ ../python.bin/ && cp -R . ../python.bin && mv ../python.bin ./bin && \
-		sed -i.bak -e 's/^VERSION = .*/VERSION = "$(PYPI_VERSION)"/g' -e 's/^PLUGIN_VERSION = .*/PLUGIN_VERSION = "$(VERSION)"/g' ./bin/setup.py && \
-		rm ./bin/setup.py.bak && rm ./bin/go.mod && \
-		cd ./bin && python3 setup.py build sdist
+		sed -i.bak -e 's/^  version = .*/  version = "$(PYPI_VERSION)"/g' ./bin/pyproject.toml && \
+		rm ./bin/pyproject.toml.bak && rm ./bin/go.mod && \
+		python3 -m venv venv && \
+		./venv/bin/python -m pip install build && \
+		cd ./bin && \
+		../venv/bin/python -m build .
 
 clean:
 	rm -rf sdk/{dotnet,nodejs,go,python}

--- a/provider-ci/providers/libvirt/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/libvirt/repo/.github/workflows/main.yml
@@ -331,7 +331,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/libvirt/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/libvirt/repo/.github/workflows/master.yml
@@ -331,7 +331,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/libvirt/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/libvirt/repo/.github/workflows/prerelease.yml
@@ -277,7 +277,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/libvirt/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/libvirt/repo/.github/workflows/release.yml
@@ -289,7 +289,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/libvirt/repo/Makefile
+++ b/provider-ci/providers/libvirt/repo/Makefile
@@ -61,15 +61,18 @@ build_nodejs: upstream
 
 build_python: PYPI_VERSION := $(shell pulumictl get version --language python)
 build_python: upstream
+	rm -rf sdk/python/
 	$(WORKING_DIR)/bin/$(TFGEN) python --out sdk/python/
 	cd sdk/python/ && \
 		printf "module fake_python_module // Exclude this directory from Go tools\n\ngo 1.17\n" > go.mod && \
 		cp ../../README.md . && \
-		python3 setup.py clean --all 2>/dev/null && \
 		rm -rf ./bin/ ../python.bin/ && cp -R . ../python.bin && mv ../python.bin ./bin && \
-		sed -i.bak -e 's/^VERSION = .*/VERSION = "$(PYPI_VERSION)"/g' -e 's/^PLUGIN_VERSION = .*/PLUGIN_VERSION = "$(VERSION)"/g' ./bin/setup.py && \
-		rm ./bin/setup.py.bak && rm ./bin/go.mod && \
-		cd ./bin && python3 setup.py build sdist
+		sed -i.bak -e 's/^  version = .*/  version = "$(PYPI_VERSION)"/g' ./bin/pyproject.toml && \
+		rm ./bin/pyproject.toml.bak && rm ./bin/go.mod && \
+		python3 -m venv venv && \
+		./venv/bin/python -m pip install build && \
+		cd ./bin && \
+		../venv/bin/python -m build .
 
 clean:
 	rm -rf sdk/{dotnet,nodejs,go,python}

--- a/provider-ci/providers/linode/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/linode/repo/.github/workflows/main.yml
@@ -331,7 +331,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/linode/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/linode/repo/.github/workflows/master.yml
@@ -331,7 +331,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/linode/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/linode/repo/.github/workflows/prerelease.yml
@@ -277,7 +277,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/linode/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/linode/repo/.github/workflows/release.yml
@@ -289,7 +289,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/linode/repo/Makefile
+++ b/provider-ci/providers/linode/repo/Makefile
@@ -61,15 +61,18 @@ build_nodejs: upstream
 
 build_python: PYPI_VERSION := $(shell pulumictl get version --language python)
 build_python: upstream
+	rm -rf sdk/python/
 	$(WORKING_DIR)/bin/$(TFGEN) python --out sdk/python/
 	cd sdk/python/ && \
 		printf "module fake_python_module // Exclude this directory from Go tools\n\ngo 1.17\n" > go.mod && \
 		cp ../../README.md . && \
-		python3 setup.py clean --all 2>/dev/null && \
 		rm -rf ./bin/ ../python.bin/ && cp -R . ../python.bin && mv ../python.bin ./bin && \
-		sed -i.bak -e 's/^VERSION = .*/VERSION = "$(PYPI_VERSION)"/g' -e 's/^PLUGIN_VERSION = .*/PLUGIN_VERSION = "$(VERSION)"/g' ./bin/setup.py && \
-		rm ./bin/setup.py.bak && rm ./bin/go.mod && \
-		cd ./bin && python3 setup.py build sdist
+		sed -i.bak -e 's/^  version = .*/  version = "$(PYPI_VERSION)"/g' ./bin/pyproject.toml && \
+		rm ./bin/pyproject.toml.bak && rm ./bin/go.mod && \
+		python3 -m venv venv && \
+		./venv/bin/python -m pip install build && \
+		cd ./bin && \
+		../venv/bin/python -m build .
 
 clean:
 	rm -rf sdk/{dotnet,nodejs,go,python}

--- a/provider-ci/providers/local/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/local/repo/.github/workflows/main.yml
@@ -301,7 +301,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/local/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/local/repo/.github/workflows/master.yml
@@ -301,7 +301,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/local/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/local/repo/.github/workflows/prerelease.yml
@@ -247,7 +247,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/local/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/local/repo/.github/workflows/release.yml
@@ -245,7 +245,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/local/repo/Makefile
+++ b/provider-ci/providers/local/repo/Makefile
@@ -61,15 +61,18 @@ build_nodejs: upstream
 
 build_python: PYPI_VERSION := $(shell pulumictl get version --language python)
 build_python: upstream
+	rm -rf sdk/python/
 	$(WORKING_DIR)/bin/$(TFGEN) python --out sdk/python/
 	cd sdk/python/ && \
 		printf "module fake_python_module // Exclude this directory from Go tools\n\ngo 1.17\n" > go.mod && \
 		cp ../../README.md . && \
-		python3 setup.py clean --all 2>/dev/null && \
 		rm -rf ./bin/ ../python.bin/ && cp -R . ../python.bin && mv ../python.bin ./bin && \
-		sed -i.bak -e 's/^VERSION = .*/VERSION = "$(PYPI_VERSION)"/g' -e 's/^PLUGIN_VERSION = .*/PLUGIN_VERSION = "$(VERSION)"/g' ./bin/setup.py && \
-		rm ./bin/setup.py.bak && rm ./bin/go.mod && \
-		cd ./bin && python3 setup.py build sdist
+		sed -i.bak -e 's/^  version = .*/  version = "$(PYPI_VERSION)"/g' ./bin/pyproject.toml && \
+		rm ./bin/pyproject.toml.bak && rm ./bin/go.mod && \
+		python3 -m venv venv && \
+		./venv/bin/python -m pip install build && \
+		cd ./bin && \
+		../venv/bin/python -m build .
 
 clean:
 	rm -rf sdk/{dotnet,nodejs,go,python}

--- a/provider-ci/providers/mailgun/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/mailgun/repo/.github/workflows/main.yml
@@ -331,7 +331,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/mailgun/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/mailgun/repo/.github/workflows/master.yml
@@ -331,7 +331,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/mailgun/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/mailgun/repo/.github/workflows/prerelease.yml
@@ -277,7 +277,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/mailgun/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/mailgun/repo/.github/workflows/release.yml
@@ -289,7 +289,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/mailgun/repo/Makefile
+++ b/provider-ci/providers/mailgun/repo/Makefile
@@ -61,15 +61,18 @@ build_nodejs: upstream
 
 build_python: PYPI_VERSION := $(shell pulumictl get version --language python)
 build_python: upstream
+	rm -rf sdk/python/
 	$(WORKING_DIR)/bin/$(TFGEN) python --out sdk/python/
 	cd sdk/python/ && \
 		printf "module fake_python_module // Exclude this directory from Go tools\n\ngo 1.17\n" > go.mod && \
 		cp ../../README.md . && \
-		python3 setup.py clean --all 2>/dev/null && \
 		rm -rf ./bin/ ../python.bin/ && cp -R . ../python.bin && mv ../python.bin ./bin && \
-		sed -i.bak -e 's/^VERSION = .*/VERSION = "$(PYPI_VERSION)"/g' -e 's/^PLUGIN_VERSION = .*/PLUGIN_VERSION = "$(VERSION)"/g' ./bin/setup.py && \
-		rm ./bin/setup.py.bak && rm ./bin/go.mod && \
-		cd ./bin && python3 setup.py build sdist
+		sed -i.bak -e 's/^  version = .*/  version = "$(PYPI_VERSION)"/g' ./bin/pyproject.toml && \
+		rm ./bin/pyproject.toml.bak && rm ./bin/go.mod && \
+		python3 -m venv venv && \
+		./venv/bin/python -m pip install build && \
+		cd ./bin && \
+		../venv/bin/python -m build .
 
 clean:
 	rm -rf sdk/{dotnet,nodejs,go,python}

--- a/provider-ci/providers/minio/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/minio/repo/.github/workflows/main.yml
@@ -334,7 +334,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/minio/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/minio/repo/.github/workflows/master.yml
@@ -334,7 +334,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/minio/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/minio/repo/.github/workflows/prerelease.yml
@@ -280,7 +280,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/minio/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/minio/repo/.github/workflows/release.yml
@@ -292,7 +292,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/minio/repo/Makefile
+++ b/provider-ci/providers/minio/repo/Makefile
@@ -61,15 +61,18 @@ build_nodejs: upstream
 
 build_python: PYPI_VERSION := $(shell pulumictl get version --language python)
 build_python: upstream
+	rm -rf sdk/python/
 	$(WORKING_DIR)/bin/$(TFGEN) python --out sdk/python/
 	cd sdk/python/ && \
 		printf "module fake_python_module // Exclude this directory from Go tools\n\ngo 1.17\n" > go.mod && \
 		cp ../../README.md . && \
-		python3 setup.py clean --all 2>/dev/null && \
 		rm -rf ./bin/ ../python.bin/ && cp -R . ../python.bin && mv ../python.bin ./bin && \
-		sed -i.bak -e 's/^VERSION = .*/VERSION = "$(PYPI_VERSION)"/g' -e 's/^PLUGIN_VERSION = .*/PLUGIN_VERSION = "$(VERSION)"/g' ./bin/setup.py && \
-		rm ./bin/setup.py.bak && rm ./bin/go.mod && \
-		cd ./bin && python3 setup.py build sdist
+		sed -i.bak -e 's/^  version = .*/  version = "$(PYPI_VERSION)"/g' ./bin/pyproject.toml && \
+		rm ./bin/pyproject.toml.bak && rm ./bin/go.mod && \
+		python3 -m venv venv && \
+		./venv/bin/python -m pip install build && \
+		cd ./bin && \
+		../venv/bin/python -m build .
 
 clean:
 	rm -rf sdk/{dotnet,nodejs,go,python}

--- a/provider-ci/providers/mongodbatlas/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/mongodbatlas/repo/.github/workflows/main.yml
@@ -333,7 +333,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/mongodbatlas/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/mongodbatlas/repo/.github/workflows/master.yml
@@ -333,7 +333,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/mongodbatlas/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/mongodbatlas/repo/.github/workflows/prerelease.yml
@@ -279,7 +279,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/mongodbatlas/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/mongodbatlas/repo/.github/workflows/release.yml
@@ -291,7 +291,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/mongodbatlas/repo/Makefile
+++ b/provider-ci/providers/mongodbatlas/repo/Makefile
@@ -61,15 +61,18 @@ build_nodejs: upstream
 
 build_python: PYPI_VERSION := $(shell pulumictl get version --language python)
 build_python: upstream
+	rm -rf sdk/python/
 	$(WORKING_DIR)/bin/$(TFGEN) python --out sdk/python/
 	cd sdk/python/ && \
 		printf "module fake_python_module // Exclude this directory from Go tools\n\ngo 1.17\n" > go.mod && \
 		cp ../../README.md . && \
-		python3 setup.py clean --all 2>/dev/null && \
 		rm -rf ./bin/ ../python.bin/ && cp -R . ../python.bin && mv ../python.bin ./bin && \
-		sed -i.bak -e 's/^VERSION = .*/VERSION = "$(PYPI_VERSION)"/g' -e 's/^PLUGIN_VERSION = .*/PLUGIN_VERSION = "$(VERSION)"/g' ./bin/setup.py && \
-		rm ./bin/setup.py.bak && rm ./bin/go.mod && \
-		cd ./bin && python3 setup.py build sdist
+		sed -i.bak -e 's/^  version = .*/  version = "$(PYPI_VERSION)"/g' ./bin/pyproject.toml && \
+		rm ./bin/pyproject.toml.bak && rm ./bin/go.mod && \
+		python3 -m venv venv && \
+		./venv/bin/python -m pip install build && \
+		cd ./bin && \
+		../venv/bin/python -m build .
 
 clean:
 	rm -rf sdk/{dotnet,nodejs,go,python}

--- a/provider-ci/providers/mysql/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/mysql/repo/.github/workflows/main.yml
@@ -330,7 +330,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/mysql/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/mysql/repo/.github/workflows/master.yml
@@ -330,7 +330,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/mysql/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/mysql/repo/.github/workflows/prerelease.yml
@@ -276,7 +276,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/mysql/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/mysql/repo/.github/workflows/release.yml
@@ -288,7 +288,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/mysql/repo/Makefile
+++ b/provider-ci/providers/mysql/repo/Makefile
@@ -61,15 +61,18 @@ build_nodejs: upstream
 
 build_python: PYPI_VERSION := $(shell pulumictl get version --language python)
 build_python: upstream
+	rm -rf sdk/python/
 	$(WORKING_DIR)/bin/$(TFGEN) python --out sdk/python/
 	cd sdk/python/ && \
 		printf "module fake_python_module // Exclude this directory from Go tools\n\ngo 1.17\n" > go.mod && \
 		cp ../../README.md . && \
-		python3 setup.py clean --all 2>/dev/null && \
 		rm -rf ./bin/ ../python.bin/ && cp -R . ../python.bin && mv ../python.bin ./bin && \
-		sed -i.bak -e 's/^VERSION = .*/VERSION = "$(PYPI_VERSION)"/g' -e 's/^PLUGIN_VERSION = .*/PLUGIN_VERSION = "$(VERSION)"/g' ./bin/setup.py && \
-		rm ./bin/setup.py.bak && rm ./bin/go.mod && \
-		cd ./bin && python3 setup.py build sdist
+		sed -i.bak -e 's/^  version = .*/  version = "$(PYPI_VERSION)"/g' ./bin/pyproject.toml && \
+		rm ./bin/pyproject.toml.bak && rm ./bin/go.mod && \
+		python3 -m venv venv && \
+		./venv/bin/python -m pip install build && \
+		cd ./bin && \
+		../venv/bin/python -m build .
 
 clean:
 	rm -rf sdk/{dotnet,nodejs,go,python}

--- a/provider-ci/providers/newrelic/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/newrelic/repo/.github/workflows/main.yml
@@ -332,7 +332,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/newrelic/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/newrelic/repo/.github/workflows/master.yml
@@ -332,7 +332,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/newrelic/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/newrelic/repo/.github/workflows/prerelease.yml
@@ -278,7 +278,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/newrelic/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/newrelic/repo/.github/workflows/release.yml
@@ -290,7 +290,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/newrelic/repo/Makefile
+++ b/provider-ci/providers/newrelic/repo/Makefile
@@ -61,15 +61,18 @@ build_nodejs: upstream
 
 build_python: PYPI_VERSION := $(shell pulumictl get version --language python)
 build_python: upstream
+	rm -rf sdk/python/
 	$(WORKING_DIR)/bin/$(TFGEN) python --out sdk/python/
 	cd sdk/python/ && \
 		printf "module fake_python_module // Exclude this directory from Go tools\n\ngo 1.17\n" > go.mod && \
 		cp ../../README.md . && \
-		python3 setup.py clean --all 2>/dev/null && \
 		rm -rf ./bin/ ../python.bin/ && cp -R . ../python.bin && mv ../python.bin ./bin && \
-		sed -i.bak -e 's/^VERSION = .*/VERSION = "$(PYPI_VERSION)"/g' -e 's/^PLUGIN_VERSION = .*/PLUGIN_VERSION = "$(VERSION)"/g' ./bin/setup.py && \
-		rm ./bin/setup.py.bak && rm ./bin/go.mod && \
-		cd ./bin && python3 setup.py build sdist
+		sed -i.bak -e 's/^  version = .*/  version = "$(PYPI_VERSION)"/g' ./bin/pyproject.toml && \
+		rm ./bin/pyproject.toml.bak && rm ./bin/go.mod && \
+		python3 -m venv venv && \
+		./venv/bin/python -m pip install build && \
+		cd ./bin && \
+		../venv/bin/python -m build .
 
 clean:
 	rm -rf sdk/{dotnet,nodejs,go,python}

--- a/provider-ci/providers/nomad/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/nomad/repo/.github/workflows/main.yml
@@ -331,7 +331,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/nomad/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/nomad/repo/.github/workflows/master.yml
@@ -331,7 +331,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/nomad/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/nomad/repo/.github/workflows/prerelease.yml
@@ -277,7 +277,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/nomad/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/nomad/repo/.github/workflows/release.yml
@@ -289,7 +289,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/nomad/repo/Makefile
+++ b/provider-ci/providers/nomad/repo/Makefile
@@ -61,15 +61,18 @@ build_nodejs: upstream
 
 build_python: PYPI_VERSION := $(shell pulumictl get version --language python)
 build_python: upstream
+	rm -rf sdk/python/
 	$(WORKING_DIR)/bin/$(TFGEN) python --out sdk/python/
 	cd sdk/python/ && \
 		printf "module fake_python_module // Exclude this directory from Go tools\n\ngo 1.17\n" > go.mod && \
 		cp ../../README.md . && \
-		python3 setup.py clean --all 2>/dev/null && \
 		rm -rf ./bin/ ../python.bin/ && cp -R . ../python.bin && mv ../python.bin ./bin && \
-		sed -i.bak -e 's/^VERSION = .*/VERSION = "$(PYPI_VERSION)"/g' -e 's/^PLUGIN_VERSION = .*/PLUGIN_VERSION = "$(VERSION)"/g' ./bin/setup.py && \
-		rm ./bin/setup.py.bak && rm ./bin/go.mod && \
-		cd ./bin && python3 setup.py build sdist
+		sed -i.bak -e 's/^  version = .*/  version = "$(PYPI_VERSION)"/g' ./bin/pyproject.toml && \
+		rm ./bin/pyproject.toml.bak && rm ./bin/go.mod && \
+		python3 -m venv venv && \
+		./venv/bin/python -m pip install build && \
+		cd ./bin && \
+		../venv/bin/python -m build .
 
 clean:
 	rm -rf sdk/{dotnet,nodejs,go,python}

--- a/provider-ci/providers/ns1/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/ns1/repo/.github/workflows/main.yml
@@ -331,7 +331,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/ns1/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/ns1/repo/.github/workflows/master.yml
@@ -331,7 +331,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/ns1/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/ns1/repo/.github/workflows/prerelease.yml
@@ -277,7 +277,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/ns1/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/ns1/repo/.github/workflows/release.yml
@@ -289,7 +289,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/ns1/repo/Makefile
+++ b/provider-ci/providers/ns1/repo/Makefile
@@ -61,15 +61,18 @@ build_nodejs: upstream
 
 build_python: PYPI_VERSION := $(shell pulumictl get version --language python)
 build_python: upstream
+	rm -rf sdk/python/
 	$(WORKING_DIR)/bin/$(TFGEN) python --out sdk/python/
 	cd sdk/python/ && \
 		printf "module fake_python_module // Exclude this directory from Go tools\n\ngo 1.17\n" > go.mod && \
 		cp ../../README.md . && \
-		python3 setup.py clean --all 2>/dev/null && \
 		rm -rf ./bin/ ../python.bin/ && cp -R . ../python.bin && mv ../python.bin ./bin && \
-		sed -i.bak -e 's/^VERSION = .*/VERSION = "$(PYPI_VERSION)"/g' -e 's/^PLUGIN_VERSION = .*/PLUGIN_VERSION = "$(VERSION)"/g' ./bin/setup.py && \
-		rm ./bin/setup.py.bak && rm ./bin/go.mod && \
-		cd ./bin && python3 setup.py build sdist
+		sed -i.bak -e 's/^  version = .*/  version = "$(PYPI_VERSION)"/g' ./bin/pyproject.toml && \
+		rm ./bin/pyproject.toml.bak && rm ./bin/go.mod && \
+		python3 -m venv venv && \
+		./venv/bin/python -m pip install build && \
+		cd ./bin && \
+		../venv/bin/python -m build .
 
 clean:
 	rm -rf sdk/{dotnet,nodejs,go,python}

--- a/provider-ci/providers/null/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/null/repo/.github/workflows/main.yml
@@ -301,7 +301,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/null/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/null/repo/.github/workflows/master.yml
@@ -301,7 +301,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/null/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/null/repo/.github/workflows/prerelease.yml
@@ -247,7 +247,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/null/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/null/repo/.github/workflows/release.yml
@@ -245,7 +245,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/null/repo/Makefile
+++ b/provider-ci/providers/null/repo/Makefile
@@ -61,15 +61,18 @@ build_nodejs: upstream
 
 build_python: PYPI_VERSION := $(shell pulumictl get version --language python)
 build_python: upstream
+	rm -rf sdk/python/
 	$(WORKING_DIR)/bin/$(TFGEN) python --out sdk/python/
 	cd sdk/python/ && \
 		printf "module fake_python_module // Exclude this directory from Go tools\n\ngo 1.17\n" > go.mod && \
 		cp ../../README.md . && \
-		python3 setup.py clean --all 2>/dev/null && \
 		rm -rf ./bin/ ../python.bin/ && cp -R . ../python.bin && mv ../python.bin ./bin && \
-		sed -i.bak -e 's/^VERSION = .*/VERSION = "$(PYPI_VERSION)"/g' -e 's/^PLUGIN_VERSION = .*/PLUGIN_VERSION = "$(VERSION)"/g' ./bin/setup.py && \
-		rm ./bin/setup.py.bak && rm ./bin/go.mod && \
-		cd ./bin && python3 setup.py build sdist
+		sed -i.bak -e 's/^  version = .*/  version = "$(PYPI_VERSION)"/g' ./bin/pyproject.toml && \
+		rm ./bin/pyproject.toml.bak && rm ./bin/go.mod && \
+		python3 -m venv venv && \
+		./venv/bin/python -m pip install build && \
+		cd ./bin && \
+		../venv/bin/python -m build .
 
 clean:
 	rm -rf sdk/{dotnet,nodejs,go,python}

--- a/provider-ci/providers/oci/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/oci/repo/.github/workflows/main.yml
@@ -304,7 +304,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/oci/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/oci/repo/.github/workflows/master.yml
@@ -304,7 +304,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/oci/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/oci/repo/.github/workflows/prerelease.yml
@@ -250,7 +250,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/oci/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/oci/repo/.github/workflows/release.yml
@@ -262,7 +262,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/oci/repo/Makefile
+++ b/provider-ci/providers/oci/repo/Makefile
@@ -62,15 +62,18 @@ build_nodejs: upstream
 
 build_python: PYPI_VERSION := $(shell pulumictl get version --language python)
 build_python: upstream
+	rm -rf sdk/python/
 	$(WORKING_DIR)/bin/$(TFGEN) python --out sdk/python/
 	cd sdk/python/ && \
 		printf "module fake_python_module // Exclude this directory from Go tools\n\ngo 1.17\n" > go.mod && \
 		cp ../../README.md . && \
-		python3 setup.py clean --all 2>/dev/null && \
 		rm -rf ./bin/ ../python.bin/ && cp -R . ../python.bin && mv ../python.bin ./bin && \
-		sed -i.bak -e 's/^VERSION = .*/VERSION = "$(PYPI_VERSION)"/g' -e 's/^PLUGIN_VERSION = .*/PLUGIN_VERSION = "$(VERSION)"/g' ./bin/setup.py && \
-		rm ./bin/setup.py.bak && rm ./bin/go.mod && \
-		cd ./bin && python3 setup.py build sdist
+		sed -i.bak -e 's/^  version = .*/  version = "$(PYPI_VERSION)"/g' ./bin/pyproject.toml && \
+		rm ./bin/pyproject.toml.bak && rm ./bin/go.mod && \
+		python3 -m venv venv && \
+		./venv/bin/python -m pip install build && \
+		cd ./bin && \
+		../venv/bin/python -m build .
 
 clean:
 	rm -rf sdk/{dotnet,nodejs,go,python}

--- a/provider-ci/providers/okta/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/okta/repo/.github/workflows/main.yml
@@ -333,7 +333,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/okta/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/okta/repo/.github/workflows/master.yml
@@ -333,7 +333,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/okta/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/okta/repo/.github/workflows/prerelease.yml
@@ -279,7 +279,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/okta/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/okta/repo/.github/workflows/release.yml
@@ -291,7 +291,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/okta/repo/Makefile
+++ b/provider-ci/providers/okta/repo/Makefile
@@ -61,15 +61,18 @@ build_nodejs: upstream
 
 build_python: PYPI_VERSION := $(shell pulumictl get version --language python)
 build_python: upstream
+	rm -rf sdk/python/
 	$(WORKING_DIR)/bin/$(TFGEN) python --out sdk/python/
 	cd sdk/python/ && \
 		printf "module fake_python_module // Exclude this directory from Go tools\n\ngo 1.17\n" > go.mod && \
 		cp ../../README.md . && \
-		python3 setup.py clean --all 2>/dev/null && \
 		rm -rf ./bin/ ../python.bin/ && cp -R . ../python.bin && mv ../python.bin ./bin && \
-		sed -i.bak -e 's/^VERSION = .*/VERSION = "$(PYPI_VERSION)"/g' -e 's/^PLUGIN_VERSION = .*/PLUGIN_VERSION = "$(VERSION)"/g' ./bin/setup.py && \
-		rm ./bin/setup.py.bak && rm ./bin/go.mod && \
-		cd ./bin && python3 setup.py build sdist
+		sed -i.bak -e 's/^  version = .*/  version = "$(PYPI_VERSION)"/g' ./bin/pyproject.toml && \
+		rm ./bin/pyproject.toml.bak && rm ./bin/go.mod && \
+		python3 -m venv venv && \
+		./venv/bin/python -m pip install build && \
+		cd ./bin && \
+		../venv/bin/python -m build .
 
 clean:
 	rm -rf sdk/{dotnet,nodejs,go,python}

--- a/provider-ci/providers/onelogin/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/onelogin/repo/.github/workflows/main.yml
@@ -330,7 +330,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/onelogin/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/onelogin/repo/.github/workflows/master.yml
@@ -330,7 +330,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/onelogin/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/onelogin/repo/.github/workflows/prerelease.yml
@@ -276,7 +276,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/onelogin/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/onelogin/repo/.github/workflows/release.yml
@@ -288,7 +288,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/onelogin/repo/Makefile
+++ b/provider-ci/providers/onelogin/repo/Makefile
@@ -61,15 +61,18 @@ build_nodejs: upstream
 
 build_python: PYPI_VERSION := $(shell pulumictl get version --language python)
 build_python: upstream
+	rm -rf sdk/python/
 	$(WORKING_DIR)/bin/$(TFGEN) python --out sdk/python/
 	cd sdk/python/ && \
 		printf "module fake_python_module // Exclude this directory from Go tools\n\ngo 1.17\n" > go.mod && \
 		cp ../../README.md . && \
-		python3 setup.py clean --all 2>/dev/null && \
 		rm -rf ./bin/ ../python.bin/ && cp -R . ../python.bin && mv ../python.bin ./bin && \
-		sed -i.bak -e 's/^VERSION = .*/VERSION = "$(PYPI_VERSION)"/g' -e 's/^PLUGIN_VERSION = .*/PLUGIN_VERSION = "$(VERSION)"/g' ./bin/setup.py && \
-		rm ./bin/setup.py.bak && rm ./bin/go.mod && \
-		cd ./bin && python3 setup.py build sdist
+		sed -i.bak -e 's/^  version = .*/  version = "$(PYPI_VERSION)"/g' ./bin/pyproject.toml && \
+		rm ./bin/pyproject.toml.bak && rm ./bin/go.mod && \
+		python3 -m venv venv && \
+		./venv/bin/python -m pip install build && \
+		cd ./bin && \
+		../venv/bin/python -m build .
 
 clean:
 	rm -rf sdk/{dotnet,nodejs,go,python}

--- a/provider-ci/providers/openstack/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/openstack/repo/.github/workflows/main.yml
@@ -339,7 +339,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/openstack/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/openstack/repo/.github/workflows/master.yml
@@ -339,7 +339,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/openstack/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/openstack/repo/.github/workflows/prerelease.yml
@@ -285,7 +285,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/openstack/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/openstack/repo/.github/workflows/release.yml
@@ -297,7 +297,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/openstack/repo/Makefile
+++ b/provider-ci/providers/openstack/repo/Makefile
@@ -61,15 +61,18 @@ build_nodejs: upstream
 
 build_python: PYPI_VERSION := $(shell pulumictl get version --language python)
 build_python: upstream
+	rm -rf sdk/python/
 	$(WORKING_DIR)/bin/$(TFGEN) python --out sdk/python/
 	cd sdk/python/ && \
 		printf "module fake_python_module // Exclude this directory from Go tools\n\ngo 1.17\n" > go.mod && \
 		cp ../../README.md . && \
-		python3 setup.py clean --all 2>/dev/null && \
 		rm -rf ./bin/ ../python.bin/ && cp -R . ../python.bin && mv ../python.bin ./bin && \
-		sed -i.bak -e 's/^VERSION = .*/VERSION = "$(PYPI_VERSION)"/g' -e 's/^PLUGIN_VERSION = .*/PLUGIN_VERSION = "$(VERSION)"/g' ./bin/setup.py && \
-		rm ./bin/setup.py.bak && rm ./bin/go.mod && \
-		cd ./bin && python3 setup.py build sdist
+		sed -i.bak -e 's/^  version = .*/  version = "$(PYPI_VERSION)"/g' ./bin/pyproject.toml && \
+		rm ./bin/pyproject.toml.bak && rm ./bin/go.mod && \
+		python3 -m venv venv && \
+		./venv/bin/python -m pip install build && \
+		cd ./bin && \
+		../venv/bin/python -m build .
 
 clean:
 	rm -rf sdk/{dotnet,nodejs,go,python}

--- a/provider-ci/providers/opsgenie/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/opsgenie/repo/.github/workflows/main.yml
@@ -331,7 +331,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/opsgenie/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/opsgenie/repo/.github/workflows/master.yml
@@ -331,7 +331,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/opsgenie/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/opsgenie/repo/.github/workflows/prerelease.yml
@@ -277,7 +277,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/opsgenie/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/opsgenie/repo/.github/workflows/release.yml
@@ -289,7 +289,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/opsgenie/repo/Makefile
+++ b/provider-ci/providers/opsgenie/repo/Makefile
@@ -61,15 +61,18 @@ build_nodejs: upstream
 
 build_python: PYPI_VERSION := $(shell pulumictl get version --language python)
 build_python: upstream
+	rm -rf sdk/python/
 	$(WORKING_DIR)/bin/$(TFGEN) python --out sdk/python/
 	cd sdk/python/ && \
 		printf "module fake_python_module // Exclude this directory from Go tools\n\ngo 1.17\n" > go.mod && \
 		cp ../../README.md . && \
-		python3 setup.py clean --all 2>/dev/null && \
 		rm -rf ./bin/ ../python.bin/ && cp -R . ../python.bin && mv ../python.bin ./bin && \
-		sed -i.bak -e 's/^VERSION = .*/VERSION = "$(PYPI_VERSION)"/g' -e 's/^PLUGIN_VERSION = .*/PLUGIN_VERSION = "$(VERSION)"/g' ./bin/setup.py && \
-		rm ./bin/setup.py.bak && rm ./bin/go.mod && \
-		cd ./bin && python3 setup.py build sdist
+		sed -i.bak -e 's/^  version = .*/  version = "$(PYPI_VERSION)"/g' ./bin/pyproject.toml && \
+		rm ./bin/pyproject.toml.bak && rm ./bin/go.mod && \
+		python3 -m venv venv && \
+		./venv/bin/python -m pip install build && \
+		cd ./bin && \
+		../venv/bin/python -m build .
 
 clean:
 	rm -rf sdk/{dotnet,nodejs,go,python}

--- a/provider-ci/providers/pagerduty/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/pagerduty/repo/.github/workflows/main.yml
@@ -331,7 +331,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/pagerduty/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/pagerduty/repo/.github/workflows/master.yml
@@ -331,7 +331,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/pagerduty/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/pagerduty/repo/.github/workflows/prerelease.yml
@@ -277,7 +277,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/pagerduty/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/pagerduty/repo/.github/workflows/release.yml
@@ -289,7 +289,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/pagerduty/repo/Makefile
+++ b/provider-ci/providers/pagerduty/repo/Makefile
@@ -61,15 +61,18 @@ build_nodejs: upstream
 
 build_python: PYPI_VERSION := $(shell pulumictl get version --language python)
 build_python: upstream
+	rm -rf sdk/python/
 	$(WORKING_DIR)/bin/$(TFGEN) python --out sdk/python/
 	cd sdk/python/ && \
 		printf "module fake_python_module // Exclude this directory from Go tools\n\ngo 1.17\n" > go.mod && \
 		cp ../../README.md . && \
-		python3 setup.py clean --all 2>/dev/null && \
 		rm -rf ./bin/ ../python.bin/ && cp -R . ../python.bin && mv ../python.bin ./bin && \
-		sed -i.bak -e 's/^VERSION = .*/VERSION = "$(PYPI_VERSION)"/g' -e 's/^PLUGIN_VERSION = .*/PLUGIN_VERSION = "$(VERSION)"/g' ./bin/setup.py && \
-		rm ./bin/setup.py.bak && rm ./bin/go.mod && \
-		cd ./bin && python3 setup.py build sdist
+		sed -i.bak -e 's/^  version = .*/  version = "$(PYPI_VERSION)"/g' ./bin/pyproject.toml && \
+		rm ./bin/pyproject.toml.bak && rm ./bin/go.mod && \
+		python3 -m venv venv && \
+		./venv/bin/python -m pip install build && \
+		cd ./bin && \
+		../venv/bin/python -m build .
 
 clean:
 	rm -rf sdk/{dotnet,nodejs,go,python}

--- a/provider-ci/providers/postgresql/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/postgresql/repo/.github/workflows/main.yml
@@ -330,7 +330,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/postgresql/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/postgresql/repo/.github/workflows/master.yml
@@ -330,7 +330,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/postgresql/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/postgresql/repo/.github/workflows/prerelease.yml
@@ -276,7 +276,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/postgresql/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/postgresql/repo/.github/workflows/release.yml
@@ -288,7 +288,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/postgresql/repo/Makefile
+++ b/provider-ci/providers/postgresql/repo/Makefile
@@ -61,15 +61,18 @@ build_nodejs: upstream
 
 build_python: PYPI_VERSION := $(shell pulumictl get version --language python)
 build_python: upstream
+	rm -rf sdk/python/
 	$(WORKING_DIR)/bin/$(TFGEN) python --out sdk/python/
 	cd sdk/python/ && \
 		printf "module fake_python_module // Exclude this directory from Go tools\n\ngo 1.17\n" > go.mod && \
 		cp ../../README.md . && \
-		python3 setup.py clean --all 2>/dev/null && \
 		rm -rf ./bin/ ../python.bin/ && cp -R . ../python.bin && mv ../python.bin ./bin && \
-		sed -i.bak -e 's/^VERSION = .*/VERSION = "$(PYPI_VERSION)"/g' -e 's/^PLUGIN_VERSION = .*/PLUGIN_VERSION = "$(VERSION)"/g' ./bin/setup.py && \
-		rm ./bin/setup.py.bak && rm ./bin/go.mod && \
-		cd ./bin && python3 setup.py build sdist
+		sed -i.bak -e 's/^  version = .*/  version = "$(PYPI_VERSION)"/g' ./bin/pyproject.toml && \
+		rm ./bin/pyproject.toml.bak && rm ./bin/go.mod && \
+		python3 -m venv venv && \
+		./venv/bin/python -m pip install build && \
+		cd ./bin && \
+		../venv/bin/python -m build .
 
 clean:
 	rm -rf sdk/{dotnet,nodejs,go,python}

--- a/provider-ci/providers/rabbitmq/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/rabbitmq/repo/.github/workflows/main.yml
@@ -330,7 +330,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/rabbitmq/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/rabbitmq/repo/.github/workflows/master.yml
@@ -330,7 +330,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/rabbitmq/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/rabbitmq/repo/.github/workflows/prerelease.yml
@@ -276,7 +276,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/rabbitmq/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/rabbitmq/repo/.github/workflows/release.yml
@@ -288,7 +288,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/rabbitmq/repo/Makefile
+++ b/provider-ci/providers/rabbitmq/repo/Makefile
@@ -61,15 +61,18 @@ build_nodejs: upstream
 
 build_python: PYPI_VERSION := $(shell pulumictl get version --language python)
 build_python: upstream
+	rm -rf sdk/python/
 	$(WORKING_DIR)/bin/$(TFGEN) python --out sdk/python/
 	cd sdk/python/ && \
 		printf "module fake_python_module // Exclude this directory from Go tools\n\ngo 1.17\n" > go.mod && \
 		cp ../../README.md . && \
-		python3 setup.py clean --all 2>/dev/null && \
 		rm -rf ./bin/ ../python.bin/ && cp -R . ../python.bin && mv ../python.bin ./bin && \
-		sed -i.bak -e 's/^VERSION = .*/VERSION = "$(PYPI_VERSION)"/g' -e 's/^PLUGIN_VERSION = .*/PLUGIN_VERSION = "$(VERSION)"/g' ./bin/setup.py && \
-		rm ./bin/setup.py.bak && rm ./bin/go.mod && \
-		cd ./bin && python3 setup.py build sdist
+		sed -i.bak -e 's/^  version = .*/  version = "$(PYPI_VERSION)"/g' ./bin/pyproject.toml && \
+		rm ./bin/pyproject.toml.bak && rm ./bin/go.mod && \
+		python3 -m venv venv && \
+		./venv/bin/python -m pip install build && \
+		cd ./bin && \
+		../venv/bin/python -m build .
 
 clean:
 	rm -rf sdk/{dotnet,nodejs,go,python}

--- a/provider-ci/providers/rancher2/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/rancher2/repo/.github/workflows/main.yml
@@ -302,7 +302,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/rancher2/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/rancher2/repo/.github/workflows/master.yml
@@ -302,7 +302,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/rancher2/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/rancher2/repo/.github/workflows/prerelease.yml
@@ -248,7 +248,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/rancher2/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/rancher2/repo/.github/workflows/release.yml
@@ -260,7 +260,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/rancher2/repo/Makefile
+++ b/provider-ci/providers/rancher2/repo/Makefile
@@ -61,15 +61,18 @@ build_nodejs: upstream
 
 build_python: PYPI_VERSION := $(shell pulumictl get version --language python)
 build_python: upstream
+	rm -rf sdk/python/
 	$(WORKING_DIR)/bin/$(TFGEN) python --out sdk/python/
 	cd sdk/python/ && \
 		printf "module fake_python_module // Exclude this directory from Go tools\n\ngo 1.17\n" > go.mod && \
 		cp ../../README.md . && \
-		python3 setup.py clean --all 2>/dev/null && \
 		rm -rf ./bin/ ../python.bin/ && cp -R . ../python.bin && mv ../python.bin ./bin && \
-		sed -i.bak -e 's/^VERSION = .*/VERSION = "$(PYPI_VERSION)"/g' -e 's/^PLUGIN_VERSION = .*/PLUGIN_VERSION = "$(VERSION)"/g' ./bin/setup.py && \
-		rm ./bin/setup.py.bak && rm ./bin/go.mod && \
-		cd ./bin && python3 setup.py build sdist
+		sed -i.bak -e 's/^  version = .*/  version = "$(PYPI_VERSION)"/g' ./bin/pyproject.toml && \
+		rm ./bin/pyproject.toml.bak && rm ./bin/go.mod && \
+		python3 -m venv venv && \
+		./venv/bin/python -m pip install build && \
+		cd ./bin && \
+		../venv/bin/python -m build .
 
 clean:
 	rm -rf sdk/{dotnet,nodejs,go,python}

--- a/provider-ci/providers/random/config.yaml
+++ b/provider-ci/providers/random/config.yaml
@@ -10,6 +10,3 @@ plugins:
     version: "5.24.0"
 team: ecosystem
 javaGenVersion: "v0.9.3"
-actionVersions:
-   publishProviderSDKs: pulumi/pulumi-package-publisher@v0.0.11
-wheels: true

--- a/provider-ci/providers/rke/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/rke/repo/.github/workflows/main.yml
@@ -331,7 +331,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/rke/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/rke/repo/.github/workflows/master.yml
@@ -331,7 +331,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/rke/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/rke/repo/.github/workflows/prerelease.yml
@@ -277,7 +277,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/rke/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/rke/repo/.github/workflows/release.yml
@@ -289,7 +289,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/rke/repo/Makefile
+++ b/provider-ci/providers/rke/repo/Makefile
@@ -61,15 +61,18 @@ build_nodejs: upstream
 
 build_python: PYPI_VERSION := $(shell pulumictl get version --language python)
 build_python: upstream
+	rm -rf sdk/python/
 	$(WORKING_DIR)/bin/$(TFGEN) python --out sdk/python/
 	cd sdk/python/ && \
 		printf "module fake_python_module // Exclude this directory from Go tools\n\ngo 1.17\n" > go.mod && \
 		cp ../../README.md . && \
-		python3 setup.py clean --all 2>/dev/null && \
 		rm -rf ./bin/ ../python.bin/ && cp -R . ../python.bin && mv ../python.bin ./bin && \
-		sed -i.bak -e 's/^VERSION = .*/VERSION = "$(PYPI_VERSION)"/g' -e 's/^PLUGIN_VERSION = .*/PLUGIN_VERSION = "$(VERSION)"/g' ./bin/setup.py && \
-		rm ./bin/setup.py.bak && rm ./bin/go.mod && \
-		cd ./bin && python3 setup.py build sdist
+		sed -i.bak -e 's/^  version = .*/  version = "$(PYPI_VERSION)"/g' ./bin/pyproject.toml && \
+		rm ./bin/pyproject.toml.bak && rm ./bin/go.mod && \
+		python3 -m venv venv && \
+		./venv/bin/python -m pip install build && \
+		cd ./bin && \
+		../venv/bin/python -m build .
 
 clean:
 	rm -rf sdk/{dotnet,nodejs,go,python}

--- a/provider-ci/providers/signalfx/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/signalfx/repo/.github/workflows/main.yml
@@ -330,7 +330,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/signalfx/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/signalfx/repo/.github/workflows/master.yml
@@ -330,7 +330,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/signalfx/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/signalfx/repo/.github/workflows/prerelease.yml
@@ -276,7 +276,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/signalfx/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/signalfx/repo/.github/workflows/release.yml
@@ -288,7 +288,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/signalfx/repo/Makefile
+++ b/provider-ci/providers/signalfx/repo/Makefile
@@ -61,15 +61,18 @@ build_nodejs: upstream
 
 build_python: PYPI_VERSION := $(shell pulumictl get version --language python)
 build_python: upstream
+	rm -rf sdk/python/
 	$(WORKING_DIR)/bin/$(TFGEN) python --out sdk/python/
 	cd sdk/python/ && \
 		printf "module fake_python_module // Exclude this directory from Go tools\n\ngo 1.17\n" > go.mod && \
 		cp ../../README.md . && \
-		python3 setup.py clean --all 2>/dev/null && \
 		rm -rf ./bin/ ../python.bin/ && cp -R . ../python.bin && mv ../python.bin ./bin && \
-		sed -i.bak -e 's/^VERSION = .*/VERSION = "$(PYPI_VERSION)"/g' -e 's/^PLUGIN_VERSION = .*/PLUGIN_VERSION = "$(VERSION)"/g' ./bin/setup.py && \
-		rm ./bin/setup.py.bak && rm ./bin/go.mod && \
-		cd ./bin && python3 setup.py build sdist
+		sed -i.bak -e 's/^  version = .*/  version = "$(PYPI_VERSION)"/g' ./bin/pyproject.toml && \
+		rm ./bin/pyproject.toml.bak && rm ./bin/go.mod && \
+		python3 -m venv venv && \
+		./venv/bin/python -m pip install build && \
+		cd ./bin && \
+		../venv/bin/python -m build .
 
 clean:
 	rm -rf sdk/{dotnet,nodejs,go,python}

--- a/provider-ci/providers/slack/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/slack/repo/.github/workflows/main.yml
@@ -331,7 +331,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/slack/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/slack/repo/.github/workflows/master.yml
@@ -331,7 +331,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/slack/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/slack/repo/.github/workflows/prerelease.yml
@@ -277,7 +277,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/slack/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/slack/repo/.github/workflows/release.yml
@@ -289,7 +289,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/slack/repo/Makefile
+++ b/provider-ci/providers/slack/repo/Makefile
@@ -61,15 +61,18 @@ build_nodejs: upstream
 
 build_python: PYPI_VERSION := $(shell pulumictl get version --language python)
 build_python: upstream
+	rm -rf sdk/python/
 	$(WORKING_DIR)/bin/$(TFGEN) python --out sdk/python/
 	cd sdk/python/ && \
 		printf "module fake_python_module // Exclude this directory from Go tools\n\ngo 1.17\n" > go.mod && \
 		cp ../../README.md . && \
-		python3 setup.py clean --all 2>/dev/null && \
 		rm -rf ./bin/ ../python.bin/ && cp -R . ../python.bin && mv ../python.bin ./bin && \
-		sed -i.bak -e 's/^VERSION = .*/VERSION = "$(PYPI_VERSION)"/g' -e 's/^PLUGIN_VERSION = .*/PLUGIN_VERSION = "$(VERSION)"/g' ./bin/setup.py && \
-		rm ./bin/setup.py.bak && rm ./bin/go.mod && \
-		cd ./bin && python3 setup.py build sdist
+		sed -i.bak -e 's/^  version = .*/  version = "$(PYPI_VERSION)"/g' ./bin/pyproject.toml && \
+		rm ./bin/pyproject.toml.bak && rm ./bin/go.mod && \
+		python3 -m venv venv && \
+		./venv/bin/python -m pip install build && \
+		cd ./bin && \
+		../venv/bin/python -m build .
 
 clean:
 	rm -rf sdk/{dotnet,nodejs,go,python}

--- a/provider-ci/providers/snowflake/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/snowflake/repo/.github/workflows/main.yml
@@ -335,7 +335,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/snowflake/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/snowflake/repo/.github/workflows/master.yml
@@ -335,7 +335,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/snowflake/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/snowflake/repo/.github/workflows/prerelease.yml
@@ -281,7 +281,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/snowflake/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/snowflake/repo/.github/workflows/release.yml
@@ -293,7 +293,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/snowflake/repo/Makefile
+++ b/provider-ci/providers/snowflake/repo/Makefile
@@ -61,15 +61,18 @@ build_nodejs: upstream
 
 build_python: PYPI_VERSION := $(shell pulumictl get version --language python)
 build_python: upstream
+	rm -rf sdk/python/
 	$(WORKING_DIR)/bin/$(TFGEN) python --out sdk/python/
 	cd sdk/python/ && \
 		printf "module fake_python_module // Exclude this directory from Go tools\n\ngo 1.17\n" > go.mod && \
 		cp ../../README.md . && \
-		python3 setup.py clean --all 2>/dev/null && \
 		rm -rf ./bin/ ../python.bin/ && cp -R . ../python.bin && mv ../python.bin ./bin && \
-		sed -i.bak -e 's/^VERSION = .*/VERSION = "$(PYPI_VERSION)"/g' -e 's/^PLUGIN_VERSION = .*/PLUGIN_VERSION = "$(VERSION)"/g' ./bin/setup.py && \
-		rm ./bin/setup.py.bak && rm ./bin/go.mod && \
-		cd ./bin && python3 setup.py build sdist
+		sed -i.bak -e 's/^  version = .*/  version = "$(PYPI_VERSION)"/g' ./bin/pyproject.toml && \
+		rm ./bin/pyproject.toml.bak && rm ./bin/go.mod && \
+		python3 -m venv venv && \
+		./venv/bin/python -m pip install build && \
+		cd ./bin && \
+		../venv/bin/python -m build .
 
 clean:
 	rm -rf sdk/{dotnet,nodejs,go,python}

--- a/provider-ci/providers/splunk/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/splunk/repo/.github/workflows/main.yml
@@ -333,7 +333,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/splunk/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/splunk/repo/.github/workflows/master.yml
@@ -333,7 +333,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/splunk/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/splunk/repo/.github/workflows/prerelease.yml
@@ -279,7 +279,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/splunk/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/splunk/repo/.github/workflows/release.yml
@@ -291,7 +291,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/splunk/repo/Makefile
+++ b/provider-ci/providers/splunk/repo/Makefile
@@ -61,15 +61,18 @@ build_nodejs: upstream
 
 build_python: PYPI_VERSION := $(shell pulumictl get version --language python)
 build_python: upstream
+	rm -rf sdk/python/
 	$(WORKING_DIR)/bin/$(TFGEN) python --out sdk/python/
 	cd sdk/python/ && \
 		printf "module fake_python_module // Exclude this directory from Go tools\n\ngo 1.17\n" > go.mod && \
 		cp ../../README.md . && \
-		python3 setup.py clean --all 2>/dev/null && \
 		rm -rf ./bin/ ../python.bin/ && cp -R . ../python.bin && mv ../python.bin ./bin && \
-		sed -i.bak -e 's/^VERSION = .*/VERSION = "$(PYPI_VERSION)"/g' -e 's/^PLUGIN_VERSION = .*/PLUGIN_VERSION = "$(VERSION)"/g' ./bin/setup.py && \
-		rm ./bin/setup.py.bak && rm ./bin/go.mod && \
-		cd ./bin && python3 setup.py build sdist
+		sed -i.bak -e 's/^  version = .*/  version = "$(PYPI_VERSION)"/g' ./bin/pyproject.toml && \
+		rm ./bin/pyproject.toml.bak && rm ./bin/go.mod && \
+		python3 -m venv venv && \
+		./venv/bin/python -m pip install build && \
+		cd ./bin && \
+		../venv/bin/python -m build .
 
 clean:
 	rm -rf sdk/{dotnet,nodejs,go,python}

--- a/provider-ci/providers/spotinst/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/spotinst/repo/.github/workflows/main.yml
@@ -333,7 +333,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/spotinst/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/spotinst/repo/.github/workflows/master.yml
@@ -333,7 +333,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/spotinst/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/spotinst/repo/.github/workflows/prerelease.yml
@@ -279,7 +279,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/spotinst/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/spotinst/repo/.github/workflows/release.yml
@@ -291,7 +291,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/spotinst/repo/Makefile
+++ b/provider-ci/providers/spotinst/repo/Makefile
@@ -61,15 +61,18 @@ build_nodejs: upstream
 
 build_python: PYPI_VERSION := $(shell pulumictl get version --language python)
 build_python: upstream
+	rm -rf sdk/python/
 	$(WORKING_DIR)/bin/$(TFGEN) python --out sdk/python/
 	cd sdk/python/ && \
 		printf "module fake_python_module // Exclude this directory from Go tools\n\ngo 1.17\n" > go.mod && \
 		cp ../../README.md . && \
-		python3 setup.py clean --all 2>/dev/null && \
 		rm -rf ./bin/ ../python.bin/ && cp -R . ../python.bin && mv ../python.bin ./bin && \
-		sed -i.bak -e 's/^VERSION = .*/VERSION = "$(PYPI_VERSION)"/g' -e 's/^PLUGIN_VERSION = .*/PLUGIN_VERSION = "$(VERSION)"/g' ./bin/setup.py && \
-		rm ./bin/setup.py.bak && rm ./bin/go.mod && \
-		cd ./bin && python3 setup.py build sdist
+		sed -i.bak -e 's/^  version = .*/  version = "$(PYPI_VERSION)"/g' ./bin/pyproject.toml && \
+		rm ./bin/pyproject.toml.bak && rm ./bin/go.mod && \
+		python3 -m venv venv && \
+		./venv/bin/python -m pip install build && \
+		cd ./bin && \
+		../venv/bin/python -m build .
 
 clean:
 	rm -rf sdk/{dotnet,nodejs,go,python}

--- a/provider-ci/providers/sumologic/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/sumologic/repo/.github/workflows/main.yml
@@ -333,7 +333,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/sumologic/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/sumologic/repo/.github/workflows/master.yml
@@ -333,7 +333,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/sumologic/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/sumologic/repo/.github/workflows/prerelease.yml
@@ -279,7 +279,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/sumologic/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/sumologic/repo/.github/workflows/release.yml
@@ -291,7 +291,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/sumologic/repo/Makefile
+++ b/provider-ci/providers/sumologic/repo/Makefile
@@ -61,15 +61,18 @@ build_nodejs: upstream
 
 build_python: PYPI_VERSION := $(shell pulumictl get version --language python)
 build_python: upstream
+	rm -rf sdk/python/
 	$(WORKING_DIR)/bin/$(TFGEN) python --out sdk/python/
 	cd sdk/python/ && \
 		printf "module fake_python_module // Exclude this directory from Go tools\n\ngo 1.17\n" > go.mod && \
 		cp ../../README.md . && \
-		python3 setup.py clean --all 2>/dev/null && \
 		rm -rf ./bin/ ../python.bin/ && cp -R . ../python.bin && mv ../python.bin ./bin && \
-		sed -i.bak -e 's/^VERSION = .*/VERSION = "$(PYPI_VERSION)"/g' -e 's/^PLUGIN_VERSION = .*/PLUGIN_VERSION = "$(VERSION)"/g' ./bin/setup.py && \
-		rm ./bin/setup.py.bak && rm ./bin/go.mod && \
-		cd ./bin && python3 setup.py build sdist
+		sed -i.bak -e 's/^  version = .*/  version = "$(PYPI_VERSION)"/g' ./bin/pyproject.toml && \
+		rm ./bin/pyproject.toml.bak && rm ./bin/go.mod && \
+		python3 -m venv venv && \
+		./venv/bin/python -m pip install build && \
+		cd ./bin && \
+		../venv/bin/python -m build .
 
 clean:
 	rm -rf sdk/{dotnet,nodejs,go,python}

--- a/provider-ci/providers/tailscale/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/tailscale/repo/.github/workflows/main.yml
@@ -333,7 +333,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/tailscale/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/tailscale/repo/.github/workflows/master.yml
@@ -333,7 +333,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/tailscale/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/tailscale/repo/.github/workflows/prerelease.yml
@@ -279,7 +279,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/tailscale/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/tailscale/repo/.github/workflows/release.yml
@@ -291,7 +291,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/tailscale/repo/Makefile
+++ b/provider-ci/providers/tailscale/repo/Makefile
@@ -61,15 +61,18 @@ build_nodejs: upstream
 
 build_python: PYPI_VERSION := $(shell pulumictl get version --language python)
 build_python: upstream
+	rm -rf sdk/python/
 	$(WORKING_DIR)/bin/$(TFGEN) python --out sdk/python/
 	cd sdk/python/ && \
 		printf "module fake_python_module // Exclude this directory from Go tools\n\ngo 1.17\n" > go.mod && \
 		cp ../../README.md . && \
-		python3 setup.py clean --all 2>/dev/null && \
 		rm -rf ./bin/ ../python.bin/ && cp -R . ../python.bin && mv ../python.bin ./bin && \
-		sed -i.bak -e 's/^VERSION = .*/VERSION = "$(PYPI_VERSION)"/g' -e 's/^PLUGIN_VERSION = .*/PLUGIN_VERSION = "$(VERSION)"/g' ./bin/setup.py && \
-		rm ./bin/setup.py.bak && rm ./bin/go.mod && \
-		cd ./bin && python3 setup.py build sdist
+		sed -i.bak -e 's/^  version = .*/  version = "$(PYPI_VERSION)"/g' ./bin/pyproject.toml && \
+		rm ./bin/pyproject.toml.bak && rm ./bin/go.mod && \
+		python3 -m venv venv && \
+		./venv/bin/python -m pip install build && \
+		cd ./bin && \
+		../venv/bin/python -m build .
 
 clean:
 	rm -rf sdk/{dotnet,nodejs,go,python}

--- a/provider-ci/providers/tls/config.yaml
+++ b/provider-ci/providers/tls/config.yaml
@@ -8,7 +8,4 @@ plugins:
     version: "4.26.0"
 javaGenVersion: "v0.9.7"
 team: ecosystem
-actionVersions:
-   publishProviderSDKs: pulumi/pulumi-package-publisher@v0.0.11
-wheels: true
 

--- a/provider-ci/providers/venafi/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/venafi/repo/.github/workflows/main.yml
@@ -334,7 +334,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/venafi/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/venafi/repo/.github/workflows/master.yml
@@ -334,7 +334,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/venafi/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/venafi/repo/.github/workflows/prerelease.yml
@@ -280,7 +280,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/venafi/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/venafi/repo/.github/workflows/release.yml
@@ -292,7 +292,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/venafi/repo/Makefile
+++ b/provider-ci/providers/venafi/repo/Makefile
@@ -61,15 +61,18 @@ build_nodejs: upstream
 
 build_python: PYPI_VERSION := $(shell pulumictl get version --language python)
 build_python: upstream
+	rm -rf sdk/python/
 	$(WORKING_DIR)/bin/$(TFGEN) python --out sdk/python/
 	cd sdk/python/ && \
 		printf "module fake_python_module // Exclude this directory from Go tools\n\ngo 1.17\n" > go.mod && \
 		cp ../../README.md . && \
-		python3 setup.py clean --all 2>/dev/null && \
 		rm -rf ./bin/ ../python.bin/ && cp -R . ../python.bin && mv ../python.bin ./bin && \
-		sed -i.bak -e 's/^VERSION = .*/VERSION = "$(PYPI_VERSION)"/g' -e 's/^PLUGIN_VERSION = .*/PLUGIN_VERSION = "$(VERSION)"/g' ./bin/setup.py && \
-		rm ./bin/setup.py.bak && rm ./bin/go.mod && \
-		cd ./bin && python3 setup.py build sdist
+		sed -i.bak -e 's/^  version = .*/  version = "$(PYPI_VERSION)"/g' ./bin/pyproject.toml && \
+		rm ./bin/pyproject.toml.bak && rm ./bin/go.mod && \
+		python3 -m venv venv && \
+		./venv/bin/python -m pip install build && \
+		cd ./bin && \
+		../venv/bin/python -m build .
 
 clean:
 	rm -rf sdk/{dotnet,nodejs,go,python}

--- a/provider-ci/providers/vsphere/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/vsphere/repo/.github/workflows/main.yml
@@ -330,7 +330,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/vsphere/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/vsphere/repo/.github/workflows/master.yml
@@ -330,7 +330,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/vsphere/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/vsphere/repo/.github/workflows/prerelease.yml
@@ -276,7 +276,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/vsphere/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/vsphere/repo/.github/workflows/release.yml
@@ -288,7 +288,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/vsphere/repo/Makefile
+++ b/provider-ci/providers/vsphere/repo/Makefile
@@ -61,15 +61,18 @@ build_nodejs: upstream
 
 build_python: PYPI_VERSION := $(shell pulumictl get version --language python)
 build_python: upstream
+	rm -rf sdk/python/
 	$(WORKING_DIR)/bin/$(TFGEN) python --out sdk/python/
 	cd sdk/python/ && \
 		printf "module fake_python_module // Exclude this directory from Go tools\n\ngo 1.17\n" > go.mod && \
 		cp ../../README.md . && \
-		python3 setup.py clean --all 2>/dev/null && \
 		rm -rf ./bin/ ../python.bin/ && cp -R . ../python.bin && mv ../python.bin ./bin && \
-		sed -i.bak -e 's/^VERSION = .*/VERSION = "$(PYPI_VERSION)"/g' -e 's/^PLUGIN_VERSION = .*/PLUGIN_VERSION = "$(VERSION)"/g' ./bin/setup.py && \
-		rm ./bin/setup.py.bak && rm ./bin/go.mod && \
-		cd ./bin && python3 setup.py build sdist
+		sed -i.bak -e 's/^  version = .*/  version = "$(PYPI_VERSION)"/g' ./bin/pyproject.toml && \
+		rm ./bin/pyproject.toml.bak && rm ./bin/go.mod && \
+		python3 -m venv venv && \
+		./venv/bin/python -m pip install build && \
+		cd ./bin && \
+		../venv/bin/python -m build .
 
 clean:
 	rm -rf sdk/{dotnet,nodejs,go,python}

--- a/provider-ci/providers/wavefront/repo/.github/workflows/main.yml
+++ b/provider-ci/providers/wavefront/repo/.github/workflows/main.yml
@@ -332,7 +332,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/wavefront/repo/.github/workflows/master.yml
+++ b/provider-ci/providers/wavefront/repo/.github/workflows/master.yml
@@ -332,7 +332,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/wavefront/repo/.github/workflows/prerelease.yml
+++ b/provider-ci/providers/wavefront/repo/.github/workflows/prerelease.yml
@@ -278,7 +278,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/wavefront/repo/.github/workflows/release.yml
+++ b/provider-ci/providers/wavefront/repo/.github/workflows/release.yml
@@ -290,7 +290,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.9
+      uses: pulumi/pulumi-package-publisher@v0.0.11
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/providers/wavefront/repo/Makefile
+++ b/provider-ci/providers/wavefront/repo/Makefile
@@ -61,15 +61,18 @@ build_nodejs: upstream
 
 build_python: PYPI_VERSION := $(shell pulumictl get version --language python)
 build_python: upstream
+	rm -rf sdk/python/
 	$(WORKING_DIR)/bin/$(TFGEN) python --out sdk/python/
 	cd sdk/python/ && \
 		printf "module fake_python_module // Exclude this directory from Go tools\n\ngo 1.17\n" > go.mod && \
 		cp ../../README.md . && \
-		python3 setup.py clean --all 2>/dev/null && \
 		rm -rf ./bin/ ../python.bin/ && cp -R . ../python.bin && mv ../python.bin ./bin && \
-		sed -i.bak -e 's/^VERSION = .*/VERSION = "$(PYPI_VERSION)"/g' -e 's/^PLUGIN_VERSION = .*/PLUGIN_VERSION = "$(VERSION)"/g' ./bin/setup.py && \
-		rm ./bin/setup.py.bak && rm ./bin/go.mod && \
-		cd ./bin && python3 setup.py build sdist
+		sed -i.bak -e 's/^  version = .*/  version = "$(PYPI_VERSION)"/g' ./bin/pyproject.toml && \
+		rm ./bin/pyproject.toml.bak && rm ./bin/go.mod && \
+		python3 -m venv venv && \
+		./venv/bin/python -m pip install build && \
+		cd ./bin && \
+		../venv/bin/python -m build .
 
 clean:
 	rm -rf sdk/{dotnet,nodejs,go,python}


### PR DESCRIPTION
Also remove extra if/else logic and `wheels:true` config.
Wheels are true everywhere going forward.

Closes https://github.com/pulumi/pulumi-package-publisher/issues/12.

- Remove extra Makefile logic for Wheels and update pulumi-package-publisher actionVersion in template config
- Remove extraneous config from AWS, GCP, random, and TLS providers
- Update pulumi-package-publisher to v0.0.11 everywhere
