### PR TITLE
Add devbox config to providers

### DIFF
--- a/provider-ci/internal/pkg/templates/bridged-provider.config.yaml
+++ b/provider-ci/internal/pkg/templates/bridged-provider.config.yaml
@@ -15,6 +15,7 @@ env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   GOVERSION: 1.21.x
   JAVAVERSION: "11"
+  GRADLEVERSION: "7.6"
   NODEVERSION: 20.x
   NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
   NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/provider-ci/internal/pkg/templates/bridged-provider/.devcontainer/Dockerfile
+++ b/provider-ci/internal/pkg/templates/bridged-provider/.devcontainer/Dockerfile
@@ -1,0 +1,12 @@
+FROM jetpackio/devbox:latest
+
+# Installing your devbox project
+WORKDIR /code
+COPY devbox.json devbox.json
+COPY devbox.lock devbox.lock
+RUN sudo chown -R "${DEVBOX_USER}:${DEVBOX_USER}" /code
+
+
+RUN devbox run -- echo "Installed Packages."
+
+RUN devbox shellenv --init-hook >> ~/.profile

--- a/provider-ci/internal/pkg/templates/bridged-provider/.devcontainer/devcontainer.json
+++ b/provider-ci/internal/pkg/templates/bridged-provider/.devcontainer/devcontainer.json
@@ -1,0 +1,16 @@
+{
+  "name": "Devbox Remote Container",
+  "build": {
+    "dockerfile": "./Dockerfile",
+    "context": ".."
+  },
+  "customizations": {
+    "vscode": {
+      "settings": {},
+      "extensions": [
+        "jetpack-io.devbox"
+      ]
+    }
+  },
+  "remoteUser": "devbox"
+}

--- a/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/main.yml
+++ b/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/main.yml
@@ -54,7 +54,7 @@ jobs:
     - name: Setup Gradle
       uses: #{{ .Config.actionVersions.setupGradle }}#
       with:
-        gradle-version: "7.6"
+        gradle-version: ${{ env.GRADLEVERSION }}
     - name: Download provider + tfgen binaries
       uses: #{{ .Config.actionVersions.downloadArtifact }}#
       with:
@@ -301,7 +301,7 @@ jobs:
     - name: Setup Gradle
       uses: #{{ .Config.actionVersions.setupGradle }}#
       with:
-        gradle-version: "7.6"
+        gradle-version: ${{ env.GRADLEVERSION }}
     - name: Download provider + tfgen binaries
       uses: #{{ .Config.actionVersions.downloadArtifact }}#
       with:

--- a/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/nightly-test.yml
+++ b/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/nightly-test.yml
@@ -51,7 +51,7 @@ jobs:
     - name: Setup Gradle
       uses: #{{ .Config.actionVersions.setupGradle }}#
       with:
-        gradle-version: "7.6"
+        gradle-version: ${{ env.GRADLEVERSION }}
     - name: Download provider + tfgen binaries
       uses: #{{ .Config.actionVersions.downloadArtifact }}#
       with:
@@ -152,7 +152,7 @@ jobs:
     - name: Setup Gradle
       uses: #{{ .Config.actionVersions.setupGradle }}#
       with:
-        gradle-version: "7.6"
+        gradle-version: ${{ env.GRADLEVERSION }}
     - name: Download provider + tfgen binaries
       uses: #{{ .Config.actionVersions.downloadArtifact }}#
       with:

--- a/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/prerelease.yml
+++ b/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/prerelease.yml
@@ -55,7 +55,7 @@ jobs:
     - name: Setup Gradle
       uses: #{{ .Config.actionVersions.setupGradle }}#
       with:
-        gradle-version: "7.6"
+        gradle-version: ${{ env.GRADLEVERSION }}
     - name: Download provider + tfgen binaries
       uses: #{{ .Config.actionVersions.downloadArtifact }}#
       with:
@@ -232,7 +232,7 @@ jobs:
     - name: Setup Gradle
       uses: #{{ .Config.actionVersions.setupGradle }}#
       with:
-        gradle-version: "7.6"
+        gradle-version: ${{ env.GRADLEVERSION }}
     - name: Download provider + tfgen binaries
       uses: #{{ .Config.actionVersions.downloadArtifact }}#
       with:

--- a/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/release.yml
+++ b/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/release.yml
@@ -54,7 +54,7 @@ jobs:
     - name: Setup Gradle
       uses: #{{ .Config.actionVersions.setupGradle }}#
       with:
-        gradle-version: "7.6"
+        gradle-version: ${{ env.GRADLEVERSION }}
     - name: Download provider + tfgen binaries
       uses: #{{ .Config.actionVersions.downloadArtifact }}#
       with:
@@ -287,7 +287,7 @@ jobs:
     - name: Setup Gradle
       uses: #{{ .Config.actionVersions.setupGradle }}#
       with:
-        gradle-version: "7.6"
+        gradle-version: ${{ env.GRADLEVERSION }}
     - name: Download provider + tfgen binaries
       uses: #{{ .Config.actionVersions.downloadArtifact }}#
       with:

--- a/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/run-acceptance-tests.yml
@@ -58,7 +58,7 @@ jobs:
     - name: Setup Gradle
       uses: #{{ .Config.actionVersions.setupGradle }}#
       with:
-        gradle-version: "7.6"
+        gradle-version: ${{ env.GRADLEVERSION }}
     - name: Download provider + tfgen binaries
       uses: #{{ .Config.actionVersions.downloadArtifact }}#
       with:
@@ -148,17 +148,17 @@ jobs:
     #
     # GitHub documents `jobs.result` as:
     #
-    #	The result of a job in the reusable workflow. Possible values are success,
-    #	failure, cancelled, or skipped.
+    # The result of a job in the reusable workflow. Possible values are success,
+    # failure, cancelled, or skipped.
     #
     # GitHub documents `cancelled()` as:
     #
-    #	Returns true if the workflow was canceled.
+    # Returns true if the workflow was canceled.
     #
     # Combining these terms gives us an intuitive definition of success:
     #
-    #	We have succeeded when no dependent workflow has failed and the job was
-    #	not cancelled.
+    # We have succeeded when no dependent workflow has failed and the job was
+    # not cancelled.
     #
     if: (github.event_name == 'repository_dispatch' ||
       github.event.pull_request.head.repo.full_name == github.repository) &&
@@ -231,7 +231,7 @@ jobs:
     - name: Setup Gradle
       uses: #{{ .Config.actionVersions.setupGradle }}#
       with:
-        gradle-version: "7.6"
+        gradle-version: ${{ env.GRADLEVERSION }}
     - name: Download provider + tfgen binaries
       uses: #{{ .Config.actionVersions.downloadArtifact }}#
       with:

--- a/provider-ci/internal/pkg/templates/bridged-provider/devbox.json
+++ b/provider-ci/internal/pkg/templates/bridged-provider/devbox.json
@@ -1,0 +1,22 @@
+{
+  "packages": [
+    #{{- range .Config.nixpkgs }}#
+      "#{{ .name }}#@#{{ .version }}#",
+    #{{- end }}#
+    "go@#{{ trimAll "x" .Config.env.GOVERSION }}#",
+    "nodejs@#{{ trimAll "x" .Config.env.NODEVERSION }}#",
+    "python3@#{{ trimAll "x" .Config.env.PYTHONVERSION }}#",
+    "dotnet-sdk@#{{ splitList "\n" .Config.env.DOTNETVERSION | first | trimAll "x"  }}#",
+    "gradle_7@#{{ trimAll "x" .Config.env.GRADLEVERSION }}#"
+  ],
+  "shell": {
+    "init_hook": [
+      "export PATH=\"$(pwd)/bin/:$PATH\""
+    ],
+    "scripts": {
+      "test": [
+        "echo \"Error: no test specified\" && exit 1"
+      ]
+    }
+  }
+}

--- a/provider-ci/providers/aws/config.yaml
+++ b/provider-ci/providers/aws/config.yaml
@@ -13,6 +13,9 @@ checkoutSubmodules: true
 # TODO: remove XrunUpstreamTools flag after work to add docs replacement strategies to resources.go is completed
 # Tracked in in https://github.com/pulumi/pulumi-aws/issues/2757
 XrunUpstreamTools: true
+nixpkgs:
+  - name: awscli2
+    version: latest
 plugins:
   - name: archive
     version: "0.0.1"

--- a/provider-ci/test-workflows/aws/.devcontainer/Dockerfile
+++ b/provider-ci/test-workflows/aws/.devcontainer/Dockerfile
@@ -1,0 +1,12 @@
+FROM jetpackio/devbox:latest
+
+# Installing your devbox project
+WORKDIR /code
+COPY devbox.json devbox.json
+COPY devbox.lock devbox.lock
+RUN sudo chown -R "${DEVBOX_USER}:${DEVBOX_USER}" /code
+
+
+RUN devbox run -- echo "Installed Packages."
+
+RUN devbox shellenv --init-hook >> ~/.profile

--- a/provider-ci/test-workflows/aws/.devcontainer/devcontainer.json
+++ b/provider-ci/test-workflows/aws/.devcontainer/devcontainer.json
@@ -1,0 +1,16 @@
+{
+  "name": "Devbox Remote Container",
+  "build": {
+    "dockerfile": "./Dockerfile",
+    "context": ".."
+  },
+  "customizations": {
+    "vscode": {
+      "settings": {},
+      "extensions": [
+        "jetpack-io.devbox"
+      ]
+    }
+  },
+  "remoteUser": "devbox"
+}

--- a/provider-ci/test-workflows/aws/.github/workflows/command-dispatch.yml
+++ b/provider-ci/test-workflows/aws/.github/workflows/command-dispatch.yml
@@ -8,6 +8,7 @@ env:
       3.1.301
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   GOVERSION: 1.21.x
+  GRADLEVERSION: "7.6"
   JAVAVERSION: "11"
   NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
   NODEVERSION: 20.x

--- a/provider-ci/test-workflows/aws/.github/workflows/license.yml
+++ b/provider-ci/test-workflows/aws/.github/workflows/license.yml
@@ -14,6 +14,7 @@ env:
       3.1.301
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   GOVERSION: 1.21.x
+  GRADLEVERSION: "7.6"
   JAVAVERSION: "11"
   NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
   NODEVERSION: 20.x

--- a/provider-ci/test-workflows/aws/.github/workflows/lint.yml
+++ b/provider-ci/test-workflows/aws/.github/workflows/lint.yml
@@ -13,6 +13,7 @@ env:
       3.1.301
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   GOVERSION: 1.21.x
+  GRADLEVERSION: "7.6"
   JAVAVERSION: "11"
   NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
   NODEVERSION: 20.x

--- a/provider-ci/test-workflows/aws/.github/workflows/master.yml
+++ b/provider-ci/test-workflows/aws/.github/workflows/master.yml
@@ -8,6 +8,7 @@ env:
       3.1.301
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   GOVERSION: 1.21.x
+  GRADLEVERSION: "7.6"
   JAVAVERSION: "11"
   NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
   NODEVERSION: 20.x
@@ -81,7 +82,7 @@ jobs:
     - name: Setup Gradle
       uses: gradle/gradle-build-action@v2
       with:
-        gradle-version: "7.6"
+        gradle-version: ${{ env.GRADLEVERSION }}
     - name: Download provider + tfgen binaries
       uses: actions/download-artifact@v2
       with:
@@ -423,7 +424,7 @@ jobs:
     - name: Setup Gradle
       uses: gradle/gradle-build-action@v2
       with:
-        gradle-version: "7.6"
+        gradle-version: ${{ env.GRADLEVERSION }}
     - name: Download provider + tfgen binaries
       uses: actions/download-artifact@v2
       with:

--- a/provider-ci/test-workflows/aws/.github/workflows/nightly-test.yml
+++ b/provider-ci/test-workflows/aws/.github/workflows/nightly-test.yml
@@ -8,6 +8,7 @@ env:
       3.1.301
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   GOVERSION: 1.21.x
+  GRADLEVERSION: "7.6"
   JAVAVERSION: "11"
   NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
   NODEVERSION: 20.x
@@ -81,7 +82,7 @@ jobs:
     - name: Setup Gradle
       uses: gradle/gradle-build-action@v2
       with:
-        gradle-version: "7.6"
+        gradle-version: ${{ env.GRADLEVERSION }}
     - name: Download provider + tfgen binaries
       uses: actions/download-artifact@v2
       with:
@@ -274,7 +275,7 @@ jobs:
     - name: Setup Gradle
       uses: gradle/gradle-build-action@v2
       with:
-        gradle-version: "7.6"
+        gradle-version: ${{ env.GRADLEVERSION }}
     - name: Download provider + tfgen binaries
       uses: actions/download-artifact@v2
       with:

--- a/provider-ci/test-workflows/aws/.github/workflows/prerelease.yml
+++ b/provider-ci/test-workflows/aws/.github/workflows/prerelease.yml
@@ -9,6 +9,7 @@ env:
       3.1.301
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   GOVERSION: 1.21.x
+  GRADLEVERSION: "7.6"
   JAVAVERSION: "11"
   NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
   NODEVERSION: 20.x
@@ -82,7 +83,7 @@ jobs:
     - name: Setup Gradle
       uses: gradle/gradle-build-action@v2
       with:
-        gradle-version: "7.6"
+        gradle-version: ${{ env.GRADLEVERSION }}
     - name: Download provider + tfgen binaries
       uses: actions/download-artifact@v2
       with:
@@ -348,7 +349,7 @@ jobs:
     - name: Setup Gradle
       uses: gradle/gradle-build-action@v2
       with:
-        gradle-version: "7.6"
+        gradle-version: ${{ env.GRADLEVERSION }}
     - name: Download provider + tfgen binaries
       uses: actions/download-artifact@v2
       with:

--- a/provider-ci/test-workflows/aws/.github/workflows/pull-request.yml
+++ b/provider-ci/test-workflows/aws/.github/workflows/pull-request.yml
@@ -8,6 +8,7 @@ env:
       3.1.301
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   GOVERSION: 1.21.x
+  GRADLEVERSION: "7.6"
   JAVAVERSION: "11"
   NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
   NODEVERSION: 20.x

--- a/provider-ci/test-workflows/aws/.github/workflows/release.yml
+++ b/provider-ci/test-workflows/aws/.github/workflows/release.yml
@@ -8,6 +8,7 @@ env:
       3.1.301
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   GOVERSION: 1.21.x
+  GRADLEVERSION: "7.6"
   JAVAVERSION: "11"
   NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
   NODEVERSION: 20.x
@@ -81,7 +82,7 @@ jobs:
     - name: Setup Gradle
       uses: gradle/gradle-build-action@v2
       with:
-        gradle-version: "7.6"
+        gradle-version: ${{ env.GRADLEVERSION }}
     - name: Download provider + tfgen binaries
       uses: actions/download-artifact@v2
       with:
@@ -396,7 +397,7 @@ jobs:
     - name: Setup Gradle
       uses: gradle/gradle-build-action@v2
       with:
-        gradle-version: "7.6"
+        gradle-version: ${{ env.GRADLEVERSION }}
     - name: Download provider + tfgen binaries
       uses: actions/download-artifact@v2
       with:

--- a/provider-ci/test-workflows/aws/.github/workflows/resync-build.yml
+++ b/provider-ci/test-workflows/aws/.github/workflows/resync-build.yml
@@ -10,6 +10,7 @@ env:
       3.1.301
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   GOVERSION: 1.21.x
+  GRADLEVERSION: "7.6"
   JAVAVERSION: "11"
   NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
   NODEVERSION: 20.x

--- a/provider-ci/test-workflows/aws/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/test-workflows/aws/.github/workflows/run-acceptance-tests.yml
@@ -9,6 +9,7 @@ env:
       3.1.301
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   GOVERSION: 1.21.x
+  GRADLEVERSION: "7.6"
   JAVAVERSION: "11"
   NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
   NODEVERSION: 20.x
@@ -85,7 +86,7 @@ jobs:
     - name: Setup Gradle
       uses: gradle/gradle-build-action@v2
       with:
-        gradle-version: "7.6"
+        gradle-version: ${{ env.GRADLEVERSION }}
     - name: Download provider + tfgen binaries
       uses: actions/download-artifact@v2
       with:
@@ -252,17 +253,17 @@ jobs:
     #
     # GitHub documents `jobs.result` as:
     #
-    #	The result of a job in the reusable workflow. Possible values are success,
-    #	failure, cancelled, or skipped.
+    # The result of a job in the reusable workflow. Possible values are success,
+    # failure, cancelled, or skipped.
     #
     # GitHub documents `cancelled()` as:
     #
-    #	Returns true if the workflow was canceled.
+    # Returns true if the workflow was canceled.
     #
     # Combining these terms gives us an intuitive definition of success:
     #
-    #	We have succeeded when no dependent workflow has failed and the job was
-    #	not cancelled.
+    # We have succeeded when no dependent workflow has failed and the job was
+    # not cancelled.
     #
     if: (github.event_name == 'repository_dispatch' ||
       github.event.pull_request.head.repo.full_name == github.repository) &&
@@ -336,7 +337,7 @@ jobs:
     - name: Setup Gradle
       uses: gradle/gradle-build-action@v2
       with:
-        gradle-version: "7.6"
+        gradle-version: ${{ env.GRADLEVERSION }}
     - name: Download provider + tfgen binaries
       uses: actions/download-artifact@v2
       with:

--- a/provider-ci/test-workflows/aws/devbox.json
+++ b/provider-ci/test-workflows/aws/devbox.json
@@ -1,0 +1,20 @@
+{
+  "packages": [
+      "awscli2@latest",
+    "go@1.21.",
+    "nodejs@20.",
+    "python3@3.9",
+    "dotnet-sdk@6.0.",
+    "gradle_7@7.6"
+  ],
+  "shell": {
+    "init_hook": [
+      "export PATH=\"$(pwd)/bin/:$PATH\""
+    ],
+    "scripts": {
+      "test": [
+        "echo \"Error: no test specified\" && exit 1"
+      ]
+    }
+  }
+}

--- a/provider-ci/test-workflows/cloudflare/.devcontainer/Dockerfile
+++ b/provider-ci/test-workflows/cloudflare/.devcontainer/Dockerfile
@@ -1,0 +1,12 @@
+FROM jetpackio/devbox:latest
+
+# Installing your devbox project
+WORKDIR /code
+COPY devbox.json devbox.json
+COPY devbox.lock devbox.lock
+RUN sudo chown -R "${DEVBOX_USER}:${DEVBOX_USER}" /code
+
+
+RUN devbox run -- echo "Installed Packages."
+
+RUN devbox shellenv --init-hook >> ~/.profile

--- a/provider-ci/test-workflows/cloudflare/.devcontainer/devcontainer.json
+++ b/provider-ci/test-workflows/cloudflare/.devcontainer/devcontainer.json
@@ -1,0 +1,16 @@
+{
+  "name": "Devbox Remote Container",
+  "build": {
+    "dockerfile": "./Dockerfile",
+    "context": ".."
+  },
+  "customizations": {
+    "vscode": {
+      "settings": {},
+      "extensions": [
+        "jetpack-io.devbox"
+      ]
+    }
+  },
+  "remoteUser": "devbox"
+}

--- a/provider-ci/test-workflows/cloudflare/.github/workflows/command-dispatch.yml
+++ b/provider-ci/test-workflows/cloudflare/.github/workflows/command-dispatch.yml
@@ -9,6 +9,7 @@ env:
       3.1.301
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   GOVERSION: 1.21.x
+  GRADLEVERSION: "7.6"
   JAVAVERSION: "11"
   NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
   NODEVERSION: 20.x

--- a/provider-ci/test-workflows/cloudflare/.github/workflows/license.yml
+++ b/provider-ci/test-workflows/cloudflare/.github/workflows/license.yml
@@ -15,6 +15,7 @@ env:
       3.1.301
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   GOVERSION: 1.21.x
+  GRADLEVERSION: "7.6"
   JAVAVERSION: "11"
   NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
   NODEVERSION: 20.x

--- a/provider-ci/test-workflows/cloudflare/.github/workflows/lint.yml
+++ b/provider-ci/test-workflows/cloudflare/.github/workflows/lint.yml
@@ -14,6 +14,7 @@ env:
       3.1.301
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   GOVERSION: 1.21.x
+  GRADLEVERSION: "7.6"
   JAVAVERSION: "11"
   NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
   NODEVERSION: 20.x

--- a/provider-ci/test-workflows/cloudflare/.github/workflows/master.yml
+++ b/provider-ci/test-workflows/cloudflare/.github/workflows/master.yml
@@ -9,6 +9,7 @@ env:
       3.1.301
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   GOVERSION: 1.21.x
+  GRADLEVERSION: "7.6"
   JAVAVERSION: "11"
   NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
   NODEVERSION: 20.x
@@ -77,7 +78,7 @@ jobs:
     - name: Setup Gradle
       uses: gradle/gradle-build-action@v2
       with:
-        gradle-version: "7.6"
+        gradle-version: ${{ env.GRADLEVERSION }}
     - name: Download provider + tfgen binaries
       uses: actions/download-artifact@v2
       with:
@@ -397,7 +398,7 @@ jobs:
     - name: Setup Gradle
       uses: gradle/gradle-build-action@v2
       with:
-        gradle-version: "7.6"
+        gradle-version: ${{ env.GRADLEVERSION }}
     - name: Download provider + tfgen binaries
       uses: actions/download-artifact@v2
       with:

--- a/provider-ci/test-workflows/cloudflare/.github/workflows/prerelease.yml
+++ b/provider-ci/test-workflows/cloudflare/.github/workflows/prerelease.yml
@@ -10,6 +10,7 @@ env:
       3.1.301
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   GOVERSION: 1.21.x
+  GRADLEVERSION: "7.6"
   JAVAVERSION: "11"
   NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
   NODEVERSION: 20.x
@@ -78,7 +79,7 @@ jobs:
     - name: Setup Gradle
       uses: gradle/gradle-build-action@v2
       with:
-        gradle-version: "7.6"
+        gradle-version: ${{ env.GRADLEVERSION }}
     - name: Download provider + tfgen binaries
       uses: actions/download-artifact@v2
       with:
@@ -326,7 +327,7 @@ jobs:
     - name: Setup Gradle
       uses: gradle/gradle-build-action@v2
       with:
-        gradle-version: "7.6"
+        gradle-version: ${{ env.GRADLEVERSION }}
     - name: Download provider + tfgen binaries
       uses: actions/download-artifact@v2
       with:

--- a/provider-ci/test-workflows/cloudflare/.github/workflows/pull-request.yml
+++ b/provider-ci/test-workflows/cloudflare/.github/workflows/pull-request.yml
@@ -9,6 +9,7 @@ env:
       3.1.301
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   GOVERSION: 1.21.x
+  GRADLEVERSION: "7.6"
   JAVAVERSION: "11"
   NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
   NODEVERSION: 20.x

--- a/provider-ci/test-workflows/cloudflare/.github/workflows/release.yml
+++ b/provider-ci/test-workflows/cloudflare/.github/workflows/release.yml
@@ -9,6 +9,7 @@ env:
       3.1.301
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   GOVERSION: 1.21.x
+  GRADLEVERSION: "7.6"
   JAVAVERSION: "11"
   NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
   NODEVERSION: 20.x
@@ -77,7 +78,7 @@ jobs:
     - name: Setup Gradle
       uses: gradle/gradle-build-action@v2
       with:
-        gradle-version: "7.6"
+        gradle-version: ${{ env.GRADLEVERSION }}
     - name: Download provider + tfgen binaries
       uses: actions/download-artifact@v2
       with:
@@ -372,7 +373,7 @@ jobs:
     - name: Setup Gradle
       uses: gradle/gradle-build-action@v2
       with:
-        gradle-version: "7.6"
+        gradle-version: ${{ env.GRADLEVERSION }}
     - name: Download provider + tfgen binaries
       uses: actions/download-artifact@v2
       with:

--- a/provider-ci/test-workflows/cloudflare/.github/workflows/resync-build.yml
+++ b/provider-ci/test-workflows/cloudflare/.github/workflows/resync-build.yml
@@ -11,6 +11,7 @@ env:
       3.1.301
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   GOVERSION: 1.21.x
+  GRADLEVERSION: "7.6"
   JAVAVERSION: "11"
   NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
   NODEVERSION: 20.x

--- a/provider-ci/test-workflows/cloudflare/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/test-workflows/cloudflare/.github/workflows/run-acceptance-tests.yml
@@ -10,6 +10,7 @@ env:
       3.1.301
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   GOVERSION: 1.21.x
+  GRADLEVERSION: "7.6"
   JAVAVERSION: "11"
   NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
   NODEVERSION: 20.x
@@ -82,7 +83,7 @@ jobs:
     - name: Setup Gradle
       uses: gradle/gradle-build-action@v2
       with:
-        gradle-version: "7.6"
+        gradle-version: ${{ env.GRADLEVERSION }}
     - name: Download provider + tfgen binaries
       uses: actions/download-artifact@v2
       with:
@@ -242,17 +243,17 @@ jobs:
     #
     # GitHub documents `jobs.result` as:
     #
-    #	The result of a job in the reusable workflow. Possible values are success,
-    #	failure, cancelled, or skipped.
+    # The result of a job in the reusable workflow. Possible values are success,
+    # failure, cancelled, or skipped.
     #
     # GitHub documents `cancelled()` as:
     #
-    #	Returns true if the workflow was canceled.
+    # Returns true if the workflow was canceled.
     #
     # Combining these terms gives us an intuitive definition of success:
     #
-    #	We have succeeded when no dependent workflow has failed and the job was
-    #	not cancelled.
+    # We have succeeded when no dependent workflow has failed and the job was
+    # not cancelled.
     #
     if: (github.event_name == 'repository_dispatch' ||
       github.event.pull_request.head.repo.full_name == github.repository) &&
@@ -323,7 +324,7 @@ jobs:
     - name: Setup Gradle
       uses: gradle/gradle-build-action@v2
       with:
-        gradle-version: "7.6"
+        gradle-version: ${{ env.GRADLEVERSION }}
     - name: Download provider + tfgen binaries
       uses: actions/download-artifact@v2
       with:

--- a/provider-ci/test-workflows/cloudflare/devbox.json
+++ b/provider-ci/test-workflows/cloudflare/devbox.json
@@ -1,0 +1,19 @@
+{
+  "packages": [
+    "go@1.21.",
+    "nodejs@20.",
+    "python3@3.9",
+    "dotnet-sdk@6.0.",
+    "gradle_7@7.6"
+  ],
+  "shell": {
+    "init_hook": [
+      "export PATH=\"$(pwd)/bin/:$PATH\""
+    ],
+    "scripts": {
+      "test": [
+        "echo \"Error: no test specified\" && exit 1"
+      ]
+    }
+  }
+}

--- a/provider-ci/test-workflows/docker/.devcontainer/Dockerfile
+++ b/provider-ci/test-workflows/docker/.devcontainer/Dockerfile
@@ -1,0 +1,12 @@
+FROM jetpackio/devbox:latest
+
+# Installing your devbox project
+WORKDIR /code
+COPY devbox.json devbox.json
+COPY devbox.lock devbox.lock
+RUN sudo chown -R "${DEVBOX_USER}:${DEVBOX_USER}" /code
+
+
+RUN devbox run -- echo "Installed Packages."
+
+RUN devbox shellenv --init-hook >> ~/.profile

--- a/provider-ci/test-workflows/docker/.devcontainer/devcontainer.json
+++ b/provider-ci/test-workflows/docker/.devcontainer/devcontainer.json
@@ -1,0 +1,16 @@
+{
+  "name": "Devbox Remote Container",
+  "build": {
+    "dockerfile": "./Dockerfile",
+    "context": ".."
+  },
+  "customizations": {
+    "vscode": {
+      "settings": {},
+      "extensions": [
+        "jetpack-io.devbox"
+      ]
+    }
+  },
+  "remoteUser": "devbox"
+}

--- a/provider-ci/test-workflows/docker/.github/workflows/command-dispatch.yml
+++ b/provider-ci/test-workflows/docker/.github/workflows/command-dispatch.yml
@@ -22,6 +22,7 @@ env:
   GOOGLE_REGION: us-central1
   GOOGLE_ZONE: us-central1-a
   GOVERSION: 1.21.x
+  GRADLEVERSION: "7.6"
   JAVAVERSION: "11"
   NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
   NODEVERSION: 20.x

--- a/provider-ci/test-workflows/docker/.github/workflows/license.yml
+++ b/provider-ci/test-workflows/docker/.github/workflows/license.yml
@@ -28,6 +28,7 @@ env:
   GOOGLE_REGION: us-central1
   GOOGLE_ZONE: us-central1-a
   GOVERSION: 1.21.x
+  GRADLEVERSION: "7.6"
   JAVAVERSION: "11"
   NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
   NODEVERSION: 20.x

--- a/provider-ci/test-workflows/docker/.github/workflows/lint.yml
+++ b/provider-ci/test-workflows/docker/.github/workflows/lint.yml
@@ -27,6 +27,7 @@ env:
   GOOGLE_REGION: us-central1
   GOOGLE_ZONE: us-central1-a
   GOVERSION: 1.21.x
+  GRADLEVERSION: "7.6"
   JAVAVERSION: "11"
   NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
   NODEVERSION: 20.x

--- a/provider-ci/test-workflows/docker/.github/workflows/master.yml
+++ b/provider-ci/test-workflows/docker/.github/workflows/master.yml
@@ -22,6 +22,7 @@ env:
   GOOGLE_REGION: us-central1
   GOOGLE_ZONE: us-central1-a
   GOVERSION: 1.21.x
+  GRADLEVERSION: "7.6"
   JAVAVERSION: "11"
   NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
   NODEVERSION: 20.x
@@ -90,7 +91,7 @@ jobs:
     - name: Setup Gradle
       uses: gradle/gradle-build-action@v2
       with:
-        gradle-version: "7.6"
+        gradle-version: ${{ env.GRADLEVERSION }}
     - name: Download provider + tfgen binaries
       uses: actions/download-artifact@v2
       with:
@@ -410,7 +411,7 @@ jobs:
     - name: Setup Gradle
       uses: gradle/gradle-build-action@v2
       with:
-        gradle-version: "7.6"
+        gradle-version: ${{ env.GRADLEVERSION }}
     - name: Download provider + tfgen binaries
       uses: actions/download-artifact@v2
       with:

--- a/provider-ci/test-workflows/docker/.github/workflows/prerelease.yml
+++ b/provider-ci/test-workflows/docker/.github/workflows/prerelease.yml
@@ -23,6 +23,7 @@ env:
   GOOGLE_REGION: us-central1
   GOOGLE_ZONE: us-central1-a
   GOVERSION: 1.21.x
+  GRADLEVERSION: "7.6"
   JAVAVERSION: "11"
   NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
   NODEVERSION: 20.x
@@ -91,7 +92,7 @@ jobs:
     - name: Setup Gradle
       uses: gradle/gradle-build-action@v2
       with:
-        gradle-version: "7.6"
+        gradle-version: ${{ env.GRADLEVERSION }}
     - name: Download provider + tfgen binaries
       uses: actions/download-artifact@v2
       with:
@@ -339,7 +340,7 @@ jobs:
     - name: Setup Gradle
       uses: gradle/gradle-build-action@v2
       with:
-        gradle-version: "7.6"
+        gradle-version: ${{ env.GRADLEVERSION }}
     - name: Download provider + tfgen binaries
       uses: actions/download-artifact@v2
       with:

--- a/provider-ci/test-workflows/docker/.github/workflows/pull-request.yml
+++ b/provider-ci/test-workflows/docker/.github/workflows/pull-request.yml
@@ -22,6 +22,7 @@ env:
   GOOGLE_REGION: us-central1
   GOOGLE_ZONE: us-central1-a
   GOVERSION: 1.21.x
+  GRADLEVERSION: "7.6"
   JAVAVERSION: "11"
   NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
   NODEVERSION: 20.x

--- a/provider-ci/test-workflows/docker/.github/workflows/release.yml
+++ b/provider-ci/test-workflows/docker/.github/workflows/release.yml
@@ -22,6 +22,7 @@ env:
   GOOGLE_REGION: us-central1
   GOOGLE_ZONE: us-central1-a
   GOVERSION: 1.21.x
+  GRADLEVERSION: "7.6"
   JAVAVERSION: "11"
   NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
   NODEVERSION: 20.x
@@ -90,7 +91,7 @@ jobs:
     - name: Setup Gradle
       uses: gradle/gradle-build-action@v2
       with:
-        gradle-version: "7.6"
+        gradle-version: ${{ env.GRADLEVERSION }}
     - name: Download provider + tfgen binaries
       uses: actions/download-artifact@v2
       with:
@@ -385,7 +386,7 @@ jobs:
     - name: Setup Gradle
       uses: gradle/gradle-build-action@v2
       with:
-        gradle-version: "7.6"
+        gradle-version: ${{ env.GRADLEVERSION }}
     - name: Download provider + tfgen binaries
       uses: actions/download-artifact@v2
       with:

--- a/provider-ci/test-workflows/docker/.github/workflows/resync-build.yml
+++ b/provider-ci/test-workflows/docker/.github/workflows/resync-build.yml
@@ -24,6 +24,7 @@ env:
   GOOGLE_REGION: us-central1
   GOOGLE_ZONE: us-central1-a
   GOVERSION: 1.21.x
+  GRADLEVERSION: "7.6"
   JAVAVERSION: "11"
   NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
   NODEVERSION: 20.x

--- a/provider-ci/test-workflows/docker/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/test-workflows/docker/.github/workflows/run-acceptance-tests.yml
@@ -23,6 +23,7 @@ env:
   GOOGLE_REGION: us-central1
   GOOGLE_ZONE: us-central1-a
   GOVERSION: 1.21.x
+  GRADLEVERSION: "7.6"
   JAVAVERSION: "11"
   NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
   NODEVERSION: 20.x
@@ -95,7 +96,7 @@ jobs:
     - name: Setup Gradle
       uses: gradle/gradle-build-action@v2
       with:
-        gradle-version: "7.6"
+        gradle-version: ${{ env.GRADLEVERSION }}
     - name: Download provider + tfgen binaries
       uses: actions/download-artifact@v2
       with:
@@ -255,17 +256,17 @@ jobs:
     #
     # GitHub documents `jobs.result` as:
     #
-    #	The result of a job in the reusable workflow. Possible values are success,
-    #	failure, cancelled, or skipped.
+    # The result of a job in the reusable workflow. Possible values are success,
+    # failure, cancelled, or skipped.
     #
     # GitHub documents `cancelled()` as:
     #
-    #	Returns true if the workflow was canceled.
+    # Returns true if the workflow was canceled.
     #
     # Combining these terms gives us an intuitive definition of success:
     #
-    #	We have succeeded when no dependent workflow has failed and the job was
-    #	not cancelled.
+    # We have succeeded when no dependent workflow has failed and the job was
+    # not cancelled.
     #
     if: (github.event_name == 'repository_dispatch' ||
       github.event.pull_request.head.repo.full_name == github.repository) &&
@@ -336,7 +337,7 @@ jobs:
     - name: Setup Gradle
       uses: gradle/gradle-build-action@v2
       with:
-        gradle-version: "7.6"
+        gradle-version: ${{ env.GRADLEVERSION }}
     - name: Download provider + tfgen binaries
       uses: actions/download-artifact@v2
       with:

--- a/provider-ci/test-workflows/docker/devbox.json
+++ b/provider-ci/test-workflows/docker/devbox.json
@@ -1,0 +1,19 @@
+{
+  "packages": [
+    "go@1.21.",
+    "nodejs@20.",
+    "python3@3.9",
+    "dotnet-sdk@6.0.",
+    "gradle_7@7.6"
+  ],
+  "shell": {
+    "init_hook": [
+      "export PATH=\"$(pwd)/bin/:$PATH\""
+    ],
+    "scripts": {
+      "test": [
+        "echo \"Error: no test specified\" && exit 1"
+      ]
+    }
+  }
+}


### PR DESCRIPTION
Adds templates for devbox.json and .devcontainer to bridged providers with the goal of simplifying environment setup for building providers. 

As part of this work, I refactored the gradle version to be explicit in the config file so we can ensure that the devbox environment uses the same version.

I'm explicitly not including the pulumi cli or any plugins in the devbox environment. Keeping pulumi up to date in nixpkgs is not something I want to take on right now, and we already have a decent system for loading a pinned version in the Makefile (at least for the bridged providers).

