### PR TITLE
Show which patch failed

### DIFF
--- a/provider-ci/internal/pkg/templates/bridged-provider/scripts/upstream.sh
+++ b/provider-ci/internal/pkg/templates/bridged-provider/scripts/upstream.sh
@@ -97,7 +97,7 @@ start_rebase() {
     echo "Applying $patch"
     if ! git am --3way "$patch"; then
       echo
-      echo "Failed to apply patch. Please run 'make upstream.rebase FROM=$TAG' where '$TAG' allows the patch set to apply cleanly"
+      echo "Failed to apply ${patch}. Please run 'make upstream.rebase FROM=$TAG' where '$TAG' allows the patch set to apply cleanly"
       echo
       exit 1
     fi
@@ -145,7 +145,7 @@ apply() {
     if ! git apply --3way "$patch"; then
       cat <<EOF
 
-make "$1"' failed to apply a patch. This is because there is a conflict between
+make "$1"' failed to apply ${patch}. This is because there is a conflict between
 the checked out version of upstream and the patch set. To resolve this conflict
 run:
 

--- a/provider-ci/test-workflows/aws/scripts/upstream.sh
+++ b/provider-ci/test-workflows/aws/scripts/upstream.sh
@@ -97,7 +97,7 @@ start_rebase() {
     echo "Applying $patch"
     if ! git am --3way "$patch"; then
       echo
-      echo "Failed to apply patch. Please run 'make upstream.rebase FROM=$TAG' where '$TAG' allows the patch set to apply cleanly"
+      echo "Failed to apply ${patch}. Please run 'make upstream.rebase FROM=$TAG' where '$TAG' allows the patch set to apply cleanly"
       echo
       exit 1
     fi
@@ -145,7 +145,7 @@ apply() {
     if ! git apply --3way "$patch"; then
       cat <<EOF
 
-make "$1"' failed to apply a patch. This is because there is a conflict between
+make "$1"' failed to apply ${patch}. This is because there is a conflict between
 the checked out version of upstream and the patch set. To resolve this conflict
 run:
 

--- a/provider-ci/test-workflows/cloudflare/scripts/upstream.sh
+++ b/provider-ci/test-workflows/cloudflare/scripts/upstream.sh
@@ -97,7 +97,7 @@ start_rebase() {
     echo "Applying $patch"
     if ! git am --3way "$patch"; then
       echo
-      echo "Failed to apply patch. Please run 'make upstream.rebase FROM=$TAG' where '$TAG' allows the patch set to apply cleanly"
+      echo "Failed to apply ${patch}. Please run 'make upstream.rebase FROM=$TAG' where '$TAG' allows the patch set to apply cleanly"
       echo
       exit 1
     fi
@@ -145,7 +145,7 @@ apply() {
     if ! git apply --3way "$patch"; then
       cat <<EOF
 
-make "$1"' failed to apply a patch. This is because there is a conflict between
+make "$1"' failed to apply ${patch}. This is because there is a conflict between
 the checked out version of upstream and the patch set. To resolve this conflict
 run:
 

--- a/provider-ci/test-workflows/docker/scripts/upstream.sh
+++ b/provider-ci/test-workflows/docker/scripts/upstream.sh
@@ -97,7 +97,7 @@ start_rebase() {
     echo "Applying $patch"
     if ! git am --3way "$patch"; then
       echo
-      echo "Failed to apply patch. Please run 'make upstream.rebase FROM=$TAG' where '$TAG' allows the patch set to apply cleanly"
+      echo "Failed to apply ${patch}. Please run 'make upstream.rebase FROM=$TAG' where '$TAG' allows the patch set to apply cleanly"
       echo
       exit 1
     fi
@@ -145,7 +145,7 @@ apply() {
     if ! git apply --3way "$patch"; then
       cat <<EOF
 
-make "$1"' failed to apply a patch. This is because there is a conflict between
+make "$1"' failed to apply ${patch}. This is because there is a conflict between
 the checked out version of upstream and the patch set. To resolve this conflict
 run:
 


### PR DESCRIPTION
When calling make upstream that fails on applying a patch, I would love too see immediately which patch failed. This helps fix that one.