### PR TITLE
Error on missing docs during tfgen

### DIFF
--- a/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/main.yml
+++ b/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/main.yml
@@ -142,7 +142,7 @@ jobs:
     - name: Echo Coverage Output Dir
       run: 'echo "Coverage output directory: ${{ env.COVERAGE_OUTPUT_DIR }}"'
     - name: Generate Coverage Data
-      run: make tfgen
+      run: PULUMI_MISSING_DOCS_ERROR=true make tfgen
     - name: Summarize Provider Coverage Results
       run: cat ${{ env.COVERAGE_OUTPUT_DIR }}/shortSummary.txt
     - name: Upload coverage data to S3

--- a/provider-ci/test-workflows/aws/.github/workflows/master.yml
+++ b/provider-ci/test-workflows/aws/.github/workflows/master.yml
@@ -177,7 +177,7 @@ jobs:
     - name: Echo Coverage Output Dir
       run: 'echo "Coverage output directory: ${{ env.COVERAGE_OUTPUT_DIR }}"'
     - name: Generate Coverage Data
-      run: make tfgen
+      run: PULUMI_MISSING_DOCS_ERROR=true make tfgen
     - name: Summarize Provider Coverage Results
       run: cat ${{ env.COVERAGE_OUTPUT_DIR }}/shortSummary.txt
     - name: Upload coverage data to S3

--- a/provider-ci/test-workflows/cloudflare/.github/workflows/master.yml
+++ b/provider-ci/test-workflows/cloudflare/.github/workflows/master.yml
@@ -173,7 +173,7 @@ jobs:
     - name: Echo Coverage Output Dir
       run: 'echo "Coverage output directory: ${{ env.COVERAGE_OUTPUT_DIR }}"'
     - name: Generate Coverage Data
-      run: make tfgen
+      run: PULUMI_MISSING_DOCS_ERROR=true make tfgen
     - name: Summarize Provider Coverage Results
       run: cat ${{ env.COVERAGE_OUTPUT_DIR }}/shortSummary.txt
     - name: Upload coverage data to S3

--- a/provider-ci/test-workflows/docker/.github/workflows/master.yml
+++ b/provider-ci/test-workflows/docker/.github/workflows/master.yml
@@ -186,7 +186,7 @@ jobs:
     - name: Echo Coverage Output Dir
       run: 'echo "Coverage output directory: ${{ env.COVERAGE_OUTPUT_DIR }}"'
     - name: Generate Coverage Data
-      run: make tfgen
+      run: PULUMI_MISSING_DOCS_ERROR=true make tfgen
     - name: Summarize Provider Coverage Results
       run: cat ${{ env.COVERAGE_OUTPUT_DIR }}/shortSummary.txt
     - name: Upload coverage data to S3


### PR DESCRIPTION
We run this during upgrade workflows so they should run during normal CI.

Should prevent errors like https://github.com/pulumi/pulumi-keycloak/issues/355