### PR TITLE
Sync confluentcloud Java version with manually edited Makefile

### DIFF
--- a/provider-ci/providers/confluentcloud/config.yaml
+++ b/provider-ci/providers/confluentcloud/config.yaml
@@ -11,3 +11,4 @@ plugins:
   - name: random 
     version: "4.1.1"
 team: ecosystem
+javaGenVersion: "v0.9.5"

--- a/provider-ci/providers/confluentcloud/repo/Makefile
+++ b/provider-ci/providers/confluentcloud/repo/Makefile
@@ -9,7 +9,7 @@ TFGEN := pulumi-tfgen-$(PACK)
 PROVIDER := pulumi-resource-$(PACK)
 VERSION := $(shell pulumictl get version)
 JAVA_GEN := pulumi-java-gen
-JAVA_GEN_VERSION := v0.5.4
+JAVA_GEN_VERSION := v0.9.5
 TESTPARALLELISM := 10
 WORKING_DIR := $(shell pwd)
 


### PR DESCRIPTION
The downstream Makefile was [manually edited to this version](https://github.com/pulumi/pulumi-confluentcloud/commit/4441db356984909297342397545a5a03f6ea6002), so now ci-mgmt cannot sync with this repo as CI fails with dirty worktree.