### PR TITLE
Allow manual upgrade-provider dispatch

### DIFF
--- a/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/upgrade-provider.yml
+++ b/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/upgrade-provider.yml
@@ -5,7 +5,7 @@ env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 jobs:
   upgrade_provider:
-    if: ${{ contains(github.event.issue.title, 'Upgrade terraform-provider-') }}
+    if: ${{ contains(github.event.issue.title, 'Upgrade terraform-provider-') || github.event_name == 'workflow_dispatch' }}
     name: upgrade-provider
     runs-on: #{{ .Config.runner.default }}#
     steps:

--- a/provider-ci/test-workflows/aws/repo/.github/workflows/upgrade-provider.yml
+++ b/provider-ci/test-workflows/aws/repo/.github/workflows/upgrade-provider.yml
@@ -5,7 +5,7 @@ env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 jobs:
   upgrade_provider:
-    if: ${{ contains(github.event.issue.title, 'Upgrade terraform-provider-') }}
+    if: ${{ contains(github.event.issue.title, 'Upgrade terraform-provider-') || github.event_name == 'workflow_dispatch' }}
     name: upgrade-provider
     runs-on: ubuntu-latest
     steps:

--- a/provider-ci/test-workflows/cloudflare/repo/.github/workflows/upgrade-provider.yml
+++ b/provider-ci/test-workflows/cloudflare/repo/.github/workflows/upgrade-provider.yml
@@ -5,7 +5,7 @@ env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 jobs:
   upgrade_provider:
-    if: ${{ contains(github.event.issue.title, 'Upgrade terraform-provider-') }}
+    if: ${{ contains(github.event.issue.title, 'Upgrade terraform-provider-') || github.event_name == 'workflow_dispatch' }}
     name: upgrade-provider
     runs-on: ubuntu-latest
     steps:

--- a/provider-ci/test-workflows/docker/repo/.github/workflows/upgrade-provider.yml
+++ b/provider-ci/test-workflows/docker/repo/.github/workflows/upgrade-provider.yml
@@ -5,7 +5,7 @@ env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 jobs:
   upgrade_provider:
-    if: ${{ contains(github.event.issue.title, 'Upgrade terraform-provider-') }}
+    if: ${{ contains(github.event.issue.title, 'Upgrade terraform-provider-') || github.event_name == 'workflow_dispatch' }}
     name: upgrade-provider
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
We currently allow upgrade-provider to be dispatched manually, but skip if the action
wasn't caused by an opened issue. This makes an exception for manual dispatch.

This was tested in pulumi-civo:
https://github.com/pulumi/pulumi-civo/actions/runs/6412620513