### PR TITLE
Free disk space for go releaser

### DIFF
--- a/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/release.yml
+++ b/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/release.yml
@@ -144,6 +144,12 @@ jobs:
       #{{- end }}#
     runs-on: #{{ if .Config.runner.publish }}##{{- .Config.runner.publish }}##{{ else }}##{{- .Config.runner.default }}##{{ end }}#
     steps:
+    - name: Free Disk Space (Ubuntu)
+      uses: jlumbroso/free-disk-space@main
+      with:
+        # this might remove tools that are actually needed,
+        # if set to "true" but frees about 6 GB
+        tool-cache: false
     - name: Checkout Repo
       uses: #{{ .Config.actionVersions.checkout }}#
 #{{- if .Config.checkoutSubmodules }}#

--- a/provider-ci/test-workflows/aws/.github/workflows/release.yml
+++ b/provider-ci/test-workflows/aws/.github/workflows/release.yml
@@ -250,6 +250,12 @@ jobs:
       - go_test_shim
     runs-on: pulumi-ubuntu-8core
     steps:
+    - name: Free Disk Space (Ubuntu)
+      uses: jlumbroso/free-disk-space@main
+      with:
+        # this might remove tools that are actually needed,
+        # if set to "true" but frees about 6 GB
+        tool-cache: false
     - name: Checkout Repo
       uses: actions/checkout@v4
       with:

--- a/provider-ci/test-workflows/cloudflare/.github/workflows/release.yml
+++ b/provider-ci/test-workflows/cloudflare/.github/workflows/release.yml
@@ -240,6 +240,12 @@ jobs:
       - license_check
     runs-on: ubuntu-latest
     steps:
+    - name: Free Disk Space (Ubuntu)
+      uses: jlumbroso/free-disk-space@main
+      with:
+        # this might remove tools that are actually needed,
+        # if set to "true" but frees about 6 GB
+        tool-cache: false
     - name: Checkout Repo
       uses: actions/checkout@v4
     - name: Unshallow clone for tags

--- a/provider-ci/test-workflows/docker/.github/workflows/release.yml
+++ b/provider-ci/test-workflows/docker/.github/workflows/release.yml
@@ -253,6 +253,12 @@ jobs:
       - license_check
     runs-on: ubuntu-latest
     steps:
+    - name: Free Disk Space (Ubuntu)
+      uses: jlumbroso/free-disk-space@main
+      with:
+        # this might remove tools that are actually needed,
+        # if set to "true" but frees about 6 GB
+        tool-cache: false
     - name: Checkout Repo
       uses: actions/checkout@v4
     - name: Unshallow clone for tags


### PR DESCRIPTION
Seems to be quite disk space hungry: https://github.com/pulumi/pulumi-azure/actions/runs/8005595075/job/21867100794