### PR TITLE
Parameterize upgrade-bridge job kind

### DIFF
--- a/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/upgrade-bridge.yml
+++ b/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/upgrade-bridge.yml
@@ -7,6 +7,11 @@ on:
       - upgrade-bridge
   workflow_dispatch:
     inputs:
+      kind:
+        description: Overrides the kind of upgrade. Must be one of `all`, `bridge`, `provider`, `code`, `pf`, or `pulumi`.
+        required: false
+        type: string
+        default: "bridge"
       target-bridge-version:
         description: pulumi-terraform-bridge version or hash reference
         required: false
@@ -50,7 +55,7 @@ jobs:
       if: github.event_name == 'workflow_dispatch'
       uses: #{{ .Config.actionVersions.upgradeProviderAction }}#
       with:
-        kind: bridge
+        kind: ${{ inputs.kind }}
         email: bot@pulumi.com
         username: pulumi-bot
         automerge: ${{ inputs.automerge }}
@@ -65,7 +70,7 @@ jobs:
       if: github.event_name == 'repository_dispatch'
       uses: #{{ .Config.actionVersions.upgradeProviderAction }}#
       with:
-        kind: bridge
+        kind: ${{ inputs.kind }}
         email: bot@pulumi.com
         username: pulumi-bot
         automerge: ${{ github.event.client_payload.automerge }}

--- a/provider-ci/test-workflows/aws/.github/workflows/upgrade-bridge.yml
+++ b/provider-ci/test-workflows/aws/.github/workflows/upgrade-bridge.yml
@@ -7,6 +7,11 @@ on:
       - upgrade-bridge
   workflow_dispatch:
     inputs:
+      kind:
+        description: Overrides the kind of upgrade. Must be one of `all`, `bridge`, `provider`, `code`, `pf`, or `pulumi`.
+        required: false
+        type: string
+        default: "bridge"
       target-bridge-version:
         description: pulumi-terraform-bridge version or hash reference
         required: false
@@ -50,7 +55,7 @@ jobs:
       if: github.event_name == 'workflow_dispatch'
       uses: pulumi/pulumi-upgrade-provider-action@v0.0.11
       with:
-        kind: bridge
+        kind: ${{ inputs.kind }}
         email: bot@pulumi.com
         username: pulumi-bot
         automerge: ${{ inputs.automerge }}
@@ -62,7 +67,7 @@ jobs:
       if: github.event_name == 'repository_dispatch'
       uses: pulumi/pulumi-upgrade-provider-action@v0.0.11
       with:
-        kind: bridge
+        kind: ${{ inputs.kind }}
         email: bot@pulumi.com
         username: pulumi-bot
         automerge: ${{ github.event.client_payload.automerge }}

--- a/provider-ci/test-workflows/cloudflare/.github/workflows/upgrade-bridge.yml
+++ b/provider-ci/test-workflows/cloudflare/.github/workflows/upgrade-bridge.yml
@@ -7,6 +7,11 @@ on:
       - upgrade-bridge
   workflow_dispatch:
     inputs:
+      kind:
+        description: Overrides the kind of upgrade. Must be one of `all`, `bridge`, `provider`, `code`, `pf`, or `pulumi`.
+        required: false
+        type: string
+        default: "bridge"
       target-bridge-version:
         description: pulumi-terraform-bridge version or hash reference
         required: false
@@ -50,7 +55,7 @@ jobs:
       if: github.event_name == 'workflow_dispatch'
       uses: pulumi/pulumi-upgrade-provider-action@v0.0.11
       with:
-        kind: bridge
+        kind: ${{ inputs.kind }}
         email: bot@pulumi.com
         username: pulumi-bot
         automerge: ${{ inputs.automerge }}
@@ -63,7 +68,7 @@ jobs:
       if: github.event_name == 'repository_dispatch'
       uses: pulumi/pulumi-upgrade-provider-action@v0.0.11
       with:
-        kind: bridge
+        kind: ${{ inputs.kind }}
         email: bot@pulumi.com
         username: pulumi-bot
         automerge: ${{ github.event.client_payload.automerge }}

--- a/provider-ci/test-workflows/docker/.github/workflows/upgrade-bridge.yml
+++ b/provider-ci/test-workflows/docker/.github/workflows/upgrade-bridge.yml
@@ -7,6 +7,11 @@ on:
       - upgrade-bridge
   workflow_dispatch:
     inputs:
+      kind:
+        description: Overrides the kind of upgrade. Must be one of `all`, `bridge`, `provider`, `code`, `pf`, or `pulumi`.
+        required: false
+        type: string
+        default: "bridge"
       target-bridge-version:
         description: pulumi-terraform-bridge version or hash reference
         required: false
@@ -50,7 +55,7 @@ jobs:
       if: github.event_name == 'workflow_dispatch'
       uses: pulumi/pulumi-upgrade-provider-action@v0.0.11
       with:
-        kind: bridge
+        kind: ${{ inputs.kind }}
         email: bot@pulumi.com
         username: pulumi-bot
         automerge: ${{ inputs.automerge }}
@@ -62,7 +67,7 @@ jobs:
       if: github.event_name == 'repository_dispatch'
       uses: pulumi/pulumi-upgrade-provider-action@v0.0.11
       with:
-        kind: bridge
+        kind: ${{ inputs.kind }}
         email: bot@pulumi.com
         username: pulumi-bot
         automerge: ${{ github.event.client_payload.automerge }}


### PR DESCRIPTION
Part of https://github.com/pulumi/pulumi/issues/15140

This parameterizes the kind run on upgrade-provider to enable downstream codegen tests to only upgrade pulumi (they currently may upgrade the bridge which could cause the bridge to block pulumi/pulumi releases).

We could copy the job as well to an `upgrade-pulumi.yml`, but I'm unfamiliar with the repository so I'm unsure of the consequences of such an approach.