### PR TITLE
Migrate config.yaml from ci-mgmt to the provider repo

### DIFF
--- a/.github/workflows/update-workflows.yml
+++ b/.github/workflows/update-workflows.yml
@@ -69,13 +69,21 @@ jobs:
           rm pulumi-${{ inputs.provider_name }}/.github/workflows/cleanup-artifacts.yml || echo "not found"
           rm pulumi-${{ inputs.provider_name }}/.github/workflows/pull_request.yml || echo "not found"
           rm pulumi-${{ inputs.provider_name }}/.github/workflows/master.yml || echo "not found"
+      - name: Migrate config.yaml from ci-mgmt to the host repo
+        if: inputs.bridged
+        run: |
+          if ! [ -f pulumi-${{ inputs.provider_name }}/.ci-mgmt.yaml ]; then
+          	cp ci-mgmt/provider-ci/providers/${{ inputs.provider_name }}/config.yaml pulumi-${{ inputs.provider_name }}/.ci-mgmt.yaml
+          else
+          	echo "No migration necessary"
+          fi
       - name: Generate workflow files into pulumi-${{ inputs.provider_name }}
         if: inputs.bridged
         run: |
           cd ci-mgmt/provider-ci && go run ./... generate \
           	--name pulumi/pulumi-${{ inputs.provider_name }} \
                 --template bridged-provider \
-                --config providers/${{ inputs.provider_name }}/config.yaml \
+                --config ../../pulumi-${{ inputs.provider_name }}/.ci-mgmt.yaml \
                 --out ../../pulumi-${{ inputs.provider_name }}
       - name: Copy files from ci-mgmt to pulumi-${{ inputs.provider_name }}
         if: ${{ inputs.bridged != true }}


### PR DESCRIPTION
Storing .ci-mgmt.yaml in the provider's repository will enable single PR upgrades of:
- The java version
- Major provider version
- Everything else controlled by the config file