### PR TITLE
Propagate title prefix arg to ci-mgmt

### DIFF
--- a/provider-ci/internal/pkg/templates/bridged-provider.config.yaml
+++ b/provider-ci/internal/pkg/templates/bridged-provider.config.yaml
@@ -90,7 +90,7 @@ actionVersions:
   prComment: thollander/actions-comment-pull-request@v2
   slashCommand: peter-evans/slash-command-dispatch@v2
   uploadArtifact: actions/upload-artifact@v4
-  upgradeProviderAction: pulumi/pulumi-upgrade-provider-action@v0.0.11
+  upgradeProviderAction: pulumi/pulumi-upgrade-provider-action@v0.0.12
   slackNotification: rtCamp/action-slack-notify@v2
 publish:
   publisherAction: pulumi/pulumi-package-publisher@v0.0.14

--- a/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/upgrade-bridge.yml
+++ b/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/upgrade-bridge.yml
@@ -38,6 +38,11 @@ on:
         required: false
         type: string
         default: ""
+      pr-title-prefix:
+        description: Prefix to add to the auto-opened pull request title
+        required: false
+        type: string
+        default: ""
       automerge:
         description: Mark created PR for auto-merging?
         required: false
@@ -66,6 +71,7 @@ jobs:
         #{{- end }}#
         pr-reviewers: ${{ inputs.pr-reviewers }}
         pr-description: ${{ inputs.pr-description }}
+        pr-title-prefix: ${{ inputs.pr-title-prefix }}
     - name: Call upgrade provider action
       if: github.event_name == 'repository_dispatch'
       uses: #{{ .Config.actionVersions.upgradeProviderAction }}#
@@ -78,6 +84,7 @@ jobs:
         target-bridge-version: ${{ github.event.client_payload.target-bridge-version }}
         pr-reviewers: ${{ github.event.client_payload.pr-reviewers }}
         pr-description: ${{ github.event.client_payload.pr-description }}
+        pr-title-prefix: ${{ github.event.client_payload.pr-title-prefix }}
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#7CFC00"

--- a/provider-ci/test-workflows/aws/.github/workflows/upgrade-bridge.yml
+++ b/provider-ci/test-workflows/aws/.github/workflows/upgrade-bridge.yml
@@ -38,6 +38,11 @@ on:
         required: false
         type: string
         default: ""
+      pr-title-prefix:
+        description: Prefix to add to the auto-opened pull request title
+        required: false
+        type: string
+        default: ""
       automerge:
         description: Mark created PR for auto-merging?
         required: false
@@ -63,6 +68,7 @@ jobs:
         target-pulumi-version: ${{ inputs.target-pulumi-version }}
         pr-reviewers: ${{ inputs.pr-reviewers }}
         pr-description: ${{ inputs.pr-description }}
+        pr-title-prefix: ${{ inputs.pr-title-prefix }}
     - name: Call upgrade provider action
       if: github.event_name == 'repository_dispatch'
       uses: pulumi/pulumi-upgrade-provider-action@v0.0.12
@@ -75,6 +81,7 @@ jobs:
         target-bridge-version: ${{ github.event.client_payload.target-bridge-version }}
         pr-reviewers: ${{ github.event.client_payload.pr-reviewers }}
         pr-description: ${{ github.event.client_payload.pr-description }}
+        pr-title-prefix: ${{ github.event.client_payload.pr-title-prefix }}
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#7CFC00"

--- a/provider-ci/test-workflows/aws/.github/workflows/upgrade-bridge.yml
+++ b/provider-ci/test-workflows/aws/.github/workflows/upgrade-bridge.yml
@@ -53,7 +53,7 @@ jobs:
     steps:
     - name: Call upgrade provider action
       if: github.event_name == 'workflow_dispatch'
-      uses: pulumi/pulumi-upgrade-provider-action@v0.0.11
+      uses: pulumi/pulumi-upgrade-provider-action@v0.0.12
       with:
         kind: ${{ inputs.kind }}
         email: bot@pulumi.com
@@ -65,7 +65,7 @@ jobs:
         pr-description: ${{ inputs.pr-description }}
     - name: Call upgrade provider action
       if: github.event_name == 'repository_dispatch'
-      uses: pulumi/pulumi-upgrade-provider-action@v0.0.11
+      uses: pulumi/pulumi-upgrade-provider-action@v0.0.12
       with:
         kind: ${{ github.event.client_payload.kind || 'bridge' }}
         email: bot@pulumi.com

--- a/provider-ci/test-workflows/aws/.github/workflows/upgrade-provider.yml
+++ b/provider-ci/test-workflows/aws/.github/workflows/upgrade-provider.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Call upgrade provider action
-      uses: pulumi/pulumi-upgrade-provider-action@v0.0.11
+      uses: pulumi/pulumi-upgrade-provider-action@v0.0.12
       with:
         kind: all
         email: bot@pulumi.com

--- a/provider-ci/test-workflows/cloudflare/.github/workflows/upgrade-bridge.yml
+++ b/provider-ci/test-workflows/cloudflare/.github/workflows/upgrade-bridge.yml
@@ -38,6 +38,11 @@ on:
         required: false
         type: string
         default: ""
+      pr-title-prefix:
+        description: Prefix to add to the auto-opened pull request title
+        required: false
+        type: string
+        default: ""
       automerge:
         description: Mark created PR for auto-merging?
         required: false
@@ -64,6 +69,7 @@ jobs:
         target-java-version: v0.9.3
         pr-reviewers: ${{ inputs.pr-reviewers }}
         pr-description: ${{ inputs.pr-description }}
+        pr-title-prefix: ${{ inputs.pr-title-prefix }}
     - name: Call upgrade provider action
       if: github.event_name == 'repository_dispatch'
       uses: pulumi/pulumi-upgrade-provider-action@v0.0.12
@@ -76,6 +82,7 @@ jobs:
         target-bridge-version: ${{ github.event.client_payload.target-bridge-version }}
         pr-reviewers: ${{ github.event.client_payload.pr-reviewers }}
         pr-description: ${{ github.event.client_payload.pr-description }}
+        pr-title-prefix: ${{ github.event.client_payload.pr-title-prefix }}
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#7CFC00"

--- a/provider-ci/test-workflows/cloudflare/.github/workflows/upgrade-bridge.yml
+++ b/provider-ci/test-workflows/cloudflare/.github/workflows/upgrade-bridge.yml
@@ -53,7 +53,7 @@ jobs:
     steps:
     - name: Call upgrade provider action
       if: github.event_name == 'workflow_dispatch'
-      uses: pulumi/pulumi-upgrade-provider-action@v0.0.11
+      uses: pulumi/pulumi-upgrade-provider-action@v0.0.12
       with:
         kind: ${{ inputs.kind }}
         email: bot@pulumi.com
@@ -66,7 +66,7 @@ jobs:
         pr-description: ${{ inputs.pr-description }}
     - name: Call upgrade provider action
       if: github.event_name == 'repository_dispatch'
-      uses: pulumi/pulumi-upgrade-provider-action@v0.0.11
+      uses: pulumi/pulumi-upgrade-provider-action@v0.0.12
       with:
         kind: ${{ github.event.client_payload.kind || 'bridge' }}
         email: bot@pulumi.com

--- a/provider-ci/test-workflows/cloudflare/.github/workflows/upgrade-provider.yml
+++ b/provider-ci/test-workflows/cloudflare/.github/workflows/upgrade-provider.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Call upgrade provider action
-      uses: pulumi/pulumi-upgrade-provider-action@v0.0.11
+      uses: pulumi/pulumi-upgrade-provider-action@v0.0.12
       with:
         kind: all
         target-java-version: v0.9.3

--- a/provider-ci/test-workflows/docker/.github/workflows/upgrade-bridge.yml
+++ b/provider-ci/test-workflows/docker/.github/workflows/upgrade-bridge.yml
@@ -38,6 +38,11 @@ on:
         required: false
         type: string
         default: ""
+      pr-title-prefix:
+        description: Prefix to add to the auto-opened pull request title
+        required: false
+        type: string
+        default: ""
       automerge:
         description: Mark created PR for auto-merging?
         required: false
@@ -63,6 +68,7 @@ jobs:
         target-pulumi-version: ${{ inputs.target-pulumi-version }}
         pr-reviewers: ${{ inputs.pr-reviewers }}
         pr-description: ${{ inputs.pr-description }}
+        pr-title-prefix: ${{ inputs.pr-title-prefix }}
     - name: Call upgrade provider action
       if: github.event_name == 'repository_dispatch'
       uses: pulumi/pulumi-upgrade-provider-action@v0.0.12
@@ -75,6 +81,7 @@ jobs:
         target-bridge-version: ${{ github.event.client_payload.target-bridge-version }}
         pr-reviewers: ${{ github.event.client_payload.pr-reviewers }}
         pr-description: ${{ github.event.client_payload.pr-description }}
+        pr-title-prefix: ${{ github.event.client_payload.pr-title-prefix }}
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#7CFC00"

--- a/provider-ci/test-workflows/docker/.github/workflows/upgrade-bridge.yml
+++ b/provider-ci/test-workflows/docker/.github/workflows/upgrade-bridge.yml
@@ -53,7 +53,7 @@ jobs:
     steps:
     - name: Call upgrade provider action
       if: github.event_name == 'workflow_dispatch'
-      uses: pulumi/pulumi-upgrade-provider-action@v0.0.11
+      uses: pulumi/pulumi-upgrade-provider-action@v0.0.12
       with:
         kind: ${{ inputs.kind }}
         email: bot@pulumi.com
@@ -65,7 +65,7 @@ jobs:
         pr-description: ${{ inputs.pr-description }}
     - name: Call upgrade provider action
       if: github.event_name == 'repository_dispatch'
-      uses: pulumi/pulumi-upgrade-provider-action@v0.0.11
+      uses: pulumi/pulumi-upgrade-provider-action@v0.0.12
       with:
         kind: ${{ github.event.client_payload.kind || 'bridge' }}
         email: bot@pulumi.com

--- a/provider-ci/test-workflows/docker/.github/workflows/upgrade-provider.yml
+++ b/provider-ci/test-workflows/docker/.github/workflows/upgrade-provider.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Call upgrade provider action
-      uses: pulumi/pulumi-upgrade-provider-action@v0.0.11
+      uses: pulumi/pulumi-upgrade-provider-action@v0.0.12
       with:
         kind: all
         email: bot@pulumi.com


### PR DESCRIPTION
Propagate https://github.com/pulumi/pulumi-upgrade-provider-action/pull/25 and https://github.com/pulumi/upgrade-provider/pull/252 to ci-mgmt.

Only pu/pu (and bridge) left...