### PR TITLE
Pin kubectl to v1.28

### DIFF
--- a/native-provider-ci/providers/kubernetes/repo/.github/workflows/build.yml
+++ b/native-provider-ci/providers/kubernetes/repo/.github/workflows/build.yml
@@ -348,7 +348,7 @@ jobs:
       run: >
         curl -LO
         https://storage.googleapis.com/kubernetes-release/release/$(curl -s
-        https://storage.googleapis.com/kubernetes-release/release/stable.txt)/bin/linux/amd64/kubectl
+        https://storage.googleapis.com/kubernetes-release/release/stable-1.28.txt)/bin/linux/amd64/kubectl
 
         chmod +x ./kubectl
 
@@ -593,7 +593,7 @@ jobs:
       run: >
         curl -LO
         https://storage.googleapis.com/kubernetes-release/release/$(curl -s
-        https://storage.googleapis.com/kubernetes-release/release/stable.txt)/bin/linux/amd64/kubectl
+        https://storage.googleapis.com/kubernetes-release/release/stable-1.28.txt)/bin/linux/amd64/kubectl
 
         chmod +x ./kubectl
 
@@ -654,7 +654,7 @@ jobs:
       run: >
         curl -LO
         https://storage.googleapis.com/kubernetes-release/release/$(curl -s
-        https://storage.googleapis.com/kubernetes-release/release/stable.txt)/bin/linux/amd64/kubectl
+        https://storage.googleapis.com/kubernetes-release/release/stable-1.28.txt)/bin/linux/amd64/kubectl
 
         chmod +x ./kubectl
 

--- a/native-provider-ci/providers/kubernetes/repo/.github/workflows/prerelease.yml
+++ b/native-provider-ci/providers/kubernetes/repo/.github/workflows/prerelease.yml
@@ -339,7 +339,7 @@ jobs:
       run: >
         curl -LO
         https://storage.googleapis.com/kubernetes-release/release/$(curl -s
-        https://storage.googleapis.com/kubernetes-release/release/stable.txt)/bin/linux/amd64/kubectl
+        https://storage.googleapis.com/kubernetes-release/release/stable-1.28.txt)/bin/linux/amd64/kubectl
 
         chmod +x ./kubectl
 
@@ -584,7 +584,7 @@ jobs:
       run: >
         curl -LO
         https://storage.googleapis.com/kubernetes-release/release/$(curl -s
-        https://storage.googleapis.com/kubernetes-release/release/stable.txt)/bin/linux/amd64/kubectl
+        https://storage.googleapis.com/kubernetes-release/release/stable-1.28.txt)/bin/linux/amd64/kubectl
 
         chmod +x ./kubectl
 
@@ -645,7 +645,7 @@ jobs:
       run: >
         curl -LO
         https://storage.googleapis.com/kubernetes-release/release/$(curl -s
-        https://storage.googleapis.com/kubernetes-release/release/stable.txt)/bin/linux/amd64/kubectl
+        https://storage.googleapis.com/kubernetes-release/release/stable-1.28.txt)/bin/linux/amd64/kubectl
 
         chmod +x ./kubectl
 

--- a/native-provider-ci/providers/kubernetes/repo/.github/workflows/release.yml
+++ b/native-provider-ci/providers/kubernetes/repo/.github/workflows/release.yml
@@ -339,7 +339,7 @@ jobs:
       run: >
         curl -LO
         https://storage.googleapis.com/kubernetes-release/release/$(curl -s
-        https://storage.googleapis.com/kubernetes-release/release/stable.txt)/bin/linux/amd64/kubectl
+        https://storage.googleapis.com/kubernetes-release/release/stable-1.28.txt)/bin/linux/amd64/kubectl
 
         chmod +x ./kubectl
 
@@ -613,7 +613,7 @@ jobs:
       run: >
         curl -LO
         https://storage.googleapis.com/kubernetes-release/release/$(curl -s
-        https://storage.googleapis.com/kubernetes-release/release/stable.txt)/bin/linux/amd64/kubectl
+        https://storage.googleapis.com/kubernetes-release/release/stable-1.28.txt)/bin/linux/amd64/kubectl
 
         chmod +x ./kubectl
 
@@ -674,7 +674,7 @@ jobs:
       run: >
         curl -LO
         https://storage.googleapis.com/kubernetes-release/release/$(curl -s
-        https://storage.googleapis.com/kubernetes-release/release/stable.txt)/bin/linux/amd64/kubectl
+        https://storage.googleapis.com/kubernetes-release/release/stable-1.28.txt)/bin/linux/amd64/kubectl
 
         chmod +x ./kubectl
 

--- a/native-provider-ci/providers/kubernetes/repo/.github/workflows/run-acceptance-tests.yml
+++ b/native-provider-ci/providers/kubernetes/repo/.github/workflows/run-acceptance-tests.yml
@@ -371,7 +371,7 @@ jobs:
       run: >
         curl -LO
         https://storage.googleapis.com/kubernetes-release/release/$(curl -s
-        https://storage.googleapis.com/kubernetes-release/release/stable.txt)/bin/linux/amd64/kubectl
+        https://storage.googleapis.com/kubernetes-release/release/stable-1.28.txt)/bin/linux/amd64/kubectl
 
         chmod +x ./kubectl
 
@@ -453,7 +453,7 @@ jobs:
       run: >
         curl -LO
         https://storage.googleapis.com/kubernetes-release/release/$(curl -s
-        https://storage.googleapis.com/kubernetes-release/release/stable.txt)/bin/linux/amd64/kubectl
+        https://storage.googleapis.com/kubernetes-release/release/stable-1.28.txt)/bin/linux/amd64/kubectl
 
         chmod +x ./kubectl
 
@@ -517,7 +517,7 @@ jobs:
       run: >
         curl -LO
         https://storage.googleapis.com/kubernetes-release/release/$(curl -s
-        https://storage.googleapis.com/kubernetes-release/release/stable.txt)/bin/linux/amd64/kubectl
+        https://storage.googleapis.com/kubernetes-release/release/stable-1.28.txt)/bin/linux/amd64/kubectl
 
         chmod +x ./kubectl
 

--- a/native-provider-ci/src/steps.ts
+++ b/native-provider-ci/src/steps.ts
@@ -706,7 +706,7 @@ export function InstallKubectl(provider: string): Step {
     return {
       name: "Install Kubectl",
       run:
-        "curl -LO https://storage.googleapis.com/kubernetes-release/release/$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)/bin/linux/amd64/kubectl\n" +
+        "curl -LO https://storage.googleapis.com/kubernetes-release/release/$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable-1.28.txt)/bin/linux/amd64/kubectl\n" +
         "chmod +x ./kubectl\n" +
         "sudo mv kubectl /usr/local/bin\n",
     };


### PR DESCRIPTION
Our CI cluster will (soon) be pinned to Kubernetes v1.28. To prevent skew between the API server and kubectl client version, this PR pins the installed kubectl to v1.28.