### PR TITLE
Enable actionlint for ci-mgmt's workflows

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -19,6 +19,11 @@ jobs:
           repo: pulumi/pulumictl
       - name: lint providers
         run: cd provider-ci && make lint-providers
+      - name: lint workflows
+        run: |
+          bash <(curl https://raw.githubusercontent.com/rhysd/actionlint/main/scripts/download-actionlint.bash)
+          ./actionlint -color -shellcheck=""
+        shell: bash
   test:
     name: Verify against testdata
     runs-on: ubuntu-latest

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -22,7 +22,7 @@ jobs:
       - name: lint workflows
         run: |
           bash <(curl https://raw.githubusercontent.com/rhysd/actionlint/main/scripts/download-actionlint.bash)
-          ./actionlint -color -shellcheck=""
+          ./actionlint -color
         shell: bash
   test:
     name: Verify against testdata

--- a/.github/workflows/update-bridge-all-providers.yml
+++ b/.github/workflows/update-bridge-all-providers.yml
@@ -30,7 +30,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - id: get-providers
-        run: echo "providers=$(jq . providers.json --compact-output)" >> $GITHUB_OUTPUT
+        run: echo "providers=$(jq . providers.json --compact-output)" >> "$GITHUB_OUTPUT"
         working-directory: provider-ci
     outputs:
       providers: ${{ steps.get-providers.outputs.providers }}

--- a/.github/workflows/update-bridge-all-providers.yml
+++ b/.github/workflows/update-bridge-all-providers.yml
@@ -48,7 +48,7 @@ jobs:
         provider: ${{ fromJson(needs.generate-providers-list.outputs.providers ) }}
     steps:
       - name: pulumi-${{ matrix.provider }}
-        run: gh workflow run update-bridge.yml -R pulumi/pulumi-${{ matrix.provider }} -f bridge_version=${{ github.event.inputs.bridge_version }} -f sdk_version=${{ github.event.inputs.sdk_version }} -f automerge=${{ github.events.inputs.automerge }}
+        run: gh workflow run update-bridge.yml -R pulumi/pulumi-${{ matrix.provider }} -f bridge_version=${{ github.event.inputs.bridge_version }} -f sdk_version=${{ github.event.inputs.sdk_version }} -f automerge=${{ github.event.inputs.automerge }}
       # See: https://docs.github.com/en/rest/guides/best-practices-for-integrators#dealing-with-secondary-rate-limits
       - name: Sleep to prevent hitting secondary rate limits
         run: sleep 1

--- a/.github/workflows/update-bridge-ecosystem-providers.yml
+++ b/.github/workflows/update-bridge-ecosystem-providers.yml
@@ -22,7 +22,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - id: get-providers
-        run: echo "providers=$(jq . providers.json --compact-output)" >> $GITHUB_OUTPUT
+        run: echo "providers=$(jq . providers.json --compact-output)" >> "$GITHUB_OUTPUT"
         working-directory: provider-ci
     outputs:
       providers: ${{ steps.get-providers.outputs.providers }}

--- a/.github/workflows/update-bridge-single-provider.yml
+++ b/.github/workflows/update-bridge-single-provider.yml
@@ -33,4 +33,4 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Trigger workflow on pulumi-${{ github.event.inputs.provider_name }}
-        run: gh workflow run update-bridge.yml -R pulumi/pulumi-${{ github.event.inputs.provider_name }} -f bridge_version=${{ github.event.inputs.bridge_version }} -f sdk_version=${{ github.event.inputs.sdk_version }} -f automerge=${{ github.events.inputs.automerge }}
+        run: gh workflow run update-bridge.yml -R pulumi/pulumi-${{ github.event.inputs.provider_name }} -f bridge_version=${{ github.event.inputs.bridge_version }} -f sdk_version=${{ github.event.inputs.sdk_version }} -f automerge=${{ github.event.inputs.automerge }}

--- a/.github/workflows/update-native-provider-workflows.yml
+++ b/.github/workflows/update-native-provider-workflows.yml
@@ -14,7 +14,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - id: get-providers
-        run: echo "::set-output name=providers::$(python generate_native_providers_list.py --for-auto-pr)'"
+        run: echo "providers=$(python generate_native_providers_list.py --for-auto-pr)'" >> $GITHUB_OUTPUT
         working-directory: scripts
     outputs:
       providers: ${{ steps.get-providers.outputs.providers }}

--- a/.github/workflows/update-native-provider-workflows.yml
+++ b/.github/workflows/update-native-provider-workflows.yml
@@ -14,7 +14,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - id: get-providers
-        run: echo "providers=$(python generate_native_providers_list.py --for-auto-pr)'" >> $GITHUB_OUTPUT
+        run: echo "providers=$(python generate_native_providers_list.py --for-auto-pr)'" >> "$GITHUB_OUTPUT"
         working-directory: scripts
     outputs:
       providers: ${{ steps.get-providers.outputs.providers }}

--- a/.github/workflows/update-workflows-ecosystem-providers.yml
+++ b/.github/workflows/update-workflows-ecosystem-providers.yml
@@ -24,7 +24,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - id: get-providers
-        run: echo "providers=$(jq . providers.json --compact-output)" >> $GITHUB_OUTPUT
+        run: echo "providers=$(jq . providers.json --compact-output)" >> "$GITHUB_OUTPUT"
         working-directory: provider-ci
     outputs:
       providers: ${{ steps.get-providers.outputs.providers }}

--- a/.github/workflows/update-workflows.yml
+++ b/.github/workflows/update-workflows.yml
@@ -15,11 +15,9 @@ on:
         description: "Mark created PRs for auto-merging?"
         required: true
         type: boolean
-        default: false
       bridged:
         description: "Whether the provider is bridged or native"
         type: boolean
-        default: false
         required: true
 
 env:


### PR DESCRIPTION
We use actionlint to check our generated actions, but we don't employ it for our hand-written actions. This PR applies actionlint to the workflows used by this repo.