### PR TITLE
Add project_name to goreleaser configs

### DIFF
--- a/provider-ci/internal/pkg/generate.go
+++ b/provider-ci/internal/pkg/generate.go
@@ -29,8 +29,9 @@ type GenerateOpts struct {
 }
 
 type templateContext struct {
-	Repository string
-	Config     interface{}
+	Repository  string
+	ProjectName string // e.g.: pulumi-aws (this is the name of the repository)
+	Config      interface{}
 }
 
 func GeneratePackage(opts GenerateOpts) error {
@@ -78,9 +79,12 @@ func GeneratePackage(opts GenerateOpts) error {
 		}
 	}
 
+	projName := strings.TrimPrefix(opts.RepositoryName, "pulumi/")
+
 	ctx := templateContext{
-		Repository: opts.RepositoryName,
-		Config:     config,
+		Repository:  opts.RepositoryName,
+		ProjectName: projName,
+		Config:      config,
 	}
 
 	templateDir := filepath.Join("templates", opts.TemplateName)

--- a/provider-ci/internal/pkg/templates/bridged-provider/.goreleaser.prerelease.yml
+++ b/provider-ci/internal/pkg/templates/bridged-provider/.goreleaser.prerelease.yml
@@ -59,3 +59,4 @@ release:
   disable: true
 snapshot:
   name_template: "{{ .Tag }}-SNAPSHOT"
+project_name: "#{{ .ProjectName }}#"

--- a/provider-ci/internal/pkg/templates/bridged-provider/.goreleaser.yml
+++ b/provider-ci/internal/pkg/templates/bridged-provider/.goreleaser.yml
@@ -68,3 +68,4 @@ release:
   disable: false
 snapshot:
   name_template: "{{ .Tag }}-SNAPSHOT"
+project_name: "#{{ .ProjectName }}#"

--- a/provider-ci/providers/aiven/repo/.goreleaser.prerelease.yml
+++ b/provider-ci/providers/aiven/repo/.goreleaser.prerelease.yml
@@ -40,3 +40,4 @@ release:
   disable: true
 snapshot:
   name_template: "{{ .Tag }}-SNAPSHOT"
+project_name: "pulumi-aiven"

--- a/provider-ci/providers/aiven/repo/.goreleaser.yml
+++ b/provider-ci/providers/aiven/repo/.goreleaser.yml
@@ -48,3 +48,4 @@ release:
   disable: false
 snapshot:
   name_template: "{{ .Tag }}-SNAPSHOT"
+project_name: "pulumi-aiven"

--- a/provider-ci/providers/akamai/repo/.goreleaser.prerelease.yml
+++ b/provider-ci/providers/akamai/repo/.goreleaser.prerelease.yml
@@ -40,3 +40,4 @@ release:
   disable: true
 snapshot:
   name_template: "{{ .Tag }}-SNAPSHOT"
+project_name: "pulumi-akamai"

--- a/provider-ci/providers/akamai/repo/.goreleaser.yml
+++ b/provider-ci/providers/akamai/repo/.goreleaser.yml
@@ -48,3 +48,4 @@ release:
   disable: false
 snapshot:
   name_template: "{{ .Tag }}-SNAPSHOT"
+project_name: "pulumi-akamai"

--- a/provider-ci/providers/alicloud/repo/.goreleaser.prerelease.yml
+++ b/provider-ci/providers/alicloud/repo/.goreleaser.prerelease.yml
@@ -40,3 +40,4 @@ release:
   disable: true
 snapshot:
   name_template: "{{ .Tag }}-SNAPSHOT"
+project_name: "pulumi-alicloud"

--- a/provider-ci/providers/alicloud/repo/.goreleaser.yml
+++ b/provider-ci/providers/alicloud/repo/.goreleaser.yml
@@ -48,3 +48,4 @@ release:
   disable: false
 snapshot:
   name_template: "{{ .Tag }}-SNAPSHOT"
+project_name: "pulumi-alicloud"

--- a/provider-ci/providers/archive/repo/.goreleaser.prerelease.yml
+++ b/provider-ci/providers/archive/repo/.goreleaser.prerelease.yml
@@ -40,3 +40,4 @@ release:
   disable: true
 snapshot:
   name_template: "{{ .Tag }}-SNAPSHOT"
+project_name: "pulumi-archive"

--- a/provider-ci/providers/archive/repo/.goreleaser.yml
+++ b/provider-ci/providers/archive/repo/.goreleaser.yml
@@ -48,3 +48,4 @@ release:
   disable: false
 snapshot:
   name_template: "{{ .Tag }}-SNAPSHOT"
+project_name: "pulumi-archive"

--- a/provider-ci/providers/artifactory/repo/.goreleaser.prerelease.yml
+++ b/provider-ci/providers/artifactory/repo/.goreleaser.prerelease.yml
@@ -40,3 +40,4 @@ release:
   disable: true
 snapshot:
   name_template: "{{ .Tag }}-SNAPSHOT"
+project_name: "pulumi-artifactory"

--- a/provider-ci/providers/artifactory/repo/.goreleaser.yml
+++ b/provider-ci/providers/artifactory/repo/.goreleaser.yml
@@ -49,3 +49,4 @@ release:
   disable: false
 snapshot:
   name_template: "{{ .Tag }}-SNAPSHOT"
+project_name: "pulumi-artifactory"

--- a/provider-ci/providers/auth0/repo/.goreleaser.prerelease.yml
+++ b/provider-ci/providers/auth0/repo/.goreleaser.prerelease.yml
@@ -40,3 +40,4 @@ release:
   disable: true
 snapshot:
   name_template: "{{ .Tag }}-SNAPSHOT"
+project_name: "pulumi-auth0"

--- a/provider-ci/providers/auth0/repo/.goreleaser.yml
+++ b/provider-ci/providers/auth0/repo/.goreleaser.yml
@@ -48,3 +48,4 @@ release:
   disable: false
 snapshot:
   name_template: "{{ .Tag }}-SNAPSHOT"
+project_name: "pulumi-auth0"

--- a/provider-ci/providers/aws/repo/.goreleaser.prerelease.yml
+++ b/provider-ci/providers/aws/repo/.goreleaser.prerelease.yml
@@ -41,3 +41,4 @@ release:
   disable: true
 snapshot:
   name_template: "{{ .Tag }}-SNAPSHOT"
+project_name: "pulumi-aws"

--- a/provider-ci/providers/aws/repo/.goreleaser.yml
+++ b/provider-ci/providers/aws/repo/.goreleaser.yml
@@ -50,3 +50,4 @@ release:
   disable: false
 snapshot:
   name_template: "{{ .Tag }}-SNAPSHOT"
+project_name: "pulumi-aws"

--- a/provider-ci/providers/azure/repo/.goreleaser.prerelease.yml
+++ b/provider-ci/providers/azure/repo/.goreleaser.prerelease.yml
@@ -41,3 +41,4 @@ release:
   disable: true
 snapshot:
   name_template: "{{ .Tag }}-SNAPSHOT"
+project_name: "pulumi-azure"

--- a/provider-ci/providers/azure/repo/.goreleaser.yml
+++ b/provider-ci/providers/azure/repo/.goreleaser.yml
@@ -50,3 +50,4 @@ release:
   disable: false
 snapshot:
   name_template: "{{ .Tag }}-SNAPSHOT"
+project_name: "pulumi-azure"

--- a/provider-ci/providers/azuread/repo/.goreleaser.prerelease.yml
+++ b/provider-ci/providers/azuread/repo/.goreleaser.prerelease.yml
@@ -40,3 +40,4 @@ release:
   disable: true
 snapshot:
   name_template: "{{ .Tag }}-SNAPSHOT"
+project_name: "pulumi-azuread"

--- a/provider-ci/providers/azuread/repo/.goreleaser.yml
+++ b/provider-ci/providers/azuread/repo/.goreleaser.yml
@@ -48,3 +48,4 @@ release:
   disable: false
 snapshot:
   name_template: "{{ .Tag }}-SNAPSHOT"
+project_name: "pulumi-azuread"

--- a/provider-ci/providers/azuredevops/repo/.goreleaser.prerelease.yml
+++ b/provider-ci/providers/azuredevops/repo/.goreleaser.prerelease.yml
@@ -40,3 +40,4 @@ release:
   disable: true
 snapshot:
   name_template: "{{ .Tag }}-SNAPSHOT"
+project_name: "pulumi-azuredevops"

--- a/provider-ci/providers/azuredevops/repo/.goreleaser.yml
+++ b/provider-ci/providers/azuredevops/repo/.goreleaser.yml
@@ -49,3 +49,4 @@ release:
   disable: false
 snapshot:
   name_template: "{{ .Tag }}-SNAPSHOT"
+project_name: "pulumi-azuredevops"

--- a/provider-ci/providers/civo/repo/.goreleaser.prerelease.yml
+++ b/provider-ci/providers/civo/repo/.goreleaser.prerelease.yml
@@ -40,3 +40,4 @@ release:
   disable: true
 snapshot:
   name_template: "{{ .Tag }}-SNAPSHOT"
+project_name: "pulumi-civo"

--- a/provider-ci/providers/civo/repo/.goreleaser.yml
+++ b/provider-ci/providers/civo/repo/.goreleaser.yml
@@ -48,3 +48,4 @@ release:
   disable: false
 snapshot:
   name_template: "{{ .Tag }}-SNAPSHOT"
+project_name: "pulumi-civo"

--- a/provider-ci/providers/cloudamqp/repo/.goreleaser.prerelease.yml
+++ b/provider-ci/providers/cloudamqp/repo/.goreleaser.prerelease.yml
@@ -40,3 +40,4 @@ release:
   disable: true
 snapshot:
   name_template: "{{ .Tag }}-SNAPSHOT"
+project_name: "pulumi-cloudamqp"

--- a/provider-ci/providers/cloudamqp/repo/.goreleaser.yml
+++ b/provider-ci/providers/cloudamqp/repo/.goreleaser.yml
@@ -49,3 +49,4 @@ release:
   disable: false
 snapshot:
   name_template: "{{ .Tag }}-SNAPSHOT"
+project_name: "pulumi-cloudamqp"

--- a/provider-ci/providers/cloudflare/repo/.goreleaser.prerelease.yml
+++ b/provider-ci/providers/cloudflare/repo/.goreleaser.prerelease.yml
@@ -40,3 +40,4 @@ release:
   disable: true
 snapshot:
   name_template: "{{ .Tag }}-SNAPSHOT"
+project_name: "pulumi-cloudflare"

--- a/provider-ci/providers/cloudflare/repo/.goreleaser.yml
+++ b/provider-ci/providers/cloudflare/repo/.goreleaser.yml
@@ -49,3 +49,4 @@ release:
   disable: false
 snapshot:
   name_template: "{{ .Tag }}-SNAPSHOT"
+project_name: "pulumi-cloudflare"

--- a/provider-ci/providers/cloudinit/repo/.goreleaser.prerelease.yml
+++ b/provider-ci/providers/cloudinit/repo/.goreleaser.prerelease.yml
@@ -40,3 +40,4 @@ release:
   disable: true
 snapshot:
   name_template: "{{ .Tag }}-SNAPSHOT"
+project_name: "pulumi-cloudinit"

--- a/provider-ci/providers/cloudinit/repo/.goreleaser.yml
+++ b/provider-ci/providers/cloudinit/repo/.goreleaser.yml
@@ -48,3 +48,4 @@ release:
   disable: false
 snapshot:
   name_template: "{{ .Tag }}-SNAPSHOT"
+project_name: "pulumi-cloudinit"

--- a/provider-ci/providers/confluentcloud/repo/.goreleaser.prerelease.yml
+++ b/provider-ci/providers/confluentcloud/repo/.goreleaser.prerelease.yml
@@ -40,3 +40,4 @@ release:
   disable: true
 snapshot:
   name_template: "{{ .Tag }}-SNAPSHOT"
+project_name: "pulumi-confluentcloud"

--- a/provider-ci/providers/confluentcloud/repo/.goreleaser.yml
+++ b/provider-ci/providers/confluentcloud/repo/.goreleaser.yml
@@ -49,3 +49,4 @@ release:
   disable: false
 snapshot:
   name_template: "{{ .Tag }}-SNAPSHOT"
+project_name: "pulumi-confluentcloud"

--- a/provider-ci/providers/consul/repo/.goreleaser.prerelease.yml
+++ b/provider-ci/providers/consul/repo/.goreleaser.prerelease.yml
@@ -40,3 +40,4 @@ release:
   disable: true
 snapshot:
   name_template: "{{ .Tag }}-SNAPSHOT"
+project_name: "pulumi-consul"

--- a/provider-ci/providers/consul/repo/.goreleaser.yml
+++ b/provider-ci/providers/consul/repo/.goreleaser.yml
@@ -48,3 +48,4 @@ release:
   disable: false
 snapshot:
   name_template: "{{ .Tag }}-SNAPSHOT"
+project_name: "pulumi-consul"

--- a/provider-ci/providers/databricks/repo/.goreleaser.prerelease.yml
+++ b/provider-ci/providers/databricks/repo/.goreleaser.prerelease.yml
@@ -40,3 +40,4 @@ release:
   disable: true
 snapshot:
   name_template: "{{ .Tag }}-SNAPSHOT"
+project_name: "pulumi-databricks"

--- a/provider-ci/providers/databricks/repo/.goreleaser.yml
+++ b/provider-ci/providers/databricks/repo/.goreleaser.yml
@@ -48,3 +48,4 @@ release:
   disable: false
 snapshot:
   name_template: "{{ .Tag }}-SNAPSHOT"
+project_name: "pulumi-databricks"

--- a/provider-ci/providers/datadog/repo/.goreleaser.prerelease.yml
+++ b/provider-ci/providers/datadog/repo/.goreleaser.prerelease.yml
@@ -40,3 +40,4 @@ release:
   disable: true
 snapshot:
   name_template: "{{ .Tag }}-SNAPSHOT"
+project_name: "pulumi-datadog"

--- a/provider-ci/providers/datadog/repo/.goreleaser.yml
+++ b/provider-ci/providers/datadog/repo/.goreleaser.yml
@@ -48,3 +48,4 @@ release:
   disable: false
 snapshot:
   name_template: "{{ .Tag }}-SNAPSHOT"
+project_name: "pulumi-datadog"

--- a/provider-ci/providers/digitalocean/repo/.goreleaser.prerelease.yml
+++ b/provider-ci/providers/digitalocean/repo/.goreleaser.prerelease.yml
@@ -40,3 +40,4 @@ release:
   disable: true
 snapshot:
   name_template: "{{ .Tag }}-SNAPSHOT"
+project_name: "pulumi-digitalocean"

--- a/provider-ci/providers/digitalocean/repo/.goreleaser.yml
+++ b/provider-ci/providers/digitalocean/repo/.goreleaser.yml
@@ -49,3 +49,4 @@ release:
   disable: false
 snapshot:
   name_template: "{{ .Tag }}-SNAPSHOT"
+project_name: "pulumi-digitalocean"

--- a/provider-ci/providers/dnsimple/repo/.goreleaser.prerelease.yml
+++ b/provider-ci/providers/dnsimple/repo/.goreleaser.prerelease.yml
@@ -40,3 +40,4 @@ release:
   disable: true
 snapshot:
   name_template: "{{ .Tag }}-SNAPSHOT"
+project_name: "pulumi-dnsimple"

--- a/provider-ci/providers/dnsimple/repo/.goreleaser.yml
+++ b/provider-ci/providers/dnsimple/repo/.goreleaser.yml
@@ -48,3 +48,4 @@ release:
   disable: false
 snapshot:
   name_template: "{{ .Tag }}-SNAPSHOT"
+project_name: "pulumi-dnsimple"

--- a/provider-ci/providers/docker/repo/.goreleaser.prerelease.yml
+++ b/provider-ci/providers/docker/repo/.goreleaser.prerelease.yml
@@ -40,3 +40,4 @@ release:
   disable: true
 snapshot:
   name_template: "{{ .Tag }}-SNAPSHOT"
+project_name: "pulumi-docker"

--- a/provider-ci/providers/docker/repo/.goreleaser.yml
+++ b/provider-ci/providers/docker/repo/.goreleaser.yml
@@ -48,3 +48,4 @@ release:
   disable: false
 snapshot:
   name_template: "{{ .Tag }}-SNAPSHOT"
+project_name: "pulumi-docker"

--- a/provider-ci/providers/ec/repo/.goreleaser.prerelease.yml
+++ b/provider-ci/providers/ec/repo/.goreleaser.prerelease.yml
@@ -40,3 +40,4 @@ release:
   disable: true
 snapshot:
   name_template: "{{ .Tag }}-SNAPSHOT"
+project_name: "pulumi-ec"

--- a/provider-ci/providers/ec/repo/.goreleaser.yml
+++ b/provider-ci/providers/ec/repo/.goreleaser.yml
@@ -48,3 +48,4 @@ release:
   disable: false
 snapshot:
   name_template: "{{ .Tag }}-SNAPSHOT"
+project_name: "pulumi-ec"

--- a/provider-ci/providers/equinix-metal/repo/.goreleaser.prerelease.yml
+++ b/provider-ci/providers/equinix-metal/repo/.goreleaser.prerelease.yml
@@ -40,3 +40,4 @@ release:
   disable: true
 snapshot:
   name_template: "{{ .Tag }}-SNAPSHOT"
+project_name: "pulumi-equinix-metal"

--- a/provider-ci/providers/equinix-metal/repo/.goreleaser.yml
+++ b/provider-ci/providers/equinix-metal/repo/.goreleaser.yml
@@ -49,3 +49,4 @@ release:
   disable: false
 snapshot:
   name_template: "{{ .Tag }}-SNAPSHOT"
+project_name: "pulumi-equinix-metal"

--- a/provider-ci/providers/external/repo/.goreleaser.prerelease.yml
+++ b/provider-ci/providers/external/repo/.goreleaser.prerelease.yml
@@ -40,3 +40,4 @@ release:
   disable: true
 snapshot:
   name_template: "{{ .Tag }}-SNAPSHOT"
+project_name: "pulumi-external"

--- a/provider-ci/providers/external/repo/.goreleaser.yml
+++ b/provider-ci/providers/external/repo/.goreleaser.yml
@@ -48,3 +48,4 @@ release:
   disable: false
 snapshot:
   name_template: "{{ .Tag }}-SNAPSHOT"
+project_name: "pulumi-external"

--- a/provider-ci/providers/f5bigip/repo/.goreleaser.prerelease.yml
+++ b/provider-ci/providers/f5bigip/repo/.goreleaser.prerelease.yml
@@ -40,3 +40,4 @@ release:
   disable: true
 snapshot:
   name_template: "{{ .Tag }}-SNAPSHOT"
+project_name: "pulumi-f5bigip"

--- a/provider-ci/providers/f5bigip/repo/.goreleaser.yml
+++ b/provider-ci/providers/f5bigip/repo/.goreleaser.yml
@@ -48,3 +48,4 @@ release:
   disable: false
 snapshot:
   name_template: "{{ .Tag }}-SNAPSHOT"
+project_name: "pulumi-f5bigip"

--- a/provider-ci/providers/fastly/repo/.goreleaser.prerelease.yml
+++ b/provider-ci/providers/fastly/repo/.goreleaser.prerelease.yml
@@ -40,3 +40,4 @@ release:
   disable: true
 snapshot:
   name_template: "{{ .Tag }}-SNAPSHOT"
+project_name: "pulumi-fastly"

--- a/provider-ci/providers/fastly/repo/.goreleaser.yml
+++ b/provider-ci/providers/fastly/repo/.goreleaser.yml
@@ -48,3 +48,4 @@ release:
   disable: false
 snapshot:
   name_template: "{{ .Tag }}-SNAPSHOT"
+project_name: "pulumi-fastly"

--- a/provider-ci/providers/gcp/repo/.goreleaser.prerelease.yml
+++ b/provider-ci/providers/gcp/repo/.goreleaser.prerelease.yml
@@ -37,3 +37,4 @@ release:
   disable: true
 snapshot:
   name_template: "{{ .Tag }}-SNAPSHOT"
+project_name: "pulumi-gcp"

--- a/provider-ci/providers/gcp/repo/.goreleaser.yml
+++ b/provider-ci/providers/gcp/repo/.goreleaser.yml
@@ -46,3 +46,4 @@ release:
   disable: false
 snapshot:
   name_template: "{{ .Tag }}-SNAPSHOT"
+project_name: "pulumi-gcp"

--- a/provider-ci/providers/github/repo/.goreleaser.prerelease.yml
+++ b/provider-ci/providers/github/repo/.goreleaser.prerelease.yml
@@ -40,3 +40,4 @@ release:
   disable: true
 snapshot:
   name_template: "{{ .Tag }}-SNAPSHOT"
+project_name: "pulumi-github"

--- a/provider-ci/providers/github/repo/.goreleaser.yml
+++ b/provider-ci/providers/github/repo/.goreleaser.yml
@@ -48,3 +48,4 @@ release:
   disable: false
 snapshot:
   name_template: "{{ .Tag }}-SNAPSHOT"
+project_name: "pulumi-github"

--- a/provider-ci/providers/gitlab/repo/.goreleaser.prerelease.yml
+++ b/provider-ci/providers/gitlab/repo/.goreleaser.prerelease.yml
@@ -40,3 +40,4 @@ release:
   disable: true
 snapshot:
   name_template: "{{ .Tag }}-SNAPSHOT"
+project_name: "pulumi-gitlab"

--- a/provider-ci/providers/gitlab/repo/.goreleaser.yml
+++ b/provider-ci/providers/gitlab/repo/.goreleaser.yml
@@ -48,3 +48,4 @@ release:
   disable: false
 snapshot:
   name_template: "{{ .Tag }}-SNAPSHOT"
+project_name: "pulumi-gitlab"

--- a/provider-ci/providers/hcloud/repo/.goreleaser.prerelease.yml
+++ b/provider-ci/providers/hcloud/repo/.goreleaser.prerelease.yml
@@ -40,3 +40,4 @@ release:
   disable: true
 snapshot:
   name_template: "{{ .Tag }}-SNAPSHOT"
+project_name: "pulumi-hcloud"

--- a/provider-ci/providers/hcloud/repo/.goreleaser.yml
+++ b/provider-ci/providers/hcloud/repo/.goreleaser.yml
@@ -48,3 +48,4 @@ release:
   disable: false
 snapshot:
   name_template: "{{ .Tag }}-SNAPSHOT"
+project_name: "pulumi-hcloud"

--- a/provider-ci/providers/http/repo/.goreleaser.prerelease.yml
+++ b/provider-ci/providers/http/repo/.goreleaser.prerelease.yml
@@ -40,3 +40,4 @@ release:
   disable: true
 snapshot:
   name_template: "{{ .Tag }}-SNAPSHOT"
+project_name: "pulumi-http"

--- a/provider-ci/providers/http/repo/.goreleaser.yml
+++ b/provider-ci/providers/http/repo/.goreleaser.yml
@@ -48,3 +48,4 @@ release:
   disable: false
 snapshot:
   name_template: "{{ .Tag }}-SNAPSHOT"
+project_name: "pulumi-http"

--- a/provider-ci/providers/kafka/repo/.goreleaser.prerelease.yml
+++ b/provider-ci/providers/kafka/repo/.goreleaser.prerelease.yml
@@ -40,3 +40,4 @@ release:
   disable: true
 snapshot:
   name_template: "{{ .Tag }}-SNAPSHOT"
+project_name: "pulumi-kafka"

--- a/provider-ci/providers/kafka/repo/.goreleaser.yml
+++ b/provider-ci/providers/kafka/repo/.goreleaser.yml
@@ -48,3 +48,4 @@ release:
   disable: false
 snapshot:
   name_template: "{{ .Tag }}-SNAPSHOT"
+project_name: "pulumi-kafka"

--- a/provider-ci/providers/keycloak/repo/.goreleaser.prerelease.yml
+++ b/provider-ci/providers/keycloak/repo/.goreleaser.prerelease.yml
@@ -40,3 +40,4 @@ release:
   disable: true
 snapshot:
   name_template: "{{ .Tag }}-SNAPSHOT"
+project_name: "pulumi-keycloak"

--- a/provider-ci/providers/keycloak/repo/.goreleaser.yml
+++ b/provider-ci/providers/keycloak/repo/.goreleaser.yml
@@ -48,3 +48,4 @@ release:
   disable: false
 snapshot:
   name_template: "{{ .Tag }}-SNAPSHOT"
+project_name: "pulumi-keycloak"

--- a/provider-ci/providers/kong/repo/.goreleaser.prerelease.yml
+++ b/provider-ci/providers/kong/repo/.goreleaser.prerelease.yml
@@ -40,3 +40,4 @@ release:
   disable: true
 snapshot:
   name_template: "{{ .Tag }}-SNAPSHOT"
+project_name: "pulumi-kong"

--- a/provider-ci/providers/kong/repo/.goreleaser.yml
+++ b/provider-ci/providers/kong/repo/.goreleaser.yml
@@ -48,3 +48,4 @@ release:
   disable: false
 snapshot:
   name_template: "{{ .Tag }}-SNAPSHOT"
+project_name: "pulumi-kong"

--- a/provider-ci/providers/libvirt/repo/.goreleaser.prerelease.yml
+++ b/provider-ci/providers/libvirt/repo/.goreleaser.prerelease.yml
@@ -40,3 +40,4 @@ release:
   disable: true
 snapshot:
   name_template: "{{ .Tag }}-SNAPSHOT"
+project_name: "pulumi-libvirt"

--- a/provider-ci/providers/libvirt/repo/.goreleaser.yml
+++ b/provider-ci/providers/libvirt/repo/.goreleaser.yml
@@ -48,3 +48,4 @@ release:
   disable: false
 snapshot:
   name_template: "{{ .Tag }}-SNAPSHOT"
+project_name: "pulumi-libvirt"

--- a/provider-ci/providers/linode/repo/.goreleaser.prerelease.yml
+++ b/provider-ci/providers/linode/repo/.goreleaser.prerelease.yml
@@ -40,3 +40,4 @@ release:
   disable: true
 snapshot:
   name_template: "{{ .Tag }}-SNAPSHOT"
+project_name: "pulumi-linode"

--- a/provider-ci/providers/linode/repo/.goreleaser.yml
+++ b/provider-ci/providers/linode/repo/.goreleaser.yml
@@ -48,3 +48,4 @@ release:
   disable: false
 snapshot:
   name_template: "{{ .Tag }}-SNAPSHOT"
+project_name: "pulumi-linode"

--- a/provider-ci/providers/local/repo/.goreleaser.prerelease.yml
+++ b/provider-ci/providers/local/repo/.goreleaser.prerelease.yml
@@ -40,3 +40,4 @@ release:
   disable: true
 snapshot:
   name_template: "{{ .Tag }}-SNAPSHOT"
+project_name: "pulumi-local"

--- a/provider-ci/providers/local/repo/.goreleaser.yml
+++ b/provider-ci/providers/local/repo/.goreleaser.yml
@@ -48,3 +48,4 @@ release:
   disable: false
 snapshot:
   name_template: "{{ .Tag }}-SNAPSHOT"
+project_name: "pulumi-local"

--- a/provider-ci/providers/mailgun/repo/.goreleaser.prerelease.yml
+++ b/provider-ci/providers/mailgun/repo/.goreleaser.prerelease.yml
@@ -40,3 +40,4 @@ release:
   disable: true
 snapshot:
   name_template: "{{ .Tag }}-SNAPSHOT"
+project_name: "pulumi-mailgun"

--- a/provider-ci/providers/mailgun/repo/.goreleaser.yml
+++ b/provider-ci/providers/mailgun/repo/.goreleaser.yml
@@ -48,3 +48,4 @@ release:
   disable: false
 snapshot:
   name_template: "{{ .Tag }}-SNAPSHOT"
+project_name: "pulumi-mailgun"

--- a/provider-ci/providers/minio/repo/.goreleaser.prerelease.yml
+++ b/provider-ci/providers/minio/repo/.goreleaser.prerelease.yml
@@ -42,3 +42,4 @@ release:
   disable: true
 snapshot:
   name_template: "{{ .Tag }}-SNAPSHOT"
+project_name: "pulumi-minio"

--- a/provider-ci/providers/minio/repo/.goreleaser.yml
+++ b/provider-ci/providers/minio/repo/.goreleaser.yml
@@ -50,3 +50,4 @@ release:
   disable: false
 snapshot:
   name_template: "{{ .Tag }}-SNAPSHOT"
+project_name: "pulumi-minio"

--- a/provider-ci/providers/mongodbatlas/repo/.goreleaser.prerelease.yml
+++ b/provider-ci/providers/mongodbatlas/repo/.goreleaser.prerelease.yml
@@ -40,3 +40,4 @@ release:
   disable: true
 snapshot:
   name_template: "{{ .Tag }}-SNAPSHOT"
+project_name: "pulumi-mongodbatlas"

--- a/provider-ci/providers/mongodbatlas/repo/.goreleaser.yml
+++ b/provider-ci/providers/mongodbatlas/repo/.goreleaser.yml
@@ -49,3 +49,4 @@ release:
   disable: false
 snapshot:
   name_template: "{{ .Tag }}-SNAPSHOT"
+project_name: "pulumi-mongodbatlas"

--- a/provider-ci/providers/mysql/repo/.goreleaser.prerelease.yml
+++ b/provider-ci/providers/mysql/repo/.goreleaser.prerelease.yml
@@ -40,3 +40,4 @@ release:
   disable: true
 snapshot:
   name_template: "{{ .Tag }}-SNAPSHOT"
+project_name: "pulumi-mysql"

--- a/provider-ci/providers/mysql/repo/.goreleaser.yml
+++ b/provider-ci/providers/mysql/repo/.goreleaser.yml
@@ -48,3 +48,4 @@ release:
   disable: false
 snapshot:
   name_template: "{{ .Tag }}-SNAPSHOT"
+project_name: "pulumi-mysql"

--- a/provider-ci/providers/newrelic/repo/.goreleaser.prerelease.yml
+++ b/provider-ci/providers/newrelic/repo/.goreleaser.prerelease.yml
@@ -41,3 +41,4 @@ release:
   disable: true
 snapshot:
   name_template: "{{ .Tag }}-SNAPSHOT"
+project_name: "pulumi-newrelic"

--- a/provider-ci/providers/newrelic/repo/.goreleaser.yml
+++ b/provider-ci/providers/newrelic/repo/.goreleaser.yml
@@ -49,3 +49,4 @@ release:
   disable: false
 snapshot:
   name_template: "{{ .Tag }}-SNAPSHOT"
+project_name: "pulumi-newrelic"

--- a/provider-ci/providers/nomad/repo/.goreleaser.prerelease.yml
+++ b/provider-ci/providers/nomad/repo/.goreleaser.prerelease.yml
@@ -40,3 +40,4 @@ release:
   disable: true
 snapshot:
   name_template: "{{ .Tag }}-SNAPSHOT"
+project_name: "pulumi-nomad"

--- a/provider-ci/providers/nomad/repo/.goreleaser.yml
+++ b/provider-ci/providers/nomad/repo/.goreleaser.yml
@@ -48,3 +48,4 @@ release:
   disable: false
 snapshot:
   name_template: "{{ .Tag }}-SNAPSHOT"
+project_name: "pulumi-nomad"

--- a/provider-ci/providers/ns1/repo/.goreleaser.prerelease.yml
+++ b/provider-ci/providers/ns1/repo/.goreleaser.prerelease.yml
@@ -40,3 +40,4 @@ release:
   disable: true
 snapshot:
   name_template: "{{ .Tag }}-SNAPSHOT"
+project_name: "pulumi-ns1"

--- a/provider-ci/providers/ns1/repo/.goreleaser.yml
+++ b/provider-ci/providers/ns1/repo/.goreleaser.yml
@@ -48,3 +48,4 @@ release:
   disable: false
 snapshot:
   name_template: "{{ .Tag }}-SNAPSHOT"
+project_name: "pulumi-ns1"

--- a/provider-ci/providers/null/repo/.goreleaser.prerelease.yml
+++ b/provider-ci/providers/null/repo/.goreleaser.prerelease.yml
@@ -40,3 +40,4 @@ release:
   disable: true
 snapshot:
   name_template: "{{ .Tag }}-SNAPSHOT"
+project_name: "pulumi-null"

--- a/provider-ci/providers/null/repo/.goreleaser.yml
+++ b/provider-ci/providers/null/repo/.goreleaser.yml
@@ -48,3 +48,4 @@ release:
   disable: false
 snapshot:
   name_template: "{{ .Tag }}-SNAPSHOT"
+project_name: "pulumi-null"

--- a/provider-ci/providers/oci/repo/.goreleaser.prerelease.yml
+++ b/provider-ci/providers/oci/repo/.goreleaser.prerelease.yml
@@ -40,3 +40,4 @@ release:
   disable: true
 snapshot:
   name_template: "{{ .Tag }}-SNAPSHOT"
+project_name: "pulumi-oci"

--- a/provider-ci/providers/oci/repo/.goreleaser.yml
+++ b/provider-ci/providers/oci/repo/.goreleaser.yml
@@ -48,3 +48,4 @@ release:
   disable: false
 snapshot:
   name_template: "{{ .Tag }}-SNAPSHOT"
+project_name: "pulumi-oci"

--- a/provider-ci/providers/okta/repo/.goreleaser.prerelease.yml
+++ b/provider-ci/providers/okta/repo/.goreleaser.prerelease.yml
@@ -40,3 +40,4 @@ release:
   disable: true
 snapshot:
   name_template: "{{ .Tag }}-SNAPSHOT"
+project_name: "pulumi-okta"

--- a/provider-ci/providers/okta/repo/.goreleaser.yml
+++ b/provider-ci/providers/okta/repo/.goreleaser.yml
@@ -48,3 +48,4 @@ release:
   disable: false
 snapshot:
   name_template: "{{ .Tag }}-SNAPSHOT"
+project_name: "pulumi-okta"

--- a/provider-ci/providers/onelogin/repo/.goreleaser.prerelease.yml
+++ b/provider-ci/providers/onelogin/repo/.goreleaser.prerelease.yml
@@ -40,3 +40,4 @@ release:
   disable: true
 snapshot:
   name_template: "{{ .Tag }}-SNAPSHOT"
+project_name: "pulumi-onelogin"

--- a/provider-ci/providers/onelogin/repo/.goreleaser.yml
+++ b/provider-ci/providers/onelogin/repo/.goreleaser.yml
@@ -48,3 +48,4 @@ release:
   disable: false
 snapshot:
   name_template: "{{ .Tag }}-SNAPSHOT"
+project_name: "pulumi-onelogin"

--- a/provider-ci/providers/openstack/repo/.goreleaser.prerelease.yml
+++ b/provider-ci/providers/openstack/repo/.goreleaser.prerelease.yml
@@ -40,3 +40,4 @@ release:
   disable: true
 snapshot:
   name_template: "{{ .Tag }}-SNAPSHOT"
+project_name: "pulumi-openstack"

--- a/provider-ci/providers/openstack/repo/.goreleaser.yml
+++ b/provider-ci/providers/openstack/repo/.goreleaser.yml
@@ -49,3 +49,4 @@ release:
   disable: false
 snapshot:
   name_template: "{{ .Tag }}-SNAPSHOT"
+project_name: "pulumi-openstack"

--- a/provider-ci/providers/opsgenie/repo/.goreleaser.prerelease.yml
+++ b/provider-ci/providers/opsgenie/repo/.goreleaser.prerelease.yml
@@ -40,3 +40,4 @@ release:
   disable: true
 snapshot:
   name_template: "{{ .Tag }}-SNAPSHOT"
+project_name: "pulumi-opsgenie"

--- a/provider-ci/providers/opsgenie/repo/.goreleaser.yml
+++ b/provider-ci/providers/opsgenie/repo/.goreleaser.yml
@@ -48,3 +48,4 @@ release:
   disable: false
 snapshot:
   name_template: "{{ .Tag }}-SNAPSHOT"
+project_name: "pulumi-opsgenie"

--- a/provider-ci/providers/pagerduty/repo/.goreleaser.prerelease.yml
+++ b/provider-ci/providers/pagerduty/repo/.goreleaser.prerelease.yml
@@ -40,3 +40,4 @@ release:
   disable: true
 snapshot:
   name_template: "{{ .Tag }}-SNAPSHOT"
+project_name: "pulumi-pagerduty"

--- a/provider-ci/providers/pagerduty/repo/.goreleaser.yml
+++ b/provider-ci/providers/pagerduty/repo/.goreleaser.yml
@@ -49,3 +49,4 @@ release:
   disable: false
 snapshot:
   name_template: "{{ .Tag }}-SNAPSHOT"
+project_name: "pulumi-pagerduty"

--- a/provider-ci/providers/postgresql/repo/.goreleaser.prerelease.yml
+++ b/provider-ci/providers/postgresql/repo/.goreleaser.prerelease.yml
@@ -40,3 +40,4 @@ release:
   disable: true
 snapshot:
   name_template: "{{ .Tag }}-SNAPSHOT"
+project_name: "pulumi-postgresql"

--- a/provider-ci/providers/postgresql/repo/.goreleaser.yml
+++ b/provider-ci/providers/postgresql/repo/.goreleaser.yml
@@ -49,3 +49,4 @@ release:
   disable: false
 snapshot:
   name_template: "{{ .Tag }}-SNAPSHOT"
+project_name: "pulumi-postgresql"

--- a/provider-ci/providers/rabbitmq/repo/.goreleaser.prerelease.yml
+++ b/provider-ci/providers/rabbitmq/repo/.goreleaser.prerelease.yml
@@ -40,3 +40,4 @@ release:
   disable: true
 snapshot:
   name_template: "{{ .Tag }}-SNAPSHOT"
+project_name: "pulumi-rabbitmq"

--- a/provider-ci/providers/rabbitmq/repo/.goreleaser.yml
+++ b/provider-ci/providers/rabbitmq/repo/.goreleaser.yml
@@ -48,3 +48,4 @@ release:
   disable: false
 snapshot:
   name_template: "{{ .Tag }}-SNAPSHOT"
+project_name: "pulumi-rabbitmq"

--- a/provider-ci/providers/rancher2/repo/.goreleaser.prerelease.yml
+++ b/provider-ci/providers/rancher2/repo/.goreleaser.prerelease.yml
@@ -40,3 +40,4 @@ release:
   disable: true
 snapshot:
   name_template: "{{ .Tag }}-SNAPSHOT"
+project_name: "pulumi-rancher2"

--- a/provider-ci/providers/rancher2/repo/.goreleaser.yml
+++ b/provider-ci/providers/rancher2/repo/.goreleaser.yml
@@ -48,3 +48,4 @@ release:
   disable: false
 snapshot:
   name_template: "{{ .Tag }}-SNAPSHOT"
+project_name: "pulumi-rancher2"

--- a/provider-ci/providers/random/repo/.goreleaser.prerelease.yml
+++ b/provider-ci/providers/random/repo/.goreleaser.prerelease.yml
@@ -40,3 +40,4 @@ release:
   disable: true
 snapshot:
   name_template: "{{ .Tag }}-SNAPSHOT"
+project_name: "pulumi-random"

--- a/provider-ci/providers/random/repo/.goreleaser.yml
+++ b/provider-ci/providers/random/repo/.goreleaser.yml
@@ -48,3 +48,4 @@ release:
   disable: false
 snapshot:
   name_template: "{{ .Tag }}-SNAPSHOT"
+project_name: "pulumi-random"

--- a/provider-ci/providers/rke/repo/.goreleaser.prerelease.yml
+++ b/provider-ci/providers/rke/repo/.goreleaser.prerelease.yml
@@ -40,3 +40,4 @@ release:
   disable: true
 snapshot:
   name_template: "{{ .Tag }}-SNAPSHOT"
+project_name: "pulumi-rke"

--- a/provider-ci/providers/rke/repo/.goreleaser.yml
+++ b/provider-ci/providers/rke/repo/.goreleaser.yml
@@ -48,3 +48,4 @@ release:
   disable: false
 snapshot:
   name_template: "{{ .Tag }}-SNAPSHOT"
+project_name: "pulumi-rke"

--- a/provider-ci/providers/signalfx/repo/.goreleaser.prerelease.yml
+++ b/provider-ci/providers/signalfx/repo/.goreleaser.prerelease.yml
@@ -40,3 +40,4 @@ release:
   disable: true
 snapshot:
   name_template: "{{ .Tag }}-SNAPSHOT"
+project_name: "pulumi-signalfx"

--- a/provider-ci/providers/signalfx/repo/.goreleaser.yml
+++ b/provider-ci/providers/signalfx/repo/.goreleaser.yml
@@ -48,3 +48,4 @@ release:
   disable: false
 snapshot:
   name_template: "{{ .Tag }}-SNAPSHOT"
+project_name: "pulumi-signalfx"

--- a/provider-ci/providers/slack/repo/.goreleaser.prerelease.yml
+++ b/provider-ci/providers/slack/repo/.goreleaser.prerelease.yml
@@ -40,3 +40,4 @@ release:
   disable: true
 snapshot:
   name_template: "{{ .Tag }}-SNAPSHOT"
+project_name: "pulumi-slack"

--- a/provider-ci/providers/slack/repo/.goreleaser.yml
+++ b/provider-ci/providers/slack/repo/.goreleaser.yml
@@ -48,3 +48,4 @@ release:
   disable: false
 snapshot:
   name_template: "{{ .Tag }}-SNAPSHOT"
+project_name: "pulumi-slack"

--- a/provider-ci/providers/snowflake/repo/.goreleaser.prerelease.yml
+++ b/provider-ci/providers/snowflake/repo/.goreleaser.prerelease.yml
@@ -40,3 +40,4 @@ release:
   disable: true
 snapshot:
   name_template: "{{ .Tag }}-SNAPSHOT"
+project_name: "pulumi-snowflake"

--- a/provider-ci/providers/snowflake/repo/.goreleaser.yml
+++ b/provider-ci/providers/snowflake/repo/.goreleaser.yml
@@ -48,3 +48,4 @@ release:
   disable: false
 snapshot:
   name_template: "{{ .Tag }}-SNAPSHOT"
+project_name: "pulumi-snowflake"

--- a/provider-ci/providers/splunk/repo/.goreleaser.prerelease.yml
+++ b/provider-ci/providers/splunk/repo/.goreleaser.prerelease.yml
@@ -40,3 +40,4 @@ release:
   disable: true
 snapshot:
   name_template: "{{ .Tag }}-SNAPSHOT"
+project_name: "pulumi-splunk"

--- a/provider-ci/providers/splunk/repo/.goreleaser.yml
+++ b/provider-ci/providers/splunk/repo/.goreleaser.yml
@@ -48,3 +48,4 @@ release:
   disable: false
 snapshot:
   name_template: "{{ .Tag }}-SNAPSHOT"
+project_name: "pulumi-splunk"

--- a/provider-ci/providers/spotinst/repo/.goreleaser.prerelease.yml
+++ b/provider-ci/providers/spotinst/repo/.goreleaser.prerelease.yml
@@ -40,3 +40,4 @@ release:
   disable: true
 snapshot:
   name_template: "{{ .Tag }}-SNAPSHOT"
+project_name: "pulumi-spotinst"

--- a/provider-ci/providers/spotinst/repo/.goreleaser.yml
+++ b/provider-ci/providers/spotinst/repo/.goreleaser.yml
@@ -48,3 +48,4 @@ release:
   disable: false
 snapshot:
   name_template: "{{ .Tag }}-SNAPSHOT"
+project_name: "pulumi-spotinst"

--- a/provider-ci/providers/sumologic/repo/.goreleaser.prerelease.yml
+++ b/provider-ci/providers/sumologic/repo/.goreleaser.prerelease.yml
@@ -40,3 +40,4 @@ release:
   disable: true
 snapshot:
   name_template: "{{ .Tag }}-SNAPSHOT"
+project_name: "pulumi-sumologic"

--- a/provider-ci/providers/sumologic/repo/.goreleaser.yml
+++ b/provider-ci/providers/sumologic/repo/.goreleaser.yml
@@ -48,3 +48,4 @@ release:
   disable: false
 snapshot:
   name_template: "{{ .Tag }}-SNAPSHOT"
+project_name: "pulumi-sumologic"

--- a/provider-ci/providers/tailscale/repo/.goreleaser.prerelease.yml
+++ b/provider-ci/providers/tailscale/repo/.goreleaser.prerelease.yml
@@ -40,3 +40,4 @@ release:
   disable: true
 snapshot:
   name_template: "{{ .Tag }}-SNAPSHOT"
+project_name: "pulumi-tailscale"

--- a/provider-ci/providers/tailscale/repo/.goreleaser.yml
+++ b/provider-ci/providers/tailscale/repo/.goreleaser.yml
@@ -48,3 +48,4 @@ release:
   disable: false
 snapshot:
   name_template: "{{ .Tag }}-SNAPSHOT"
+project_name: "pulumi-tailscale"

--- a/provider-ci/providers/tls/repo/.goreleaser.prerelease.yml
+++ b/provider-ci/providers/tls/repo/.goreleaser.prerelease.yml
@@ -40,3 +40,4 @@ release:
   disable: true
 snapshot:
   name_template: "{{ .Tag }}-SNAPSHOT"
+project_name: "pulumi-tls"

--- a/provider-ci/providers/tls/repo/.goreleaser.yml
+++ b/provider-ci/providers/tls/repo/.goreleaser.yml
@@ -48,3 +48,4 @@ release:
   disable: false
 snapshot:
   name_template: "{{ .Tag }}-SNAPSHOT"
+project_name: "pulumi-tls"

--- a/provider-ci/providers/venafi/repo/.goreleaser.prerelease.yml
+++ b/provider-ci/providers/venafi/repo/.goreleaser.prerelease.yml
@@ -40,3 +40,4 @@ release:
   disable: true
 snapshot:
   name_template: "{{ .Tag }}-SNAPSHOT"
+project_name: "pulumi-venafi"

--- a/provider-ci/providers/venafi/repo/.goreleaser.yml
+++ b/provider-ci/providers/venafi/repo/.goreleaser.yml
@@ -48,3 +48,4 @@ release:
   disable: false
 snapshot:
   name_template: "{{ .Tag }}-SNAPSHOT"
+project_name: "pulumi-venafi"

--- a/provider-ci/providers/vsphere/repo/.goreleaser.prerelease.yml
+++ b/provider-ci/providers/vsphere/repo/.goreleaser.prerelease.yml
@@ -40,3 +40,4 @@ release:
   disable: true
 snapshot:
   name_template: "{{ .Tag }}-SNAPSHOT"
+project_name: "pulumi-vsphere"

--- a/provider-ci/providers/vsphere/repo/.goreleaser.yml
+++ b/provider-ci/providers/vsphere/repo/.goreleaser.yml
@@ -48,3 +48,4 @@ release:
   disable: false
 snapshot:
   name_template: "{{ .Tag }}-SNAPSHOT"
+project_name: "pulumi-vsphere"

--- a/provider-ci/providers/wavefront/repo/.goreleaser.prerelease.yml
+++ b/provider-ci/providers/wavefront/repo/.goreleaser.prerelease.yml
@@ -40,3 +40,4 @@ release:
   disable: true
 snapshot:
   name_template: "{{ .Tag }}-SNAPSHOT"
+project_name: "pulumi-wavefront"

--- a/provider-ci/providers/wavefront/repo/.goreleaser.yml
+++ b/provider-ci/providers/wavefront/repo/.goreleaser.yml
@@ -49,3 +49,4 @@ release:
   disable: false
 snapshot:
   name_template: "{{ .Tag }}-SNAPSHOT"
+project_name: "pulumi-wavefront"


### PR DESCRIPTION
Identified in pulumi-gcp that upgrading to GoReleaser v1.21 breaks our CI as it can't determine the project name. This PR adds this config to our gorelease.yml configs.

Passing test CI example: https://github.com/pulumi/pulumi-gcp/actions/runs/6314558946

Related: https://github.com/pulumi/pulumi-gcp/issues/1217