### PR TITLE
Reclaim some disk space in release jobs

### DIFF
--- a/native-provider-ci/providers/aws-native/repo/.github/workflows/build.yml
+++ b/native-provider-ci/providers/aws-native/repo/.github/workflows/build.yml
@@ -355,6 +355,15 @@ jobs:
       uses: actions/setup-go@v5
       with:
         go-version: ${{ env.GOVERSION }}
+    - name: Clear GitHub Actions Ubuntu runner disk space
+      uses: jlumbroso/free-disk-space@v1
+      with:
+        tool-cache: false
+        dotnet: false
+        android: true
+        haskell: true
+        swap-storage: true
+        large-packages: false
     - name: Install pulumictl
       uses: jaxxstorm/action-install-gh-release@v1.11.0
       with:
@@ -377,8 +386,7 @@ jobs:
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v5
       with:
-        args: -p 3 -f .goreleaser.prerelease.yml --rm-dist --skip-validate --timeout
-          60m0s
+        args: -p 3 -f .goreleaser.prerelease.yml --clean --skip=validate --timeout 60m0s
         version: latest
     - if: failure() && github.event_name == 'push'
       name: Notify Slack

--- a/native-provider-ci/providers/aws-native/repo/.github/workflows/cf2pulumi-release.yml
+++ b/native-provider-ci/providers/aws-native/repo/.github/workflows/cf2pulumi-release.yml
@@ -54,7 +54,7 @@ jobs:
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v5
       with:
-        args: -p 1 -f .goreleaser.cf2pulumi.yml release --rm-dist --timeout 60m0s
+        args: -p 1 -f .goreleaser.cf2pulumi.yml release --clean --timeout 60m0s
         version: latest
     - name: Chocolatey Package Deployment
       run: |-

--- a/native-provider-ci/providers/aws-native/repo/.github/workflows/prerelease.yml
+++ b/native-provider-ci/providers/aws-native/repo/.github/workflows/prerelease.yml
@@ -346,6 +346,15 @@ jobs:
       uses: actions/setup-go@v5
       with:
         go-version: ${{ env.GOVERSION }}
+    - name: Clear GitHub Actions Ubuntu runner disk space
+      uses: jlumbroso/free-disk-space@v1
+      with:
+        tool-cache: false
+        dotnet: false
+        android: true
+        haskell: true
+        swap-storage: true
+        large-packages: false
     - name: Install pulumictl
       uses: jaxxstorm/action-install-gh-release@v1.11.0
       with:
@@ -368,8 +377,7 @@ jobs:
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v5
       with:
-        args: -p 3 -f .goreleaser.prerelease.yml --rm-dist --skip-validate --timeout
-          60m0s
+        args: -p 3 -f .goreleaser.prerelease.yml --clean --skip=validate --timeout 60m0s
         version: latest
     - if: failure() && github.event_name == 'push'
       name: Notify Slack

--- a/native-provider-ci/providers/aws-native/repo/.github/workflows/release.yml
+++ b/native-provider-ci/providers/aws-native/repo/.github/workflows/release.yml
@@ -346,6 +346,15 @@ jobs:
       uses: actions/setup-go@v5
       with:
         go-version: ${{ env.GOVERSION }}
+    - name: Clear GitHub Actions Ubuntu runner disk space
+      uses: jlumbroso/free-disk-space@v1
+      with:
+        tool-cache: false
+        dotnet: false
+        android: true
+        haskell: true
+        swap-storage: true
+        large-packages: false
     - name: Install pulumictl
       uses: jaxxstorm/action-install-gh-release@v1.11.0
       with:
@@ -368,7 +377,7 @@ jobs:
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v5
       with:
-        args: -p 3 release --rm-dist --timeout 60m0s
+        args: -p 3 release --clean --timeout 60m0s
         version: latest
     - if: failure() && github.event_name == 'push'
       name: Notify Slack

--- a/native-provider-ci/providers/azure-native/repo/.github/workflows/arm2pulumi-release.yml
+++ b/native-provider-ci/providers/azure-native/repo/.github/workflows/arm2pulumi-release.yml
@@ -71,6 +71,6 @@ jobs:
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v5
       with:
-        args: -p 1 -f .goreleaser.arm2pulumi.yml release --rm-dist --timeout 60m0s
+        args: -p 1 -f .goreleaser.arm2pulumi.yml release --clean --timeout 60m0s
         version: latest
     name: release

--- a/native-provider-ci/providers/azure-native/repo/.github/workflows/build.yml
+++ b/native-provider-ci/providers/azure-native/repo/.github/workflows/build.yml
@@ -358,6 +358,15 @@ jobs:
       uses: actions/setup-go@v5
       with:
         go-version: ${{ env.GOVERSION }}
+    - name: Clear GitHub Actions Ubuntu runner disk space
+      uses: jlumbroso/free-disk-space@v1
+      with:
+        tool-cache: false
+        dotnet: false
+        android: true
+        haskell: true
+        swap-storage: true
+        large-packages: false
     - name: Install pulumictl
       uses: jaxxstorm/action-install-gh-release@v1.11.0
       with:
@@ -380,8 +389,7 @@ jobs:
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v5
       with:
-        args: -p 3 -f .goreleaser.prerelease.yml --rm-dist --skip-validate --timeout
-          60m0s
+        args: -p 3 -f .goreleaser.prerelease.yml --clean --skip=validate --timeout 60m0s
         version: latest
     - if: failure() && github.event_name == 'push'
       name: Notify Slack

--- a/native-provider-ci/providers/azure-native/repo/.github/workflows/prerelease.yml
+++ b/native-provider-ci/providers/azure-native/repo/.github/workflows/prerelease.yml
@@ -349,6 +349,15 @@ jobs:
       uses: actions/setup-go@v5
       with:
         go-version: ${{ env.GOVERSION }}
+    - name: Clear GitHub Actions Ubuntu runner disk space
+      uses: jlumbroso/free-disk-space@v1
+      with:
+        tool-cache: false
+        dotnet: false
+        android: true
+        haskell: true
+        swap-storage: true
+        large-packages: false
     - name: Install pulumictl
       uses: jaxxstorm/action-install-gh-release@v1.11.0
       with:
@@ -371,8 +380,7 @@ jobs:
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v5
       with:
-        args: -p 3 -f .goreleaser.prerelease.yml --rm-dist --skip-validate --timeout
-          60m0s
+        args: -p 3 -f .goreleaser.prerelease.yml --clean --skip=validate --timeout 60m0s
         version: latest
     - if: failure() && github.event_name == 'push'
       name: Notify Slack

--- a/native-provider-ci/providers/azure-native/repo/.github/workflows/release.yml
+++ b/native-provider-ci/providers/azure-native/repo/.github/workflows/release.yml
@@ -349,6 +349,15 @@ jobs:
       uses: actions/setup-go@v5
       with:
         go-version: ${{ env.GOVERSION }}
+    - name: Clear GitHub Actions Ubuntu runner disk space
+      uses: jlumbroso/free-disk-space@v1
+      with:
+        tool-cache: false
+        dotnet: false
+        android: true
+        haskell: true
+        swap-storage: true
+        large-packages: false
     - name: Install pulumictl
       uses: jaxxstorm/action-install-gh-release@v1.11.0
       with:
@@ -371,7 +380,7 @@ jobs:
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v5
       with:
-        args: -p 3 release --rm-dist --timeout 60m0s
+        args: -p 3 release --clean --timeout 60m0s
         version: latest
     - if: failure() && github.event_name == 'push'
       name: Notify Slack

--- a/native-provider-ci/providers/command/repo/.github/workflows/build.yml
+++ b/native-provider-ci/providers/command/repo/.github/workflows/build.yml
@@ -318,6 +318,15 @@ jobs:
       uses: actions/setup-go@v5
       with:
         go-version: ${{ env.GOVERSION }}
+    - name: Clear GitHub Actions Ubuntu runner disk space
+      uses: jlumbroso/free-disk-space@v1
+      with:
+        tool-cache: false
+        dotnet: false
+        android: true
+        haskell: true
+        swap-storage: true
+        large-packages: false
     - name: Install pulumictl
       uses: jaxxstorm/action-install-gh-release@v1.11.0
       with:
@@ -340,8 +349,7 @@ jobs:
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v5
       with:
-        args: -p 3 -f .goreleaser.prerelease.yml --rm-dist --skip-validate --timeout
-          60m0s
+        args: -p 3 -f .goreleaser.prerelease.yml --clean --skip=validate --timeout 60m0s
         version: latest
     - if: failure() && github.event_name == 'push'
       name: Notify Slack

--- a/native-provider-ci/providers/command/repo/.github/workflows/prerelease.yml
+++ b/native-provider-ci/providers/command/repo/.github/workflows/prerelease.yml
@@ -309,6 +309,15 @@ jobs:
       uses: actions/setup-go@v5
       with:
         go-version: ${{ env.GOVERSION }}
+    - name: Clear GitHub Actions Ubuntu runner disk space
+      uses: jlumbroso/free-disk-space@v1
+      with:
+        tool-cache: false
+        dotnet: false
+        android: true
+        haskell: true
+        swap-storage: true
+        large-packages: false
     - name: Install pulumictl
       uses: jaxxstorm/action-install-gh-release@v1.11.0
       with:
@@ -331,8 +340,7 @@ jobs:
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v5
       with:
-        args: -p 3 -f .goreleaser.prerelease.yml --rm-dist --skip-validate --timeout
-          60m0s
+        args: -p 3 -f .goreleaser.prerelease.yml --clean --skip=validate --timeout 60m0s
         version: latest
     - if: failure() && github.event_name == 'push'
       name: Notify Slack

--- a/native-provider-ci/providers/command/repo/.github/workflows/release.yml
+++ b/native-provider-ci/providers/command/repo/.github/workflows/release.yml
@@ -309,6 +309,15 @@ jobs:
       uses: actions/setup-go@v5
       with:
         go-version: ${{ env.GOVERSION }}
+    - name: Clear GitHub Actions Ubuntu runner disk space
+      uses: jlumbroso/free-disk-space@v1
+      with:
+        tool-cache: false
+        dotnet: false
+        android: true
+        haskell: true
+        swap-storage: true
+        large-packages: false
     - name: Install pulumictl
       uses: jaxxstorm/action-install-gh-release@v1.11.0
       with:
@@ -331,7 +340,7 @@ jobs:
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v5
       with:
-        args: -p 3 release --rm-dist --timeout 60m0s
+        args: -p 3 release --clean --timeout 60m0s
         version: latest
     - if: failure() && github.event_name == 'push'
       name: Notify Slack

--- a/native-provider-ci/providers/google-native/repo/.github/workflows/build.yml
+++ b/native-provider-ci/providers/google-native/repo/.github/workflows/build.yml
@@ -364,6 +364,15 @@ jobs:
       uses: actions/setup-go@v5
       with:
         go-version: ${{ env.GOVERSION }}
+    - name: Clear GitHub Actions Ubuntu runner disk space
+      uses: jlumbroso/free-disk-space@v1
+      with:
+        tool-cache: false
+        dotnet: false
+        android: true
+        haskell: true
+        swap-storage: true
+        large-packages: false
     - name: Install pulumictl
       uses: jaxxstorm/action-install-gh-release@v1.11.0
       with:
@@ -386,8 +395,7 @@ jobs:
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v5
       with:
-        args: -p 3 -f .goreleaser.prerelease.yml --rm-dist --skip-validate --timeout
-          60m0s
+        args: -p 3 -f .goreleaser.prerelease.yml --clean --skip=validate --timeout 60m0s
         version: latest
     - if: failure() && github.event_name == 'push'
       name: Notify Slack

--- a/native-provider-ci/providers/google-native/repo/.github/workflows/prerelease.yml
+++ b/native-provider-ci/providers/google-native/repo/.github/workflows/prerelease.yml
@@ -355,6 +355,15 @@ jobs:
       uses: actions/setup-go@v5
       with:
         go-version: ${{ env.GOVERSION }}
+    - name: Clear GitHub Actions Ubuntu runner disk space
+      uses: jlumbroso/free-disk-space@v1
+      with:
+        tool-cache: false
+        dotnet: false
+        android: true
+        haskell: true
+        swap-storage: true
+        large-packages: false
     - name: Install pulumictl
       uses: jaxxstorm/action-install-gh-release@v1.11.0
       with:
@@ -377,8 +386,7 @@ jobs:
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v5
       with:
-        args: -p 3 -f .goreleaser.prerelease.yml --rm-dist --skip-validate --timeout
-          60m0s
+        args: -p 3 -f .goreleaser.prerelease.yml --clean --skip=validate --timeout 60m0s
         version: latest
     - if: failure() && github.event_name == 'push'
       name: Notify Slack

--- a/native-provider-ci/providers/google-native/repo/.github/workflows/release.yml
+++ b/native-provider-ci/providers/google-native/repo/.github/workflows/release.yml
@@ -355,6 +355,15 @@ jobs:
       uses: actions/setup-go@v5
       with:
         go-version: ${{ env.GOVERSION }}
+    - name: Clear GitHub Actions Ubuntu runner disk space
+      uses: jlumbroso/free-disk-space@v1
+      with:
+        tool-cache: false
+        dotnet: false
+        android: true
+        haskell: true
+        swap-storage: true
+        large-packages: false
     - name: Install pulumictl
       uses: jaxxstorm/action-install-gh-release@v1.11.0
       with:
@@ -377,7 +386,7 @@ jobs:
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v5
       with:
-        args: -p 3 release --rm-dist --timeout 60m0s
+        args: -p 3 release --clean --timeout 60m0s
         version: latest
     - if: failure() && github.event_name == 'push'
       name: Notify Slack

--- a/native-provider-ci/providers/kubernetes/repo/.github/workflows/build.yml
+++ b/native-provider-ci/providers/kubernetes/repo/.github/workflows/build.yml
@@ -391,6 +391,15 @@ jobs:
       uses: actions/setup-go@v5
       with:
         go-version: ${{ env.GOVERSION }}
+    - name: Clear GitHub Actions Ubuntu runner disk space
+      uses: jlumbroso/free-disk-space@v1
+      with:
+        tool-cache: false
+        dotnet: false
+        android: true
+        haskell: true
+        swap-storage: true
+        large-packages: false
     - name: Install pulumictl
       uses: jaxxstorm/action-install-gh-release@v1.11.0
       with:
@@ -413,8 +422,7 @@ jobs:
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v5
       with:
-        args: -p 3 -f .goreleaser.prerelease.yml --rm-dist --skip-validate --timeout
-          60m0s
+        args: -p 3 -f .goreleaser.prerelease.yml --clean --skip=validate --timeout 60m0s
         version: latest
     - if: failure() && github.event_name == 'push'
       name: Notify Slack

--- a/native-provider-ci/providers/kubernetes/repo/.github/workflows/prerelease.yml
+++ b/native-provider-ci/providers/kubernetes/repo/.github/workflows/prerelease.yml
@@ -382,6 +382,15 @@ jobs:
       uses: actions/setup-go@v5
       with:
         go-version: ${{ env.GOVERSION }}
+    - name: Clear GitHub Actions Ubuntu runner disk space
+      uses: jlumbroso/free-disk-space@v1
+      with:
+        tool-cache: false
+        dotnet: false
+        android: true
+        haskell: true
+        swap-storage: true
+        large-packages: false
     - name: Install pulumictl
       uses: jaxxstorm/action-install-gh-release@v1.11.0
       with:
@@ -404,8 +413,7 @@ jobs:
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v5
       with:
-        args: -p 3 -f .goreleaser.prerelease.yml --rm-dist --skip-validate --timeout
-          60m0s
+        args: -p 3 -f .goreleaser.prerelease.yml --clean --skip=validate --timeout 60m0s
         version: latest
     - if: failure() && github.event_name == 'push'
       name: Notify Slack

--- a/native-provider-ci/providers/kubernetes/repo/.github/workflows/release.yml
+++ b/native-provider-ci/providers/kubernetes/repo/.github/workflows/release.yml
@@ -382,6 +382,15 @@ jobs:
       uses: actions/setup-go@v5
       with:
         go-version: ${{ env.GOVERSION }}
+    - name: Clear GitHub Actions Ubuntu runner disk space
+      uses: jlumbroso/free-disk-space@v1
+      with:
+        tool-cache: false
+        dotnet: false
+        android: true
+        haskell: true
+        swap-storage: true
+        large-packages: false
     - name: Install pulumictl
       uses: jaxxstorm/action-install-gh-release@v1.11.0
       with:
@@ -404,7 +413,7 @@ jobs:
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v5
       with:
-        args: -p 3 release --rm-dist --timeout 60m0s
+        args: -p 3 release --clean --timeout 60m0s
         version: latest
     - if: failure() && github.event_name == 'push'
       name: Notify Slack

--- a/native-provider-ci/src/action-versions.ts
+++ b/native-provider-ci/src/action-versions.ts
@@ -40,3 +40,4 @@ export const githubScript = "actions/github-script@v6";
 export const upgradeProviderAction =
   "pulumi/pulumi-upgrade-provider-action@v0.0.5";
 export const slackNotification = "rtCamp/action-slack-notify@v2";
+export const freeDiskSpace = "jlumbroso/free-disk-space@v1";

--- a/native-provider-ci/src/steps.ts
+++ b/native-provider-ci/src/steps.ts
@@ -1190,3 +1190,18 @@ export function Codecov(): Step {
     },
   };
 }
+
+export function FreeDiskSpace(): Step {
+  return {
+    name: "Clear GitHub Actions Ubuntu runner disk space",
+    uses: action.freeDiskSpace,
+    with: {
+      "tool-cache": false,
+      dotnet: false,
+      android: true,
+      haskell: true,
+      "swap-storage": true,
+      "large-packages": false,
+    },
+  };
+}

--- a/native-provider-ci/src/workflows.ts
+++ b/native-provider-ci/src/workflows.ts
@@ -751,12 +751,13 @@ export class PublishPrereleaseJob implements NormalJob {
       steps.CheckoutRepoStep(),
       steps.CheckoutTagsStep(),
       steps.InstallGo(),
+      steps.FreeDiskSpace(),
       steps.InstallPulumiCtl(),
       steps.InstallPulumiCli(opts.pulumiCLIVersion),
       steps.ConfigureAwsCredentialsForPublish(),
       steps.SetPreReleaseVersion(),
       steps.RunGoReleaserWithArgs(
-        `-p ${opts.parallel} -f .goreleaser.prerelease.yml --rm-dist --skip-validate --timeout ${opts.timeout}m0s`
+        `-p ${opts.parallel} -f .goreleaser.prerelease.yml --clean --skip=validate --timeout ${opts.timeout}m0s`
       ),
       steps.NotifySlack("Failure in publishing binaries"),
     ];
@@ -780,12 +781,13 @@ export class PublishJob implements NormalJob {
       steps.CheckoutRepoStep(),
       steps.CheckoutTagsStep(),
       steps.InstallGo(),
+      steps.FreeDiskSpace(),
       steps.InstallPulumiCtl(),
       steps.InstallPulumiCli(opts.pulumiCLIVersion),
       steps.ConfigureAwsCredentialsForPublish(),
       steps.SetPreReleaseVersion(),
       steps.RunGoReleaserWithArgs(
-        `-p ${opts.parallel} release --rm-dist --timeout ${opts.timeout}m0s`
+        `-p ${opts.parallel} release --clean --timeout ${opts.timeout}m0s`
       ),
       steps.NotifySlack("Failure in publishing binaries"),
     ];
@@ -887,7 +889,7 @@ export class Cf2PulumiRelease implements NormalJob {
     steps.InstallPulumiCtl(),
     steps.InstallGo(goVersion),
     steps.RunGoReleaserWithArgs(
-      "-p 1 -f .goreleaser.cf2pulumi.yml release --rm-dist --timeout 60m0s"
+      "-p 1 -f .goreleaser.cf2pulumi.yml release --clean --timeout 60m0s"
     ),
     steps.ChocolateyPackageDeployment(),
   ];
@@ -908,7 +910,7 @@ export class Arm2PulumiRelease implements NormalJob {
     steps.InstallGo(goVersion),
     steps.SetVersionIfAvailable(),
     steps.RunGoReleaserWithArgs(
-      "-p 1 -f .goreleaser.arm2pulumi.yml release --rm-dist --timeout 60m0s"
+      "-p 1 -f .goreleaser.arm2pulumi.yml release --clean --timeout 60m0s"
     ),
   ];
   name: string;


### PR DESCRIPTION
The Kubernetes builds recently started running out of disk during publish. Hoping that this will fix the problem.

Also address some deprecation warnings from goreleaser.
Fixes: https://github.com/pulumi/pulumi-kubernetes/issues/2867