### PR TITLE
Allow automerge for bridge updates

### DIFF
--- a/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/upgrade-bridge.yml
+++ b/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/upgrade-bridge.yml
@@ -14,6 +14,7 @@ jobs:
         kind: bridge
         email: bot@pulumi.com
         username: pulumi-bot
+        automerge: ${{ inputs.automerge }}
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#7CFC00"
@@ -40,4 +41,10 @@ jobs:
       uses: #{{ .Config.actionVersions.slackNotification }}#
 name: Upgrade bridge
 on:
-  workflow_dispatch: {}
+  workflow_dispatch:
+    inputs:
+      automerge:
+        description: Mark created PR for auto-merging?
+        required: false
+        type: boolean
+        default: false

--- a/provider-ci/test-workflows/aws/.github/workflows/upgrade-bridge.yml
+++ b/provider-ci/test-workflows/aws/.github/workflows/upgrade-bridge.yml
@@ -14,6 +14,7 @@ jobs:
         kind: bridge
         email: bot@pulumi.com
         username: pulumi-bot
+        automerge: ${{ inputs.automerge }}
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#7CFC00"
@@ -40,4 +41,10 @@ jobs:
       uses: rtCamp/action-slack-notify@v2
 name: Upgrade bridge
 on:
-  workflow_dispatch: {}
+  workflow_dispatch:
+    inputs:
+      automerge:
+        description: Mark created PR for auto-merging?
+        required: false
+        type: boolean
+        default: false

--- a/provider-ci/test-workflows/cloudflare/.github/workflows/upgrade-bridge.yml
+++ b/provider-ci/test-workflows/cloudflare/.github/workflows/upgrade-bridge.yml
@@ -14,6 +14,7 @@ jobs:
         kind: bridge
         email: bot@pulumi.com
         username: pulumi-bot
+        automerge: ${{ inputs.automerge }}
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#7CFC00"
@@ -40,4 +41,10 @@ jobs:
       uses: rtCamp/action-slack-notify@v2
 name: Upgrade bridge
 on:
-  workflow_dispatch: {}
+  workflow_dispatch:
+    inputs:
+      automerge:
+        description: Mark created PR for auto-merging?
+        required: false
+        type: boolean
+        default: false

--- a/provider-ci/test-workflows/docker/.github/workflows/upgrade-bridge.yml
+++ b/provider-ci/test-workflows/docker/.github/workflows/upgrade-bridge.yml
@@ -14,6 +14,7 @@ jobs:
         kind: bridge
         email: bot@pulumi.com
         username: pulumi-bot
+        automerge: ${{ inputs.automerge }}
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#7CFC00"
@@ -40,4 +41,10 @@ jobs:
       uses: rtCamp/action-slack-notify@v2
 name: Upgrade bridge
 on:
-  workflow_dispatch: {}
+  workflow_dispatch:
+    inputs:
+      automerge:
+        description: Mark created PR for auto-merging?
+        required: false
+        type: boolean
+        default: false


### PR DESCRIPTION
Tested this PR and https://github.com/pulumi/ci-mgmt/tree/iwahbe/specify-identity-for-upgrade-provider on pulumi-databricks:

Automerge checked -> automerge is [workflow](https://github.com/pulumi/pulumi-databricks/actions/runs/6473730034/job/17577082331) ([PR](https://github.com/pulumi/pulumi-databricks/pull/217)).
Automerge not checked -> not auto merge is [workflow](https://github.com/pulumi/pulumi-databricks/actions/runs/6473158307/job/17575278570) ([PR](https://github.com/pulumi/pulumi-databricks/pull/216)).