### PR TITLE
Enable ci-mgmt for pulumi-command

### DIFF
--- a/native-provider-ci/providers/command/repo/.github/workflows/build.yml
+++ b/native-provider-ci/providers/command/repo/.github/workflows/build.yml
@@ -98,7 +98,7 @@ jobs:
         status: ${{ job.status }}
   build_sdks:
     needs: prerequisites
-    runs-on: pulumi-ubuntu-8core
+    runs-on: ubuntu-latest
     strategy:
       fail-fast: true
       matrix:
@@ -186,7 +186,7 @@ jobs:
         fields: repo,commit,author,action
         status: ${{ job.status }}
   test:
-    runs-on: pulumi-ubuntu-8core
+    runs-on: ubuntu-latest
     needs:
     - build_sdks
     strategy:

--- a/native-provider-ci/providers/command/repo/.github/workflows/prerelease.yml
+++ b/native-provider-ci/providers/command/repo/.github/workflows/prerelease.yml
@@ -90,7 +90,7 @@ jobs:
         status: ${{ job.status }}
   build_sdks:
     needs: prerequisites
-    runs-on: pulumi-ubuntu-8core
+    runs-on: ubuntu-latest
     strategy:
       fail-fast: true
       matrix:
@@ -177,7 +177,7 @@ jobs:
         fields: repo,commit,author,action
         status: ${{ job.status }}
   test:
-    runs-on: pulumi-ubuntu-8core
+    runs-on: ubuntu-latest
     needs:
     - build_sdks
     strategy:

--- a/native-provider-ci/providers/command/repo/.github/workflows/release.yml
+++ b/native-provider-ci/providers/command/repo/.github/workflows/release.yml
@@ -90,7 +90,7 @@ jobs:
         status: ${{ job.status }}
   build_sdks:
     needs: prerequisites
-    runs-on: pulumi-ubuntu-8core
+    runs-on: ubuntu-latest
     strategy:
       fail-fast: true
       matrix:
@@ -177,7 +177,7 @@ jobs:
         fields: repo,commit,author,action
         status: ${{ job.status }}
   test:
-    runs-on: pulumi-ubuntu-8core
+    runs-on: ubuntu-latest
     needs:
     - build_sdks
     strategy:

--- a/native-provider-ci/providers/command/repo/.github/workflows/run-acceptance-tests.yml
+++ b/native-provider-ci/providers/command/repo/.github/workflows/run-acceptance-tests.yml
@@ -117,7 +117,7 @@ jobs:
       github.event.pull_request.head.repo.full_name == github.repository
   build_sdks:
     needs: prerequisites
-    runs-on: pulumi-ubuntu-8core
+    runs-on: ubuntu-latest
     strategy:
       fail-fast: true
       matrix:
@@ -208,7 +208,7 @@ jobs:
     if: github.event_name == 'repository_dispatch' ||
       github.event.pull_request.head.repo.full_name == github.repository
   test:
-    runs-on: pulumi-ubuntu-8core
+    runs-on: ubuntu-latest
     needs:
     - build_sdks
     strategy:

--- a/native-provider-ci/src/workflows.ts
+++ b/native-provider-ci/src/workflows.ts
@@ -451,6 +451,8 @@ export class BuildSdkJob implements NormalJob {
     if (opts.provider === "azure-native") {
       this["runs-on"] =
         "${{ matrix.language == 'dotnet' && 'macos-11' || 'ubuntu-latest' }}";
+    } else if (opts.provider === "command") {
+      this["runs-on"] = "ubuntu-latest";
     }
     this.name = name;
     this.steps = [
@@ -568,6 +570,8 @@ export class TestsJob implements NormalJob {
   constructor(name: string, opts: WorkflowOpts) {
     if (opts.provider === "kubernetes") {
       this.needs = ["build_sdks", "build-test-cluster"];
+    } else if (opts.provider === "command") {
+      this["runs-on"] = "ubuntu-latest";
     }
     this.name = name;
     this.permissions = {

--- a/scripts/generate_native_providers_list.py
+++ b/scripts/generate_native_providers_list.py
@@ -3,7 +3,7 @@ import os
 import json
 
 
-excluded_from_auto_pr =["azure-native", "google-native", "command"]
+excluded_from_auto_pr =["azure-native", "google-native"]
 
 if __name__ == '__main__':
     ap = argparse.ArgumentParser()


### PR DESCRIPTION
I tested updating pulumi-command's workflows in https://github.com/pulumi/pulumi-command/pull/329/files and it showed very little drift from the current state of ci-mgmt, so I think it should be safe to turn on automated PRs for the repo.

The only change I made was to keep runners on ubuntu-latest instead of 8core.