### PR TITLE
Remove duplicate schema check headings in GH comment

### DIFF
--- a/native-provider-ci/providers/aws-native/repo/.github/workflows/build.yml
+++ b/native-provider-ci/providers/aws-native/repo/.github/workflows/build.yml
@@ -90,8 +90,6 @@ jobs:
       uses: thollander/actions-comment-pull-request@v2
       with:
         message: |
-          ### Does the PR have any schema changes?
-
           ${{ env.SCHEMA_CHANGES }}
         comment_tag: schemaCheck
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/native-provider-ci/providers/aws-native/repo/.github/workflows/prerelease.yml
+++ b/native-provider-ci/providers/aws-native/repo/.github/workflows/prerelease.yml
@@ -82,8 +82,6 @@ jobs:
       uses: thollander/actions-comment-pull-request@v2
       with:
         message: |
-          ### Does the PR have any schema changes?
-
           ${{ env.SCHEMA_CHANGES }}
         comment_tag: schemaCheck
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/native-provider-ci/providers/aws-native/repo/.github/workflows/release.yml
+++ b/native-provider-ci/providers/aws-native/repo/.github/workflows/release.yml
@@ -82,8 +82,6 @@ jobs:
       uses: thollander/actions-comment-pull-request@v2
       with:
         message: |
-          ### Does the PR have any schema changes?
-
           ${{ env.SCHEMA_CHANGES }}
         comment_tag: schemaCheck
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/native-provider-ci/providers/aws-native/repo/.github/workflows/run-acceptance-tests.yml
+++ b/native-provider-ci/providers/aws-native/repo/.github/workflows/run-acceptance-tests.yml
@@ -106,8 +106,6 @@ jobs:
       uses: thollander/actions-comment-pull-request@v2
       with:
         message: |
-          ### Does the PR have any schema changes?
-
           ${{ env.SCHEMA_CHANGES }}
         comment_tag: schemaCheck
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/native-provider-ci/providers/azure-native/repo/.github/workflows/build.yml
+++ b/native-provider-ci/providers/azure-native/repo/.github/workflows/build.yml
@@ -96,8 +96,6 @@ jobs:
       uses: thollander/actions-comment-pull-request@v2
       with:
         message: |
-          ### Does the PR have any schema changes?
-
           ${{ env.SCHEMA_CHANGES }}
         comment_tag: schemaCheck
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/native-provider-ci/providers/azure-native/repo/.github/workflows/prerelease.yml
+++ b/native-provider-ci/providers/azure-native/repo/.github/workflows/prerelease.yml
@@ -88,8 +88,6 @@ jobs:
       uses: thollander/actions-comment-pull-request@v2
       with:
         message: |
-          ### Does the PR have any schema changes?
-
           ${{ env.SCHEMA_CHANGES }}
         comment_tag: schemaCheck
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/native-provider-ci/providers/azure-native/repo/.github/workflows/release.yml
+++ b/native-provider-ci/providers/azure-native/repo/.github/workflows/release.yml
@@ -88,8 +88,6 @@ jobs:
       uses: thollander/actions-comment-pull-request@v2
       with:
         message: |
-          ### Does the PR have any schema changes?
-
           ${{ env.SCHEMA_CHANGES }}
         comment_tag: schemaCheck
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/native-provider-ci/providers/azure-native/repo/.github/workflows/run-acceptance-tests.yml
+++ b/native-provider-ci/providers/azure-native/repo/.github/workflows/run-acceptance-tests.yml
@@ -112,8 +112,6 @@ jobs:
       uses: thollander/actions-comment-pull-request@v2
       with:
         message: |
-          ### Does the PR have any schema changes?
-
           ${{ env.SCHEMA_CHANGES }}
         comment_tag: schemaCheck
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/native-provider-ci/providers/google-native/repo/.github/workflows/build.yml
+++ b/native-provider-ci/providers/google-native/repo/.github/workflows/build.yml
@@ -96,8 +96,6 @@ jobs:
       uses: thollander/actions-comment-pull-request@v2
       with:
         message: |
-          ### Does the PR have any schema changes?
-
           ${{ env.SCHEMA_CHANGES }}
         comment_tag: schemaCheck
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/native-provider-ci/providers/google-native/repo/.github/workflows/prerelease.yml
+++ b/native-provider-ci/providers/google-native/repo/.github/workflows/prerelease.yml
@@ -88,8 +88,6 @@ jobs:
       uses: thollander/actions-comment-pull-request@v2
       with:
         message: |
-          ### Does the PR have any schema changes?
-
           ${{ env.SCHEMA_CHANGES }}
         comment_tag: schemaCheck
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/native-provider-ci/providers/google-native/repo/.github/workflows/release.yml
+++ b/native-provider-ci/providers/google-native/repo/.github/workflows/release.yml
@@ -88,8 +88,6 @@ jobs:
       uses: thollander/actions-comment-pull-request@v2
       with:
         message: |
-          ### Does the PR have any schema changes?
-
           ${{ env.SCHEMA_CHANGES }}
         comment_tag: schemaCheck
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/native-provider-ci/providers/google-native/repo/.github/workflows/run-acceptance-tests.yml
+++ b/native-provider-ci/providers/google-native/repo/.github/workflows/run-acceptance-tests.yml
@@ -112,8 +112,6 @@ jobs:
       uses: thollander/actions-comment-pull-request@v2
       with:
         message: |
-          ### Does the PR have any schema changes?
-
           ${{ env.SCHEMA_CHANGES }}
         comment_tag: schemaCheck
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/native-provider-ci/providers/kubernetes/repo/.github/workflows/build.yml
+++ b/native-provider-ci/providers/kubernetes/repo/.github/workflows/build.yml
@@ -98,8 +98,6 @@ jobs:
       uses: thollander/actions-comment-pull-request@v2
       with:
         message: |
-          ### Does the PR have any schema changes?
-
           ${{ env.SCHEMA_CHANGES }}
         comment_tag: schemaCheck
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/native-provider-ci/providers/kubernetes/repo/.github/workflows/prerelease.yml
+++ b/native-provider-ci/providers/kubernetes/repo/.github/workflows/prerelease.yml
@@ -90,8 +90,6 @@ jobs:
       uses: thollander/actions-comment-pull-request@v2
       with:
         message: |
-          ### Does the PR have any schema changes?
-
           ${{ env.SCHEMA_CHANGES }}
         comment_tag: schemaCheck
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/native-provider-ci/providers/kubernetes/repo/.github/workflows/release.yml
+++ b/native-provider-ci/providers/kubernetes/repo/.github/workflows/release.yml
@@ -90,8 +90,6 @@ jobs:
       uses: thollander/actions-comment-pull-request@v2
       with:
         message: |
-          ### Does the PR have any schema changes?
-
           ${{ env.SCHEMA_CHANGES }}
         comment_tag: schemaCheck
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/native-provider-ci/providers/kubernetes/repo/.github/workflows/run-acceptance-tests.yml
+++ b/native-provider-ci/providers/kubernetes/repo/.github/workflows/run-acceptance-tests.yml
@@ -115,8 +115,6 @@ jobs:
       uses: thollander/actions-comment-pull-request@v2
       with:
         message: |
-          ### Does the PR have any schema changes?
-
           ${{ env.SCHEMA_CHANGES }}
         comment_tag: schemaCheck
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/native-provider-ci/src/steps.ts
+++ b/native-provider-ci/src/steps.ts
@@ -573,8 +573,7 @@ export function CommentSchemaChangesOnPR(provider: string): Step {
     name: "Comment on PR with Details of Schema Check",
     uses: action.prComment,
     with: {
-      message:
-        "${{ env.SCHEMA_CHANGES }}\n",
+      message: "${{ env.SCHEMA_CHANGES }}\n",
       comment_tag: "schemaCheck",
       GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}",
     },

--- a/native-provider-ci/src/steps.ts
+++ b/native-provider-ci/src/steps.ts
@@ -574,7 +574,6 @@ export function CommentSchemaChangesOnPR(provider: string): Step {
     uses: action.prComment,
     with: {
       message:
-        "### Does the PR have any schema changes?\n\n" +
         "${{ env.SCHEMA_CHANGES }}\n",
       comment_tag: "schemaCheck",
       GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}",


### PR DESCRIPTION
The new version of schema-tools already presents a header, so no need to insert it again in the GitHub comment.

Example duplicate heading: https://github.com/pulumi/pulumi-kubernetes/pull/2697#issuecomment-1847777644