### PR TITLE
Resolve security alerts due to old gradle-build-action

### DIFF
--- a/native-provider-ci/providers/aws-native/repo/.github/workflows/build.yml
+++ b/native-provider-ci/providers/aws-native/repo/.github/workflows/build.yml
@@ -513,7 +513,7 @@ jobs:
       run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
         $GITHUB_ENV
     - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
+      uses: gradle/gradle-build-action@v2
       with:
         arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
         build-root-directory: ./sdk/java

--- a/native-provider-ci/providers/aws-native/repo/.github/workflows/prerelease.yml
+++ b/native-provider-ci/providers/aws-native/repo/.github/workflows/prerelease.yml
@@ -504,7 +504,7 @@ jobs:
       run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
         $GITHUB_ENV
     - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
+      uses: gradle/gradle-build-action@v2
       with:
         arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
         build-root-directory: ./sdk/java

--- a/native-provider-ci/providers/aws-native/repo/.github/workflows/release.yml
+++ b/native-provider-ci/providers/aws-native/repo/.github/workflows/release.yml
@@ -503,7 +503,7 @@ jobs:
       run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
         $GITHUB_ENV
     - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
+      uses: gradle/gradle-build-action@v2
       with:
         arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
         build-root-directory: ./sdk/java

--- a/native-provider-ci/providers/azure-native/repo/.github/workflows/build.yml
+++ b/native-provider-ci/providers/azure-native/repo/.github/workflows/build.yml
@@ -516,7 +516,7 @@ jobs:
       run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
         $GITHUB_ENV
     - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
+      uses: gradle/gradle-build-action@v2
       with:
         arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
         build-root-directory: ./sdk/java

--- a/native-provider-ci/providers/azure-native/repo/.github/workflows/prerelease.yml
+++ b/native-provider-ci/providers/azure-native/repo/.github/workflows/prerelease.yml
@@ -507,7 +507,7 @@ jobs:
       run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
         $GITHUB_ENV
     - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
+      uses: gradle/gradle-build-action@v2
       with:
         arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
         build-root-directory: ./sdk/java

--- a/native-provider-ci/providers/azure-native/repo/.github/workflows/release.yml
+++ b/native-provider-ci/providers/azure-native/repo/.github/workflows/release.yml
@@ -506,7 +506,7 @@ jobs:
       run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
         $GITHUB_ENV
     - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
+      uses: gradle/gradle-build-action@v2
       with:
         arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
         build-root-directory: ./sdk/java

--- a/native-provider-ci/providers/command/repo/.github/workflows/build.yml
+++ b/native-provider-ci/providers/command/repo/.github/workflows/build.yml
@@ -476,7 +476,7 @@ jobs:
       run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
         $GITHUB_ENV
     - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
+      uses: gradle/gradle-build-action@v2
       with:
         arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
         build-root-directory: ./sdk/java

--- a/native-provider-ci/providers/command/repo/.github/workflows/prerelease.yml
+++ b/native-provider-ci/providers/command/repo/.github/workflows/prerelease.yml
@@ -467,7 +467,7 @@ jobs:
       run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
         $GITHUB_ENV
     - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
+      uses: gradle/gradle-build-action@v2
       with:
         arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
         build-root-directory: ./sdk/java

--- a/native-provider-ci/providers/command/repo/.github/workflows/release.yml
+++ b/native-provider-ci/providers/command/repo/.github/workflows/release.yml
@@ -466,7 +466,7 @@ jobs:
       run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
         $GITHUB_ENV
     - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
+      uses: gradle/gradle-build-action@v2
       with:
         arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
         build-root-directory: ./sdk/java

--- a/native-provider-ci/providers/google-native/repo/.github/workflows/build.yml
+++ b/native-provider-ci/providers/google-native/repo/.github/workflows/build.yml
@@ -522,7 +522,7 @@ jobs:
       run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
         $GITHUB_ENV
     - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
+      uses: gradle/gradle-build-action@v2
       with:
         arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
         build-root-directory: ./sdk/java

--- a/native-provider-ci/providers/google-native/repo/.github/workflows/prerelease.yml
+++ b/native-provider-ci/providers/google-native/repo/.github/workflows/prerelease.yml
@@ -513,7 +513,7 @@ jobs:
       run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
         $GITHUB_ENV
     - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
+      uses: gradle/gradle-build-action@v2
       with:
         arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
         build-root-directory: ./sdk/java

--- a/native-provider-ci/providers/google-native/repo/.github/workflows/release.yml
+++ b/native-provider-ci/providers/google-native/repo/.github/workflows/release.yml
@@ -512,7 +512,7 @@ jobs:
       run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
         $GITHUB_ENV
     - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
+      uses: gradle/gradle-build-action@v2
       with:
         arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
         build-root-directory: ./sdk/java

--- a/native-provider-ci/providers/kubernetes/repo/.github/workflows/build.yml
+++ b/native-provider-ci/providers/kubernetes/repo/.github/workflows/build.yml
@@ -549,7 +549,7 @@ jobs:
       run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
         $GITHUB_ENV
     - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
+      uses: gradle/gradle-build-action@v2
       with:
         arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
         build-root-directory: ./sdk/java

--- a/native-provider-ci/providers/kubernetes/repo/.github/workflows/prerelease.yml
+++ b/native-provider-ci/providers/kubernetes/repo/.github/workflows/prerelease.yml
@@ -540,7 +540,7 @@ jobs:
       run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
         $GITHUB_ENV
     - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
+      uses: gradle/gradle-build-action@v2
       with:
         arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
         build-root-directory: ./sdk/java

--- a/native-provider-ci/providers/kubernetes/repo/.github/workflows/release.yml
+++ b/native-provider-ci/providers/kubernetes/repo/.github/workflows/release.yml
@@ -539,7 +539,7 @@ jobs:
       run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
         $GITHUB_ENV
     - name: Publish Java SDK
-      uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
+      uses: gradle/gradle-build-action@v2
       with:
         arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
         build-root-directory: ./sdk/java

--- a/native-provider-ci/src/action-versions.ts
+++ b/native-provider-ci/src/action-versions.ts
@@ -16,8 +16,7 @@ export const googleAuth = "google-github-actions/auth@v0";
 
 // Tools
 export const goReleaser = "goreleaser/goreleaser-action@v2";
-export const gradleBuildAction =
-  "gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49";
+export const gradleBuildAction = "gradle/gradle-build-action@v2";
 export const installGhRelease = "jaxxstorm/action-install-gh-release@v1.10.0";
 export const installPulumiCli = "pulumi/actions@v4";
 export const codecov = "codecov/codecov-action@v3";


### PR DESCRIPTION
We have a number of security alerts like [this one](https://github.com/pulumi/pulumi-aws-native/security/dependabot/54) that have been open for ~9 months.

Un-pinning the affected action should resolve the issue.