### PR TITLE
upgrade-provider now allows users to target java versions

### DIFF
--- a/provider-ci/internal/pkg/templates/bridged-provider/.upgrade-config.yml
+++ b/provider-ci/internal/pkg/templates/bridged-provider/.upgrade-config.yml
@@ -12,3 +12,4 @@ remove-plugins: true
 pr-reviewers: pulumi/Providers,lukehoban
 
 #{{ end -}}#
+javaVersion: "#{{ .Config.javaGenVersion }}#"

--- a/provider-ci/test-workflows/aws/.upgrade-config.yml
+++ b/provider-ci/test-workflows/aws/.upgrade-config.yml
@@ -6,3 +6,4 @@ pulumi-infer-version: true
 remove-plugins: true
 pr-reviewers: pulumi/Providers,lukehoban
 
+javaVersion: "v0.9.5"

--- a/provider-ci/test-workflows/cloudflare/.upgrade-config.yml
+++ b/provider-ci/test-workflows/cloudflare/.upgrade-config.yml
@@ -6,3 +6,4 @@ pulumi-infer-version: true
 remove-plugins: true
 pr-reviewers: pulumi/Providers,lukehoban
 
+javaVersion: "v0.9.3"

--- a/provider-ci/test-workflows/docker/.upgrade-config.yml
+++ b/provider-ci/test-workflows/docker/.upgrade-config.yml
@@ -6,3 +6,4 @@ pulumi-infer-version: true
 remove-plugins: true
 pr-reviewers: pulumi/Providers,lukehoban
 
+javaVersion: "v0.9.7"


### PR DESCRIPTION
We should specify the version we want. This is a step towards automatic java upgrades.