### PR TITLE
Update golangci-lint to v1.55.2 for Kubernetes

### DIFF
--- a/native-provider-ci/providers/kubernetes/config.yaml
+++ b/native-provider-ci/providers/kubernetes/config.yaml
@@ -6,7 +6,7 @@ major-version: 4
 env:
   AWS_REGION: us-west-2
   PULUMI_TEST_OWNER: moolumi
-  GOLANGCI_LINT_VERSION: v1.52.2
+  GOLANGCI_LINT_VERSION: v1.55.2
   GOLANGCI_LINT_TIMEOUT: 10m
   GOOGLE_CI_SERVICE_ACCOUNT_EMAIL:  pulumi-ci@pulumi-k8s-provider.iam.gserviceaccount.com
   GOOGLE_CI_WORKLOAD_IDENTITY_POOL: pulumi-ci

--- a/native-provider-ci/providers/kubernetes/repo/.github/workflows/build.yml
+++ b/native-provider-ci/providers/kubernetes/repo/.github/workflows/build.yml
@@ -40,7 +40,7 @@ env:
   JAVAVERSION: "11"
   AWS_REGION: us-west-2
   PULUMI_TEST_OWNER: moolumi
-  GOLANGCI_LINT_VERSION: v1.52.2
+  GOLANGCI_LINT_VERSION: v1.55.2
   GOLANGCI_LINT_TIMEOUT: 10m
   GOOGLE_CI_SERVICE_ACCOUNT_EMAIL: pulumi-ci@pulumi-k8s-provider.iam.gserviceaccount.com
   GOOGLE_CI_WORKLOAD_IDENTITY_POOL: pulumi-ci

--- a/native-provider-ci/providers/kubernetes/repo/.github/workflows/command-dispatch.yml
+++ b/native-provider-ci/providers/kubernetes/repo/.github/workflows/command-dispatch.yml
@@ -32,7 +32,7 @@ env:
   JAVAVERSION: "11"
   AWS_REGION: us-west-2
   PULUMI_TEST_OWNER: moolumi
-  GOLANGCI_LINT_VERSION: v1.52.2
+  GOLANGCI_LINT_VERSION: v1.55.2
   GOLANGCI_LINT_TIMEOUT: 10m
   GOOGLE_CI_SERVICE_ACCOUNT_EMAIL: pulumi-ci@pulumi-k8s-provider.iam.gserviceaccount.com
   GOOGLE_CI_WORKLOAD_IDENTITY_POOL: pulumi-ci

--- a/native-provider-ci/providers/kubernetes/repo/.github/workflows/prerelease.yml
+++ b/native-provider-ci/providers/kubernetes/repo/.github/workflows/prerelease.yml
@@ -31,7 +31,7 @@ env:
   JAVAVERSION: "11"
   AWS_REGION: us-west-2
   PULUMI_TEST_OWNER: moolumi
-  GOLANGCI_LINT_VERSION: v1.52.2
+  GOLANGCI_LINT_VERSION: v1.55.2
   GOLANGCI_LINT_TIMEOUT: 10m
   GOOGLE_CI_SERVICE_ACCOUNT_EMAIL: pulumi-ci@pulumi-k8s-provider.iam.gserviceaccount.com
   GOOGLE_CI_WORKLOAD_IDENTITY_POOL: pulumi-ci

--- a/native-provider-ci/providers/kubernetes/repo/.github/workflows/pull-request.yml
+++ b/native-provider-ci/providers/kubernetes/repo/.github/workflows/pull-request.yml
@@ -29,7 +29,7 @@ env:
   JAVAVERSION: "11"
   AWS_REGION: us-west-2
   PULUMI_TEST_OWNER: moolumi
-  GOLANGCI_LINT_VERSION: v1.52.2
+  GOLANGCI_LINT_VERSION: v1.55.2
   GOLANGCI_LINT_TIMEOUT: 10m
   GOOGLE_CI_SERVICE_ACCOUNT_EMAIL: pulumi-ci@pulumi-k8s-provider.iam.gserviceaccount.com
   GOOGLE_CI_WORKLOAD_IDENTITY_POOL: pulumi-ci

--- a/native-provider-ci/providers/kubernetes/repo/.github/workflows/release.yml
+++ b/native-provider-ci/providers/kubernetes/repo/.github/workflows/release.yml
@@ -32,7 +32,7 @@ env:
   JAVAVERSION: "11"
   AWS_REGION: us-west-2
   PULUMI_TEST_OWNER: moolumi
-  GOLANGCI_LINT_VERSION: v1.52.2
+  GOLANGCI_LINT_VERSION: v1.55.2
   GOLANGCI_LINT_TIMEOUT: 10m
   GOOGLE_CI_SERVICE_ACCOUNT_EMAIL: pulumi-ci@pulumi-k8s-provider.iam.gserviceaccount.com
   GOOGLE_CI_WORKLOAD_IDENTITY_POOL: pulumi-ci

--- a/native-provider-ci/providers/kubernetes/repo/.github/workflows/run-acceptance-tests.yml
+++ b/native-provider-ci/providers/kubernetes/repo/.github/workflows/run-acceptance-tests.yml
@@ -39,7 +39,7 @@ env:
   JAVAVERSION: "11"
   AWS_REGION: us-west-2
   PULUMI_TEST_OWNER: moolumi
-  GOLANGCI_LINT_VERSION: v1.52.2
+  GOLANGCI_LINT_VERSION: v1.55.2
   GOLANGCI_LINT_TIMEOUT: 10m
   GOOGLE_CI_SERVICE_ACCOUNT_EMAIL: pulumi-ci@pulumi-k8s-provider.iam.gserviceaccount.com
   GOOGLE_CI_WORKLOAD_IDENTITY_POOL: pulumi-ci

--- a/native-provider-ci/providers/kubernetes/repo/.github/workflows/weekly-pulumi-update.yml
+++ b/native-provider-ci/providers/kubernetes/repo/.github/workflows/weekly-pulumi-update.yml
@@ -31,7 +31,7 @@ env:
   JAVAVERSION: "11"
   AWS_REGION: us-west-2
   PULUMI_TEST_OWNER: moolumi
-  GOLANGCI_LINT_VERSION: v1.52.2
+  GOLANGCI_LINT_VERSION: v1.55.2
   GOLANGCI_LINT_TIMEOUT: 10m
   GOOGLE_CI_SERVICE_ACCOUNT_EMAIL: pulumi-ci@pulumi-k8s-provider.iam.gserviceaccount.com
   GOOGLE_CI_WORKLOAD_IDENTITY_POOL: pulumi-ci


### PR DESCRIPTION
Replicates https://github.com/pulumi/pulumi-kubernetes/pull/2694 in [pulumi/ci-mgmt](https://github.com/pulumi/ci-mgmt)