### PR TITLE
Permit x-repo triggers

### DIFF
--- a/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/upgrade-bridge.yml
+++ b/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/upgrade-bridge.yml
@@ -2,9 +2,10 @@
 
 name: Upgrade bridge
 on:
-  workflow_dispatch:
+  repository_dispatch:
     types:
       - upgrade-bridge
+  workflow_dispatch:
     inputs:
       target-bridge-version:
         description: pulumi-terraform-bridge version or hash reference
@@ -35,6 +36,7 @@ jobs:
     runs-on: #{{ if .Config.runner.buildSdk }}##{{- .Config.runner.buildSdk }}##{{ else }}##{{- .Config.runner.default }}##{{ end }}#
     steps:
     - name: Call upgrade provider action
+      if: github.event_name == 'workflow_dispatch'
       uses: #{{ .Config.actionVersions.upgradeProviderAction }}#
       with:
         kind: bridge
@@ -44,6 +46,17 @@ jobs:
         target-bridge-version: ${{ inputs.target-bridge-version }}
         pr-reviewers: ${{ inputs.pr-reviewers }}
         pr-description: ${{ inputs.pr-description }}
+    - name: Call upgrade provider action
+      if: github.event_name == 'repository_dispatch'
+      uses: #{{ .Config.actionVersions.upgradeProviderAction }}#
+      with:
+        kind: bridge
+        email: bot@pulumi.com
+        username: pulumi-bot
+        automerge: ${{ github.event.client_payload.automerge }}
+        target-bridge-version: ${{ github.event.client_payload.target-bridge-version }}
+        pr-reviewers: ${{ github.event.client_payload.pr-reviewers }}
+        pr-description: ${{ github.event.client_payload.pr-description }}
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#7CFC00"

--- a/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/upgrade-bridge.yml
+++ b/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/upgrade-bridge.yml
@@ -3,6 +3,8 @@
 name: Upgrade bridge
 on:
   workflow_dispatch:
+    types:
+      - upgrade-bridge
     inputs:
       target-bridge-version:
         description: pulumi-terraform-bridge version or hash reference

--- a/provider-ci/test-workflows/aws/.github/workflows/upgrade-bridge.yml
+++ b/provider-ci/test-workflows/aws/.github/workflows/upgrade-bridge.yml
@@ -2,6 +2,9 @@
 
 name: Upgrade bridge
 on:
+  repository_dispatch:
+    types:
+      - upgrade-bridge
   workflow_dispatch:
     inputs:
       target-bridge-version:
@@ -33,6 +36,7 @@ jobs:
     runs-on: pulumi-ubuntu-8core
     steps:
     - name: Call upgrade provider action
+      if: github.event_name == 'workflow_dispatch'
       uses: pulumi/pulumi-upgrade-provider-action@v0.0.9
       with:
         kind: bridge
@@ -42,6 +46,17 @@ jobs:
         target-bridge-version: ${{ inputs.target-bridge-version }}
         pr-reviewers: ${{ inputs.pr-reviewers }}
         pr-description: ${{ inputs.pr-description }}
+    - name: Call upgrade provider action
+      if: github.event_name == 'repository_dispatch'
+      uses: pulumi/pulumi-upgrade-provider-action@v0.0.9
+      with:
+        kind: bridge
+        email: bot@pulumi.com
+        username: pulumi-bot
+        automerge: ${{ github.event.client_payload.automerge }}
+        target-bridge-version: ${{ github.event.client_payload.target-bridge-version }}
+        pr-reviewers: ${{ github.event.client_payload.pr-reviewers }}
+        pr-description: ${{ github.event.client_payload.pr-description }}
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#7CFC00"

--- a/provider-ci/test-workflows/cloudflare/.github/workflows/upgrade-bridge.yml
+++ b/provider-ci/test-workflows/cloudflare/.github/workflows/upgrade-bridge.yml
@@ -2,6 +2,9 @@
 
 name: Upgrade bridge
 on:
+  repository_dispatch:
+    types:
+      - upgrade-bridge
   workflow_dispatch:
     inputs:
       target-bridge-version:
@@ -33,6 +36,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Call upgrade provider action
+      if: github.event_name == 'workflow_dispatch'
       uses: pulumi/pulumi-upgrade-provider-action@v0.0.9
       with:
         kind: bridge
@@ -42,6 +46,17 @@ jobs:
         target-bridge-version: ${{ inputs.target-bridge-version }}
         pr-reviewers: ${{ inputs.pr-reviewers }}
         pr-description: ${{ inputs.pr-description }}
+    - name: Call upgrade provider action
+      if: github.event_name == 'repository_dispatch'
+      uses: pulumi/pulumi-upgrade-provider-action@v0.0.9
+      with:
+        kind: bridge
+        email: bot@pulumi.com
+        username: pulumi-bot
+        automerge: ${{ github.event.client_payload.automerge }}
+        target-bridge-version: ${{ github.event.client_payload.target-bridge-version }}
+        pr-reviewers: ${{ github.event.client_payload.pr-reviewers }}
+        pr-description: ${{ github.event.client_payload.pr-description }}
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#7CFC00"

--- a/provider-ci/test-workflows/docker/.github/workflows/upgrade-bridge.yml
+++ b/provider-ci/test-workflows/docker/.github/workflows/upgrade-bridge.yml
@@ -2,6 +2,9 @@
 
 name: Upgrade bridge
 on:
+  repository_dispatch:
+    types:
+      - upgrade-bridge
   workflow_dispatch:
     inputs:
       target-bridge-version:
@@ -33,6 +36,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Call upgrade provider action
+      if: github.event_name == 'workflow_dispatch'
       uses: pulumi/pulumi-upgrade-provider-action@v0.0.9
       with:
         kind: bridge
@@ -42,6 +46,17 @@ jobs:
         target-bridge-version: ${{ inputs.target-bridge-version }}
         pr-reviewers: ${{ inputs.pr-reviewers }}
         pr-description: ${{ inputs.pr-description }}
+    - name: Call upgrade provider action
+      if: github.event_name == 'repository_dispatch'
+      uses: pulumi/pulumi-upgrade-provider-action@v0.0.9
+      with:
+        kind: bridge
+        email: bot@pulumi.com
+        username: pulumi-bot
+        automerge: ${{ github.event.client_payload.automerge }}
+        target-bridge-version: ${{ github.event.client_payload.target-bridge-version }}
+        pr-reviewers: ${{ github.event.client_payload.pr-reviewers }}
+        pr-description: ${{ github.event.client_payload.pr-description }}
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#7CFC00"


### PR DESCRIPTION
When testing cross-repo dispatch where an action in pulumi-terraform-bridge is supposed to call and start an action in pulumi-aiven, I noticed that the dispatch event is quietly being lost. I think the piece edited here is the missing configuration to get this working.

This is now tested per https://github.com/pulumi/pulumi-terraform-bridge/pull/1442 and aiven. 