### PR TITLE
Correct `package-ci` to `provider-ci`

### DIFF
--- a/provider-ci/go.mod
+++ b/provider-ci/go.mod
@@ -1,4 +1,4 @@
-module github.com/pulumi/ci-mgmt/package-ci
+module github.com/pulumi/ci-mgmt/provider-ci
 
 go 1.21
 

--- a/provider-ci/internal/cmd/generate.go
+++ b/provider-ci/internal/cmd/generate.go
@@ -1,7 +1,7 @@
 package cmd
 
 import (
-	"github.com/pulumi/ci-mgmt/package-ci/internal/pkg"
+	"github.com/pulumi/ci-mgmt/provider-ci/internal/pkg"
 	"github.com/spf13/cobra"
 )
 

--- a/provider-ci/internal/cmd/listTemplates.go
+++ b/provider-ci/internal/cmd/listTemplates.go
@@ -3,7 +3,7 @@ package cmd
 import (
 	"fmt"
 
-	"github.com/pulumi/ci-mgmt/package-ci/internal/pkg"
+	"github.com/pulumi/ci-mgmt/provider-ci/internal/pkg"
 	"github.com/spf13/cobra"
 	"gopkg.in/yaml.v3"
 )

--- a/provider-ci/internal/cmd/root.go
+++ b/provider-ci/internal/cmd/root.go
@@ -7,7 +7,7 @@ import (
 )
 
 var rootCmd = &cobra.Command{
-	Use:   "package-ci",
+	Use:   "provider-ci",
 	Short: "Configure CI/CD for Pulumi packages",
 	Long:  `Configures GitHub Actions workflows and Makefile targets for a Pulumi package.`,
 }

--- a/provider-ci/main.go
+++ b/provider-ci/main.go
@@ -1,6 +1,6 @@
 package main
 
-import "github.com/pulumi/ci-mgmt/package-ci/internal/cmd"
+import "github.com/pulumi/ci-mgmt/provider-ci/internal/cmd"
 
 func main() {
 	cmd.Execute()


### PR DESCRIPTION
We know this won't break anybody because it is not possible to depend on non-matching
moduling paths.