### PR TITLE
Fix update workflows PRs title

### DIFF
--- a/.github/workflows/update-workflows.yml
+++ b/.github/workflows/update-workflows.yml
@@ -129,7 +129,7 @@ jobs:
           committer: Pulumi Bot <bot@pulumi.com>
           commit-message: "[internal] Update GitHub Actions workflow files"
           labels: "impact/no-changelog-required"
-          title: "${{ inputs.downstream_test == true && '[DOWNSTREAM TEST] '}}Update GitHub Actions workflows."
+          title: "${{ inputs.downstream_test == true && '[DOWNSTREAM TEST] ' || ''}}Update GitHub Actions workflows."
           path: pulumi-${{ inputs.provider_name }}
           token: ${{ secrets.PULUMI_BOT_TOKEN }}
       - name: "Set PR to auto-merge"


### PR DESCRIPTION
Seems like in https://github.com/pulumi/ci-mgmt/pull/855 we regressed and update PRs are now called `falseUpdate GitHub Actions workflows.`

example: https://github.com/pulumi/pulumi-gcp/pull/1878

this should fix it and correctly return them to `Update GitHub Actions workflows.`
