### PR TITLE
docker: Upgrade javaGenVersion to v0.9.7

### DIFF
--- a/provider-ci/providers/docker/config.yaml
+++ b/provider-ci/providers/docker/config.yaml
@@ -33,3 +33,4 @@ actions:
       uses: webfactory/ssh-agent@v0.7.0
       with:
         ssh-private-key: ${{ secrets.PRIVATE_SSH_KEY_FOR_DIGITALOCEAN }}
+javaGenVersion: "v0.9.7"

--- a/provider-ci/providers/docker/repo/Makefile
+++ b/provider-ci/providers/docker/repo/Makefile
@@ -9,7 +9,7 @@ TFGEN := pulumi-tfgen-$(PACK)
 PROVIDER := pulumi-resource-$(PACK)
 VERSION := $(shell pulumictl get version)
 JAVA_GEN := pulumi-java-gen
-JAVA_GEN_VERSION := v0.5.4
+JAVA_GEN_VERSION := v0.9.7
 TESTPARALLELISM := 10
 WORKING_DIR := $(shell pwd)
 


### PR DESCRIPTION
Fixes failing workflow upgrades in pulumi-docker
