### PR TITLE
Remove pulumi/Providers,lukehuban; add iwahbe as upgrade reviewer

### DIFF
--- a/provider-ci/internal/pkg/templates/bridged-provider/.upgrade-config.yml
+++ b/provider-ci/internal/pkg/templates/bridged-provider/.upgrade-config.yml
@@ -8,5 +8,5 @@ upstream-provider-name: terraform-provider-#{{ .Config.provider }}#
 #{{- end }}#
 pulumi-infer-version: true
 remove-plugins: true
-pr-reviewers: pulumi/Providers,lukehoban
+pr-reviewers: iwahbe # Team: pulumi/Providers
 javaVersion: "#{{ .Config.javaGenVersion }}#"

--- a/provider-ci/test-workflows/aws/.upgrade-config.yml
+++ b/provider-ci/test-workflows/aws/.upgrade-config.yml
@@ -4,5 +4,5 @@
 upstream-provider-name: terraform-provider-aws
 pulumi-infer-version: true
 remove-plugins: true
-pr-reviewers: pulumi/Providers,lukehoban
+pr-reviewers: iwahbe # Team: pulumi/Providers
 javaVersion: "v0.9.5"

--- a/provider-ci/test-workflows/cloudflare/.upgrade-config.yml
+++ b/provider-ci/test-workflows/cloudflare/.upgrade-config.yml
@@ -4,5 +4,5 @@
 upstream-provider-name: terraform-provider-cloudflare
 pulumi-infer-version: true
 remove-plugins: true
-pr-reviewers: pulumi/Providers,lukehoban
+pr-reviewers: iwahbe # Team: pulumi/Providers
 javaVersion: "v0.9.3"

--- a/provider-ci/test-workflows/docker/.upgrade-config.yml
+++ b/provider-ci/test-workflows/docker/.upgrade-config.yml
@@ -4,5 +4,5 @@
 upstream-provider-name: terraform-provider-docker
 pulumi-infer-version: true
 remove-plugins: true
-pr-reviewers: pulumi/Providers,lukehoban
+pr-reviewers: iwahbe # Team: pulumi/Providers
 javaVersion: "v0.9.7"


### PR DESCRIPTION
As of #705, Luke no longer needs to perform BUSL checks on upgrade PRs. This removes him from notifications.

Since I am temporarily running updates, I thought the team would appreciate not getting pinged on PRs that they don't need to address.