### PR TITLE
Correctly read Pulumi version from  folder when installing pulumi

### DIFF
--- a/provider-ci/internal/pkg/templates/bridged-provider/Makefile
+++ b/provider-ci/internal/pkg/templates/bridged-provider/Makefile
@@ -178,7 +178,7 @@ ci-mgmt: .ci-mgmt.yaml
 		--config $<
 
 .pulumi/bin/pulumi: .pulumi/version
-	curl -fsSL https://get.pulumi.com | HOME=$(WORKING_DIR) sh -s -- --version $(cat .pulumi/version)
+	curl -fsSL https://get.pulumi.com | HOME=$(WORKING_DIR) sh -s -- --version $(shell cat .pulumi/version)
 
 # Compute the version of Pulumi to use by inspecting the Go dependencies of the provider.
 .pulumi/version:

--- a/provider-ci/test-workflows/aws/Makefile
+++ b/provider-ci/test-workflows/aws/Makefile
@@ -161,7 +161,7 @@ ci-mgmt: .ci-mgmt.yaml
 		--config $<
 
 .pulumi/bin/pulumi: .pulumi/version
-	curl -fsSL https://get.pulumi.com | HOME=$(WORKING_DIR) sh -s -- --version $(cat .pulumi/version)
+	curl -fsSL https://get.pulumi.com | HOME=$(WORKING_DIR) sh -s -- --version $(shell cat .pulumi/version)
 
 # Compute the version of Pulumi to use by inspecting the Go dependencies of the provider.
 .pulumi/version:

--- a/provider-ci/test-workflows/cloudflare/Makefile
+++ b/provider-ci/test-workflows/cloudflare/Makefile
@@ -151,7 +151,7 @@ ci-mgmt: .ci-mgmt.yaml
 		--config $<
 
 .pulumi/bin/pulumi: .pulumi/version
-	curl -fsSL https://get.pulumi.com | HOME=$(WORKING_DIR) sh -s -- --version $(cat .pulumi/version)
+	curl -fsSL https://get.pulumi.com | HOME=$(WORKING_DIR) sh -s -- --version $(shell cat .pulumi/version)
 
 # Compute the version of Pulumi to use by inspecting the Go dependencies of the provider.
 .pulumi/version:

--- a/provider-ci/test-workflows/docker/Makefile
+++ b/provider-ci/test-workflows/docker/Makefile
@@ -153,7 +153,7 @@ ci-mgmt: .ci-mgmt.yaml
 		--config $<
 
 .pulumi/bin/pulumi: .pulumi/version
-	curl -fsSL https://get.pulumi.com | HOME=$(WORKING_DIR) sh -s -- --version $(cat .pulumi/version)
+	curl -fsSL https://get.pulumi.com | HOME=$(WORKING_DIR) sh -s -- --version $(shell cat .pulumi/version)
 
 # Compute the version of Pulumi to use by inspecting the Go dependencies of the provider.
 .pulumi/version:


### PR DESCRIPTION
When we `make` our provider, we compute the pulumi version from the go.mod file and write it to a `.pulumi` folder, so we can install pulumi there.
But when we then actually install pulumi in this folder, at least when run locally, it turns out that `$(cat .pulumi/version)` is not actually reading anything, even if the file exists. 
Instead, the latest pulumi version is used. This is probably mostly fine in practice, but obviously non-deterministic in nature.
A [quick check to a GA run](https://github.com/pulumi/pulumi-aws/actions/runs/7169609015/job/19520393449#step:10:36) shows that this is not working correctly in Actions, either. 
Locally, for me, `$(shell cat .pulumi/version)` works instead. This PR adds that change.
