### PR TITLE
Pin pulumictl

### DIFF
--- a/provider-ci/internal/pkg/templates/bridged-provider.config.yaml
+++ b/provider-ci/internal/pkg/templates/bridged-provider.config.yaml
@@ -78,6 +78,7 @@ actionVersions:
   goReleaser: goreleaser/goreleaser-action@v2
   installGhRelease: jaxxstorm/action-install-gh-release@v1.10.0
   checkout: actions/checkout@v4
+  pulumictlTag: v0.0.46
   cleanupArtifact: c-hive/gha-remove-artifacts@v1
   createOrUpdateComment: peter-evans/create-or-update-comment@v1
   downloadArtifact: actions/download-artifact@v2

--- a/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/main.yml
+++ b/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/main.yml
@@ -30,7 +30,7 @@ jobs:
     - name: Install pulumictl
       uses: #{{ .Config.actionVersions.installGhRelease }}#
       with:
-        tag: #{{ .Config.pulumictlTag }}#
+        tag: #{{ .Config.actionVersions.pulumictlTag }}#
         repo: pulumi/pulumictl
 #{{ .Config.actions.setupPulumi | toYaml | indent 4 }}#
     - name: Setup Node
@@ -133,7 +133,7 @@ jobs:
     - name: Install pulumictl
       uses: #{{ .Config.actionVersions.installGhRelease }}#
       with:
-        tag: #{{ .Config.pulumictlTag }}#
+        tag: #{{ .Config.actionVersions.pulumictlTag }}#
         repo: pulumi/pulumictl
 #{{ .Config.actions.setupPulumi | toYaml | indent 4 }}#
     - if: github.event_name == 'pull_request'
@@ -191,7 +191,7 @@ jobs:
     - name: Install pulumictl
       uses: #{{ .Config.actionVersions.installGhRelease }}#
       with:
-        tag: #{{ .Config.pulumictlTag }}#
+        tag: #{{ .Config.actionVersions.pulumictlTag }}#
         repo: pulumi/pulumictl
 #{{ .Config.actions.setupPulumi | toYaml | indent 4 }}#
     - name: Configure AWS Credentials
@@ -282,7 +282,7 @@ jobs:
     - name: Install pulumictl
       uses: #{{ .Config.actionVersions.installGhRelease }}#
       with:
-        tag: #{{ .Config.pulumictlTag }}#
+        tag: #{{ .Config.actionVersions.pulumictlTag }}#
         repo: pulumi/pulumictl
 #{{ .Config.actions.setupPulumi | toYaml | indent 4 }}#
     - name: Setup Node

--- a/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/main.yml
+++ b/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/main.yml
@@ -30,6 +30,7 @@ jobs:
     - name: Install pulumictl
       uses: #{{ .Config.actionVersions.installGhRelease }}#
       with:
+        tag: #{{ .Config.pulumictlTag }}#
         repo: pulumi/pulumictl
 #{{ .Config.actions.setupPulumi | toYaml | indent 4 }}#
     - name: Setup Node
@@ -132,6 +133,7 @@ jobs:
     - name: Install pulumictl
       uses: #{{ .Config.actionVersions.installGhRelease }}#
       with:
+        tag: #{{ .Config.pulumictlTag }}#
         repo: pulumi/pulumictl
 #{{ .Config.actions.setupPulumi | toYaml | indent 4 }}#
     - if: github.event_name == 'pull_request'
@@ -189,6 +191,7 @@ jobs:
     - name: Install pulumictl
       uses: #{{ .Config.actionVersions.installGhRelease }}#
       with:
+        tag: #{{ .Config.pulumictlTag }}#
         repo: pulumi/pulumictl
 #{{ .Config.actions.setupPulumi | toYaml | indent 4 }}#
     - name: Configure AWS Credentials
@@ -279,6 +282,7 @@ jobs:
     - name: Install pulumictl
       uses: #{{ .Config.actionVersions.installGhRelease }}#
       with:
+        tag: #{{ .Config.pulumictlTag }}#
         repo: pulumi/pulumictl
 #{{ .Config.actions.setupPulumi | toYaml | indent 4 }}#
     - name: Setup Node

--- a/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/nightly-test.yml
+++ b/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/nightly-test.yml
@@ -27,7 +27,7 @@ jobs:
     - name: Install pulumictl
       uses: #{{ .Config.actionVersions.installGhRelease }}#
       with:
-        tag: #{{ .Config.pulumictlTag }}#
+        tag: #{{ .Config.actionVersions.pulumictlTag }}#
         repo: pulumi/pulumictl
 #{{ .Config.actions.setupPulumi | toYaml | indent 4 }}#
     - name: Setup Node
@@ -129,7 +129,7 @@ jobs:
     - name: Install pulumictl
       uses: #{{ .Config.actionVersions.installGhRelease }}#
       with:
-        tag: #{{ .Config.pulumictlTag }}#
+        tag: #{{ .Config.actionVersions.pulumictlTag }}#
         repo: pulumi/pulumictl
 #{{ .Config.actions.setupPulumi | toYaml | indent 4 }}#
     - name: Setup Node

--- a/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/nightly-test.yml
+++ b/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/nightly-test.yml
@@ -27,6 +27,7 @@ jobs:
     - name: Install pulumictl
       uses: #{{ .Config.actionVersions.installGhRelease }}#
       with:
+        tag: #{{ .Config.pulumictlTag }}#
         repo: pulumi/pulumictl
 #{{ .Config.actions.setupPulumi | toYaml | indent 4 }}#
     - name: Setup Node
@@ -128,6 +129,7 @@ jobs:
     - name: Install pulumictl
       uses: #{{ .Config.actionVersions.installGhRelease }}#
       with:
+        tag: #{{ .Config.pulumictlTag }}#
         repo: pulumi/pulumictl
 #{{ .Config.actions.setupPulumi | toYaml | indent 4 }}#
     - name: Setup Node

--- a/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/prerelease.yml
+++ b/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/prerelease.yml
@@ -31,6 +31,7 @@ jobs:
     - name: Install pulumictl
       uses: #{{ .Config.actionVersions.installGhRelease }}#
       with:
+        tag: #{{ .Config.pulumictlTag }}#
         repo: pulumi/pulumictl
 #{{ .Config.actions.setupPulumi | toYaml | indent 4 }}#
     - name: Setup Node
@@ -138,6 +139,7 @@ jobs:
     - name: Install pulumictl
       uses: #{{ .Config.actionVersions.installGhRelease }}#
       with:
+        tag: #{{ .Config.pulumictlTag }}#
         repo: pulumi/pulumictl
 #{{ .Config.actions.setupPulumi | toYaml | indent 4 }}#
     - name: Configure AWS Credentials
@@ -210,6 +212,7 @@ jobs:
     - name: Install pulumictl
       uses: #{{ .Config.actionVersions.installGhRelease }}#
       with:
+        tag: #{{ .Config.pulumictlTag }}#
         repo: pulumi/pulumictl
 #{{ .Config.actions.setupPulumi | toYaml | indent 4 }}#
     - name: Setup Node

--- a/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/prerelease.yml
+++ b/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/prerelease.yml
@@ -31,7 +31,7 @@ jobs:
     - name: Install pulumictl
       uses: #{{ .Config.actionVersions.installGhRelease }}#
       with:
-        tag: #{{ .Config.pulumictlTag }}#
+        tag: #{{ .Config.actionVersions.pulumictlTag }}#
         repo: pulumi/pulumictl
 #{{ .Config.actions.setupPulumi | toYaml | indent 4 }}#
     - name: Setup Node
@@ -139,7 +139,7 @@ jobs:
     - name: Install pulumictl
       uses: #{{ .Config.actionVersions.installGhRelease }}#
       with:
-        tag: #{{ .Config.pulumictlTag }}#
+        tag: #{{ .Config.actionVersions.pulumictlTag }}#
         repo: pulumi/pulumictl
 #{{ .Config.actions.setupPulumi | toYaml | indent 4 }}#
     - name: Configure AWS Credentials
@@ -212,7 +212,7 @@ jobs:
     - name: Install pulumictl
       uses: #{{ .Config.actionVersions.installGhRelease }}#
       with:
-        tag: #{{ .Config.pulumictlTag }}#
+        tag: #{{ .Config.actionVersions.pulumictlTag }}#
         repo: pulumi/pulumictl
 #{{ .Config.actions.setupPulumi | toYaml | indent 4 }}#
     - name: Setup Node

--- a/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/prerequisites.splice
+++ b/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/prerequisites.splice
@@ -17,7 +17,7 @@
     - name: Install pulumictl
       uses: #{{ .Config.actionVersions.installGhRelease }}#
       with:
-        tag: #{{ .Config.pulumictlTag }}#
+        tag: #{{ .Config.actionVersions.pulumictlTag }}#
         repo: pulumi/pulumictl
 #{{ .Config.actions.setupPulumi | toYaml | indent 4 }}#
     - if: github.event_name == 'pull_request'

--- a/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/prerequisites.splice
+++ b/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/prerequisites.splice
@@ -17,6 +17,7 @@
     - name: Install pulumictl
       uses: #{{ .Config.actionVersions.installGhRelease }}#
       with:
+        tag: #{{ .Config.pulumictlTag }}#
         repo: pulumi/pulumictl
 #{{ .Config.actions.setupPulumi | toYaml | indent 4 }}#
     - if: github.event_name == 'pull_request'

--- a/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/release.yml
+++ b/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/release.yml
@@ -30,6 +30,7 @@ jobs:
     - name: Install pulumictl
       uses: #{{ .Config.actionVersions.installGhRelease }}#
       with:
+        tag: #{{ .Config.pulumictlTag }}#
         repo: pulumi/pulumictl
 #{{ .Config.actions.setupPulumi | toYaml | indent 4 }}#
     - name: Setup Node
@@ -109,6 +110,7 @@ jobs:
     - name: Install pulumictl
       uses: #{{ .Config.actionVersions.installGhRelease }}#
       with:
+        tag: #{{ .Config.pulumictlTag }}#
         repo: pulumi/pulumictl
     - env:
         GITHUB_TOKEN: ${{ secrets.PULUMI_BOT_TOKEN }}
@@ -153,6 +155,7 @@ jobs:
     - name: Install pulumictl
       uses: #{{ .Config.actionVersions.installGhRelease }}#
       with:
+        tag: #{{ .Config.pulumictlTag }}#
         repo: pulumi/pulumictl
 #{{ .Config.actions.setupPulumi | toYaml | indent 4 }}#
     - name: Configure AWS Credentials
@@ -213,6 +216,7 @@ jobs:
     - name: Install pulumictl
       uses: #{{ .Config.actionVersions.installGhRelease }}#
       with:
+        tag: #{{ .Config.pulumictlTag }}#
         repo: pulumi/pulumictl
     - name: Add SDK version tag
       run: git tag "sdk/v$(pulumictl get version --language generic)" && git push origin
@@ -265,6 +269,7 @@ jobs:
     - name: Install pulumictl
       uses: #{{ .Config.actionVersions.installGhRelease }}#
       with:
+        tag: #{{ .Config.pulumictlTag }}#
         repo: pulumi/pulumictl
 #{{ .Config.actions.setupPulumi | toYaml | indent 4 }}#
     - name: Setup Node

--- a/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/release.yml
+++ b/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/release.yml
@@ -30,7 +30,7 @@ jobs:
     - name: Install pulumictl
       uses: #{{ .Config.actionVersions.installGhRelease }}#
       with:
-        tag: #{{ .Config.pulumictlTag }}#
+        tag: #{{ .Config.actionVersions.pulumictlTag }}#
         repo: pulumi/pulumictl
 #{{ .Config.actions.setupPulumi | toYaml | indent 4 }}#
     - name: Setup Node
@@ -110,7 +110,7 @@ jobs:
     - name: Install pulumictl
       uses: #{{ .Config.actionVersions.installGhRelease }}#
       with:
-        tag: #{{ .Config.pulumictlTag }}#
+        tag: #{{ .Config.actionVersions.pulumictlTag }}#
         repo: pulumi/pulumictl
     - env:
         GITHUB_TOKEN: ${{ secrets.PULUMI_BOT_TOKEN }}
@@ -155,7 +155,7 @@ jobs:
     - name: Install pulumictl
       uses: #{{ .Config.actionVersions.installGhRelease }}#
       with:
-        tag: #{{ .Config.pulumictlTag }}#
+        tag: #{{ .Config.actionVersions.pulumictlTag }}#
         repo: pulumi/pulumictl
 #{{ .Config.actions.setupPulumi | toYaml | indent 4 }}#
     - name: Configure AWS Credentials
@@ -216,7 +216,7 @@ jobs:
     - name: Install pulumictl
       uses: #{{ .Config.actionVersions.installGhRelease }}#
       with:
-        tag: #{{ .Config.pulumictlTag }}#
+        tag: #{{ .Config.actionVersions.pulumictlTag }}#
         repo: pulumi/pulumictl
     - name: Add SDK version tag
       run: git tag "sdk/v$(pulumictl get version --language generic)" && git push origin
@@ -269,7 +269,7 @@ jobs:
     - name: Install pulumictl
       uses: #{{ .Config.actionVersions.installGhRelease }}#
       with:
-        tag: #{{ .Config.pulumictlTag }}#
+        tag: #{{ .Config.actionVersions.pulumictlTag }}#
         repo: pulumi/pulumictl
 #{{ .Config.actions.setupPulumi | toYaml | indent 4 }}#
     - name: Setup Node

--- a/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/resync-build.yml
+++ b/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/resync-build.yml
@@ -34,6 +34,7 @@ jobs:
     - name: Install pulumictl
       uses: #{{ .Config.actionVersions.installGhRelease }}#
       with:
+        tag: #{{ .Config.pulumictlTag }}#
         repo: pulumi/pulumictl
 #{{ .Config.actions.setupPulumi | toYaml | indent 4 }}#
     - name: Setup DotNet

--- a/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/resync-build.yml
+++ b/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/resync-build.yml
@@ -34,7 +34,7 @@ jobs:
     - name: Install pulumictl
       uses: #{{ .Config.actionVersions.installGhRelease }}#
       with:
-        tag: #{{ .Config.pulumictlTag }}#
+        tag: #{{ .Config.actionVersions.pulumictlTag }}#
         repo: pulumi/pulumictl
 #{{ .Config.actions.setupPulumi | toYaml | indent 4 }}#
     - name: Setup DotNet

--- a/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/run-acceptance-tests.yml
@@ -39,7 +39,7 @@ jobs:
     - name: Install pulumictl
       uses: #{{ .Config.actionVersions.installGhRelease }}#
       with:
-        tag: #{{ .Config.pulumictlTag }}#
+        tag: #{{ .Config.actionVersions.pulumictlTag }}#
         repo: pulumi/pulumictl
 #{{ .Config.actions.setupPulumi | toYaml | indent 4 }}#
     - name: Setup Node
@@ -213,7 +213,7 @@ jobs:
     - name: Install pulumictl
       uses: #{{ .Config.actionVersions.installGhRelease }}#
       with:
-        tag: #{{ .Config.pulumictlTag }}#
+        tag: #{{ .Config.actionVersions.pulumictlTag }}#
         repo: pulumi/pulumictl
 #{{ .Config.actions.setupPulumi | toYaml | indent 4 }}#
     - name: Setup Node

--- a/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/run-acceptance-tests.yml
@@ -39,6 +39,7 @@ jobs:
     - name: Install pulumictl
       uses: #{{ .Config.actionVersions.installGhRelease }}#
       with:
+        tag: #{{ .Config.pulumictlTag }}#
         repo: pulumi/pulumictl
 #{{ .Config.actions.setupPulumi | toYaml | indent 4 }}#
     - name: Setup Node
@@ -212,6 +213,7 @@ jobs:
     - name: Install pulumictl
       uses: #{{ .Config.actionVersions.installGhRelease }}#
       with:
+        tag: #{{ .Config.pulumictlTag }}#
         repo: pulumi/pulumictl
 #{{ .Config.actions.setupPulumi | toYaml | indent 4 }}#
     - name: Setup Node

--- a/provider-ci/test-workflows/aws/.github/workflows/master.yml
+++ b/provider-ci/test-workflows/aws/.github/workflows/master.yml
@@ -56,7 +56,7 @@ jobs:
     - name: Install pulumictl
       uses: jaxxstorm/action-install-gh-release@v1.10.0
       with:
-        tag: <no value>
+        tag: v0.0.46
         repo: pulumi/pulumictl
     - name: Install Pulumi CLI
       uses: pulumi/actions@v4
@@ -165,7 +165,7 @@ jobs:
     - name: Install pulumictl
       uses: jaxxstorm/action-install-gh-release@v1.10.0
       with:
-        tag: <no value>
+        tag: v0.0.46
         repo: pulumi/pulumictl
     - name: Install Pulumi CLI
       uses: pulumi/actions@v4
@@ -217,7 +217,7 @@ jobs:
     - name: Install pulumictl
       uses: jaxxstorm/action-install-gh-release@v1.10.0
       with:
-        tag: <no value>
+        tag: v0.0.46
         repo: pulumi/pulumictl
     - name: Install Pulumi CLI
       uses: pulumi/actions@v4
@@ -307,7 +307,7 @@ jobs:
     - name: Install pulumictl
       uses: jaxxstorm/action-install-gh-release@v1.10.0
       with:
-        tag: <no value>
+        tag: v0.0.46
         repo: pulumi/pulumictl
     - name: Install Pulumi CLI
       uses: pulumi/actions@v4
@@ -404,7 +404,7 @@ jobs:
     - name: Install pulumictl
       uses: jaxxstorm/action-install-gh-release@v1.10.0
       with:
-        tag: <no value>
+        tag: v0.0.46
         repo: pulumi/pulumictl
     - name: Install Pulumi CLI
       uses: pulumi/actions@v4

--- a/provider-ci/test-workflows/aws/.github/workflows/master.yml
+++ b/provider-ci/test-workflows/aws/.github/workflows/master.yml
@@ -56,6 +56,7 @@ jobs:
     - name: Install pulumictl
       uses: jaxxstorm/action-install-gh-release@v1.10.0
       with:
+        tag: <no value>
         repo: pulumi/pulumictl
     - name: Install Pulumi CLI
       uses: pulumi/actions@v4
@@ -164,6 +165,7 @@ jobs:
     - name: Install pulumictl
       uses: jaxxstorm/action-install-gh-release@v1.10.0
       with:
+        tag: <no value>
         repo: pulumi/pulumictl
     - name: Install Pulumi CLI
       uses: pulumi/actions@v4
@@ -215,6 +217,7 @@ jobs:
     - name: Install pulumictl
       uses: jaxxstorm/action-install-gh-release@v1.10.0
       with:
+        tag: <no value>
         repo: pulumi/pulumictl
     - name: Install Pulumi CLI
       uses: pulumi/actions@v4
@@ -304,6 +307,7 @@ jobs:
     - name: Install pulumictl
       uses: jaxxstorm/action-install-gh-release@v1.10.0
       with:
+        tag: <no value>
         repo: pulumi/pulumictl
     - name: Install Pulumi CLI
       uses: pulumi/actions@v4
@@ -400,6 +404,7 @@ jobs:
     - name: Install pulumictl
       uses: jaxxstorm/action-install-gh-release@v1.10.0
       with:
+        tag: <no value>
         repo: pulumi/pulumictl
     - name: Install Pulumi CLI
       uses: pulumi/actions@v4

--- a/provider-ci/test-workflows/aws/.github/workflows/nightly-test.yml
+++ b/provider-ci/test-workflows/aws/.github/workflows/nightly-test.yml
@@ -56,6 +56,7 @@ jobs:
     - name: Install pulumictl
       uses: jaxxstorm/action-install-gh-release@v1.10.0
       with:
+        tag: <no value>
         repo: pulumi/pulumictl
     - name: Install Pulumi CLI
       uses: pulumi/actions@v4
@@ -155,6 +156,7 @@ jobs:
     - name: Install pulumictl
       uses: jaxxstorm/action-install-gh-release@v1.10.0
       with:
+        tag: <no value>
         repo: pulumi/pulumictl
     - name: Install Pulumi CLI
       uses: pulumi/actions@v4
@@ -249,6 +251,7 @@ jobs:
     - name: Install pulumictl
       uses: jaxxstorm/action-install-gh-release@v1.10.0
       with:
+        tag: <no value>
         repo: pulumi/pulumictl
     - name: Install Pulumi CLI
       uses: pulumi/actions@v4

--- a/provider-ci/test-workflows/aws/.github/workflows/nightly-test.yml
+++ b/provider-ci/test-workflows/aws/.github/workflows/nightly-test.yml
@@ -56,7 +56,7 @@ jobs:
     - name: Install pulumictl
       uses: jaxxstorm/action-install-gh-release@v1.10.0
       with:
-        tag: <no value>
+        tag: v0.0.46
         repo: pulumi/pulumictl
     - name: Install Pulumi CLI
       uses: pulumi/actions@v4
@@ -156,7 +156,7 @@ jobs:
     - name: Install pulumictl
       uses: jaxxstorm/action-install-gh-release@v1.10.0
       with:
-        tag: <no value>
+        tag: v0.0.46
         repo: pulumi/pulumictl
     - name: Install Pulumi CLI
       uses: pulumi/actions@v4
@@ -251,7 +251,7 @@ jobs:
     - name: Install pulumictl
       uses: jaxxstorm/action-install-gh-release@v1.10.0
       with:
-        tag: <no value>
+        tag: v0.0.46
         repo: pulumi/pulumictl
     - name: Install Pulumi CLI
       uses: pulumi/actions@v4

--- a/provider-ci/test-workflows/aws/.github/workflows/prerelease.yml
+++ b/provider-ci/test-workflows/aws/.github/workflows/prerelease.yml
@@ -57,6 +57,7 @@ jobs:
     - name: Install pulumictl
       uses: jaxxstorm/action-install-gh-release@v1.10.0
       with:
+        tag: <no value>
         repo: pulumi/pulumictl
     - name: Install Pulumi CLI
       uses: pulumi/actions@v4
@@ -158,6 +159,7 @@ jobs:
     - name: Install pulumictl
       uses: jaxxstorm/action-install-gh-release@v1.10.0
       with:
+        tag: <no value>
         repo: pulumi/pulumictl
     - name: Install Pulumi CLI
       uses: pulumi/actions@v4
@@ -247,6 +249,7 @@ jobs:
     - name: Install pulumictl
       uses: jaxxstorm/action-install-gh-release@v1.10.0
       with:
+        tag: <no value>
         repo: pulumi/pulumictl
     - name: Install Pulumi CLI
       uses: pulumi/actions@v4
@@ -325,6 +328,7 @@ jobs:
     - name: Install pulumictl
       uses: jaxxstorm/action-install-gh-release@v1.10.0
       with:
+        tag: <no value>
         repo: pulumi/pulumictl
     - name: Install Pulumi CLI
       uses: pulumi/actions@v4

--- a/provider-ci/test-workflows/aws/.github/workflows/prerelease.yml
+++ b/provider-ci/test-workflows/aws/.github/workflows/prerelease.yml
@@ -57,7 +57,7 @@ jobs:
     - name: Install pulumictl
       uses: jaxxstorm/action-install-gh-release@v1.10.0
       with:
-        tag: <no value>
+        tag: v0.0.46
         repo: pulumi/pulumictl
     - name: Install Pulumi CLI
       uses: pulumi/actions@v4
@@ -159,7 +159,7 @@ jobs:
     - name: Install pulumictl
       uses: jaxxstorm/action-install-gh-release@v1.10.0
       with:
-        tag: <no value>
+        tag: v0.0.46
         repo: pulumi/pulumictl
     - name: Install Pulumi CLI
       uses: pulumi/actions@v4
@@ -249,7 +249,7 @@ jobs:
     - name: Install pulumictl
       uses: jaxxstorm/action-install-gh-release@v1.10.0
       with:
-        tag: <no value>
+        tag: v0.0.46
         repo: pulumi/pulumictl
     - name: Install Pulumi CLI
       uses: pulumi/actions@v4
@@ -328,7 +328,7 @@ jobs:
     - name: Install pulumictl
       uses: jaxxstorm/action-install-gh-release@v1.10.0
       with:
-        tag: <no value>
+        tag: v0.0.46
         repo: pulumi/pulumictl
     - name: Install Pulumi CLI
       uses: pulumi/actions@v4

--- a/provider-ci/test-workflows/aws/.github/workflows/release.yml
+++ b/provider-ci/test-workflows/aws/.github/workflows/release.yml
@@ -56,6 +56,7 @@ jobs:
     - name: Install pulumictl
       uses: jaxxstorm/action-install-gh-release@v1.10.0
       with:
+        tag: <no value>
         repo: pulumi/pulumictl
     - name: Install Pulumi CLI
       uses: pulumi/actions@v4
@@ -137,6 +138,7 @@ jobs:
     - name: Install pulumictl
       uses: jaxxstorm/action-install-gh-release@v1.10.0
       with:
+        tag: <no value>
         repo: pulumi/pulumictl
     - env:
         GITHUB_TOKEN: ${{ secrets.PULUMI_BOT_TOKEN }}
@@ -171,6 +173,7 @@ jobs:
     - name: Install pulumictl
       uses: jaxxstorm/action-install-gh-release@v1.10.0
       with:
+        tag: <no value>
         repo: pulumi/pulumictl
     - name: Install Pulumi CLI
       uses: pulumi/actions@v4
@@ -260,6 +263,7 @@ jobs:
     - name: Install pulumictl
       uses: jaxxstorm/action-install-gh-release@v1.10.0
       with:
+        tag: <no value>
         repo: pulumi/pulumictl
     - name: Install Pulumi CLI
       uses: pulumi/actions@v4
@@ -321,6 +325,7 @@ jobs:
     - name: Install pulumictl
       uses: jaxxstorm/action-install-gh-release@v1.10.0
       with:
+        tag: <no value>
         repo: pulumi/pulumictl
     - name: Add SDK version tag
       run: git tag "sdk/v$(pulumictl get version --language generic)" && git push origin
@@ -373,6 +378,7 @@ jobs:
     - name: Install pulumictl
       uses: jaxxstorm/action-install-gh-release@v1.10.0
       with:
+        tag: <no value>
         repo: pulumi/pulumictl
     - name: Install Pulumi CLI
       uses: pulumi/actions@v4

--- a/provider-ci/test-workflows/aws/.github/workflows/release.yml
+++ b/provider-ci/test-workflows/aws/.github/workflows/release.yml
@@ -56,7 +56,7 @@ jobs:
     - name: Install pulumictl
       uses: jaxxstorm/action-install-gh-release@v1.10.0
       with:
-        tag: <no value>
+        tag: v0.0.46
         repo: pulumi/pulumictl
     - name: Install Pulumi CLI
       uses: pulumi/actions@v4
@@ -138,7 +138,7 @@ jobs:
     - name: Install pulumictl
       uses: jaxxstorm/action-install-gh-release@v1.10.0
       with:
-        tag: <no value>
+        tag: v0.0.46
         repo: pulumi/pulumictl
     - env:
         GITHUB_TOKEN: ${{ secrets.PULUMI_BOT_TOKEN }}
@@ -173,7 +173,7 @@ jobs:
     - name: Install pulumictl
       uses: jaxxstorm/action-install-gh-release@v1.10.0
       with:
-        tag: <no value>
+        tag: v0.0.46
         repo: pulumi/pulumictl
     - name: Install Pulumi CLI
       uses: pulumi/actions@v4
@@ -263,7 +263,7 @@ jobs:
     - name: Install pulumictl
       uses: jaxxstorm/action-install-gh-release@v1.10.0
       with:
-        tag: <no value>
+        tag: v0.0.46
         repo: pulumi/pulumictl
     - name: Install Pulumi CLI
       uses: pulumi/actions@v4
@@ -325,7 +325,7 @@ jobs:
     - name: Install pulumictl
       uses: jaxxstorm/action-install-gh-release@v1.10.0
       with:
-        tag: <no value>
+        tag: v0.0.46
         repo: pulumi/pulumictl
     - name: Add SDK version tag
       run: git tag "sdk/v$(pulumictl get version --language generic)" && git push origin
@@ -378,7 +378,7 @@ jobs:
     - name: Install pulumictl
       uses: jaxxstorm/action-install-gh-release@v1.10.0
       with:
-        tag: <no value>
+        tag: v0.0.46
         repo: pulumi/pulumictl
     - name: Install Pulumi CLI
       uses: pulumi/actions@v4

--- a/provider-ci/test-workflows/aws/.github/workflows/resync-build.yml
+++ b/provider-ci/test-workflows/aws/.github/workflows/resync-build.yml
@@ -60,6 +60,7 @@ jobs:
     - name: Install pulumictl
       uses: jaxxstorm/action-install-gh-release@v1.10.0
       with:
+        tag: <no value>
         repo: pulumi/pulumictl
     - name: Install Pulumi CLI
       uses: pulumi/actions@v4

--- a/provider-ci/test-workflows/aws/.github/workflows/resync-build.yml
+++ b/provider-ci/test-workflows/aws/.github/workflows/resync-build.yml
@@ -60,7 +60,7 @@ jobs:
     - name: Install pulumictl
       uses: jaxxstorm/action-install-gh-release@v1.10.0
       with:
-        tag: <no value>
+        tag: v0.0.46
         repo: pulumi/pulumictl
     - name: Install Pulumi CLI
       uses: pulumi/actions@v4

--- a/provider-ci/test-workflows/aws/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/test-workflows/aws/.github/workflows/run-acceptance-tests.yml
@@ -65,6 +65,7 @@ jobs:
     - name: Install pulumictl
       uses: jaxxstorm/action-install-gh-release@v1.10.0
       with:
+        tag: <no value>
         repo: pulumi/pulumictl
     - name: Install Pulumi CLI
       uses: pulumi/actions@v4
@@ -180,6 +181,7 @@ jobs:
     - name: Install pulumictl
       uses: jaxxstorm/action-install-gh-release@v1.10.0
       with:
+        tag: <no value>
         repo: pulumi/pulumictl
     - name: Install Pulumi CLI
       uses: pulumi/actions@v4
@@ -316,6 +318,7 @@ jobs:
     - name: Install pulumictl
       uses: jaxxstorm/action-install-gh-release@v1.10.0
       with:
+        tag: <no value>
         repo: pulumi/pulumictl
     - name: Install Pulumi CLI
       uses: pulumi/actions@v4

--- a/provider-ci/test-workflows/aws/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/test-workflows/aws/.github/workflows/run-acceptance-tests.yml
@@ -65,7 +65,7 @@ jobs:
     - name: Install pulumictl
       uses: jaxxstorm/action-install-gh-release@v1.10.0
       with:
-        tag: <no value>
+        tag: v0.0.46
         repo: pulumi/pulumictl
     - name: Install Pulumi CLI
       uses: pulumi/actions@v4
@@ -181,7 +181,7 @@ jobs:
     - name: Install pulumictl
       uses: jaxxstorm/action-install-gh-release@v1.10.0
       with:
-        tag: <no value>
+        tag: v0.0.46
         repo: pulumi/pulumictl
     - name: Install Pulumi CLI
       uses: pulumi/actions@v4
@@ -318,7 +318,7 @@ jobs:
     - name: Install pulumictl
       uses: jaxxstorm/action-install-gh-release@v1.10.0
       with:
-        tag: <no value>
+        tag: v0.0.46
         repo: pulumi/pulumictl
     - name: Install Pulumi CLI
       uses: pulumi/actions@v4

--- a/provider-ci/test-workflows/cloudflare/.github/workflows/master.yml
+++ b/provider-ci/test-workflows/cloudflare/.github/workflows/master.yml
@@ -54,7 +54,7 @@ jobs:
     - name: Install pulumictl
       uses: jaxxstorm/action-install-gh-release@v1.10.0
       with:
-        tag: <no value>
+        tag: v0.0.46
         repo: pulumi/pulumictl
     - name: Install Pulumi CLI
       uses: pulumi/actions@v4
@@ -161,7 +161,7 @@ jobs:
     - name: Install pulumictl
       uses: jaxxstorm/action-install-gh-release@v1.10.0
       with:
-        tag: <no value>
+        tag: v0.0.46
         repo: pulumi/pulumictl
     - name: Install Pulumi CLI
       uses: pulumi/actions@v4
@@ -215,7 +215,7 @@ jobs:
     - name: Install pulumictl
       uses: jaxxstorm/action-install-gh-release@v1.10.0
       with:
-        tag: <no value>
+        tag: v0.0.46
         repo: pulumi/pulumictl
     - name: Install Pulumi CLI
       uses: pulumi/actions@v4
@@ -293,7 +293,7 @@ jobs:
     - name: Install pulumictl
       uses: jaxxstorm/action-install-gh-release@v1.10.0
       with:
-        tag: <no value>
+        tag: v0.0.46
         repo: pulumi/pulumictl
     - name: Install Pulumi CLI
       uses: pulumi/actions@v4
@@ -388,7 +388,7 @@ jobs:
     - name: Install pulumictl
       uses: jaxxstorm/action-install-gh-release@v1.10.0
       with:
-        tag: <no value>
+        tag: v0.0.46
         repo: pulumi/pulumictl
     - name: Install Pulumi CLI
       uses: pulumi/actions@v4

--- a/provider-ci/test-workflows/cloudflare/.github/workflows/master.yml
+++ b/provider-ci/test-workflows/cloudflare/.github/workflows/master.yml
@@ -54,6 +54,7 @@ jobs:
     - name: Install pulumictl
       uses: jaxxstorm/action-install-gh-release@v1.10.0
       with:
+        tag: <no value>
         repo: pulumi/pulumictl
     - name: Install Pulumi CLI
       uses: pulumi/actions@v4
@@ -160,6 +161,7 @@ jobs:
     - name: Install pulumictl
       uses: jaxxstorm/action-install-gh-release@v1.10.0
       with:
+        tag: <no value>
         repo: pulumi/pulumictl
     - name: Install Pulumi CLI
       uses: pulumi/actions@v4
@@ -213,6 +215,7 @@ jobs:
     - name: Install pulumictl
       uses: jaxxstorm/action-install-gh-release@v1.10.0
       with:
+        tag: <no value>
         repo: pulumi/pulumictl
     - name: Install Pulumi CLI
       uses: pulumi/actions@v4
@@ -290,6 +293,7 @@ jobs:
     - name: Install pulumictl
       uses: jaxxstorm/action-install-gh-release@v1.10.0
       with:
+        tag: <no value>
         repo: pulumi/pulumictl
     - name: Install Pulumi CLI
       uses: pulumi/actions@v4
@@ -384,6 +388,7 @@ jobs:
     - name: Install pulumictl
       uses: jaxxstorm/action-install-gh-release@v1.10.0
       with:
+        tag: <no value>
         repo: pulumi/pulumictl
     - name: Install Pulumi CLI
       uses: pulumi/actions@v4

--- a/provider-ci/test-workflows/cloudflare/.github/workflows/prerelease.yml
+++ b/provider-ci/test-workflows/cloudflare/.github/workflows/prerelease.yml
@@ -55,6 +55,7 @@ jobs:
     - name: Install pulumictl
       uses: jaxxstorm/action-install-gh-release@v1.10.0
       with:
+        tag: <no value>
         repo: pulumi/pulumictl
     - name: Install Pulumi CLI
       uses: pulumi/actions@v4
@@ -158,6 +159,7 @@ jobs:
     - name: Install pulumictl
       uses: jaxxstorm/action-install-gh-release@v1.10.0
       with:
+        tag: <no value>
         repo: pulumi/pulumictl
     - name: Install Pulumi CLI
       uses: pulumi/actions@v4
@@ -235,6 +237,7 @@ jobs:
     - name: Install pulumictl
       uses: jaxxstorm/action-install-gh-release@v1.10.0
       with:
+        tag: <no value>
         repo: pulumi/pulumictl
     - name: Install Pulumi CLI
       uses: pulumi/actions@v4
@@ -311,6 +314,7 @@ jobs:
     - name: Install pulumictl
       uses: jaxxstorm/action-install-gh-release@v1.10.0
       with:
+        tag: <no value>
         repo: pulumi/pulumictl
     - name: Install Pulumi CLI
       uses: pulumi/actions@v4

--- a/provider-ci/test-workflows/cloudflare/.github/workflows/prerelease.yml
+++ b/provider-ci/test-workflows/cloudflare/.github/workflows/prerelease.yml
@@ -55,7 +55,7 @@ jobs:
     - name: Install pulumictl
       uses: jaxxstorm/action-install-gh-release@v1.10.0
       with:
-        tag: <no value>
+        tag: v0.0.46
         repo: pulumi/pulumictl
     - name: Install Pulumi CLI
       uses: pulumi/actions@v4
@@ -159,7 +159,7 @@ jobs:
     - name: Install pulumictl
       uses: jaxxstorm/action-install-gh-release@v1.10.0
       with:
-        tag: <no value>
+        tag: v0.0.46
         repo: pulumi/pulumictl
     - name: Install Pulumi CLI
       uses: pulumi/actions@v4
@@ -237,7 +237,7 @@ jobs:
     - name: Install pulumictl
       uses: jaxxstorm/action-install-gh-release@v1.10.0
       with:
-        tag: <no value>
+        tag: v0.0.46
         repo: pulumi/pulumictl
     - name: Install Pulumi CLI
       uses: pulumi/actions@v4
@@ -314,7 +314,7 @@ jobs:
     - name: Install pulumictl
       uses: jaxxstorm/action-install-gh-release@v1.10.0
       with:
-        tag: <no value>
+        tag: v0.0.46
         repo: pulumi/pulumictl
     - name: Install Pulumi CLI
       uses: pulumi/actions@v4

--- a/provider-ci/test-workflows/cloudflare/.github/workflows/release.yml
+++ b/provider-ci/test-workflows/cloudflare/.github/workflows/release.yml
@@ -54,7 +54,7 @@ jobs:
     - name: Install pulumictl
       uses: jaxxstorm/action-install-gh-release@v1.10.0
       with:
-        tag: <no value>
+        tag: v0.0.46
         repo: pulumi/pulumictl
     - name: Install Pulumi CLI
       uses: pulumi/actions@v4
@@ -136,7 +136,7 @@ jobs:
     - name: Install pulumictl
       uses: jaxxstorm/action-install-gh-release@v1.10.0
       with:
-        tag: <no value>
+        tag: v0.0.46
         repo: pulumi/pulumictl
     - env:
         GITHUB_TOKEN: ${{ secrets.PULUMI_BOT_TOKEN }}
@@ -173,7 +173,7 @@ jobs:
     - name: Install pulumictl
       uses: jaxxstorm/action-install-gh-release@v1.10.0
       with:
-        tag: <no value>
+        tag: v0.0.46
         repo: pulumi/pulumictl
     - name: Install Pulumi CLI
       uses: pulumi/actions@v4
@@ -251,7 +251,7 @@ jobs:
     - name: Install pulumictl
       uses: jaxxstorm/action-install-gh-release@v1.10.0
       with:
-        tag: <no value>
+        tag: v0.0.46
         repo: pulumi/pulumictl
     - name: Install Pulumi CLI
       uses: pulumi/actions@v4
@@ -311,7 +311,7 @@ jobs:
     - name: Install pulumictl
       uses: jaxxstorm/action-install-gh-release@v1.10.0
       with:
-        tag: <no value>
+        tag: v0.0.46
         repo: pulumi/pulumictl
     - name: Add SDK version tag
       run: git tag "sdk/v$(pulumictl get version --language generic)" && git push origin
@@ -362,7 +362,7 @@ jobs:
     - name: Install pulumictl
       uses: jaxxstorm/action-install-gh-release@v1.10.0
       with:
-        tag: <no value>
+        tag: v0.0.46
         repo: pulumi/pulumictl
     - name: Install Pulumi CLI
       uses: pulumi/actions@v4

--- a/provider-ci/test-workflows/cloudflare/.github/workflows/release.yml
+++ b/provider-ci/test-workflows/cloudflare/.github/workflows/release.yml
@@ -54,6 +54,7 @@ jobs:
     - name: Install pulumictl
       uses: jaxxstorm/action-install-gh-release@v1.10.0
       with:
+        tag: <no value>
         repo: pulumi/pulumictl
     - name: Install Pulumi CLI
       uses: pulumi/actions@v4
@@ -135,6 +136,7 @@ jobs:
     - name: Install pulumictl
       uses: jaxxstorm/action-install-gh-release@v1.10.0
       with:
+        tag: <no value>
         repo: pulumi/pulumictl
     - env:
         GITHUB_TOKEN: ${{ secrets.PULUMI_BOT_TOKEN }}
@@ -171,6 +173,7 @@ jobs:
     - name: Install pulumictl
       uses: jaxxstorm/action-install-gh-release@v1.10.0
       with:
+        tag: <no value>
         repo: pulumi/pulumictl
     - name: Install Pulumi CLI
       uses: pulumi/actions@v4
@@ -248,6 +251,7 @@ jobs:
     - name: Install pulumictl
       uses: jaxxstorm/action-install-gh-release@v1.10.0
       with:
+        tag: <no value>
         repo: pulumi/pulumictl
     - name: Install Pulumi CLI
       uses: pulumi/actions@v4
@@ -307,6 +311,7 @@ jobs:
     - name: Install pulumictl
       uses: jaxxstorm/action-install-gh-release@v1.10.0
       with:
+        tag: <no value>
         repo: pulumi/pulumictl
     - name: Add SDK version tag
       run: git tag "sdk/v$(pulumictl get version --language generic)" && git push origin
@@ -357,6 +362,7 @@ jobs:
     - name: Install pulumictl
       uses: jaxxstorm/action-install-gh-release@v1.10.0
       with:
+        tag: <no value>
         repo: pulumi/pulumictl
     - name: Install Pulumi CLI
       uses: pulumi/actions@v4

--- a/provider-ci/test-workflows/cloudflare/.github/workflows/resync-build.yml
+++ b/provider-ci/test-workflows/cloudflare/.github/workflows/resync-build.yml
@@ -58,7 +58,7 @@ jobs:
     - name: Install pulumictl
       uses: jaxxstorm/action-install-gh-release@v1.10.0
       with:
-        tag: <no value>
+        tag: v0.0.46
         repo: pulumi/pulumictl
     - name: Install Pulumi CLI
       uses: pulumi/actions@v4

--- a/provider-ci/test-workflows/cloudflare/.github/workflows/resync-build.yml
+++ b/provider-ci/test-workflows/cloudflare/.github/workflows/resync-build.yml
@@ -58,6 +58,7 @@ jobs:
     - name: Install pulumictl
       uses: jaxxstorm/action-install-gh-release@v1.10.0
       with:
+        tag: <no value>
         repo: pulumi/pulumictl
     - name: Install Pulumi CLI
       uses: pulumi/actions@v4

--- a/provider-ci/test-workflows/cloudflare/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/test-workflows/cloudflare/.github/workflows/run-acceptance-tests.yml
@@ -64,7 +64,7 @@ jobs:
     - name: Install pulumictl
       uses: jaxxstorm/action-install-gh-release@v1.10.0
       with:
-        tag: <no value>
+        tag: v0.0.46
         repo: pulumi/pulumictl
     - name: Install Pulumi CLI
       uses: pulumi/actions@v4
@@ -184,7 +184,7 @@ jobs:
     - name: Install pulumictl
       uses: jaxxstorm/action-install-gh-release@v1.10.0
       with:
-        tag: <no value>
+        tag: v0.0.46
         repo: pulumi/pulumictl
     - name: Install Pulumi CLI
       uses: pulumi/actions@v4
@@ -311,7 +311,7 @@ jobs:
     - name: Install pulumictl
       uses: jaxxstorm/action-install-gh-release@v1.10.0
       with:
-        tag: <no value>
+        tag: v0.0.46
         repo: pulumi/pulumictl
     - name: Install Pulumi CLI
       uses: pulumi/actions@v4

--- a/provider-ci/test-workflows/cloudflare/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/test-workflows/cloudflare/.github/workflows/run-acceptance-tests.yml
@@ -64,6 +64,7 @@ jobs:
     - name: Install pulumictl
       uses: jaxxstorm/action-install-gh-release@v1.10.0
       with:
+        tag: <no value>
         repo: pulumi/pulumictl
     - name: Install Pulumi CLI
       uses: pulumi/actions@v4
@@ -183,6 +184,7 @@ jobs:
     - name: Install pulumictl
       uses: jaxxstorm/action-install-gh-release@v1.10.0
       with:
+        tag: <no value>
         repo: pulumi/pulumictl
     - name: Install Pulumi CLI
       uses: pulumi/actions@v4
@@ -309,6 +311,7 @@ jobs:
     - name: Install pulumictl
       uses: jaxxstorm/action-install-gh-release@v1.10.0
       with:
+        tag: <no value>
         repo: pulumi/pulumictl
     - name: Install Pulumi CLI
       uses: pulumi/actions@v4

--- a/provider-ci/test-workflows/docker/.github/workflows/master.yml
+++ b/provider-ci/test-workflows/docker/.github/workflows/master.yml
@@ -67,7 +67,7 @@ jobs:
     - name: Install pulumictl
       uses: jaxxstorm/action-install-gh-release@v1.10.0
       with:
-        tag: <no value>
+        tag: v0.0.46
         repo: pulumi/pulumictl
     - name: Install Pulumi CLI
       uses: pulumi/actions@v4
@@ -174,7 +174,7 @@ jobs:
     - name: Install pulumictl
       uses: jaxxstorm/action-install-gh-release@v1.10.0
       with:
-        tag: <no value>
+        tag: v0.0.46
         repo: pulumi/pulumictl
     - name: Install Pulumi CLI
       uses: pulumi/actions@v4
@@ -228,7 +228,7 @@ jobs:
     - name: Install pulumictl
       uses: jaxxstorm/action-install-gh-release@v1.10.0
       with:
-        tag: <no value>
+        tag: v0.0.46
         repo: pulumi/pulumictl
     - name: Install Pulumi CLI
       uses: pulumi/actions@v4
@@ -306,7 +306,7 @@ jobs:
     - name: Install pulumictl
       uses: jaxxstorm/action-install-gh-release@v1.10.0
       with:
-        tag: <no value>
+        tag: v0.0.46
         repo: pulumi/pulumictl
     - name: Install Pulumi CLI
       uses: pulumi/actions@v4
@@ -401,7 +401,7 @@ jobs:
     - name: Install pulumictl
       uses: jaxxstorm/action-install-gh-release@v1.10.0
       with:
-        tag: <no value>
+        tag: v0.0.46
         repo: pulumi/pulumictl
     - name: Install Pulumi CLI
       uses: pulumi/actions@v4

--- a/provider-ci/test-workflows/docker/.github/workflows/master.yml
+++ b/provider-ci/test-workflows/docker/.github/workflows/master.yml
@@ -67,6 +67,7 @@ jobs:
     - name: Install pulumictl
       uses: jaxxstorm/action-install-gh-release@v1.10.0
       with:
+        tag: <no value>
         repo: pulumi/pulumictl
     - name: Install Pulumi CLI
       uses: pulumi/actions@v4
@@ -173,6 +174,7 @@ jobs:
     - name: Install pulumictl
       uses: jaxxstorm/action-install-gh-release@v1.10.0
       with:
+        tag: <no value>
         repo: pulumi/pulumictl
     - name: Install Pulumi CLI
       uses: pulumi/actions@v4
@@ -226,6 +228,7 @@ jobs:
     - name: Install pulumictl
       uses: jaxxstorm/action-install-gh-release@v1.10.0
       with:
+        tag: <no value>
         repo: pulumi/pulumictl
     - name: Install Pulumi CLI
       uses: pulumi/actions@v4
@@ -303,6 +306,7 @@ jobs:
     - name: Install pulumictl
       uses: jaxxstorm/action-install-gh-release@v1.10.0
       with:
+        tag: <no value>
         repo: pulumi/pulumictl
     - name: Install Pulumi CLI
       uses: pulumi/actions@v4
@@ -397,6 +401,7 @@ jobs:
     - name: Install pulumictl
       uses: jaxxstorm/action-install-gh-release@v1.10.0
       with:
+        tag: <no value>
         repo: pulumi/pulumictl
     - name: Install Pulumi CLI
       uses: pulumi/actions@v4

--- a/provider-ci/test-workflows/docker/.github/workflows/prerelease.yml
+++ b/provider-ci/test-workflows/docker/.github/workflows/prerelease.yml
@@ -68,6 +68,7 @@ jobs:
     - name: Install pulumictl
       uses: jaxxstorm/action-install-gh-release@v1.10.0
       with:
+        tag: <no value>
         repo: pulumi/pulumictl
     - name: Install Pulumi CLI
       uses: pulumi/actions@v4
@@ -171,6 +172,7 @@ jobs:
     - name: Install pulumictl
       uses: jaxxstorm/action-install-gh-release@v1.10.0
       with:
+        tag: <no value>
         repo: pulumi/pulumictl
     - name: Install Pulumi CLI
       uses: pulumi/actions@v4
@@ -248,6 +250,7 @@ jobs:
     - name: Install pulumictl
       uses: jaxxstorm/action-install-gh-release@v1.10.0
       with:
+        tag: <no value>
         repo: pulumi/pulumictl
     - name: Install Pulumi CLI
       uses: pulumi/actions@v4
@@ -324,6 +327,7 @@ jobs:
     - name: Install pulumictl
       uses: jaxxstorm/action-install-gh-release@v1.10.0
       with:
+        tag: <no value>
         repo: pulumi/pulumictl
     - name: Install Pulumi CLI
       uses: pulumi/actions@v4

--- a/provider-ci/test-workflows/docker/.github/workflows/prerelease.yml
+++ b/provider-ci/test-workflows/docker/.github/workflows/prerelease.yml
@@ -68,7 +68,7 @@ jobs:
     - name: Install pulumictl
       uses: jaxxstorm/action-install-gh-release@v1.10.0
       with:
-        tag: <no value>
+        tag: v0.0.46
         repo: pulumi/pulumictl
     - name: Install Pulumi CLI
       uses: pulumi/actions@v4
@@ -172,7 +172,7 @@ jobs:
     - name: Install pulumictl
       uses: jaxxstorm/action-install-gh-release@v1.10.0
       with:
-        tag: <no value>
+        tag: v0.0.46
         repo: pulumi/pulumictl
     - name: Install Pulumi CLI
       uses: pulumi/actions@v4
@@ -250,7 +250,7 @@ jobs:
     - name: Install pulumictl
       uses: jaxxstorm/action-install-gh-release@v1.10.0
       with:
-        tag: <no value>
+        tag: v0.0.46
         repo: pulumi/pulumictl
     - name: Install Pulumi CLI
       uses: pulumi/actions@v4
@@ -327,7 +327,7 @@ jobs:
     - name: Install pulumictl
       uses: jaxxstorm/action-install-gh-release@v1.10.0
       with:
-        tag: <no value>
+        tag: v0.0.46
         repo: pulumi/pulumictl
     - name: Install Pulumi CLI
       uses: pulumi/actions@v4

--- a/provider-ci/test-workflows/docker/.github/workflows/release.yml
+++ b/provider-ci/test-workflows/docker/.github/workflows/release.yml
@@ -67,7 +67,7 @@ jobs:
     - name: Install pulumictl
       uses: jaxxstorm/action-install-gh-release@v1.10.0
       with:
-        tag: <no value>
+        tag: v0.0.46
         repo: pulumi/pulumictl
     - name: Install Pulumi CLI
       uses: pulumi/actions@v4
@@ -149,7 +149,7 @@ jobs:
     - name: Install pulumictl
       uses: jaxxstorm/action-install-gh-release@v1.10.0
       with:
-        tag: <no value>
+        tag: v0.0.46
         repo: pulumi/pulumictl
     - env:
         GITHUB_TOKEN: ${{ secrets.PULUMI_BOT_TOKEN }}
@@ -186,7 +186,7 @@ jobs:
     - name: Install pulumictl
       uses: jaxxstorm/action-install-gh-release@v1.10.0
       with:
-        tag: <no value>
+        tag: v0.0.46
         repo: pulumi/pulumictl
     - name: Install Pulumi CLI
       uses: pulumi/actions@v4
@@ -264,7 +264,7 @@ jobs:
     - name: Install pulumictl
       uses: jaxxstorm/action-install-gh-release@v1.10.0
       with:
-        tag: <no value>
+        tag: v0.0.46
         repo: pulumi/pulumictl
     - name: Install Pulumi CLI
       uses: pulumi/actions@v4
@@ -324,7 +324,7 @@ jobs:
     - name: Install pulumictl
       uses: jaxxstorm/action-install-gh-release@v1.10.0
       with:
-        tag: <no value>
+        tag: v0.0.46
         repo: pulumi/pulumictl
     - name: Add SDK version tag
       run: git tag "sdk/v$(pulumictl get version --language generic)" && git push origin
@@ -375,7 +375,7 @@ jobs:
     - name: Install pulumictl
       uses: jaxxstorm/action-install-gh-release@v1.10.0
       with:
-        tag: <no value>
+        tag: v0.0.46
         repo: pulumi/pulumictl
     - name: Install Pulumi CLI
       uses: pulumi/actions@v4

--- a/provider-ci/test-workflows/docker/.github/workflows/release.yml
+++ b/provider-ci/test-workflows/docker/.github/workflows/release.yml
@@ -67,6 +67,7 @@ jobs:
     - name: Install pulumictl
       uses: jaxxstorm/action-install-gh-release@v1.10.0
       with:
+        tag: <no value>
         repo: pulumi/pulumictl
     - name: Install Pulumi CLI
       uses: pulumi/actions@v4
@@ -148,6 +149,7 @@ jobs:
     - name: Install pulumictl
       uses: jaxxstorm/action-install-gh-release@v1.10.0
       with:
+        tag: <no value>
         repo: pulumi/pulumictl
     - env:
         GITHUB_TOKEN: ${{ secrets.PULUMI_BOT_TOKEN }}
@@ -184,6 +186,7 @@ jobs:
     - name: Install pulumictl
       uses: jaxxstorm/action-install-gh-release@v1.10.0
       with:
+        tag: <no value>
         repo: pulumi/pulumictl
     - name: Install Pulumi CLI
       uses: pulumi/actions@v4
@@ -261,6 +264,7 @@ jobs:
     - name: Install pulumictl
       uses: jaxxstorm/action-install-gh-release@v1.10.0
       with:
+        tag: <no value>
         repo: pulumi/pulumictl
     - name: Install Pulumi CLI
       uses: pulumi/actions@v4
@@ -320,6 +324,7 @@ jobs:
     - name: Install pulumictl
       uses: jaxxstorm/action-install-gh-release@v1.10.0
       with:
+        tag: <no value>
         repo: pulumi/pulumictl
     - name: Add SDK version tag
       run: git tag "sdk/v$(pulumictl get version --language generic)" && git push origin
@@ -370,6 +375,7 @@ jobs:
     - name: Install pulumictl
       uses: jaxxstorm/action-install-gh-release@v1.10.0
       with:
+        tag: <no value>
         repo: pulumi/pulumictl
     - name: Install Pulumi CLI
       uses: pulumi/actions@v4

--- a/provider-ci/test-workflows/docker/.github/workflows/resync-build.yml
+++ b/provider-ci/test-workflows/docker/.github/workflows/resync-build.yml
@@ -71,7 +71,7 @@ jobs:
     - name: Install pulumictl
       uses: jaxxstorm/action-install-gh-release@v1.10.0
       with:
-        tag: <no value>
+        tag: v0.0.46
         repo: pulumi/pulumictl
     - name: Install Pulumi CLI
       uses: pulumi/actions@v4

--- a/provider-ci/test-workflows/docker/.github/workflows/resync-build.yml
+++ b/provider-ci/test-workflows/docker/.github/workflows/resync-build.yml
@@ -71,6 +71,7 @@ jobs:
     - name: Install pulumictl
       uses: jaxxstorm/action-install-gh-release@v1.10.0
       with:
+        tag: <no value>
         repo: pulumi/pulumictl
     - name: Install Pulumi CLI
       uses: pulumi/actions@v4

--- a/provider-ci/test-workflows/docker/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/test-workflows/docker/.github/workflows/run-acceptance-tests.yml
@@ -77,6 +77,7 @@ jobs:
     - name: Install pulumictl
       uses: jaxxstorm/action-install-gh-release@v1.10.0
       with:
+        tag: <no value>
         repo: pulumi/pulumictl
     - name: Install Pulumi CLI
       uses: pulumi/actions@v4
@@ -196,6 +197,7 @@ jobs:
     - name: Install pulumictl
       uses: jaxxstorm/action-install-gh-release@v1.10.0
       with:
+        tag: <no value>
         repo: pulumi/pulumictl
     - name: Install Pulumi CLI
       uses: pulumi/actions@v4
@@ -322,6 +324,7 @@ jobs:
     - name: Install pulumictl
       uses: jaxxstorm/action-install-gh-release@v1.10.0
       with:
+        tag: <no value>
         repo: pulumi/pulumictl
     - name: Install Pulumi CLI
       uses: pulumi/actions@v4

--- a/provider-ci/test-workflows/docker/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/test-workflows/docker/.github/workflows/run-acceptance-tests.yml
@@ -77,7 +77,7 @@ jobs:
     - name: Install pulumictl
       uses: jaxxstorm/action-install-gh-release@v1.10.0
       with:
-        tag: <no value>
+        tag: v0.0.46
         repo: pulumi/pulumictl
     - name: Install Pulumi CLI
       uses: pulumi/actions@v4
@@ -197,7 +197,7 @@ jobs:
     - name: Install pulumictl
       uses: jaxxstorm/action-install-gh-release@v1.10.0
       with:
-        tag: <no value>
+        tag: v0.0.46
         repo: pulumi/pulumictl
     - name: Install Pulumi CLI
       uses: pulumi/actions@v4
@@ -324,7 +324,7 @@ jobs:
     - name: Install pulumictl
       uses: jaxxstorm/action-install-gh-release@v1.10.0
       with:
-        tag: <no value>
+        tag: v0.0.46
         repo: pulumi/pulumictl
     - name: Install Pulumi CLI
       uses: pulumi/actions@v4


### PR DESCRIPTION
Use a specific tag for pulumiCtl. This speed up installing it and avoids putting pressure on the API rate limits for determining the latest release of a dependency in our builds such as https://github.com/pulumi/pulumi-azuredevops/pull/292