### PR TITLE
Upgrade all pu/pu dependencies

### DIFF
--- a/native-provider-ci/providers/aws-native/repo/.github/workflows/weekly-pulumi-update.yml
+++ b/native-provider-ci/providers/aws-native/repo/.github/workflows/weekly-pulumi-update.yml
@@ -74,25 +74,7 @@ jobs:
 
         git checkout -b update-pulumi/${{ github.run_id }}-${{ github.run_number }}
 
-        cd provider
-
-        go get github.com/pulumi/pulumi/pkg/v3
-
-        go get github.com/pulumi/pulumi/sdk/v3
-
-        go mod download
-
-        go mod tidy
-
-        cd ../sdk
-
-        go get github.com/pulumi/pulumi/sdk/v3
-
-        go mod download
-
-        go mod tidy
-
-        cd ..
+        for MODFILE in $(find . -name go.mod); do pushd $(dirname $MODFILE); go get github.com/pulumi/pulumi/pkg/v3 github.com/pulumi/pulumi/sdk/v3; go mod tidy; popd; done
 
         git update-index -q --refresh
 

--- a/native-provider-ci/providers/azure-native/repo/.github/workflows/weekly-pulumi-update.yml
+++ b/native-provider-ci/providers/azure-native/repo/.github/workflows/weekly-pulumi-update.yml
@@ -80,25 +80,7 @@ jobs:
 
         git checkout -b update-pulumi/${{ github.run_id }}-${{ github.run_number }}
 
-        cd provider
-
-        go get github.com/pulumi/pulumi/pkg/v3
-
-        go get github.com/pulumi/pulumi/sdk/v3
-
-        go mod download
-
-        go mod tidy
-
-        cd ../sdk
-
-        go get github.com/pulumi/pulumi/sdk/v3
-
-        go mod download
-
-        go mod tidy
-
-        cd ..
+        for MODFILE in $(find . -name go.mod); do pushd $(dirname $MODFILE); go get github.com/pulumi/pulumi/pkg/v3 github.com/pulumi/pulumi/sdk/v3; go mod tidy; popd; done
 
         git update-index -q --refresh
 

--- a/native-provider-ci/providers/command/repo/.github/workflows/weekly-pulumi-update.yml
+++ b/native-provider-ci/providers/command/repo/.github/workflows/weekly-pulumi-update.yml
@@ -74,25 +74,7 @@ jobs:
 
         git checkout -b update-pulumi/${{ github.run_id }}-${{ github.run_number }}
 
-        cd provider
-
-        go get github.com/pulumi/pulumi/pkg/v3
-
-        go get github.com/pulumi/pulumi/sdk/v3
-
-        go mod download
-
-        go mod tidy
-
-        cd ../sdk
-
-        go get github.com/pulumi/pulumi/sdk/v3
-
-        go mod download
-
-        go mod tidy
-
-        cd ..
+        for MODFILE in $(find . -name go.mod); do pushd $(dirname $MODFILE); go get github.com/pulumi/pulumi/pkg/v3 github.com/pulumi/pulumi/sdk/v3; go mod tidy; popd; done
 
         git update-index -q --refresh
 

--- a/native-provider-ci/providers/google-native/repo/.github/workflows/weekly-pulumi-update.yml
+++ b/native-provider-ci/providers/google-native/repo/.github/workflows/weekly-pulumi-update.yml
@@ -80,25 +80,7 @@ jobs:
 
         git checkout -b update-pulumi/${{ github.run_id }}-${{ github.run_number }}
 
-        cd provider
-
-        go get github.com/pulumi/pulumi/pkg/v3
-
-        go get github.com/pulumi/pulumi/sdk/v3
-
-        go mod download
-
-        go mod tidy
-
-        cd ../sdk
-
-        go get github.com/pulumi/pulumi/sdk/v3
-
-        go mod download
-
-        go mod tidy
-
-        cd ..
+        for MODFILE in $(find . -name go.mod); do pushd $(dirname $MODFILE); go get github.com/pulumi/pulumi/pkg/v3 github.com/pulumi/pulumi/sdk/v3; go mod tidy; popd; done
 
         git update-index -q --refresh
 

--- a/native-provider-ci/providers/kubernetes/repo/.github/workflows/weekly-pulumi-update.yml
+++ b/native-provider-ci/providers/kubernetes/repo/.github/workflows/weekly-pulumi-update.yml
@@ -80,19 +80,7 @@ jobs:
 
         git checkout -b update-pulumi/${{ github.run_id }}-${{ github.run_number }}
 
-        cd provider
-
-        go get github.com/pulumi/pulumi/pkg/v3
-
-        go get github.com/pulumi/pulumi/sdk/v3
-
-        cd ../sdk
-
-        go get github.com/pulumi/pulumi/sdk/v3
-
-        cd ..
-
-        make ensure
+        for MODFILE in $(find . -name go.mod); do pushd $(dirname $MODFILE); go get github.com/pulumi/pulumi/pkg/v3 github.com/pulumi/pulumi/sdk/v3; go mod tidy; popd; done
 
         git update-index -q --refresh
 

--- a/native-provider-ci/src/steps.ts
+++ b/native-provider-ci/src/steps.ts
@@ -894,26 +894,7 @@ export function CodegenDuringSDKBuild(provider: string) {
   return {};
 }
 
-export function UpdatePulumi(provider: string): Step {
-  if (provider === "kubernetes") {
-    return {
-      name: "Update Pulumi/Pulumi",
-      id: "gomod",
-      run:
-        "git config --local user.email 'bot@pulumi.com'\n" +
-        "git config --local user.name 'pulumi-bot'\n" +
-        "git checkout -b update-pulumi/${{ github.run_id }}-${{ github.run_number }}\n" +
-        "cd provider\n" +
-        "go get github.com/pulumi/pulumi/pkg/v3\n" +
-        "go get github.com/pulumi/pulumi/sdk/v3\n" +
-        "cd ../sdk\n" +
-        "go get github.com/pulumi/pulumi/sdk/v3\n" +
-        "cd ..\n" +
-        "make ensure\n" +
-        "git update-index -q --refresh\n" +
-        "if ! git diff-files --quiet; then \n\techo ::set-output name=changes::1 \nfi",
-    };
-  }
+export function UpdatePulumi(): Step {
   return {
     name: "Update Pulumi/Pulumi",
     id: "gomod",
@@ -921,16 +902,7 @@ export function UpdatePulumi(provider: string): Step {
       "git config --local user.email 'bot@pulumi.com'\n" +
       "git config --local user.name 'pulumi-bot'\n" +
       "git checkout -b update-pulumi/${{ github.run_id }}-${{ github.run_number }}\n" +
-      "cd provider\n" +
-      "go get github.com/pulumi/pulumi/pkg/v3\n" +
-      "go get github.com/pulumi/pulumi/sdk/v3\n" +
-      "go mod download\n" +
-      "go mod tidy\n" +
-      "cd ../sdk\n" +
-      "go get github.com/pulumi/pulumi/sdk/v3\n" +
-      "go mod download\n" +
-      "go mod tidy\n" +
-      "cd ..\n" +
+      "for MODFILE in $(find . -name go.mod); do pushd $(dirname $MODFILE); go get github.com/pulumi/pulumi/pkg/v3 github.com/pulumi/pulumi/sdk/v3; go mod tidy; popd; done\n" +
       "git update-index -q --refresh\n" +
       "if ! git diff-files --quiet; then \n\techo ::set-output name=changes::1 \nfi",
   };

--- a/native-provider-ci/src/workflows.ts
+++ b/native-provider-ci/src/workflows.ts
@@ -955,7 +955,7 @@ export class WeeklyPulumiUpdate implements NormalJob {
       steps.InstallDotNet(),
       steps.InstallNodeJS(),
       steps.InstallPython(),
-      steps.UpdatePulumi(opts.provider),
+      steps.UpdatePulumi(),
       steps.InitializeSubModules(opts.submodules),
       steps.ProviderWithPulumiUpgrade(opts.provider),
       steps.CreateUpdatePulumiPR(),


### PR DESCRIPTION
Our automation around pu/pu bumps doesn't catch every directory, e.g. `examples/go.mod` is often stale.

This is a source of dependabot noise. Updating pu/pu often has a side-effect of resolving security issues (since pu/pu is constantly bumping minimum revs). For the directories that don't bump pu/pu we end up needing followup from dependabot.

Re: special casing for p/kubernetes, AFAICT there's no behavioral difference with what we have right now. p/kubernetes skips the `go mod download` step, but `go mod tidy` does this automatically; it also runs `make ensure` at the end, but that just runs `go mod tidy`.

