### PR TITLE
Auth prerequisites job to GCP to be able to run pulumi preview tests

### DIFF
--- a/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/main.yml
+++ b/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/main.yml
@@ -186,6 +186,20 @@ jobs:
       uses: #{{ .Config.actionVersions.installGhRelease }}#
       with:
         repo: pulumi/schema-tools
+    #{{- if .Config.gcp }}#
+    - name: Authenticate to Google Cloud
+      uses: #{{ .Config.actionVersions.googleAuth }}#
+      with:
+        service_account: ${{ env.GOOGLE_CI_SERVICE_ACCOUNT_EMAIL }}
+        workload_identity_provider: projects/${{ env.GOOGLE_PROJECT_NUMBER
+          }}/locations/global/workloadIdentityPools/${{
+          env.GOOGLE_CI_WORKLOAD_IDENTITY_POOL }}/providers/${{
+          env.GOOGLE_CI_WORKLOAD_IDENTITY_PROVIDER }}
+    - name: Setup gcloud auth
+      uses: #{{ .Config.actionVersions.setupGcloud }}#
+      with:
+        install_components: gke-gcloud-auth-plugin
+    #{{- end }}#
     - name: Build tfgen & provider binaries
       run: make provider
     - name: Unit-test provider code

--- a/provider-ci/test-workflows/docker/.github/workflows/master.yml
+++ b/provider-ci/test-workflows/docker/.github/workflows/master.yml
@@ -224,6 +224,18 @@ jobs:
       uses: jaxxstorm/action-install-gh-release@v1.5.0
       with:
         repo: pulumi/schema-tools
+    - name: Authenticate to Google Cloud
+      uses: google-github-actions/auth@v0
+      with:
+        service_account: ${{ env.GOOGLE_CI_SERVICE_ACCOUNT_EMAIL }}
+        workload_identity_provider: projects/${{ env.GOOGLE_PROJECT_NUMBER
+          }}/locations/global/workloadIdentityPools/${{
+          env.GOOGLE_CI_WORKLOAD_IDENTITY_POOL }}/providers/${{
+          env.GOOGLE_CI_WORKLOAD_IDENTITY_PROVIDER }}
+    - name: Setup gcloud auth
+      uses: google-github-actions/setup-gcloud@v0
+      with:
+        install_components: gke-gcloud-auth-plugin
     - name: Build tfgen & provider binaries
       run: make provider
     - name: Unit-test provider code


### PR DESCRIPTION
Fixes https://github.com/pulumi/ci-mgmt/issues/675

It looks like enabling credentials is fairly ad-hoc so I'm not sure how to solve 675 generically but we can go provider-by-provider. I will try this on GCP to see if this enables e2e fast preview-only tests in prerequisites.

