### PR TITLE
Accurate go cache for prerequisites

### DIFF
--- a/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/prerequisites.splice
+++ b/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/prerequisites.splice
@@ -16,7 +16,13 @@
       run: git fetch --prune --unshallow --tags
     - name: Prepare upstream code
       run: make upstream
-#{{ .Config.actions.setupGo | toYaml | indent 4 }}#
+    - name: Install Go
+      uses: actions/setup-go@v5
+      with:
+        go-version: 1.21.x
+        cache-dependency-path: |
+          provider/*.sum
+          upstream/*.sum
     - name: Install pulumictl
       uses: #{{ .Config.actionVersions.installGhRelease }}#
       with:

--- a/provider-ci/test-workflows/aws/.github/workflows/master.yml
+++ b/provider-ci/test-workflows/aws/.github/workflows/master.yml
@@ -222,9 +222,10 @@ jobs:
     - name: Install Go
       uses: actions/setup-go@v5
       with:
-        cache-dependency-path: |
-            sdk/go.sum
         go-version: 1.21.x
+        cache-dependency-path: |
+          provider/*.sum
+          upstream/*.sum
     - name: Install pulumictl
       uses: jaxxstorm/action-install-gh-release@v1.11.0
       with:

--- a/provider-ci/test-workflows/aws/.github/workflows/nightly-test.yml
+++ b/provider-ci/test-workflows/aws/.github/workflows/nightly-test.yml
@@ -154,9 +154,10 @@ jobs:
     - name: Install Go
       uses: actions/setup-go@v5
       with:
-        cache-dependency-path: |
-            sdk/go.sum
         go-version: 1.21.x
+        cache-dependency-path: |
+          provider/*.sum
+          upstream/*.sum
     - name: Install pulumictl
       uses: jaxxstorm/action-install-gh-release@v1.11.0
       with:

--- a/provider-ci/test-workflows/aws/.github/workflows/prerelease.yml
+++ b/provider-ci/test-workflows/aws/.github/workflows/prerelease.yml
@@ -159,9 +159,10 @@ jobs:
     - name: Install Go
       uses: actions/setup-go@v5
       with:
-        cache-dependency-path: |
-            sdk/go.sum
         go-version: 1.21.x
+        cache-dependency-path: |
+          provider/*.sum
+          upstream/*.sum
     - name: Install pulumictl
       uses: jaxxstorm/action-install-gh-release@v1.11.0
       with:

--- a/provider-ci/test-workflows/aws/.github/workflows/release.yml
+++ b/provider-ci/test-workflows/aws/.github/workflows/release.yml
@@ -173,9 +173,10 @@ jobs:
     - name: Install Go
       uses: actions/setup-go@v5
       with:
-        cache-dependency-path: |
-            sdk/go.sum
         go-version: 1.21.x
+        cache-dependency-path: |
+          provider/*.sum
+          upstream/*.sum
     - name: Install pulumictl
       uses: jaxxstorm/action-install-gh-release@v1.11.0
       with:

--- a/provider-ci/test-workflows/aws/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/test-workflows/aws/.github/workflows/run-acceptance-tests.yml
@@ -180,9 +180,10 @@ jobs:
     - name: Install Go
       uses: actions/setup-go@v5
       with:
-        cache-dependency-path: |
-            sdk/go.sum
         go-version: 1.21.x
+        cache-dependency-path: |
+          provider/*.sum
+          upstream/*.sum
     - name: Install pulumictl
       uses: jaxxstorm/action-install-gh-release@v1.11.0
       with:

--- a/provider-ci/test-workflows/cloudflare/.github/workflows/master.yml
+++ b/provider-ci/test-workflows/cloudflare/.github/workflows/master.yml
@@ -220,9 +220,10 @@ jobs:
     - name: Install Go
       uses: actions/setup-go@v5
       with:
-        cache-dependency-path: |
-            sdk/go.sum
         go-version: 1.21.x
+        cache-dependency-path: |
+          provider/*.sum
+          upstream/*.sum
     - name: Install pulumictl
       uses: jaxxstorm/action-install-gh-release@v1.11.0
       with:

--- a/provider-ci/test-workflows/cloudflare/.github/workflows/prerelease.yml
+++ b/provider-ci/test-workflows/cloudflare/.github/workflows/prerelease.yml
@@ -159,9 +159,10 @@ jobs:
     - name: Install Go
       uses: actions/setup-go@v5
       with:
-        cache-dependency-path: |
-            sdk/go.sum
         go-version: 1.21.x
+        cache-dependency-path: |
+          provider/*.sum
+          upstream/*.sum
     - name: Install pulumictl
       uses: jaxxstorm/action-install-gh-release@v1.11.0
       with:

--- a/provider-ci/test-workflows/cloudflare/.github/workflows/release.yml
+++ b/provider-ci/test-workflows/cloudflare/.github/workflows/release.yml
@@ -173,9 +173,10 @@ jobs:
     - name: Install Go
       uses: actions/setup-go@v5
       with:
-        cache-dependency-path: |
-            sdk/go.sum
         go-version: 1.21.x
+        cache-dependency-path: |
+          provider/*.sum
+          upstream/*.sum
     - name: Install pulumictl
       uses: jaxxstorm/action-install-gh-release@v1.11.0
       with:

--- a/provider-ci/test-workflows/cloudflare/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/test-workflows/cloudflare/.github/workflows/run-acceptance-tests.yml
@@ -183,9 +183,10 @@ jobs:
     - name: Install Go
       uses: actions/setup-go@v5
       with:
-        cache-dependency-path: |
-            sdk/go.sum
         go-version: 1.21.x
+        cache-dependency-path: |
+          provider/*.sum
+          upstream/*.sum
     - name: Install pulumictl
       uses: jaxxstorm/action-install-gh-release@v1.11.0
       with:

--- a/provider-ci/test-workflows/docker/.github/workflows/master.yml
+++ b/provider-ci/test-workflows/docker/.github/workflows/master.yml
@@ -233,9 +233,10 @@ jobs:
     - name: Install Go
       uses: actions/setup-go@v5
       with:
-        cache-dependency-path: |
-            sdk/go.sum
         go-version: 1.21.x
+        cache-dependency-path: |
+          provider/*.sum
+          upstream/*.sum
     - name: Install pulumictl
       uses: jaxxstorm/action-install-gh-release@v1.11.0
       with:

--- a/provider-ci/test-workflows/docker/.github/workflows/prerelease.yml
+++ b/provider-ci/test-workflows/docker/.github/workflows/prerelease.yml
@@ -172,9 +172,10 @@ jobs:
     - name: Install Go
       uses: actions/setup-go@v5
       with:
-        cache-dependency-path: |
-            sdk/go.sum
         go-version: 1.21.x
+        cache-dependency-path: |
+          provider/*.sum
+          upstream/*.sum
     - name: Install pulumictl
       uses: jaxxstorm/action-install-gh-release@v1.11.0
       with:

--- a/provider-ci/test-workflows/docker/.github/workflows/release.yml
+++ b/provider-ci/test-workflows/docker/.github/workflows/release.yml
@@ -186,9 +186,10 @@ jobs:
     - name: Install Go
       uses: actions/setup-go@v5
       with:
-        cache-dependency-path: |
-            sdk/go.sum
         go-version: 1.21.x
+        cache-dependency-path: |
+          provider/*.sum
+          upstream/*.sum
     - name: Install pulumictl
       uses: jaxxstorm/action-install-gh-release@v1.11.0
       with:

--- a/provider-ci/test-workflows/docker/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/test-workflows/docker/.github/workflows/run-acceptance-tests.yml
@@ -196,9 +196,10 @@ jobs:
     - name: Install Go
       uses: actions/setup-go@v5
       with:
-        cache-dependency-path: |
-            sdk/go.sum
         go-version: 1.21.x
+        cache-dependency-path: |
+          provider/*.sum
+          upstream/*.sum
     - name: Install pulumictl
       uses: jaxxstorm/action-install-gh-release@v1.11.0
       with:


### PR DESCRIPTION
Running some experiments in pulumi-aws I found that for simple PRs that edit tests or resources.go it's really nice to have accurate Go cache. Specifically prerequisites job cache should be keyed on upstream/go.sum and provider/go.sum; if that is done than cache hits mean no additional go package downloading is happening, greatly speeding up builds (I got ranges from 3min to 20min, with 3 min on hot caches). 

I think some of the prior thinking here was that using an approximate cache key would allow to reuse some of the cache even when bridge or upstream upgrades are happening. However when inaccurate cache is downloaded, Go proceeds to download the actual dependences, which in AWS case are significant, causing us to run out of disk space. To compensate, we installed a disk space cleaner job that eats 2.5 minutes of build time negating any gains we might have had. Alas. 

Accurate cache is probably the more intuitive way forward here. 