### PR TITLE
Fix upgrade-bridge job

### DIFF
--- a/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/upgrade-bridge.yml
+++ b/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/upgrade-bridge.yml
@@ -70,7 +70,7 @@ jobs:
       if: github.event_name == 'repository_dispatch'
       uses: #{{ .Config.actionVersions.upgradeProviderAction }}#
       with:
-        kind: ${{ inputs.kind }}
+        kind: ${{ github.event.client_payload.kind || "bridge" }}
         email: bot@pulumi.com
         username: pulumi-bot
         automerge: ${{ github.event.client_payload.automerge }}

--- a/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/upgrade-bridge.yml
+++ b/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/upgrade-bridge.yml
@@ -70,7 +70,7 @@ jobs:
       if: github.event_name == 'repository_dispatch'
       uses: #{{ .Config.actionVersions.upgradeProviderAction }}#
       with:
-        kind: ${{ github.event.client_payload.kind || "bridge" }}
+        kind: ${{ github.event.client_payload.kind || 'bridge' }}
         email: bot@pulumi.com
         username: pulumi-bot
         automerge: ${{ github.event.client_payload.automerge }}

--- a/provider-ci/test-workflows/aws/.github/workflows/upgrade-bridge.yml
+++ b/provider-ci/test-workflows/aws/.github/workflows/upgrade-bridge.yml
@@ -67,7 +67,7 @@ jobs:
       if: github.event_name == 'repository_dispatch'
       uses: pulumi/pulumi-upgrade-provider-action@v0.0.11
       with:
-        kind: ${{ github.event.client_payload.kind || "bridge" }}
+        kind: ${{ github.event.client_payload.kind || 'bridge' }}
         email: bot@pulumi.com
         username: pulumi-bot
         automerge: ${{ github.event.client_payload.automerge }}

--- a/provider-ci/test-workflows/aws/.github/workflows/upgrade-bridge.yml
+++ b/provider-ci/test-workflows/aws/.github/workflows/upgrade-bridge.yml
@@ -67,7 +67,7 @@ jobs:
       if: github.event_name == 'repository_dispatch'
       uses: pulumi/pulumi-upgrade-provider-action@v0.0.11
       with:
-        kind: ${{ inputs.kind }}
+        kind: ${{ github.event.client_payload.kind || "bridge" }}
         email: bot@pulumi.com
         username: pulumi-bot
         automerge: ${{ github.event.client_payload.automerge }}

--- a/provider-ci/test-workflows/cloudflare/.github/workflows/upgrade-bridge.yml
+++ b/provider-ci/test-workflows/cloudflare/.github/workflows/upgrade-bridge.yml
@@ -68,7 +68,7 @@ jobs:
       if: github.event_name == 'repository_dispatch'
       uses: pulumi/pulumi-upgrade-provider-action@v0.0.11
       with:
-        kind: ${{ github.event.client_payload.kind || "bridge" }}
+        kind: ${{ github.event.client_payload.kind || 'bridge' }}
         email: bot@pulumi.com
         username: pulumi-bot
         automerge: ${{ github.event.client_payload.automerge }}

--- a/provider-ci/test-workflows/cloudflare/.github/workflows/upgrade-bridge.yml
+++ b/provider-ci/test-workflows/cloudflare/.github/workflows/upgrade-bridge.yml
@@ -68,7 +68,7 @@ jobs:
       if: github.event_name == 'repository_dispatch'
       uses: pulumi/pulumi-upgrade-provider-action@v0.0.11
       with:
-        kind: ${{ inputs.kind }}
+        kind: ${{ github.event.client_payload.kind || "bridge" }}
         email: bot@pulumi.com
         username: pulumi-bot
         automerge: ${{ github.event.client_payload.automerge }}

--- a/provider-ci/test-workflows/docker/.github/workflows/upgrade-bridge.yml
+++ b/provider-ci/test-workflows/docker/.github/workflows/upgrade-bridge.yml
@@ -67,7 +67,7 @@ jobs:
       if: github.event_name == 'repository_dispatch'
       uses: pulumi/pulumi-upgrade-provider-action@v0.0.11
       with:
-        kind: ${{ github.event.client_payload.kind || "bridge" }}
+        kind: ${{ github.event.client_payload.kind || 'bridge' }}
         email: bot@pulumi.com
         username: pulumi-bot
         automerge: ${{ github.event.client_payload.automerge }}

--- a/provider-ci/test-workflows/docker/.github/workflows/upgrade-bridge.yml
+++ b/provider-ci/test-workflows/docker/.github/workflows/upgrade-bridge.yml
@@ -67,7 +67,7 @@ jobs:
       if: github.event_name == 'repository_dispatch'
       uses: pulumi/pulumi-upgrade-provider-action@v0.0.11
       with:
-        kind: ${{ inputs.kind }}
+        kind: ${{ github.event.client_payload.kind || "bridge" }}
         email: bot@pulumi.com
         username: pulumi-bot
         automerge: ${{ github.event.client_payload.automerge }}


### PR DESCRIPTION
After https://github.com/pulumi/ci-mgmt/pull/775 the downstream checks are no longer working for testing the bridge because it invokes upgrade-provider with `kind=""`. Note that `inputs` are not defined when processing `repository_dispatch`, so the code has to work around that.