### PR TITLE
Clarify command for rebase

### DIFF
--- a/provider-ci/internal/pkg/templates/bridged-provider/scripts/upstream.sh
+++ b/provider-ci/internal/pkg/templates/bridged-provider/scripts/upstream.sh
@@ -149,7 +149,7 @@ make "$1"' failed to apply a patch. This is because there is a conflict between
 the checked out version of upstream and the patch set. To resolve this conflict
 run:
 
-    FROM=\$LAST_KNOWN_GOOD_COMMIT make upstream.rebase
+    FROM=\$LAST_KNOWN_GOOD_COMMIT TO=\$NEW_COMMIT make upstream.rebase
 
 This will walk you through resolving the conflict and producing a patch set that
 cleanly applies to the current upstream.

--- a/provider-ci/test-workflows/aws/scripts/upstream.sh
+++ b/provider-ci/test-workflows/aws/scripts/upstream.sh
@@ -149,7 +149,7 @@ make "$1"' failed to apply a patch. This is because there is a conflict between
 the checked out version of upstream and the patch set. To resolve this conflict
 run:
 
-    FROM=\$LAST_KNOWN_GOOD_COMMIT make upstream.rebase
+    FROM=\$LAST_KNOWN_GOOD_COMMIT TO=\$NEW_COMMIT make upstream.rebase
 
 This will walk you through resolving the conflict and producing a patch set that
 cleanly applies to the current upstream.

--- a/provider-ci/test-workflows/cloudflare/scripts/upstream.sh
+++ b/provider-ci/test-workflows/cloudflare/scripts/upstream.sh
@@ -149,7 +149,7 @@ make "$1"' failed to apply a patch. This is because there is a conflict between
 the checked out version of upstream and the patch set. To resolve this conflict
 run:
 
-    FROM=\$LAST_KNOWN_GOOD_COMMIT make upstream.rebase
+    FROM=\$LAST_KNOWN_GOOD_COMMIT TO=\$NEW_COMMIT make upstream.rebase
 
 This will walk you through resolving the conflict and producing a patch set that
 cleanly applies to the current upstream.

--- a/provider-ci/test-workflows/docker/scripts/upstream.sh
+++ b/provider-ci/test-workflows/docker/scripts/upstream.sh
@@ -149,7 +149,7 @@ make "$1"' failed to apply a patch. This is because there is a conflict between
 the checked out version of upstream and the patch set. To resolve this conflict
 run:
 
-    FROM=\$LAST_KNOWN_GOOD_COMMIT make upstream.rebase
+    FROM=\$LAST_KNOWN_GOOD_COMMIT TO=\$NEW_COMMIT make upstream.rebase
 
 This will walk you through resolving the conflict and producing a patch set that
 cleanly applies to the current upstream.


### PR DESCRIPTION
The command assumes you've already committed the upstream subrepo with the new commit.  
This makes it quite confusing if you haven't since `upstream.sh` will reset the subrepo.  
Specifying `TO` doesn't assume that.