### PR TITLE
[native] Suport "main" as a default branch

### DIFF
--- a/native-provider-ci/providers/docker-build/config.yaml
+++ b/native-provider-ci/providers/docker-build/config.yaml
@@ -1,6 +1,6 @@
 provider: docker-build
 major-version: 0
-provider-default-branch: main
+defaultBranch: main
 providerVersion: github.com/pulumi/pulumi-docker-build/provider.Version
 aws: true
 gcp: true

--- a/native-provider-ci/providers/docker-build/repo/.github/workflows/weekly-pulumi-update.yml
+++ b/native-provider-ci/providers/docker-build/repo/.github/workflows/weekly-pulumi-update.yml
@@ -130,7 +130,7 @@ jobs:
       uses: repo-sync/pull-request@v2.6.2
       with:
         source_branch: update-pulumi/${{ github.run_id }}-${{ github.run_number }}
-        destination_branch: master
+        destination_branch: main
         pr_title: Automated Pulumi/Pulumi upgrade
         github_token: ${{ secrets.PULUMI_BOT_TOKEN }}
       env:

--- a/native-provider-ci/src/provider.ts
+++ b/native-provider-ci/src/provider.ts
@@ -8,7 +8,7 @@ import { providersDir } from "../cmd/generate-providers";
 
 const Config = z.object({
   provider: z.string(),
-  "provider-default-branch": z.string().default("master"),
+  defaultBranch: z.string().default("master"),
   "golangci-timeout": z.string().default("20m"),
   "major-version": z.number().default(0),
   enableChangelog: z.boolean().default(false),

--- a/native-provider-ci/src/steps.ts
+++ b/native-provider-ci/src/steps.ts
@@ -509,7 +509,10 @@ export function CommitEmptySDK(): Step {
   };
 }
 
-export function PullRequestSdkGeneration(provider: string): Step {
+export function PullRequestSdkGeneration(
+  provider: string,
+  branch: string
+): Step {
   let dir;
   if (provider === "azure-native") {
     dir = "azure-rest-api-specs";
@@ -522,7 +525,7 @@ export function PullRequestSdkGeneration(provider: string): Step {
     id: "create-pr",
     uses: action.pullRequest,
     with: {
-      destination_branch: "master",
+      destination_branch: branch,
       github_token: "${{ secrets.PULUMI_BOT_TOKEN }}",
       pr_body: "*Automated PR*",
       pr_title: `Automated SDK generation @ ${dir} \${{ steps.vars.outputs.commit-hash }}`,
@@ -942,7 +945,7 @@ export function ProviderWithPulumiUpgrade(provider: string): Step {
   };
 }
 
-export function CreateUpdatePulumiPR(): Step {
+export function CreateUpdatePulumiPR(branch: string): Step {
   return {
     name: "Create PR",
     id: "create-pr",
@@ -951,7 +954,7 @@ export function CreateUpdatePulumiPR(): Step {
     with: {
       source_branch:
         "update-pulumi/${{ github.run_id }}-${{ github.run_number }}",
-      destination_branch: "master",
+      destination_branch: branch,
       pr_title: "Automated Pulumi/Pulumi upgrade",
       github_token: "${{ secrets.PULUMI_BOT_TOKEN }}",
     },

--- a/native-provider-ci/src/workflows.ts
+++ b/native-provider-ci/src/workflows.ts
@@ -26,6 +26,7 @@ export const WorkflowOpts = z.object({
   skipWindowsArmBuild: z.boolean().default(false),
   pulumiCLIVersion: z.string().optional(),
   hasGenBinary: z.boolean().default(true),
+  defaultBranch: z.string().default("master"),
 });
 
 const env = (opts: WorkflowOpts) =>
@@ -970,7 +971,7 @@ export class WeeklyPulumiUpdate implements NormalJob {
       steps.UpdatePulumi(),
       steps.InitializeSubModules(opts.submodules),
       steps.ProviderWithPulumiUpgrade(opts.provider),
-      steps.CreateUpdatePulumiPR(),
+      steps.CreateUpdatePulumiPR(opts.defaultBranch),
       // steps.SetPRAutoMerge(opts.provider),
     ].filter((step: Step) => step.uses !== undefined || step.run !== undefined);
     Object.assign(this, { name });
@@ -1003,7 +1004,7 @@ export class NightlySdkGeneration implements NormalJob {
       steps.MakeLocalGenerate(),
       steps.SetGitSubmoduleCommitHash(opts.provider),
       steps.CommitAutomatedSDKUpdates(opts.provider),
-      steps.PullRequestSdkGeneration(opts.provider),
+      steps.PullRequestSdkGeneration(opts.provider, opts.defaultBranch),
       // steps.SetPRAutoMerge(opts.provider),
       steps.NotifySlack("Failure during automated SDK generation"),
     ].filter((step: Step) => step.uses !== undefined || step.run !== undefined);


### PR DESCRIPTION
We already had a "provider-default-branch" config, but it wasn't being respected by the weekly pu/pu upgrade workflow.

Glued everything together so the workflow now respects the repo's default branch.