### PR TITLE
Run acceptance tests on all branch targets

### DIFF
--- a/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/run-acceptance-tests.yml
@@ -339,10 +339,6 @@ jobs:
 name: run-acceptance-tests
 on:
   pull_request:
-    branches:
-    - #{{ .Config.providerDefaultBranch }}#
-    - v*
-    - feature*
     paths-ignore:
     - CHANGELOG.md
   repository_dispatch:

--- a/provider-ci/test-workflows/aws/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/test-workflows/aws/.github/workflows/run-acceptance-tests.yml
@@ -439,10 +439,6 @@ jobs:
 name: run-acceptance-tests
 on:
   pull_request:
-    branches:
-    - master
-    - v*
-    - feature*
     paths-ignore:
     - CHANGELOG.md
   repository_dispatch:

--- a/provider-ci/test-workflows/cloudflare/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/test-workflows/cloudflare/.github/workflows/run-acceptance-tests.yml
@@ -396,10 +396,6 @@ jobs:
 name: run-acceptance-tests
 on:
   pull_request:
-    branches:
-    - master
-    - v*
-    - feature*
     paths-ignore:
     - CHANGELOG.md
   repository_dispatch:

--- a/provider-ci/test-workflows/docker/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/test-workflows/docker/.github/workflows/run-acceptance-tests.yml
@@ -436,10 +436,6 @@ jobs:
 name: run-acceptance-tests
 on:
   pull_request:
-    branches:
-    - master
-    - v*
-    - feature*
     paths-ignore:
     - CHANGELOG.md
   repository_dispatch:


### PR DESCRIPTION
I found it surprising when trying to [stack](https://stacking.dev) some PRs that we don't run tests unless the PR is explicitly against master. This is [awkward](https://github.com/pulumi/pulumi-docker/pull/948#issuecomment-1897531359) to work with.

This PR changes our workflow to trigger for PRs against any branch. I might be missing some context around #723 and why we chose to opt-in only some patterns, but if there are automated flows that shouldn't run tests I recommend we opt those out explicitly.