### PR TITLE
Add provider bin to PATH for test target

### DIFF
--- a/provider-ci/internal/pkg/templates/bridged-provider/Makefile
+++ b/provider-ci/internal/pkg/templates/bridged-provider/Makefile
@@ -131,6 +131,7 @@ provider_no_deps:
 
 provider: tfgen provider_no_deps
 
+test: export PATH := $(WORKING_DIR)/bin:$(PATH)
 test:
 	cd examples && go test -v -tags=all -parallel $(TESTPARALLELISM) -timeout 2h
 

--- a/provider-ci/test-workflows/aws/Makefile
+++ b/provider-ci/test-workflows/aws/Makefile
@@ -118,6 +118,7 @@ provider_no_deps:
 
 provider: tfgen provider_no_deps
 
+test: export PATH := $(WORKING_DIR)/bin:$(PATH)
 test:
 	cd examples && go test -v -tags=all -parallel $(TESTPARALLELISM) -timeout 2h
 

--- a/provider-ci/test-workflows/cloudflare/Makefile
+++ b/provider-ci/test-workflows/cloudflare/Makefile
@@ -113,6 +113,7 @@ provider_no_deps:
 
 provider: tfgen provider_no_deps
 
+test: export PATH := $(WORKING_DIR)/bin:$(PATH)
 test:
 	cd examples && go test -v -tags=all -parallel $(TESTPARALLELISM) -timeout 2h
 

--- a/provider-ci/test-workflows/docker/Makefile
+++ b/provider-ci/test-workflows/docker/Makefile
@@ -115,6 +115,7 @@ provider_no_deps:
 
 provider: tfgen provider_no_deps
 
+test: export PATH := $(WORKING_DIR)/bin:$(PATH)
 test:
 	cd examples && go test -v -tags=all -parallel $(TESTPARALLELISM) -timeout 2h
 


### PR DESCRIPTION
In provider makefiles, the `test` target doesn't seem to work because the examples cannot find the built provider.  The fix is simply to add the provider build directory to the path. That's what the CI script does when running the tests (see [code](https://github.com/pulumi/ci-mgmt/blob/1971f54d81598729424c636745ba961ee6432783/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/run-acceptance-tests.yml#L271-L272)).