### PR TITLE
Add a convenience target to locally regenerate workflow files

### DIFF
--- a/provider-ci/Makefile
+++ b/provider-ci/Makefile
@@ -63,7 +63,7 @@ test-workflows/%: providers/%/repo
 # files for other bridged provider repositories should be ephemeral.
 test-workflow-generation: test-workflows/aws test-workflows/docker test-workflows/cloudflare
 
-providers: $(PROVIDER_REPOS)
+providers: $(PROVIDER_REPOS) test-workflow-generation
 ifeq ($(NAME), all)
 provider: providers
 else

--- a/provider-ci/internal/pkg/templates/bridged-provider/Makefile
+++ b/provider-ci/internal/pkg/templates/bridged-provider/Makefile
@@ -154,4 +154,17 @@ upstream.rebase:
 bin/pulumi-java-gen:
 	$(shell pulumictl download-binary -n pulumi-language-java -v $(JAVA_GEN_VERSION) -r pulumi/pulumi-java)
 
-.PHONY: development build build_sdks install_go_sdk install_java_sdk install_python_sdk install_sdks only_build build_dotnet build_go build_java build_nodejs build_python clean cleanup#{{ if .Config.docsCmd }}# docs#{{end}}# help install_dotnet_sdk install_nodejs_sdk install_plugins lint_provider provider test tfgen#{{ if eq .Config.team "ecosystem" }}# upstream upstream.finalize upstream.rebase#{{end}}#
+# To make an immediately observable change to .ci-mgmt.yaml:
+#
+# - Edit .ci-mgmt.yaml
+# - Run make ci-mgmt to apply the change locally.
+#
+ci-mgmt: .ci-mgmt.yaml
+	go run github.com/pulumi/ci-mgmt/provider-ci@master generate \
+		--name pulumi/pulumi-$(PACK) \
+		--out . \
+		--template bridged-provider \
+		--config $<
+
+
+.PHONY: development build build_sdks install_go_sdk install_java_sdk install_python_sdk install_sdks only_build build_dotnet build_go build_java build_nodejs build_python clean cleanup#{{ if .Config.docsCmd }}# docs#{{end}}# help install_dotnet_sdk install_nodejs_sdk install_plugins lint_provider provider test tfgen#{{ if eq .Config.team "ecosystem" }}# upstream upstream.finalize upstream.rebase#{{end}}# ci-mgmt

--- a/provider-ci/internal/pkg/templates/bridged-provider/Makefile
+++ b/provider-ci/internal/pkg/templates/bridged-provider/Makefile
@@ -160,6 +160,7 @@ bin/pulumi-java-gen:
 # - Run make ci-mgmt to apply the change locally.
 #
 ci-mgmt: .ci-mgmt.yaml
+	rm .github/workflows/*.yml # Copied from update-workflows.yml
 	go run github.com/pulumi/ci-mgmt/provider-ci@master generate \
 		--name pulumi/pulumi-$(PACK) \
 		--out . \

--- a/provider-ci/test-workflows/aws/repo/Makefile
+++ b/provider-ci/test-workflows/aws/repo/Makefile
@@ -138,4 +138,17 @@ upstream.rebase:
 bin/pulumi-java-gen:
 	$(shell pulumictl download-binary -n pulumi-language-java -v $(JAVA_GEN_VERSION) -r pulumi/pulumi-java)
 
-.PHONY: development build build_sdks install_go_sdk install_java_sdk install_python_sdk install_sdks only_build build_dotnet build_go build_java build_nodejs build_python clean cleanup help install_dotnet_sdk install_nodejs_sdk install_plugins lint_provider provider test tfgen upstream upstream.finalize upstream.rebase
+# To make an immediately observable change to .ci-mgmt.yaml:
+#
+# - Edit .ci-mgmt.yaml
+# - Run make ci-mgmt to apply the change locally.
+#
+ci-mgmt: .ci-mgmt.yaml
+	go run github.com/pulumi/ci-mgmt/provider-ci@master generate \
+		--name pulumi/pulumi-$(PACK) \
+		--out . \
+		--template bridged-provider \
+		--config $<
+
+
+.PHONY: development build build_sdks install_go_sdk install_java_sdk install_python_sdk install_sdks only_build build_dotnet build_go build_java build_nodejs build_python clean cleanup help install_dotnet_sdk install_nodejs_sdk install_plugins lint_provider provider test tfgen upstream upstream.finalize upstream.rebase ci-mgmt

--- a/provider-ci/test-workflows/aws/repo/Makefile
+++ b/provider-ci/test-workflows/aws/repo/Makefile
@@ -144,6 +144,7 @@ bin/pulumi-java-gen:
 # - Run make ci-mgmt to apply the change locally.
 #
 ci-mgmt: .ci-mgmt.yaml
+	rm .github/workflows/*.yml # Copied from update-workflows.yml
 	go run github.com/pulumi/ci-mgmt/provider-ci@master generate \
 		--name pulumi/pulumi-$(PACK) \
 		--out . \

--- a/provider-ci/test-workflows/cloudflare/repo/Makefile
+++ b/provider-ci/test-workflows/cloudflare/repo/Makefile
@@ -126,4 +126,17 @@ upstream.rebase:
 bin/pulumi-java-gen:
 	$(shell pulumictl download-binary -n pulumi-language-java -v $(JAVA_GEN_VERSION) -r pulumi/pulumi-java)
 
-.PHONY: development build build_sdks install_go_sdk install_java_sdk install_python_sdk install_sdks only_build build_dotnet build_go build_java build_nodejs build_python clean cleanup help install_dotnet_sdk install_nodejs_sdk install_plugins lint_provider provider test tfgen upstream upstream.finalize upstream.rebase
+# To make an immediately observable change to .ci-mgmt.yaml:
+#
+# - Edit .ci-mgmt.yaml
+# - Run make ci-mgmt to apply the change locally.
+#
+ci-mgmt: .ci-mgmt.yaml
+	go run github.com/pulumi/ci-mgmt/provider-ci@master generate \
+		--name pulumi/pulumi-$(PACK) \
+		--out . \
+		--template bridged-provider \
+		--config $<
+
+
+.PHONY: development build build_sdks install_go_sdk install_java_sdk install_python_sdk install_sdks only_build build_dotnet build_go build_java build_nodejs build_python clean cleanup help install_dotnet_sdk install_nodejs_sdk install_plugins lint_provider provider test tfgen upstream upstream.finalize upstream.rebase ci-mgmt

--- a/provider-ci/test-workflows/cloudflare/repo/Makefile
+++ b/provider-ci/test-workflows/cloudflare/repo/Makefile
@@ -132,6 +132,7 @@ bin/pulumi-java-gen:
 # - Run make ci-mgmt to apply the change locally.
 #
 ci-mgmt: .ci-mgmt.yaml
+	rm .github/workflows/*.yml # Copied from update-workflows.yml
 	go run github.com/pulumi/ci-mgmt/provider-ci@master generate \
 		--name pulumi/pulumi-$(PACK) \
 		--out . \

--- a/provider-ci/test-workflows/docker/repo/Makefile
+++ b/provider-ci/test-workflows/docker/repo/Makefile
@@ -128,4 +128,17 @@ upstream.rebase:
 bin/pulumi-java-gen:
 	$(shell pulumictl download-binary -n pulumi-language-java -v $(JAVA_GEN_VERSION) -r pulumi/pulumi-java)
 
-.PHONY: development build build_sdks install_go_sdk install_java_sdk install_python_sdk install_sdks only_build build_dotnet build_go build_java build_nodejs build_python clean cleanup docs help install_dotnet_sdk install_nodejs_sdk install_plugins lint_provider provider test tfgen upstream upstream.finalize upstream.rebase
+# To make an immediately observable change to .ci-mgmt.yaml:
+#
+# - Edit .ci-mgmt.yaml
+# - Run make ci-mgmt to apply the change locally.
+#
+ci-mgmt: .ci-mgmt.yaml
+	go run github.com/pulumi/ci-mgmt/provider-ci@master generate \
+		--name pulumi/pulumi-$(PACK) \
+		--out . \
+		--template bridged-provider \
+		--config $<
+
+
+.PHONY: development build build_sdks install_go_sdk install_java_sdk install_python_sdk install_sdks only_build build_dotnet build_go build_java build_nodejs build_python clean cleanup docs help install_dotnet_sdk install_nodejs_sdk install_plugins lint_provider provider test tfgen upstream upstream.finalize upstream.rebase ci-mgmt

--- a/provider-ci/test-workflows/docker/repo/Makefile
+++ b/provider-ci/test-workflows/docker/repo/Makefile
@@ -134,6 +134,7 @@ bin/pulumi-java-gen:
 # - Run make ci-mgmt to apply the change locally.
 #
 ci-mgmt: .ci-mgmt.yaml
+	rm .github/workflows/*.yml # Copied from update-workflows.yml
 	go run github.com/pulumi/ci-mgmt/provider-ci@master generate \
 		--name pulumi/pulumi-$(PACK) \
 		--out . \


### PR DESCRIPTION
This makes it easier to author PRs such as https://github.com/pulumi/pulumi-azuread/pull/490.