### PR TITLE
Fix lint job

### DIFF
--- a/.github/workflows/lint-ecosystem-providers.yml
+++ b/.github/workflows/lint-ecosystem-providers.yml
@@ -2,6 +2,10 @@ on:
   pull_request:
     branches:
       - master
+env:
+  # Ignore shell check error 1007
+  #SHELLCHECK_OPTS: "-e SC1007"
+  GITHUB_TOKEN: ${{ secrets.PULUMI_BOT_TOKEN }}
 jobs:
   lint:
     name: Run actionlint and shellcheck
@@ -9,5 +13,9 @@ jobs:
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v3
+      - name: Install pulumictl
+        uses: jaxxstorm/action-install-gh-release@v1.5.0
+        with:
+          repo: pulumi/pulumictl
       - name: lint providers
         run: cd provider-ci && make lint-providers

--- a/.github/workflows/lint-ecosystem-providers.yml
+++ b/.github/workflows/lint-ecosystem-providers.yml
@@ -3,8 +3,6 @@ on:
     branches:
       - master
 env:
-  # Ignore shell check error 1007
-  #SHELLCHECK_OPTS: "-e SC1007"
   GITHUB_TOKEN: ${{ secrets.PULUMI_BOT_TOKEN }}
 jobs:
   lint:

--- a/.github/workflows/lint-ecosystem-providers.yml
+++ b/.github/workflows/lint-ecosystem-providers.yml
@@ -13,6 +13,8 @@ jobs:
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v3
+      - name: Unshallow clone for tags
+        run: git fetch --prune --unshallow --tags
       - name: Install pulumictl
         uses: jaxxstorm/action-install-gh-release@v1.5.0
         with:


### PR DESCRIPTION
Follow up on https://github.com/pulumi/ci-mgmt/pull/621 to get back to green.
We were getting a lot of lint errors when linting the bash produced by makefiles b/c pulumictl was not able to determine a version.

I added a tag to ci-mgmt, and added the steps to install pulumictl and to get a clone with tags and that seems to have been enough to get back to green. 