### PR TITLE
Disable provider building in tests

### DIFF
--- a/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/run-acceptance-tests.yml
@@ -308,6 +308,8 @@ jobs:
     - name: Run tests
       run: cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{
         matrix.language }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt
+      env:
+        DISABLE_PROVIDER_BUILD: 'TRUE'
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: #{{ .Config.actionVersions.notifySlack }}#

--- a/provider-ci/test-workflows/aws/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/test-workflows/aws/.github/workflows/run-acceptance-tests.yml
@@ -385,6 +385,8 @@ jobs:
     - name: Run tests
       run: cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{
         matrix.language }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt
+      env:
+        DISABLE_PROVIDER_BUILD: 'TRUE'
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3

--- a/provider-ci/test-workflows/cloudflare/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/test-workflows/cloudflare/.github/workflows/run-acceptance-tests.yml
@@ -361,6 +361,8 @@ jobs:
     - name: Run tests
       run: cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{
         matrix.language }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt
+      env:
+        DISABLE_PROVIDER_BUILD: 'TRUE'
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3

--- a/provider-ci/test-workflows/docker/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/test-workflows/docker/.github/workflows/run-acceptance-tests.yml
@@ -401,6 +401,8 @@ jobs:
     - name: Run tests
       run: cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{
         matrix.language }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt
+      env:
+        DISABLE_PROVIDER_BUILD: 'TRUE'
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3


### PR DESCRIPTION
This PR is meant to disable the new behaviour that will be added in https://github.com/pulumi/pulumi-aws/pull/2953 for CI.  

https://github.com/pulumi/pulumi-aws/pull/2953 will add provider building as a prerequisite of running tests, which is great for local development but is not what we want for CI, since it has a separate job for building the provider.

We set the env var `DISABLE_PROVIDER_BUILD` to disable the builds in CI.