### PR TITLE
Enable `gci` linter to sort and group imports

### DIFF
--- a/provider-ci/internal/pkg/templates/bridged-provider/.golangci.yml
+++ b/provider-ci/internal/pkg/templates/bridged-provider/.golangci.yml
@@ -18,9 +18,19 @@ linters:
   - structcheck
   - unconvert
   - varcheck
+  - gci
   enable-all: false
 run:
   skip-files:
   - schema.go
   - pulumiManifest.go
   timeout: 20m
+linters-settings:
+  gci:
+    sections:
+      - standard # Standard section: captures all standard library packages.
+      - blank # Blank section: contains all blank imports.
+      - default # Default section: contains all imports that could not be matched to another section type.
+      - prefix(github.com/pulumi/) # Custom section: groups all imports with the github.com/pulumi/ prefix.
+      - prefix(github.com/pulumi/pulumi-#{{ .Config.provider }}#) # Custom section: local imports
+    custom-order: true

--- a/provider-ci/internal/pkg/templates/bridged-provider/Makefile
+++ b/provider-ci/internal/pkg/templates/bridged-provider/Makefile
@@ -118,6 +118,11 @@ install_plugins: .pulumi/bin/pulumi
 lint_provider: provider
 	cd provider && golangci-lint run -c ../.golangci.yml
 
+# `lint_provider.fix` is a utility target meant to be run manually
+# that will run the linter and fix errors when possible.
+lint_provider.fix:
+	cd provider && golangci-lint run -c ../.golangci.yml --fix
+
 # `make provider_no_deps` builds the provider binary directly, without ensuring that 
 # `cmd/pulumi-resource-#{{ .Config.provider }}#/schema.json` is valid and up to date. 
 # To create a release ready binary, you should use `make provider`.

--- a/provider-ci/test-workflows/aws/.golangci.yml
+++ b/provider-ci/test-workflows/aws/.golangci.yml
@@ -18,9 +18,19 @@ linters:
   - structcheck
   - unconvert
   - varcheck
+  - gci
   enable-all: false
 run:
   skip-files:
   - schema.go
   - pulumiManifest.go
   timeout: 20m
+linters-settings:
+  gci:
+    sections:
+      - standard # Standard section: captures all standard library packages.
+      - blank # Blank section: contains all blank imports.
+      - default # Default section: contains all imports that could not be matched to another section type.
+      - prefix(github.com/pulumi/) # Custom section: groups all imports with the github.com/pulumi/ prefix.
+      - prefix(github.com/pulumi/pulumi-aws) # Custom section: local imports
+    custom-order: true

--- a/provider-ci/test-workflows/aws/Makefile
+++ b/provider-ci/test-workflows/aws/Makefile
@@ -105,6 +105,11 @@ install_plugins: .pulumi/bin/pulumi
 lint_provider: provider
 	cd provider && golangci-lint run -c ../.golangci.yml
 
+# `lint_provider.fix` is a utility target meant to be run manually
+# that will run the linter and fix errors when possible.
+lint_provider.fix:
+	cd provider && golangci-lint run -c ../.golangci.yml --fix
+
 # `make provider_no_deps` builds the provider binary directly, without ensuring that 
 # `cmd/pulumi-resource-aws/schema.json` is valid and up to date. 
 # To create a release ready binary, you should use `make provider`.

--- a/provider-ci/test-workflows/cloudflare/.golangci.yml
+++ b/provider-ci/test-workflows/cloudflare/.golangci.yml
@@ -18,9 +18,19 @@ linters:
   - structcheck
   - unconvert
   - varcheck
+  - gci
   enable-all: false
 run:
   skip-files:
   - schema.go
   - pulumiManifest.go
   timeout: 20m
+linters-settings:
+  gci:
+    sections:
+      - standard # Standard section: captures all standard library packages.
+      - blank # Blank section: contains all blank imports.
+      - default # Default section: contains all imports that could not be matched to another section type.
+      - prefix(github.com/pulumi/) # Custom section: groups all imports with the github.com/pulumi/ prefix.
+      - prefix(github.com/pulumi/pulumi-cloudflare) # Custom section: local imports
+    custom-order: true

--- a/provider-ci/test-workflows/cloudflare/Makefile
+++ b/provider-ci/test-workflows/cloudflare/Makefile
@@ -100,6 +100,11 @@ install_plugins: .pulumi/bin/pulumi
 lint_provider: provider
 	cd provider && golangci-lint run -c ../.golangci.yml
 
+# `lint_provider.fix` is a utility target meant to be run manually
+# that will run the linter and fix errors when possible.
+lint_provider.fix:
+	cd provider && golangci-lint run -c ../.golangci.yml --fix
+
 # `make provider_no_deps` builds the provider binary directly, without ensuring that 
 # `cmd/pulumi-resource-cloudflare/schema.json` is valid and up to date. 
 # To create a release ready binary, you should use `make provider`.

--- a/provider-ci/test-workflows/docker/.golangci.yml
+++ b/provider-ci/test-workflows/docker/.golangci.yml
@@ -18,9 +18,19 @@ linters:
   - structcheck
   - unconvert
   - varcheck
+  - gci
   enable-all: false
 run:
   skip-files:
   - schema.go
   - pulumiManifest.go
   timeout: 20m
+linters-settings:
+  gci:
+    sections:
+      - standard # Standard section: captures all standard library packages.
+      - blank # Blank section: contains all blank imports.
+      - default # Default section: contains all imports that could not be matched to another section type.
+      - prefix(github.com/pulumi/) # Custom section: groups all imports with the github.com/pulumi/ prefix.
+      - prefix(github.com/pulumi/pulumi-docker) # Custom section: local imports
+    custom-order: true

--- a/provider-ci/test-workflows/docker/Makefile
+++ b/provider-ci/test-workflows/docker/Makefile
@@ -102,6 +102,11 @@ install_plugins: .pulumi/bin/pulumi
 lint_provider: provider
 	cd provider && golangci-lint run -c ../.golangci.yml
 
+# `lint_provider.fix` is a utility target meant to be run manually
+# that will run the linter and fix errors when possible.
+lint_provider.fix:
+	cd provider && golangci-lint run -c ../.golangci.yml --fix
+
 # `make provider_no_deps` builds the provider binary directly, without ensuring that 
 # `cmd/pulumi-resource-docker/schema.json` is valid and up to date. 
 # To create a release ready binary, you should use `make provider`.


### PR DESCRIPTION
This PR adds the [gci linter](https://github.com/daixiang0/gci) to the enabled Go linters. Additionally adds a `lint_provider.fix` Make target that maintainers may run locally to help fix linting errors.

The custom order for the import blocks is defined as follows:
- standard library imports
- blank imports
- default imports
- pulumi/* imports
- local imports (i.e. within the provider repo itself.

A typical import section in `resources.go` would look like this:
```
package cloudinit

import (
	"fmt"
	"path/filepath"
	"unicode"

	// embed is used to store bridge-metadata.json in the compiled binary
	_ "embed"

	"github.com/hashicorp/terraform-provider-cloudinit/shim"

	pf "github.com/pulumi/pulumi-terraform-bridge/pf/tfbridge"
	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfbridge"
	tfbridgetokens "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfbridge/tokens"
	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"

	"github.com/pulumi/pulumi-cloudinit/provider/pkg/version"
)
```

Notice that this change needs a focused migration, as on providers with strict linting, it will cause a failure in CI.
The proposed plan is to merge this PR and run a script that checks out each provider repo, runs `make ci-mgmt && golanci-lint --fix`, commit, push, and automerge.

