### PR TITLE
Remove duplicated 'Does the PR'

### DIFF
--- a/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/prerequisites.splice
+++ b/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/prerequisites.splice
@@ -69,9 +69,6 @@
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         comment_tag: schemaCheck
         message: >+
-          ### Does the PR have any schema changes?
-
-
           ${{ env.SCHEMA_CHANGES }}
 
 

--- a/provider-ci/test-workflows/aws/.github/workflows/master.yml
+++ b/provider-ci/test-workflows/aws/.github/workflows/master.yml
@@ -287,9 +287,6 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         comment_tag: schemaCheck
         message: >+
-          ### Does the PR have any schema changes?
-
-
           ${{ env.SCHEMA_CHANGES }}
 
 

--- a/provider-ci/test-workflows/aws/.github/workflows/nightly-test.yml
+++ b/provider-ci/test-workflows/aws/.github/workflows/nightly-test.yml
@@ -219,9 +219,6 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         comment_tag: schemaCheck
         message: >+
-          ### Does the PR have any schema changes?
-
-
           ${{ env.SCHEMA_CHANGES }}
 
 

--- a/provider-ci/test-workflows/aws/.github/workflows/prerelease.yml
+++ b/provider-ci/test-workflows/aws/.github/workflows/prerelease.yml
@@ -224,9 +224,6 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         comment_tag: schemaCheck
         message: >+
-          ### Does the PR have any schema changes?
-
-
           ${{ env.SCHEMA_CHANGES }}
 
 

--- a/provider-ci/test-workflows/aws/.github/workflows/release.yml
+++ b/provider-ci/test-workflows/aws/.github/workflows/release.yml
@@ -238,9 +238,6 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         comment_tag: schemaCheck
         message: >+
-          ### Does the PR have any schema changes?
-
-
           ${{ env.SCHEMA_CHANGES }}
 
 

--- a/provider-ci/test-workflows/aws/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/test-workflows/aws/.github/workflows/run-acceptance-tests.yml
@@ -245,9 +245,6 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         comment_tag: schemaCheck
         message: >+
-          ### Does the PR have any schema changes?
-
-
           ${{ env.SCHEMA_CHANGES }}
 
 

--- a/provider-ci/test-workflows/cloudflare/.github/workflows/master.yml
+++ b/provider-ci/test-workflows/cloudflare/.github/workflows/master.yml
@@ -276,9 +276,6 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         comment_tag: schemaCheck
         message: >+
-          ### Does the PR have any schema changes?
-
-
           ${{ env.SCHEMA_CHANGES }}
 
 

--- a/provider-ci/test-workflows/cloudflare/.github/workflows/prerelease.yml
+++ b/provider-ci/test-workflows/cloudflare/.github/workflows/prerelease.yml
@@ -215,9 +215,6 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         comment_tag: schemaCheck
         message: >+
-          ### Does the PR have any schema changes?
-
-
           ${{ env.SCHEMA_CHANGES }}
 
 

--- a/provider-ci/test-workflows/cloudflare/.github/workflows/release.yml
+++ b/provider-ci/test-workflows/cloudflare/.github/workflows/release.yml
@@ -229,9 +229,6 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         comment_tag: schemaCheck
         message: >+
-          ### Does the PR have any schema changes?
-
-
           ${{ env.SCHEMA_CHANGES }}
 
 

--- a/provider-ci/test-workflows/cloudflare/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/test-workflows/cloudflare/.github/workflows/run-acceptance-tests.yml
@@ -239,9 +239,6 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         comment_tag: schemaCheck
         message: >+
-          ### Does the PR have any schema changes?
-
-
           ${{ env.SCHEMA_CHANGES }}
 
 

--- a/provider-ci/test-workflows/docker/.github/workflows/master.yml
+++ b/provider-ci/test-workflows/docker/.github/workflows/master.yml
@@ -289,9 +289,6 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         comment_tag: schemaCheck
         message: >+
-          ### Does the PR have any schema changes?
-
-
           ${{ env.SCHEMA_CHANGES }}
 
 

--- a/provider-ci/test-workflows/docker/.github/workflows/prerelease.yml
+++ b/provider-ci/test-workflows/docker/.github/workflows/prerelease.yml
@@ -228,9 +228,6 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         comment_tag: schemaCheck
         message: >+
-          ### Does the PR have any schema changes?
-
-
           ${{ env.SCHEMA_CHANGES }}
 
 

--- a/provider-ci/test-workflows/docker/.github/workflows/release.yml
+++ b/provider-ci/test-workflows/docker/.github/workflows/release.yml
@@ -242,9 +242,6 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         comment_tag: schemaCheck
         message: >+
-          ### Does the PR have any schema changes?
-
-
           ${{ env.SCHEMA_CHANGES }}
 
 

--- a/provider-ci/test-workflows/docker/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/test-workflows/docker/.github/workflows/run-acceptance-tests.yml
@@ -252,9 +252,6 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         comment_tag: schemaCheck
         message: >+
-          ### Does the PR have any schema changes?
-
-
           ${{ env.SCHEMA_CHANGES }}
 
 


### PR DESCRIPTION
Our schema comparison comments annoyingly have two headers:

<img width="529" alt="image" src="https://github.com/pulumi/ci-mgmt/assets/1454008/b97e52ab-6915-42c1-a91f-c8a85cae3530">

Example in aws: https://github.com/pulumi/pulumi-aws/pull/3758#issuecomment-2027664224
Example in cloudflare: https://github.com/pulumi/pulumi-cloudflare/pull/713#issuecomment-2033452175

This is because they are defined both in CI jobs and in schema-tools [here](https://github.com/pulumi/schema-tools/blob/bc3dae99a9ab5d2ad52f4c1029f35b65248a0118/internal/cmd/compare.go#L302). This PR removes the duplication.