### PR TITLE
Update set-output command references in the generator for all providers to $GITHUB_OUTPUT

### DIFF
--- a/native-provider-ci/providers/aws-native/repo/.github/workflows/nightly-sdk-generation.yml
+++ b/native-provider-ci/providers/aws-native/repo/.github/workflows/nightly-sdk-generation.yml
@@ -83,7 +83,7 @@ jobs:
       run: make local_generate
     - name: Git submodule commit hash
       id: vars
-      run: echo ::set-output name=commit-hash::$(git rev-parse HEAD)
+      run: echo commit-hash=$(git rev-parse HEAD) >> "$GITHUB_OUTPUT"
       working-directory: aws-cloudformation-user-guide
     - name: Commit changes
       run: >-

--- a/native-provider-ci/providers/aws-native/repo/.github/workflows/run-acceptance-tests.yml
+++ b/native-provider-ci/providers/aws-native/repo/.github/workflows/run-acceptance-tests.yml
@@ -47,8 +47,7 @@ jobs:
     steps:
     - name: Create URL to the run output
       id: vars
-      run: echo ::set-output
-        name=run-url::https://github.com/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID
+      run: echo run-url=https://github.com/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID >> "$GITHUB_OUTPUT"
     - name: Update with Result
       uses: peter-evans/create-or-update-comment@v1
       with:

--- a/native-provider-ci/providers/aws-native/repo/.github/workflows/run-acceptance-tests.yml
+++ b/native-provider-ci/providers/aws-native/repo/.github/workflows/run-acceptance-tests.yml
@@ -47,7 +47,9 @@ jobs:
     steps:
     - name: Create URL to the run output
       id: vars
-      run: echo run-url=https://github.com/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID >> "$GITHUB_OUTPUT"
+      run: echo
+        run-url=https://github.com/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID
+        >> "$GITHUB_OUTPUT"
     - name: Update with Result
       uses: peter-evans/create-or-update-comment@v1
       with:

--- a/native-provider-ci/providers/aws-native/repo/.github/workflows/weekly-pulumi-update.yml
+++ b/native-provider-ci/providers/aws-native/repo/.github/workflows/weekly-pulumi-update.yml
@@ -79,7 +79,7 @@ jobs:
         git update-index -q --refresh
 
         if ! git diff-files --quiet; then 
-        	echo ::set-output name=changes::1 
+        	echo changes=1  >> "$GITHUB_OUTPUT"
         fi
     - name: Initialize submodules
       run: make init_submodules

--- a/native-provider-ci/providers/aws-native/repo/.github/workflows/weekly-pulumi-update.yml
+++ b/native-provider-ci/providers/aws-native/repo/.github/workflows/weekly-pulumi-update.yml
@@ -78,9 +78,7 @@ jobs:
 
         git update-index -q --refresh
 
-        if ! git diff-files --quiet; then 
-        	echo changes=1  >> "$GITHUB_OUTPUT"
-        fi
+        if ! git diff-files --quiet; then echo changes=1 >> "$GITHUB_OUTPUT"; fi
     - name: Initialize submodules
       run: make init_submodules
     - name: Provider with Pulumi Upgrade

--- a/native-provider-ci/providers/azure-native/repo/.github/workflows/nightly-sdk-generation.yml
+++ b/native-provider-ci/providers/azure-native/repo/.github/workflows/nightly-sdk-generation.yml
@@ -81,7 +81,7 @@ jobs:
       run: make local_generate
     - name: Git submodule commit hash
       id: vars
-      run: echo ::set-output name=commit-hash::$(git rev-parse HEAD)
+      run: echo commit-hash=$(git rev-parse HEAD) >> "$GITHUB_OUTPUT"
       working-directory: azure-rest-api-specs
     - name: Commit changes
       run: >-

--- a/native-provider-ci/providers/azure-native/repo/.github/workflows/run-acceptance-tests.yml
+++ b/native-provider-ci/providers/azure-native/repo/.github/workflows/run-acceptance-tests.yml
@@ -53,7 +53,9 @@ jobs:
     steps:
     - name: Create URL to the run output
       id: vars
-      run: echo run-url=https://github.com/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID >> "$GITHUB_OUTPUT"
+      run: echo
+        run-url=https://github.com/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID
+        >> "$GITHUB_OUTPUT"
     - name: Update with Result
       uses: peter-evans/create-or-update-comment@v1
       with:

--- a/native-provider-ci/providers/azure-native/repo/.github/workflows/run-acceptance-tests.yml
+++ b/native-provider-ci/providers/azure-native/repo/.github/workflows/run-acceptance-tests.yml
@@ -53,8 +53,7 @@ jobs:
     steps:
     - name: Create URL to the run output
       id: vars
-      run: echo ::set-output
-        name=run-url::https://github.com/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID
+      run: echo run-url=https://github.com/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID >> "$GITHUB_OUTPUT"
     - name: Update with Result
       uses: peter-evans/create-or-update-comment@v1
       with:

--- a/native-provider-ci/providers/azure-native/repo/.github/workflows/weekly-pulumi-update.yml
+++ b/native-provider-ci/providers/azure-native/repo/.github/workflows/weekly-pulumi-update.yml
@@ -84,9 +84,7 @@ jobs:
 
         git update-index -q --refresh
 
-        if ! git diff-files --quiet; then 
-        	echo changes=1  >> "$GITHUB_OUTPUT"
-        fi
+        if ! git diff-files --quiet; then echo changes=1 >> "$GITHUB_OUTPUT"; fi
     - name: Initialize submodules
       run: make init_submodules
     - name: Provider with Pulumi Upgrade

--- a/native-provider-ci/providers/azure-native/repo/.github/workflows/weekly-pulumi-update.yml
+++ b/native-provider-ci/providers/azure-native/repo/.github/workflows/weekly-pulumi-update.yml
@@ -85,7 +85,7 @@ jobs:
         git update-index -q --refresh
 
         if ! git diff-files --quiet; then 
-        	echo ::set-output name=changes::1 
+        	echo changes=1  >> "$GITHUB_OUTPUT"
         fi
     - name: Initialize submodules
       run: make init_submodules

--- a/native-provider-ci/providers/command/repo/.github/workflows/run-acceptance-tests.yml
+++ b/native-provider-ci/providers/command/repo/.github/workflows/run-acceptance-tests.yml
@@ -47,8 +47,7 @@ jobs:
     steps:
     - name: Create URL to the run output
       id: vars
-      run: echo ::set-output
-        name=run-url::https://github.com/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID
+      run: echo run-url=https://github.com/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID >> "$GITHUB_OUTPUT"
     - name: Update with Result
       uses: peter-evans/create-or-update-comment@v1
       with:

--- a/native-provider-ci/providers/command/repo/.github/workflows/run-acceptance-tests.yml
+++ b/native-provider-ci/providers/command/repo/.github/workflows/run-acceptance-tests.yml
@@ -47,7 +47,9 @@ jobs:
     steps:
     - name: Create URL to the run output
       id: vars
-      run: echo run-url=https://github.com/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID >> "$GITHUB_OUTPUT"
+      run: echo
+        run-url=https://github.com/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID
+        >> "$GITHUB_OUTPUT"
     - name: Update with Result
       uses: peter-evans/create-or-update-comment@v1
       with:

--- a/native-provider-ci/providers/command/repo/.github/workflows/weekly-pulumi-update.yml
+++ b/native-provider-ci/providers/command/repo/.github/workflows/weekly-pulumi-update.yml
@@ -78,9 +78,7 @@ jobs:
 
         git update-index -q --refresh
 
-        if ! git diff-files --quiet; then 
-        	echo changes=1  >> "$GITHUB_OUTPUT"
-        fi
+        if ! git diff-files --quiet; then echo changes=1 >> "$GITHUB_OUTPUT"; fi
     - name: Provider with Pulumi Upgrade
       if: steps.gomod.outputs.changes != 0
       run: >-

--- a/native-provider-ci/providers/command/repo/.github/workflows/weekly-pulumi-update.yml
+++ b/native-provider-ci/providers/command/repo/.github/workflows/weekly-pulumi-update.yml
@@ -79,7 +79,7 @@ jobs:
         git update-index -q --refresh
 
         if ! git diff-files --quiet; then 
-        	echo ::set-output name=changes::1 
+        	echo changes=1  >> "$GITHUB_OUTPUT"
         fi
     - name: Provider with Pulumi Upgrade
       if: steps.gomod.outputs.changes != 0

--- a/native-provider-ci/providers/google-native/repo/.github/workflows/run-acceptance-tests.yml
+++ b/native-provider-ci/providers/google-native/repo/.github/workflows/run-acceptance-tests.yml
@@ -53,7 +53,9 @@ jobs:
     steps:
     - name: Create URL to the run output
       id: vars
-      run: echo run-url=https://github.com/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID >> "$GITHUB_OUTPUT"
+      run: echo
+        run-url=https://github.com/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID
+        >> "$GITHUB_OUTPUT"
     - name: Update with Result
       uses: peter-evans/create-or-update-comment@v1
       with:

--- a/native-provider-ci/providers/google-native/repo/.github/workflows/run-acceptance-tests.yml
+++ b/native-provider-ci/providers/google-native/repo/.github/workflows/run-acceptance-tests.yml
@@ -53,8 +53,7 @@ jobs:
     steps:
     - name: Create URL to the run output
       id: vars
-      run: echo ::set-output
-        name=run-url::https://github.com/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID
+      run: echo run-url=https://github.com/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID >> "$GITHUB_OUTPUT"
     - name: Update with Result
       uses: peter-evans/create-or-update-comment@v1
       with:

--- a/native-provider-ci/providers/google-native/repo/.github/workflows/weekly-pulumi-update.yml
+++ b/native-provider-ci/providers/google-native/repo/.github/workflows/weekly-pulumi-update.yml
@@ -84,9 +84,7 @@ jobs:
 
         git update-index -q --refresh
 
-        if ! git diff-files --quiet; then 
-        	echo changes=1  >> "$GITHUB_OUTPUT"
-        fi
+        if ! git diff-files --quiet; then echo changes=1 >> "$GITHUB_OUTPUT"; fi
     - name: Initialize submodules
       run: make init_submodules
     - name: Provider with Pulumi Upgrade

--- a/native-provider-ci/providers/google-native/repo/.github/workflows/weekly-pulumi-update.yml
+++ b/native-provider-ci/providers/google-native/repo/.github/workflows/weekly-pulumi-update.yml
@@ -85,7 +85,7 @@ jobs:
         git update-index -q --refresh
 
         if ! git diff-files --quiet; then 
-        	echo ::set-output name=changes::1 
+        	echo changes=1  >> "$GITHUB_OUTPUT"
         fi
     - name: Initialize submodules
       run: make init_submodules

--- a/native-provider-ci/providers/kubernetes/repo/.github/workflows/build.yml
+++ b/native-provider-ci/providers/kubernetes/repo/.github/workflows/build.yml
@@ -603,7 +603,8 @@ jobs:
       run: gcloud --quiet auth configure-docker
     - name: Set stack name in output
       id: stackname
-      run: echo 'stack-name=${{ env.PULUMI_TEST_OWNER }}/${{ github.sha }}-${{ github.run_id }}-${{ github.run_attempt }}' >> "$GITHUB_OUTPUT"
+      run: echo 'stack-name=${{ env.PULUMI_TEST_OWNER }}/${{ github.sha }}-${{
+        github.run_id }}-${{ github.run_attempt }}' >> "$GITHUB_OUTPUT"
     - name: Create test infrastructure
       run: ./scripts/ci-cluster-create.sh ${{ steps.stackname.outputs.stack-name }}
     - name: Upload Kubernetes Artifacts

--- a/native-provider-ci/providers/kubernetes/repo/.github/workflows/build.yml
+++ b/native-provider-ci/providers/kubernetes/repo/.github/workflows/build.yml
@@ -603,8 +603,7 @@ jobs:
       run: gcloud --quiet auth configure-docker
     - name: Set stack name in output
       id: stackname
-      run: echo '::set-output name=stack-name::${{ env.PULUMI_TEST_OWNER }}/${{
-        github.sha }}-${{ github.run_id }}-${{ github.run_attempt }}'
+      run: echo 'stack-name=${{ env.PULUMI_TEST_OWNER }}/${{ github.sha }}-${{ github.run_id }}-${{ github.run_attempt }}' >> "$GITHUB_OUTPUT"
     - name: Create test infrastructure
       run: ./scripts/ci-cluster-create.sh ${{ steps.stackname.outputs.stack-name }}
     - name: Upload Kubernetes Artifacts

--- a/native-provider-ci/providers/kubernetes/repo/.github/workflows/prerelease.yml
+++ b/native-provider-ci/providers/kubernetes/repo/.github/workflows/prerelease.yml
@@ -594,7 +594,7 @@ jobs:
       run: gcloud --quiet auth configure-docker
     - name: Set stack name in output
       id: stackname
-      run: echo '::set-output name=stack-name::${{ env.PULUMI_TEST_OWNER }}/${{
+      run: echo 'stack-name=${{ env.PULUMI_TEST_OWNER }}/${{ >> "$GITHUB_OUTPUT"
         github.sha }}-${{ github.run_id }}-${{ github.run_attempt }}'
     - name: Create test infrastructure
       run: ./scripts/ci-cluster-create.sh ${{ steps.stackname.outputs.stack-name }}

--- a/native-provider-ci/providers/kubernetes/repo/.github/workflows/prerelease.yml
+++ b/native-provider-ci/providers/kubernetes/repo/.github/workflows/prerelease.yml
@@ -594,8 +594,8 @@ jobs:
       run: gcloud --quiet auth configure-docker
     - name: Set stack name in output
       id: stackname
-      run: echo 'stack-name=${{ env.PULUMI_TEST_OWNER }}/${{ >> "$GITHUB_OUTPUT"
-        github.sha }}-${{ github.run_id }}-${{ github.run_attempt }}'
+      run: echo 'stack-name=${{ env.PULUMI_TEST_OWNER }}/${{ github.sha }}-${{
+        github.run_id }}-${{ github.run_attempt }}' >> "$GITHUB_OUTPUT"
     - name: Create test infrastructure
       run: ./scripts/ci-cluster-create.sh ${{ steps.stackname.outputs.stack-name }}
     - name: Upload Kubernetes Artifacts

--- a/native-provider-ci/providers/kubernetes/repo/.github/workflows/release.yml
+++ b/native-provider-ci/providers/kubernetes/repo/.github/workflows/release.yml
@@ -623,7 +623,7 @@ jobs:
       run: gcloud --quiet auth configure-docker
     - name: Set stack name in output
       id: stackname
-      run: echo '::set-output name=stack-name::${{ env.PULUMI_TEST_OWNER }}/${{
+      run: echo 'stack-name=${{ env.PULUMI_TEST_OWNER }}/${{ >> "$GITHUB_OUTPUT"
         github.sha }}-${{ github.run_id }}-${{ github.run_attempt }}'
     - name: Create test infrastructure
       run: ./scripts/ci-cluster-create.sh ${{ steps.stackname.outputs.stack-name }}

--- a/native-provider-ci/providers/kubernetes/repo/.github/workflows/release.yml
+++ b/native-provider-ci/providers/kubernetes/repo/.github/workflows/release.yml
@@ -623,8 +623,8 @@ jobs:
       run: gcloud --quiet auth configure-docker
     - name: Set stack name in output
       id: stackname
-      run: echo 'stack-name=${{ env.PULUMI_TEST_OWNER }}/${{ >> "$GITHUB_OUTPUT"
-        github.sha }}-${{ github.run_id }}-${{ github.run_attempt }}'
+      run: echo 'stack-name=${{ env.PULUMI_TEST_OWNER }}/${{ github.sha }}-${{
+        github.run_id }}-${{ github.run_attempt }}' >> "$GITHUB_OUTPUT"
     - name: Create test infrastructure
       run: ./scripts/ci-cluster-create.sh ${{ steps.stackname.outputs.stack-name }}
     - name: Upload Kubernetes Artifacts

--- a/native-provider-ci/providers/kubernetes/repo/.github/workflows/run-acceptance-tests.yml
+++ b/native-provider-ci/providers/kubernetes/repo/.github/workflows/run-acceptance-tests.yml
@@ -463,7 +463,7 @@ jobs:
       run: gcloud --quiet auth configure-docker
     - name: Set stack name in output
       id: stackname
-      run: echo '::set-output name=stack-name::${{ env.PULUMI_TEST_OWNER }}/${{
+      run: echo 'stack-name=${{ env.PULUMI_TEST_OWNER }}/${{ >> "$GITHUB_OUTPUT"
         github.sha }}-${{ github.run_id }}-${{ github.run_attempt }}'
     - name: Create test infrastructure
       run: ./scripts/ci-cluster-create.sh ${{ steps.stackname.outputs.stack-name }}

--- a/native-provider-ci/providers/kubernetes/repo/.github/workflows/run-acceptance-tests.yml
+++ b/native-provider-ci/providers/kubernetes/repo/.github/workflows/run-acceptance-tests.yml
@@ -54,8 +54,7 @@ jobs:
     steps:
     - name: Create URL to the run output
       id: vars
-      run: echo ::set-output
-        name=run-url::https://github.com/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID
+      run: echo run-url=https://github.com/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID >> "$GITHUB_OUTPUT"
     - name: Update with Result
       uses: peter-evans/create-or-update-comment@v1
       with:

--- a/native-provider-ci/providers/kubernetes/repo/.github/workflows/run-acceptance-tests.yml
+++ b/native-provider-ci/providers/kubernetes/repo/.github/workflows/run-acceptance-tests.yml
@@ -54,7 +54,9 @@ jobs:
     steps:
     - name: Create URL to the run output
       id: vars
-      run: echo run-url=https://github.com/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID >> "$GITHUB_OUTPUT"
+      run: echo
+        run-url=https://github.com/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID
+        >> "$GITHUB_OUTPUT"
     - name: Update with Result
       uses: peter-evans/create-or-update-comment@v1
       with:
@@ -462,8 +464,8 @@ jobs:
       run: gcloud --quiet auth configure-docker
     - name: Set stack name in output
       id: stackname
-      run: echo 'stack-name=${{ env.PULUMI_TEST_OWNER }}/${{ >> "$GITHUB_OUTPUT"
-        github.sha }}-${{ github.run_id }}-${{ github.run_attempt }}'
+      run: echo 'stack-name=${{ env.PULUMI_TEST_OWNER }}/${{ github.sha }}-${{
+        github.run_id }}-${{ github.run_attempt }}' >> "$GITHUB_OUTPUT"
     - name: Create test infrastructure
       run: ./scripts/ci-cluster-create.sh ${{ steps.stackname.outputs.stack-name }}
     - name: Upload Kubernetes Artifacts

--- a/native-provider-ci/providers/kubernetes/repo/.github/workflows/weekly-pulumi-update.yml
+++ b/native-provider-ci/providers/kubernetes/repo/.github/workflows/weekly-pulumi-update.yml
@@ -85,7 +85,7 @@ jobs:
         git update-index -q --refresh
 
         if ! git diff-files --quiet; then 
-        	echo ::set-output name=changes::1 
+        	echo changes=1  >> "$GITHUB_OUTPUT"
         fi
     - name: Provider with Pulumi Upgrade
       if: steps.gomod.outputs.changes != 0

--- a/native-provider-ci/providers/kubernetes/repo/.github/workflows/weekly-pulumi-update.yml
+++ b/native-provider-ci/providers/kubernetes/repo/.github/workflows/weekly-pulumi-update.yml
@@ -84,9 +84,7 @@ jobs:
 
         git update-index -q --refresh
 
-        if ! git diff-files --quiet; then 
-        	echo changes=1  >> "$GITHUB_OUTPUT"
-        fi
+        if ! git diff-files --quiet; then echo changes=1 >> "$GITHUB_OUTPUT"; fi
     - name: Provider with Pulumi Upgrade
       if: steps.gomod.outputs.changes != 0
       run: >-

--- a/native-provider-ci/src/steps.ts
+++ b/native-provider-ci/src/steps.ts
@@ -44,7 +44,7 @@ export function CreateCommentsUrlStep(): Step {
   return {
     name: "Create URL to the run output",
     id: "vars",
-    run: "echo run-url=https://github.com/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID >> \"$GITHUB_OUTPUT\"",
+    run: 'echo run-url=https://github.com/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID >> "$GITHUB_OUTPUT"',
   };
 }
 
@@ -62,7 +62,7 @@ export function SetGitSubmoduleCommitHash(provider: string): Step {
   return {
     name: "Git submodule commit hash",
     id: "vars",
-    run: "echo commit-hash=$(git rev-parse HEAD) >> \"$GITHUB_OUTPUT\"",
+    run: 'echo commit-hash=$(git rev-parse HEAD) >> "$GITHUB_OUTPUT"',
     "working-directory": dir,
   };
 }
@@ -904,7 +904,7 @@ export function UpdatePulumi(): Step {
       "git checkout -b update-pulumi/${{ github.run_id }}-${{ github.run_number }}\n" +
       "for MODFILE in $(find . -name go.mod); do pushd $(dirname $MODFILE); go get github.com/pulumi/pulumi/pkg/v3 github.com/pulumi/pulumi/sdk/v3; go mod tidy; popd; done\n" +
       "git update-index -q --refresh\n" +
-      "if ! git diff-files --quiet; then \n\techo changes=1 >> \"$GITHUB_OUTPUT\"\nfi",
+      'if ! git diff-files --quiet; then echo changes=1 >> "$GITHUB_OUTPUT"; fi',
   };
 }
 

--- a/native-provider-ci/src/steps.ts
+++ b/native-provider-ci/src/steps.ts
@@ -62,7 +62,7 @@ export function SetGitSubmoduleCommitHash(provider: string): Step {
   return {
     name: "Git submodule commit hash",
     id: "vars",
-    run: "echo ::set-output name=commit-hash::$(git rev-parse HEAD)",
+    run: "echo commit-hash=$(git rev-parse HEAD) >> \"$GITHUB_OUTPUT\"",
     "working-directory": dir,
   };
 }
@@ -729,7 +729,7 @@ export function SetStackName(provider: string): Step {
     return {
       name: "Set stack name in output",
       id: "stackname",
-      run: "echo '::set-output name=stack-name::${{ env.PULUMI_TEST_OWNER }}/${{ github.sha }}-${{ github.run_id }}-${{ github.run_attempt }}'",
+      run: "echo 'stack-name=${{ env.PULUMI_TEST_OWNER }}/${{ github.sha }}-${{ github.run_id }}-${{ github.run_attempt }}' >> \"$GITHUB_OUTPUT\"",
     };
   }
   return {};
@@ -904,7 +904,7 @@ export function UpdatePulumi(): Step {
       "git checkout -b update-pulumi/${{ github.run_id }}-${{ github.run_number }}\n" +
       "for MODFILE in $(find . -name go.mod); do pushd $(dirname $MODFILE); go get github.com/pulumi/pulumi/pkg/v3 github.com/pulumi/pulumi/sdk/v3; go mod tidy; popd; done\n" +
       "git update-index -q --refresh\n" +
-      "if ! git diff-files --quiet; then \n\techo ::set-output name=changes::1 \nfi",
+      "if ! git diff-files --quiet; then \n\techo changes=1 >> \"$GITHUB_OUTPUT\"\nfi",
   };
 }
 

--- a/native-provider-ci/src/steps.ts
+++ b/native-provider-ci/src/steps.ts
@@ -44,7 +44,7 @@ export function CreateCommentsUrlStep(): Step {
   return {
     name: "Create URL to the run output",
     id: "vars",
-    run: "echo ::set-output name=run-url::https://github.com/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID",
+    run: "echo run-url=https://github.com/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID >> \"$GITHUB_OUTPUT\"",
   };
 }
 


### PR DESCRIPTION
This is a followup to my previous PR here: https://github.com/pulumi/pulumi-aws-native/pull/1283

Based on @mjeffryes's helpful direction there, this PR updates the usage of `::set-output` to `"$GITHUB_OUTPUT"` format for all provider workflow files. [The former command is deprecated by GitHub](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/).

Instructions for envvar usage from GitHub docs:

https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-output-parameter