### PR TITLE
Linter needs pulumictl

### DIFF
--- a/.github/workflows/lint-ecosystem-providers.yml
+++ b/.github/workflows/lint-ecosystem-providers.yml
@@ -5,6 +5,7 @@ on:
 env:
   # Ignore shell check error 1007
   SHELLCHECK_OPTS: "-e SC1007"
+  GITHUB_TOKEN: ${{ secrets.PULUMI_BOT_TOKEN }}
 jobs:
   lint:
     name: Run actionlint and shellcheck

--- a/.github/workflows/lint-ecosystem-providers.yml
+++ b/.github/workflows/lint-ecosystem-providers.yml
@@ -4,7 +4,6 @@ on:
       - master
 env:
   # Ignore shell check error 1007
-  SHELLCHECK_OPTS: "-e SC1007"
   GITHUB_TOKEN: ${{ secrets.PULUMI_BOT_TOKEN }}
 jobs:
   lint:

--- a/.github/workflows/lint-ecosystem-providers.yml
+++ b/.github/workflows/lint-ecosystem-providers.yml
@@ -9,5 +9,9 @@ jobs:
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v3
+      - name: Install pulumictl
+        uses: jaxxstorm/action-install-gh-release@v1.5.0
+        with:
+          repo: pulumi/pulumictl
       - name: lint providers
         run: cd provider-ci && make lint-providers

--- a/.github/workflows/lint-ecosystem-providers.yml
+++ b/.github/workflows/lint-ecosystem-providers.yml
@@ -2,6 +2,9 @@ on:
   pull_request:
     branches:
       - master
+env:
+  # Ignore shell check error 1007
+  SHELLCHECK_OPTS: "-e SC1007"
 jobs:
   lint:
     name: Run actionlint and shellcheck


### PR DESCRIPTION
Apparently, the shellcheck in CI is a bit stricter than locally?
