### PR TITLE
Signalfx is now at v7

### DIFF
--- a/provider-ci/providers/signalfx/config.yaml
+++ b/provider-ci/providers/signalfx/config.yaml
@@ -5,3 +5,4 @@ plugins:
   - name: aws 
     version: "4.10.0"
 team: ecosystem
+javaGenVersion: "v0.9.4"

--- a/provider-ci/providers/signalfx/config.yaml
+++ b/provider-ci/providers/signalfx/config.yaml
@@ -1,5 +1,5 @@
 provider: signalfx
-major-version: 6
+major-version: 7
 makeTemplate: bridged
 plugins:
   - name: aws 

--- a/provider-ci/providers/signalfx/repo/.goreleaser.prerelease.yml
+++ b/provider-ci/providers/signalfx/repo/.goreleaser.prerelease.yml
@@ -32,7 +32,7 @@ builds:
     - env GOOS={{ .Os }} GOARCH={{ .Arch }} go clean -modcache
   ignore: []
   ldflags:
-  - -X github.com/pulumi/pulumi-signalfx/provider/v6/pkg/version.Version={{.Tag}}
+  - -X github.com/pulumi/pulumi-signalfx/provider/v7/pkg/version.Version={{.Tag}}
   main: ./cmd/pulumi-resource-signalfx/
 changelog:
   skip: true

--- a/provider-ci/providers/signalfx/repo/.goreleaser.yml
+++ b/provider-ci/providers/signalfx/repo/.goreleaser.yml
@@ -32,7 +32,7 @@ builds:
     - env GOOS={{ .Os }} GOARCH={{ .Arch }} go clean -modcache
   ignore: []
   ldflags:
-  - -X github.com/pulumi/pulumi-signalfx/provider/v6/pkg/version.Version={{.Tag}}
+  - -X github.com/pulumi/pulumi-signalfx/provider/v7/pkg/version.Version={{.Tag}}
   main: ./cmd/pulumi-resource-signalfx/
 changelog:
   filters:

--- a/provider-ci/providers/signalfx/repo/Makefile
+++ b/provider-ci/providers/signalfx/repo/Makefile
@@ -9,7 +9,7 @@ TFGEN := pulumi-tfgen-$(PACK)
 PROVIDER := pulumi-resource-$(PACK)
 VERSION := $(shell pulumictl get version)
 JAVA_GEN := pulumi-java-gen
-JAVA_GEN_VERSION := v0.5.4
+JAVA_GEN_VERSION := v0.9.4
 TESTPARALLELISM := 10
 WORKING_DIR := $(shell pwd)
 

--- a/provider-ci/providers/signalfx/repo/Makefile
+++ b/provider-ci/providers/signalfx/repo/Makefile
@@ -3,7 +3,7 @@
 PACK := signalfx
 ORG := pulumi
 PROJECT := github.com/$(ORG)/pulumi-$(PACK)
-PROVIDER_PATH := provider/v6
+PROVIDER_PATH := provider/v7
 VERSION_PATH := $(PROVIDER_PATH)/pkg/version.Version
 TFGEN := pulumi-tfgen-$(PACK)
 PROVIDER := pulumi-resource-$(PACK)


### PR DESCRIPTION
This should unblock automated workflow updates for it.

Applied in https://github.com/pulumi/pulumi-signalfx/pull/303

This fixes https://github.com/pulumi/ci-mgmt/issues/622

I've logged https://github.com/pulumi/upgrade-provider/issues/165 - there's some kind of process/sync failure that left signalfx in this unexpected state.