### PR TITLE
Pin additional plugins for azuread

### DIFF
--- a/provider-ci/providers/azuread/config.yaml
+++ b/provider-ci/providers/azuread/config.yaml
@@ -10,3 +10,10 @@ env:
 makeTemplate: bridged
 team: ecosystem
 javaGenVersion: "v0.9.7"
+plugins:
+  - name: time
+    version: "0.0.15"
+  - name: std
+    version: "1.4.0"
+  - name: azure
+    version: "5.52.0"


### PR DESCRIPTION
These are observed to be auto-installed with `make tfgen`. Running a bit ahead, `azure` is only auto-installed with the new converter, but it would make sense that azuread examples depend on the azure provider.