### PR TITLE
Update Makefile detection of java version

### DIFF
--- a/provider-ci/internal/pkg/templates/bridged-provider.config.yaml
+++ b/provider-ci/internal/pkg/templates/bridged-provider.config.yaml
@@ -82,6 +82,6 @@ actionVersions:
   prComment: thollander/actions-comment-pull-request@v2
   slashCommand: peter-evans/slash-command-dispatch@v2
   uploadArtifact: actions/upload-artifact@v2
-  upgradeProviderAction: pulumi/pulumi-upgrade-provider-action@v0.0.10
+  upgradeProviderAction: pulumi/pulumi-upgrade-provider-action@v0.0.11
   publishProviderSDKs: pulumi/pulumi-package-publisher@v0.0.12
   slackNotification: rtCamp/action-slack-notify@v2

--- a/provider-ci/internal/pkg/templates/bridged-provider.config.yaml
+++ b/provider-ci/internal/pkg/templates/bridged-provider.config.yaml
@@ -1,5 +1,5 @@
 major-version: 2
-javaGenVersion: v0.5.4
+#javaGenVersion: 0.0.0
 parallel: 3
 timeout: 60
 lint: true

--- a/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/upgrade-bridge.yml
+++ b/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/upgrade-bridge.yml
@@ -56,6 +56,9 @@ jobs:
         automerge: ${{ inputs.automerge }}
         target-bridge-version: ${{ inputs.target-bridge-version }}
         target-pulumi-version: ${{ inputs.target-pulumi-version }}
+        #{{- if .Config.javaGenVersion }}#
+        target-java-version: #{{ .Config.javaGenVersion }}#
+        #{{- end }}#
         pr-reviewers: ${{ inputs.pr-reviewers }}
         pr-description: ${{ inputs.pr-description }}
     - name: Call upgrade provider action

--- a/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/upgrade-provider.yml
+++ b/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/upgrade-provider.yml
@@ -13,6 +13,9 @@ jobs:
       uses: #{{ .Config.actionVersions.upgradeProviderAction }}#
       with:
         kind: all
+        #{{- if .Config.javaGenVersion }}#
+        target-java-version: #{{ .Config.javaGenVersion }}#
+        #{{- end }}#
         email: bot@pulumi.com
         username: pulumi-bot
     - env:

--- a/provider-ci/internal/pkg/templates/bridged-provider/.upgrade-config.yml
+++ b/provider-ci/internal/pkg/templates/bridged-provider/.upgrade-config.yml
@@ -9,4 +9,6 @@ upstream-provider-name: terraform-provider-#{{ .Config.provider }}#
 pulumi-infer-version: true
 remove-plugins: true
 pr-reviewers: iwahbe # Team: pulumi/Providers
+#{{- if (index .Config "javaGenVersion") }}#
 javaVersion: "#{{ .Config.javaGenVersion }}#"
+#{{- end }}#

--- a/provider-ci/internal/pkg/templates/bridged-provider/Makefile
+++ b/provider-ci/internal/pkg/templates/bridged-provider/Makefile
@@ -13,7 +13,6 @@ TFGEN := pulumi-tfgen-$(PACK)
 PROVIDER := pulumi-resource-$(PACK)
 VERSION := $(shell pulumictl get version)
 JAVA_GEN := pulumi-java-gen
-JAVA_GEN_VERSION := #{{ .Config.javaGenVersion }}#
 TESTPARALLELISM := 10
 WORKING_DIR := $(shell pwd)
 #{{- if .Config.goBuildParallelism }}#
@@ -161,8 +160,8 @@ upstream.finalize:
 upstream.rebase:
 	scripts/upstream.sh "$@" start_rebase
 
-bin/pulumi-java-gen:
-	pulumictl download-binary -n pulumi-language-java -v $(JAVA_GEN_VERSION) -r pulumi/pulumi-java
+bin/pulumi-java-gen: .pulumi/java-gen-version
+	pulumictl download-binary -n pulumi-language-java -v v$(shell cat .pulumi/java-gen-version) -r pulumi/pulumi-java
 
 # To make an immediately observable change to .ci-mgmt.yaml:
 #

--- a/provider-ci/internal/pkg/templates/bridged-provider/Makefile
+++ b/provider-ci/internal/pkg/templates/bridged-provider/Makefile
@@ -160,8 +160,8 @@ upstream.finalize:
 upstream.rebase:
 	scripts/upstream.sh "$@" start_rebase
 
-bin/pulumi-java-gen: .pulumi/java-gen-version
-	pulumictl download-binary -n pulumi-language-java -v v$(shell cat .pulumi/java-gen-version) -r pulumi/pulumi-java
+bin/pulumi-java-gen: .pulumi-java-gen.version
+	pulumictl download-binary -n pulumi-language-java -v v$(shell cat .pulumi-java-gen.version) -r pulumi/pulumi-java
 
 # To make an immediately observable change to .ci-mgmt.yaml:
 #

--- a/provider-ci/providers/aws/config.yaml
+++ b/provider-ci/providers/aws/config.yaml
@@ -31,7 +31,6 @@ plugins:
     version: "5.14.0"
 team: ecosystem
 goBuildParallelism: 2
-javaGenVersion: "v0.9.5"
 runner:
   publish: pulumi-ubuntu-8core
   buildSdk: pulumi-ubuntu-8core

--- a/provider-ci/providers/docker/config.yaml
+++ b/provider-ci/providers/docker/config.yaml
@@ -32,4 +32,3 @@ actions:
       uses: webfactory/ssh-agent@v0.7.0
       with:
         ssh-private-key: ${{ secrets.PRIVATE_SSH_KEY_FOR_DIGITALOCEAN }}
-javaGenVersion: "v0.9.7"

--- a/provider-ci/test-workflows/aws/.github/workflows/upgrade-bridge.yml
+++ b/provider-ci/test-workflows/aws/.github/workflows/upgrade-bridge.yml
@@ -48,7 +48,7 @@ jobs:
     steps:
     - name: Call upgrade provider action
       if: github.event_name == 'workflow_dispatch'
-      uses: pulumi/pulumi-upgrade-provider-action@v0.0.10
+      uses: pulumi/pulumi-upgrade-provider-action@v0.0.11
       with:
         kind: bridge
         email: bot@pulumi.com
@@ -60,7 +60,7 @@ jobs:
         pr-description: ${{ inputs.pr-description }}
     - name: Call upgrade provider action
       if: github.event_name == 'repository_dispatch'
-      uses: pulumi/pulumi-upgrade-provider-action@v0.0.10
+      uses: pulumi/pulumi-upgrade-provider-action@v0.0.11
       with:
         kind: bridge
         email: bot@pulumi.com

--- a/provider-ci/test-workflows/aws/.github/workflows/upgrade-provider.yml
+++ b/provider-ci/test-workflows/aws/.github/workflows/upgrade-provider.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Call upgrade provider action
-      uses: pulumi/pulumi-upgrade-provider-action@v0.0.10
+      uses: pulumi/pulumi-upgrade-provider-action@v0.0.11
       with:
         kind: all
         email: bot@pulumi.com

--- a/provider-ci/test-workflows/aws/.upgrade-config.yml
+++ b/provider-ci/test-workflows/aws/.upgrade-config.yml
@@ -5,4 +5,3 @@ upstream-provider-name: terraform-provider-aws
 pulumi-infer-version: true
 remove-plugins: true
 pr-reviewers: iwahbe # Team: pulumi/Providers
-javaVersion: "v0.9.5"

--- a/provider-ci/test-workflows/aws/Makefile
+++ b/provider-ci/test-workflows/aws/Makefile
@@ -143,8 +143,8 @@ upstream.finalize:
 upstream.rebase:
 	scripts/upstream.sh "$@" start_rebase
 
-bin/pulumi-java-gen: .pulumi/java-gen-version
-	pulumictl download-binary -n pulumi-language-java -v v$(shell cat .pulumi/java-gen-version) -r pulumi/pulumi-java
+bin/pulumi-java-gen: .pulumi-java-gen.version
+	pulumictl download-binary -n pulumi-language-java -v v$(shell cat .pulumi-java-gen.version) -r pulumi/pulumi-java
 
 # To make an immediately observable change to .ci-mgmt.yaml:
 #

--- a/provider-ci/test-workflows/aws/Makefile
+++ b/provider-ci/test-workflows/aws/Makefile
@@ -9,7 +9,6 @@ TFGEN := pulumi-tfgen-$(PACK)
 PROVIDER := pulumi-resource-$(PACK)
 VERSION := $(shell pulumictl get version)
 JAVA_GEN := pulumi-java-gen
-JAVA_GEN_VERSION := v0.9.5
 TESTPARALLELISM := 10
 WORKING_DIR := $(shell pwd)
 PULUMI_PROVIDER_BUILD_PARALLELISM ?= -p 2
@@ -144,8 +143,8 @@ upstream.finalize:
 upstream.rebase:
 	scripts/upstream.sh "$@" start_rebase
 
-bin/pulumi-java-gen:
-	pulumictl download-binary -n pulumi-language-java -v $(JAVA_GEN_VERSION) -r pulumi/pulumi-java
+bin/pulumi-java-gen: .pulumi/java-gen-version
+	pulumictl download-binary -n pulumi-language-java -v v$(shell cat .pulumi/java-gen-version) -r pulumi/pulumi-java
 
 # To make an immediately observable change to .ci-mgmt.yaml:
 #

--- a/provider-ci/test-workflows/cloudflare/.github/workflows/upgrade-bridge.yml
+++ b/provider-ci/test-workflows/cloudflare/.github/workflows/upgrade-bridge.yml
@@ -48,7 +48,7 @@ jobs:
     steps:
     - name: Call upgrade provider action
       if: github.event_name == 'workflow_dispatch'
-      uses: pulumi/pulumi-upgrade-provider-action@v0.0.10
+      uses: pulumi/pulumi-upgrade-provider-action@v0.0.11
       with:
         kind: bridge
         email: bot@pulumi.com
@@ -61,7 +61,7 @@ jobs:
         pr-description: ${{ inputs.pr-description }}
     - name: Call upgrade provider action
       if: github.event_name == 'repository_dispatch'
-      uses: pulumi/pulumi-upgrade-provider-action@v0.0.10
+      uses: pulumi/pulumi-upgrade-provider-action@v0.0.11
       with:
         kind: bridge
         email: bot@pulumi.com

--- a/provider-ci/test-workflows/cloudflare/.github/workflows/upgrade-bridge.yml
+++ b/provider-ci/test-workflows/cloudflare/.github/workflows/upgrade-bridge.yml
@@ -56,6 +56,7 @@ jobs:
         automerge: ${{ inputs.automerge }}
         target-bridge-version: ${{ inputs.target-bridge-version }}
         target-pulumi-version: ${{ inputs.target-pulumi-version }}
+        target-java-version: v0.9.3
         pr-reviewers: ${{ inputs.pr-reviewers }}
         pr-description: ${{ inputs.pr-description }}
     - name: Call upgrade provider action

--- a/provider-ci/test-workflows/cloudflare/.github/workflows/upgrade-provider.yml
+++ b/provider-ci/test-workflows/cloudflare/.github/workflows/upgrade-provider.yml
@@ -13,6 +13,7 @@ jobs:
       uses: pulumi/pulumi-upgrade-provider-action@v0.0.10
       with:
         kind: all
+        target-java-version: v0.9.3
         email: bot@pulumi.com
         username: pulumi-bot
     - env:

--- a/provider-ci/test-workflows/cloudflare/.github/workflows/upgrade-provider.yml
+++ b/provider-ci/test-workflows/cloudflare/.github/workflows/upgrade-provider.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Call upgrade provider action
-      uses: pulumi/pulumi-upgrade-provider-action@v0.0.10
+      uses: pulumi/pulumi-upgrade-provider-action@v0.0.11
       with:
         kind: all
         target-java-version: v0.9.3

--- a/provider-ci/test-workflows/cloudflare/Makefile
+++ b/provider-ci/test-workflows/cloudflare/Makefile
@@ -9,7 +9,6 @@ TFGEN := pulumi-tfgen-$(PACK)
 PROVIDER := pulumi-resource-$(PACK)
 VERSION := $(shell pulumictl get version)
 JAVA_GEN := pulumi-java-gen
-JAVA_GEN_VERSION := v0.9.3
 TESTPARALLELISM := 10
 WORKING_DIR := $(shell pwd)
 PULUMI_CONVERT := 0
@@ -134,8 +133,8 @@ upstream.finalize:
 upstream.rebase:
 	scripts/upstream.sh "$@" start_rebase
 
-bin/pulumi-java-gen:
-	pulumictl download-binary -n pulumi-language-java -v $(JAVA_GEN_VERSION) -r pulumi/pulumi-java
+bin/pulumi-java-gen: .pulumi/java-gen-version
+	pulumictl download-binary -n pulumi-language-java -v v$(shell cat .pulumi/java-gen-version) -r pulumi/pulumi-java
 
 # To make an immediately observable change to .ci-mgmt.yaml:
 #

--- a/provider-ci/test-workflows/cloudflare/Makefile
+++ b/provider-ci/test-workflows/cloudflare/Makefile
@@ -133,8 +133,8 @@ upstream.finalize:
 upstream.rebase:
 	scripts/upstream.sh "$@" start_rebase
 
-bin/pulumi-java-gen: .pulumi/java-gen-version
-	pulumictl download-binary -n pulumi-language-java -v v$(shell cat .pulumi/java-gen-version) -r pulumi/pulumi-java
+bin/pulumi-java-gen: .pulumi-java-gen.version
+	pulumictl download-binary -n pulumi-language-java -v v$(shell cat .pulumi-java-gen.version) -r pulumi/pulumi-java
 
 # To make an immediately observable change to .ci-mgmt.yaml:
 #

--- a/provider-ci/test-workflows/docker/.github/workflows/upgrade-bridge.yml
+++ b/provider-ci/test-workflows/docker/.github/workflows/upgrade-bridge.yml
@@ -48,7 +48,7 @@ jobs:
     steps:
     - name: Call upgrade provider action
       if: github.event_name == 'workflow_dispatch'
-      uses: pulumi/pulumi-upgrade-provider-action@v0.0.10
+      uses: pulumi/pulumi-upgrade-provider-action@v0.0.11
       with:
         kind: bridge
         email: bot@pulumi.com
@@ -60,7 +60,7 @@ jobs:
         pr-description: ${{ inputs.pr-description }}
     - name: Call upgrade provider action
       if: github.event_name == 'repository_dispatch'
-      uses: pulumi/pulumi-upgrade-provider-action@v0.0.10
+      uses: pulumi/pulumi-upgrade-provider-action@v0.0.11
       with:
         kind: bridge
         email: bot@pulumi.com

--- a/provider-ci/test-workflows/docker/.github/workflows/upgrade-provider.yml
+++ b/provider-ci/test-workflows/docker/.github/workflows/upgrade-provider.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Call upgrade provider action
-      uses: pulumi/pulumi-upgrade-provider-action@v0.0.10
+      uses: pulumi/pulumi-upgrade-provider-action@v0.0.11
       with:
         kind: all
         email: bot@pulumi.com

--- a/provider-ci/test-workflows/docker/.upgrade-config.yml
+++ b/provider-ci/test-workflows/docker/.upgrade-config.yml
@@ -5,4 +5,3 @@ upstream-provider-name: terraform-provider-docker
 pulumi-infer-version: true
 remove-plugins: true
 pr-reviewers: iwahbe # Team: pulumi/Providers
-javaVersion: "v0.9.7"

--- a/provider-ci/test-workflows/docker/Makefile
+++ b/provider-ci/test-workflows/docker/Makefile
@@ -135,8 +135,8 @@ upstream.finalize:
 upstream.rebase:
 	scripts/upstream.sh "$@" start_rebase
 
-bin/pulumi-java-gen: .pulumi/java-gen-version
-	pulumictl download-binary -n pulumi-language-java -v v$(shell cat .pulumi/java-gen-version) -r pulumi/pulumi-java
+bin/pulumi-java-gen: .pulumi-java-gen.version
+	pulumictl download-binary -n pulumi-language-java -v v$(shell cat .pulumi-java-gen.version) -r pulumi/pulumi-java
 
 # To make an immediately observable change to .ci-mgmt.yaml:
 #

--- a/provider-ci/test-workflows/docker/Makefile
+++ b/provider-ci/test-workflows/docker/Makefile
@@ -9,7 +9,6 @@ TFGEN := pulumi-tfgen-$(PACK)
 PROVIDER := pulumi-resource-$(PACK)
 VERSION := $(shell pulumictl get version)
 JAVA_GEN := pulumi-java-gen
-JAVA_GEN_VERSION := v0.9.7
 TESTPARALLELISM := 10
 WORKING_DIR := $(shell pwd)
 PULUMI_CONVERT := 0
@@ -136,8 +135,8 @@ upstream.finalize:
 upstream.rebase:
 	scripts/upstream.sh "$@" start_rebase
 
-bin/pulumi-java-gen:
-	pulumictl download-binary -n pulumi-language-java -v $(JAVA_GEN_VERSION) -r pulumi/pulumi-java
+bin/pulumi-java-gen: .pulumi/java-gen-version
+	pulumictl download-binary -n pulumi-language-java -v v$(shell cat .pulumi/java-gen-version) -r pulumi/pulumi-java
 
 # To make an immediately observable change to .ci-mgmt.yaml:
 #


### PR DESCRIPTION
As part of https://github.com/pulumi/ci-mgmt/issues/506, we are setting the Java version in a provider-level version file, acting as our "lockfile". 

This PR mainly updates the provider Makefiles to be in sync with the changes propagated with the latest  (and hopefully last) bulk Java upgrade. [Sample update here](https://github.com/pulumi/pulumi-civo/pull/348). The rollout has been a bit messy; there are currently failing updates in a few providers. They should clear up as soon as this change is merged.