### PR TITLE
Disable AWS Native

### DIFF
--- a/scripts/generate_native_providers_list.py
+++ b/scripts/generate_native_providers_list.py
@@ -3,7 +3,7 @@ import os
 import json
 
 
-excluded_from_auto_pr =["azure-native", "google-native", "command"]
+excluded_from_auto_pr =["azure-native", "google-native", "command", "aws-native"]
 
 if __name__ == '__main__':
     ap = argparse.ArgumentParser()


### PR DESCRIPTION
We're needing to diverge from the generic pattern due to test restructuring so are off-boarding from ci-mgmt for the time being.

Connected to https://github.com/pulumi/pulumi-aws-native/pull/1292