### PR TITLE
Use pulumi-ubuntu-8core runner for Azure prerequisites CI step

### DIFF
--- a/provider-ci/internal/pkg/templates/bridged-provider.config.yaml
+++ b/provider-ci/internal/pkg/templates/bridged-provider.config.yaml
@@ -57,6 +57,7 @@ extraTests:
 #     ...
 runner:
   default: ubuntu-latest
+  prerequisites: ubuntu-latest
   # publish: ubuntu-latest
   # buildSdk: ubuntu-latest
 actionVersions:

--- a/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/main.yml
+++ b/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/main.yml
@@ -107,7 +107,7 @@ jobs:
       COVERAGE_OUTPUT_DIR: ${{ secrets.COVERAGE_OUTPUT_DIR }}
     name: generate_coverage_data
     needs: prerequisites
-    runs-on: #{{ .Config.runner.default }}#
+    runs-on: #{{ .Config.runner.prerequisites }}#
     steps:
     - name: Checkout Repo
       uses: #{{ .Config.actionVersions.checkout }}#

--- a/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/nightly-test.yml
+++ b/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/nightly-test.yml
@@ -100,7 +100,7 @@ jobs:
         - java
   prerequisites:
     name: prerequisites
-    runs-on: #{{ .Config.runner.default }}#
+    runs-on: #{{ .Config.runner.prerequisites }}#
     steps:
     - name: Checkout Repo
       uses: #{{ .Config.actionVersions.checkout }}#

--- a/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/prerelease.yml
+++ b/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/prerelease.yml
@@ -109,7 +109,7 @@ jobs:
   #{{ end -}}#
   prerequisites:
     name: prerequisites
-    runs-on: #{{ .Config.runner.default }}#
+    runs-on: #{{ .Config.runner.prerequisites }}#
     steps:
     - name: Checkout Repo
       uses: #{{ .Config.actionVersions.checkout }}#

--- a/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/release.yml
+++ b/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/release.yml
@@ -124,7 +124,7 @@ jobs:
   #{{ end -}}#
   prerequisites:
     name: prerequisites
-    runs-on: #{{ .Config.runner.default }}#
+    runs-on: #{{ .Config.runner.prerequisites }}#
     steps:
     - name: Checkout Repo
       uses: #{{ .Config.actionVersions.checkout }}#

--- a/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/run-acceptance-tests.yml
@@ -132,7 +132,7 @@ jobs:
     if: github.event_name == 'repository_dispatch' ||
       github.event.pull_request.head.repo.full_name == github.repository
     name: prerequisites
-    runs-on: #{{ .Config.runner.default }}#
+    runs-on: #{{ .Config.runner.prerequisites }}#
     steps:
     - name: Checkout Repo
       uses: #{{ .Config.actionVersions.checkout }}#

--- a/provider-ci/providers/azure/config.yaml
+++ b/provider-ci/providers/azure/config.yaml
@@ -28,5 +28,6 @@ team: ecosystem
 goBuildParallelism: 2
 javaGenVersion: "v0.8.0"
 runner:
+  prerequisites: pulumi-ubuntu-8core
   buildSdk: pulumi-ubuntu-8core
   publish: pulumi-ubuntu-8core


### PR DESCRIPTION
This PR adds a new parameterized runner for the `prerequisite` job of each bridged CI workflow. The default is for this runner is still `ubuntu-latest`, but `pulumi-ubuntu-8core` is used for pulumi-azure to unblock the out of disk space issue.