### PR TITLE
Remove aws's Check (mirroring pulumi-aws)

### DIFF
--- a/provider-ci/internal/pkg/templates/bridged-provider/Makefile
+++ b/provider-ci/internal/pkg/templates/bridged-provider/Makefile
@@ -147,8 +147,6 @@ endif
 	cd upstream-tools && yarn install --frozen-lockfile
 	# Apply all automated changes
 	cd upstream-tools && yarn --silent run apply
-	# Check for any pending replacements
-	cd upstream-tools && yarn --silent run check
 
 #{{- end }}#
 

--- a/provider-ci/test-workflows/aws/Makefile
+++ b/provider-ci/test-workflows/aws/Makefile
@@ -132,8 +132,6 @@ endif
 	cd upstream-tools && yarn install --frozen-lockfile
 	# Apply all automated changes
 	cd upstream-tools && yarn --silent run apply
-	# Check for any pending replacements
-	cd upstream-tools && yarn --silent run check
 
 upstream.finalize:
 	@$(SHELL) ./scripts/upstream.sh "$@" end_rebase


### PR DESCRIPTION
Check adds TODOs to `replacements.json`. As of https://github.com/pulumi/pulumi-aws/pull/2886, it no longer works, since the `replacements.json` file has moved.