### PR TITLE
Add github.com/in-toto/in-toto-golang to license check ignore

### DIFF
--- a/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/license.yml
+++ b/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/license.yml
@@ -41,6 +41,7 @@ jobs:
           github.com/cloudflare/circl,
           github.com/golang,
           github.com/gorhill/cronexpr,
+          github.com/in-toto/in-toto-golang,
           github.com/jmespath/go-jmespath,
           github.com/keybase/go-crypto,
           github.com/klauspost/compress,

--- a/provider-ci/test-workflows/aws/.github/workflows/license.yml
+++ b/provider-ci/test-workflows/aws/.github/workflows/license.yml
@@ -65,6 +65,7 @@ jobs:
           github.com/cloudflare/circl,
           github.com/golang,
           github.com/gorhill/cronexpr,
+          github.com/in-toto/in-toto-golang,
           github.com/jmespath/go-jmespath,
           github.com/keybase/go-crypto,
           github.com/klauspost/compress,

--- a/provider-ci/test-workflows/cloudflare/.github/workflows/license.yml
+++ b/provider-ci/test-workflows/cloudflare/.github/workflows/license.yml
@@ -66,6 +66,7 @@ jobs:
           github.com/cloudflare/circl,
           github.com/golang,
           github.com/gorhill/cronexpr,
+          github.com/in-toto/in-toto-golang,
           github.com/jmespath/go-jmespath,
           github.com/keybase/go-crypto,
           github.com/klauspost/compress,

--- a/provider-ci/test-workflows/docker/.github/workflows/license.yml
+++ b/provider-ci/test-workflows/docker/.github/workflows/license.yml
@@ -78,6 +78,7 @@ jobs:
           github.com/cloudflare/circl,
           github.com/golang,
           github.com/gorhill/cronexpr,
+          github.com/in-toto/in-toto-golang,
           github.com/jmespath/go-jmespath,
           github.com/keybase/go-crypto,
           github.com/klauspost/compress,


### PR DESCRIPTION
[github.com/in-toto/in-toto-golang](https://github.com/in-toto/in-toto-golang) has an [Apache 2.0 license](https://github.com/in-toto/in-toto-golang/blob/v0.5.0/LICENSE) and is a dependency of newer [github.com/docker/buildx](https://github.com/docker/buildx) releases, but it's incorrectly flagged by the license check action.

This PR adds it to our ignore list.

Refs https://github.com/pulumi/license-check-action/issues/2
Unblocks https://github.com/pulumi/pulumi-docker/pull/898

```
❯ go mod graph | grep in-toto
github.com/pulumi/pulumi-docker/provider/v4 github.com/in-toto/in-toto-golang@v0.5.0
github.com/docker/buildx@v0.12.0 github.com/in-toto/in-toto-golang@v0.5.0
github.com/in-toto/in-toto-golang@v0.5.0 github.com/google/go-cmp@v0.5.9
github.com/in-toto/in-toto-golang@v0.5.0 github.com/secure-systems-lab/go-securesystemslib@v0.4.0
github.com/in-toto/in-toto-golang@v0.5.0 github.com/shibumi/go-pathspec@v1.3.0
github.com/in-toto/in-toto-golang@v0.5.0 github.com/spf13/cobra@v1.6.0
github.com/in-toto/in-toto-golang@v0.5.0 github.com/spiffe/go-spiffe/v2@v2.1.1
github.com/in-toto/in-toto-golang@v0.5.0 github.com/stretchr/testify@v1.8.0
github.com/in-toto/in-toto-golang@v0.5.0 golang.org/x/sys@v0.0.0-20211210111614-af8b64212486
github.com/in-toto/in-toto-golang@v0.5.0 google.golang.org/grpc@v1.50.1
github.com/in-toto/in-toto-golang@v0.5.0 github.com/Microsoft/go-winio@v0.5.2
github.com/in-toto/in-toto-golang@v0.5.0 github.com/cpuguy83/go-md2man/v2@v2.0.2
github.com/in-toto/in-toto-golang@v0.5.0 github.com/davecgh/go-spew@v1.1.1
github.com/in-toto/in-toto-golang@v0.5.0 github.com/golang/protobuf@v1.5.2
github.com/in-toto/in-toto-golang@v0.5.0 github.com/inconshreveable/mousetrap@v1.0.1
github.com/in-toto/in-toto-golang@v0.5.0 github.com/pmezard/go-difflib@v1.0.0
github.com/in-toto/in-toto-golang@v0.5.0 github.com/russross/blackfriday/v2@v2.1.0
github.com/in-toto/in-toto-golang@v0.5.0 github.com/spf13/pflag@v1.0.5
github.com/in-toto/in-toto-golang@v0.5.0 github.com/zeebo/errs@v1.2.2
github.com/in-toto/in-toto-golang@v0.5.0 golang.org/x/crypto@v0.0.0-20211209193657-4570a0811e8b
github.com/in-toto/in-toto-golang@v0.5.0 golang.org/x/net@v0.0.0-20211112202133-69e39bad7dc2
github.com/in-toto/in-toto-golang@v0.5.0 golang.org/x/text@v0.3.6
github.com/in-toto/in-toto-golang@v0.5.0 google.golang.org/genproto@v0.0.0-20200806141610-86f49bd18e98
github.com/in-toto/in-toto-golang@v0.5.0 google.golang.org/protobuf@v1.28.0
github.com/in-toto/in-toto-golang@v0.5.0 gopkg.in/square/go-jose.v2@v2.4.1
github.com/in-toto/in-toto-golang@v0.5.0 gopkg.in/yaml.v3@v3.0.1
github.com/moby/buildkit@v0.13.0-beta1.0.20231023114302-d5c1d785b042 github.com/in-toto/in-toto-golang@v0.5.0
```