### PR TITLE
docker-build: fix missing version

### DIFF
--- a/native-provider-ci/providers/docker-build/config.yaml
+++ b/native-provider-ci/providers/docker-build/config.yaml
@@ -1,6 +1,7 @@
 provider: docker-build
 major-version: 0
 provider-default-branch: main
+providerVersion: github.com/pulumi/pulumi-docker-build/provider.Version
 aws: true
 gcp: true
 env:

--- a/native-provider-ci/providers/docker-build/repo/.goreleaser.prerelease.yml
+++ b/native-provider-ci/providers/docker-build/repo/.goreleaser.prerelease.yml
@@ -18,6 +18,7 @@ builds:
   ldflags:
   - -X
     github.com/pulumi/pulumi-docker-build/provider/pkg/version.Version={{.Tag}}
+  - -X github.com/pulumi/pulumi-docker-build/provider.Version={{.Tag}}
   binary: pulumi-resource-docker-build
 archives:
 - name_template: "{{ .Binary }}-{{ .Tag }}-{{ .Os }}-{{ .Arch }}"

--- a/native-provider-ci/providers/docker-build/repo/.goreleaser.yml
+++ b/native-provider-ci/providers/docker-build/repo/.goreleaser.yml
@@ -18,6 +18,7 @@ builds:
   ldflags:
   - -X
     github.com/pulumi/pulumi-docker-build/provider/pkg/version.Version={{.Tag}}
+  - -X github.com/pulumi/pulumi-docker-build/provider.Version={{.Tag}}
   binary: pulumi-resource-docker-build
 archives:
 - name_template: "{{ .Binary }}-{{ .Tag }}-{{ .Os }}-{{ .Arch }}"


### PR DESCRIPTION
The provider currently emits this warning:

> warning: resource plugin dockerbuild is expected to have version >=0.0.1-alpha.2, but has ; the wrong version may be on your path, or this may be a bug in the plugin

The version is set correctly on all builds _until_ the goreleaser step, which uses its own ldflags specified here. It assumes a non-idiomatic `pkg` directory which we don't use in pulumi-docker.