### PR TITLE
Option to set upstream provider org in upgrade config

### DIFF
--- a/provider-ci/internal/pkg/templates/bridged-provider.config.yaml
+++ b/provider-ci/internal/pkg/templates/bridged-provider.config.yaml
@@ -1,5 +1,6 @@
 major-version: 2
 #javaGenVersion: 0.0.0
+#upstreamProviderOrg: terraform-providers"
 parallel: 3
 timeout: 60
 lint: true

--- a/provider-ci/internal/pkg/templates/bridged-provider/.upgrade-config.yml
+++ b/provider-ci/internal/pkg/templates/bridged-provider/.upgrade-config.yml
@@ -6,6 +6,9 @@ upstream-provider-name: #{{ index .Config "upstream-provider-repo" }}#
 #{{- else }}#
 upstream-provider-name: terraform-provider-#{{ .Config.provider }}#
 #{{- end }}#
+#{{- if (index .Config "upstreamProviderOrg") }}#
+upstream-provider-org: #{{ .Config.upstreamProviderOrg }}#
+#{{- end }}#
 pulumi-infer-version: true
 remove-plugins: true
 pr-reviewers: iwahbe # Team: pulumi/Providers

--- a/provider-ci/providers/docker/config.yaml
+++ b/provider-ci/providers/docker/config.yaml
@@ -3,6 +3,7 @@
 # actual provider. Edit .ci-mgmt.yml in pulumi/pulumi-docker to reconfigure the actual provider build.
 provider: docker
 major-version: 4
+upstreamProviderOrg: kreuzwerker
 aws: true
 gcp: true
 gcpRegistry: true

--- a/provider-ci/test-workflows/docker/.upgrade-config.yml
+++ b/provider-ci/test-workflows/docker/.upgrade-config.yml
@@ -2,6 +2,7 @@
 
 ---
 upstream-provider-name: terraform-provider-docker
+upstream-provider-org: kreuzwerker
 pulumi-infer-version: true
 remove-plugins: true
 pr-reviewers: iwahbe # Team: pulumi/Providers


### PR DESCRIPTION
Part of https://github.com/pulumi/upgrade-provider/issues/221 - refer to issue for details.

Explicitly telling our upgrade machinery the upstream org name allows us to reliably detect upstream upgrades every time.
 


