### PR TITLE
chore: add `upgrade-bridge-test` as possible repository_dispatch type

### DIFF
--- a/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/upgrade-bridge.yml
+++ b/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/upgrade-bridge.yml
@@ -5,6 +5,7 @@ on:
   repository_dispatch:
     types:
       - upgrade-bridge
+      - upgrade-bridge-test
   workflow_dispatch:
     inputs:
       kind:

--- a/provider-ci/test-workflows/aws/.github/workflows/upgrade-bridge.yml
+++ b/provider-ci/test-workflows/aws/.github/workflows/upgrade-bridge.yml
@@ -5,6 +5,7 @@ on:
   repository_dispatch:
     types:
       - upgrade-bridge
+      - upgrade-bridge-test
   workflow_dispatch:
     inputs:
       kind:

--- a/provider-ci/test-workflows/cloudflare/.github/workflows/upgrade-bridge.yml
+++ b/provider-ci/test-workflows/cloudflare/.github/workflows/upgrade-bridge.yml
@@ -5,6 +5,7 @@ on:
   repository_dispatch:
     types:
       - upgrade-bridge
+      - upgrade-bridge-test
   workflow_dispatch:
     inputs:
       kind:

--- a/provider-ci/test-workflows/docker/.github/workflows/upgrade-bridge.yml
+++ b/provider-ci/test-workflows/docker/.github/workflows/upgrade-bridge.yml
@@ -5,6 +5,7 @@ on:
   repository_dispatch:
     types:
       - upgrade-bridge
+      - upgrade-bridge-test
   workflow_dispatch:
     inputs:
       kind:


### PR DESCRIPTION
When you trigger a workflow via a repository_dispatch, you have to specify a custom `type`. This type appears in the workflow_run webhook event so it can be used to filter different types of runs.

I'm adding a new type `upgrade-bridge-test` which can be used by the downstream test workflows. This will allow us to [filter out those workflow runs](https://github.com/pulumi/home/pull/3359) from creating p1 tickets.

re https://github.com/pulumi/ci-mgmt/issues/815