### PR TITLE
Upgrade golangci-lint version

### DIFF
--- a/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/lint.yml
+++ b/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/lint.yml
@@ -37,7 +37,7 @@ jobs:
     - name: golangci-lint
       uses: golangci/golangci-lint-action@v3
       with:
-        version: v1.54.1
+        version: v1.55.2
         working-directory: provider
     - if: failure() && github.event_name == 'push'
       name: Notify Slack

--- a/provider-ci/test-workflows/aws/.github/workflows/lint.yml
+++ b/provider-ci/test-workflows/aws/.github/workflows/lint.yml
@@ -62,7 +62,7 @@ jobs:
     - name: golangci-lint
       uses: golangci/golangci-lint-action@v3
       with:
-        version: v1.54.1
+        version: v1.55.2
         working-directory: provider
     - if: failure() && github.event_name == 'push'
       name: Notify Slack

--- a/provider-ci/test-workflows/cloudflare/.github/workflows/lint.yml
+++ b/provider-ci/test-workflows/cloudflare/.github/workflows/lint.yml
@@ -60,7 +60,7 @@ jobs:
     - name: golangci-lint
       uses: golangci/golangci-lint-action@v3
       with:
-        version: v1.54.1
+        version: v1.55.2
         working-directory: provider
     - if: failure() && github.event_name == 'push'
       name: Notify Slack

--- a/provider-ci/test-workflows/docker/.github/workflows/lint.yml
+++ b/provider-ci/test-workflows/docker/.github/workflows/lint.yml
@@ -73,7 +73,7 @@ jobs:
     - name: golangci-lint
       uses: golangci/golangci-lint-action@v3
       with:
-        version: v1.54.1
+        version: v1.55.2
         working-directory: provider
     - if: failure() && github.event_name == 'push'
       name: Notify Slack


### PR DESCRIPTION
This was necessary to unblock the [azure provider
upgrade](https://github.com/pulumi/pulumi-azure/actions/runs/7892457062/job/21538972574?pr=1711).