### PR TITLE
Allow no gen binary for pulumi-command

### DIFF
--- a/native-provider-ci/providers/command/config.yaml
+++ b/native-provider-ci/providers/command/config.yaml
@@ -1,7 +1,7 @@
 provider: command
 major-version: 0
 aws: true
-has-gen-binary: false
+hasGenBinary: false
 env:
   AWS_REGION: us-west-2
   PULUMI_API: "https://api.pulumi-staging.io"

--- a/native-provider-ci/providers/command/config.yaml
+++ b/native-provider-ci/providers/command/config.yaml
@@ -1,7 +1,7 @@
 provider: command
-lint: false
 major-version: 0
 aws: true
+has-gen-binary: false
 env:
   AWS_REGION: us-west-2
   PULUMI_API: "https://api.pulumi-staging.io"

--- a/native-provider-ci/providers/command/repo/.github/workflows/build.yml
+++ b/native-provider-ci/providers/command/repo/.github/workflows/build.yml
@@ -77,7 +77,6 @@ jobs:
     - name: Tar provider binaries
       run: tar -zcf ${{ github.workspace }}/bin/provider.tar.gz -C ${{
         github.workspace}}/bin/ pulumi-resource-${{ env.PROVIDER }}
-        pulumi-gen-${{ env.PROVIDER}}
     - name: Upload artifacts
       uses: actions/upload-artifact@v4
       with:
@@ -489,3 +488,24 @@ jobs:
         arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
         build-root-directory: ./sdk/java
         gradle-version: 7.4.1
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout Repo
+      uses: actions/checkout@v4
+      with:
+        lfs: true
+        ref: ${{ env.PR_COMMIT_SHA }}
+    - name: Install Go
+      uses: actions/setup-go@v5
+      with:
+        go-version: ${{ env.GOVERSION }}
+    - name: golangci-lint provider pkg
+      uses: golangci/golangci-lint-action@v4
+      with:
+        version: ${{ env.GOLANGCI_LINT_VERSION }}
+        args: -c ../.golangci.yml --timeout ${{ env.GOLANGCI_LINT_TIMEOUT }}
+        working-directory: provider
+    name: lint
+    if: github.event_name == 'repository_dispatch' ||
+      github.event.pull_request.head.repo.full_name == github.repository

--- a/native-provider-ci/providers/command/repo/.github/workflows/prerelease.yml
+++ b/native-provider-ci/providers/command/repo/.github/workflows/prerelease.yml
@@ -69,7 +69,6 @@ jobs:
     - name: Tar provider binaries
       run: tar -zcf ${{ github.workspace }}/bin/provider.tar.gz -C ${{
         github.workspace}}/bin/ pulumi-resource-${{ env.PROVIDER }}
-        pulumi-gen-${{ env.PROVIDER}}
     - name: Upload artifacts
       uses: actions/upload-artifact@v4
       with:

--- a/native-provider-ci/providers/command/repo/.github/workflows/release.yml
+++ b/native-provider-ci/providers/command/repo/.github/workflows/release.yml
@@ -69,7 +69,6 @@ jobs:
     - name: Tar provider binaries
       run: tar -zcf ${{ github.workspace }}/bin/provider.tar.gz -C ${{
         github.workspace}}/bin/ pulumi-resource-${{ env.PROVIDER }}
-        pulumi-gen-${{ env.PROVIDER}}
     - name: Upload artifacts
       uses: actions/upload-artifact@v4
       with:

--- a/native-provider-ci/providers/command/repo/.github/workflows/run-acceptance-tests.yml
+++ b/native-provider-ci/providers/command/repo/.github/workflows/run-acceptance-tests.yml
@@ -94,7 +94,6 @@ jobs:
     - name: Tar provider binaries
       run: tar -zcf ${{ github.workspace }}/bin/provider.tar.gz -C ${{
         github.workspace}}/bin/ pulumi-resource-${{ env.PROVIDER }}
-        pulumi-gen-${{ env.PROVIDER}}
     - name: Upload artifacts
       uses: actions/upload-artifact@v4
       with:
@@ -338,3 +337,25 @@ jobs:
       github.event.pull_request.head.repo.full_name == github.repository
     needs:
     - test
+    - lint
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout Repo
+      uses: actions/checkout@v4
+      with:
+        lfs: true
+        ref: ${{ env.PR_COMMIT_SHA }}
+    - name: Install Go
+      uses: actions/setup-go@v5
+      with:
+        go-version: ${{ env.GOVERSION }}
+    - name: golangci-lint provider pkg
+      uses: golangci/golangci-lint-action@v4
+      with:
+        version: ${{ env.GOLANGCI_LINT_VERSION }}
+        args: -c ../.golangci.yml --timeout ${{ env.GOLANGCI_LINT_TIMEOUT }}
+        working-directory: provider
+    name: lint
+    if: github.event_name == 'repository_dispatch' ||
+      github.event.pull_request.head.repo.full_name == github.repository

--- a/native-provider-ci/src/steps.ts
+++ b/native-provider-ci/src/steps.ts
@@ -819,7 +819,9 @@ export function MakeKubernetesProvider(provider: string): Step {
 export function TarProviderBinaries(hasGenBinary: boolean): Step {
   return {
     name: "Tar provider binaries",
-    run: "tar -zcf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace}}/bin/ pulumi-resource-${{ env.PROVIDER }}"+ (hasGenBinary ? " pulumi-gen-${{ env.PROVIDER}}" : ""),
+    run:
+      "tar -zcf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace}}/bin/ pulumi-resource-${{ env.PROVIDER }}" +
+      (hasGenBinary ? " pulumi-gen-${{ env.PROVIDER}}" : ""),
   };
 }
 

--- a/native-provider-ci/src/steps.ts
+++ b/native-provider-ci/src/steps.ts
@@ -816,10 +816,10 @@ export function MakeKubernetesProvider(provider: string): Step {
   return {};
 }
 
-export function TarProviderBinaries(): Step {
+export function TarProviderBinaries(hasGenBinary: boolean): Step {
   return {
     name: "Tar provider binaries",
-    run: "tar -zcf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace}}/bin/ pulumi-resource-${{ env.PROVIDER }} pulumi-gen-${{ env.PROVIDER}}",
+    run: "tar -zcf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace}}/bin/ pulumi-resource-${{ env.PROVIDER }}"+ (hasGenBinary ? " pulumi-gen-${{ env.PROVIDER}}" : ""),
   };
 }
 

--- a/native-provider-ci/src/workflows.ts
+++ b/native-provider-ci/src/workflows.ts
@@ -9,6 +9,7 @@ const nodeVersion = "16.x";
 const dotnetVersion = "6.0.x\n3.1.301\n";
 const javaVersion = "11";
 
+type WorkflowOpts = z.infer<typeof WorkflowOpts>;
 export const WorkflowOpts = z.object({
   provider: z.string(),
   env: z.record(z.any()).optional(),
@@ -24,8 +25,8 @@ export const WorkflowOpts = z.object({
   skipCodegen: z.boolean().default(false),
   skipWindowsArmBuild: z.boolean().default(false),
   pulumiCLIVersion: z.string().optional(),
+  hasGenBinary: z.boolean().default(true),
 });
-type WorkflowOpts = z.infer<typeof WorkflowOpts>;
 
 const env = (opts: WorkflowOpts) =>
   Object.assign(
@@ -524,7 +525,7 @@ export class PrerequisitesJob implements NormalJob {
       steps.BuildProvider(opts.provider),
       steps.CheckCleanWorkTree(),
       steps.Porcelain(),
-      steps.TarProviderBinaries(),
+      steps.TarProviderBinaries(opts.hasGenBinary),
       steps.UploadProviderBinaries(),
       steps.TestProviderLibrary(),
       steps.Codecov(),


### PR DESCRIPTION
I merged https://github.com/pulumi/pulumi-command/pull/391, but wasn't aware that ci-mgmt needed to accommodate the new shape of the provider.

This change accommodates https://github.com/pulumi/pulumi-command/pull/391. In light of https://github.com/pulumi/pulumi-command/pull/395, it turns linting back on.