### PR TITLE
Enable automerge on the nightly workflow updates for native providers

### DIFF
--- a/.github/workflows/update-native-provider-workflows.yml
+++ b/.github/workflows/update-native-provider-workflows.yml
@@ -33,7 +33,7 @@ jobs:
     with:
       bridged: false
       provider_name: ${{ matrix.provider }}
-      automerge: false
+      automerge: true
       caller_workflow: update-native-provider-workflows
-      
+
 


### PR DESCRIPTION
Only aws-native (and soon kubernetes(https://github.com/pulumi/ci-mgmt/pull/634)) get these updates, but if they build successfully, we should just let the bot merge them to reduce drift 