### PR TITLE
Split out tfgen steps in CI

### DIFF
--- a/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/prerequisites.splice
+++ b/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/prerequisites.splice
@@ -14,6 +14,8 @@
         ref: #{{ .Config.pulumiScriptsRef }}#
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
+    - name: Prepare upstream code
+      run: make upstream
 #{{ .Config.actions.setupGo | toYaml | indent 4 }}#
     - name: Install pulumictl
       uses: #{{ .Config.actionVersions.installGhRelease }}#
@@ -29,8 +31,14 @@
 #{{- if .Config.actions.preBuild }}#
 #{{ .Config.actions.preBuild | toYaml | indent 4 }}#
 #{{- end }}#
-    - name: Build tfgen & provider binaries
-      run: make provider
+    - name: Build schema generator binary
+      run: make tfgen_build_only
+    - name: Install plugins
+      run: make install_plugins
+    - name: Generate schema
+      run: make tfgen_no_deps
+    - name: Build provider binary
+      run: make_provider_no_deps
     - name: Unit-test provider code
       run: make test_provider
     - if: github.event_name == 'pull_request'

--- a/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/prerequisites.splice
+++ b/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/prerequisites.splice
@@ -38,7 +38,7 @@
     - name: Generate schema
       run: make tfgen_no_deps
     - name: Build provider binary
-      run: make_provider_no_deps
+      run: make provider_no_deps
     - name: Unit-test provider code
       run: make test_provider
     - if: github.event_name == 'pull_request'

--- a/provider-ci/internal/pkg/templates/bridged-provider/Makefile
+++ b/provider-ci/internal/pkg/templates/bridged-provider/Makefile
@@ -153,11 +153,14 @@ test_provider:
 	@echo ""
 	cd provider && go test -v -short ./... -parallel $(TESTPARALLELISM)
 
-tfgen: export PULUMI_HOME := $(WORKING_DIR)/.pulumi
-tfgen: export PATH := $(WORKING_DIR)/.pulumi/bin:$(PATH)
-tfgen: install_plugins upstream#{{ if .Config.docsCmd }}# docs#{{ end }}#
-	(cd provider && go build $(PULUMI_PROVIDER_BUILD_PARALLELISM) -o $(WORKING_DIR)/bin/$(TFGEN) -ldflags "-X $(PROJECT)/$(VERSION_PATH)=$(VERSION)" $(PROJECT)/$(PROVIDER_PATH)/cmd/$(TFGEN))
-	PULUMI_CONVERT=$(PULUMI_CONVERT) PULUMI_DISABLE_AUTOMATIC_PLUGIN_ACQUISITION=$(PULUMI_CONVERT) $(WORKING_DIR)/bin/$(TFGEN) schema --out provider/cmd/$(PROVIDER)
+tfgen: install_plugins upstream#{{ if .Config.docsCmd }}# docs#{{ end }}# tfgen_no_deps
+
+tfgen_no_deps: export PULUMI_HOME := $(WORKING_DIR)/.pulumi
+tfgen_no_deps: export PATH := $(WORKING_DIR)/.pulumi/bin:$(PATH)
+tfgen_no_deps: export PULUMI_CONVERT := $(PULUMI_CONVERT)
+tfgen_no_deps: export PULUMI_DISABLE_AUTOMATIC_PLUGIN_ACQUISITION := $(PULUMI_CONVERT)
+tfgen_no_deps: tfgen_build_only
+	$(WORKING_DIR)/bin/$(TFGEN) schema --out provider/cmd/$(PROVIDER)
 	(cd provider && VERSION=$(VERSION) go generate cmd/$(PROVIDER)/main.go)
 
 tfgen_build_only:

--- a/provider-ci/test-workflows/aws/.github/workflows/master.yml
+++ b/provider-ci/test-workflows/aws/.github/workflows/master.yml
@@ -217,6 +217,8 @@ jobs:
         ref: deca2c5c6015ad7aaea6f572a1c2b198ca323592
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
+    - name: Prepare upstream code
+      run: make upstream
     - name: Install Go
       uses: actions/setup-go@v5
       with:
@@ -246,8 +248,14 @@ jobs:
         large-packages: false
         swap-storage: true
         tool-cache: false
-    - name: Build tfgen & provider binaries
-      run: make provider
+    - name: Build schema generator binary
+      run: make tfgen_build_only
+    - name: Install plugins
+      run: make install_plugins
+    - name: Generate schema
+      run: make tfgen_no_deps
+    - name: Build provider binary
+      run: make_provider_no_deps
     - name: Unit-test provider code
       run: make test_provider
     - if: github.event_name == 'pull_request'

--- a/provider-ci/test-workflows/aws/.github/workflows/master.yml
+++ b/provider-ci/test-workflows/aws/.github/workflows/master.yml
@@ -255,7 +255,7 @@ jobs:
     - name: Generate schema
       run: make tfgen_no_deps
     - name: Build provider binary
-      run: make_provider_no_deps
+      run: make provider_no_deps
     - name: Unit-test provider code
       run: make test_provider
     - if: github.event_name == 'pull_request'

--- a/provider-ci/test-workflows/aws/.github/workflows/nightly-test.yml
+++ b/provider-ci/test-workflows/aws/.github/workflows/nightly-test.yml
@@ -187,7 +187,7 @@ jobs:
     - name: Generate schema
       run: make tfgen_no_deps
     - name: Build provider binary
-      run: make_provider_no_deps
+      run: make provider_no_deps
     - name: Unit-test provider code
       run: make test_provider
     - if: github.event_name == 'pull_request'

--- a/provider-ci/test-workflows/aws/.github/workflows/nightly-test.yml
+++ b/provider-ci/test-workflows/aws/.github/workflows/nightly-test.yml
@@ -149,6 +149,8 @@ jobs:
         ref: deca2c5c6015ad7aaea6f572a1c2b198ca323592
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
+    - name: Prepare upstream code
+      run: make upstream
     - name: Install Go
       uses: actions/setup-go@v5
       with:
@@ -178,8 +180,14 @@ jobs:
         large-packages: false
         swap-storage: true
         tool-cache: false
-    - name: Build tfgen & provider binaries
-      run: make provider
+    - name: Build schema generator binary
+      run: make tfgen_build_only
+    - name: Install plugins
+      run: make install_plugins
+    - name: Generate schema
+      run: make tfgen_no_deps
+    - name: Build provider binary
+      run: make_provider_no_deps
     - name: Unit-test provider code
       run: make test_provider
     - if: github.event_name == 'pull_request'

--- a/provider-ci/test-workflows/aws/.github/workflows/prerelease.yml
+++ b/provider-ci/test-workflows/aws/.github/workflows/prerelease.yml
@@ -154,6 +154,8 @@ jobs:
         ref: deca2c5c6015ad7aaea6f572a1c2b198ca323592
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
+    - name: Prepare upstream code
+      run: make upstream
     - name: Install Go
       uses: actions/setup-go@v5
       with:
@@ -183,8 +185,14 @@ jobs:
         large-packages: false
         swap-storage: true
         tool-cache: false
-    - name: Build tfgen & provider binaries
-      run: make provider
+    - name: Build schema generator binary
+      run: make tfgen_build_only
+    - name: Install plugins
+      run: make install_plugins
+    - name: Generate schema
+      run: make tfgen_no_deps
+    - name: Build provider binary
+      run: make_provider_no_deps
     - name: Unit-test provider code
       run: make test_provider
     - if: github.event_name == 'pull_request'

--- a/provider-ci/test-workflows/aws/.github/workflows/prerelease.yml
+++ b/provider-ci/test-workflows/aws/.github/workflows/prerelease.yml
@@ -192,7 +192,7 @@ jobs:
     - name: Generate schema
       run: make tfgen_no_deps
     - name: Build provider binary
-      run: make_provider_no_deps
+      run: make provider_no_deps
     - name: Unit-test provider code
       run: make test_provider
     - if: github.event_name == 'pull_request'

--- a/provider-ci/test-workflows/aws/.github/workflows/release.yml
+++ b/provider-ci/test-workflows/aws/.github/workflows/release.yml
@@ -168,6 +168,8 @@ jobs:
         ref: deca2c5c6015ad7aaea6f572a1c2b198ca323592
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
+    - name: Prepare upstream code
+      run: make upstream
     - name: Install Go
       uses: actions/setup-go@v5
       with:
@@ -197,8 +199,14 @@ jobs:
         large-packages: false
         swap-storage: true
         tool-cache: false
-    - name: Build tfgen & provider binaries
-      run: make provider
+    - name: Build schema generator binary
+      run: make tfgen_build_only
+    - name: Install plugins
+      run: make install_plugins
+    - name: Generate schema
+      run: make tfgen_no_deps
+    - name: Build provider binary
+      run: make_provider_no_deps
     - name: Unit-test provider code
       run: make test_provider
     - if: github.event_name == 'pull_request'

--- a/provider-ci/test-workflows/aws/.github/workflows/release.yml
+++ b/provider-ci/test-workflows/aws/.github/workflows/release.yml
@@ -206,7 +206,7 @@ jobs:
     - name: Generate schema
       run: make tfgen_no_deps
     - name: Build provider binary
-      run: make_provider_no_deps
+      run: make provider_no_deps
     - name: Unit-test provider code
       run: make test_provider
     - if: github.event_name == 'pull_request'

--- a/provider-ci/test-workflows/aws/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/test-workflows/aws/.github/workflows/run-acceptance-tests.yml
@@ -175,6 +175,8 @@ jobs:
         ref: deca2c5c6015ad7aaea6f572a1c2b198ca323592
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
+    - name: Prepare upstream code
+      run: make upstream
     - name: Install Go
       uses: actions/setup-go@v5
       with:
@@ -204,8 +206,14 @@ jobs:
         large-packages: false
         swap-storage: true
         tool-cache: false
-    - name: Build tfgen & provider binaries
-      run: make provider
+    - name: Build schema generator binary
+      run: make tfgen_build_only
+    - name: Install plugins
+      run: make install_plugins
+    - name: Generate schema
+      run: make tfgen_no_deps
+    - name: Build provider binary
+      run: make_provider_no_deps
     - name: Unit-test provider code
       run: make test_provider
     - if: github.event_name == 'pull_request'

--- a/provider-ci/test-workflows/aws/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/test-workflows/aws/.github/workflows/run-acceptance-tests.yml
@@ -213,7 +213,7 @@ jobs:
     - name: Generate schema
       run: make tfgen_no_deps
     - name: Build provider binary
-      run: make_provider_no_deps
+      run: make provider_no_deps
     - name: Unit-test provider code
       run: make test_provider
     - if: github.event_name == 'pull_request'

--- a/provider-ci/test-workflows/aws/Makefile
+++ b/provider-ci/test-workflows/aws/Makefile
@@ -140,11 +140,14 @@ test_provider:
 	@echo ""
 	cd provider && go test -v -short ./... -parallel $(TESTPARALLELISM)
 
-tfgen: export PULUMI_HOME := $(WORKING_DIR)/.pulumi
-tfgen: export PATH := $(WORKING_DIR)/.pulumi/bin:$(PATH)
-tfgen: install_plugins upstream
-	(cd provider && go build $(PULUMI_PROVIDER_BUILD_PARALLELISM) -o $(WORKING_DIR)/bin/$(TFGEN) -ldflags "-X $(PROJECT)/$(VERSION_PATH)=$(VERSION)" $(PROJECT)/$(PROVIDER_PATH)/cmd/$(TFGEN))
-	PULUMI_CONVERT=$(PULUMI_CONVERT) PULUMI_DISABLE_AUTOMATIC_PLUGIN_ACQUISITION=$(PULUMI_CONVERT) $(WORKING_DIR)/bin/$(TFGEN) schema --out provider/cmd/$(PROVIDER)
+tfgen: install_plugins upstream tfgen_no_deps
+
+tfgen_no_deps: export PULUMI_HOME := $(WORKING_DIR)/.pulumi
+tfgen_no_deps: export PATH := $(WORKING_DIR)/.pulumi/bin:$(PATH)
+tfgen_no_deps: export PULUMI_CONVERT := $(PULUMI_CONVERT)
+tfgen_no_deps: export PULUMI_DISABLE_AUTOMATIC_PLUGIN_ACQUISITION := $(PULUMI_CONVERT)
+tfgen_no_deps: tfgen_build_only
+	$(WORKING_DIR)/bin/$(TFGEN) schema --out provider/cmd/$(PROVIDER)
 	(cd provider && VERSION=$(VERSION) go generate cmd/$(PROVIDER)/main.go)
 
 tfgen_build_only:

--- a/provider-ci/test-workflows/cloudflare/.github/workflows/master.yml
+++ b/provider-ci/test-workflows/cloudflare/.github/workflows/master.yml
@@ -215,6 +215,8 @@ jobs:
         ref: deca2c5c6015ad7aaea6f572a1c2b198ca323592
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
+    - name: Prepare upstream code
+      run: make upstream
     - name: Install Go
       uses: actions/setup-go@v5
       with:
@@ -235,8 +237,14 @@ jobs:
       uses: jaxxstorm/action-install-gh-release@v1.11.0
       with:
         repo: pulumi/schema-tools
-    - name: Build tfgen & provider binaries
-      run: make provider
+    - name: Build schema generator binary
+      run: make tfgen_build_only
+    - name: Install plugins
+      run: make install_plugins
+    - name: Generate schema
+      run: make tfgen_no_deps
+    - name: Build provider binary
+      run: make_provider_no_deps
     - name: Unit-test provider code
       run: make test_provider
     - if: github.event_name == 'pull_request'

--- a/provider-ci/test-workflows/cloudflare/.github/workflows/master.yml
+++ b/provider-ci/test-workflows/cloudflare/.github/workflows/master.yml
@@ -244,7 +244,7 @@ jobs:
     - name: Generate schema
       run: make tfgen_no_deps
     - name: Build provider binary
-      run: make_provider_no_deps
+      run: make provider_no_deps
     - name: Unit-test provider code
       run: make test_provider
     - if: github.event_name == 'pull_request'

--- a/provider-ci/test-workflows/cloudflare/.github/workflows/prerelease.yml
+++ b/provider-ci/test-workflows/cloudflare/.github/workflows/prerelease.yml
@@ -183,7 +183,7 @@ jobs:
     - name: Generate schema
       run: make tfgen_no_deps
     - name: Build provider binary
-      run: make_provider_no_deps
+      run: make provider_no_deps
     - name: Unit-test provider code
       run: make test_provider
     - if: github.event_name == 'pull_request'

--- a/provider-ci/test-workflows/cloudflare/.github/workflows/prerelease.yml
+++ b/provider-ci/test-workflows/cloudflare/.github/workflows/prerelease.yml
@@ -154,6 +154,8 @@ jobs:
         ref: deca2c5c6015ad7aaea6f572a1c2b198ca323592
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
+    - name: Prepare upstream code
+      run: make upstream
     - name: Install Go
       uses: actions/setup-go@v5
       with:
@@ -174,8 +176,14 @@ jobs:
       uses: jaxxstorm/action-install-gh-release@v1.11.0
       with:
         repo: pulumi/schema-tools
-    - name: Build tfgen & provider binaries
-      run: make provider
+    - name: Build schema generator binary
+      run: make tfgen_build_only
+    - name: Install plugins
+      run: make install_plugins
+    - name: Generate schema
+      run: make tfgen_no_deps
+    - name: Build provider binary
+      run: make_provider_no_deps
     - name: Unit-test provider code
       run: make test_provider
     - if: github.event_name == 'pull_request'

--- a/provider-ci/test-workflows/cloudflare/.github/workflows/release.yml
+++ b/provider-ci/test-workflows/cloudflare/.github/workflows/release.yml
@@ -168,6 +168,8 @@ jobs:
         ref: deca2c5c6015ad7aaea6f572a1c2b198ca323592
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
+    - name: Prepare upstream code
+      run: make upstream
     - name: Install Go
       uses: actions/setup-go@v5
       with:
@@ -188,8 +190,14 @@ jobs:
       uses: jaxxstorm/action-install-gh-release@v1.11.0
       with:
         repo: pulumi/schema-tools
-    - name: Build tfgen & provider binaries
-      run: make provider
+    - name: Build schema generator binary
+      run: make tfgen_build_only
+    - name: Install plugins
+      run: make install_plugins
+    - name: Generate schema
+      run: make tfgen_no_deps
+    - name: Build provider binary
+      run: make_provider_no_deps
     - name: Unit-test provider code
       run: make test_provider
     - if: github.event_name == 'pull_request'

--- a/provider-ci/test-workflows/cloudflare/.github/workflows/release.yml
+++ b/provider-ci/test-workflows/cloudflare/.github/workflows/release.yml
@@ -197,7 +197,7 @@ jobs:
     - name: Generate schema
       run: make tfgen_no_deps
     - name: Build provider binary
-      run: make_provider_no_deps
+      run: make provider_no_deps
     - name: Unit-test provider code
       run: make test_provider
     - if: github.event_name == 'pull_request'

--- a/provider-ci/test-workflows/cloudflare/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/test-workflows/cloudflare/.github/workflows/run-acceptance-tests.yml
@@ -207,7 +207,7 @@ jobs:
     - name: Generate schema
       run: make tfgen_no_deps
     - name: Build provider binary
-      run: make_provider_no_deps
+      run: make provider_no_deps
     - name: Unit-test provider code
       run: make test_provider
     - if: github.event_name == 'pull_request'

--- a/provider-ci/test-workflows/cloudflare/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/test-workflows/cloudflare/.github/workflows/run-acceptance-tests.yml
@@ -178,6 +178,8 @@ jobs:
         ref: deca2c5c6015ad7aaea6f572a1c2b198ca323592
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
+    - name: Prepare upstream code
+      run: make upstream
     - name: Install Go
       uses: actions/setup-go@v5
       with:
@@ -198,8 +200,14 @@ jobs:
       uses: jaxxstorm/action-install-gh-release@v1.11.0
       with:
         repo: pulumi/schema-tools
-    - name: Build tfgen & provider binaries
-      run: make provider
+    - name: Build schema generator binary
+      run: make tfgen_build_only
+    - name: Install plugins
+      run: make install_plugins
+    - name: Generate schema
+      run: make tfgen_no_deps
+    - name: Build provider binary
+      run: make_provider_no_deps
     - name: Unit-test provider code
       run: make test_provider
     - if: github.event_name == 'pull_request'

--- a/provider-ci/test-workflows/cloudflare/Makefile
+++ b/provider-ci/test-workflows/cloudflare/Makefile
@@ -135,11 +135,14 @@ test_provider:
 	@echo ""
 	cd provider && go test -v -short ./... -parallel $(TESTPARALLELISM)
 
-tfgen: export PULUMI_HOME := $(WORKING_DIR)/.pulumi
-tfgen: export PATH := $(WORKING_DIR)/.pulumi/bin:$(PATH)
-tfgen: install_plugins upstream
-	(cd provider && go build $(PULUMI_PROVIDER_BUILD_PARALLELISM) -o $(WORKING_DIR)/bin/$(TFGEN) -ldflags "-X $(PROJECT)/$(VERSION_PATH)=$(VERSION)" $(PROJECT)/$(PROVIDER_PATH)/cmd/$(TFGEN))
-	PULUMI_CONVERT=$(PULUMI_CONVERT) PULUMI_DISABLE_AUTOMATIC_PLUGIN_ACQUISITION=$(PULUMI_CONVERT) $(WORKING_DIR)/bin/$(TFGEN) schema --out provider/cmd/$(PROVIDER)
+tfgen: install_plugins upstream tfgen_no_deps
+
+tfgen_no_deps: export PULUMI_HOME := $(WORKING_DIR)/.pulumi
+tfgen_no_deps: export PATH := $(WORKING_DIR)/.pulumi/bin:$(PATH)
+tfgen_no_deps: export PULUMI_CONVERT := $(PULUMI_CONVERT)
+tfgen_no_deps: export PULUMI_DISABLE_AUTOMATIC_PLUGIN_ACQUISITION := $(PULUMI_CONVERT)
+tfgen_no_deps: tfgen_build_only
+	$(WORKING_DIR)/bin/$(TFGEN) schema --out provider/cmd/$(PROVIDER)
 	(cd provider && VERSION=$(VERSION) go generate cmd/$(PROVIDER)/main.go)
 
 tfgen_build_only:

--- a/provider-ci/test-workflows/docker/.github/workflows/master.yml
+++ b/provider-ci/test-workflows/docker/.github/workflows/master.yml
@@ -257,7 +257,7 @@ jobs:
     - name: Generate schema
       run: make tfgen_no_deps
     - name: Build provider binary
-      run: make_provider_no_deps
+      run: make provider_no_deps
     - name: Unit-test provider code
       run: make test_provider
     - if: github.event_name == 'pull_request'

--- a/provider-ci/test-workflows/docker/.github/workflows/master.yml
+++ b/provider-ci/test-workflows/docker/.github/workflows/master.yml
@@ -228,6 +228,8 @@ jobs:
         ref: deca2c5c6015ad7aaea6f572a1c2b198ca323592
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
+    - name: Prepare upstream code
+      run: make upstream
     - name: Install Go
       uses: actions/setup-go@v5
       with:
@@ -248,8 +250,14 @@ jobs:
       uses: jaxxstorm/action-install-gh-release@v1.11.0
       with:
         repo: pulumi/schema-tools
-    - name: Build tfgen & provider binaries
-      run: make provider
+    - name: Build schema generator binary
+      run: make tfgen_build_only
+    - name: Install plugins
+      run: make install_plugins
+    - name: Generate schema
+      run: make tfgen_no_deps
+    - name: Build provider binary
+      run: make_provider_no_deps
     - name: Unit-test provider code
       run: make test_provider
     - if: github.event_name == 'pull_request'

--- a/provider-ci/test-workflows/docker/.github/workflows/prerelease.yml
+++ b/provider-ci/test-workflows/docker/.github/workflows/prerelease.yml
@@ -167,6 +167,8 @@ jobs:
         ref: deca2c5c6015ad7aaea6f572a1c2b198ca323592
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
+    - name: Prepare upstream code
+      run: make upstream
     - name: Install Go
       uses: actions/setup-go@v5
       with:
@@ -187,8 +189,14 @@ jobs:
       uses: jaxxstorm/action-install-gh-release@v1.11.0
       with:
         repo: pulumi/schema-tools
-    - name: Build tfgen & provider binaries
-      run: make provider
+    - name: Build schema generator binary
+      run: make tfgen_build_only
+    - name: Install plugins
+      run: make install_plugins
+    - name: Generate schema
+      run: make tfgen_no_deps
+    - name: Build provider binary
+      run: make_provider_no_deps
     - name: Unit-test provider code
       run: make test_provider
     - if: github.event_name == 'pull_request'

--- a/provider-ci/test-workflows/docker/.github/workflows/prerelease.yml
+++ b/provider-ci/test-workflows/docker/.github/workflows/prerelease.yml
@@ -196,7 +196,7 @@ jobs:
     - name: Generate schema
       run: make tfgen_no_deps
     - name: Build provider binary
-      run: make_provider_no_deps
+      run: make provider_no_deps
     - name: Unit-test provider code
       run: make test_provider
     - if: github.event_name == 'pull_request'

--- a/provider-ci/test-workflows/docker/.github/workflows/release.yml
+++ b/provider-ci/test-workflows/docker/.github/workflows/release.yml
@@ -210,7 +210,7 @@ jobs:
     - name: Generate schema
       run: make tfgen_no_deps
     - name: Build provider binary
-      run: make_provider_no_deps
+      run: make provider_no_deps
     - name: Unit-test provider code
       run: make test_provider
     - if: github.event_name == 'pull_request'

--- a/provider-ci/test-workflows/docker/.github/workflows/release.yml
+++ b/provider-ci/test-workflows/docker/.github/workflows/release.yml
@@ -181,6 +181,8 @@ jobs:
         ref: deca2c5c6015ad7aaea6f572a1c2b198ca323592
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
+    - name: Prepare upstream code
+      run: make upstream
     - name: Install Go
       uses: actions/setup-go@v5
       with:
@@ -201,8 +203,14 @@ jobs:
       uses: jaxxstorm/action-install-gh-release@v1.11.0
       with:
         repo: pulumi/schema-tools
-    - name: Build tfgen & provider binaries
-      run: make provider
+    - name: Build schema generator binary
+      run: make tfgen_build_only
+    - name: Install plugins
+      run: make install_plugins
+    - name: Generate schema
+      run: make tfgen_no_deps
+    - name: Build provider binary
+      run: make_provider_no_deps
     - name: Unit-test provider code
       run: make test_provider
     - if: github.event_name == 'pull_request'

--- a/provider-ci/test-workflows/docker/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/test-workflows/docker/.github/workflows/run-acceptance-tests.yml
@@ -220,7 +220,7 @@ jobs:
     - name: Generate schema
       run: make tfgen_no_deps
     - name: Build provider binary
-      run: make_provider_no_deps
+      run: make provider_no_deps
     - name: Unit-test provider code
       run: make test_provider
     - if: github.event_name == 'pull_request'

--- a/provider-ci/test-workflows/docker/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/test-workflows/docker/.github/workflows/run-acceptance-tests.yml
@@ -191,6 +191,8 @@ jobs:
         ref: deca2c5c6015ad7aaea6f572a1c2b198ca323592
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
+    - name: Prepare upstream code
+      run: make upstream
     - name: Install Go
       uses: actions/setup-go@v5
       with:
@@ -211,8 +213,14 @@ jobs:
       uses: jaxxstorm/action-install-gh-release@v1.11.0
       with:
         repo: pulumi/schema-tools
-    - name: Build tfgen & provider binaries
-      run: make provider
+    - name: Build schema generator binary
+      run: make tfgen_build_only
+    - name: Install plugins
+      run: make install_plugins
+    - name: Generate schema
+      run: make tfgen_no_deps
+    - name: Build provider binary
+      run: make_provider_no_deps
     - name: Unit-test provider code
       run: make test_provider
     - if: github.event_name == 'pull_request'

--- a/provider-ci/test-workflows/docker/Makefile
+++ b/provider-ci/test-workflows/docker/Makefile
@@ -137,11 +137,14 @@ test_provider:
 	@echo ""
 	cd provider && go test -v -short ./... -parallel $(TESTPARALLELISM)
 
-tfgen: export PULUMI_HOME := $(WORKING_DIR)/.pulumi
-tfgen: export PATH := $(WORKING_DIR)/.pulumi/bin:$(PATH)
-tfgen: install_plugins upstream docs
-	(cd provider && go build $(PULUMI_PROVIDER_BUILD_PARALLELISM) -o $(WORKING_DIR)/bin/$(TFGEN) -ldflags "-X $(PROJECT)/$(VERSION_PATH)=$(VERSION)" $(PROJECT)/$(PROVIDER_PATH)/cmd/$(TFGEN))
-	PULUMI_CONVERT=$(PULUMI_CONVERT) PULUMI_DISABLE_AUTOMATIC_PLUGIN_ACQUISITION=$(PULUMI_CONVERT) $(WORKING_DIR)/bin/$(TFGEN) schema --out provider/cmd/$(PROVIDER)
+tfgen: install_plugins upstream docs tfgen_no_deps
+
+tfgen_no_deps: export PULUMI_HOME := $(WORKING_DIR)/.pulumi
+tfgen_no_deps: export PATH := $(WORKING_DIR)/.pulumi/bin:$(PATH)
+tfgen_no_deps: export PULUMI_CONVERT := $(PULUMI_CONVERT)
+tfgen_no_deps: export PULUMI_DISABLE_AUTOMATIC_PLUGIN_ACQUISITION := $(PULUMI_CONVERT)
+tfgen_no_deps: tfgen_build_only
+	$(WORKING_DIR)/bin/$(TFGEN) schema --out provider/cmd/$(PROVIDER)
 	(cd provider && VERSION=$(VERSION) go generate cmd/$(PROVIDER)/main.go)
 
 tfgen_build_only:


### PR DESCRIPTION
It appears helpful to split out individual activities related to `make tfgen` into separate GitHub Action steps so we can see how much time they take and peruse their logs individually. 