### PR TITLE
chore: create upstream patch files with `--no-numbered`

### DIFF
--- a/provider-ci/internal/pkg/templates/bridged-provider/scripts/upstream.sh
+++ b/provider-ci/internal/pkg/templates/bridged-provider/scripts/upstream.sh
@@ -176,7 +176,7 @@ end_rebase() {
 
   rm patches/*.patch
   cd upstream
-  git format-patch local -o ../patches --zero-commit --no-signature --no-stat
+  git format-patch local -o ../patches --zero-commit --no-signature --no-stat --no-numbered
   cd ..
   rm rebase-in-progress
   apply "$1"

--- a/provider-ci/test-workflows/aws/scripts/upstream.sh
+++ b/provider-ci/test-workflows/aws/scripts/upstream.sh
@@ -176,7 +176,7 @@ end_rebase() {
 
   rm patches/*.patch
   cd upstream
-  git format-patch local -o ../patches --zero-commit --no-signature --no-stat
+  git format-patch local -o ../patches --zero-commit --no-signature --no-stat --no-numbered
   cd ..
   rm rebase-in-progress
   apply "$1"

--- a/provider-ci/test-workflows/cloudflare/scripts/upstream.sh
+++ b/provider-ci/test-workflows/cloudflare/scripts/upstream.sh
@@ -176,7 +176,7 @@ end_rebase() {
 
   rm patches/*.patch
   cd upstream
-  git format-patch local -o ../patches --zero-commit --no-signature --no-stat
+  git format-patch local -o ../patches --zero-commit --no-signature --no-stat --no-numbered
   cd ..
   rm rebase-in-progress
   apply "$1"

--- a/provider-ci/test-workflows/docker/scripts/upstream.sh
+++ b/provider-ci/test-workflows/docker/scripts/upstream.sh
@@ -176,7 +176,7 @@ end_rebase() {
 
   rm patches/*.patch
   cd upstream
-  git format-patch local -o ../patches --zero-commit --no-signature --no-stat
+  git format-patch local -o ../patches --zero-commit --no-signature --no-stat --no-numbered
   cd ..
   rm rebase-in-progress
   apply "$1"


### PR DESCRIPTION
Currently the patch files are generated with subjects that contain the patch number (i.e. `Subject: [PATCH 02/52] Add S3 legacy bucket to resources`). This makes diffs too verbose since everytime I add or remove a patch I have a diff on _every_ one of the patches.

The patches have the patch number in the name of the file already so the number in the subject is redundant.