### PR TITLE
Add gomod Make dependency

### DIFF
--- a/provider-ci/Makefile
+++ b/provider-ci/Makefile
@@ -56,6 +56,10 @@ lint-providers/%/repo: $(ACTIONLINT) providers/%/repo providers/%/config.yaml
 	# directory it either starts checking ci-mgmt workflows itself or checks workflows
 	# file-by-file and incorrectly reports dangling cross-references.
 	cd providers/$*/repo &&	git init && ../../../$(ACTIONLINT) -config-file ../../../actionlint.yml && rm -rf .git
+	# Allow Makefile to reference go.mod.
+	mkdir -p providers/$*/repo/provider && touch providers/$*/repo/provider/go.mod
+	# Assume .pulumi/version exists
+	mkdir -p providers/$*/repo/.pulumi && touch providers/$*/repo/.pulumi/version
 	@scripts/shellcheck.sh providers/$*/repo
 
 lint-providers: lint-providers/aws/repo lint-providers/docker/repo lint-providers/cloudflare/repo

--- a/provider-ci/internal/pkg/templates/bridged-provider/Makefile
+++ b/provider-ci/internal/pkg/templates/bridged-provider/Makefile
@@ -123,8 +123,8 @@ lint_provider: provider
 lint_provider.fix:
 	cd provider && golangci-lint run -c ../.golangci.yml --fix
 
-# `make provider_no_deps` builds the provider binary directly, without ensuring that 
-# `cmd/pulumi-resource-#{{ .Config.provider }}#/schema.json` is valid and up to date. 
+# `make provider_no_deps` builds the provider binary directly, without ensuring that
+# `cmd/pulumi-resource-#{{ .Config.provider }}#/schema.json` is valid and up to date.
 # To create a release ready binary, you should use `make provider`.
 provider_no_deps:
 	(cd provider && go build $(PULUMI_PROVIDER_BUILD_PARALLELISM) -o $(WORKING_DIR)/bin/$(PROVIDER) -ldflags "-X $(PROJECT)/$(VERSION_PATH)=$(VERSION)#{{if .Config.providerVersion}}# -X #{{ .Config.providerVersion }}#=$(VERSION)#{{end}}#" $(PROJECT)/$(PROVIDER_PATH)/cmd/$(PROVIDER))
@@ -185,7 +185,7 @@ ci-mgmt: .ci-mgmt.yaml
 	curl -fsSL https://get.pulumi.com | HOME=$(WORKING_DIR) sh -s -- --version $(shell cat .pulumi/version)
 
 # Compute the version of Pulumi to use by inspecting the Go dependencies of the provider.
-.pulumi/version:
+.pulumi/version: provider/go.mod
 	@mkdir -p .pulumi
 	@cd provider && go list -f "{{slice .Version 1}}" -m github.com/pulumi/pulumi/pkg/v3 | tee ../$@
 

--- a/provider-ci/test-workflows/aws/Makefile
+++ b/provider-ci/test-workflows/aws/Makefile
@@ -110,8 +110,8 @@ lint_provider: provider
 lint_provider.fix:
 	cd provider && golangci-lint run -c ../.golangci.yml --fix
 
-# `make provider_no_deps` builds the provider binary directly, without ensuring that 
-# `cmd/pulumi-resource-aws/schema.json` is valid and up to date. 
+# `make provider_no_deps` builds the provider binary directly, without ensuring that
+# `cmd/pulumi-resource-aws/schema.json` is valid and up to date.
 # To create a release ready binary, you should use `make provider`.
 provider_no_deps:
 	(cd provider && go build $(PULUMI_PROVIDER_BUILD_PARALLELISM) -o $(WORKING_DIR)/bin/$(PROVIDER) -ldflags "-X $(PROJECT)/$(VERSION_PATH)=$(VERSION) -X github.com/hashicorp/terraform-provider-aws/version.ProviderVersion=$(VERSION)" $(PROJECT)/$(PROVIDER_PATH)/cmd/$(PROVIDER))
@@ -168,7 +168,7 @@ ci-mgmt: .ci-mgmt.yaml
 	curl -fsSL https://get.pulumi.com | HOME=$(WORKING_DIR) sh -s -- --version $(shell cat .pulumi/version)
 
 # Compute the version of Pulumi to use by inspecting the Go dependencies of the provider.
-.pulumi/version:
+.pulumi/version: provider/go.mod
 	@mkdir -p .pulumi
 	@cd provider && go list -f "{{slice .Version 1}}" -m github.com/pulumi/pulumi/pkg/v3 | tee ../$@
 

--- a/provider-ci/test-workflows/cloudflare/Makefile
+++ b/provider-ci/test-workflows/cloudflare/Makefile
@@ -105,8 +105,8 @@ lint_provider: provider
 lint_provider.fix:
 	cd provider && golangci-lint run -c ../.golangci.yml --fix
 
-# `make provider_no_deps` builds the provider binary directly, without ensuring that 
-# `cmd/pulumi-resource-cloudflare/schema.json` is valid and up to date. 
+# `make provider_no_deps` builds the provider binary directly, without ensuring that
+# `cmd/pulumi-resource-cloudflare/schema.json` is valid and up to date.
 # To create a release ready binary, you should use `make provider`.
 provider_no_deps:
 	(cd provider && go build $(PULUMI_PROVIDER_BUILD_PARALLELISM) -o $(WORKING_DIR)/bin/$(PROVIDER) -ldflags "-X $(PROJECT)/$(VERSION_PATH)=$(VERSION)" $(PROJECT)/$(PROVIDER_PATH)/cmd/$(PROVIDER))
@@ -158,7 +158,7 @@ ci-mgmt: .ci-mgmt.yaml
 	curl -fsSL https://get.pulumi.com | HOME=$(WORKING_DIR) sh -s -- --version $(shell cat .pulumi/version)
 
 # Compute the version of Pulumi to use by inspecting the Go dependencies of the provider.
-.pulumi/version:
+.pulumi/version: provider/go.mod
 	@mkdir -p .pulumi
 	@cd provider && go list -f "{{slice .Version 1}}" -m github.com/pulumi/pulumi/pkg/v3 | tee ../$@
 

--- a/provider-ci/test-workflows/docker/Makefile
+++ b/provider-ci/test-workflows/docker/Makefile
@@ -107,8 +107,8 @@ lint_provider: provider
 lint_provider.fix:
 	cd provider && golangci-lint run -c ../.golangci.yml --fix
 
-# `make provider_no_deps` builds the provider binary directly, without ensuring that 
-# `cmd/pulumi-resource-docker/schema.json` is valid and up to date. 
+# `make provider_no_deps` builds the provider binary directly, without ensuring that
+# `cmd/pulumi-resource-docker/schema.json` is valid and up to date.
 # To create a release ready binary, you should use `make provider`.
 provider_no_deps:
 	(cd provider && go build $(PULUMI_PROVIDER_BUILD_PARALLELISM) -o $(WORKING_DIR)/bin/$(PROVIDER) -ldflags "-X $(PROJECT)/$(VERSION_PATH)=$(VERSION)" $(PROJECT)/$(PROVIDER_PATH)/cmd/$(PROVIDER))
@@ -160,7 +160,7 @@ ci-mgmt: .ci-mgmt.yaml
 	curl -fsSL https://get.pulumi.com | HOME=$(WORKING_DIR) sh -s -- --version $(shell cat .pulumi/version)
 
 # Compute the version of Pulumi to use by inspecting the Go dependencies of the provider.
-.pulumi/version:
+.pulumi/version: provider/go.mod
 	@mkdir -p .pulumi
 	@cd provider && go list -f "{{slice .Version 1}}" -m github.com/pulumi/pulumi/pkg/v3 | tee ../$@
 


### PR DESCRIPTION
The Makefile uses a trick to get a Pulumi CLI version that matches the provider/go.mod dependency on pkg. However since we did not explain to Make that reading go.mod is literally a dependency here, @guineveresaenger machine got into a state where `make` locally was using an out-of-date Pulumi CLI compared to CI. This is probably benign just yet, but with turning on example conversion via Pulumi CLI we can easily get this to produce discrepancies in generated examples between local and CI.