### PR TITLE
feat: enable goreleaser automatic changelog generation for native providers

### DIFF
--- a/native-provider-ci/providers/aws-native/config.yaml
+++ b/native-provider-ci/providers/aws-native/config.yaml
@@ -3,6 +3,7 @@ lint: false
 major-version: 0
 aws: true
 submodules: true
+enableChangelog: true
 env:
   AWS_REGION: us-west-2
   PULUMI_API: "https://api.pulumi-staging.io"

--- a/native-provider-ci/providers/aws-native/repo/.goreleaser.prerelease.yml
+++ b/native-provider-ci/providers/aws-native/repo/.goreleaser.prerelease.yml
@@ -28,7 +28,15 @@ archives:
 snapshot:
   name_template: "{{ .Tag }}-SNAPSHOT"
 changelog:
-  skip: true
+  filters:
+    exclude:
+    - Merge branch
+    - Merge pull request
+    - \Winternal\W
+    - \Wci\W
+    - \Wchore\W
+  sort: asc
+  use: git
 release:
   disable: true
 blobs:

--- a/native-provider-ci/providers/aws-native/repo/.goreleaser.yml
+++ b/native-provider-ci/providers/aws-native/repo/.goreleaser.yml
@@ -28,7 +28,15 @@ archives:
 snapshot:
   name_template: "{{ .Tag }}-SNAPSHOT"
 changelog:
-  skip: true
+  filters:
+    exclude:
+    - Merge branch
+    - Merge pull request
+    - \Winternal\W
+    - \Wci\W
+    - \Wchore\W
+  sort: asc
+  use: git
 release:
   disable: false
 blobs:

--- a/native-provider-ci/src/goreleaser.ts
+++ b/native-provider-ci/src/goreleaser.ts
@@ -84,6 +84,15 @@ interface GoReleaserOpts {
   "major-version": number;
   providerVersion: string;
   skipCodegen: boolean;
+
+  /**
+   * Whether or not to enable changelog generation on the GitHub release.
+   * This will set some default filters on what commits to exclude from the
+   * changelog
+   *
+   * @default false
+   */
+  enableChangelog: boolean;
 }
 
 export class PulumiGoreleaserPreConfig implements GoreleaserConfig {
@@ -187,9 +196,25 @@ export class PulumiGoreleaserPreConfig implements GoreleaserConfig {
     this.snapshot = {
       name_template: "{{ .Tag }}-SNAPSHOT",
     };
-    this.changelog = {
-      skip: true,
-    };
+    if (opts.enableChangelog) {
+      this.changelog = {
+        filters: {
+          exclude: [
+            "Merge branch",
+            "Merge pull request",
+            "\\Winternal\\W",
+            "\\Wci\\W",
+            "\\Wchore\\W",
+          ],
+        },
+        sort: "asc",
+        use: "git",
+      };
+    } else {
+      this.changelog = {
+        skip: true,
+      };
+    }
     this.release = {
       disable: true,
     };
@@ -210,9 +235,6 @@ export class PulumiGoreleaserConfig extends PulumiGoreleaserPreConfig {
     super(opts);
     this.release = {
       disable: false,
-    };
-    this.changelog = {
-      skip: true,
     };
   }
 }

--- a/native-provider-ci/src/provider.ts
+++ b/native-provider-ci/src/provider.ts
@@ -11,6 +11,7 @@ const Config = z.object({
   "provider-default-branch": z.string().default("master"),
   "golangci-timeout": z.string().default("20m"),
   "major-version": z.number().default(0),
+  enableChangelog: z.boolean().default(false),
   customLdFlag: z.string().default(""),
   skipWindowsArmBuild: z.boolean().default(false),
 });


### PR DESCRIPTION
This has already been enabled for bridged providers and I want to get this working for the `aws-native` provider.