### PR TITLE
Fix KeyError in close_outdated_bridge_prs.py

### DIFF
--- a/scripts/close_outdated_bridge_prs.py
+++ b/scripts/close_outdated_bridge_prs.py
@@ -72,7 +72,9 @@ def close_outdated(repo: str):
             # auto-merge: we don't need to close
             # non-bot author: not our concern
             continue
-        if issue["labels"]:
+        if "labels" in issue:
+            # if there are labels applied to the issue, assume a human added them and is working on it
+            # Eg. a "needs-release/<version>" label would indicate that a release is in process.
             continue
 
         issue_title = issue["title"]


### PR DESCRIPTION
Fixes https://github.com/pulumi/ci-mgmt/issues/743

In #730, @iwahbe added logic  to avoid closing PRs that have a label on them b/c this probably indicates a human is working on that PR.

Unfortunately, python throws a `KeyError` rather than returning `None` when it can't find a key in a dict, so this broke ci for issues that don't have labels.

This change should fix the code to match the intent.