### PR TITLE
Fix lint step for new providers

### DIFF
--- a/native-provider-ci/providers/kubernetes/repo/.github/workflows/build.yml
+++ b/native-provider-ci/providers/kubernetes/repo/.github/workflows/build.yml
@@ -562,6 +562,27 @@ jobs:
         arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
         build-root-directory: ./sdk/java
         gradle-version: 7.4.1
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout Repo
+      uses: actions/checkout@v4
+      with:
+        lfs: true
+        ref: ${{ env.PR_COMMIT_SHA }}
+    - name: Install Go
+      uses: actions/setup-go@v5
+      with:
+        go-version: ${{ env.GOVERSION }}
+    - name: golangci-lint provider pkg
+      uses: golangci/golangci-lint-action@v4
+      with:
+        version: ${{ env.GOLANGCI_LINT_VERSION }}
+        args: -c ../.golangci.yml --timeout ${{ env.GOLANGCI_LINT_TIMEOUT }}
+        working-directory: provider
+    name: lint
+    if: github.event_name == 'repository_dispatch' ||
+      github.event.pull_request.head.repo.full_name == github.repository
   build-test-cluster:
     runs-on: ubuntu-latest
     name: build-test-cluster
@@ -676,24 +697,3 @@ jobs:
     - uses: geekyeggo/delete-artifact@v1
       with:
         name: config
-  lint:
-    runs-on: ubuntu-latest
-    steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v4
-      with:
-        lfs: true
-        ref: ${{ env.PR_COMMIT_SHA }}
-    - name: Install Go
-      uses: actions/setup-go@v5
-      with:
-        go-version: ${{ env.GOVERSION }}
-    - name: golangci-lint provider pkg
-      uses: golangci/golangci-lint-action@v4
-      with:
-        version: ${{ env.GOLANGCI_LINT_VERSION }}
-        args: -c ../../.golangci.yml --timeout ${{ env.GOLANGCI_LINT_TIMEOUT }}
-        working-directory: provider/pkg
-    name: lint
-    if: github.event_name == 'repository_dispatch' ||
-      github.event.pull_request.head.repo.full_name == github.repository

--- a/native-provider-ci/providers/kubernetes/repo/.github/workflows/run-acceptance-tests.yml
+++ b/native-provider-ci/providers/kubernetes/repo/.github/workflows/run-acceptance-tests.yml
@@ -426,8 +426,8 @@ jobs:
       uses: golangci/golangci-lint-action@v4
       with:
         version: ${{ env.GOLANGCI_LINT_VERSION }}
-        args: -c ../../.golangci.yml --timeout ${{ env.GOLANGCI_LINT_TIMEOUT }}
-        working-directory: provider/pkg
+        args: -c ../.golangci.yml --timeout ${{ env.GOLANGCI_LINT_TIMEOUT }}
+        working-directory: provider
     name: lint
     if: github.event_name == 'repository_dispatch' ||
       github.event.pull_request.head.repo.full_name == github.repository

--- a/native-provider-ci/src/steps.ts
+++ b/native-provider-ci/src/steps.ts
@@ -880,7 +880,7 @@ export function GolangciLint(): Step {
     with: {
       version: "${{ env.GOLANGCI_LINT_VERSION }}",
       args: "-c ../../.golangci.yml --timeout ${{ env.GOLANGCI_LINT_TIMEOUT }}",
-      "working-directory": "provider/pkg",
+      "working-directory": "provider",
     },
   };
 }

--- a/native-provider-ci/src/steps.ts
+++ b/native-provider-ci/src/steps.ts
@@ -879,7 +879,7 @@ export function GolangciLint(): Step {
     uses: action.goLint,
     with: {
       version: "${{ env.GOLANGCI_LINT_VERSION }}",
-      args: "-c ../../.golangci.yml --timeout ${{ env.GOLANGCI_LINT_TIMEOUT }}",
+      args: "-c ../.golangci.yml --timeout ${{ env.GOLANGCI_LINT_TIMEOUT }}",
       "working-directory": "provider",
     },
   };

--- a/native-provider-ci/src/workflows.ts
+++ b/native-provider-ci/src/workflows.ts
@@ -148,10 +148,12 @@ export function RunAcceptanceTestsWorkflow(
         .addNeeds(calculateSentinelNeeds(name, opts.lint, opts.provider)),
     },
   };
-  if (opts.provider === "kubernetes") {
+  if (opts.lint) {
     workflow.jobs = Object.assign(workflow.jobs, {
-      lint: new LintKubernetesJob("lint").addDispatchConditional(true),
+      lint: new LintJob("lint").addDispatchConditional(true),
     });
+  }
+  if (opts.provider === "kubernetes") {
     workflow.on = Object.assign(workflow.on, {
       pull_request: {
         branches: ["master", "main", "v4"],
@@ -207,6 +209,11 @@ export function BuildWorkflow(
       publish_java_sdk: new PublishJavaSDKJob("publish_java_sdk"),
     },
   };
+  if (opts.lint) {
+    workflow.jobs = Object.assign(workflow.jobs, {
+      lint: new LintJob("lint").addDispatchConditional(true),
+    });
+  }
   if (opts.provider === "kubernetes") {
     workflow.jobs = Object.assign(workflow.jobs, {
       "build-test-cluster": new BuildTestClusterJob("build-test-cluster", opts),
@@ -216,9 +223,6 @@ export function BuildWorkflow(
         "teardown-test-cluster",
         opts
       ),
-    });
-    workflow.jobs = Object.assign(workflow.jobs, {
-      lint: new LintKubernetesJob("lint").addDispatchConditional(true),
     });
   }
   return workflow;
@@ -713,7 +717,7 @@ export class TeardownTestClusterJob implements NormalJob {
   }
 }
 
-export class LintKubernetesJob implements NormalJob {
+export class LintJob implements NormalJob {
   "runs-on" = "ubuntu-latest";
   steps = [steps.CheckoutRepoStep(), steps.InstallGo(), steps.GolangciLint()];
   name: string;


### PR DESCRIPTION
We default to [`lint: true`](https://github.com/pulumi/ci-mgmt/blob/master/native-provider-ci/src/workflows.ts#L19), which is good, but then we only add a lint job for the Kubernetes provider.

This PR fixes the lint job to be added whenever `opts.lint` is `true`, and it changes the job's working directory to just `provider`. This is backwards-compatible with the kubernetes provider's current usage and doesn't require new providers to have an unidiomatic `pkg` directory.

(A directory that exists only to hold other packages is a potential design smell -- as [Dave Cheney](https://dave.cheney.net/2019/10/06/use-internal-packages-to-reduce-your-public-api-surface) puts it.)