### PR TITLE
Only fire upgrades on pulumi bot issues

### DIFF
--- a/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/upgrade-provider.yml
+++ b/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/upgrade-provider.yml
@@ -5,7 +5,7 @@ env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 jobs:
   upgrade_provider:
-    if: ${{ contains(github.event.issue.title, 'Upgrade terraform-provider-') || github.event_name == 'workflow_dispatch' }}
+    if: ${{ (github.event.issue.user.login == 'pulumi-bot' && contains(github.event.issue.title, 'Upgrade terraform-provider-')) || github.event_name == 'workflow_dispatch' }}
     name: upgrade-provider
     runs-on: #{{ .Config.runner.default }}#
     steps:

--- a/provider-ci/test-workflows/aws/.github/workflows/upgrade-provider.yml
+++ b/provider-ci/test-workflows/aws/.github/workflows/upgrade-provider.yml
@@ -5,7 +5,7 @@ env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 jobs:
   upgrade_provider:
-    if: ${{ contains(github.event.issue.title, 'Upgrade terraform-provider-') || github.event_name == 'workflow_dispatch' }}
+    if: ${{ (github.event.issue.user.login == 'pulumi-bot' && contains(github.event.issue.title, 'Upgrade terraform-provider-')) || github.event_name == 'workflow_dispatch' }}
     name: upgrade-provider
     runs-on: ubuntu-latest
     steps:

--- a/provider-ci/test-workflows/cloudflare/.github/workflows/upgrade-provider.yml
+++ b/provider-ci/test-workflows/cloudflare/.github/workflows/upgrade-provider.yml
@@ -5,7 +5,7 @@ env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 jobs:
   upgrade_provider:
-    if: ${{ contains(github.event.issue.title, 'Upgrade terraform-provider-') || github.event_name == 'workflow_dispatch' }}
+    if: ${{ (github.event.issue.user.login == 'pulumi-bot' && contains(github.event.issue.title, 'Upgrade terraform-provider-')) || github.event_name == 'workflow_dispatch' }}
     name: upgrade-provider
     runs-on: ubuntu-latest
     steps:

--- a/provider-ci/test-workflows/docker/.github/workflows/upgrade-provider.yml
+++ b/provider-ci/test-workflows/docker/.github/workflows/upgrade-provider.yml
@@ -5,7 +5,7 @@ env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 jobs:
   upgrade_provider:
-    if: ${{ contains(github.event.issue.title, 'Upgrade terraform-provider-') || github.event_name == 'workflow_dispatch' }}
+    if: ${{ (github.event.issue.user.login == 'pulumi-bot' && contains(github.event.issue.title, 'Upgrade terraform-provider-')) || github.event_name == 'workflow_dispatch' }}
     name: upgrade-provider
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
This avoids accidental upgrades such as those caused by https://github.com/pulumi/pulumi-aws/issues/3160.


--- 

I will test before merging:

- Does not fire on user (non `Pulumi-bot` issues): https://github.com/pulumi/pulumi-linode/actions/runs/7279564493
- Does fire on `Pulumi-bot` issues: https://github.com/pulumi/pulumi-linode/actions/runs/7279555195