### PR TITLE
fix(native): don't enable changelog on prerelease

### DIFF
--- a/native-provider-ci/providers/aws-native/repo/.goreleaser.prerelease.yml
+++ b/native-provider-ci/providers/aws-native/repo/.goreleaser.prerelease.yml
@@ -28,15 +28,7 @@ archives:
 snapshot:
   name_template: "{{ .Tag }}-SNAPSHOT"
 changelog:
-  filters:
-    exclude:
-    - Merge branch
-    - Merge pull request
-    - \Winternal\W
-    - \Wci\W
-    - \Wchore\W
-  sort: asc
-  use: git
+  skip: true
 release:
   disable: true
 blobs:

--- a/native-provider-ci/src/goreleaser.ts
+++ b/native-provider-ci/src/goreleaser.ts
@@ -196,25 +196,9 @@ export class PulumiGoreleaserPreConfig implements GoreleaserConfig {
     this.snapshot = {
       name_template: "{{ .Tag }}-SNAPSHOT",
     };
-    if (opts.enableChangelog) {
-      this.changelog = {
-        filters: {
-          exclude: [
-            "Merge branch",
-            "Merge pull request",
-            "\\Winternal\\W",
-            "\\Wci\\W",
-            "\\Wchore\\W",
-          ],
-        },
-        sort: "asc",
-        use: "git",
-      };
-    } else {
-      this.changelog = {
-        skip: true,
-      };
-    }
+    this.changelog = {
+      skip: true,
+    };
     this.release = {
       disable: true,
     };
@@ -233,6 +217,21 @@ export class PulumiGoreleaserPreConfig implements GoreleaserConfig {
 export class PulumiGoreleaserConfig extends PulumiGoreleaserPreConfig {
   constructor(opts: GoReleaserOpts) {
     super(opts);
+    if (opts.enableChangelog) {
+      this.changelog = {
+        filters: {
+          exclude: [
+            "Merge branch",
+            "Merge pull request",
+            "\\Winternal\\W",
+            "\\Wci\\W",
+            "\\Wchore\\W",
+          ],
+        },
+        sort: "asc",
+        use: "git",
+      };
+    }
     this.release = {
       disable: false,
     };


### PR DESCRIPTION
This is a follow up to #883. Prereleases do not actually create a release so changelog generation will fail.

re https://github.com/pulumi/pulumi-aws-native/issues/1485