### PR TITLE
Automatically collapse generated SDKs in code review

### DIFF
--- a/provider-ci/internal/pkg/templates/bridged-provider/.gitattributes
+++ b/provider-ci/internal/pkg/templates/bridged-provider/.gitattributes
@@ -1,0 +1,1 @@
+sdk/**/* linguist-generated=true

--- a/provider-ci/test-workflows/aws/.gitattributes
+++ b/provider-ci/test-workflows/aws/.gitattributes
@@ -1,0 +1,1 @@
+sdk/**/* linguist-generated=true

--- a/provider-ci/test-workflows/cloudflare/.gitattributes
+++ b/provider-ci/test-workflows/cloudflare/.gitattributes
@@ -1,0 +1,1 @@
+sdk/**/* linguist-generated=true

--- a/provider-ci/test-workflows/docker/.gitattributes
+++ b/provider-ci/test-workflows/docker/.gitattributes
@@ -1,0 +1,1 @@
+sdk/**/* linguist-generated=true


### PR DESCRIPTION
This will help make PRs marginally easier to review by hiding some of the autogenerated noise.

See the [GitHub docs](https://docs.github.com/en/repositories/working-with-files/managing-files/customizing-how-changed-files-appear-on-github) for details.