### PR TITLE
Fix: swap runner config for main.yaml template

### DIFF
--- a/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/main.yml
+++ b/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/main.yml
@@ -107,7 +107,7 @@ jobs:
       COVERAGE_OUTPUT_DIR: ${{ secrets.COVERAGE_OUTPUT_DIR }}
     name: generate_coverage_data
     needs: prerequisites
-    runs-on: #{{ .Config.runner.prerequisites }}#
+    runs-on: #{{ .Config.runner.default }}#
     steps:
     - name: Checkout Repo
       uses: #{{ .Config.actionVersions.checkout }}#
@@ -160,7 +160,7 @@ jobs:
   #{{ end -}}#
   prerequisites:
     name: prerequisites
-    runs-on: #{{ .Config.runner.default }}#
+    runs-on: #{{ .Config.runner.prerequisites }}#
     steps:
     - name: Checkout Repo
       uses: #{{ .Config.actionVersions.checkout }}#


### PR DESCRIPTION
#671 incorrectly used `.Config.runner.prerequisites` for the `generate_coverage_data` job. This PR fixes the template.