### PR TITLE
Enable setting custom Pulumi CLI version to install for native providers

### DIFF
--- a/native-provider-ci/providers/aws-native/repo/.github/workflows/build.yml
+++ b/native-provider-ci/providers/aws-native/repo/.github/workflows/build.yml
@@ -65,7 +65,7 @@ jobs:
       with:
         repo: pulumi/pulumictl
     - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
+      uses: pulumi/actions@v4
     - if: github.event_name == 'pull_request'
       name: Install Schema Tools
       uses: jaxxstorm/action-install-gh-release@v1.5.0
@@ -164,7 +164,7 @@ jobs:
       with:
         repo: pulumi/pulumictl
     - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
+      uses: pulumi/actions@v4
     - name: Setup Node
       uses: actions/setup-node@v2
       with:
@@ -261,7 +261,7 @@ jobs:
       with:
         repo: pulumi/pulumictl
     - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
+      uses: pulumi/actions@v4
     - name: Setup Node
       uses: actions/setup-node@v2
       with:
@@ -361,7 +361,7 @@ jobs:
       with:
         repo: pulumi/pulumictl
     - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
+      uses: pulumi/actions@v4
     - name: Configure AWS Credentials
       uses: aws-actions/configure-aws-credentials@v1
       with:
@@ -413,7 +413,7 @@ jobs:
       with:
         repo: pulumi/pulumictl
     - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
+      uses: pulumi/actions@v4
     - name: Setup Node
       uses: actions/setup-node@v2
       with:
@@ -491,7 +491,7 @@ jobs:
       with:
         repo: pulumi/pulumictl
     - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
+      uses: pulumi/actions@v4
     - name: Setup Java
       uses: actions/setup-java@v3
       with:

--- a/native-provider-ci/providers/aws-native/repo/.github/workflows/nightly-sdk-generation.yml
+++ b/native-provider-ci/providers/aws-native/repo/.github/workflows/nightly-sdk-generation.yml
@@ -51,7 +51,7 @@ jobs:
       with:
         repo: pulumi/pulumictl
     - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
+      uses: pulumi/actions@v4
     - name: Configure AWS Credentials
       uses: aws-actions/configure-aws-credentials@v1
       with:

--- a/native-provider-ci/providers/aws-native/repo/.github/workflows/prerelease.yml
+++ b/native-provider-ci/providers/aws-native/repo/.github/workflows/prerelease.yml
@@ -57,7 +57,7 @@ jobs:
       with:
         repo: pulumi/pulumictl
     - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
+      uses: pulumi/actions@v4
     - if: github.event_name == 'pull_request'
       name: Install Schema Tools
       uses: jaxxstorm/action-install-gh-release@v1.5.0
@@ -156,7 +156,7 @@ jobs:
       with:
         repo: pulumi/pulumictl
     - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
+      uses: pulumi/actions@v4
     - name: Setup Node
       uses: actions/setup-node@v2
       with:
@@ -252,7 +252,7 @@ jobs:
       with:
         repo: pulumi/pulumictl
     - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
+      uses: pulumi/actions@v4
     - name: Setup Node
       uses: actions/setup-node@v2
       with:
@@ -352,7 +352,7 @@ jobs:
       with:
         repo: pulumi/pulumictl
     - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
+      uses: pulumi/actions@v4
     - name: Configure AWS Credentials
       uses: aws-actions/configure-aws-credentials@v1
       with:
@@ -404,7 +404,7 @@ jobs:
       with:
         repo: pulumi/pulumictl
     - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
+      uses: pulumi/actions@v4
     - name: Setup Node
       uses: actions/setup-node@v2
       with:
@@ -482,7 +482,7 @@ jobs:
       with:
         repo: pulumi/pulumictl
     - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
+      uses: pulumi/actions@v4
     - name: Setup Java
       uses: actions/setup-java@v3
       with:

--- a/native-provider-ci/providers/aws-native/repo/.github/workflows/release.yml
+++ b/native-provider-ci/providers/aws-native/repo/.github/workflows/release.yml
@@ -57,7 +57,7 @@ jobs:
       with:
         repo: pulumi/pulumictl
     - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
+      uses: pulumi/actions@v4
     - if: github.event_name == 'pull_request'
       name: Install Schema Tools
       uses: jaxxstorm/action-install-gh-release@v1.5.0
@@ -156,7 +156,7 @@ jobs:
       with:
         repo: pulumi/pulumictl
     - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
+      uses: pulumi/actions@v4
     - name: Setup Node
       uses: actions/setup-node@v2
       with:
@@ -252,7 +252,7 @@ jobs:
       with:
         repo: pulumi/pulumictl
     - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
+      uses: pulumi/actions@v4
     - name: Setup Node
       uses: actions/setup-node@v2
       with:
@@ -352,7 +352,7 @@ jobs:
       with:
         repo: pulumi/pulumictl
     - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
+      uses: pulumi/actions@v4
     - name: Configure AWS Credentials
       uses: aws-actions/configure-aws-credentials@v1
       with:
@@ -403,7 +403,7 @@ jobs:
       with:
         repo: pulumi/pulumictl
     - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
+      uses: pulumi/actions@v4
     - name: Setup Node
       uses: actions/setup-node@v2
       with:
@@ -481,7 +481,7 @@ jobs:
       with:
         repo: pulumi/pulumictl
     - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
+      uses: pulumi/actions@v4
     - name: Setup Java
       uses: actions/setup-java@v3
       with:

--- a/native-provider-ci/providers/aws-native/repo/.github/workflows/run-acceptance-tests.yml
+++ b/native-provider-ci/providers/aws-native/repo/.github/workflows/run-acceptance-tests.yml
@@ -81,7 +81,7 @@ jobs:
       with:
         repo: pulumi/pulumictl
     - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
+      uses: pulumi/actions@v4
     - if: github.event_name == 'pull_request'
       name: Install Schema Tools
       uses: jaxxstorm/action-install-gh-release@v1.5.0
@@ -183,7 +183,7 @@ jobs:
       with:
         repo: pulumi/pulumictl
     - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
+      uses: pulumi/actions@v4
     - name: Setup Node
       uses: actions/setup-node@v2
       with:
@@ -283,7 +283,7 @@ jobs:
       with:
         repo: pulumi/pulumictl
     - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
+      uses: pulumi/actions@v4
     - name: Setup Node
       uses: actions/setup-node@v2
       with:

--- a/native-provider-ci/providers/aws-native/repo/.github/workflows/weekly-pulumi-update.yml
+++ b/native-provider-ci/providers/aws-native/repo/.github/workflows/weekly-pulumi-update.yml
@@ -50,7 +50,7 @@ jobs:
       with:
         repo: pulumi/pulumictl
     - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
+      uses: pulumi/actions@v4
     - name: Setup DotNet
       uses: actions/setup-dotnet@v3
       with:

--- a/native-provider-ci/providers/azure-native/repo/.github/workflows/arm2pulumi-coverage-report.yml
+++ b/native-provider-ci/providers/azure-native/repo/.github/workflows/arm2pulumi-coverage-report.yml
@@ -54,7 +54,7 @@ jobs:
       with:
         repo: pulumi/pulumictl
     - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
+      uses: pulumi/actions@v4
     - uses: azure/login@v1
       with:
         creds: ${{ secrets.AZURE_RBAC_SERVICE_PRINCIPAL }}

--- a/native-provider-ci/providers/azure-native/repo/.github/workflows/build.yml
+++ b/native-provider-ci/providers/azure-native/repo/.github/workflows/build.yml
@@ -71,7 +71,7 @@ jobs:
       with:
         repo: pulumi/pulumictl
     - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
+      uses: pulumi/actions@v4
     - if: github.event_name == 'pull_request'
       name: Install Schema Tools
       uses: jaxxstorm/action-install-gh-release@v1.5.0
@@ -170,7 +170,7 @@ jobs:
       with:
         repo: pulumi/pulumictl
     - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
+      uses: pulumi/actions@v4
     - name: Setup Node
       uses: actions/setup-node@v2
       with:
@@ -273,7 +273,7 @@ jobs:
       with:
         repo: pulumi/pulumictl
     - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
+      uses: pulumi/actions@v4
     - name: Setup Node
       uses: actions/setup-node@v2
       with:
@@ -364,7 +364,7 @@ jobs:
       with:
         repo: pulumi/pulumictl
     - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
+      uses: pulumi/actions@v4
     - name: Configure AWS Credentials
       uses: aws-actions/configure-aws-credentials@v1
       with:
@@ -416,7 +416,7 @@ jobs:
       with:
         repo: pulumi/pulumictl
     - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
+      uses: pulumi/actions@v4
     - name: Setup Node
       uses: actions/setup-node@v2
       with:
@@ -494,7 +494,7 @@ jobs:
       with:
         repo: pulumi/pulumictl
     - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
+      uses: pulumi/actions@v4
     - name: Setup Java
       uses: actions/setup-java@v3
       with:

--- a/native-provider-ci/providers/azure-native/repo/.github/workflows/nightly-sdk-generation.yml
+++ b/native-provider-ci/providers/azure-native/repo/.github/workflows/nightly-sdk-generation.yml
@@ -55,7 +55,7 @@ jobs:
       with:
         repo: pulumi/pulumictl
     - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
+      uses: pulumi/actions@v4
     - uses: azure/login@v1
       with:
         creds: ${{ secrets.AZURE_RBAC_SERVICE_PRINCIPAL }}

--- a/native-provider-ci/providers/azure-native/repo/.github/workflows/prerelease.yml
+++ b/native-provider-ci/providers/azure-native/repo/.github/workflows/prerelease.yml
@@ -63,7 +63,7 @@ jobs:
       with:
         repo: pulumi/pulumictl
     - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
+      uses: pulumi/actions@v4
     - if: github.event_name == 'pull_request'
       name: Install Schema Tools
       uses: jaxxstorm/action-install-gh-release@v1.5.0
@@ -162,7 +162,7 @@ jobs:
       with:
         repo: pulumi/pulumictl
     - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
+      uses: pulumi/actions@v4
     - name: Setup Node
       uses: actions/setup-node@v2
       with:
@@ -264,7 +264,7 @@ jobs:
       with:
         repo: pulumi/pulumictl
     - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
+      uses: pulumi/actions@v4
     - name: Setup Node
       uses: actions/setup-node@v2
       with:
@@ -355,7 +355,7 @@ jobs:
       with:
         repo: pulumi/pulumictl
     - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
+      uses: pulumi/actions@v4
     - name: Configure AWS Credentials
       uses: aws-actions/configure-aws-credentials@v1
       with:
@@ -407,7 +407,7 @@ jobs:
       with:
         repo: pulumi/pulumictl
     - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
+      uses: pulumi/actions@v4
     - name: Setup Node
       uses: actions/setup-node@v2
       with:
@@ -485,7 +485,7 @@ jobs:
       with:
         repo: pulumi/pulumictl
     - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
+      uses: pulumi/actions@v4
     - name: Setup Java
       uses: actions/setup-java@v3
       with:

--- a/native-provider-ci/providers/azure-native/repo/.github/workflows/release.yml
+++ b/native-provider-ci/providers/azure-native/repo/.github/workflows/release.yml
@@ -63,7 +63,7 @@ jobs:
       with:
         repo: pulumi/pulumictl
     - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
+      uses: pulumi/actions@v4
     - if: github.event_name == 'pull_request'
       name: Install Schema Tools
       uses: jaxxstorm/action-install-gh-release@v1.5.0
@@ -162,7 +162,7 @@ jobs:
       with:
         repo: pulumi/pulumictl
     - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
+      uses: pulumi/actions@v4
     - name: Setup Node
       uses: actions/setup-node@v2
       with:
@@ -264,7 +264,7 @@ jobs:
       with:
         repo: pulumi/pulumictl
     - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
+      uses: pulumi/actions@v4
     - name: Setup Node
       uses: actions/setup-node@v2
       with:
@@ -355,7 +355,7 @@ jobs:
       with:
         repo: pulumi/pulumictl
     - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
+      uses: pulumi/actions@v4
     - name: Configure AWS Credentials
       uses: aws-actions/configure-aws-credentials@v1
       with:
@@ -406,7 +406,7 @@ jobs:
       with:
         repo: pulumi/pulumictl
     - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
+      uses: pulumi/actions@v4
     - name: Setup Node
       uses: actions/setup-node@v2
       with:
@@ -484,7 +484,7 @@ jobs:
       with:
         repo: pulumi/pulumictl
     - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
+      uses: pulumi/actions@v4
     - name: Setup Java
       uses: actions/setup-java@v3
       with:

--- a/native-provider-ci/providers/azure-native/repo/.github/workflows/run-acceptance-tests.yml
+++ b/native-provider-ci/providers/azure-native/repo/.github/workflows/run-acceptance-tests.yml
@@ -87,7 +87,7 @@ jobs:
       with:
         repo: pulumi/pulumictl
     - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
+      uses: pulumi/actions@v4
     - if: github.event_name == 'pull_request'
       name: Install Schema Tools
       uses: jaxxstorm/action-install-gh-release@v1.5.0
@@ -189,7 +189,7 @@ jobs:
       with:
         repo: pulumi/pulumictl
     - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
+      uses: pulumi/actions@v4
     - name: Setup Node
       uses: actions/setup-node@v2
       with:
@@ -295,7 +295,7 @@ jobs:
       with:
         repo: pulumi/pulumictl
     - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
+      uses: pulumi/actions@v4
     - name: Setup Node
       uses: actions/setup-node@v2
       with:

--- a/native-provider-ci/providers/azure-native/repo/.github/workflows/weekly-pulumi-update.yml
+++ b/native-provider-ci/providers/azure-native/repo/.github/workflows/weekly-pulumi-update.yml
@@ -56,7 +56,7 @@ jobs:
       with:
         repo: pulumi/pulumictl
     - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
+      uses: pulumi/actions@v4
     - name: Setup DotNet
       uses: actions/setup-dotnet@v3
       with:

--- a/native-provider-ci/providers/command/repo/.github/workflows/build.yml
+++ b/native-provider-ci/providers/command/repo/.github/workflows/build.yml
@@ -65,7 +65,7 @@ jobs:
       with:
         repo: pulumi/pulumictl
     - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
+      uses: pulumi/actions@v4
     - name: Build codegen binaries
       run: make codegen
     - name: Build Provider
@@ -129,7 +129,7 @@ jobs:
       with:
         repo: pulumi/pulumictl
     - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
+      uses: pulumi/actions@v4
     - name: Setup Node
       uses: actions/setup-node@v2
       with:
@@ -222,7 +222,7 @@ jobs:
       with:
         repo: pulumi/pulumictl
     - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
+      uses: pulumi/actions@v4
     - name: Setup Node
       uses: actions/setup-node@v2
       with:
@@ -322,7 +322,7 @@ jobs:
       with:
         repo: pulumi/pulumictl
     - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
+      uses: pulumi/actions@v4
     - name: Configure AWS Credentials
       uses: aws-actions/configure-aws-credentials@v1
       with:
@@ -374,7 +374,7 @@ jobs:
       with:
         repo: pulumi/pulumictl
     - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
+      uses: pulumi/actions@v4
     - name: Setup Node
       uses: actions/setup-node@v2
       with:
@@ -452,7 +452,7 @@ jobs:
       with:
         repo: pulumi/pulumictl
     - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
+      uses: pulumi/actions@v4
     - name: Setup Java
       uses: actions/setup-java@v3
       with:

--- a/native-provider-ci/providers/command/repo/.github/workflows/prerelease.yml
+++ b/native-provider-ci/providers/command/repo/.github/workflows/prerelease.yml
@@ -57,7 +57,7 @@ jobs:
       with:
         repo: pulumi/pulumictl
     - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
+      uses: pulumi/actions@v4
     - name: Build codegen binaries
       run: make codegen
     - name: Build Provider
@@ -121,7 +121,7 @@ jobs:
       with:
         repo: pulumi/pulumictl
     - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
+      uses: pulumi/actions@v4
     - name: Setup Node
       uses: actions/setup-node@v2
       with:
@@ -213,7 +213,7 @@ jobs:
       with:
         repo: pulumi/pulumictl
     - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
+      uses: pulumi/actions@v4
     - name: Setup Node
       uses: actions/setup-node@v2
       with:
@@ -313,7 +313,7 @@ jobs:
       with:
         repo: pulumi/pulumictl
     - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
+      uses: pulumi/actions@v4
     - name: Configure AWS Credentials
       uses: aws-actions/configure-aws-credentials@v1
       with:
@@ -365,7 +365,7 @@ jobs:
       with:
         repo: pulumi/pulumictl
     - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
+      uses: pulumi/actions@v4
     - name: Setup Node
       uses: actions/setup-node@v2
       with:
@@ -443,7 +443,7 @@ jobs:
       with:
         repo: pulumi/pulumictl
     - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
+      uses: pulumi/actions@v4
     - name: Setup Java
       uses: actions/setup-java@v3
       with:

--- a/native-provider-ci/providers/command/repo/.github/workflows/release.yml
+++ b/native-provider-ci/providers/command/repo/.github/workflows/release.yml
@@ -57,7 +57,7 @@ jobs:
       with:
         repo: pulumi/pulumictl
     - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
+      uses: pulumi/actions@v4
     - name: Build codegen binaries
       run: make codegen
     - name: Build Provider
@@ -121,7 +121,7 @@ jobs:
       with:
         repo: pulumi/pulumictl
     - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
+      uses: pulumi/actions@v4
     - name: Setup Node
       uses: actions/setup-node@v2
       with:
@@ -213,7 +213,7 @@ jobs:
       with:
         repo: pulumi/pulumictl
     - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
+      uses: pulumi/actions@v4
     - name: Setup Node
       uses: actions/setup-node@v2
       with:
@@ -313,7 +313,7 @@ jobs:
       with:
         repo: pulumi/pulumictl
     - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
+      uses: pulumi/actions@v4
     - name: Configure AWS Credentials
       uses: aws-actions/configure-aws-credentials@v1
       with:
@@ -364,7 +364,7 @@ jobs:
       with:
         repo: pulumi/pulumictl
     - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
+      uses: pulumi/actions@v4
     - name: Setup Node
       uses: actions/setup-node@v2
       with:
@@ -442,7 +442,7 @@ jobs:
       with:
         repo: pulumi/pulumictl
     - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
+      uses: pulumi/actions@v4
     - name: Setup Java
       uses: actions/setup-java@v3
       with:

--- a/native-provider-ci/providers/command/repo/.github/workflows/run-acceptance-tests.yml
+++ b/native-provider-ci/providers/command/repo/.github/workflows/run-acceptance-tests.yml
@@ -81,7 +81,7 @@ jobs:
       with:
         repo: pulumi/pulumictl
     - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
+      uses: pulumi/actions@v4
     - name: Build codegen binaries
       run: make codegen
     - name: Build Provider
@@ -148,7 +148,7 @@ jobs:
       with:
         repo: pulumi/pulumictl
     - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
+      uses: pulumi/actions@v4
     - name: Setup Node
       uses: actions/setup-node@v2
       with:
@@ -244,7 +244,7 @@ jobs:
       with:
         repo: pulumi/pulumictl
     - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
+      uses: pulumi/actions@v4
     - name: Setup Node
       uses: actions/setup-node@v2
       with:

--- a/native-provider-ci/providers/command/repo/.github/workflows/weekly-pulumi-update.yml
+++ b/native-provider-ci/providers/command/repo/.github/workflows/weekly-pulumi-update.yml
@@ -50,7 +50,7 @@ jobs:
       with:
         repo: pulumi/pulumictl
     - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
+      uses: pulumi/actions@v4
     - name: Setup DotNet
       uses: actions/setup-dotnet@v3
       with:

--- a/native-provider-ci/providers/google-native/repo/.github/workflows/build.yml
+++ b/native-provider-ci/providers/google-native/repo/.github/workflows/build.yml
@@ -71,7 +71,7 @@ jobs:
       with:
         repo: pulumi/pulumictl
     - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
+      uses: pulumi/actions@v4
     - if: github.event_name == 'pull_request'
       name: Install Schema Tools
       uses: jaxxstorm/action-install-gh-release@v1.5.0
@@ -170,7 +170,7 @@ jobs:
       with:
         repo: pulumi/pulumictl
     - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
+      uses: pulumi/actions@v4
     - name: Setup Node
       uses: actions/setup-node@v2
       with:
@@ -267,7 +267,7 @@ jobs:
       with:
         repo: pulumi/pulumictl
     - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
+      uses: pulumi/actions@v4
     - name: Setup Node
       uses: actions/setup-node@v2
       with:
@@ -370,7 +370,7 @@ jobs:
       with:
         repo: pulumi/pulumictl
     - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
+      uses: pulumi/actions@v4
     - name: Configure AWS Credentials
       uses: aws-actions/configure-aws-credentials@v1
       with:
@@ -422,7 +422,7 @@ jobs:
       with:
         repo: pulumi/pulumictl
     - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
+      uses: pulumi/actions@v4
     - name: Setup Node
       uses: actions/setup-node@v2
       with:
@@ -500,7 +500,7 @@ jobs:
       with:
         repo: pulumi/pulumictl
     - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
+      uses: pulumi/actions@v4
     - name: Setup Java
       uses: actions/setup-java@v3
       with:

--- a/native-provider-ci/providers/google-native/repo/.github/workflows/nightly-sdk-generation.yml
+++ b/native-provider-ci/providers/google-native/repo/.github/workflows/nightly-sdk-generation.yml
@@ -57,7 +57,7 @@ jobs:
       with:
         repo: pulumi/pulumictl
     - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
+      uses: pulumi/actions@v4
     - name: Cleanup SDK Folder
       run: make clean
     - name: Preparing Git Branch

--- a/native-provider-ci/providers/google-native/repo/.github/workflows/prerelease.yml
+++ b/native-provider-ci/providers/google-native/repo/.github/workflows/prerelease.yml
@@ -63,7 +63,7 @@ jobs:
       with:
         repo: pulumi/pulumictl
     - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
+      uses: pulumi/actions@v4
     - if: github.event_name == 'pull_request'
       name: Install Schema Tools
       uses: jaxxstorm/action-install-gh-release@v1.5.0
@@ -162,7 +162,7 @@ jobs:
       with:
         repo: pulumi/pulumictl
     - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
+      uses: pulumi/actions@v4
     - name: Setup Node
       uses: actions/setup-node@v2
       with:
@@ -258,7 +258,7 @@ jobs:
       with:
         repo: pulumi/pulumictl
     - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
+      uses: pulumi/actions@v4
     - name: Setup Node
       uses: actions/setup-node@v2
       with:
@@ -361,7 +361,7 @@ jobs:
       with:
         repo: pulumi/pulumictl
     - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
+      uses: pulumi/actions@v4
     - name: Configure AWS Credentials
       uses: aws-actions/configure-aws-credentials@v1
       with:
@@ -413,7 +413,7 @@ jobs:
       with:
         repo: pulumi/pulumictl
     - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
+      uses: pulumi/actions@v4
     - name: Setup Node
       uses: actions/setup-node@v2
       with:
@@ -491,7 +491,7 @@ jobs:
       with:
         repo: pulumi/pulumictl
     - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
+      uses: pulumi/actions@v4
     - name: Setup Java
       uses: actions/setup-java@v3
       with:

--- a/native-provider-ci/providers/google-native/repo/.github/workflows/release.yml
+++ b/native-provider-ci/providers/google-native/repo/.github/workflows/release.yml
@@ -63,7 +63,7 @@ jobs:
       with:
         repo: pulumi/pulumictl
     - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
+      uses: pulumi/actions@v4
     - if: github.event_name == 'pull_request'
       name: Install Schema Tools
       uses: jaxxstorm/action-install-gh-release@v1.5.0
@@ -162,7 +162,7 @@ jobs:
       with:
         repo: pulumi/pulumictl
     - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
+      uses: pulumi/actions@v4
     - name: Setup Node
       uses: actions/setup-node@v2
       with:
@@ -258,7 +258,7 @@ jobs:
       with:
         repo: pulumi/pulumictl
     - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
+      uses: pulumi/actions@v4
     - name: Setup Node
       uses: actions/setup-node@v2
       with:
@@ -361,7 +361,7 @@ jobs:
       with:
         repo: pulumi/pulumictl
     - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
+      uses: pulumi/actions@v4
     - name: Configure AWS Credentials
       uses: aws-actions/configure-aws-credentials@v1
       with:
@@ -412,7 +412,7 @@ jobs:
       with:
         repo: pulumi/pulumictl
     - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
+      uses: pulumi/actions@v4
     - name: Setup Node
       uses: actions/setup-node@v2
       with:
@@ -490,7 +490,7 @@ jobs:
       with:
         repo: pulumi/pulumictl
     - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
+      uses: pulumi/actions@v4
     - name: Setup Java
       uses: actions/setup-java@v3
       with:

--- a/native-provider-ci/providers/google-native/repo/.github/workflows/run-acceptance-tests.yml
+++ b/native-provider-ci/providers/google-native/repo/.github/workflows/run-acceptance-tests.yml
@@ -87,7 +87,7 @@ jobs:
       with:
         repo: pulumi/pulumictl
     - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
+      uses: pulumi/actions@v4
     - if: github.event_name == 'pull_request'
       name: Install Schema Tools
       uses: jaxxstorm/action-install-gh-release@v1.5.0
@@ -189,7 +189,7 @@ jobs:
       with:
         repo: pulumi/pulumictl
     - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
+      uses: pulumi/actions@v4
     - name: Setup Node
       uses: actions/setup-node@v2
       with:
@@ -289,7 +289,7 @@ jobs:
       with:
         repo: pulumi/pulumictl
     - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
+      uses: pulumi/actions@v4
     - name: Setup Node
       uses: actions/setup-node@v2
       with:

--- a/native-provider-ci/providers/google-native/repo/.github/workflows/weekly-pulumi-update.yml
+++ b/native-provider-ci/providers/google-native/repo/.github/workflows/weekly-pulumi-update.yml
@@ -56,7 +56,7 @@ jobs:
       with:
         repo: pulumi/pulumictl
     - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
+      uses: pulumi/actions@v4
     - name: Setup DotNet
       uses: actions/setup-dotnet@v3
       with:

--- a/native-provider-ci/providers/kubernetes/config.yaml
+++ b/native-provider-ci/providers/kubernetes/config.yaml
@@ -3,6 +3,7 @@ lint: true
 aws: true
 gcp: true
 major-version: 4
+pulumiCLIVersion: v3.89.0
 env:
   AWS_REGION: us-west-2
   PULUMI_TEST_OWNER: moolumi

--- a/native-provider-ci/providers/kubernetes/repo/.github/workflows/build.yml
+++ b/native-provider-ci/providers/kubernetes/repo/.github/workflows/build.yml
@@ -71,7 +71,9 @@ jobs:
       with:
         repo: pulumi/pulumictl
     - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
+      uses: pulumi/actions@v4
+      with:
+        pulumi-version: v3.89.0
     - if: github.event_name == 'pull_request'
       name: Install Schema Tools
       uses: jaxxstorm/action-install-gh-release@v1.5.0
@@ -170,7 +172,9 @@ jobs:
       with:
         repo: pulumi/pulumictl
     - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
+      uses: pulumi/actions@v4
+      with:
+        pulumi-version: v3.89.0
     - name: Setup Node
       uses: actions/setup-node@v2
       with:
@@ -264,7 +268,9 @@ jobs:
       with:
         repo: pulumi/pulumictl
     - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
+      uses: pulumi/actions@v4
+      with:
+        pulumi-version: v3.89.0
     - name: Setup Node
       uses: actions/setup-node@v2
       with:
@@ -397,7 +403,9 @@ jobs:
       with:
         repo: pulumi/pulumictl
     - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
+      uses: pulumi/actions@v4
+      with:
+        pulumi-version: v3.89.0
     - name: Configure AWS Credentials
       uses: aws-actions/configure-aws-credentials@v1
       with:
@@ -449,7 +457,7 @@ jobs:
       with:
         repo: pulumi/pulumictl
     - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
+      uses: pulumi/actions@v4
     - name: Setup Node
       uses: actions/setup-node@v2
       with:
@@ -527,7 +535,7 @@ jobs:
       with:
         repo: pulumi/pulumictl
     - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
+      uses: pulumi/actions@v4
     - name: Setup Java
       uses: actions/setup-java@v3
       with:
@@ -573,7 +581,9 @@ jobs:
       with:
         go-version: ${{ env.GOVERSION }}
     - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
+      uses: pulumi/actions@v4
+      with:
+        pulumi-version: v3.89.0
     - name: Setup Node
       uses: actions/setup-node@v2
       with:
@@ -634,7 +644,9 @@ jobs:
       with:
         go-version: ${{ env.GOVERSION }}
     - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
+      uses: pulumi/actions@v4
+      with:
+        pulumi-version: v3.89.0
     - name: Setup Node
       uses: actions/setup-node@v2
       with:

--- a/native-provider-ci/providers/kubernetes/repo/.github/workflows/prerelease.yml
+++ b/native-provider-ci/providers/kubernetes/repo/.github/workflows/prerelease.yml
@@ -63,7 +63,9 @@ jobs:
       with:
         repo: pulumi/pulumictl
     - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
+      uses: pulumi/actions@v4
+      with:
+        pulumi-version: v3.89.0
     - if: github.event_name == 'pull_request'
       name: Install Schema Tools
       uses: jaxxstorm/action-install-gh-release@v1.5.0
@@ -162,7 +164,9 @@ jobs:
       with:
         repo: pulumi/pulumictl
     - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
+      uses: pulumi/actions@v4
+      with:
+        pulumi-version: v3.89.0
     - name: Setup Node
       uses: actions/setup-node@v2
       with:
@@ -255,7 +259,9 @@ jobs:
       with:
         repo: pulumi/pulumictl
     - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
+      uses: pulumi/actions@v4
+      with:
+        pulumi-version: v3.89.0
     - name: Setup Node
       uses: actions/setup-node@v2
       with:
@@ -388,7 +394,9 @@ jobs:
       with:
         repo: pulumi/pulumictl
     - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
+      uses: pulumi/actions@v4
+      with:
+        pulumi-version: v3.89.0
     - name: Configure AWS Credentials
       uses: aws-actions/configure-aws-credentials@v1
       with:
@@ -440,7 +448,7 @@ jobs:
       with:
         repo: pulumi/pulumictl
     - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
+      uses: pulumi/actions@v4
     - name: Setup Node
       uses: actions/setup-node@v2
       with:
@@ -518,7 +526,7 @@ jobs:
       with:
         repo: pulumi/pulumictl
     - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
+      uses: pulumi/actions@v4
     - name: Setup Java
       uses: actions/setup-java@v3
       with:
@@ -564,7 +572,9 @@ jobs:
       with:
         go-version: ${{ env.GOVERSION }}
     - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
+      uses: pulumi/actions@v4
+      with:
+        pulumi-version: v3.89.0
     - name: Setup Node
       uses: actions/setup-node@v2
       with:
@@ -625,7 +635,9 @@ jobs:
       with:
         go-version: ${{ env.GOVERSION }}
     - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
+      uses: pulumi/actions@v4
+      with:
+        pulumi-version: v3.89.0
     - name: Setup Node
       uses: actions/setup-node@v2
       with:

--- a/native-provider-ci/providers/kubernetes/repo/.github/workflows/release.yml
+++ b/native-provider-ci/providers/kubernetes/repo/.github/workflows/release.yml
@@ -63,7 +63,9 @@ jobs:
       with:
         repo: pulumi/pulumictl
     - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
+      uses: pulumi/actions@v4
+      with:
+        pulumi-version: v3.89.0
     - if: github.event_name == 'pull_request'
       name: Install Schema Tools
       uses: jaxxstorm/action-install-gh-release@v1.5.0
@@ -162,7 +164,9 @@ jobs:
       with:
         repo: pulumi/pulumictl
     - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
+      uses: pulumi/actions@v4
+      with:
+        pulumi-version: v3.89.0
     - name: Setup Node
       uses: actions/setup-node@v2
       with:
@@ -255,7 +259,9 @@ jobs:
       with:
         repo: pulumi/pulumictl
     - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
+      uses: pulumi/actions@v4
+      with:
+        pulumi-version: v3.89.0
     - name: Setup Node
       uses: actions/setup-node@v2
       with:
@@ -388,7 +394,9 @@ jobs:
       with:
         repo: pulumi/pulumictl
     - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
+      uses: pulumi/actions@v4
+      with:
+        pulumi-version: v3.89.0
     - name: Configure AWS Credentials
       uses: aws-actions/configure-aws-credentials@v1
       with:
@@ -439,7 +447,7 @@ jobs:
       with:
         repo: pulumi/pulumictl
     - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
+      uses: pulumi/actions@v4
     - name: Setup Node
       uses: actions/setup-node@v2
       with:
@@ -517,7 +525,7 @@ jobs:
       with:
         repo: pulumi/pulumictl
     - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
+      uses: pulumi/actions@v4
     - name: Setup Java
       uses: actions/setup-java@v3
       with:
@@ -593,7 +601,9 @@ jobs:
       with:
         go-version: ${{ env.GOVERSION }}
     - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
+      uses: pulumi/actions@v4
+      with:
+        pulumi-version: v3.89.0
     - name: Setup Node
       uses: actions/setup-node@v2
       with:
@@ -654,7 +664,9 @@ jobs:
       with:
         go-version: ${{ env.GOVERSION }}
     - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
+      uses: pulumi/actions@v4
+      with:
+        pulumi-version: v3.89.0
     - name: Setup Node
       uses: actions/setup-node@v2
       with:

--- a/native-provider-ci/providers/kubernetes/repo/.github/workflows/run-acceptance-tests.yml
+++ b/native-provider-ci/providers/kubernetes/repo/.github/workflows/run-acceptance-tests.yml
@@ -88,7 +88,9 @@ jobs:
       with:
         repo: pulumi/pulumictl
     - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
+      uses: pulumi/actions@v4
+      with:
+        pulumi-version: v3.89.0
     - if: github.event_name == 'pull_request'
       name: Install Schema Tools
       uses: jaxxstorm/action-install-gh-release@v1.5.0
@@ -190,7 +192,9 @@ jobs:
       with:
         repo: pulumi/pulumictl
     - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
+      uses: pulumi/actions@v4
+      with:
+        pulumi-version: v3.89.0
     - name: Setup Node
       uses: actions/setup-node@v2
       with:
@@ -287,7 +291,9 @@ jobs:
       with:
         repo: pulumi/pulumictl
     - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
+      uses: pulumi/actions@v4
+      with:
+        pulumi-version: v3.89.0
     - name: Setup Node
       uses: actions/setup-node@v2
       with:
@@ -433,7 +439,9 @@ jobs:
       with:
         go-version: ${{ env.GOVERSION }}
     - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
+      uses: pulumi/actions@v4
+      with:
+        pulumi-version: v3.89.0
     - name: Setup Node
       uses: actions/setup-node@v2
       with:
@@ -497,7 +505,9 @@ jobs:
       with:
         go-version: ${{ env.GOVERSION }}
     - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
+      uses: pulumi/actions@v4
+      with:
+        pulumi-version: v3.89.0
     - name: Setup Node
       uses: actions/setup-node@v2
       with:

--- a/native-provider-ci/providers/kubernetes/repo/.github/workflows/weekly-pulumi-update.yml
+++ b/native-provider-ci/providers/kubernetes/repo/.github/workflows/weekly-pulumi-update.yml
@@ -56,7 +56,9 @@ jobs:
       with:
         repo: pulumi/pulumictl
     - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
+      uses: pulumi/actions@v4
+      with:
+        pulumi-version: v3.89.0
     - name: Setup DotNet
       uses: actions/setup-dotnet@v3
       with:

--- a/native-provider-ci/src/action-versions.ts
+++ b/native-provider-ci/src/action-versions.ts
@@ -19,7 +19,7 @@ export const goReleaser = "goreleaser/goreleaser-action@v2";
 export const gradleBuildAction =
   "gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49";
 export const installGhRelease = "jaxxstorm/action-install-gh-release@v1.5.0";
-export const installPulumiCli = "pulumi/action-install-pulumi-cli@v2";
+export const installPulumiCli = "pulumi/actions@v4";
 export const codecov = "codecov/codecov-action@v3";
 
 // GHA Utilities

--- a/native-provider-ci/src/steps.ts
+++ b/native-provider-ci/src/steps.ts
@@ -332,10 +332,12 @@ export function DispatchDocsBuildEvent(): Step {
   };
 }
 
-export function InstallPulumiCli(): Step {
+export function InstallPulumiCli(version?: string): Step {
+  const withBlock = version ? { "pulumi-version": version } : undefined;
   return {
     name: "Install Pulumi CLI",
     uses: action.installPulumiCli,
+    with: withBlock,
   };
 }
 

--- a/native-provider-ci/src/workflows.ts
+++ b/native-provider-ci/src/workflows.ts
@@ -23,6 +23,7 @@ export const WorkflowOpts = z.object({
   providerVersion: z.string().default(""),
   skipCodegen: z.boolean().default(false),
   skipWindowsArmBuild: z.boolean().default(false),
+  pulumiCLIVersion: z.string().optional(),
 });
 type WorkflowOpts = z.infer<typeof WorkflowOpts>;
 
@@ -457,7 +458,7 @@ export class BuildSdkJob implements NormalJob {
       steps.CheckoutTagsStep(),
       steps.InstallGo(),
       steps.InstallPulumiCtl(),
-      steps.InstallPulumiCli(),
+      steps.InstallPulumiCli(opts.pulumiCLIVersion),
       steps.InstallNodeJS(),
       steps.InstallDotNet(),
       steps.InstallPython(),
@@ -513,7 +514,7 @@ export class PrerequisitesJob implements NormalJob {
       steps.CheckoutTagsStep(),
       steps.InstallGo(),
       steps.InstallPulumiCtl(),
-      steps.InstallPulumiCli(),
+      steps.InstallPulumiCli(opts.pulumiCLIVersion),
       steps.InstallSchemaChecker(opts.provider),
       steps.BuildK8sgen(opts.provider),
       steps.PrepareOpenAPIFile(opts.provider),
@@ -578,7 +579,7 @@ export class TestsJob implements NormalJob {
       steps.CheckoutTagsStep(),
       steps.InstallGo(),
       steps.InstallPulumiCtl(),
-      steps.InstallPulumiCli(),
+      steps.InstallPulumiCli(opts.pulumiCLIVersion),
       steps.InstallNodeJS(),
       steps.InstallDotNet(),
       steps.InstallPython(),
@@ -640,7 +641,7 @@ export class BuildTestClusterJob implements NormalJob {
     this.steps = [
       steps.CheckoutRepoStep(),
       steps.InstallGo(),
-      steps.InstallPulumiCli(),
+      steps.InstallPulumiCli(opts.pulumiCLIVersion),
       steps.InstallNodeJS(),
       steps.GoogleAuth(opts.gcp),
       steps.SetupGCloud(opts.gcp),
@@ -685,7 +686,7 @@ export class TeardownTestClusterJob implements NormalJob {
     this.steps = [
       steps.CheckoutRepoStep(),
       steps.InstallGo(),
-      steps.InstallPulumiCli(),
+      steps.InstallPulumiCli(opts.pulumiCLIVersion),
       steps.InstallNodeJS(),
       steps.GoogleAuth(opts.gcp),
       steps.SetupGCloud(opts.gcp),
@@ -746,7 +747,7 @@ export class PublishPrereleaseJob implements NormalJob {
       steps.CheckoutTagsStep(),
       steps.InstallGo(),
       steps.InstallPulumiCtl(),
-      steps.InstallPulumiCli(),
+      steps.InstallPulumiCli(opts.pulumiCLIVersion),
       steps.ConfigureAwsCredentialsForPublish(),
       steps.SetPreReleaseVersion(),
       steps.RunGoReleaserWithArgs(
@@ -775,7 +776,7 @@ export class PublishJob implements NormalJob {
       steps.CheckoutTagsStep(),
       steps.InstallGo(),
       steps.InstallPulumiCtl(),
-      steps.InstallPulumiCli(),
+      steps.InstallPulumiCli(opts.pulumiCLIVersion),
       steps.ConfigureAwsCredentialsForPublish(),
       steps.SetPreReleaseVersion(),
       steps.RunGoReleaserWithArgs(
@@ -949,7 +950,7 @@ export class WeeklyPulumiUpdate implements NormalJob {
       steps.CheckoutTagsStep(),
       steps.InstallGo(),
       steps.InstallPulumiCtl(),
-      steps.InstallPulumiCli(),
+      steps.InstallPulumiCli(opts.pulumiCLIVersion),
       steps.InstallDotNet(),
       steps.InstallNodeJS(),
       steps.InstallPython(),
@@ -977,7 +978,7 @@ export class NightlySdkGeneration implements NormalJob {
       steps.CheckoutTagsStep(opts.provider),
       steps.InstallGo(goVersion),
       steps.InstallPulumiCtl(),
-      steps.InstallPulumiCli(),
+      steps.InstallPulumiCli(opts.pulumiCLIVersion),
       steps.ConfigureAwsCredentialsForTests(opts.aws),
       steps.AzureLogin(opts.provider),
       steps.MakeClean(),


### PR DESCRIPTION
This PR changes the Pulumi CLI installation step to use `pulumi/actions@v4` which allows us to pin a specific version of the CLI to install. A new config variable: `pulumiCLIVersion` allows us to specify if a version should be pinned.

This PR also pins the Pulumi CLI version to v3.89.0 for the Kubernetes provider.