### PR TITLE
Test PRs targeting branches other than master

### DIFF
--- a/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/run-acceptance-tests.yml
@@ -341,6 +341,8 @@ on:
   pull_request:
     branches:
     - #{{ .Config.providerDefaultBranch }}#
+    - v*
+    - feature*
     paths-ignore:
     - CHANGELOG.md
   repository_dispatch:

--- a/provider-ci/test-workflows/aws/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/test-workflows/aws/.github/workflows/run-acceptance-tests.yml
@@ -440,6 +440,8 @@ on:
   pull_request:
     branches:
     - master
+    - v*
+    - feature*
     paths-ignore:
     - CHANGELOG.md
   repository_dispatch:

--- a/provider-ci/test-workflows/cloudflare/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/test-workflows/cloudflare/.github/workflows/run-acceptance-tests.yml
@@ -391,6 +391,8 @@ on:
   pull_request:
     branches:
     - master
+    - v*
+    - feature*
     paths-ignore:
     - CHANGELOG.md
   repository_dispatch:

--- a/provider-ci/test-workflows/docker/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/test-workflows/docker/.github/workflows/run-acceptance-tests.yml
@@ -431,6 +431,8 @@ on:
   pull_request:
     branches:
     - master
+    - v*
+    - feature*
     paths-ignore:
     - CHANGELOG.md
   repository_dispatch:


### PR DESCRIPTION
In context of https://github.com/pulumi/pulumi-aws/pull/3025 it would be great to be able to maintain multiple "main" branches, such as "v5" branch in AWS, and have tests qualify this branch and PRs targeting it. This change specifically enables testing PRs that target feature-* or v* branches.