### PR TITLE
Init upstream if present before rebuilding Python SDK

### DIFF
--- a/.github/workflows/update-workflows.yml
+++ b/.github/workflows/update-workflows.yml
@@ -50,6 +50,9 @@ jobs:
         with:
           repository: pulumi/pulumi-${{ inputs.provider_name }}
           path: pulumi-${{ inputs.provider_name }}
+      - name: Initialize submodule in pulumi-${{ inputs.provider_name }}
+        run: cd pulumi-${{ inputs.provider_name }} && make upstream && cd ..
+        continue-on-error: true
       - name: Delete existing workflows
         # Bridged providers completely replace workflow files from ci-mgmt currently.
         if: inputs.bridged


### PR DESCRIPTION
Following up on https://github.com/pulumi/ci-mgmt/pull/610

There's a small block I've missed.  IN the case when patched upstream restoration is needed, current migration code would not work to automatically roll out Python wheels. This bit got lost when factoring out update-workflows.yml but I found it necessary for repos like pulumi-gcp and pulumi-aws. Adding it back. Ignoring errors so that repositories without a patched upstream are not affected.