### PR TITLE
Clean go sdk build artifacts

### DIFF
--- a/provider-ci/internal/pkg/templates/bridged-provider/Makefile
+++ b/provider-ci/internal/pkg/templates/bridged-provider/Makefile
@@ -51,7 +51,7 @@ build_dotnet: upstream
 
 build_go: upstream
 	PULUMI_CONVERT=$(PULUMI_CONVERT) $(WORKING_DIR)/bin/$(TFGEN) go --out sdk/go/
-	cd sdk && go list "$$(grep -e "^module" go.mod | cut -d ' ' -f 2)/go/..." | xargs go build
+	cd sdk && go list "$$(grep -e "^module" go.mod | cut -d ' ' -f 2)/go/..." | xargs -I {} bash -c 'go build {} && go clean -i {}'
 
 build_java: PACKAGE_VERSION := $(shell pulumictl get version --language generic)
 build_java: bin/pulumi-java-gen upstream

--- a/provider-ci/test-workflows/aws/Makefile
+++ b/provider-ci/test-workflows/aws/Makefile
@@ -41,7 +41,7 @@ build_dotnet: upstream
 
 build_go: upstream
 	PULUMI_CONVERT=$(PULUMI_CONVERT) $(WORKING_DIR)/bin/$(TFGEN) go --out sdk/go/
-	cd sdk && go list "$$(grep -e "^module" go.mod | cut -d ' ' -f 2)/go/..." | xargs go build
+	cd sdk && go list "$$(grep -e "^module" go.mod | cut -d ' ' -f 2)/go/..." | xargs -I {} bash -c 'go build {} && go clean -i {}'
 
 build_java: PACKAGE_VERSION := $(shell pulumictl get version --language generic)
 build_java: bin/pulumi-java-gen upstream

--- a/provider-ci/test-workflows/cloudflare/Makefile
+++ b/provider-ci/test-workflows/cloudflare/Makefile
@@ -40,7 +40,7 @@ build_dotnet: upstream
 
 build_go: upstream
 	PULUMI_CONVERT=$(PULUMI_CONVERT) $(WORKING_DIR)/bin/$(TFGEN) go --out sdk/go/
-	cd sdk && go list "$$(grep -e "^module" go.mod | cut -d ' ' -f 2)/go/..." | xargs go build
+	cd sdk && go list "$$(grep -e "^module" go.mod | cut -d ' ' -f 2)/go/..." | xargs -I {} bash -c 'go build {} && go clean -i {}'
 
 build_java: PACKAGE_VERSION := $(shell pulumictl get version --language generic)
 build_java: bin/pulumi-java-gen upstream

--- a/provider-ci/test-workflows/docker/Makefile
+++ b/provider-ci/test-workflows/docker/Makefile
@@ -40,7 +40,7 @@ build_dotnet: upstream
 
 build_go: upstream
 	PULUMI_CONVERT=$(PULUMI_CONVERT) $(WORKING_DIR)/bin/$(TFGEN) go --out sdk/go/
-	cd sdk && go list "$$(grep -e "^module" go.mod | cut -d ' ' -f 2)/go/..." | xargs go build
+	cd sdk && go list "$$(grep -e "^module" go.mod | cut -d ' ' -f 2)/go/..." | xargs -I {} bash -c 'go build {} && go clean -i {}'
 
 build_java: PACKAGE_VERSION := $(shell pulumictl get version --language generic)
 build_java: bin/pulumi-java-gen upstream


### PR DESCRIPTION
This save some disk space and allows AWS to run on normal runners.

Tested in https://github.com/pulumi/pulumi-aws/pull/3469