### PR TITLE
Exclude ci-scripts from check-worktree-is-clean

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -44,14 +44,13 @@ jobs:
         with:
           path: ci-scripts
           repository: pulumi/scripts
-        env:
-          GITHUB_WORKSPACE: ${{ runner.temp }}
+      - run: mv ci-scripts ../ci-scripts # actions/checkout#197
       - name: Validate native-providers
         run: cd native-provider-ci && make all
       - name: Validate that our test workflows match checked in workflows
         run: cd provider-ci && make test-workflow-generation
       - name: Check worktree clean
-        run: ${{ runner.temp }}/ci-scripts/ci/check-worktree-is-clean
+        run: ../ci-scripts/ci/check-worktree-is-clean
 
   deploy:
     uses: ./.github/workflows/update-workflows.yml

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -42,8 +42,10 @@ jobs:
       - name: Checkout Scripts Repo
         uses: actions/checkout@v4
         with:
-          path: ${{ runner.temp }}/ci-scripts
+          path: ci-scripts
           repository: pulumi/scripts
+        env:
+          GITHUB_WORKSPACE: ${{ runner.temp }}
       - name: Validate native-providers
         run: cd native-provider-ci && make all
       - name: Validate that our test workflows match checked in workflows

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -42,14 +42,14 @@ jobs:
       - name: Checkout Scripts Repo
         uses: actions/checkout@v4
         with:
-          path: ci-scripts
+          path: ../ci-scripts
           repository: pulumi/scripts
       - name: Validate native-providers
         run: cd native-provider-ci && make all
       - name: Validate that our test workflows match checked in workflows
         run: cd provider-ci && make test-workflow-generation
       - name: Check worktree clean
-        run: ./ci-scripts/ci/check-worktree-is-clean
+        run: ../ci-scripts/ci/check-worktree-is-clean
 
   deploy:
     uses: ./.github/workflows/update-workflows.yml

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -42,14 +42,14 @@ jobs:
       - name: Checkout Scripts Repo
         uses: actions/checkout@v4
         with:
-          path: ../ci-scripts
+          path: ${{ runner.temp }}/ci-scripts
           repository: pulumi/scripts
       - name: Validate native-providers
         run: cd native-provider-ci && make all
       - name: Validate that our test workflows match checked in workflows
         run: cd provider-ci && make test-workflow-generation
       - name: Check worktree clean
-        run: ../ci-scripts/ci/check-worktree-is-clean
+        run: ${{ runner.temp }}/ci-scripts/ci/check-worktree-is-clean
 
   deploy:
     uses: ./.github/workflows/update-workflows.yml

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -44,13 +44,13 @@ jobs:
         with:
           path: ci-scripts
           repository: pulumi/scripts
-      - run: mv ci-scripts ../ci-scripts # actions/checkout#197
+      - run: echo "ci-scripts" >> .git/info/exclude # actions/checkout#197
       - name: Validate native-providers
         run: cd native-provider-ci && make all
       - name: Validate that our test workflows match checked in workflows
         run: cd provider-ci && make test-workflow-generation
       - name: Check worktree clean
-        run: ../ci-scripts/ci/check-worktree-is-clean
+        run: ./ci-scripts/ci/check-worktree-is-clean
 
   deploy:
     uses: ./.github/workflows/update-workflows.yml

--- a/native-provider-ci/providers/aws-native/repo/.github/workflows/build.yml
+++ b/native-provider-ci/providers/aws-native/repo/.github/workflows/build.yml
@@ -53,8 +53,10 @@ jobs:
     - name: Checkout Scripts Repo
       uses: actions/checkout@v4
       with:
-        path: ${{ runner.temp }}/ci-scripts
+        path: ci-scripts
         repository: pulumi/scripts
+      env:
+        GITHUB_WORKSPACE: ${{ runner.temp }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -153,8 +155,10 @@ jobs:
     - name: Checkout Scripts Repo
       uses: actions/checkout@v4
       with:
-        path: ${{ runner.temp }}/ci-scripts
+        path: ci-scripts
         repository: pulumi/scripts
+      env:
+        GITHUB_WORKSPACE: ${{ runner.temp }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -251,8 +255,10 @@ jobs:
     - name: Checkout Scripts Repo
       uses: actions/checkout@v4
       with:
-        path: ${{ runner.temp }}/ci-scripts
+        path: ci-scripts
         repository: pulumi/scripts
+      env:
+        GITHUB_WORKSPACE: ${{ runner.temp }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -404,8 +410,10 @@ jobs:
     - name: Checkout Scripts Repo
       uses: actions/checkout@v4
       with:
-        path: ${{ runner.temp }}/ci-scripts
+        path: ci-scripts
         repository: pulumi/scripts
+      env:
+        GITHUB_WORKSPACE: ${{ runner.temp }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -484,8 +492,10 @@ jobs:
     - name: Checkout Scripts Repo
       uses: actions/checkout@v4
       with:
-        path: ${{ runner.temp }}/ci-scripts
+        path: ci-scripts
         repository: pulumi/scripts
+      env:
+        GITHUB_WORKSPACE: ${{ runner.temp }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/native-provider-ci/providers/aws-native/repo/.github/workflows/build.yml
+++ b/native-provider-ci/providers/aws-native/repo/.github/workflows/build.yml
@@ -55,7 +55,7 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
-    - run: mv ci-scripts ../ci-scripts
+    - run: echo "ci-scripts" >> .git/info/exclude
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -109,7 +109,7 @@ jobs:
     - name: Build Provider
       run: make provider
     - name: Check worktree clean
-      run: ../ci-scripts/ci/check-worktree-is-clean
+      run: ./ci-scripts/ci/check-worktree-is-clean
     - run: git status --porcelain
     - name: Tar provider binaries
       run: tar -zcf ${{ github.workspace }}/bin/provider.tar.gz -C ${{
@@ -156,7 +156,7 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
-    - run: mv ci-scripts ../ci-scripts
+    - run: echo "ci-scripts" >> .git/info/exclude
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -211,7 +211,7 @@ jobs:
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
-      run: ../ci-scripts/ci/check-worktree-is-clean
+      run: ./ci-scripts/ci/check-worktree-is-clean
     - run: git status --porcelain
     - name: Tar SDK folder
       run: tar -zcf sdk/${{ matrix.language }}.tar.gz -C sdk/${{ matrix.language }} .
@@ -255,7 +255,7 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
-    - run: mv ci-scripts ../ci-scripts
+    - run: echo "ci-scripts" >> .git/info/exclude
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -409,7 +409,7 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
-    - run: mv ci-scripts ../ci-scripts
+    - run: echo "ci-scripts" >> .git/info/exclude
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -463,7 +463,7 @@ jobs:
     - name: Install Twine
       run: python -m pip install pip twine
     - name: Publish SDKs
-      run: ../ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
+      run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
       env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         PYPI_PUBLISH_ARTIFACTS: all
@@ -489,7 +489,7 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
-    - run: mv ci-scripts ../ci-scripts
+    - run: echo "ci-scripts" >> .git/info/exclude
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/native-provider-ci/providers/aws-native/repo/.github/workflows/build.yml
+++ b/native-provider-ci/providers/aws-native/repo/.github/workflows/build.yml
@@ -53,7 +53,7 @@ jobs:
     - name: Checkout Scripts Repo
       uses: actions/checkout@v4
       with:
-        path: ci-scripts
+        path: ../ci-scripts
         repository: pulumi/scripts
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
@@ -108,7 +108,7 @@ jobs:
     - name: Build Provider
       run: make provider
     - name: Check worktree clean
-      run: ./ci-scripts/ci/check-worktree-is-clean
+      run: ../ci-scripts/ci/check-worktree-is-clean
     - run: git status --porcelain
     - name: Tar provider binaries
       run: tar -zcf ${{ github.workspace }}/bin/provider.tar.gz -C ${{
@@ -153,7 +153,7 @@ jobs:
     - name: Checkout Scripts Repo
       uses: actions/checkout@v4
       with:
-        path: ci-scripts
+        path: ../ci-scripts
         repository: pulumi/scripts
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
@@ -209,7 +209,7 @@ jobs:
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
-      run: ./ci-scripts/ci/check-worktree-is-clean
+      run: ../ci-scripts/ci/check-worktree-is-clean
     - run: git status --porcelain
     - name: Tar SDK folder
       run: tar -zcf sdk/${{ matrix.language }}.tar.gz -C sdk/${{ matrix.language }} .
@@ -251,7 +251,7 @@ jobs:
     - name: Checkout Scripts Repo
       uses: actions/checkout@v4
       with:
-        path: ci-scripts
+        path: ../ci-scripts
         repository: pulumi/scripts
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
@@ -404,7 +404,7 @@ jobs:
     - name: Checkout Scripts Repo
       uses: actions/checkout@v4
       with:
-        path: ci-scripts
+        path: ../ci-scripts
         repository: pulumi/scripts
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
@@ -459,7 +459,7 @@ jobs:
     - name: Install Twine
       run: python -m pip install pip twine
     - name: Publish SDKs
-      run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
+      run: ../ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
       env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         PYPI_PUBLISH_ARTIFACTS: all
@@ -483,7 +483,7 @@ jobs:
     - name: Checkout Scripts Repo
       uses: actions/checkout@v4
       with:
-        path: ci-scripts
+        path: ../ci-scripts
         repository: pulumi/scripts
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags

--- a/native-provider-ci/providers/aws-native/repo/.github/workflows/build.yml
+++ b/native-provider-ci/providers/aws-native/repo/.github/workflows/build.yml
@@ -55,8 +55,7 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
-      env:
-        GITHUB_WORKSPACE: ${{ runner.temp }}
+    - run: mv ci-scripts ../ci-scripts
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -110,7 +109,7 @@ jobs:
     - name: Build Provider
       run: make provider
     - name: Check worktree clean
-      run: ${{ runner.temp }}/ci-scripts/ci/check-worktree-is-clean
+      run: ../ci-scripts/ci/check-worktree-is-clean
     - run: git status --porcelain
     - name: Tar provider binaries
       run: tar -zcf ${{ github.workspace }}/bin/provider.tar.gz -C ${{
@@ -157,8 +156,7 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
-      env:
-        GITHUB_WORKSPACE: ${{ runner.temp }}
+    - run: mv ci-scripts ../ci-scripts
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -213,7 +211,7 @@ jobs:
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
-      run: ${{ runner.temp }}/ci-scripts/ci/check-worktree-is-clean
+      run: ../ci-scripts/ci/check-worktree-is-clean
     - run: git status --porcelain
     - name: Tar SDK folder
       run: tar -zcf sdk/${{ matrix.language }}.tar.gz -C sdk/${{ matrix.language }} .
@@ -257,8 +255,7 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
-      env:
-        GITHUB_WORKSPACE: ${{ runner.temp }}
+    - run: mv ci-scripts ../ci-scripts
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -412,8 +409,7 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
-      env:
-        GITHUB_WORKSPACE: ${{ runner.temp }}
+    - run: mv ci-scripts ../ci-scripts
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -467,8 +463,7 @@ jobs:
     - name: Install Twine
       run: python -m pip install pip twine
     - name: Publish SDKs
-      run: ${{ runner.temp }}/ci-scripts/ci/publish-tfgen-package ${{ github.workspace
-        }}
+      run: ../ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
       env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         PYPI_PUBLISH_ARTIFACTS: all
@@ -494,8 +489,7 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
-      env:
-        GITHUB_WORKSPACE: ${{ runner.temp }}
+    - run: mv ci-scripts ../ci-scripts
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/native-provider-ci/providers/aws-native/repo/.github/workflows/build.yml
+++ b/native-provider-ci/providers/aws-native/repo/.github/workflows/build.yml
@@ -53,7 +53,7 @@ jobs:
     - name: Checkout Scripts Repo
       uses: actions/checkout@v4
       with:
-        path: ../ci-scripts
+        path: ${{ runner.temp }}/ci-scripts
         repository: pulumi/scripts
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
@@ -108,7 +108,7 @@ jobs:
     - name: Build Provider
       run: make provider
     - name: Check worktree clean
-      run: ../ci-scripts/ci/check-worktree-is-clean
+      run: ${{ runner.temp }}/ci-scripts/ci/check-worktree-is-clean
     - run: git status --porcelain
     - name: Tar provider binaries
       run: tar -zcf ${{ github.workspace }}/bin/provider.tar.gz -C ${{
@@ -153,7 +153,7 @@ jobs:
     - name: Checkout Scripts Repo
       uses: actions/checkout@v4
       with:
-        path: ../ci-scripts
+        path: ${{ runner.temp }}/ci-scripts
         repository: pulumi/scripts
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
@@ -209,7 +209,7 @@ jobs:
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
-      run: ../ci-scripts/ci/check-worktree-is-clean
+      run: ${{ runner.temp }}/ci-scripts/ci/check-worktree-is-clean
     - run: git status --porcelain
     - name: Tar SDK folder
       run: tar -zcf sdk/${{ matrix.language }}.tar.gz -C sdk/${{ matrix.language }} .
@@ -251,7 +251,7 @@ jobs:
     - name: Checkout Scripts Repo
       uses: actions/checkout@v4
       with:
-        path: ../ci-scripts
+        path: ${{ runner.temp }}/ci-scripts
         repository: pulumi/scripts
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
@@ -404,7 +404,7 @@ jobs:
     - name: Checkout Scripts Repo
       uses: actions/checkout@v4
       with:
-        path: ../ci-scripts
+        path: ${{ runner.temp }}/ci-scripts
         repository: pulumi/scripts
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
@@ -459,7 +459,8 @@ jobs:
     - name: Install Twine
       run: python -m pip install pip twine
     - name: Publish SDKs
-      run: ../ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
+      run: ${{ runner.temp }}/ci-scripts/ci/publish-tfgen-package ${{ github.workspace
+        }}
       env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         PYPI_PUBLISH_ARTIFACTS: all
@@ -483,7 +484,7 @@ jobs:
     - name: Checkout Scripts Repo
       uses: actions/checkout@v4
       with:
-        path: ../ci-scripts
+        path: ${{ runner.temp }}/ci-scripts
         repository: pulumi/scripts
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags

--- a/native-provider-ci/providers/aws-native/repo/.github/workflows/prerelease.yml
+++ b/native-provider-ci/providers/aws-native/repo/.github/workflows/prerelease.yml
@@ -45,7 +45,7 @@ jobs:
     - name: Checkout Scripts Repo
       uses: actions/checkout@v4
       with:
-        path: ../ci-scripts
+        path: ${{ runner.temp }}/ci-scripts
         repository: pulumi/scripts
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
@@ -100,7 +100,7 @@ jobs:
     - name: Build Provider
       run: make provider
     - name: Check worktree clean
-      run: ../ci-scripts/ci/check-worktree-is-clean
+      run: ${{ runner.temp }}/ci-scripts/ci/check-worktree-is-clean
     - run: git status --porcelain
     - name: Tar provider binaries
       run: tar -zcf ${{ github.workspace }}/bin/provider.tar.gz -C ${{
@@ -145,7 +145,7 @@ jobs:
     - name: Checkout Scripts Repo
       uses: actions/checkout@v4
       with:
-        path: ../ci-scripts
+        path: ${{ runner.temp }}/ci-scripts
         repository: pulumi/scripts
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
@@ -201,7 +201,7 @@ jobs:
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
-      run: ../ci-scripts/ci/check-worktree-is-clean
+      run: ${{ runner.temp }}/ci-scripts/ci/check-worktree-is-clean
     - run: git status --porcelain
     - name: Tar SDK folder
       run: tar -zcf sdk/${{ matrix.language }}.tar.gz -C sdk/${{ matrix.language }} .
@@ -242,7 +242,7 @@ jobs:
     - name: Checkout Scripts Repo
       uses: actions/checkout@v4
       with:
-        path: ../ci-scripts
+        path: ${{ runner.temp }}/ci-scripts
         repository: pulumi/scripts
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
@@ -395,7 +395,7 @@ jobs:
     - name: Checkout Scripts Repo
       uses: actions/checkout@v4
       with:
-        path: ../ci-scripts
+        path: ${{ runner.temp }}/ci-scripts
         repository: pulumi/scripts
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
@@ -450,7 +450,8 @@ jobs:
     - name: Install Twine
       run: python -m pip install pip twine
     - name: Publish SDKs
-      run: ../ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
+      run: ${{ runner.temp }}/ci-scripts/ci/publish-tfgen-package ${{ github.workspace
+        }}
       env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         PYPI_PUBLISH_ARTIFACTS: all
@@ -474,7 +475,7 @@ jobs:
     - name: Checkout Scripts Repo
       uses: actions/checkout@v4
       with:
-        path: ../ci-scripts
+        path: ${{ runner.temp }}/ci-scripts
         repository: pulumi/scripts
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags

--- a/native-provider-ci/providers/aws-native/repo/.github/workflows/prerelease.yml
+++ b/native-provider-ci/providers/aws-native/repo/.github/workflows/prerelease.yml
@@ -47,8 +47,7 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
-      env:
-        GITHUB_WORKSPACE: ${{ runner.temp }}
+    - run: mv ci-scripts ../ci-scripts
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -102,7 +101,7 @@ jobs:
     - name: Build Provider
       run: make provider
     - name: Check worktree clean
-      run: ${{ runner.temp }}/ci-scripts/ci/check-worktree-is-clean
+      run: ../ci-scripts/ci/check-worktree-is-clean
     - run: git status --porcelain
     - name: Tar provider binaries
       run: tar -zcf ${{ github.workspace }}/bin/provider.tar.gz -C ${{
@@ -149,8 +148,7 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
-      env:
-        GITHUB_WORKSPACE: ${{ runner.temp }}
+    - run: mv ci-scripts ../ci-scripts
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -205,7 +203,7 @@ jobs:
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
-      run: ${{ runner.temp }}/ci-scripts/ci/check-worktree-is-clean
+      run: ../ci-scripts/ci/check-worktree-is-clean
     - run: git status --porcelain
     - name: Tar SDK folder
       run: tar -zcf sdk/${{ matrix.language }}.tar.gz -C sdk/${{ matrix.language }} .
@@ -248,8 +246,7 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
-      env:
-        GITHUB_WORKSPACE: ${{ runner.temp }}
+    - run: mv ci-scripts ../ci-scripts
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -403,8 +400,7 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
-      env:
-        GITHUB_WORKSPACE: ${{ runner.temp }}
+    - run: mv ci-scripts ../ci-scripts
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -458,8 +454,7 @@ jobs:
     - name: Install Twine
       run: python -m pip install pip twine
     - name: Publish SDKs
-      run: ${{ runner.temp }}/ci-scripts/ci/publish-tfgen-package ${{ github.workspace
-        }}
+      run: ../ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
       env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         PYPI_PUBLISH_ARTIFACTS: all
@@ -485,8 +480,7 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
-      env:
-        GITHUB_WORKSPACE: ${{ runner.temp }}
+    - run: mv ci-scripts ../ci-scripts
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/native-provider-ci/providers/aws-native/repo/.github/workflows/prerelease.yml
+++ b/native-provider-ci/providers/aws-native/repo/.github/workflows/prerelease.yml
@@ -45,8 +45,10 @@ jobs:
     - name: Checkout Scripts Repo
       uses: actions/checkout@v4
       with:
-        path: ${{ runner.temp }}/ci-scripts
+        path: ci-scripts
         repository: pulumi/scripts
+      env:
+        GITHUB_WORKSPACE: ${{ runner.temp }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -145,8 +147,10 @@ jobs:
     - name: Checkout Scripts Repo
       uses: actions/checkout@v4
       with:
-        path: ${{ runner.temp }}/ci-scripts
+        path: ci-scripts
         repository: pulumi/scripts
+      env:
+        GITHUB_WORKSPACE: ${{ runner.temp }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -242,8 +246,10 @@ jobs:
     - name: Checkout Scripts Repo
       uses: actions/checkout@v4
       with:
-        path: ${{ runner.temp }}/ci-scripts
+        path: ci-scripts
         repository: pulumi/scripts
+      env:
+        GITHUB_WORKSPACE: ${{ runner.temp }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -395,8 +401,10 @@ jobs:
     - name: Checkout Scripts Repo
       uses: actions/checkout@v4
       with:
-        path: ${{ runner.temp }}/ci-scripts
+        path: ci-scripts
         repository: pulumi/scripts
+      env:
+        GITHUB_WORKSPACE: ${{ runner.temp }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -475,8 +483,10 @@ jobs:
     - name: Checkout Scripts Repo
       uses: actions/checkout@v4
       with:
-        path: ${{ runner.temp }}/ci-scripts
+        path: ci-scripts
         repository: pulumi/scripts
+      env:
+        GITHUB_WORKSPACE: ${{ runner.temp }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/native-provider-ci/providers/aws-native/repo/.github/workflows/prerelease.yml
+++ b/native-provider-ci/providers/aws-native/repo/.github/workflows/prerelease.yml
@@ -45,7 +45,7 @@ jobs:
     - name: Checkout Scripts Repo
       uses: actions/checkout@v4
       with:
-        path: ci-scripts
+        path: ../ci-scripts
         repository: pulumi/scripts
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
@@ -100,7 +100,7 @@ jobs:
     - name: Build Provider
       run: make provider
     - name: Check worktree clean
-      run: ./ci-scripts/ci/check-worktree-is-clean
+      run: ../ci-scripts/ci/check-worktree-is-clean
     - run: git status --porcelain
     - name: Tar provider binaries
       run: tar -zcf ${{ github.workspace }}/bin/provider.tar.gz -C ${{
@@ -145,7 +145,7 @@ jobs:
     - name: Checkout Scripts Repo
       uses: actions/checkout@v4
       with:
-        path: ci-scripts
+        path: ../ci-scripts
         repository: pulumi/scripts
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
@@ -201,7 +201,7 @@ jobs:
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
-      run: ./ci-scripts/ci/check-worktree-is-clean
+      run: ../ci-scripts/ci/check-worktree-is-clean
     - run: git status --porcelain
     - name: Tar SDK folder
       run: tar -zcf sdk/${{ matrix.language }}.tar.gz -C sdk/${{ matrix.language }} .
@@ -242,7 +242,7 @@ jobs:
     - name: Checkout Scripts Repo
       uses: actions/checkout@v4
       with:
-        path: ci-scripts
+        path: ../ci-scripts
         repository: pulumi/scripts
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
@@ -395,7 +395,7 @@ jobs:
     - name: Checkout Scripts Repo
       uses: actions/checkout@v4
       with:
-        path: ci-scripts
+        path: ../ci-scripts
         repository: pulumi/scripts
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
@@ -450,7 +450,7 @@ jobs:
     - name: Install Twine
       run: python -m pip install pip twine
     - name: Publish SDKs
-      run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
+      run: ../ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
       env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         PYPI_PUBLISH_ARTIFACTS: all
@@ -474,7 +474,7 @@ jobs:
     - name: Checkout Scripts Repo
       uses: actions/checkout@v4
       with:
-        path: ci-scripts
+        path: ../ci-scripts
         repository: pulumi/scripts
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags

--- a/native-provider-ci/providers/aws-native/repo/.github/workflows/prerelease.yml
+++ b/native-provider-ci/providers/aws-native/repo/.github/workflows/prerelease.yml
@@ -47,7 +47,7 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
-    - run: mv ci-scripts ../ci-scripts
+    - run: echo "ci-scripts" >> .git/info/exclude
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -101,7 +101,7 @@ jobs:
     - name: Build Provider
       run: make provider
     - name: Check worktree clean
-      run: ../ci-scripts/ci/check-worktree-is-clean
+      run: ./ci-scripts/ci/check-worktree-is-clean
     - run: git status --porcelain
     - name: Tar provider binaries
       run: tar -zcf ${{ github.workspace }}/bin/provider.tar.gz -C ${{
@@ -148,7 +148,7 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
-    - run: mv ci-scripts ../ci-scripts
+    - run: echo "ci-scripts" >> .git/info/exclude
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -203,7 +203,7 @@ jobs:
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
-      run: ../ci-scripts/ci/check-worktree-is-clean
+      run: ./ci-scripts/ci/check-worktree-is-clean
     - run: git status --porcelain
     - name: Tar SDK folder
       run: tar -zcf sdk/${{ matrix.language }}.tar.gz -C sdk/${{ matrix.language }} .
@@ -246,7 +246,7 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
-    - run: mv ci-scripts ../ci-scripts
+    - run: echo "ci-scripts" >> .git/info/exclude
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -400,7 +400,7 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
-    - run: mv ci-scripts ../ci-scripts
+    - run: echo "ci-scripts" >> .git/info/exclude
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -454,7 +454,7 @@ jobs:
     - name: Install Twine
       run: python -m pip install pip twine
     - name: Publish SDKs
-      run: ../ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
+      run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
       env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         PYPI_PUBLISH_ARTIFACTS: all
@@ -480,7 +480,7 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
-    - run: mv ci-scripts ../ci-scripts
+    - run: echo "ci-scripts" >> .git/info/exclude
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/native-provider-ci/providers/aws-native/repo/.github/workflows/release.yml
+++ b/native-provider-ci/providers/aws-native/repo/.github/workflows/release.yml
@@ -45,7 +45,7 @@ jobs:
     - name: Checkout Scripts Repo
       uses: actions/checkout@v4
       with:
-        path: ../ci-scripts
+        path: ${{ runner.temp }}/ci-scripts
         repository: pulumi/scripts
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
@@ -100,7 +100,7 @@ jobs:
     - name: Build Provider
       run: make provider
     - name: Check worktree clean
-      run: ../ci-scripts/ci/check-worktree-is-clean
+      run: ${{ runner.temp }}/ci-scripts/ci/check-worktree-is-clean
     - run: git status --porcelain
     - name: Tar provider binaries
       run: tar -zcf ${{ github.workspace }}/bin/provider.tar.gz -C ${{
@@ -145,7 +145,7 @@ jobs:
     - name: Checkout Scripts Repo
       uses: actions/checkout@v4
       with:
-        path: ../ci-scripts
+        path: ${{ runner.temp }}/ci-scripts
         repository: pulumi/scripts
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
@@ -201,7 +201,7 @@ jobs:
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
-      run: ../ci-scripts/ci/check-worktree-is-clean
+      run: ${{ runner.temp }}/ci-scripts/ci/check-worktree-is-clean
     - run: git status --porcelain
     - name: Tar SDK folder
       run: tar -zcf sdk/${{ matrix.language }}.tar.gz -C sdk/${{ matrix.language }} .
@@ -242,7 +242,7 @@ jobs:
     - name: Checkout Scripts Repo
       uses: actions/checkout@v4
       with:
-        path: ../ci-scripts
+        path: ${{ runner.temp }}/ci-scripts
         repository: pulumi/scripts
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
@@ -395,7 +395,7 @@ jobs:
     - name: Checkout Scripts Repo
       uses: actions/checkout@v4
       with:
-        path: ../ci-scripts
+        path: ${{ runner.temp }}/ci-scripts
         repository: pulumi/scripts
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
@@ -450,7 +450,8 @@ jobs:
     - name: Install Twine
       run: python -m pip install pip twine
     - name: Publish SDKs
-      run: ../ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
+      run: ${{ runner.temp }}/ci-scripts/ci/publish-tfgen-package ${{ github.workspace
+        }}
       env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         PYPI_PUBLISH_ARTIFACTS: all
@@ -474,7 +475,7 @@ jobs:
     - name: Checkout Scripts Repo
       uses: actions/checkout@v4
       with:
-        path: ../ci-scripts
+        path: ${{ runner.temp }}/ci-scripts
         repository: pulumi/scripts
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags

--- a/native-provider-ci/providers/aws-native/repo/.github/workflows/release.yml
+++ b/native-provider-ci/providers/aws-native/repo/.github/workflows/release.yml
@@ -47,8 +47,7 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
-      env:
-        GITHUB_WORKSPACE: ${{ runner.temp }}
+    - run: mv ci-scripts ../ci-scripts
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -102,7 +101,7 @@ jobs:
     - name: Build Provider
       run: make provider
     - name: Check worktree clean
-      run: ${{ runner.temp }}/ci-scripts/ci/check-worktree-is-clean
+      run: ../ci-scripts/ci/check-worktree-is-clean
     - run: git status --porcelain
     - name: Tar provider binaries
       run: tar -zcf ${{ github.workspace }}/bin/provider.tar.gz -C ${{
@@ -149,8 +148,7 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
-      env:
-        GITHUB_WORKSPACE: ${{ runner.temp }}
+    - run: mv ci-scripts ../ci-scripts
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -205,7 +203,7 @@ jobs:
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
-      run: ${{ runner.temp }}/ci-scripts/ci/check-worktree-is-clean
+      run: ../ci-scripts/ci/check-worktree-is-clean
     - run: git status --porcelain
     - name: Tar SDK folder
       run: tar -zcf sdk/${{ matrix.language }}.tar.gz -C sdk/${{ matrix.language }} .
@@ -248,8 +246,7 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
-      env:
-        GITHUB_WORKSPACE: ${{ runner.temp }}
+    - run: mv ci-scripts ../ci-scripts
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -403,8 +400,7 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
-      env:
-        GITHUB_WORKSPACE: ${{ runner.temp }}
+    - run: mv ci-scripts ../ci-scripts
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -458,8 +454,7 @@ jobs:
     - name: Install Twine
       run: python -m pip install pip twine
     - name: Publish SDKs
-      run: ${{ runner.temp }}/ci-scripts/ci/publish-tfgen-package ${{ github.workspace
-        }}
+      run: ../ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
       env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         PYPI_PUBLISH_ARTIFACTS: all
@@ -485,8 +480,7 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
-      env:
-        GITHUB_WORKSPACE: ${{ runner.temp }}
+    - run: mv ci-scripts ../ci-scripts
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/native-provider-ci/providers/aws-native/repo/.github/workflows/release.yml
+++ b/native-provider-ci/providers/aws-native/repo/.github/workflows/release.yml
@@ -45,8 +45,10 @@ jobs:
     - name: Checkout Scripts Repo
       uses: actions/checkout@v4
       with:
-        path: ${{ runner.temp }}/ci-scripts
+        path: ci-scripts
         repository: pulumi/scripts
+      env:
+        GITHUB_WORKSPACE: ${{ runner.temp }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -145,8 +147,10 @@ jobs:
     - name: Checkout Scripts Repo
       uses: actions/checkout@v4
       with:
-        path: ${{ runner.temp }}/ci-scripts
+        path: ci-scripts
         repository: pulumi/scripts
+      env:
+        GITHUB_WORKSPACE: ${{ runner.temp }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -242,8 +246,10 @@ jobs:
     - name: Checkout Scripts Repo
       uses: actions/checkout@v4
       with:
-        path: ${{ runner.temp }}/ci-scripts
+        path: ci-scripts
         repository: pulumi/scripts
+      env:
+        GITHUB_WORKSPACE: ${{ runner.temp }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -395,8 +401,10 @@ jobs:
     - name: Checkout Scripts Repo
       uses: actions/checkout@v4
       with:
-        path: ${{ runner.temp }}/ci-scripts
+        path: ci-scripts
         repository: pulumi/scripts
+      env:
+        GITHUB_WORKSPACE: ${{ runner.temp }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -475,8 +483,10 @@ jobs:
     - name: Checkout Scripts Repo
       uses: actions/checkout@v4
       with:
-        path: ${{ runner.temp }}/ci-scripts
+        path: ci-scripts
         repository: pulumi/scripts
+      env:
+        GITHUB_WORKSPACE: ${{ runner.temp }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/native-provider-ci/providers/aws-native/repo/.github/workflows/release.yml
+++ b/native-provider-ci/providers/aws-native/repo/.github/workflows/release.yml
@@ -45,7 +45,7 @@ jobs:
     - name: Checkout Scripts Repo
       uses: actions/checkout@v4
       with:
-        path: ci-scripts
+        path: ../ci-scripts
         repository: pulumi/scripts
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
@@ -100,7 +100,7 @@ jobs:
     - name: Build Provider
       run: make provider
     - name: Check worktree clean
-      run: ./ci-scripts/ci/check-worktree-is-clean
+      run: ../ci-scripts/ci/check-worktree-is-clean
     - run: git status --porcelain
     - name: Tar provider binaries
       run: tar -zcf ${{ github.workspace }}/bin/provider.tar.gz -C ${{
@@ -145,7 +145,7 @@ jobs:
     - name: Checkout Scripts Repo
       uses: actions/checkout@v4
       with:
-        path: ci-scripts
+        path: ../ci-scripts
         repository: pulumi/scripts
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
@@ -201,7 +201,7 @@ jobs:
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
-      run: ./ci-scripts/ci/check-worktree-is-clean
+      run: ../ci-scripts/ci/check-worktree-is-clean
     - run: git status --porcelain
     - name: Tar SDK folder
       run: tar -zcf sdk/${{ matrix.language }}.tar.gz -C sdk/${{ matrix.language }} .
@@ -242,7 +242,7 @@ jobs:
     - name: Checkout Scripts Repo
       uses: actions/checkout@v4
       with:
-        path: ci-scripts
+        path: ../ci-scripts
         repository: pulumi/scripts
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
@@ -395,7 +395,7 @@ jobs:
     - name: Checkout Scripts Repo
       uses: actions/checkout@v4
       with:
-        path: ci-scripts
+        path: ../ci-scripts
         repository: pulumi/scripts
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
@@ -450,7 +450,7 @@ jobs:
     - name: Install Twine
       run: python -m pip install pip twine
     - name: Publish SDKs
-      run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
+      run: ../ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
       env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         PYPI_PUBLISH_ARTIFACTS: all
@@ -474,7 +474,7 @@ jobs:
     - name: Checkout Scripts Repo
       uses: actions/checkout@v4
       with:
-        path: ci-scripts
+        path: ../ci-scripts
         repository: pulumi/scripts
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags

--- a/native-provider-ci/providers/aws-native/repo/.github/workflows/release.yml
+++ b/native-provider-ci/providers/aws-native/repo/.github/workflows/release.yml
@@ -47,7 +47,7 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
-    - run: mv ci-scripts ../ci-scripts
+    - run: echo "ci-scripts" >> .git/info/exclude
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -101,7 +101,7 @@ jobs:
     - name: Build Provider
       run: make provider
     - name: Check worktree clean
-      run: ../ci-scripts/ci/check-worktree-is-clean
+      run: ./ci-scripts/ci/check-worktree-is-clean
     - run: git status --porcelain
     - name: Tar provider binaries
       run: tar -zcf ${{ github.workspace }}/bin/provider.tar.gz -C ${{
@@ -148,7 +148,7 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
-    - run: mv ci-scripts ../ci-scripts
+    - run: echo "ci-scripts" >> .git/info/exclude
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -203,7 +203,7 @@ jobs:
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
-      run: ../ci-scripts/ci/check-worktree-is-clean
+      run: ./ci-scripts/ci/check-worktree-is-clean
     - run: git status --porcelain
     - name: Tar SDK folder
       run: tar -zcf sdk/${{ matrix.language }}.tar.gz -C sdk/${{ matrix.language }} .
@@ -246,7 +246,7 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
-    - run: mv ci-scripts ../ci-scripts
+    - run: echo "ci-scripts" >> .git/info/exclude
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -400,7 +400,7 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
-    - run: mv ci-scripts ../ci-scripts
+    - run: echo "ci-scripts" >> .git/info/exclude
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -454,7 +454,7 @@ jobs:
     - name: Install Twine
       run: python -m pip install pip twine
     - name: Publish SDKs
-      run: ../ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
+      run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
       env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         PYPI_PUBLISH_ARTIFACTS: all
@@ -480,7 +480,7 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
-    - run: mv ci-scripts ../ci-scripts
+    - run: echo "ci-scripts" >> .git/info/exclude
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/native-provider-ci/providers/aws-native/repo/.github/workflows/run-acceptance-tests.yml
+++ b/native-provider-ci/providers/aws-native/repo/.github/workflows/run-acceptance-tests.yml
@@ -70,7 +70,7 @@ jobs:
     - name: Checkout Scripts Repo
       uses: actions/checkout@v4
       with:
-        path: ../ci-scripts
+        path: ${{ runner.temp }}/ci-scripts
         repository: pulumi/scripts
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
@@ -125,7 +125,7 @@ jobs:
     - name: Build Provider
       run: make provider
     - name: Check worktree clean
-      run: ../ci-scripts/ci/check-worktree-is-clean
+      run: ${{ runner.temp }}/ci-scripts/ci/check-worktree-is-clean
     - run: git status --porcelain
     - name: Tar provider binaries
       run: tar -zcf ${{ github.workspace }}/bin/provider.tar.gz -C ${{
@@ -173,7 +173,7 @@ jobs:
     - name: Checkout Scripts Repo
       uses: actions/checkout@v4
       with:
-        path: ../ci-scripts
+        path: ${{ runner.temp }}/ci-scripts
         repository: pulumi/scripts
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
@@ -229,7 +229,7 @@ jobs:
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
-      run: ../ci-scripts/ci/check-worktree-is-clean
+      run: ${{ runner.temp }}/ci-scripts/ci/check-worktree-is-clean
     - run: git status --porcelain
     - name: Tar SDK folder
       run: tar -zcf sdk/${{ matrix.language }}.tar.gz -C sdk/${{ matrix.language }} .
@@ -274,7 +274,7 @@ jobs:
     - name: Checkout Scripts Repo
       uses: actions/checkout@v4
       with:
-        path: ../ci-scripts
+        path: ${{ runner.temp }}/ci-scripts
         repository: pulumi/scripts
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags

--- a/native-provider-ci/providers/aws-native/repo/.github/workflows/run-acceptance-tests.yml
+++ b/native-provider-ci/providers/aws-native/repo/.github/workflows/run-acceptance-tests.yml
@@ -72,8 +72,7 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
-      env:
-        GITHUB_WORKSPACE: ${{ runner.temp }}
+    - run: mv ci-scripts ../ci-scripts
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -127,7 +126,7 @@ jobs:
     - name: Build Provider
       run: make provider
     - name: Check worktree clean
-      run: ${{ runner.temp }}/ci-scripts/ci/check-worktree-is-clean
+      run: ../ci-scripts/ci/check-worktree-is-clean
     - run: git status --porcelain
     - name: Tar provider binaries
       run: tar -zcf ${{ github.workspace }}/bin/provider.tar.gz -C ${{
@@ -177,8 +176,7 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
-      env:
-        GITHUB_WORKSPACE: ${{ runner.temp }}
+    - run: mv ci-scripts ../ci-scripts
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -233,7 +231,7 @@ jobs:
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
-      run: ${{ runner.temp }}/ci-scripts/ci/check-worktree-is-clean
+      run: ../ci-scripts/ci/check-worktree-is-clean
     - run: git status --porcelain
     - name: Tar SDK folder
       run: tar -zcf sdk/${{ matrix.language }}.tar.gz -C sdk/${{ matrix.language }} .
@@ -280,8 +278,7 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
-      env:
-        GITHUB_WORKSPACE: ${{ runner.temp }}
+    - run: mv ci-scripts ../ci-scripts
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/native-provider-ci/providers/aws-native/repo/.github/workflows/run-acceptance-tests.yml
+++ b/native-provider-ci/providers/aws-native/repo/.github/workflows/run-acceptance-tests.yml
@@ -72,7 +72,7 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
-    - run: mv ci-scripts ../ci-scripts
+    - run: echo "ci-scripts" >> .git/info/exclude
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -126,7 +126,7 @@ jobs:
     - name: Build Provider
       run: make provider
     - name: Check worktree clean
-      run: ../ci-scripts/ci/check-worktree-is-clean
+      run: ./ci-scripts/ci/check-worktree-is-clean
     - run: git status --porcelain
     - name: Tar provider binaries
       run: tar -zcf ${{ github.workspace }}/bin/provider.tar.gz -C ${{
@@ -176,7 +176,7 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
-    - run: mv ci-scripts ../ci-scripts
+    - run: echo "ci-scripts" >> .git/info/exclude
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -231,7 +231,7 @@ jobs:
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
-      run: ../ci-scripts/ci/check-worktree-is-clean
+      run: ./ci-scripts/ci/check-worktree-is-clean
     - run: git status --porcelain
     - name: Tar SDK folder
       run: tar -zcf sdk/${{ matrix.language }}.tar.gz -C sdk/${{ matrix.language }} .
@@ -278,7 +278,7 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
-    - run: mv ci-scripts ../ci-scripts
+    - run: echo "ci-scripts" >> .git/info/exclude
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/native-provider-ci/providers/aws-native/repo/.github/workflows/run-acceptance-tests.yml
+++ b/native-provider-ci/providers/aws-native/repo/.github/workflows/run-acceptance-tests.yml
@@ -70,7 +70,7 @@ jobs:
     - name: Checkout Scripts Repo
       uses: actions/checkout@v4
       with:
-        path: ci-scripts
+        path: ../ci-scripts
         repository: pulumi/scripts
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
@@ -125,7 +125,7 @@ jobs:
     - name: Build Provider
       run: make provider
     - name: Check worktree clean
-      run: ./ci-scripts/ci/check-worktree-is-clean
+      run: ../ci-scripts/ci/check-worktree-is-clean
     - run: git status --porcelain
     - name: Tar provider binaries
       run: tar -zcf ${{ github.workspace }}/bin/provider.tar.gz -C ${{
@@ -173,7 +173,7 @@ jobs:
     - name: Checkout Scripts Repo
       uses: actions/checkout@v4
       with:
-        path: ci-scripts
+        path: ../ci-scripts
         repository: pulumi/scripts
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
@@ -229,7 +229,7 @@ jobs:
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
-      run: ./ci-scripts/ci/check-worktree-is-clean
+      run: ../ci-scripts/ci/check-worktree-is-clean
     - run: git status --porcelain
     - name: Tar SDK folder
       run: tar -zcf sdk/${{ matrix.language }}.tar.gz -C sdk/${{ matrix.language }} .
@@ -274,7 +274,7 @@ jobs:
     - name: Checkout Scripts Repo
       uses: actions/checkout@v4
       with:
-        path: ci-scripts
+        path: ../ci-scripts
         repository: pulumi/scripts
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags

--- a/native-provider-ci/providers/aws-native/repo/.github/workflows/run-acceptance-tests.yml
+++ b/native-provider-ci/providers/aws-native/repo/.github/workflows/run-acceptance-tests.yml
@@ -70,8 +70,10 @@ jobs:
     - name: Checkout Scripts Repo
       uses: actions/checkout@v4
       with:
-        path: ${{ runner.temp }}/ci-scripts
+        path: ci-scripts
         repository: pulumi/scripts
+      env:
+        GITHUB_WORKSPACE: ${{ runner.temp }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -173,8 +175,10 @@ jobs:
     - name: Checkout Scripts Repo
       uses: actions/checkout@v4
       with:
-        path: ${{ runner.temp }}/ci-scripts
+        path: ci-scripts
         repository: pulumi/scripts
+      env:
+        GITHUB_WORKSPACE: ${{ runner.temp }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -274,8 +278,10 @@ jobs:
     - name: Checkout Scripts Repo
       uses: actions/checkout@v4
       with:
-        path: ${{ runner.temp }}/ci-scripts
+        path: ci-scripts
         repository: pulumi/scripts
+      env:
+        GITHUB_WORKSPACE: ${{ runner.temp }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/native-provider-ci/providers/azure-native/repo/.github/workflows/build.yml
+++ b/native-provider-ci/providers/azure-native/repo/.github/workflows/build.yml
@@ -61,7 +61,7 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
-    - run: mv ci-scripts ../ci-scripts
+    - run: echo "ci-scripts" >> .git/info/exclude
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -115,7 +115,7 @@ jobs:
     - name: Build Provider
       run: make provider
     - name: Check worktree clean
-      run: ../ci-scripts/ci/check-worktree-is-clean
+      run: ./ci-scripts/ci/check-worktree-is-clean
     - run: git status --porcelain
     - name: Tar provider binaries
       run: tar -zcf ${{ github.workspace }}/bin/provider.tar.gz -C ${{
@@ -162,7 +162,7 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
-    - run: mv ci-scripts ../ci-scripts
+    - run: echo "ci-scripts" >> .git/info/exclude
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -223,7 +223,7 @@ jobs:
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
-      run: ../ci-scripts/ci/check-worktree-is-clean
+      run: ./ci-scripts/ci/check-worktree-is-clean
     - run: git status --porcelain
     - name: Tar SDK folder
       run: tar -zcf sdk/${{ matrix.language }}.tar.gz -C sdk/${{ matrix.language }} .
@@ -267,7 +267,7 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
-    - run: mv ci-scripts ../ci-scripts
+    - run: echo "ci-scripts" >> .git/info/exclude
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -412,7 +412,7 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
-    - run: mv ci-scripts ../ci-scripts
+    - run: echo "ci-scripts" >> .git/info/exclude
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -466,7 +466,7 @@ jobs:
     - name: Install Twine
       run: python -m pip install pip twine
     - name: Publish SDKs
-      run: ../ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
+      run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
       env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         PYPI_PUBLISH_ARTIFACTS: all
@@ -492,7 +492,7 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
-    - run: mv ci-scripts ../ci-scripts
+    - run: echo "ci-scripts" >> .git/info/exclude
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/native-provider-ci/providers/azure-native/repo/.github/workflows/build.yml
+++ b/native-provider-ci/providers/azure-native/repo/.github/workflows/build.yml
@@ -59,8 +59,10 @@ jobs:
     - name: Checkout Scripts Repo
       uses: actions/checkout@v4
       with:
-        path: ${{ runner.temp }}/ci-scripts
+        path: ci-scripts
         repository: pulumi/scripts
+      env:
+        GITHUB_WORKSPACE: ${{ runner.temp }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -159,8 +161,10 @@ jobs:
     - name: Checkout Scripts Repo
       uses: actions/checkout@v4
       with:
-        path: ${{ runner.temp }}/ci-scripts
+        path: ci-scripts
         repository: pulumi/scripts
+      env:
+        GITHUB_WORKSPACE: ${{ runner.temp }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -263,8 +267,10 @@ jobs:
     - name: Checkout Scripts Repo
       uses: actions/checkout@v4
       with:
-        path: ${{ runner.temp }}/ci-scripts
+        path: ci-scripts
         repository: pulumi/scripts
+      env:
+        GITHUB_WORKSPACE: ${{ runner.temp }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -407,8 +413,10 @@ jobs:
     - name: Checkout Scripts Repo
       uses: actions/checkout@v4
       with:
-        path: ${{ runner.temp }}/ci-scripts
+        path: ci-scripts
         repository: pulumi/scripts
+      env:
+        GITHUB_WORKSPACE: ${{ runner.temp }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -487,8 +495,10 @@ jobs:
     - name: Checkout Scripts Repo
       uses: actions/checkout@v4
       with:
-        path: ${{ runner.temp }}/ci-scripts
+        path: ci-scripts
         repository: pulumi/scripts
+      env:
+        GITHUB_WORKSPACE: ${{ runner.temp }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/native-provider-ci/providers/azure-native/repo/.github/workflows/build.yml
+++ b/native-provider-ci/providers/azure-native/repo/.github/workflows/build.yml
@@ -59,7 +59,7 @@ jobs:
     - name: Checkout Scripts Repo
       uses: actions/checkout@v4
       with:
-        path: ../ci-scripts
+        path: ${{ runner.temp }}/ci-scripts
         repository: pulumi/scripts
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
@@ -114,7 +114,7 @@ jobs:
     - name: Build Provider
       run: make provider
     - name: Check worktree clean
-      run: ../ci-scripts/ci/check-worktree-is-clean
+      run: ${{ runner.temp }}/ci-scripts/ci/check-worktree-is-clean
     - run: git status --porcelain
     - name: Tar provider binaries
       run: tar -zcf ${{ github.workspace }}/bin/provider.tar.gz -C ${{
@@ -159,7 +159,7 @@ jobs:
     - name: Checkout Scripts Repo
       uses: actions/checkout@v4
       with:
-        path: ../ci-scripts
+        path: ${{ runner.temp }}/ci-scripts
         repository: pulumi/scripts
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
@@ -221,7 +221,7 @@ jobs:
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
-      run: ../ci-scripts/ci/check-worktree-is-clean
+      run: ${{ runner.temp }}/ci-scripts/ci/check-worktree-is-clean
     - run: git status --porcelain
     - name: Tar SDK folder
       run: tar -zcf sdk/${{ matrix.language }}.tar.gz -C sdk/${{ matrix.language }} .
@@ -263,7 +263,7 @@ jobs:
     - name: Checkout Scripts Repo
       uses: actions/checkout@v4
       with:
-        path: ../ci-scripts
+        path: ${{ runner.temp }}/ci-scripts
         repository: pulumi/scripts
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
@@ -407,7 +407,7 @@ jobs:
     - name: Checkout Scripts Repo
       uses: actions/checkout@v4
       with:
-        path: ../ci-scripts
+        path: ${{ runner.temp }}/ci-scripts
         repository: pulumi/scripts
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
@@ -462,7 +462,8 @@ jobs:
     - name: Install Twine
       run: python -m pip install pip twine
     - name: Publish SDKs
-      run: ../ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
+      run: ${{ runner.temp }}/ci-scripts/ci/publish-tfgen-package ${{ github.workspace
+        }}
       env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         PYPI_PUBLISH_ARTIFACTS: all
@@ -486,7 +487,7 @@ jobs:
     - name: Checkout Scripts Repo
       uses: actions/checkout@v4
       with:
-        path: ../ci-scripts
+        path: ${{ runner.temp }}/ci-scripts
         repository: pulumi/scripts
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags

--- a/native-provider-ci/providers/azure-native/repo/.github/workflows/build.yml
+++ b/native-provider-ci/providers/azure-native/repo/.github/workflows/build.yml
@@ -61,8 +61,7 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
-      env:
-        GITHUB_WORKSPACE: ${{ runner.temp }}
+    - run: mv ci-scripts ../ci-scripts
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -116,7 +115,7 @@ jobs:
     - name: Build Provider
       run: make provider
     - name: Check worktree clean
-      run: ${{ runner.temp }}/ci-scripts/ci/check-worktree-is-clean
+      run: ../ci-scripts/ci/check-worktree-is-clean
     - run: git status --porcelain
     - name: Tar provider binaries
       run: tar -zcf ${{ github.workspace }}/bin/provider.tar.gz -C ${{
@@ -163,8 +162,7 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
-      env:
-        GITHUB_WORKSPACE: ${{ runner.temp }}
+    - run: mv ci-scripts ../ci-scripts
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -225,7 +223,7 @@ jobs:
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
-      run: ${{ runner.temp }}/ci-scripts/ci/check-worktree-is-clean
+      run: ../ci-scripts/ci/check-worktree-is-clean
     - run: git status --porcelain
     - name: Tar SDK folder
       run: tar -zcf sdk/${{ matrix.language }}.tar.gz -C sdk/${{ matrix.language }} .
@@ -269,8 +267,7 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
-      env:
-        GITHUB_WORKSPACE: ${{ runner.temp }}
+    - run: mv ci-scripts ../ci-scripts
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -415,8 +412,7 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
-      env:
-        GITHUB_WORKSPACE: ${{ runner.temp }}
+    - run: mv ci-scripts ../ci-scripts
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -470,8 +466,7 @@ jobs:
     - name: Install Twine
       run: python -m pip install pip twine
     - name: Publish SDKs
-      run: ${{ runner.temp }}/ci-scripts/ci/publish-tfgen-package ${{ github.workspace
-        }}
+      run: ../ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
       env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         PYPI_PUBLISH_ARTIFACTS: all
@@ -497,8 +492,7 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
-      env:
-        GITHUB_WORKSPACE: ${{ runner.temp }}
+    - run: mv ci-scripts ../ci-scripts
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/native-provider-ci/providers/azure-native/repo/.github/workflows/build.yml
+++ b/native-provider-ci/providers/azure-native/repo/.github/workflows/build.yml
@@ -59,7 +59,7 @@ jobs:
     - name: Checkout Scripts Repo
       uses: actions/checkout@v4
       with:
-        path: ci-scripts
+        path: ../ci-scripts
         repository: pulumi/scripts
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
@@ -114,7 +114,7 @@ jobs:
     - name: Build Provider
       run: make provider
     - name: Check worktree clean
-      run: ./ci-scripts/ci/check-worktree-is-clean
+      run: ../ci-scripts/ci/check-worktree-is-clean
     - run: git status --porcelain
     - name: Tar provider binaries
       run: tar -zcf ${{ github.workspace }}/bin/provider.tar.gz -C ${{
@@ -159,7 +159,7 @@ jobs:
     - name: Checkout Scripts Repo
       uses: actions/checkout@v4
       with:
-        path: ci-scripts
+        path: ../ci-scripts
         repository: pulumi/scripts
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
@@ -221,7 +221,7 @@ jobs:
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
-      run: ./ci-scripts/ci/check-worktree-is-clean
+      run: ../ci-scripts/ci/check-worktree-is-clean
     - run: git status --porcelain
     - name: Tar SDK folder
       run: tar -zcf sdk/${{ matrix.language }}.tar.gz -C sdk/${{ matrix.language }} .
@@ -263,7 +263,7 @@ jobs:
     - name: Checkout Scripts Repo
       uses: actions/checkout@v4
       with:
-        path: ci-scripts
+        path: ../ci-scripts
         repository: pulumi/scripts
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
@@ -407,7 +407,7 @@ jobs:
     - name: Checkout Scripts Repo
       uses: actions/checkout@v4
       with:
-        path: ci-scripts
+        path: ../ci-scripts
         repository: pulumi/scripts
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
@@ -462,7 +462,7 @@ jobs:
     - name: Install Twine
       run: python -m pip install pip twine
     - name: Publish SDKs
-      run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
+      run: ../ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
       env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         PYPI_PUBLISH_ARTIFACTS: all
@@ -486,7 +486,7 @@ jobs:
     - name: Checkout Scripts Repo
       uses: actions/checkout@v4
       with:
-        path: ci-scripts
+        path: ../ci-scripts
         repository: pulumi/scripts
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags

--- a/native-provider-ci/providers/azure-native/repo/.github/workflows/prerelease.yml
+++ b/native-provider-ci/providers/azure-native/repo/.github/workflows/prerelease.yml
@@ -53,7 +53,7 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
-    - run: mv ci-scripts ../ci-scripts
+    - run: echo "ci-scripts" >> .git/info/exclude
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -107,7 +107,7 @@ jobs:
     - name: Build Provider
       run: make provider
     - name: Check worktree clean
-      run: ../ci-scripts/ci/check-worktree-is-clean
+      run: ./ci-scripts/ci/check-worktree-is-clean
     - run: git status --porcelain
     - name: Tar provider binaries
       run: tar -zcf ${{ github.workspace }}/bin/provider.tar.gz -C ${{
@@ -154,7 +154,7 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
-    - run: mv ci-scripts ../ci-scripts
+    - run: echo "ci-scripts" >> .git/info/exclude
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -215,7 +215,7 @@ jobs:
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
-      run: ../ci-scripts/ci/check-worktree-is-clean
+      run: ./ci-scripts/ci/check-worktree-is-clean
     - run: git status --porcelain
     - name: Tar SDK folder
       run: tar -zcf sdk/${{ matrix.language }}.tar.gz -C sdk/${{ matrix.language }} .
@@ -258,7 +258,7 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
-    - run: mv ci-scripts ../ci-scripts
+    - run: echo "ci-scripts" >> .git/info/exclude
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -403,7 +403,7 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
-    - run: mv ci-scripts ../ci-scripts
+    - run: echo "ci-scripts" >> .git/info/exclude
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -457,7 +457,7 @@ jobs:
     - name: Install Twine
       run: python -m pip install pip twine
     - name: Publish SDKs
-      run: ../ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
+      run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
       env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         PYPI_PUBLISH_ARTIFACTS: all
@@ -483,7 +483,7 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
-    - run: mv ci-scripts ../ci-scripts
+    - run: echo "ci-scripts" >> .git/info/exclude
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/native-provider-ci/providers/azure-native/repo/.github/workflows/prerelease.yml
+++ b/native-provider-ci/providers/azure-native/repo/.github/workflows/prerelease.yml
@@ -51,7 +51,7 @@ jobs:
     - name: Checkout Scripts Repo
       uses: actions/checkout@v4
       with:
-        path: ci-scripts
+        path: ../ci-scripts
         repository: pulumi/scripts
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
@@ -106,7 +106,7 @@ jobs:
     - name: Build Provider
       run: make provider
     - name: Check worktree clean
-      run: ./ci-scripts/ci/check-worktree-is-clean
+      run: ../ci-scripts/ci/check-worktree-is-clean
     - run: git status --porcelain
     - name: Tar provider binaries
       run: tar -zcf ${{ github.workspace }}/bin/provider.tar.gz -C ${{
@@ -151,7 +151,7 @@ jobs:
     - name: Checkout Scripts Repo
       uses: actions/checkout@v4
       with:
-        path: ci-scripts
+        path: ../ci-scripts
         repository: pulumi/scripts
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
@@ -213,7 +213,7 @@ jobs:
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
-      run: ./ci-scripts/ci/check-worktree-is-clean
+      run: ../ci-scripts/ci/check-worktree-is-clean
     - run: git status --porcelain
     - name: Tar SDK folder
       run: tar -zcf sdk/${{ matrix.language }}.tar.gz -C sdk/${{ matrix.language }} .
@@ -254,7 +254,7 @@ jobs:
     - name: Checkout Scripts Repo
       uses: actions/checkout@v4
       with:
-        path: ci-scripts
+        path: ../ci-scripts
         repository: pulumi/scripts
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
@@ -398,7 +398,7 @@ jobs:
     - name: Checkout Scripts Repo
       uses: actions/checkout@v4
       with:
-        path: ci-scripts
+        path: ../ci-scripts
         repository: pulumi/scripts
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
@@ -453,7 +453,7 @@ jobs:
     - name: Install Twine
       run: python -m pip install pip twine
     - name: Publish SDKs
-      run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
+      run: ../ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
       env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         PYPI_PUBLISH_ARTIFACTS: all
@@ -477,7 +477,7 @@ jobs:
     - name: Checkout Scripts Repo
       uses: actions/checkout@v4
       with:
-        path: ci-scripts
+        path: ../ci-scripts
         repository: pulumi/scripts
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags

--- a/native-provider-ci/providers/azure-native/repo/.github/workflows/prerelease.yml
+++ b/native-provider-ci/providers/azure-native/repo/.github/workflows/prerelease.yml
@@ -51,7 +51,7 @@ jobs:
     - name: Checkout Scripts Repo
       uses: actions/checkout@v4
       with:
-        path: ../ci-scripts
+        path: ${{ runner.temp }}/ci-scripts
         repository: pulumi/scripts
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
@@ -106,7 +106,7 @@ jobs:
     - name: Build Provider
       run: make provider
     - name: Check worktree clean
-      run: ../ci-scripts/ci/check-worktree-is-clean
+      run: ${{ runner.temp }}/ci-scripts/ci/check-worktree-is-clean
     - run: git status --porcelain
     - name: Tar provider binaries
       run: tar -zcf ${{ github.workspace }}/bin/provider.tar.gz -C ${{
@@ -151,7 +151,7 @@ jobs:
     - name: Checkout Scripts Repo
       uses: actions/checkout@v4
       with:
-        path: ../ci-scripts
+        path: ${{ runner.temp }}/ci-scripts
         repository: pulumi/scripts
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
@@ -213,7 +213,7 @@ jobs:
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
-      run: ../ci-scripts/ci/check-worktree-is-clean
+      run: ${{ runner.temp }}/ci-scripts/ci/check-worktree-is-clean
     - run: git status --porcelain
     - name: Tar SDK folder
       run: tar -zcf sdk/${{ matrix.language }}.tar.gz -C sdk/${{ matrix.language }} .
@@ -254,7 +254,7 @@ jobs:
     - name: Checkout Scripts Repo
       uses: actions/checkout@v4
       with:
-        path: ../ci-scripts
+        path: ${{ runner.temp }}/ci-scripts
         repository: pulumi/scripts
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
@@ -398,7 +398,7 @@ jobs:
     - name: Checkout Scripts Repo
       uses: actions/checkout@v4
       with:
-        path: ../ci-scripts
+        path: ${{ runner.temp }}/ci-scripts
         repository: pulumi/scripts
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
@@ -453,7 +453,8 @@ jobs:
     - name: Install Twine
       run: python -m pip install pip twine
     - name: Publish SDKs
-      run: ../ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
+      run: ${{ runner.temp }}/ci-scripts/ci/publish-tfgen-package ${{ github.workspace
+        }}
       env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         PYPI_PUBLISH_ARTIFACTS: all
@@ -477,7 +478,7 @@ jobs:
     - name: Checkout Scripts Repo
       uses: actions/checkout@v4
       with:
-        path: ../ci-scripts
+        path: ${{ runner.temp }}/ci-scripts
         repository: pulumi/scripts
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags

--- a/native-provider-ci/providers/azure-native/repo/.github/workflows/prerelease.yml
+++ b/native-provider-ci/providers/azure-native/repo/.github/workflows/prerelease.yml
@@ -51,8 +51,10 @@ jobs:
     - name: Checkout Scripts Repo
       uses: actions/checkout@v4
       with:
-        path: ${{ runner.temp }}/ci-scripts
+        path: ci-scripts
         repository: pulumi/scripts
+      env:
+        GITHUB_WORKSPACE: ${{ runner.temp }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -151,8 +153,10 @@ jobs:
     - name: Checkout Scripts Repo
       uses: actions/checkout@v4
       with:
-        path: ${{ runner.temp }}/ci-scripts
+        path: ci-scripts
         repository: pulumi/scripts
+      env:
+        GITHUB_WORKSPACE: ${{ runner.temp }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -254,8 +258,10 @@ jobs:
     - name: Checkout Scripts Repo
       uses: actions/checkout@v4
       with:
-        path: ${{ runner.temp }}/ci-scripts
+        path: ci-scripts
         repository: pulumi/scripts
+      env:
+        GITHUB_WORKSPACE: ${{ runner.temp }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -398,8 +404,10 @@ jobs:
     - name: Checkout Scripts Repo
       uses: actions/checkout@v4
       with:
-        path: ${{ runner.temp }}/ci-scripts
+        path: ci-scripts
         repository: pulumi/scripts
+      env:
+        GITHUB_WORKSPACE: ${{ runner.temp }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -478,8 +486,10 @@ jobs:
     - name: Checkout Scripts Repo
       uses: actions/checkout@v4
       with:
-        path: ${{ runner.temp }}/ci-scripts
+        path: ci-scripts
         repository: pulumi/scripts
+      env:
+        GITHUB_WORKSPACE: ${{ runner.temp }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/native-provider-ci/providers/azure-native/repo/.github/workflows/prerelease.yml
+++ b/native-provider-ci/providers/azure-native/repo/.github/workflows/prerelease.yml
@@ -53,8 +53,7 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
-      env:
-        GITHUB_WORKSPACE: ${{ runner.temp }}
+    - run: mv ci-scripts ../ci-scripts
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -108,7 +107,7 @@ jobs:
     - name: Build Provider
       run: make provider
     - name: Check worktree clean
-      run: ${{ runner.temp }}/ci-scripts/ci/check-worktree-is-clean
+      run: ../ci-scripts/ci/check-worktree-is-clean
     - run: git status --porcelain
     - name: Tar provider binaries
       run: tar -zcf ${{ github.workspace }}/bin/provider.tar.gz -C ${{
@@ -155,8 +154,7 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
-      env:
-        GITHUB_WORKSPACE: ${{ runner.temp }}
+    - run: mv ci-scripts ../ci-scripts
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -217,7 +215,7 @@ jobs:
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
-      run: ${{ runner.temp }}/ci-scripts/ci/check-worktree-is-clean
+      run: ../ci-scripts/ci/check-worktree-is-clean
     - run: git status --porcelain
     - name: Tar SDK folder
       run: tar -zcf sdk/${{ matrix.language }}.tar.gz -C sdk/${{ matrix.language }} .
@@ -260,8 +258,7 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
-      env:
-        GITHUB_WORKSPACE: ${{ runner.temp }}
+    - run: mv ci-scripts ../ci-scripts
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -406,8 +403,7 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
-      env:
-        GITHUB_WORKSPACE: ${{ runner.temp }}
+    - run: mv ci-scripts ../ci-scripts
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -461,8 +457,7 @@ jobs:
     - name: Install Twine
       run: python -m pip install pip twine
     - name: Publish SDKs
-      run: ${{ runner.temp }}/ci-scripts/ci/publish-tfgen-package ${{ github.workspace
-        }}
+      run: ../ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
       env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         PYPI_PUBLISH_ARTIFACTS: all
@@ -488,8 +483,7 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
-      env:
-        GITHUB_WORKSPACE: ${{ runner.temp }}
+    - run: mv ci-scripts ../ci-scripts
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/native-provider-ci/providers/azure-native/repo/.github/workflows/release.yml
+++ b/native-provider-ci/providers/azure-native/repo/.github/workflows/release.yml
@@ -53,7 +53,7 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
-    - run: mv ci-scripts ../ci-scripts
+    - run: echo "ci-scripts" >> .git/info/exclude
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -107,7 +107,7 @@ jobs:
     - name: Build Provider
       run: make provider
     - name: Check worktree clean
-      run: ../ci-scripts/ci/check-worktree-is-clean
+      run: ./ci-scripts/ci/check-worktree-is-clean
     - run: git status --porcelain
     - name: Tar provider binaries
       run: tar -zcf ${{ github.workspace }}/bin/provider.tar.gz -C ${{
@@ -154,7 +154,7 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
-    - run: mv ci-scripts ../ci-scripts
+    - run: echo "ci-scripts" >> .git/info/exclude
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -215,7 +215,7 @@ jobs:
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
-      run: ../ci-scripts/ci/check-worktree-is-clean
+      run: ./ci-scripts/ci/check-worktree-is-clean
     - run: git status --porcelain
     - name: Tar SDK folder
       run: tar -zcf sdk/${{ matrix.language }}.tar.gz -C sdk/${{ matrix.language }} .
@@ -258,7 +258,7 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
-    - run: mv ci-scripts ../ci-scripts
+    - run: echo "ci-scripts" >> .git/info/exclude
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -403,7 +403,7 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
-    - run: mv ci-scripts ../ci-scripts
+    - run: echo "ci-scripts" >> .git/info/exclude
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -457,7 +457,7 @@ jobs:
     - name: Install Twine
       run: python -m pip install pip twine
     - name: Publish SDKs
-      run: ../ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
+      run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
       env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         PYPI_PUBLISH_ARTIFACTS: all
@@ -483,7 +483,7 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
-    - run: mv ci-scripts ../ci-scripts
+    - run: echo "ci-scripts" >> .git/info/exclude
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/native-provider-ci/providers/azure-native/repo/.github/workflows/release.yml
+++ b/native-provider-ci/providers/azure-native/repo/.github/workflows/release.yml
@@ -51,7 +51,7 @@ jobs:
     - name: Checkout Scripts Repo
       uses: actions/checkout@v4
       with:
-        path: ci-scripts
+        path: ../ci-scripts
         repository: pulumi/scripts
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
@@ -106,7 +106,7 @@ jobs:
     - name: Build Provider
       run: make provider
     - name: Check worktree clean
-      run: ./ci-scripts/ci/check-worktree-is-clean
+      run: ../ci-scripts/ci/check-worktree-is-clean
     - run: git status --porcelain
     - name: Tar provider binaries
       run: tar -zcf ${{ github.workspace }}/bin/provider.tar.gz -C ${{
@@ -151,7 +151,7 @@ jobs:
     - name: Checkout Scripts Repo
       uses: actions/checkout@v4
       with:
-        path: ci-scripts
+        path: ../ci-scripts
         repository: pulumi/scripts
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
@@ -213,7 +213,7 @@ jobs:
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
-      run: ./ci-scripts/ci/check-worktree-is-clean
+      run: ../ci-scripts/ci/check-worktree-is-clean
     - run: git status --porcelain
     - name: Tar SDK folder
       run: tar -zcf sdk/${{ matrix.language }}.tar.gz -C sdk/${{ matrix.language }} .
@@ -254,7 +254,7 @@ jobs:
     - name: Checkout Scripts Repo
       uses: actions/checkout@v4
       with:
-        path: ci-scripts
+        path: ../ci-scripts
         repository: pulumi/scripts
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
@@ -398,7 +398,7 @@ jobs:
     - name: Checkout Scripts Repo
       uses: actions/checkout@v4
       with:
-        path: ci-scripts
+        path: ../ci-scripts
         repository: pulumi/scripts
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
@@ -453,7 +453,7 @@ jobs:
     - name: Install Twine
       run: python -m pip install pip twine
     - name: Publish SDKs
-      run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
+      run: ../ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
       env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         PYPI_PUBLISH_ARTIFACTS: all
@@ -477,7 +477,7 @@ jobs:
     - name: Checkout Scripts Repo
       uses: actions/checkout@v4
       with:
-        path: ci-scripts
+        path: ../ci-scripts
         repository: pulumi/scripts
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags

--- a/native-provider-ci/providers/azure-native/repo/.github/workflows/release.yml
+++ b/native-provider-ci/providers/azure-native/repo/.github/workflows/release.yml
@@ -51,7 +51,7 @@ jobs:
     - name: Checkout Scripts Repo
       uses: actions/checkout@v4
       with:
-        path: ../ci-scripts
+        path: ${{ runner.temp }}/ci-scripts
         repository: pulumi/scripts
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
@@ -106,7 +106,7 @@ jobs:
     - name: Build Provider
       run: make provider
     - name: Check worktree clean
-      run: ../ci-scripts/ci/check-worktree-is-clean
+      run: ${{ runner.temp }}/ci-scripts/ci/check-worktree-is-clean
     - run: git status --porcelain
     - name: Tar provider binaries
       run: tar -zcf ${{ github.workspace }}/bin/provider.tar.gz -C ${{
@@ -151,7 +151,7 @@ jobs:
     - name: Checkout Scripts Repo
       uses: actions/checkout@v4
       with:
-        path: ../ci-scripts
+        path: ${{ runner.temp }}/ci-scripts
         repository: pulumi/scripts
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
@@ -213,7 +213,7 @@ jobs:
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
-      run: ../ci-scripts/ci/check-worktree-is-clean
+      run: ${{ runner.temp }}/ci-scripts/ci/check-worktree-is-clean
     - run: git status --porcelain
     - name: Tar SDK folder
       run: tar -zcf sdk/${{ matrix.language }}.tar.gz -C sdk/${{ matrix.language }} .
@@ -254,7 +254,7 @@ jobs:
     - name: Checkout Scripts Repo
       uses: actions/checkout@v4
       with:
-        path: ../ci-scripts
+        path: ${{ runner.temp }}/ci-scripts
         repository: pulumi/scripts
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
@@ -398,7 +398,7 @@ jobs:
     - name: Checkout Scripts Repo
       uses: actions/checkout@v4
       with:
-        path: ../ci-scripts
+        path: ${{ runner.temp }}/ci-scripts
         repository: pulumi/scripts
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
@@ -453,7 +453,8 @@ jobs:
     - name: Install Twine
       run: python -m pip install pip twine
     - name: Publish SDKs
-      run: ../ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
+      run: ${{ runner.temp }}/ci-scripts/ci/publish-tfgen-package ${{ github.workspace
+        }}
       env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         PYPI_PUBLISH_ARTIFACTS: all
@@ -477,7 +478,7 @@ jobs:
     - name: Checkout Scripts Repo
       uses: actions/checkout@v4
       with:
-        path: ../ci-scripts
+        path: ${{ runner.temp }}/ci-scripts
         repository: pulumi/scripts
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags

--- a/native-provider-ci/providers/azure-native/repo/.github/workflows/release.yml
+++ b/native-provider-ci/providers/azure-native/repo/.github/workflows/release.yml
@@ -51,8 +51,10 @@ jobs:
     - name: Checkout Scripts Repo
       uses: actions/checkout@v4
       with:
-        path: ${{ runner.temp }}/ci-scripts
+        path: ci-scripts
         repository: pulumi/scripts
+      env:
+        GITHUB_WORKSPACE: ${{ runner.temp }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -151,8 +153,10 @@ jobs:
     - name: Checkout Scripts Repo
       uses: actions/checkout@v4
       with:
-        path: ${{ runner.temp }}/ci-scripts
+        path: ci-scripts
         repository: pulumi/scripts
+      env:
+        GITHUB_WORKSPACE: ${{ runner.temp }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -254,8 +258,10 @@ jobs:
     - name: Checkout Scripts Repo
       uses: actions/checkout@v4
       with:
-        path: ${{ runner.temp }}/ci-scripts
+        path: ci-scripts
         repository: pulumi/scripts
+      env:
+        GITHUB_WORKSPACE: ${{ runner.temp }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -398,8 +404,10 @@ jobs:
     - name: Checkout Scripts Repo
       uses: actions/checkout@v4
       with:
-        path: ${{ runner.temp }}/ci-scripts
+        path: ci-scripts
         repository: pulumi/scripts
+      env:
+        GITHUB_WORKSPACE: ${{ runner.temp }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -478,8 +486,10 @@ jobs:
     - name: Checkout Scripts Repo
       uses: actions/checkout@v4
       with:
-        path: ${{ runner.temp }}/ci-scripts
+        path: ci-scripts
         repository: pulumi/scripts
+      env:
+        GITHUB_WORKSPACE: ${{ runner.temp }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/native-provider-ci/providers/azure-native/repo/.github/workflows/release.yml
+++ b/native-provider-ci/providers/azure-native/repo/.github/workflows/release.yml
@@ -53,8 +53,7 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
-      env:
-        GITHUB_WORKSPACE: ${{ runner.temp }}
+    - run: mv ci-scripts ../ci-scripts
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -108,7 +107,7 @@ jobs:
     - name: Build Provider
       run: make provider
     - name: Check worktree clean
-      run: ${{ runner.temp }}/ci-scripts/ci/check-worktree-is-clean
+      run: ../ci-scripts/ci/check-worktree-is-clean
     - run: git status --porcelain
     - name: Tar provider binaries
       run: tar -zcf ${{ github.workspace }}/bin/provider.tar.gz -C ${{
@@ -155,8 +154,7 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
-      env:
-        GITHUB_WORKSPACE: ${{ runner.temp }}
+    - run: mv ci-scripts ../ci-scripts
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -217,7 +215,7 @@ jobs:
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
-      run: ${{ runner.temp }}/ci-scripts/ci/check-worktree-is-clean
+      run: ../ci-scripts/ci/check-worktree-is-clean
     - run: git status --porcelain
     - name: Tar SDK folder
       run: tar -zcf sdk/${{ matrix.language }}.tar.gz -C sdk/${{ matrix.language }} .
@@ -260,8 +258,7 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
-      env:
-        GITHUB_WORKSPACE: ${{ runner.temp }}
+    - run: mv ci-scripts ../ci-scripts
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -406,8 +403,7 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
-      env:
-        GITHUB_WORKSPACE: ${{ runner.temp }}
+    - run: mv ci-scripts ../ci-scripts
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -461,8 +457,7 @@ jobs:
     - name: Install Twine
       run: python -m pip install pip twine
     - name: Publish SDKs
-      run: ${{ runner.temp }}/ci-scripts/ci/publish-tfgen-package ${{ github.workspace
-        }}
+      run: ../ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
       env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         PYPI_PUBLISH_ARTIFACTS: all
@@ -488,8 +483,7 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
-      env:
-        GITHUB_WORKSPACE: ${{ runner.temp }}
+    - run: mv ci-scripts ../ci-scripts
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/native-provider-ci/providers/azure-native/repo/.github/workflows/run-acceptance-tests.yml
+++ b/native-provider-ci/providers/azure-native/repo/.github/workflows/run-acceptance-tests.yml
@@ -78,7 +78,7 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
-    - run: mv ci-scripts ../ci-scripts
+    - run: echo "ci-scripts" >> .git/info/exclude
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -132,7 +132,7 @@ jobs:
     - name: Build Provider
       run: make provider
     - name: Check worktree clean
-      run: ../ci-scripts/ci/check-worktree-is-clean
+      run: ./ci-scripts/ci/check-worktree-is-clean
     - run: git status --porcelain
     - name: Tar provider binaries
       run: tar -zcf ${{ github.workspace }}/bin/provider.tar.gz -C ${{
@@ -182,7 +182,7 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
-    - run: mv ci-scripts ../ci-scripts
+    - run: echo "ci-scripts" >> .git/info/exclude
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -243,7 +243,7 @@ jobs:
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
-      run: ../ci-scripts/ci/check-worktree-is-clean
+      run: ./ci-scripts/ci/check-worktree-is-clean
     - run: git status --porcelain
     - name: Tar SDK folder
       run: tar -zcf sdk/${{ matrix.language }}.tar.gz -C sdk/${{ matrix.language }} .
@@ -290,7 +290,7 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
-    - run: mv ci-scripts ../ci-scripts
+    - run: echo "ci-scripts" >> .git/info/exclude
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/native-provider-ci/providers/azure-native/repo/.github/workflows/run-acceptance-tests.yml
+++ b/native-provider-ci/providers/azure-native/repo/.github/workflows/run-acceptance-tests.yml
@@ -78,8 +78,7 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
-      env:
-        GITHUB_WORKSPACE: ${{ runner.temp }}
+    - run: mv ci-scripts ../ci-scripts
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -133,7 +132,7 @@ jobs:
     - name: Build Provider
       run: make provider
     - name: Check worktree clean
-      run: ${{ runner.temp }}/ci-scripts/ci/check-worktree-is-clean
+      run: ../ci-scripts/ci/check-worktree-is-clean
     - run: git status --porcelain
     - name: Tar provider binaries
       run: tar -zcf ${{ github.workspace }}/bin/provider.tar.gz -C ${{
@@ -183,8 +182,7 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
-      env:
-        GITHUB_WORKSPACE: ${{ runner.temp }}
+    - run: mv ci-scripts ../ci-scripts
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -245,7 +243,7 @@ jobs:
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
-      run: ${{ runner.temp }}/ci-scripts/ci/check-worktree-is-clean
+      run: ../ci-scripts/ci/check-worktree-is-clean
     - run: git status --porcelain
     - name: Tar SDK folder
       run: tar -zcf sdk/${{ matrix.language }}.tar.gz -C sdk/${{ matrix.language }} .
@@ -292,8 +290,7 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
-      env:
-        GITHUB_WORKSPACE: ${{ runner.temp }}
+    - run: mv ci-scripts ../ci-scripts
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/native-provider-ci/providers/azure-native/repo/.github/workflows/run-acceptance-tests.yml
+++ b/native-provider-ci/providers/azure-native/repo/.github/workflows/run-acceptance-tests.yml
@@ -76,8 +76,10 @@ jobs:
     - name: Checkout Scripts Repo
       uses: actions/checkout@v4
       with:
-        path: ${{ runner.temp }}/ci-scripts
+        path: ci-scripts
         repository: pulumi/scripts
+      env:
+        GITHUB_WORKSPACE: ${{ runner.temp }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -179,8 +181,10 @@ jobs:
     - name: Checkout Scripts Repo
       uses: actions/checkout@v4
       with:
-        path: ${{ runner.temp }}/ci-scripts
+        path: ci-scripts
         repository: pulumi/scripts
+      env:
+        GITHUB_WORKSPACE: ${{ runner.temp }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -286,8 +290,10 @@ jobs:
     - name: Checkout Scripts Repo
       uses: actions/checkout@v4
       with:
-        path: ${{ runner.temp }}/ci-scripts
+        path: ci-scripts
         repository: pulumi/scripts
+      env:
+        GITHUB_WORKSPACE: ${{ runner.temp }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/native-provider-ci/providers/azure-native/repo/.github/workflows/run-acceptance-tests.yml
+++ b/native-provider-ci/providers/azure-native/repo/.github/workflows/run-acceptance-tests.yml
@@ -76,7 +76,7 @@ jobs:
     - name: Checkout Scripts Repo
       uses: actions/checkout@v4
       with:
-        path: ../ci-scripts
+        path: ${{ runner.temp }}/ci-scripts
         repository: pulumi/scripts
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
@@ -131,7 +131,7 @@ jobs:
     - name: Build Provider
       run: make provider
     - name: Check worktree clean
-      run: ../ci-scripts/ci/check-worktree-is-clean
+      run: ${{ runner.temp }}/ci-scripts/ci/check-worktree-is-clean
     - run: git status --porcelain
     - name: Tar provider binaries
       run: tar -zcf ${{ github.workspace }}/bin/provider.tar.gz -C ${{
@@ -179,7 +179,7 @@ jobs:
     - name: Checkout Scripts Repo
       uses: actions/checkout@v4
       with:
-        path: ../ci-scripts
+        path: ${{ runner.temp }}/ci-scripts
         repository: pulumi/scripts
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
@@ -241,7 +241,7 @@ jobs:
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
-      run: ../ci-scripts/ci/check-worktree-is-clean
+      run: ${{ runner.temp }}/ci-scripts/ci/check-worktree-is-clean
     - run: git status --porcelain
     - name: Tar SDK folder
       run: tar -zcf sdk/${{ matrix.language }}.tar.gz -C sdk/${{ matrix.language }} .
@@ -286,7 +286,7 @@ jobs:
     - name: Checkout Scripts Repo
       uses: actions/checkout@v4
       with:
-        path: ../ci-scripts
+        path: ${{ runner.temp }}/ci-scripts
         repository: pulumi/scripts
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags

--- a/native-provider-ci/providers/azure-native/repo/.github/workflows/run-acceptance-tests.yml
+++ b/native-provider-ci/providers/azure-native/repo/.github/workflows/run-acceptance-tests.yml
@@ -76,7 +76,7 @@ jobs:
     - name: Checkout Scripts Repo
       uses: actions/checkout@v4
       with:
-        path: ci-scripts
+        path: ../ci-scripts
         repository: pulumi/scripts
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
@@ -131,7 +131,7 @@ jobs:
     - name: Build Provider
       run: make provider
     - name: Check worktree clean
-      run: ./ci-scripts/ci/check-worktree-is-clean
+      run: ../ci-scripts/ci/check-worktree-is-clean
     - run: git status --porcelain
     - name: Tar provider binaries
       run: tar -zcf ${{ github.workspace }}/bin/provider.tar.gz -C ${{
@@ -179,7 +179,7 @@ jobs:
     - name: Checkout Scripts Repo
       uses: actions/checkout@v4
       with:
-        path: ci-scripts
+        path: ../ci-scripts
         repository: pulumi/scripts
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
@@ -241,7 +241,7 @@ jobs:
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
-      run: ./ci-scripts/ci/check-worktree-is-clean
+      run: ../ci-scripts/ci/check-worktree-is-clean
     - run: git status --porcelain
     - name: Tar SDK folder
       run: tar -zcf sdk/${{ matrix.language }}.tar.gz -C sdk/${{ matrix.language }} .
@@ -286,7 +286,7 @@ jobs:
     - name: Checkout Scripts Repo
       uses: actions/checkout@v4
       with:
-        path: ci-scripts
+        path: ../ci-scripts
         repository: pulumi/scripts
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags

--- a/native-provider-ci/providers/command/repo/.github/workflows/build.yml
+++ b/native-provider-ci/providers/command/repo/.github/workflows/build.yml
@@ -53,8 +53,10 @@ jobs:
     - name: Checkout Scripts Repo
       uses: actions/checkout@v4
       with:
-        path: ${{ runner.temp }}/ci-scripts
+        path: ci-scripts
         repository: pulumi/scripts
+      env:
+        GITHUB_WORKSPACE: ${{ runner.temp }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -117,8 +119,10 @@ jobs:
     - name: Checkout Scripts Repo
       uses: actions/checkout@v4
       with:
-        path: ${{ runner.temp }}/ci-scripts
+        path: ci-scripts
         repository: pulumi/scripts
+      env:
+        GITHUB_WORKSPACE: ${{ runner.temp }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -211,8 +215,10 @@ jobs:
     - name: Checkout Scripts Repo
       uses: actions/checkout@v4
       with:
-        path: ${{ runner.temp }}/ci-scripts
+        path: ci-scripts
         repository: pulumi/scripts
+      env:
+        GITHUB_WORKSPACE: ${{ runner.temp }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -373,8 +379,10 @@ jobs:
     - name: Checkout Scripts Repo
       uses: actions/checkout@v4
       with:
-        path: ${{ runner.temp }}/ci-scripts
+        path: ci-scripts
         repository: pulumi/scripts
+      env:
+        GITHUB_WORKSPACE: ${{ runner.temp }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -453,8 +461,10 @@ jobs:
     - name: Checkout Scripts Repo
       uses: actions/checkout@v4
       with:
-        path: ${{ runner.temp }}/ci-scripts
+        path: ci-scripts
         repository: pulumi/scripts
+      env:
+        GITHUB_WORKSPACE: ${{ runner.temp }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/native-provider-ci/providers/command/repo/.github/workflows/build.yml
+++ b/native-provider-ci/providers/command/repo/.github/workflows/build.yml
@@ -55,7 +55,7 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
-    - run: mv ci-scripts ../ci-scripts
+    - run: echo "ci-scripts" >> .git/info/exclude
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -74,7 +74,7 @@ jobs:
     - name: Build Provider
       run: make provider
     - name: Check worktree clean
-      run: ../ci-scripts/ci/check-worktree-is-clean
+      run: ./ci-scripts/ci/check-worktree-is-clean
     - run: git status --porcelain
     - name: Tar provider binaries
       run: tar -zcf ${{ github.workspace }}/bin/provider.tar.gz -C ${{
@@ -120,7 +120,7 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
-    - run: mv ci-scripts ../ci-scripts
+    - run: echo "ci-scripts" >> .git/info/exclude
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -171,7 +171,7 @@ jobs:
     - name: Generate SDK
       run: make ${{ matrix.language }}_sdk
     - name: Check worktree clean
-      run: ../ci-scripts/ci/check-worktree-is-clean
+      run: ./ci-scripts/ci/check-worktree-is-clean
     - run: git status --porcelain
     - name: Tar SDK folder
       run: tar -zcf sdk/${{ matrix.language }}.tar.gz -C sdk/${{ matrix.language }} .
@@ -215,7 +215,7 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
-    - run: mv ci-scripts ../ci-scripts
+    - run: echo "ci-scripts" >> .git/info/exclude
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -378,7 +378,7 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
-    - run: mv ci-scripts ../ci-scripts
+    - run: echo "ci-scripts" >> .git/info/exclude
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -432,7 +432,7 @@ jobs:
     - name: Install Twine
       run: python -m pip install pip twine
     - name: Publish SDKs
-      run: ../ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
+      run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
       env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         PYPI_PUBLISH_ARTIFACTS: all
@@ -458,7 +458,7 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
-    - run: mv ci-scripts ../ci-scripts
+    - run: echo "ci-scripts" >> .git/info/exclude
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/native-provider-ci/providers/command/repo/.github/workflows/build.yml
+++ b/native-provider-ci/providers/command/repo/.github/workflows/build.yml
@@ -53,7 +53,7 @@ jobs:
     - name: Checkout Scripts Repo
       uses: actions/checkout@v4
       with:
-        path: ci-scripts
+        path: ../ci-scripts
         repository: pulumi/scripts
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
@@ -73,7 +73,7 @@ jobs:
     - name: Build Provider
       run: make provider
     - name: Check worktree clean
-      run: ./ci-scripts/ci/check-worktree-is-clean
+      run: ../ci-scripts/ci/check-worktree-is-clean
     - run: git status --porcelain
     - name: Tar provider binaries
       run: tar -zcf ${{ github.workspace }}/bin/provider.tar.gz -C ${{
@@ -117,7 +117,7 @@ jobs:
     - name: Checkout Scripts Repo
       uses: actions/checkout@v4
       with:
-        path: ci-scripts
+        path: ../ci-scripts
         repository: pulumi/scripts
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
@@ -169,7 +169,7 @@ jobs:
     - name: Generate SDK
       run: make ${{ matrix.language }}_sdk
     - name: Check worktree clean
-      run: ./ci-scripts/ci/check-worktree-is-clean
+      run: ../ci-scripts/ci/check-worktree-is-clean
     - run: git status --porcelain
     - name: Tar SDK folder
       run: tar -zcf sdk/${{ matrix.language }}.tar.gz -C sdk/${{ matrix.language }} .
@@ -211,7 +211,7 @@ jobs:
     - name: Checkout Scripts Repo
       uses: actions/checkout@v4
       with:
-        path: ci-scripts
+        path: ../ci-scripts
         repository: pulumi/scripts
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
@@ -373,7 +373,7 @@ jobs:
     - name: Checkout Scripts Repo
       uses: actions/checkout@v4
       with:
-        path: ci-scripts
+        path: ../ci-scripts
         repository: pulumi/scripts
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
@@ -428,7 +428,7 @@ jobs:
     - name: Install Twine
       run: python -m pip install pip twine
     - name: Publish SDKs
-      run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
+      run: ../ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
       env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         PYPI_PUBLISH_ARTIFACTS: all
@@ -452,7 +452,7 @@ jobs:
     - name: Checkout Scripts Repo
       uses: actions/checkout@v4
       with:
-        path: ci-scripts
+        path: ../ci-scripts
         repository: pulumi/scripts
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags

--- a/native-provider-ci/providers/command/repo/.github/workflows/build.yml
+++ b/native-provider-ci/providers/command/repo/.github/workflows/build.yml
@@ -53,7 +53,7 @@ jobs:
     - name: Checkout Scripts Repo
       uses: actions/checkout@v4
       with:
-        path: ../ci-scripts
+        path: ${{ runner.temp }}/ci-scripts
         repository: pulumi/scripts
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
@@ -73,7 +73,7 @@ jobs:
     - name: Build Provider
       run: make provider
     - name: Check worktree clean
-      run: ../ci-scripts/ci/check-worktree-is-clean
+      run: ${{ runner.temp }}/ci-scripts/ci/check-worktree-is-clean
     - run: git status --porcelain
     - name: Tar provider binaries
       run: tar -zcf ${{ github.workspace }}/bin/provider.tar.gz -C ${{
@@ -117,7 +117,7 @@ jobs:
     - name: Checkout Scripts Repo
       uses: actions/checkout@v4
       with:
-        path: ../ci-scripts
+        path: ${{ runner.temp }}/ci-scripts
         repository: pulumi/scripts
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
@@ -169,7 +169,7 @@ jobs:
     - name: Generate SDK
       run: make ${{ matrix.language }}_sdk
     - name: Check worktree clean
-      run: ../ci-scripts/ci/check-worktree-is-clean
+      run: ${{ runner.temp }}/ci-scripts/ci/check-worktree-is-clean
     - run: git status --porcelain
     - name: Tar SDK folder
       run: tar -zcf sdk/${{ matrix.language }}.tar.gz -C sdk/${{ matrix.language }} .
@@ -211,7 +211,7 @@ jobs:
     - name: Checkout Scripts Repo
       uses: actions/checkout@v4
       with:
-        path: ../ci-scripts
+        path: ${{ runner.temp }}/ci-scripts
         repository: pulumi/scripts
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
@@ -373,7 +373,7 @@ jobs:
     - name: Checkout Scripts Repo
       uses: actions/checkout@v4
       with:
-        path: ../ci-scripts
+        path: ${{ runner.temp }}/ci-scripts
         repository: pulumi/scripts
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
@@ -428,7 +428,8 @@ jobs:
     - name: Install Twine
       run: python -m pip install pip twine
     - name: Publish SDKs
-      run: ../ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
+      run: ${{ runner.temp }}/ci-scripts/ci/publish-tfgen-package ${{ github.workspace
+        }}
       env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         PYPI_PUBLISH_ARTIFACTS: all
@@ -452,7 +453,7 @@ jobs:
     - name: Checkout Scripts Repo
       uses: actions/checkout@v4
       with:
-        path: ../ci-scripts
+        path: ${{ runner.temp }}/ci-scripts
         repository: pulumi/scripts
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags

--- a/native-provider-ci/providers/command/repo/.github/workflows/build.yml
+++ b/native-provider-ci/providers/command/repo/.github/workflows/build.yml
@@ -55,8 +55,7 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
-      env:
-        GITHUB_WORKSPACE: ${{ runner.temp }}
+    - run: mv ci-scripts ../ci-scripts
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -75,7 +74,7 @@ jobs:
     - name: Build Provider
       run: make provider
     - name: Check worktree clean
-      run: ${{ runner.temp }}/ci-scripts/ci/check-worktree-is-clean
+      run: ../ci-scripts/ci/check-worktree-is-clean
     - run: git status --porcelain
     - name: Tar provider binaries
       run: tar -zcf ${{ github.workspace }}/bin/provider.tar.gz -C ${{
@@ -121,8 +120,7 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
-      env:
-        GITHUB_WORKSPACE: ${{ runner.temp }}
+    - run: mv ci-scripts ../ci-scripts
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -173,7 +171,7 @@ jobs:
     - name: Generate SDK
       run: make ${{ matrix.language }}_sdk
     - name: Check worktree clean
-      run: ${{ runner.temp }}/ci-scripts/ci/check-worktree-is-clean
+      run: ../ci-scripts/ci/check-worktree-is-clean
     - run: git status --porcelain
     - name: Tar SDK folder
       run: tar -zcf sdk/${{ matrix.language }}.tar.gz -C sdk/${{ matrix.language }} .
@@ -217,8 +215,7 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
-      env:
-        GITHUB_WORKSPACE: ${{ runner.temp }}
+    - run: mv ci-scripts ../ci-scripts
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -381,8 +378,7 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
-      env:
-        GITHUB_WORKSPACE: ${{ runner.temp }}
+    - run: mv ci-scripts ../ci-scripts
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -436,8 +432,7 @@ jobs:
     - name: Install Twine
       run: python -m pip install pip twine
     - name: Publish SDKs
-      run: ${{ runner.temp }}/ci-scripts/ci/publish-tfgen-package ${{ github.workspace
-        }}
+      run: ../ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
       env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         PYPI_PUBLISH_ARTIFACTS: all
@@ -463,8 +458,7 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
-      env:
-        GITHUB_WORKSPACE: ${{ runner.temp }}
+    - run: mv ci-scripts ../ci-scripts
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/native-provider-ci/providers/command/repo/.github/workflows/prerelease.yml
+++ b/native-provider-ci/providers/command/repo/.github/workflows/prerelease.yml
@@ -45,7 +45,7 @@ jobs:
     - name: Checkout Scripts Repo
       uses: actions/checkout@v4
       with:
-        path: ci-scripts
+        path: ../ci-scripts
         repository: pulumi/scripts
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
@@ -65,7 +65,7 @@ jobs:
     - name: Build Provider
       run: make provider
     - name: Check worktree clean
-      run: ./ci-scripts/ci/check-worktree-is-clean
+      run: ../ci-scripts/ci/check-worktree-is-clean
     - run: git status --porcelain
     - name: Tar provider binaries
       run: tar -zcf ${{ github.workspace }}/bin/provider.tar.gz -C ${{
@@ -109,7 +109,7 @@ jobs:
     - name: Checkout Scripts Repo
       uses: actions/checkout@v4
       with:
-        path: ci-scripts
+        path: ../ci-scripts
         repository: pulumi/scripts
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
@@ -161,7 +161,7 @@ jobs:
     - name: Generate SDK
       run: make ${{ matrix.language }}_sdk
     - name: Check worktree clean
-      run: ./ci-scripts/ci/check-worktree-is-clean
+      run: ../ci-scripts/ci/check-worktree-is-clean
     - run: git status --porcelain
     - name: Tar SDK folder
       run: tar -zcf sdk/${{ matrix.language }}.tar.gz -C sdk/${{ matrix.language }} .
@@ -202,7 +202,7 @@ jobs:
     - name: Checkout Scripts Repo
       uses: actions/checkout@v4
       with:
-        path: ci-scripts
+        path: ../ci-scripts
         repository: pulumi/scripts
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
@@ -364,7 +364,7 @@ jobs:
     - name: Checkout Scripts Repo
       uses: actions/checkout@v4
       with:
-        path: ci-scripts
+        path: ../ci-scripts
         repository: pulumi/scripts
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
@@ -419,7 +419,7 @@ jobs:
     - name: Install Twine
       run: python -m pip install pip twine
     - name: Publish SDKs
-      run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
+      run: ../ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
       env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         PYPI_PUBLISH_ARTIFACTS: all
@@ -443,7 +443,7 @@ jobs:
     - name: Checkout Scripts Repo
       uses: actions/checkout@v4
       with:
-        path: ci-scripts
+        path: ../ci-scripts
         repository: pulumi/scripts
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags

--- a/native-provider-ci/providers/command/repo/.github/workflows/prerelease.yml
+++ b/native-provider-ci/providers/command/repo/.github/workflows/prerelease.yml
@@ -45,7 +45,7 @@ jobs:
     - name: Checkout Scripts Repo
       uses: actions/checkout@v4
       with:
-        path: ../ci-scripts
+        path: ${{ runner.temp }}/ci-scripts
         repository: pulumi/scripts
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
@@ -65,7 +65,7 @@ jobs:
     - name: Build Provider
       run: make provider
     - name: Check worktree clean
-      run: ../ci-scripts/ci/check-worktree-is-clean
+      run: ${{ runner.temp }}/ci-scripts/ci/check-worktree-is-clean
     - run: git status --porcelain
     - name: Tar provider binaries
       run: tar -zcf ${{ github.workspace }}/bin/provider.tar.gz -C ${{
@@ -109,7 +109,7 @@ jobs:
     - name: Checkout Scripts Repo
       uses: actions/checkout@v4
       with:
-        path: ../ci-scripts
+        path: ${{ runner.temp }}/ci-scripts
         repository: pulumi/scripts
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
@@ -161,7 +161,7 @@ jobs:
     - name: Generate SDK
       run: make ${{ matrix.language }}_sdk
     - name: Check worktree clean
-      run: ../ci-scripts/ci/check-worktree-is-clean
+      run: ${{ runner.temp }}/ci-scripts/ci/check-worktree-is-clean
     - run: git status --porcelain
     - name: Tar SDK folder
       run: tar -zcf sdk/${{ matrix.language }}.tar.gz -C sdk/${{ matrix.language }} .
@@ -202,7 +202,7 @@ jobs:
     - name: Checkout Scripts Repo
       uses: actions/checkout@v4
       with:
-        path: ../ci-scripts
+        path: ${{ runner.temp }}/ci-scripts
         repository: pulumi/scripts
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
@@ -364,7 +364,7 @@ jobs:
     - name: Checkout Scripts Repo
       uses: actions/checkout@v4
       with:
-        path: ../ci-scripts
+        path: ${{ runner.temp }}/ci-scripts
         repository: pulumi/scripts
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
@@ -419,7 +419,8 @@ jobs:
     - name: Install Twine
       run: python -m pip install pip twine
     - name: Publish SDKs
-      run: ../ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
+      run: ${{ runner.temp }}/ci-scripts/ci/publish-tfgen-package ${{ github.workspace
+        }}
       env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         PYPI_PUBLISH_ARTIFACTS: all
@@ -443,7 +444,7 @@ jobs:
     - name: Checkout Scripts Repo
       uses: actions/checkout@v4
       with:
-        path: ../ci-scripts
+        path: ${{ runner.temp }}/ci-scripts
         repository: pulumi/scripts
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags

--- a/native-provider-ci/providers/command/repo/.github/workflows/prerelease.yml
+++ b/native-provider-ci/providers/command/repo/.github/workflows/prerelease.yml
@@ -45,8 +45,10 @@ jobs:
     - name: Checkout Scripts Repo
       uses: actions/checkout@v4
       with:
-        path: ${{ runner.temp }}/ci-scripts
+        path: ci-scripts
         repository: pulumi/scripts
+      env:
+        GITHUB_WORKSPACE: ${{ runner.temp }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -109,8 +111,10 @@ jobs:
     - name: Checkout Scripts Repo
       uses: actions/checkout@v4
       with:
-        path: ${{ runner.temp }}/ci-scripts
+        path: ci-scripts
         repository: pulumi/scripts
+      env:
+        GITHUB_WORKSPACE: ${{ runner.temp }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -202,8 +206,10 @@ jobs:
     - name: Checkout Scripts Repo
       uses: actions/checkout@v4
       with:
-        path: ${{ runner.temp }}/ci-scripts
+        path: ci-scripts
         repository: pulumi/scripts
+      env:
+        GITHUB_WORKSPACE: ${{ runner.temp }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -364,8 +370,10 @@ jobs:
     - name: Checkout Scripts Repo
       uses: actions/checkout@v4
       with:
-        path: ${{ runner.temp }}/ci-scripts
+        path: ci-scripts
         repository: pulumi/scripts
+      env:
+        GITHUB_WORKSPACE: ${{ runner.temp }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -444,8 +452,10 @@ jobs:
     - name: Checkout Scripts Repo
       uses: actions/checkout@v4
       with:
-        path: ${{ runner.temp }}/ci-scripts
+        path: ci-scripts
         repository: pulumi/scripts
+      env:
+        GITHUB_WORKSPACE: ${{ runner.temp }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/native-provider-ci/providers/command/repo/.github/workflows/prerelease.yml
+++ b/native-provider-ci/providers/command/repo/.github/workflows/prerelease.yml
@@ -47,7 +47,7 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
-    - run: mv ci-scripts ../ci-scripts
+    - run: echo "ci-scripts" >> .git/info/exclude
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -66,7 +66,7 @@ jobs:
     - name: Build Provider
       run: make provider
     - name: Check worktree clean
-      run: ../ci-scripts/ci/check-worktree-is-clean
+      run: ./ci-scripts/ci/check-worktree-is-clean
     - run: git status --porcelain
     - name: Tar provider binaries
       run: tar -zcf ${{ github.workspace }}/bin/provider.tar.gz -C ${{
@@ -112,7 +112,7 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
-    - run: mv ci-scripts ../ci-scripts
+    - run: echo "ci-scripts" >> .git/info/exclude
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -163,7 +163,7 @@ jobs:
     - name: Generate SDK
       run: make ${{ matrix.language }}_sdk
     - name: Check worktree clean
-      run: ../ci-scripts/ci/check-worktree-is-clean
+      run: ./ci-scripts/ci/check-worktree-is-clean
     - run: git status --porcelain
     - name: Tar SDK folder
       run: tar -zcf sdk/${{ matrix.language }}.tar.gz -C sdk/${{ matrix.language }} .
@@ -206,7 +206,7 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
-    - run: mv ci-scripts ../ci-scripts
+    - run: echo "ci-scripts" >> .git/info/exclude
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -369,7 +369,7 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
-    - run: mv ci-scripts ../ci-scripts
+    - run: echo "ci-scripts" >> .git/info/exclude
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -423,7 +423,7 @@ jobs:
     - name: Install Twine
       run: python -m pip install pip twine
     - name: Publish SDKs
-      run: ../ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
+      run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
       env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         PYPI_PUBLISH_ARTIFACTS: all
@@ -449,7 +449,7 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
-    - run: mv ci-scripts ../ci-scripts
+    - run: echo "ci-scripts" >> .git/info/exclude
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/native-provider-ci/providers/command/repo/.github/workflows/prerelease.yml
+++ b/native-provider-ci/providers/command/repo/.github/workflows/prerelease.yml
@@ -47,8 +47,7 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
-      env:
-        GITHUB_WORKSPACE: ${{ runner.temp }}
+    - run: mv ci-scripts ../ci-scripts
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -67,7 +66,7 @@ jobs:
     - name: Build Provider
       run: make provider
     - name: Check worktree clean
-      run: ${{ runner.temp }}/ci-scripts/ci/check-worktree-is-clean
+      run: ../ci-scripts/ci/check-worktree-is-clean
     - run: git status --porcelain
     - name: Tar provider binaries
       run: tar -zcf ${{ github.workspace }}/bin/provider.tar.gz -C ${{
@@ -113,8 +112,7 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
-      env:
-        GITHUB_WORKSPACE: ${{ runner.temp }}
+    - run: mv ci-scripts ../ci-scripts
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -165,7 +163,7 @@ jobs:
     - name: Generate SDK
       run: make ${{ matrix.language }}_sdk
     - name: Check worktree clean
-      run: ${{ runner.temp }}/ci-scripts/ci/check-worktree-is-clean
+      run: ../ci-scripts/ci/check-worktree-is-clean
     - run: git status --porcelain
     - name: Tar SDK folder
       run: tar -zcf sdk/${{ matrix.language }}.tar.gz -C sdk/${{ matrix.language }} .
@@ -208,8 +206,7 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
-      env:
-        GITHUB_WORKSPACE: ${{ runner.temp }}
+    - run: mv ci-scripts ../ci-scripts
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -372,8 +369,7 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
-      env:
-        GITHUB_WORKSPACE: ${{ runner.temp }}
+    - run: mv ci-scripts ../ci-scripts
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -427,8 +423,7 @@ jobs:
     - name: Install Twine
       run: python -m pip install pip twine
     - name: Publish SDKs
-      run: ${{ runner.temp }}/ci-scripts/ci/publish-tfgen-package ${{ github.workspace
-        }}
+      run: ../ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
       env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         PYPI_PUBLISH_ARTIFACTS: all
@@ -454,8 +449,7 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
-      env:
-        GITHUB_WORKSPACE: ${{ runner.temp }}
+    - run: mv ci-scripts ../ci-scripts
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/native-provider-ci/providers/command/repo/.github/workflows/release.yml
+++ b/native-provider-ci/providers/command/repo/.github/workflows/release.yml
@@ -45,7 +45,7 @@ jobs:
     - name: Checkout Scripts Repo
       uses: actions/checkout@v4
       with:
-        path: ci-scripts
+        path: ../ci-scripts
         repository: pulumi/scripts
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
@@ -65,7 +65,7 @@ jobs:
     - name: Build Provider
       run: make provider
     - name: Check worktree clean
-      run: ./ci-scripts/ci/check-worktree-is-clean
+      run: ../ci-scripts/ci/check-worktree-is-clean
     - run: git status --porcelain
     - name: Tar provider binaries
       run: tar -zcf ${{ github.workspace }}/bin/provider.tar.gz -C ${{
@@ -109,7 +109,7 @@ jobs:
     - name: Checkout Scripts Repo
       uses: actions/checkout@v4
       with:
-        path: ci-scripts
+        path: ../ci-scripts
         repository: pulumi/scripts
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
@@ -161,7 +161,7 @@ jobs:
     - name: Generate SDK
       run: make ${{ matrix.language }}_sdk
     - name: Check worktree clean
-      run: ./ci-scripts/ci/check-worktree-is-clean
+      run: ../ci-scripts/ci/check-worktree-is-clean
     - run: git status --porcelain
     - name: Tar SDK folder
       run: tar -zcf sdk/${{ matrix.language }}.tar.gz -C sdk/${{ matrix.language }} .
@@ -202,7 +202,7 @@ jobs:
     - name: Checkout Scripts Repo
       uses: actions/checkout@v4
       with:
-        path: ci-scripts
+        path: ../ci-scripts
         repository: pulumi/scripts
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
@@ -364,7 +364,7 @@ jobs:
     - name: Checkout Scripts Repo
       uses: actions/checkout@v4
       with:
-        path: ci-scripts
+        path: ../ci-scripts
         repository: pulumi/scripts
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
@@ -419,7 +419,7 @@ jobs:
     - name: Install Twine
       run: python -m pip install pip twine
     - name: Publish SDKs
-      run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
+      run: ../ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
       env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         PYPI_PUBLISH_ARTIFACTS: all
@@ -443,7 +443,7 @@ jobs:
     - name: Checkout Scripts Repo
       uses: actions/checkout@v4
       with:
-        path: ci-scripts
+        path: ../ci-scripts
         repository: pulumi/scripts
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags

--- a/native-provider-ci/providers/command/repo/.github/workflows/release.yml
+++ b/native-provider-ci/providers/command/repo/.github/workflows/release.yml
@@ -45,7 +45,7 @@ jobs:
     - name: Checkout Scripts Repo
       uses: actions/checkout@v4
       with:
-        path: ../ci-scripts
+        path: ${{ runner.temp }}/ci-scripts
         repository: pulumi/scripts
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
@@ -65,7 +65,7 @@ jobs:
     - name: Build Provider
       run: make provider
     - name: Check worktree clean
-      run: ../ci-scripts/ci/check-worktree-is-clean
+      run: ${{ runner.temp }}/ci-scripts/ci/check-worktree-is-clean
     - run: git status --porcelain
     - name: Tar provider binaries
       run: tar -zcf ${{ github.workspace }}/bin/provider.tar.gz -C ${{
@@ -109,7 +109,7 @@ jobs:
     - name: Checkout Scripts Repo
       uses: actions/checkout@v4
       with:
-        path: ../ci-scripts
+        path: ${{ runner.temp }}/ci-scripts
         repository: pulumi/scripts
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
@@ -161,7 +161,7 @@ jobs:
     - name: Generate SDK
       run: make ${{ matrix.language }}_sdk
     - name: Check worktree clean
-      run: ../ci-scripts/ci/check-worktree-is-clean
+      run: ${{ runner.temp }}/ci-scripts/ci/check-worktree-is-clean
     - run: git status --porcelain
     - name: Tar SDK folder
       run: tar -zcf sdk/${{ matrix.language }}.tar.gz -C sdk/${{ matrix.language }} .
@@ -202,7 +202,7 @@ jobs:
     - name: Checkout Scripts Repo
       uses: actions/checkout@v4
       with:
-        path: ../ci-scripts
+        path: ${{ runner.temp }}/ci-scripts
         repository: pulumi/scripts
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
@@ -364,7 +364,7 @@ jobs:
     - name: Checkout Scripts Repo
       uses: actions/checkout@v4
       with:
-        path: ../ci-scripts
+        path: ${{ runner.temp }}/ci-scripts
         repository: pulumi/scripts
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
@@ -419,7 +419,8 @@ jobs:
     - name: Install Twine
       run: python -m pip install pip twine
     - name: Publish SDKs
-      run: ../ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
+      run: ${{ runner.temp }}/ci-scripts/ci/publish-tfgen-package ${{ github.workspace
+        }}
       env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         PYPI_PUBLISH_ARTIFACTS: all
@@ -443,7 +444,7 @@ jobs:
     - name: Checkout Scripts Repo
       uses: actions/checkout@v4
       with:
-        path: ../ci-scripts
+        path: ${{ runner.temp }}/ci-scripts
         repository: pulumi/scripts
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags

--- a/native-provider-ci/providers/command/repo/.github/workflows/release.yml
+++ b/native-provider-ci/providers/command/repo/.github/workflows/release.yml
@@ -45,8 +45,10 @@ jobs:
     - name: Checkout Scripts Repo
       uses: actions/checkout@v4
       with:
-        path: ${{ runner.temp }}/ci-scripts
+        path: ci-scripts
         repository: pulumi/scripts
+      env:
+        GITHUB_WORKSPACE: ${{ runner.temp }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -109,8 +111,10 @@ jobs:
     - name: Checkout Scripts Repo
       uses: actions/checkout@v4
       with:
-        path: ${{ runner.temp }}/ci-scripts
+        path: ci-scripts
         repository: pulumi/scripts
+      env:
+        GITHUB_WORKSPACE: ${{ runner.temp }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -202,8 +206,10 @@ jobs:
     - name: Checkout Scripts Repo
       uses: actions/checkout@v4
       with:
-        path: ${{ runner.temp }}/ci-scripts
+        path: ci-scripts
         repository: pulumi/scripts
+      env:
+        GITHUB_WORKSPACE: ${{ runner.temp }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -364,8 +370,10 @@ jobs:
     - name: Checkout Scripts Repo
       uses: actions/checkout@v4
       with:
-        path: ${{ runner.temp }}/ci-scripts
+        path: ci-scripts
         repository: pulumi/scripts
+      env:
+        GITHUB_WORKSPACE: ${{ runner.temp }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -444,8 +452,10 @@ jobs:
     - name: Checkout Scripts Repo
       uses: actions/checkout@v4
       with:
-        path: ${{ runner.temp }}/ci-scripts
+        path: ci-scripts
         repository: pulumi/scripts
+      env:
+        GITHUB_WORKSPACE: ${{ runner.temp }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/native-provider-ci/providers/command/repo/.github/workflows/release.yml
+++ b/native-provider-ci/providers/command/repo/.github/workflows/release.yml
@@ -47,7 +47,7 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
-    - run: mv ci-scripts ../ci-scripts
+    - run: echo "ci-scripts" >> .git/info/exclude
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -66,7 +66,7 @@ jobs:
     - name: Build Provider
       run: make provider
     - name: Check worktree clean
-      run: ../ci-scripts/ci/check-worktree-is-clean
+      run: ./ci-scripts/ci/check-worktree-is-clean
     - run: git status --porcelain
     - name: Tar provider binaries
       run: tar -zcf ${{ github.workspace }}/bin/provider.tar.gz -C ${{
@@ -112,7 +112,7 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
-    - run: mv ci-scripts ../ci-scripts
+    - run: echo "ci-scripts" >> .git/info/exclude
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -163,7 +163,7 @@ jobs:
     - name: Generate SDK
       run: make ${{ matrix.language }}_sdk
     - name: Check worktree clean
-      run: ../ci-scripts/ci/check-worktree-is-clean
+      run: ./ci-scripts/ci/check-worktree-is-clean
     - run: git status --porcelain
     - name: Tar SDK folder
       run: tar -zcf sdk/${{ matrix.language }}.tar.gz -C sdk/${{ matrix.language }} .
@@ -206,7 +206,7 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
-    - run: mv ci-scripts ../ci-scripts
+    - run: echo "ci-scripts" >> .git/info/exclude
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -369,7 +369,7 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
-    - run: mv ci-scripts ../ci-scripts
+    - run: echo "ci-scripts" >> .git/info/exclude
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -423,7 +423,7 @@ jobs:
     - name: Install Twine
       run: python -m pip install pip twine
     - name: Publish SDKs
-      run: ../ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
+      run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
       env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         PYPI_PUBLISH_ARTIFACTS: all
@@ -449,7 +449,7 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
-    - run: mv ci-scripts ../ci-scripts
+    - run: echo "ci-scripts" >> .git/info/exclude
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/native-provider-ci/providers/command/repo/.github/workflows/release.yml
+++ b/native-provider-ci/providers/command/repo/.github/workflows/release.yml
@@ -47,8 +47,7 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
-      env:
-        GITHUB_WORKSPACE: ${{ runner.temp }}
+    - run: mv ci-scripts ../ci-scripts
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -67,7 +66,7 @@ jobs:
     - name: Build Provider
       run: make provider
     - name: Check worktree clean
-      run: ${{ runner.temp }}/ci-scripts/ci/check-worktree-is-clean
+      run: ../ci-scripts/ci/check-worktree-is-clean
     - run: git status --porcelain
     - name: Tar provider binaries
       run: tar -zcf ${{ github.workspace }}/bin/provider.tar.gz -C ${{
@@ -113,8 +112,7 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
-      env:
-        GITHUB_WORKSPACE: ${{ runner.temp }}
+    - run: mv ci-scripts ../ci-scripts
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -165,7 +163,7 @@ jobs:
     - name: Generate SDK
       run: make ${{ matrix.language }}_sdk
     - name: Check worktree clean
-      run: ${{ runner.temp }}/ci-scripts/ci/check-worktree-is-clean
+      run: ../ci-scripts/ci/check-worktree-is-clean
     - run: git status --porcelain
     - name: Tar SDK folder
       run: tar -zcf sdk/${{ matrix.language }}.tar.gz -C sdk/${{ matrix.language }} .
@@ -208,8 +206,7 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
-      env:
-        GITHUB_WORKSPACE: ${{ runner.temp }}
+    - run: mv ci-scripts ../ci-scripts
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -372,8 +369,7 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
-      env:
-        GITHUB_WORKSPACE: ${{ runner.temp }}
+    - run: mv ci-scripts ../ci-scripts
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -427,8 +423,7 @@ jobs:
     - name: Install Twine
       run: python -m pip install pip twine
     - name: Publish SDKs
-      run: ${{ runner.temp }}/ci-scripts/ci/publish-tfgen-package ${{ github.workspace
-        }}
+      run: ../ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
       env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         PYPI_PUBLISH_ARTIFACTS: all
@@ -454,8 +449,7 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
-      env:
-        GITHUB_WORKSPACE: ${{ runner.temp }}
+    - run: mv ci-scripts ../ci-scripts
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/native-provider-ci/providers/command/repo/.github/workflows/run-acceptance-tests.yml
+++ b/native-provider-ci/providers/command/repo/.github/workflows/run-acceptance-tests.yml
@@ -70,7 +70,7 @@ jobs:
     - name: Checkout Scripts Repo
       uses: actions/checkout@v4
       with:
-        path: ../ci-scripts
+        path: ${{ runner.temp }}/ci-scripts
         repository: pulumi/scripts
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
@@ -90,7 +90,7 @@ jobs:
     - name: Build Provider
       run: make provider
     - name: Check worktree clean
-      run: ../ci-scripts/ci/check-worktree-is-clean
+      run: ${{ runner.temp }}/ci-scripts/ci/check-worktree-is-clean
     - run: git status --porcelain
     - name: Tar provider binaries
       run: tar -zcf ${{ github.workspace }}/bin/provider.tar.gz -C ${{
@@ -137,7 +137,7 @@ jobs:
     - name: Checkout Scripts Repo
       uses: actions/checkout@v4
       with:
-        path: ../ci-scripts
+        path: ${{ runner.temp }}/ci-scripts
         repository: pulumi/scripts
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
@@ -189,7 +189,7 @@ jobs:
     - name: Generate SDK
       run: make ${{ matrix.language }}_sdk
     - name: Check worktree clean
-      run: ../ci-scripts/ci/check-worktree-is-clean
+      run: ${{ runner.temp }}/ci-scripts/ci/check-worktree-is-clean
     - run: git status --porcelain
     - name: Tar SDK folder
       run: tar -zcf sdk/${{ matrix.language }}.tar.gz -C sdk/${{ matrix.language }} .
@@ -234,7 +234,7 @@ jobs:
     - name: Checkout Scripts Repo
       uses: actions/checkout@v4
       with:
-        path: ../ci-scripts
+        path: ${{ runner.temp }}/ci-scripts
         repository: pulumi/scripts
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags

--- a/native-provider-ci/providers/command/repo/.github/workflows/run-acceptance-tests.yml
+++ b/native-provider-ci/providers/command/repo/.github/workflows/run-acceptance-tests.yml
@@ -70,7 +70,7 @@ jobs:
     - name: Checkout Scripts Repo
       uses: actions/checkout@v4
       with:
-        path: ci-scripts
+        path: ../ci-scripts
         repository: pulumi/scripts
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
@@ -90,7 +90,7 @@ jobs:
     - name: Build Provider
       run: make provider
     - name: Check worktree clean
-      run: ./ci-scripts/ci/check-worktree-is-clean
+      run: ../ci-scripts/ci/check-worktree-is-clean
     - run: git status --porcelain
     - name: Tar provider binaries
       run: tar -zcf ${{ github.workspace }}/bin/provider.tar.gz -C ${{
@@ -137,7 +137,7 @@ jobs:
     - name: Checkout Scripts Repo
       uses: actions/checkout@v4
       with:
-        path: ci-scripts
+        path: ../ci-scripts
         repository: pulumi/scripts
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
@@ -189,7 +189,7 @@ jobs:
     - name: Generate SDK
       run: make ${{ matrix.language }}_sdk
     - name: Check worktree clean
-      run: ./ci-scripts/ci/check-worktree-is-clean
+      run: ../ci-scripts/ci/check-worktree-is-clean
     - run: git status --porcelain
     - name: Tar SDK folder
       run: tar -zcf sdk/${{ matrix.language }}.tar.gz -C sdk/${{ matrix.language }} .
@@ -234,7 +234,7 @@ jobs:
     - name: Checkout Scripts Repo
       uses: actions/checkout@v4
       with:
-        path: ci-scripts
+        path: ../ci-scripts
         repository: pulumi/scripts
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags

--- a/native-provider-ci/providers/command/repo/.github/workflows/run-acceptance-tests.yml
+++ b/native-provider-ci/providers/command/repo/.github/workflows/run-acceptance-tests.yml
@@ -72,7 +72,7 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
-    - run: mv ci-scripts ../ci-scripts
+    - run: echo "ci-scripts" >> .git/info/exclude
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -91,7 +91,7 @@ jobs:
     - name: Build Provider
       run: make provider
     - name: Check worktree clean
-      run: ../ci-scripts/ci/check-worktree-is-clean
+      run: ./ci-scripts/ci/check-worktree-is-clean
     - run: git status --porcelain
     - name: Tar provider binaries
       run: tar -zcf ${{ github.workspace }}/bin/provider.tar.gz -C ${{
@@ -140,7 +140,7 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
-    - run: mv ci-scripts ../ci-scripts
+    - run: echo "ci-scripts" >> .git/info/exclude
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -191,7 +191,7 @@ jobs:
     - name: Generate SDK
       run: make ${{ matrix.language }}_sdk
     - name: Check worktree clean
-      run: ../ci-scripts/ci/check-worktree-is-clean
+      run: ./ci-scripts/ci/check-worktree-is-clean
     - run: git status --porcelain
     - name: Tar SDK folder
       run: tar -zcf sdk/${{ matrix.language }}.tar.gz -C sdk/${{ matrix.language }} .
@@ -238,7 +238,7 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
-    - run: mv ci-scripts ../ci-scripts
+    - run: echo "ci-scripts" >> .git/info/exclude
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/native-provider-ci/providers/command/repo/.github/workflows/run-acceptance-tests.yml
+++ b/native-provider-ci/providers/command/repo/.github/workflows/run-acceptance-tests.yml
@@ -70,8 +70,10 @@ jobs:
     - name: Checkout Scripts Repo
       uses: actions/checkout@v4
       with:
-        path: ${{ runner.temp }}/ci-scripts
+        path: ci-scripts
         repository: pulumi/scripts
+      env:
+        GITHUB_WORKSPACE: ${{ runner.temp }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -137,8 +139,10 @@ jobs:
     - name: Checkout Scripts Repo
       uses: actions/checkout@v4
       with:
-        path: ${{ runner.temp }}/ci-scripts
+        path: ci-scripts
         repository: pulumi/scripts
+      env:
+        GITHUB_WORKSPACE: ${{ runner.temp }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -234,8 +238,10 @@ jobs:
     - name: Checkout Scripts Repo
       uses: actions/checkout@v4
       with:
-        path: ${{ runner.temp }}/ci-scripts
+        path: ci-scripts
         repository: pulumi/scripts
+      env:
+        GITHUB_WORKSPACE: ${{ runner.temp }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/native-provider-ci/providers/command/repo/.github/workflows/run-acceptance-tests.yml
+++ b/native-provider-ci/providers/command/repo/.github/workflows/run-acceptance-tests.yml
@@ -72,8 +72,7 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
-      env:
-        GITHUB_WORKSPACE: ${{ runner.temp }}
+    - run: mv ci-scripts ../ci-scripts
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -92,7 +91,7 @@ jobs:
     - name: Build Provider
       run: make provider
     - name: Check worktree clean
-      run: ${{ runner.temp }}/ci-scripts/ci/check-worktree-is-clean
+      run: ../ci-scripts/ci/check-worktree-is-clean
     - run: git status --porcelain
     - name: Tar provider binaries
       run: tar -zcf ${{ github.workspace }}/bin/provider.tar.gz -C ${{
@@ -141,8 +140,7 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
-      env:
-        GITHUB_WORKSPACE: ${{ runner.temp }}
+    - run: mv ci-scripts ../ci-scripts
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -193,7 +191,7 @@ jobs:
     - name: Generate SDK
       run: make ${{ matrix.language }}_sdk
     - name: Check worktree clean
-      run: ${{ runner.temp }}/ci-scripts/ci/check-worktree-is-clean
+      run: ../ci-scripts/ci/check-worktree-is-clean
     - run: git status --porcelain
     - name: Tar SDK folder
       run: tar -zcf sdk/${{ matrix.language }}.tar.gz -C sdk/${{ matrix.language }} .
@@ -240,8 +238,7 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
-      env:
-        GITHUB_WORKSPACE: ${{ runner.temp }}
+    - run: mv ci-scripts ../ci-scripts
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/native-provider-ci/providers/docker-build/repo/.github/workflows/build.yml
+++ b/native-provider-ci/providers/docker-build/repo/.github/workflows/build.yml
@@ -67,8 +67,10 @@ jobs:
     - name: Checkout Scripts Repo
       uses: actions/checkout@v4
       with:
-        path: ${{ runner.temp }}/ci-scripts
+        path: ci-scripts
         repository: pulumi/scripts
+      env:
+        GITHUB_WORKSPACE: ${{ runner.temp }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -165,8 +167,10 @@ jobs:
     - name: Checkout Scripts Repo
       uses: actions/checkout@v4
       with:
-        path: ${{ runner.temp }}/ci-scripts
+        path: ci-scripts
         repository: pulumi/scripts
+      env:
+        GITHUB_WORKSPACE: ${{ runner.temp }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -261,8 +265,10 @@ jobs:
     - name: Checkout Scripts Repo
       uses: actions/checkout@v4
       with:
-        path: ${{ runner.temp }}/ci-scripts
+        path: ci-scripts
         repository: pulumi/scripts
+      env:
+        GITHUB_WORKSPACE: ${{ runner.temp }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -435,8 +441,10 @@ jobs:
     - name: Checkout Scripts Repo
       uses: actions/checkout@v4
       with:
-        path: ${{ runner.temp }}/ci-scripts
+        path: ci-scripts
         repository: pulumi/scripts
+      env:
+        GITHUB_WORKSPACE: ${{ runner.temp }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -515,8 +523,10 @@ jobs:
     - name: Checkout Scripts Repo
       uses: actions/checkout@v4
       with:
-        path: ${{ runner.temp }}/ci-scripts
+        path: ci-scripts
         repository: pulumi/scripts
+      env:
+        GITHUB_WORKSPACE: ${{ runner.temp }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/native-provider-ci/providers/docker-build/repo/.github/workflows/build.yml
+++ b/native-provider-ci/providers/docker-build/repo/.github/workflows/build.yml
@@ -67,7 +67,7 @@ jobs:
     - name: Checkout Scripts Repo
       uses: actions/checkout@v4
       with:
-        path: ../ci-scripts
+        path: ${{ runner.temp }}/ci-scripts
         repository: pulumi/scripts
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
@@ -120,7 +120,7 @@ jobs:
     - name: Build Provider
       run: make provider
     - name: Check worktree clean
-      run: ../ci-scripts/ci/check-worktree-is-clean
+      run: ${{ runner.temp }}/ci-scripts/ci/check-worktree-is-clean
     - run: git status --porcelain
     - name: Tar provider binaries
       run: tar -zcf ${{ github.workspace }}/bin/provider.tar.gz -C ${{
@@ -165,7 +165,7 @@ jobs:
     - name: Checkout Scripts Repo
       uses: actions/checkout@v4
       with:
-        path: ../ci-scripts
+        path: ${{ runner.temp }}/ci-scripts
         repository: pulumi/scripts
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
@@ -219,7 +219,7 @@ jobs:
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
-      run: ../ci-scripts/ci/check-worktree-is-clean
+      run: ${{ runner.temp }}/ci-scripts/ci/check-worktree-is-clean
     - run: git status --porcelain
     - name: Tar SDK folder
       run: tar -zcf sdk/${{ matrix.language }}.tar.gz -C sdk/${{ matrix.language }} .
@@ -261,7 +261,7 @@ jobs:
     - name: Checkout Scripts Repo
       uses: actions/checkout@v4
       with:
-        path: ../ci-scripts
+        path: ${{ runner.temp }}/ci-scripts
         repository: pulumi/scripts
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
@@ -435,7 +435,7 @@ jobs:
     - name: Checkout Scripts Repo
       uses: actions/checkout@v4
       with:
-        path: ../ci-scripts
+        path: ${{ runner.temp }}/ci-scripts
         repository: pulumi/scripts
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
@@ -490,7 +490,8 @@ jobs:
     - name: Install Twine
       run: python -m pip install pip twine
     - name: Publish SDKs
-      run: ../ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
+      run: ${{ runner.temp }}/ci-scripts/ci/publish-tfgen-package ${{ github.workspace
+        }}
       env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         PYPI_PUBLISH_ARTIFACTS: all
@@ -514,7 +515,7 @@ jobs:
     - name: Checkout Scripts Repo
       uses: actions/checkout@v4
       with:
-        path: ../ci-scripts
+        path: ${{ runner.temp }}/ci-scripts
         repository: pulumi/scripts
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags

--- a/native-provider-ci/providers/docker-build/repo/.github/workflows/build.yml
+++ b/native-provider-ci/providers/docker-build/repo/.github/workflows/build.yml
@@ -69,7 +69,7 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
-    - run: mv ci-scripts ../ci-scripts
+    - run: echo "ci-scripts" >> .git/info/exclude
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -121,7 +121,7 @@ jobs:
     - name: Build Provider
       run: make provider
     - name: Check worktree clean
-      run: ../ci-scripts/ci/check-worktree-is-clean
+      run: ./ci-scripts/ci/check-worktree-is-clean
     - run: git status --porcelain
     - name: Tar provider binaries
       run: tar -zcf ${{ github.workspace }}/bin/provider.tar.gz -C ${{
@@ -168,7 +168,7 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
-    - run: mv ci-scripts ../ci-scripts
+    - run: echo "ci-scripts" >> .git/info/exclude
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -221,7 +221,7 @@ jobs:
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
-      run: ../ci-scripts/ci/check-worktree-is-clean
+      run: ./ci-scripts/ci/check-worktree-is-clean
     - run: git status --porcelain
     - name: Tar SDK folder
       run: tar -zcf sdk/${{ matrix.language }}.tar.gz -C sdk/${{ matrix.language }} .
@@ -265,7 +265,7 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
-    - run: mv ci-scripts ../ci-scripts
+    - run: echo "ci-scripts" >> .git/info/exclude
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -440,7 +440,7 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
-    - run: mv ci-scripts ../ci-scripts
+    - run: echo "ci-scripts" >> .git/info/exclude
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -494,7 +494,7 @@ jobs:
     - name: Install Twine
       run: python -m pip install pip twine
     - name: Publish SDKs
-      run: ../ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
+      run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
       env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         PYPI_PUBLISH_ARTIFACTS: all
@@ -520,7 +520,7 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
-    - run: mv ci-scripts ../ci-scripts
+    - run: echo "ci-scripts" >> .git/info/exclude
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/native-provider-ci/providers/docker-build/repo/.github/workflows/build.yml
+++ b/native-provider-ci/providers/docker-build/repo/.github/workflows/build.yml
@@ -67,7 +67,7 @@ jobs:
     - name: Checkout Scripts Repo
       uses: actions/checkout@v4
       with:
-        path: ci-scripts
+        path: ../ci-scripts
         repository: pulumi/scripts
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
@@ -120,7 +120,7 @@ jobs:
     - name: Build Provider
       run: make provider
     - name: Check worktree clean
-      run: ./ci-scripts/ci/check-worktree-is-clean
+      run: ../ci-scripts/ci/check-worktree-is-clean
     - run: git status --porcelain
     - name: Tar provider binaries
       run: tar -zcf ${{ github.workspace }}/bin/provider.tar.gz -C ${{
@@ -165,7 +165,7 @@ jobs:
     - name: Checkout Scripts Repo
       uses: actions/checkout@v4
       with:
-        path: ci-scripts
+        path: ../ci-scripts
         repository: pulumi/scripts
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
@@ -219,7 +219,7 @@ jobs:
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
-      run: ./ci-scripts/ci/check-worktree-is-clean
+      run: ../ci-scripts/ci/check-worktree-is-clean
     - run: git status --porcelain
     - name: Tar SDK folder
       run: tar -zcf sdk/${{ matrix.language }}.tar.gz -C sdk/${{ matrix.language }} .
@@ -261,7 +261,7 @@ jobs:
     - name: Checkout Scripts Repo
       uses: actions/checkout@v4
       with:
-        path: ci-scripts
+        path: ../ci-scripts
         repository: pulumi/scripts
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
@@ -435,7 +435,7 @@ jobs:
     - name: Checkout Scripts Repo
       uses: actions/checkout@v4
       with:
-        path: ci-scripts
+        path: ../ci-scripts
         repository: pulumi/scripts
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
@@ -490,7 +490,7 @@ jobs:
     - name: Install Twine
       run: python -m pip install pip twine
     - name: Publish SDKs
-      run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
+      run: ../ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
       env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         PYPI_PUBLISH_ARTIFACTS: all
@@ -514,7 +514,7 @@ jobs:
     - name: Checkout Scripts Repo
       uses: actions/checkout@v4
       with:
-        path: ci-scripts
+        path: ../ci-scripts
         repository: pulumi/scripts
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags

--- a/native-provider-ci/providers/docker-build/repo/.github/workflows/build.yml
+++ b/native-provider-ci/providers/docker-build/repo/.github/workflows/build.yml
@@ -69,8 +69,7 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
-      env:
-        GITHUB_WORKSPACE: ${{ runner.temp }}
+    - run: mv ci-scripts ../ci-scripts
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -122,7 +121,7 @@ jobs:
     - name: Build Provider
       run: make provider
     - name: Check worktree clean
-      run: ${{ runner.temp }}/ci-scripts/ci/check-worktree-is-clean
+      run: ../ci-scripts/ci/check-worktree-is-clean
     - run: git status --porcelain
     - name: Tar provider binaries
       run: tar -zcf ${{ github.workspace }}/bin/provider.tar.gz -C ${{
@@ -169,8 +168,7 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
-      env:
-        GITHUB_WORKSPACE: ${{ runner.temp }}
+    - run: mv ci-scripts ../ci-scripts
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -223,7 +221,7 @@ jobs:
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
-      run: ${{ runner.temp }}/ci-scripts/ci/check-worktree-is-clean
+      run: ../ci-scripts/ci/check-worktree-is-clean
     - run: git status --porcelain
     - name: Tar SDK folder
       run: tar -zcf sdk/${{ matrix.language }}.tar.gz -C sdk/${{ matrix.language }} .
@@ -267,8 +265,7 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
-      env:
-        GITHUB_WORKSPACE: ${{ runner.temp }}
+    - run: mv ci-scripts ../ci-scripts
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -443,8 +440,7 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
-      env:
-        GITHUB_WORKSPACE: ${{ runner.temp }}
+    - run: mv ci-scripts ../ci-scripts
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -498,8 +494,7 @@ jobs:
     - name: Install Twine
       run: python -m pip install pip twine
     - name: Publish SDKs
-      run: ${{ runner.temp }}/ci-scripts/ci/publish-tfgen-package ${{ github.workspace
-        }}
+      run: ../ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
       env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         PYPI_PUBLISH_ARTIFACTS: all
@@ -525,8 +520,7 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
-      env:
-        GITHUB_WORKSPACE: ${{ runner.temp }}
+    - run: mv ci-scripts ../ci-scripts
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/native-provider-ci/providers/docker-build/repo/.github/workflows/prerelease.yml
+++ b/native-provider-ci/providers/docker-build/repo/.github/workflows/prerelease.yml
@@ -59,7 +59,7 @@ jobs:
     - name: Checkout Scripts Repo
       uses: actions/checkout@v4
       with:
-        path: ci-scripts
+        path: ../ci-scripts
         repository: pulumi/scripts
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
@@ -112,7 +112,7 @@ jobs:
     - name: Build Provider
       run: make provider
     - name: Check worktree clean
-      run: ./ci-scripts/ci/check-worktree-is-clean
+      run: ../ci-scripts/ci/check-worktree-is-clean
     - run: git status --porcelain
     - name: Tar provider binaries
       run: tar -zcf ${{ github.workspace }}/bin/provider.tar.gz -C ${{
@@ -157,7 +157,7 @@ jobs:
     - name: Checkout Scripts Repo
       uses: actions/checkout@v4
       with:
-        path: ci-scripts
+        path: ../ci-scripts
         repository: pulumi/scripts
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
@@ -211,7 +211,7 @@ jobs:
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
-      run: ./ci-scripts/ci/check-worktree-is-clean
+      run: ../ci-scripts/ci/check-worktree-is-clean
     - run: git status --porcelain
     - name: Tar SDK folder
       run: tar -zcf sdk/${{ matrix.language }}.tar.gz -C sdk/${{ matrix.language }} .
@@ -252,7 +252,7 @@ jobs:
     - name: Checkout Scripts Repo
       uses: actions/checkout@v4
       with:
-        path: ci-scripts
+        path: ../ci-scripts
         repository: pulumi/scripts
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
@@ -426,7 +426,7 @@ jobs:
     - name: Checkout Scripts Repo
       uses: actions/checkout@v4
       with:
-        path: ci-scripts
+        path: ../ci-scripts
         repository: pulumi/scripts
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
@@ -481,7 +481,7 @@ jobs:
     - name: Install Twine
       run: python -m pip install pip twine
     - name: Publish SDKs
-      run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
+      run: ../ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
       env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         PYPI_PUBLISH_ARTIFACTS: all
@@ -505,7 +505,7 @@ jobs:
     - name: Checkout Scripts Repo
       uses: actions/checkout@v4
       with:
-        path: ci-scripts
+        path: ../ci-scripts
         repository: pulumi/scripts
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags

--- a/native-provider-ci/providers/docker-build/repo/.github/workflows/prerelease.yml
+++ b/native-provider-ci/providers/docker-build/repo/.github/workflows/prerelease.yml
@@ -59,7 +59,7 @@ jobs:
     - name: Checkout Scripts Repo
       uses: actions/checkout@v4
       with:
-        path: ../ci-scripts
+        path: ${{ runner.temp }}/ci-scripts
         repository: pulumi/scripts
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
@@ -112,7 +112,7 @@ jobs:
     - name: Build Provider
       run: make provider
     - name: Check worktree clean
-      run: ../ci-scripts/ci/check-worktree-is-clean
+      run: ${{ runner.temp }}/ci-scripts/ci/check-worktree-is-clean
     - run: git status --porcelain
     - name: Tar provider binaries
       run: tar -zcf ${{ github.workspace }}/bin/provider.tar.gz -C ${{
@@ -157,7 +157,7 @@ jobs:
     - name: Checkout Scripts Repo
       uses: actions/checkout@v4
       with:
-        path: ../ci-scripts
+        path: ${{ runner.temp }}/ci-scripts
         repository: pulumi/scripts
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
@@ -211,7 +211,7 @@ jobs:
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
-      run: ../ci-scripts/ci/check-worktree-is-clean
+      run: ${{ runner.temp }}/ci-scripts/ci/check-worktree-is-clean
     - run: git status --porcelain
     - name: Tar SDK folder
       run: tar -zcf sdk/${{ matrix.language }}.tar.gz -C sdk/${{ matrix.language }} .
@@ -252,7 +252,7 @@ jobs:
     - name: Checkout Scripts Repo
       uses: actions/checkout@v4
       with:
-        path: ../ci-scripts
+        path: ${{ runner.temp }}/ci-scripts
         repository: pulumi/scripts
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
@@ -426,7 +426,7 @@ jobs:
     - name: Checkout Scripts Repo
       uses: actions/checkout@v4
       with:
-        path: ../ci-scripts
+        path: ${{ runner.temp }}/ci-scripts
         repository: pulumi/scripts
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
@@ -481,7 +481,8 @@ jobs:
     - name: Install Twine
       run: python -m pip install pip twine
     - name: Publish SDKs
-      run: ../ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
+      run: ${{ runner.temp }}/ci-scripts/ci/publish-tfgen-package ${{ github.workspace
+        }}
       env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         PYPI_PUBLISH_ARTIFACTS: all
@@ -505,7 +506,7 @@ jobs:
     - name: Checkout Scripts Repo
       uses: actions/checkout@v4
       with:
-        path: ../ci-scripts
+        path: ${{ runner.temp }}/ci-scripts
         repository: pulumi/scripts
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags

--- a/native-provider-ci/providers/docker-build/repo/.github/workflows/prerelease.yml
+++ b/native-provider-ci/providers/docker-build/repo/.github/workflows/prerelease.yml
@@ -61,7 +61,7 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
-    - run: mv ci-scripts ../ci-scripts
+    - run: echo "ci-scripts" >> .git/info/exclude
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -113,7 +113,7 @@ jobs:
     - name: Build Provider
       run: make provider
     - name: Check worktree clean
-      run: ../ci-scripts/ci/check-worktree-is-clean
+      run: ./ci-scripts/ci/check-worktree-is-clean
     - run: git status --porcelain
     - name: Tar provider binaries
       run: tar -zcf ${{ github.workspace }}/bin/provider.tar.gz -C ${{
@@ -160,7 +160,7 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
-    - run: mv ci-scripts ../ci-scripts
+    - run: echo "ci-scripts" >> .git/info/exclude
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -213,7 +213,7 @@ jobs:
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
-      run: ../ci-scripts/ci/check-worktree-is-clean
+      run: ./ci-scripts/ci/check-worktree-is-clean
     - run: git status --porcelain
     - name: Tar SDK folder
       run: tar -zcf sdk/${{ matrix.language }}.tar.gz -C sdk/${{ matrix.language }} .
@@ -256,7 +256,7 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
-    - run: mv ci-scripts ../ci-scripts
+    - run: echo "ci-scripts" >> .git/info/exclude
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -431,7 +431,7 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
-    - run: mv ci-scripts ../ci-scripts
+    - run: echo "ci-scripts" >> .git/info/exclude
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -485,7 +485,7 @@ jobs:
     - name: Install Twine
       run: python -m pip install pip twine
     - name: Publish SDKs
-      run: ../ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
+      run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
       env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         PYPI_PUBLISH_ARTIFACTS: all
@@ -511,7 +511,7 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
-    - run: mv ci-scripts ../ci-scripts
+    - run: echo "ci-scripts" >> .git/info/exclude
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/native-provider-ci/providers/docker-build/repo/.github/workflows/prerelease.yml
+++ b/native-provider-ci/providers/docker-build/repo/.github/workflows/prerelease.yml
@@ -61,8 +61,7 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
-      env:
-        GITHUB_WORKSPACE: ${{ runner.temp }}
+    - run: mv ci-scripts ../ci-scripts
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -114,7 +113,7 @@ jobs:
     - name: Build Provider
       run: make provider
     - name: Check worktree clean
-      run: ${{ runner.temp }}/ci-scripts/ci/check-worktree-is-clean
+      run: ../ci-scripts/ci/check-worktree-is-clean
     - run: git status --porcelain
     - name: Tar provider binaries
       run: tar -zcf ${{ github.workspace }}/bin/provider.tar.gz -C ${{
@@ -161,8 +160,7 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
-      env:
-        GITHUB_WORKSPACE: ${{ runner.temp }}
+    - run: mv ci-scripts ../ci-scripts
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -215,7 +213,7 @@ jobs:
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
-      run: ${{ runner.temp }}/ci-scripts/ci/check-worktree-is-clean
+      run: ../ci-scripts/ci/check-worktree-is-clean
     - run: git status --porcelain
     - name: Tar SDK folder
       run: tar -zcf sdk/${{ matrix.language }}.tar.gz -C sdk/${{ matrix.language }} .
@@ -258,8 +256,7 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
-      env:
-        GITHUB_WORKSPACE: ${{ runner.temp }}
+    - run: mv ci-scripts ../ci-scripts
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -434,8 +431,7 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
-      env:
-        GITHUB_WORKSPACE: ${{ runner.temp }}
+    - run: mv ci-scripts ../ci-scripts
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -489,8 +485,7 @@ jobs:
     - name: Install Twine
       run: python -m pip install pip twine
     - name: Publish SDKs
-      run: ${{ runner.temp }}/ci-scripts/ci/publish-tfgen-package ${{ github.workspace
-        }}
+      run: ../ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
       env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         PYPI_PUBLISH_ARTIFACTS: all
@@ -516,8 +511,7 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
-      env:
-        GITHUB_WORKSPACE: ${{ runner.temp }}
+    - run: mv ci-scripts ../ci-scripts
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/native-provider-ci/providers/docker-build/repo/.github/workflows/prerelease.yml
+++ b/native-provider-ci/providers/docker-build/repo/.github/workflows/prerelease.yml
@@ -59,8 +59,10 @@ jobs:
     - name: Checkout Scripts Repo
       uses: actions/checkout@v4
       with:
-        path: ${{ runner.temp }}/ci-scripts
+        path: ci-scripts
         repository: pulumi/scripts
+      env:
+        GITHUB_WORKSPACE: ${{ runner.temp }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -157,8 +159,10 @@ jobs:
     - name: Checkout Scripts Repo
       uses: actions/checkout@v4
       with:
-        path: ${{ runner.temp }}/ci-scripts
+        path: ci-scripts
         repository: pulumi/scripts
+      env:
+        GITHUB_WORKSPACE: ${{ runner.temp }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -252,8 +256,10 @@ jobs:
     - name: Checkout Scripts Repo
       uses: actions/checkout@v4
       with:
-        path: ${{ runner.temp }}/ci-scripts
+        path: ci-scripts
         repository: pulumi/scripts
+      env:
+        GITHUB_WORKSPACE: ${{ runner.temp }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -426,8 +432,10 @@ jobs:
     - name: Checkout Scripts Repo
       uses: actions/checkout@v4
       with:
-        path: ${{ runner.temp }}/ci-scripts
+        path: ci-scripts
         repository: pulumi/scripts
+      env:
+        GITHUB_WORKSPACE: ${{ runner.temp }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -506,8 +514,10 @@ jobs:
     - name: Checkout Scripts Repo
       uses: actions/checkout@v4
       with:
-        path: ${{ runner.temp }}/ci-scripts
+        path: ci-scripts
         repository: pulumi/scripts
+      env:
+        GITHUB_WORKSPACE: ${{ runner.temp }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/native-provider-ci/providers/docker-build/repo/.github/workflows/release.yml
+++ b/native-provider-ci/providers/docker-build/repo/.github/workflows/release.yml
@@ -59,7 +59,7 @@ jobs:
     - name: Checkout Scripts Repo
       uses: actions/checkout@v4
       with:
-        path: ci-scripts
+        path: ../ci-scripts
         repository: pulumi/scripts
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
@@ -112,7 +112,7 @@ jobs:
     - name: Build Provider
       run: make provider
     - name: Check worktree clean
-      run: ./ci-scripts/ci/check-worktree-is-clean
+      run: ../ci-scripts/ci/check-worktree-is-clean
     - run: git status --porcelain
     - name: Tar provider binaries
       run: tar -zcf ${{ github.workspace }}/bin/provider.tar.gz -C ${{
@@ -157,7 +157,7 @@ jobs:
     - name: Checkout Scripts Repo
       uses: actions/checkout@v4
       with:
-        path: ci-scripts
+        path: ../ci-scripts
         repository: pulumi/scripts
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
@@ -211,7 +211,7 @@ jobs:
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
-      run: ./ci-scripts/ci/check-worktree-is-clean
+      run: ../ci-scripts/ci/check-worktree-is-clean
     - run: git status --porcelain
     - name: Tar SDK folder
       run: tar -zcf sdk/${{ matrix.language }}.tar.gz -C sdk/${{ matrix.language }} .
@@ -252,7 +252,7 @@ jobs:
     - name: Checkout Scripts Repo
       uses: actions/checkout@v4
       with:
-        path: ci-scripts
+        path: ../ci-scripts
         repository: pulumi/scripts
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
@@ -426,7 +426,7 @@ jobs:
     - name: Checkout Scripts Repo
       uses: actions/checkout@v4
       with:
-        path: ci-scripts
+        path: ../ci-scripts
         repository: pulumi/scripts
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
@@ -481,7 +481,7 @@ jobs:
     - name: Install Twine
       run: python -m pip install pip twine
     - name: Publish SDKs
-      run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
+      run: ../ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
       env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         PYPI_PUBLISH_ARTIFACTS: all
@@ -505,7 +505,7 @@ jobs:
     - name: Checkout Scripts Repo
       uses: actions/checkout@v4
       with:
-        path: ci-scripts
+        path: ../ci-scripts
         repository: pulumi/scripts
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags

--- a/native-provider-ci/providers/docker-build/repo/.github/workflows/release.yml
+++ b/native-provider-ci/providers/docker-build/repo/.github/workflows/release.yml
@@ -59,7 +59,7 @@ jobs:
     - name: Checkout Scripts Repo
       uses: actions/checkout@v4
       with:
-        path: ../ci-scripts
+        path: ${{ runner.temp }}/ci-scripts
         repository: pulumi/scripts
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
@@ -112,7 +112,7 @@ jobs:
     - name: Build Provider
       run: make provider
     - name: Check worktree clean
-      run: ../ci-scripts/ci/check-worktree-is-clean
+      run: ${{ runner.temp }}/ci-scripts/ci/check-worktree-is-clean
     - run: git status --porcelain
     - name: Tar provider binaries
       run: tar -zcf ${{ github.workspace }}/bin/provider.tar.gz -C ${{
@@ -157,7 +157,7 @@ jobs:
     - name: Checkout Scripts Repo
       uses: actions/checkout@v4
       with:
-        path: ../ci-scripts
+        path: ${{ runner.temp }}/ci-scripts
         repository: pulumi/scripts
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
@@ -211,7 +211,7 @@ jobs:
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
-      run: ../ci-scripts/ci/check-worktree-is-clean
+      run: ${{ runner.temp }}/ci-scripts/ci/check-worktree-is-clean
     - run: git status --porcelain
     - name: Tar SDK folder
       run: tar -zcf sdk/${{ matrix.language }}.tar.gz -C sdk/${{ matrix.language }} .
@@ -252,7 +252,7 @@ jobs:
     - name: Checkout Scripts Repo
       uses: actions/checkout@v4
       with:
-        path: ../ci-scripts
+        path: ${{ runner.temp }}/ci-scripts
         repository: pulumi/scripts
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
@@ -426,7 +426,7 @@ jobs:
     - name: Checkout Scripts Repo
       uses: actions/checkout@v4
       with:
-        path: ../ci-scripts
+        path: ${{ runner.temp }}/ci-scripts
         repository: pulumi/scripts
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
@@ -481,7 +481,8 @@ jobs:
     - name: Install Twine
       run: python -m pip install pip twine
     - name: Publish SDKs
-      run: ../ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
+      run: ${{ runner.temp }}/ci-scripts/ci/publish-tfgen-package ${{ github.workspace
+        }}
       env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         PYPI_PUBLISH_ARTIFACTS: all
@@ -505,7 +506,7 @@ jobs:
     - name: Checkout Scripts Repo
       uses: actions/checkout@v4
       with:
-        path: ../ci-scripts
+        path: ${{ runner.temp }}/ci-scripts
         repository: pulumi/scripts
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags

--- a/native-provider-ci/providers/docker-build/repo/.github/workflows/release.yml
+++ b/native-provider-ci/providers/docker-build/repo/.github/workflows/release.yml
@@ -61,7 +61,7 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
-    - run: mv ci-scripts ../ci-scripts
+    - run: echo "ci-scripts" >> .git/info/exclude
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -113,7 +113,7 @@ jobs:
     - name: Build Provider
       run: make provider
     - name: Check worktree clean
-      run: ../ci-scripts/ci/check-worktree-is-clean
+      run: ./ci-scripts/ci/check-worktree-is-clean
     - run: git status --porcelain
     - name: Tar provider binaries
       run: tar -zcf ${{ github.workspace }}/bin/provider.tar.gz -C ${{
@@ -160,7 +160,7 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
-    - run: mv ci-scripts ../ci-scripts
+    - run: echo "ci-scripts" >> .git/info/exclude
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -213,7 +213,7 @@ jobs:
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
-      run: ../ci-scripts/ci/check-worktree-is-clean
+      run: ./ci-scripts/ci/check-worktree-is-clean
     - run: git status --porcelain
     - name: Tar SDK folder
       run: tar -zcf sdk/${{ matrix.language }}.tar.gz -C sdk/${{ matrix.language }} .
@@ -256,7 +256,7 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
-    - run: mv ci-scripts ../ci-scripts
+    - run: echo "ci-scripts" >> .git/info/exclude
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -431,7 +431,7 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
-    - run: mv ci-scripts ../ci-scripts
+    - run: echo "ci-scripts" >> .git/info/exclude
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -485,7 +485,7 @@ jobs:
     - name: Install Twine
       run: python -m pip install pip twine
     - name: Publish SDKs
-      run: ../ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
+      run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
       env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         PYPI_PUBLISH_ARTIFACTS: all
@@ -511,7 +511,7 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
-    - run: mv ci-scripts ../ci-scripts
+    - run: echo "ci-scripts" >> .git/info/exclude
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/native-provider-ci/providers/docker-build/repo/.github/workflows/release.yml
+++ b/native-provider-ci/providers/docker-build/repo/.github/workflows/release.yml
@@ -61,8 +61,7 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
-      env:
-        GITHUB_WORKSPACE: ${{ runner.temp }}
+    - run: mv ci-scripts ../ci-scripts
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -114,7 +113,7 @@ jobs:
     - name: Build Provider
       run: make provider
     - name: Check worktree clean
-      run: ${{ runner.temp }}/ci-scripts/ci/check-worktree-is-clean
+      run: ../ci-scripts/ci/check-worktree-is-clean
     - run: git status --porcelain
     - name: Tar provider binaries
       run: tar -zcf ${{ github.workspace }}/bin/provider.tar.gz -C ${{
@@ -161,8 +160,7 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
-      env:
-        GITHUB_WORKSPACE: ${{ runner.temp }}
+    - run: mv ci-scripts ../ci-scripts
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -215,7 +213,7 @@ jobs:
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
-      run: ${{ runner.temp }}/ci-scripts/ci/check-worktree-is-clean
+      run: ../ci-scripts/ci/check-worktree-is-clean
     - run: git status --porcelain
     - name: Tar SDK folder
       run: tar -zcf sdk/${{ matrix.language }}.tar.gz -C sdk/${{ matrix.language }} .
@@ -258,8 +256,7 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
-      env:
-        GITHUB_WORKSPACE: ${{ runner.temp }}
+    - run: mv ci-scripts ../ci-scripts
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -434,8 +431,7 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
-      env:
-        GITHUB_WORKSPACE: ${{ runner.temp }}
+    - run: mv ci-scripts ../ci-scripts
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -489,8 +485,7 @@ jobs:
     - name: Install Twine
       run: python -m pip install pip twine
     - name: Publish SDKs
-      run: ${{ runner.temp }}/ci-scripts/ci/publish-tfgen-package ${{ github.workspace
-        }}
+      run: ../ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
       env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         PYPI_PUBLISH_ARTIFACTS: all
@@ -516,8 +511,7 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
-      env:
-        GITHUB_WORKSPACE: ${{ runner.temp }}
+    - run: mv ci-scripts ../ci-scripts
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/native-provider-ci/providers/docker-build/repo/.github/workflows/release.yml
+++ b/native-provider-ci/providers/docker-build/repo/.github/workflows/release.yml
@@ -59,8 +59,10 @@ jobs:
     - name: Checkout Scripts Repo
       uses: actions/checkout@v4
       with:
-        path: ${{ runner.temp }}/ci-scripts
+        path: ci-scripts
         repository: pulumi/scripts
+      env:
+        GITHUB_WORKSPACE: ${{ runner.temp }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -157,8 +159,10 @@ jobs:
     - name: Checkout Scripts Repo
       uses: actions/checkout@v4
       with:
-        path: ${{ runner.temp }}/ci-scripts
+        path: ci-scripts
         repository: pulumi/scripts
+      env:
+        GITHUB_WORKSPACE: ${{ runner.temp }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -252,8 +256,10 @@ jobs:
     - name: Checkout Scripts Repo
       uses: actions/checkout@v4
       with:
-        path: ${{ runner.temp }}/ci-scripts
+        path: ci-scripts
         repository: pulumi/scripts
+      env:
+        GITHUB_WORKSPACE: ${{ runner.temp }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -426,8 +432,10 @@ jobs:
     - name: Checkout Scripts Repo
       uses: actions/checkout@v4
       with:
-        path: ${{ runner.temp }}/ci-scripts
+        path: ci-scripts
         repository: pulumi/scripts
+      env:
+        GITHUB_WORKSPACE: ${{ runner.temp }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -506,8 +514,10 @@ jobs:
     - name: Checkout Scripts Repo
       uses: actions/checkout@v4
       with:
-        path: ${{ runner.temp }}/ci-scripts
+        path: ci-scripts
         repository: pulumi/scripts
+      env:
+        GITHUB_WORKSPACE: ${{ runner.temp }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/native-provider-ci/providers/docker-build/repo/.github/workflows/run-acceptance-tests.yml
+++ b/native-provider-ci/providers/docker-build/repo/.github/workflows/run-acceptance-tests.yml
@@ -86,8 +86,7 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
-      env:
-        GITHUB_WORKSPACE: ${{ runner.temp }}
+    - run: mv ci-scripts ../ci-scripts
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -139,7 +138,7 @@ jobs:
     - name: Build Provider
       run: make provider
     - name: Check worktree clean
-      run: ${{ runner.temp }}/ci-scripts/ci/check-worktree-is-clean
+      run: ../ci-scripts/ci/check-worktree-is-clean
     - run: git status --porcelain
     - name: Tar provider binaries
       run: tar -zcf ${{ github.workspace }}/bin/provider.tar.gz -C ${{
@@ -189,8 +188,7 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
-      env:
-        GITHUB_WORKSPACE: ${{ runner.temp }}
+    - run: mv ci-scripts ../ci-scripts
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -243,7 +241,7 @@ jobs:
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
-      run: ${{ runner.temp }}/ci-scripts/ci/check-worktree-is-clean
+      run: ../ci-scripts/ci/check-worktree-is-clean
     - run: git status --porcelain
     - name: Tar SDK folder
       run: tar -zcf sdk/${{ matrix.language }}.tar.gz -C sdk/${{ matrix.language }} .
@@ -290,8 +288,7 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
-      env:
-        GITHUB_WORKSPACE: ${{ runner.temp }}
+    - run: mv ci-scripts ../ci-scripts
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/native-provider-ci/providers/docker-build/repo/.github/workflows/run-acceptance-tests.yml
+++ b/native-provider-ci/providers/docker-build/repo/.github/workflows/run-acceptance-tests.yml
@@ -86,7 +86,7 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
-    - run: mv ci-scripts ../ci-scripts
+    - run: echo "ci-scripts" >> .git/info/exclude
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -138,7 +138,7 @@ jobs:
     - name: Build Provider
       run: make provider
     - name: Check worktree clean
-      run: ../ci-scripts/ci/check-worktree-is-clean
+      run: ./ci-scripts/ci/check-worktree-is-clean
     - run: git status --porcelain
     - name: Tar provider binaries
       run: tar -zcf ${{ github.workspace }}/bin/provider.tar.gz -C ${{
@@ -188,7 +188,7 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
-    - run: mv ci-scripts ../ci-scripts
+    - run: echo "ci-scripts" >> .git/info/exclude
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -241,7 +241,7 @@ jobs:
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
-      run: ../ci-scripts/ci/check-worktree-is-clean
+      run: ./ci-scripts/ci/check-worktree-is-clean
     - run: git status --porcelain
     - name: Tar SDK folder
       run: tar -zcf sdk/${{ matrix.language }}.tar.gz -C sdk/${{ matrix.language }} .
@@ -288,7 +288,7 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
-    - run: mv ci-scripts ../ci-scripts
+    - run: echo "ci-scripts" >> .git/info/exclude
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/native-provider-ci/providers/docker-build/repo/.github/workflows/run-acceptance-tests.yml
+++ b/native-provider-ci/providers/docker-build/repo/.github/workflows/run-acceptance-tests.yml
@@ -84,7 +84,7 @@ jobs:
     - name: Checkout Scripts Repo
       uses: actions/checkout@v4
       with:
-        path: ../ci-scripts
+        path: ${{ runner.temp }}/ci-scripts
         repository: pulumi/scripts
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
@@ -137,7 +137,7 @@ jobs:
     - name: Build Provider
       run: make provider
     - name: Check worktree clean
-      run: ../ci-scripts/ci/check-worktree-is-clean
+      run: ${{ runner.temp }}/ci-scripts/ci/check-worktree-is-clean
     - run: git status --porcelain
     - name: Tar provider binaries
       run: tar -zcf ${{ github.workspace }}/bin/provider.tar.gz -C ${{
@@ -185,7 +185,7 @@ jobs:
     - name: Checkout Scripts Repo
       uses: actions/checkout@v4
       with:
-        path: ../ci-scripts
+        path: ${{ runner.temp }}/ci-scripts
         repository: pulumi/scripts
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
@@ -239,7 +239,7 @@ jobs:
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
-      run: ../ci-scripts/ci/check-worktree-is-clean
+      run: ${{ runner.temp }}/ci-scripts/ci/check-worktree-is-clean
     - run: git status --porcelain
     - name: Tar SDK folder
       run: tar -zcf sdk/${{ matrix.language }}.tar.gz -C sdk/${{ matrix.language }} .
@@ -284,7 +284,7 @@ jobs:
     - name: Checkout Scripts Repo
       uses: actions/checkout@v4
       with:
-        path: ../ci-scripts
+        path: ${{ runner.temp }}/ci-scripts
         repository: pulumi/scripts
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags

--- a/native-provider-ci/providers/docker-build/repo/.github/workflows/run-acceptance-tests.yml
+++ b/native-provider-ci/providers/docker-build/repo/.github/workflows/run-acceptance-tests.yml
@@ -84,8 +84,10 @@ jobs:
     - name: Checkout Scripts Repo
       uses: actions/checkout@v4
       with:
-        path: ${{ runner.temp }}/ci-scripts
+        path: ci-scripts
         repository: pulumi/scripts
+      env:
+        GITHUB_WORKSPACE: ${{ runner.temp }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -185,8 +187,10 @@ jobs:
     - name: Checkout Scripts Repo
       uses: actions/checkout@v4
       with:
-        path: ${{ runner.temp }}/ci-scripts
+        path: ci-scripts
         repository: pulumi/scripts
+      env:
+        GITHUB_WORKSPACE: ${{ runner.temp }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -284,8 +288,10 @@ jobs:
     - name: Checkout Scripts Repo
       uses: actions/checkout@v4
       with:
-        path: ${{ runner.temp }}/ci-scripts
+        path: ci-scripts
         repository: pulumi/scripts
+      env:
+        GITHUB_WORKSPACE: ${{ runner.temp }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/native-provider-ci/providers/docker-build/repo/.github/workflows/run-acceptance-tests.yml
+++ b/native-provider-ci/providers/docker-build/repo/.github/workflows/run-acceptance-tests.yml
@@ -84,7 +84,7 @@ jobs:
     - name: Checkout Scripts Repo
       uses: actions/checkout@v4
       with:
-        path: ci-scripts
+        path: ../ci-scripts
         repository: pulumi/scripts
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
@@ -137,7 +137,7 @@ jobs:
     - name: Build Provider
       run: make provider
     - name: Check worktree clean
-      run: ./ci-scripts/ci/check-worktree-is-clean
+      run: ../ci-scripts/ci/check-worktree-is-clean
     - run: git status --porcelain
     - name: Tar provider binaries
       run: tar -zcf ${{ github.workspace }}/bin/provider.tar.gz -C ${{
@@ -185,7 +185,7 @@ jobs:
     - name: Checkout Scripts Repo
       uses: actions/checkout@v4
       with:
-        path: ci-scripts
+        path: ../ci-scripts
         repository: pulumi/scripts
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
@@ -239,7 +239,7 @@ jobs:
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
-      run: ./ci-scripts/ci/check-worktree-is-clean
+      run: ../ci-scripts/ci/check-worktree-is-clean
     - run: git status --porcelain
     - name: Tar SDK folder
       run: tar -zcf sdk/${{ matrix.language }}.tar.gz -C sdk/${{ matrix.language }} .
@@ -284,7 +284,7 @@ jobs:
     - name: Checkout Scripts Repo
       uses: actions/checkout@v4
       with:
-        path: ci-scripts
+        path: ../ci-scripts
         repository: pulumi/scripts
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags

--- a/native-provider-ci/providers/google-native/repo/.github/workflows/build.yml
+++ b/native-provider-ci/providers/google-native/repo/.github/workflows/build.yml
@@ -61,7 +61,7 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
-    - run: mv ci-scripts ../ci-scripts
+    - run: echo "ci-scripts" >> .git/info/exclude
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -115,7 +115,7 @@ jobs:
     - name: Build Provider
       run: make provider
     - name: Check worktree clean
-      run: ../ci-scripts/ci/check-worktree-is-clean
+      run: ./ci-scripts/ci/check-worktree-is-clean
     - run: git status --porcelain
     - name: Tar provider binaries
       run: tar -zcf ${{ github.workspace }}/bin/provider.tar.gz -C ${{
@@ -162,7 +162,7 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
-    - run: mv ci-scripts ../ci-scripts
+    - run: echo "ci-scripts" >> .git/info/exclude
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -217,7 +217,7 @@ jobs:
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
-      run: ../ci-scripts/ci/check-worktree-is-clean
+      run: ./ci-scripts/ci/check-worktree-is-clean
     - run: git status --porcelain
     - name: Tar SDK folder
       run: tar -zcf sdk/${{ matrix.language }}.tar.gz -C sdk/${{ matrix.language }} .
@@ -261,7 +261,7 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
-    - run: mv ci-scripts ../ci-scripts
+    - run: echo "ci-scripts" >> .git/info/exclude
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -427,7 +427,7 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
-    - run: mv ci-scripts ../ci-scripts
+    - run: echo "ci-scripts" >> .git/info/exclude
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -481,7 +481,7 @@ jobs:
     - name: Install Twine
       run: python -m pip install pip twine
     - name: Publish SDKs
-      run: ../ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
+      run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
       env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         PYPI_PUBLISH_ARTIFACTS: all
@@ -507,7 +507,7 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
-    - run: mv ci-scripts ../ci-scripts
+    - run: echo "ci-scripts" >> .git/info/exclude
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/native-provider-ci/providers/google-native/repo/.github/workflows/build.yml
+++ b/native-provider-ci/providers/google-native/repo/.github/workflows/build.yml
@@ -61,8 +61,7 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
-      env:
-        GITHUB_WORKSPACE: ${{ runner.temp }}
+    - run: mv ci-scripts ../ci-scripts
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -116,7 +115,7 @@ jobs:
     - name: Build Provider
       run: make provider
     - name: Check worktree clean
-      run: ${{ runner.temp }}/ci-scripts/ci/check-worktree-is-clean
+      run: ../ci-scripts/ci/check-worktree-is-clean
     - run: git status --porcelain
     - name: Tar provider binaries
       run: tar -zcf ${{ github.workspace }}/bin/provider.tar.gz -C ${{
@@ -163,8 +162,7 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
-      env:
-        GITHUB_WORKSPACE: ${{ runner.temp }}
+    - run: mv ci-scripts ../ci-scripts
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -219,7 +217,7 @@ jobs:
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
-      run: ${{ runner.temp }}/ci-scripts/ci/check-worktree-is-clean
+      run: ../ci-scripts/ci/check-worktree-is-clean
     - run: git status --porcelain
     - name: Tar SDK folder
       run: tar -zcf sdk/${{ matrix.language }}.tar.gz -C sdk/${{ matrix.language }} .
@@ -263,8 +261,7 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
-      env:
-        GITHUB_WORKSPACE: ${{ runner.temp }}
+    - run: mv ci-scripts ../ci-scripts
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -430,8 +427,7 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
-      env:
-        GITHUB_WORKSPACE: ${{ runner.temp }}
+    - run: mv ci-scripts ../ci-scripts
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -485,8 +481,7 @@ jobs:
     - name: Install Twine
       run: python -m pip install pip twine
     - name: Publish SDKs
-      run: ${{ runner.temp }}/ci-scripts/ci/publish-tfgen-package ${{ github.workspace
-        }}
+      run: ../ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
       env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         PYPI_PUBLISH_ARTIFACTS: all
@@ -512,8 +507,7 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
-      env:
-        GITHUB_WORKSPACE: ${{ runner.temp }}
+    - run: mv ci-scripts ../ci-scripts
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/native-provider-ci/providers/google-native/repo/.github/workflows/build.yml
+++ b/native-provider-ci/providers/google-native/repo/.github/workflows/build.yml
@@ -59,8 +59,10 @@ jobs:
     - name: Checkout Scripts Repo
       uses: actions/checkout@v4
       with:
-        path: ${{ runner.temp }}/ci-scripts
+        path: ci-scripts
         repository: pulumi/scripts
+      env:
+        GITHUB_WORKSPACE: ${{ runner.temp }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -159,8 +161,10 @@ jobs:
     - name: Checkout Scripts Repo
       uses: actions/checkout@v4
       with:
-        path: ${{ runner.temp }}/ci-scripts
+        path: ci-scripts
         repository: pulumi/scripts
+      env:
+        GITHUB_WORKSPACE: ${{ runner.temp }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -257,8 +261,10 @@ jobs:
     - name: Checkout Scripts Repo
       uses: actions/checkout@v4
       with:
-        path: ${{ runner.temp }}/ci-scripts
+        path: ci-scripts
         repository: pulumi/scripts
+      env:
+        GITHUB_WORKSPACE: ${{ runner.temp }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -422,8 +428,10 @@ jobs:
     - name: Checkout Scripts Repo
       uses: actions/checkout@v4
       with:
-        path: ${{ runner.temp }}/ci-scripts
+        path: ci-scripts
         repository: pulumi/scripts
+      env:
+        GITHUB_WORKSPACE: ${{ runner.temp }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -502,8 +510,10 @@ jobs:
     - name: Checkout Scripts Repo
       uses: actions/checkout@v4
       with:
-        path: ${{ runner.temp }}/ci-scripts
+        path: ci-scripts
         repository: pulumi/scripts
+      env:
+        GITHUB_WORKSPACE: ${{ runner.temp }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/native-provider-ci/providers/google-native/repo/.github/workflows/build.yml
+++ b/native-provider-ci/providers/google-native/repo/.github/workflows/build.yml
@@ -59,7 +59,7 @@ jobs:
     - name: Checkout Scripts Repo
       uses: actions/checkout@v4
       with:
-        path: ci-scripts
+        path: ../ci-scripts
         repository: pulumi/scripts
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
@@ -114,7 +114,7 @@ jobs:
     - name: Build Provider
       run: make provider
     - name: Check worktree clean
-      run: ./ci-scripts/ci/check-worktree-is-clean
+      run: ../ci-scripts/ci/check-worktree-is-clean
     - run: git status --porcelain
     - name: Tar provider binaries
       run: tar -zcf ${{ github.workspace }}/bin/provider.tar.gz -C ${{
@@ -159,7 +159,7 @@ jobs:
     - name: Checkout Scripts Repo
       uses: actions/checkout@v4
       with:
-        path: ci-scripts
+        path: ../ci-scripts
         repository: pulumi/scripts
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
@@ -215,7 +215,7 @@ jobs:
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
-      run: ./ci-scripts/ci/check-worktree-is-clean
+      run: ../ci-scripts/ci/check-worktree-is-clean
     - run: git status --porcelain
     - name: Tar SDK folder
       run: tar -zcf sdk/${{ matrix.language }}.tar.gz -C sdk/${{ matrix.language }} .
@@ -257,7 +257,7 @@ jobs:
     - name: Checkout Scripts Repo
       uses: actions/checkout@v4
       with:
-        path: ci-scripts
+        path: ../ci-scripts
         repository: pulumi/scripts
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
@@ -422,7 +422,7 @@ jobs:
     - name: Checkout Scripts Repo
       uses: actions/checkout@v4
       with:
-        path: ci-scripts
+        path: ../ci-scripts
         repository: pulumi/scripts
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
@@ -477,7 +477,7 @@ jobs:
     - name: Install Twine
       run: python -m pip install pip twine
     - name: Publish SDKs
-      run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
+      run: ../ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
       env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         PYPI_PUBLISH_ARTIFACTS: all
@@ -501,7 +501,7 @@ jobs:
     - name: Checkout Scripts Repo
       uses: actions/checkout@v4
       with:
-        path: ci-scripts
+        path: ../ci-scripts
         repository: pulumi/scripts
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags

--- a/native-provider-ci/providers/google-native/repo/.github/workflows/build.yml
+++ b/native-provider-ci/providers/google-native/repo/.github/workflows/build.yml
@@ -59,7 +59,7 @@ jobs:
     - name: Checkout Scripts Repo
       uses: actions/checkout@v4
       with:
-        path: ../ci-scripts
+        path: ${{ runner.temp }}/ci-scripts
         repository: pulumi/scripts
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
@@ -114,7 +114,7 @@ jobs:
     - name: Build Provider
       run: make provider
     - name: Check worktree clean
-      run: ../ci-scripts/ci/check-worktree-is-clean
+      run: ${{ runner.temp }}/ci-scripts/ci/check-worktree-is-clean
     - run: git status --porcelain
     - name: Tar provider binaries
       run: tar -zcf ${{ github.workspace }}/bin/provider.tar.gz -C ${{
@@ -159,7 +159,7 @@ jobs:
     - name: Checkout Scripts Repo
       uses: actions/checkout@v4
       with:
-        path: ../ci-scripts
+        path: ${{ runner.temp }}/ci-scripts
         repository: pulumi/scripts
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
@@ -215,7 +215,7 @@ jobs:
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
-      run: ../ci-scripts/ci/check-worktree-is-clean
+      run: ${{ runner.temp }}/ci-scripts/ci/check-worktree-is-clean
     - run: git status --porcelain
     - name: Tar SDK folder
       run: tar -zcf sdk/${{ matrix.language }}.tar.gz -C sdk/${{ matrix.language }} .
@@ -257,7 +257,7 @@ jobs:
     - name: Checkout Scripts Repo
       uses: actions/checkout@v4
       with:
-        path: ../ci-scripts
+        path: ${{ runner.temp }}/ci-scripts
         repository: pulumi/scripts
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
@@ -422,7 +422,7 @@ jobs:
     - name: Checkout Scripts Repo
       uses: actions/checkout@v4
       with:
-        path: ../ci-scripts
+        path: ${{ runner.temp }}/ci-scripts
         repository: pulumi/scripts
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
@@ -477,7 +477,8 @@ jobs:
     - name: Install Twine
       run: python -m pip install pip twine
     - name: Publish SDKs
-      run: ../ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
+      run: ${{ runner.temp }}/ci-scripts/ci/publish-tfgen-package ${{ github.workspace
+        }}
       env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         PYPI_PUBLISH_ARTIFACTS: all
@@ -501,7 +502,7 @@ jobs:
     - name: Checkout Scripts Repo
       uses: actions/checkout@v4
       with:
-        path: ../ci-scripts
+        path: ${{ runner.temp }}/ci-scripts
         repository: pulumi/scripts
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags

--- a/native-provider-ci/providers/google-native/repo/.github/workflows/prerelease.yml
+++ b/native-provider-ci/providers/google-native/repo/.github/workflows/prerelease.yml
@@ -51,8 +51,10 @@ jobs:
     - name: Checkout Scripts Repo
       uses: actions/checkout@v4
       with:
-        path: ${{ runner.temp }}/ci-scripts
+        path: ci-scripts
         repository: pulumi/scripts
+      env:
+        GITHUB_WORKSPACE: ${{ runner.temp }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -151,8 +153,10 @@ jobs:
     - name: Checkout Scripts Repo
       uses: actions/checkout@v4
       with:
-        path: ${{ runner.temp }}/ci-scripts
+        path: ci-scripts
         repository: pulumi/scripts
+      env:
+        GITHUB_WORKSPACE: ${{ runner.temp }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -248,8 +252,10 @@ jobs:
     - name: Checkout Scripts Repo
       uses: actions/checkout@v4
       with:
-        path: ${{ runner.temp }}/ci-scripts
+        path: ci-scripts
         repository: pulumi/scripts
+      env:
+        GITHUB_WORKSPACE: ${{ runner.temp }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -413,8 +419,10 @@ jobs:
     - name: Checkout Scripts Repo
       uses: actions/checkout@v4
       with:
-        path: ${{ runner.temp }}/ci-scripts
+        path: ci-scripts
         repository: pulumi/scripts
+      env:
+        GITHUB_WORKSPACE: ${{ runner.temp }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -493,8 +501,10 @@ jobs:
     - name: Checkout Scripts Repo
       uses: actions/checkout@v4
       with:
-        path: ${{ runner.temp }}/ci-scripts
+        path: ci-scripts
         repository: pulumi/scripts
+      env:
+        GITHUB_WORKSPACE: ${{ runner.temp }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/native-provider-ci/providers/google-native/repo/.github/workflows/prerelease.yml
+++ b/native-provider-ci/providers/google-native/repo/.github/workflows/prerelease.yml
@@ -51,7 +51,7 @@ jobs:
     - name: Checkout Scripts Repo
       uses: actions/checkout@v4
       with:
-        path: ci-scripts
+        path: ../ci-scripts
         repository: pulumi/scripts
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
@@ -106,7 +106,7 @@ jobs:
     - name: Build Provider
       run: make provider
     - name: Check worktree clean
-      run: ./ci-scripts/ci/check-worktree-is-clean
+      run: ../ci-scripts/ci/check-worktree-is-clean
     - run: git status --porcelain
     - name: Tar provider binaries
       run: tar -zcf ${{ github.workspace }}/bin/provider.tar.gz -C ${{
@@ -151,7 +151,7 @@ jobs:
     - name: Checkout Scripts Repo
       uses: actions/checkout@v4
       with:
-        path: ci-scripts
+        path: ../ci-scripts
         repository: pulumi/scripts
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
@@ -207,7 +207,7 @@ jobs:
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
-      run: ./ci-scripts/ci/check-worktree-is-clean
+      run: ../ci-scripts/ci/check-worktree-is-clean
     - run: git status --porcelain
     - name: Tar SDK folder
       run: tar -zcf sdk/${{ matrix.language }}.tar.gz -C sdk/${{ matrix.language }} .
@@ -248,7 +248,7 @@ jobs:
     - name: Checkout Scripts Repo
       uses: actions/checkout@v4
       with:
-        path: ci-scripts
+        path: ../ci-scripts
         repository: pulumi/scripts
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
@@ -413,7 +413,7 @@ jobs:
     - name: Checkout Scripts Repo
       uses: actions/checkout@v4
       with:
-        path: ci-scripts
+        path: ../ci-scripts
         repository: pulumi/scripts
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
@@ -468,7 +468,7 @@ jobs:
     - name: Install Twine
       run: python -m pip install pip twine
     - name: Publish SDKs
-      run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
+      run: ../ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
       env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         PYPI_PUBLISH_ARTIFACTS: all
@@ -492,7 +492,7 @@ jobs:
     - name: Checkout Scripts Repo
       uses: actions/checkout@v4
       with:
-        path: ci-scripts
+        path: ../ci-scripts
         repository: pulumi/scripts
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags

--- a/native-provider-ci/providers/google-native/repo/.github/workflows/prerelease.yml
+++ b/native-provider-ci/providers/google-native/repo/.github/workflows/prerelease.yml
@@ -53,8 +53,7 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
-      env:
-        GITHUB_WORKSPACE: ${{ runner.temp }}
+    - run: mv ci-scripts ../ci-scripts
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -108,7 +107,7 @@ jobs:
     - name: Build Provider
       run: make provider
     - name: Check worktree clean
-      run: ${{ runner.temp }}/ci-scripts/ci/check-worktree-is-clean
+      run: ../ci-scripts/ci/check-worktree-is-clean
     - run: git status --porcelain
     - name: Tar provider binaries
       run: tar -zcf ${{ github.workspace }}/bin/provider.tar.gz -C ${{
@@ -155,8 +154,7 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
-      env:
-        GITHUB_WORKSPACE: ${{ runner.temp }}
+    - run: mv ci-scripts ../ci-scripts
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -211,7 +209,7 @@ jobs:
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
-      run: ${{ runner.temp }}/ci-scripts/ci/check-worktree-is-clean
+      run: ../ci-scripts/ci/check-worktree-is-clean
     - run: git status --porcelain
     - name: Tar SDK folder
       run: tar -zcf sdk/${{ matrix.language }}.tar.gz -C sdk/${{ matrix.language }} .
@@ -254,8 +252,7 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
-      env:
-        GITHUB_WORKSPACE: ${{ runner.temp }}
+    - run: mv ci-scripts ../ci-scripts
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -421,8 +418,7 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
-      env:
-        GITHUB_WORKSPACE: ${{ runner.temp }}
+    - run: mv ci-scripts ../ci-scripts
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -476,8 +472,7 @@ jobs:
     - name: Install Twine
       run: python -m pip install pip twine
     - name: Publish SDKs
-      run: ${{ runner.temp }}/ci-scripts/ci/publish-tfgen-package ${{ github.workspace
-        }}
+      run: ../ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
       env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         PYPI_PUBLISH_ARTIFACTS: all
@@ -503,8 +498,7 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
-      env:
-        GITHUB_WORKSPACE: ${{ runner.temp }}
+    - run: mv ci-scripts ../ci-scripts
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/native-provider-ci/providers/google-native/repo/.github/workflows/prerelease.yml
+++ b/native-provider-ci/providers/google-native/repo/.github/workflows/prerelease.yml
@@ -51,7 +51,7 @@ jobs:
     - name: Checkout Scripts Repo
       uses: actions/checkout@v4
       with:
-        path: ../ci-scripts
+        path: ${{ runner.temp }}/ci-scripts
         repository: pulumi/scripts
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
@@ -106,7 +106,7 @@ jobs:
     - name: Build Provider
       run: make provider
     - name: Check worktree clean
-      run: ../ci-scripts/ci/check-worktree-is-clean
+      run: ${{ runner.temp }}/ci-scripts/ci/check-worktree-is-clean
     - run: git status --porcelain
     - name: Tar provider binaries
       run: tar -zcf ${{ github.workspace }}/bin/provider.tar.gz -C ${{
@@ -151,7 +151,7 @@ jobs:
     - name: Checkout Scripts Repo
       uses: actions/checkout@v4
       with:
-        path: ../ci-scripts
+        path: ${{ runner.temp }}/ci-scripts
         repository: pulumi/scripts
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
@@ -207,7 +207,7 @@ jobs:
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
-      run: ../ci-scripts/ci/check-worktree-is-clean
+      run: ${{ runner.temp }}/ci-scripts/ci/check-worktree-is-clean
     - run: git status --porcelain
     - name: Tar SDK folder
       run: tar -zcf sdk/${{ matrix.language }}.tar.gz -C sdk/${{ matrix.language }} .
@@ -248,7 +248,7 @@ jobs:
     - name: Checkout Scripts Repo
       uses: actions/checkout@v4
       with:
-        path: ../ci-scripts
+        path: ${{ runner.temp }}/ci-scripts
         repository: pulumi/scripts
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
@@ -413,7 +413,7 @@ jobs:
     - name: Checkout Scripts Repo
       uses: actions/checkout@v4
       with:
-        path: ../ci-scripts
+        path: ${{ runner.temp }}/ci-scripts
         repository: pulumi/scripts
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
@@ -468,7 +468,8 @@ jobs:
     - name: Install Twine
       run: python -m pip install pip twine
     - name: Publish SDKs
-      run: ../ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
+      run: ${{ runner.temp }}/ci-scripts/ci/publish-tfgen-package ${{ github.workspace
+        }}
       env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         PYPI_PUBLISH_ARTIFACTS: all
@@ -492,7 +493,7 @@ jobs:
     - name: Checkout Scripts Repo
       uses: actions/checkout@v4
       with:
-        path: ../ci-scripts
+        path: ${{ runner.temp }}/ci-scripts
         repository: pulumi/scripts
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags

--- a/native-provider-ci/providers/google-native/repo/.github/workflows/prerelease.yml
+++ b/native-provider-ci/providers/google-native/repo/.github/workflows/prerelease.yml
@@ -53,7 +53,7 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
-    - run: mv ci-scripts ../ci-scripts
+    - run: echo "ci-scripts" >> .git/info/exclude
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -107,7 +107,7 @@ jobs:
     - name: Build Provider
       run: make provider
     - name: Check worktree clean
-      run: ../ci-scripts/ci/check-worktree-is-clean
+      run: ./ci-scripts/ci/check-worktree-is-clean
     - run: git status --porcelain
     - name: Tar provider binaries
       run: tar -zcf ${{ github.workspace }}/bin/provider.tar.gz -C ${{
@@ -154,7 +154,7 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
-    - run: mv ci-scripts ../ci-scripts
+    - run: echo "ci-scripts" >> .git/info/exclude
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -209,7 +209,7 @@ jobs:
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
-      run: ../ci-scripts/ci/check-worktree-is-clean
+      run: ./ci-scripts/ci/check-worktree-is-clean
     - run: git status --porcelain
     - name: Tar SDK folder
       run: tar -zcf sdk/${{ matrix.language }}.tar.gz -C sdk/${{ matrix.language }} .
@@ -252,7 +252,7 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
-    - run: mv ci-scripts ../ci-scripts
+    - run: echo "ci-scripts" >> .git/info/exclude
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -418,7 +418,7 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
-    - run: mv ci-scripts ../ci-scripts
+    - run: echo "ci-scripts" >> .git/info/exclude
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -472,7 +472,7 @@ jobs:
     - name: Install Twine
       run: python -m pip install pip twine
     - name: Publish SDKs
-      run: ../ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
+      run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
       env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         PYPI_PUBLISH_ARTIFACTS: all
@@ -498,7 +498,7 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
-    - run: mv ci-scripts ../ci-scripts
+    - run: echo "ci-scripts" >> .git/info/exclude
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/native-provider-ci/providers/google-native/repo/.github/workflows/release.yml
+++ b/native-provider-ci/providers/google-native/repo/.github/workflows/release.yml
@@ -51,8 +51,10 @@ jobs:
     - name: Checkout Scripts Repo
       uses: actions/checkout@v4
       with:
-        path: ${{ runner.temp }}/ci-scripts
+        path: ci-scripts
         repository: pulumi/scripts
+      env:
+        GITHUB_WORKSPACE: ${{ runner.temp }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -151,8 +153,10 @@ jobs:
     - name: Checkout Scripts Repo
       uses: actions/checkout@v4
       with:
-        path: ${{ runner.temp }}/ci-scripts
+        path: ci-scripts
         repository: pulumi/scripts
+      env:
+        GITHUB_WORKSPACE: ${{ runner.temp }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -248,8 +252,10 @@ jobs:
     - name: Checkout Scripts Repo
       uses: actions/checkout@v4
       with:
-        path: ${{ runner.temp }}/ci-scripts
+        path: ci-scripts
         repository: pulumi/scripts
+      env:
+        GITHUB_WORKSPACE: ${{ runner.temp }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -413,8 +419,10 @@ jobs:
     - name: Checkout Scripts Repo
       uses: actions/checkout@v4
       with:
-        path: ${{ runner.temp }}/ci-scripts
+        path: ci-scripts
         repository: pulumi/scripts
+      env:
+        GITHUB_WORKSPACE: ${{ runner.temp }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -493,8 +501,10 @@ jobs:
     - name: Checkout Scripts Repo
       uses: actions/checkout@v4
       with:
-        path: ${{ runner.temp }}/ci-scripts
+        path: ci-scripts
         repository: pulumi/scripts
+      env:
+        GITHUB_WORKSPACE: ${{ runner.temp }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/native-provider-ci/providers/google-native/repo/.github/workflows/release.yml
+++ b/native-provider-ci/providers/google-native/repo/.github/workflows/release.yml
@@ -51,7 +51,7 @@ jobs:
     - name: Checkout Scripts Repo
       uses: actions/checkout@v4
       with:
-        path: ci-scripts
+        path: ../ci-scripts
         repository: pulumi/scripts
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
@@ -106,7 +106,7 @@ jobs:
     - name: Build Provider
       run: make provider
     - name: Check worktree clean
-      run: ./ci-scripts/ci/check-worktree-is-clean
+      run: ../ci-scripts/ci/check-worktree-is-clean
     - run: git status --porcelain
     - name: Tar provider binaries
       run: tar -zcf ${{ github.workspace }}/bin/provider.tar.gz -C ${{
@@ -151,7 +151,7 @@ jobs:
     - name: Checkout Scripts Repo
       uses: actions/checkout@v4
       with:
-        path: ci-scripts
+        path: ../ci-scripts
         repository: pulumi/scripts
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
@@ -207,7 +207,7 @@ jobs:
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
-      run: ./ci-scripts/ci/check-worktree-is-clean
+      run: ../ci-scripts/ci/check-worktree-is-clean
     - run: git status --porcelain
     - name: Tar SDK folder
       run: tar -zcf sdk/${{ matrix.language }}.tar.gz -C sdk/${{ matrix.language }} .
@@ -248,7 +248,7 @@ jobs:
     - name: Checkout Scripts Repo
       uses: actions/checkout@v4
       with:
-        path: ci-scripts
+        path: ../ci-scripts
         repository: pulumi/scripts
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
@@ -413,7 +413,7 @@ jobs:
     - name: Checkout Scripts Repo
       uses: actions/checkout@v4
       with:
-        path: ci-scripts
+        path: ../ci-scripts
         repository: pulumi/scripts
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
@@ -468,7 +468,7 @@ jobs:
     - name: Install Twine
       run: python -m pip install pip twine
     - name: Publish SDKs
-      run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
+      run: ../ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
       env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         PYPI_PUBLISH_ARTIFACTS: all
@@ -492,7 +492,7 @@ jobs:
     - name: Checkout Scripts Repo
       uses: actions/checkout@v4
       with:
-        path: ci-scripts
+        path: ../ci-scripts
         repository: pulumi/scripts
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags

--- a/native-provider-ci/providers/google-native/repo/.github/workflows/release.yml
+++ b/native-provider-ci/providers/google-native/repo/.github/workflows/release.yml
@@ -53,8 +53,7 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
-      env:
-        GITHUB_WORKSPACE: ${{ runner.temp }}
+    - run: mv ci-scripts ../ci-scripts
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -108,7 +107,7 @@ jobs:
     - name: Build Provider
       run: make provider
     - name: Check worktree clean
-      run: ${{ runner.temp }}/ci-scripts/ci/check-worktree-is-clean
+      run: ../ci-scripts/ci/check-worktree-is-clean
     - run: git status --porcelain
     - name: Tar provider binaries
       run: tar -zcf ${{ github.workspace }}/bin/provider.tar.gz -C ${{
@@ -155,8 +154,7 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
-      env:
-        GITHUB_WORKSPACE: ${{ runner.temp }}
+    - run: mv ci-scripts ../ci-scripts
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -211,7 +209,7 @@ jobs:
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
-      run: ${{ runner.temp }}/ci-scripts/ci/check-worktree-is-clean
+      run: ../ci-scripts/ci/check-worktree-is-clean
     - run: git status --porcelain
     - name: Tar SDK folder
       run: tar -zcf sdk/${{ matrix.language }}.tar.gz -C sdk/${{ matrix.language }} .
@@ -254,8 +252,7 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
-      env:
-        GITHUB_WORKSPACE: ${{ runner.temp }}
+    - run: mv ci-scripts ../ci-scripts
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -421,8 +418,7 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
-      env:
-        GITHUB_WORKSPACE: ${{ runner.temp }}
+    - run: mv ci-scripts ../ci-scripts
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -476,8 +472,7 @@ jobs:
     - name: Install Twine
       run: python -m pip install pip twine
     - name: Publish SDKs
-      run: ${{ runner.temp }}/ci-scripts/ci/publish-tfgen-package ${{ github.workspace
-        }}
+      run: ../ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
       env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         PYPI_PUBLISH_ARTIFACTS: all
@@ -503,8 +498,7 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
-      env:
-        GITHUB_WORKSPACE: ${{ runner.temp }}
+    - run: mv ci-scripts ../ci-scripts
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/native-provider-ci/providers/google-native/repo/.github/workflows/release.yml
+++ b/native-provider-ci/providers/google-native/repo/.github/workflows/release.yml
@@ -51,7 +51,7 @@ jobs:
     - name: Checkout Scripts Repo
       uses: actions/checkout@v4
       with:
-        path: ../ci-scripts
+        path: ${{ runner.temp }}/ci-scripts
         repository: pulumi/scripts
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
@@ -106,7 +106,7 @@ jobs:
     - name: Build Provider
       run: make provider
     - name: Check worktree clean
-      run: ../ci-scripts/ci/check-worktree-is-clean
+      run: ${{ runner.temp }}/ci-scripts/ci/check-worktree-is-clean
     - run: git status --porcelain
     - name: Tar provider binaries
       run: tar -zcf ${{ github.workspace }}/bin/provider.tar.gz -C ${{
@@ -151,7 +151,7 @@ jobs:
     - name: Checkout Scripts Repo
       uses: actions/checkout@v4
       with:
-        path: ../ci-scripts
+        path: ${{ runner.temp }}/ci-scripts
         repository: pulumi/scripts
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
@@ -207,7 +207,7 @@ jobs:
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
-      run: ../ci-scripts/ci/check-worktree-is-clean
+      run: ${{ runner.temp }}/ci-scripts/ci/check-worktree-is-clean
     - run: git status --porcelain
     - name: Tar SDK folder
       run: tar -zcf sdk/${{ matrix.language }}.tar.gz -C sdk/${{ matrix.language }} .
@@ -248,7 +248,7 @@ jobs:
     - name: Checkout Scripts Repo
       uses: actions/checkout@v4
       with:
-        path: ../ci-scripts
+        path: ${{ runner.temp }}/ci-scripts
         repository: pulumi/scripts
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
@@ -413,7 +413,7 @@ jobs:
     - name: Checkout Scripts Repo
       uses: actions/checkout@v4
       with:
-        path: ../ci-scripts
+        path: ${{ runner.temp }}/ci-scripts
         repository: pulumi/scripts
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
@@ -468,7 +468,8 @@ jobs:
     - name: Install Twine
       run: python -m pip install pip twine
     - name: Publish SDKs
-      run: ../ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
+      run: ${{ runner.temp }}/ci-scripts/ci/publish-tfgen-package ${{ github.workspace
+        }}
       env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         PYPI_PUBLISH_ARTIFACTS: all
@@ -492,7 +493,7 @@ jobs:
     - name: Checkout Scripts Repo
       uses: actions/checkout@v4
       with:
-        path: ../ci-scripts
+        path: ${{ runner.temp }}/ci-scripts
         repository: pulumi/scripts
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags

--- a/native-provider-ci/providers/google-native/repo/.github/workflows/release.yml
+++ b/native-provider-ci/providers/google-native/repo/.github/workflows/release.yml
@@ -53,7 +53,7 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
-    - run: mv ci-scripts ../ci-scripts
+    - run: echo "ci-scripts" >> .git/info/exclude
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -107,7 +107,7 @@ jobs:
     - name: Build Provider
       run: make provider
     - name: Check worktree clean
-      run: ../ci-scripts/ci/check-worktree-is-clean
+      run: ./ci-scripts/ci/check-worktree-is-clean
     - run: git status --porcelain
     - name: Tar provider binaries
       run: tar -zcf ${{ github.workspace }}/bin/provider.tar.gz -C ${{
@@ -154,7 +154,7 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
-    - run: mv ci-scripts ../ci-scripts
+    - run: echo "ci-scripts" >> .git/info/exclude
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -209,7 +209,7 @@ jobs:
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
-      run: ../ci-scripts/ci/check-worktree-is-clean
+      run: ./ci-scripts/ci/check-worktree-is-clean
     - run: git status --porcelain
     - name: Tar SDK folder
       run: tar -zcf sdk/${{ matrix.language }}.tar.gz -C sdk/${{ matrix.language }} .
@@ -252,7 +252,7 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
-    - run: mv ci-scripts ../ci-scripts
+    - run: echo "ci-scripts" >> .git/info/exclude
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -418,7 +418,7 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
-    - run: mv ci-scripts ../ci-scripts
+    - run: echo "ci-scripts" >> .git/info/exclude
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -472,7 +472,7 @@ jobs:
     - name: Install Twine
       run: python -m pip install pip twine
     - name: Publish SDKs
-      run: ../ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
+      run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
       env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         PYPI_PUBLISH_ARTIFACTS: all
@@ -498,7 +498,7 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
-    - run: mv ci-scripts ../ci-scripts
+    - run: echo "ci-scripts" >> .git/info/exclude
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/native-provider-ci/providers/google-native/repo/.github/workflows/run-acceptance-tests.yml
+++ b/native-provider-ci/providers/google-native/repo/.github/workflows/run-acceptance-tests.yml
@@ -76,7 +76,7 @@ jobs:
     - name: Checkout Scripts Repo
       uses: actions/checkout@v4
       with:
-        path: ../ci-scripts
+        path: ${{ runner.temp }}/ci-scripts
         repository: pulumi/scripts
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
@@ -131,7 +131,7 @@ jobs:
     - name: Build Provider
       run: make provider
     - name: Check worktree clean
-      run: ../ci-scripts/ci/check-worktree-is-clean
+      run: ${{ runner.temp }}/ci-scripts/ci/check-worktree-is-clean
     - run: git status --porcelain
     - name: Tar provider binaries
       run: tar -zcf ${{ github.workspace }}/bin/provider.tar.gz -C ${{
@@ -179,7 +179,7 @@ jobs:
     - name: Checkout Scripts Repo
       uses: actions/checkout@v4
       with:
-        path: ../ci-scripts
+        path: ${{ runner.temp }}/ci-scripts
         repository: pulumi/scripts
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
@@ -235,7 +235,7 @@ jobs:
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
-      run: ../ci-scripts/ci/check-worktree-is-clean
+      run: ${{ runner.temp }}/ci-scripts/ci/check-worktree-is-clean
     - run: git status --porcelain
     - name: Tar SDK folder
       run: tar -zcf sdk/${{ matrix.language }}.tar.gz -C sdk/${{ matrix.language }} .
@@ -280,7 +280,7 @@ jobs:
     - name: Checkout Scripts Repo
       uses: actions/checkout@v4
       with:
-        path: ../ci-scripts
+        path: ${{ runner.temp }}/ci-scripts
         repository: pulumi/scripts
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags

--- a/native-provider-ci/providers/google-native/repo/.github/workflows/run-acceptance-tests.yml
+++ b/native-provider-ci/providers/google-native/repo/.github/workflows/run-acceptance-tests.yml
@@ -78,7 +78,7 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
-    - run: mv ci-scripts ../ci-scripts
+    - run: echo "ci-scripts" >> .git/info/exclude
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -132,7 +132,7 @@ jobs:
     - name: Build Provider
       run: make provider
     - name: Check worktree clean
-      run: ../ci-scripts/ci/check-worktree-is-clean
+      run: ./ci-scripts/ci/check-worktree-is-clean
     - run: git status --porcelain
     - name: Tar provider binaries
       run: tar -zcf ${{ github.workspace }}/bin/provider.tar.gz -C ${{
@@ -182,7 +182,7 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
-    - run: mv ci-scripts ../ci-scripts
+    - run: echo "ci-scripts" >> .git/info/exclude
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -237,7 +237,7 @@ jobs:
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
-      run: ../ci-scripts/ci/check-worktree-is-clean
+      run: ./ci-scripts/ci/check-worktree-is-clean
     - run: git status --porcelain
     - name: Tar SDK folder
       run: tar -zcf sdk/${{ matrix.language }}.tar.gz -C sdk/${{ matrix.language }} .
@@ -284,7 +284,7 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
-    - run: mv ci-scripts ../ci-scripts
+    - run: echo "ci-scripts" >> .git/info/exclude
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/native-provider-ci/providers/google-native/repo/.github/workflows/run-acceptance-tests.yml
+++ b/native-provider-ci/providers/google-native/repo/.github/workflows/run-acceptance-tests.yml
@@ -76,7 +76,7 @@ jobs:
     - name: Checkout Scripts Repo
       uses: actions/checkout@v4
       with:
-        path: ci-scripts
+        path: ../ci-scripts
         repository: pulumi/scripts
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
@@ -131,7 +131,7 @@ jobs:
     - name: Build Provider
       run: make provider
     - name: Check worktree clean
-      run: ./ci-scripts/ci/check-worktree-is-clean
+      run: ../ci-scripts/ci/check-worktree-is-clean
     - run: git status --porcelain
     - name: Tar provider binaries
       run: tar -zcf ${{ github.workspace }}/bin/provider.tar.gz -C ${{
@@ -179,7 +179,7 @@ jobs:
     - name: Checkout Scripts Repo
       uses: actions/checkout@v4
       with:
-        path: ci-scripts
+        path: ../ci-scripts
         repository: pulumi/scripts
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
@@ -235,7 +235,7 @@ jobs:
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
-      run: ./ci-scripts/ci/check-worktree-is-clean
+      run: ../ci-scripts/ci/check-worktree-is-clean
     - run: git status --porcelain
     - name: Tar SDK folder
       run: tar -zcf sdk/${{ matrix.language }}.tar.gz -C sdk/${{ matrix.language }} .
@@ -280,7 +280,7 @@ jobs:
     - name: Checkout Scripts Repo
       uses: actions/checkout@v4
       with:
-        path: ci-scripts
+        path: ../ci-scripts
         repository: pulumi/scripts
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags

--- a/native-provider-ci/providers/google-native/repo/.github/workflows/run-acceptance-tests.yml
+++ b/native-provider-ci/providers/google-native/repo/.github/workflows/run-acceptance-tests.yml
@@ -76,8 +76,10 @@ jobs:
     - name: Checkout Scripts Repo
       uses: actions/checkout@v4
       with:
-        path: ${{ runner.temp }}/ci-scripts
+        path: ci-scripts
         repository: pulumi/scripts
+      env:
+        GITHUB_WORKSPACE: ${{ runner.temp }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -179,8 +181,10 @@ jobs:
     - name: Checkout Scripts Repo
       uses: actions/checkout@v4
       with:
-        path: ${{ runner.temp }}/ci-scripts
+        path: ci-scripts
         repository: pulumi/scripts
+      env:
+        GITHUB_WORKSPACE: ${{ runner.temp }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -280,8 +284,10 @@ jobs:
     - name: Checkout Scripts Repo
       uses: actions/checkout@v4
       with:
-        path: ${{ runner.temp }}/ci-scripts
+        path: ci-scripts
         repository: pulumi/scripts
+      env:
+        GITHUB_WORKSPACE: ${{ runner.temp }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/native-provider-ci/providers/google-native/repo/.github/workflows/run-acceptance-tests.yml
+++ b/native-provider-ci/providers/google-native/repo/.github/workflows/run-acceptance-tests.yml
@@ -78,8 +78,7 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
-      env:
-        GITHUB_WORKSPACE: ${{ runner.temp }}
+    - run: mv ci-scripts ../ci-scripts
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -133,7 +132,7 @@ jobs:
     - name: Build Provider
       run: make provider
     - name: Check worktree clean
-      run: ${{ runner.temp }}/ci-scripts/ci/check-worktree-is-clean
+      run: ../ci-scripts/ci/check-worktree-is-clean
     - run: git status --porcelain
     - name: Tar provider binaries
       run: tar -zcf ${{ github.workspace }}/bin/provider.tar.gz -C ${{
@@ -183,8 +182,7 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
-      env:
-        GITHUB_WORKSPACE: ${{ runner.temp }}
+    - run: mv ci-scripts ../ci-scripts
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -239,7 +237,7 @@ jobs:
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
-      run: ${{ runner.temp }}/ci-scripts/ci/check-worktree-is-clean
+      run: ../ci-scripts/ci/check-worktree-is-clean
     - run: git status --porcelain
     - name: Tar SDK folder
       run: tar -zcf sdk/${{ matrix.language }}.tar.gz -C sdk/${{ matrix.language }} .
@@ -286,8 +284,7 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
-      env:
-        GITHUB_WORKSPACE: ${{ runner.temp }}
+    - run: mv ci-scripts ../ci-scripts
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/native-provider-ci/providers/kubernetes-cert-manager/repo/.github/workflows/build.yml
+++ b/native-provider-ci/providers/kubernetes-cert-manager/repo/.github/workflows/build.yml
@@ -60,8 +60,7 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
-      env:
-        GITHUB_WORKSPACE: ${{ runner.temp }}
+    - run: mv ci-scripts ../ci-scripts
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -113,7 +112,7 @@ jobs:
     - name: Build Provider
       run: make provider
     - name: Check worktree clean
-      run: ${{ runner.temp }}/ci-scripts/ci/check-worktree-is-clean
+      run: ../ci-scripts/ci/check-worktree-is-clean
     - run: git status --porcelain
     - name: Tar provider binaries
       run: tar -zcf ${{ github.workspace }}/bin/provider.tar.gz -C ${{
@@ -160,8 +159,7 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
-      env:
-        GITHUB_WORKSPACE: ${{ runner.temp }}
+    - run: mv ci-scripts ../ci-scripts
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -214,7 +212,7 @@ jobs:
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
-      run: ${{ runner.temp }}/ci-scripts/ci/check-worktree-is-clean
+      run: ../ci-scripts/ci/check-worktree-is-clean
     - run: git status --porcelain
     - name: Tar SDK folder
       run: tar -zcf sdk/${{ matrix.language }}.tar.gz -C sdk/${{ matrix.language }} .
@@ -258,8 +256,7 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
-      env:
-        GITHUB_WORKSPACE: ${{ runner.temp }}
+    - run: mv ci-scripts ../ci-scripts
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -413,8 +410,7 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
-      env:
-        GITHUB_WORKSPACE: ${{ runner.temp }}
+    - run: mv ci-scripts ../ci-scripts
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -468,8 +464,7 @@ jobs:
     - name: Install Twine
       run: python -m pip install pip twine
     - name: Publish SDKs
-      run: ${{ runner.temp }}/ci-scripts/ci/publish-tfgen-package ${{ github.workspace
-        }}
+      run: ../ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
       env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         PYPI_PUBLISH_ARTIFACTS: all
@@ -495,8 +490,7 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
-      env:
-        GITHUB_WORKSPACE: ${{ runner.temp }}
+    - run: mv ci-scripts ../ci-scripts
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/native-provider-ci/providers/kubernetes-cert-manager/repo/.github/workflows/build.yml
+++ b/native-provider-ci/providers/kubernetes-cert-manager/repo/.github/workflows/build.yml
@@ -58,7 +58,7 @@ jobs:
     - name: Checkout Scripts Repo
       uses: actions/checkout@v4
       with:
-        path: ../ci-scripts
+        path: ${{ runner.temp }}/ci-scripts
         repository: pulumi/scripts
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
@@ -111,7 +111,7 @@ jobs:
     - name: Build Provider
       run: make provider
     - name: Check worktree clean
-      run: ../ci-scripts/ci/check-worktree-is-clean
+      run: ${{ runner.temp }}/ci-scripts/ci/check-worktree-is-clean
     - run: git status --porcelain
     - name: Tar provider binaries
       run: tar -zcf ${{ github.workspace }}/bin/provider.tar.gz -C ${{
@@ -156,7 +156,7 @@ jobs:
     - name: Checkout Scripts Repo
       uses: actions/checkout@v4
       with:
-        path: ../ci-scripts
+        path: ${{ runner.temp }}/ci-scripts
         repository: pulumi/scripts
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
@@ -210,7 +210,7 @@ jobs:
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
-      run: ../ci-scripts/ci/check-worktree-is-clean
+      run: ${{ runner.temp }}/ci-scripts/ci/check-worktree-is-clean
     - run: git status --porcelain
     - name: Tar SDK folder
       run: tar -zcf sdk/${{ matrix.language }}.tar.gz -C sdk/${{ matrix.language }} .
@@ -252,7 +252,7 @@ jobs:
     - name: Checkout Scripts Repo
       uses: actions/checkout@v4
       with:
-        path: ../ci-scripts
+        path: ${{ runner.temp }}/ci-scripts
         repository: pulumi/scripts
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
@@ -405,7 +405,7 @@ jobs:
     - name: Checkout Scripts Repo
       uses: actions/checkout@v4
       with:
-        path: ../ci-scripts
+        path: ${{ runner.temp }}/ci-scripts
         repository: pulumi/scripts
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
@@ -460,7 +460,8 @@ jobs:
     - name: Install Twine
       run: python -m pip install pip twine
     - name: Publish SDKs
-      run: ../ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
+      run: ${{ runner.temp }}/ci-scripts/ci/publish-tfgen-package ${{ github.workspace
+        }}
       env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         PYPI_PUBLISH_ARTIFACTS: all
@@ -484,7 +485,7 @@ jobs:
     - name: Checkout Scripts Repo
       uses: actions/checkout@v4
       with:
-        path: ../ci-scripts
+        path: ${{ runner.temp }}/ci-scripts
         repository: pulumi/scripts
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags

--- a/native-provider-ci/providers/kubernetes-cert-manager/repo/.github/workflows/build.yml
+++ b/native-provider-ci/providers/kubernetes-cert-manager/repo/.github/workflows/build.yml
@@ -58,8 +58,10 @@ jobs:
     - name: Checkout Scripts Repo
       uses: actions/checkout@v4
       with:
-        path: ${{ runner.temp }}/ci-scripts
+        path: ci-scripts
         repository: pulumi/scripts
+      env:
+        GITHUB_WORKSPACE: ${{ runner.temp }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -156,8 +158,10 @@ jobs:
     - name: Checkout Scripts Repo
       uses: actions/checkout@v4
       with:
-        path: ${{ runner.temp }}/ci-scripts
+        path: ci-scripts
         repository: pulumi/scripts
+      env:
+        GITHUB_WORKSPACE: ${{ runner.temp }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -252,8 +256,10 @@ jobs:
     - name: Checkout Scripts Repo
       uses: actions/checkout@v4
       with:
-        path: ${{ runner.temp }}/ci-scripts
+        path: ci-scripts
         repository: pulumi/scripts
+      env:
+        GITHUB_WORKSPACE: ${{ runner.temp }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -405,8 +411,10 @@ jobs:
     - name: Checkout Scripts Repo
       uses: actions/checkout@v4
       with:
-        path: ${{ runner.temp }}/ci-scripts
+        path: ci-scripts
         repository: pulumi/scripts
+      env:
+        GITHUB_WORKSPACE: ${{ runner.temp }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -485,8 +493,10 @@ jobs:
     - name: Checkout Scripts Repo
       uses: actions/checkout@v4
       with:
-        path: ${{ runner.temp }}/ci-scripts
+        path: ci-scripts
         repository: pulumi/scripts
+      env:
+        GITHUB_WORKSPACE: ${{ runner.temp }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/native-provider-ci/providers/kubernetes-cert-manager/repo/.github/workflows/build.yml
+++ b/native-provider-ci/providers/kubernetes-cert-manager/repo/.github/workflows/build.yml
@@ -60,7 +60,7 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
-    - run: mv ci-scripts ../ci-scripts
+    - run: echo "ci-scripts" >> .git/info/exclude
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -112,7 +112,7 @@ jobs:
     - name: Build Provider
       run: make provider
     - name: Check worktree clean
-      run: ../ci-scripts/ci/check-worktree-is-clean
+      run: ./ci-scripts/ci/check-worktree-is-clean
     - run: git status --porcelain
     - name: Tar provider binaries
       run: tar -zcf ${{ github.workspace }}/bin/provider.tar.gz -C ${{
@@ -159,7 +159,7 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
-    - run: mv ci-scripts ../ci-scripts
+    - run: echo "ci-scripts" >> .git/info/exclude
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -212,7 +212,7 @@ jobs:
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
-      run: ../ci-scripts/ci/check-worktree-is-clean
+      run: ./ci-scripts/ci/check-worktree-is-clean
     - run: git status --porcelain
     - name: Tar SDK folder
       run: tar -zcf sdk/${{ matrix.language }}.tar.gz -C sdk/${{ matrix.language }} .
@@ -256,7 +256,7 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
-    - run: mv ci-scripts ../ci-scripts
+    - run: echo "ci-scripts" >> .git/info/exclude
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -410,7 +410,7 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
-    - run: mv ci-scripts ../ci-scripts
+    - run: echo "ci-scripts" >> .git/info/exclude
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -464,7 +464,7 @@ jobs:
     - name: Install Twine
       run: python -m pip install pip twine
     - name: Publish SDKs
-      run: ../ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
+      run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
       env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         PYPI_PUBLISH_ARTIFACTS: all
@@ -490,7 +490,7 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
-    - run: mv ci-scripts ../ci-scripts
+    - run: echo "ci-scripts" >> .git/info/exclude
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/native-provider-ci/providers/kubernetes-cert-manager/repo/.github/workflows/build.yml
+++ b/native-provider-ci/providers/kubernetes-cert-manager/repo/.github/workflows/build.yml
@@ -58,7 +58,7 @@ jobs:
     - name: Checkout Scripts Repo
       uses: actions/checkout@v4
       with:
-        path: ci-scripts
+        path: ../ci-scripts
         repository: pulumi/scripts
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
@@ -111,7 +111,7 @@ jobs:
     - name: Build Provider
       run: make provider
     - name: Check worktree clean
-      run: ./ci-scripts/ci/check-worktree-is-clean
+      run: ../ci-scripts/ci/check-worktree-is-clean
     - run: git status --porcelain
     - name: Tar provider binaries
       run: tar -zcf ${{ github.workspace }}/bin/provider.tar.gz -C ${{
@@ -156,7 +156,7 @@ jobs:
     - name: Checkout Scripts Repo
       uses: actions/checkout@v4
       with:
-        path: ci-scripts
+        path: ../ci-scripts
         repository: pulumi/scripts
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
@@ -210,7 +210,7 @@ jobs:
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
-      run: ./ci-scripts/ci/check-worktree-is-clean
+      run: ../ci-scripts/ci/check-worktree-is-clean
     - run: git status --porcelain
     - name: Tar SDK folder
       run: tar -zcf sdk/${{ matrix.language }}.tar.gz -C sdk/${{ matrix.language }} .
@@ -252,7 +252,7 @@ jobs:
     - name: Checkout Scripts Repo
       uses: actions/checkout@v4
       with:
-        path: ci-scripts
+        path: ../ci-scripts
         repository: pulumi/scripts
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
@@ -405,7 +405,7 @@ jobs:
     - name: Checkout Scripts Repo
       uses: actions/checkout@v4
       with:
-        path: ci-scripts
+        path: ../ci-scripts
         repository: pulumi/scripts
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
@@ -460,7 +460,7 @@ jobs:
     - name: Install Twine
       run: python -m pip install pip twine
     - name: Publish SDKs
-      run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
+      run: ../ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
       env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         PYPI_PUBLISH_ARTIFACTS: all
@@ -484,7 +484,7 @@ jobs:
     - name: Checkout Scripts Repo
       uses: actions/checkout@v4
       with:
-        path: ci-scripts
+        path: ../ci-scripts
         repository: pulumi/scripts
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags

--- a/native-provider-ci/providers/kubernetes-cert-manager/repo/.github/workflows/prerelease.yml
+++ b/native-provider-ci/providers/kubernetes-cert-manager/repo/.github/workflows/prerelease.yml
@@ -50,8 +50,10 @@ jobs:
     - name: Checkout Scripts Repo
       uses: actions/checkout@v4
       with:
-        path: ${{ runner.temp }}/ci-scripts
+        path: ci-scripts
         repository: pulumi/scripts
+      env:
+        GITHUB_WORKSPACE: ${{ runner.temp }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -148,8 +150,10 @@ jobs:
     - name: Checkout Scripts Repo
       uses: actions/checkout@v4
       with:
-        path: ${{ runner.temp }}/ci-scripts
+        path: ci-scripts
         repository: pulumi/scripts
+      env:
+        GITHUB_WORKSPACE: ${{ runner.temp }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -243,8 +247,10 @@ jobs:
     - name: Checkout Scripts Repo
       uses: actions/checkout@v4
       with:
-        path: ${{ runner.temp }}/ci-scripts
+        path: ci-scripts
         repository: pulumi/scripts
+      env:
+        GITHUB_WORKSPACE: ${{ runner.temp }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -396,8 +402,10 @@ jobs:
     - name: Checkout Scripts Repo
       uses: actions/checkout@v4
       with:
-        path: ${{ runner.temp }}/ci-scripts
+        path: ci-scripts
         repository: pulumi/scripts
+      env:
+        GITHUB_WORKSPACE: ${{ runner.temp }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -476,8 +484,10 @@ jobs:
     - name: Checkout Scripts Repo
       uses: actions/checkout@v4
       with:
-        path: ${{ runner.temp }}/ci-scripts
+        path: ci-scripts
         repository: pulumi/scripts
+      env:
+        GITHUB_WORKSPACE: ${{ runner.temp }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/native-provider-ci/providers/kubernetes-cert-manager/repo/.github/workflows/prerelease.yml
+++ b/native-provider-ci/providers/kubernetes-cert-manager/repo/.github/workflows/prerelease.yml
@@ -50,7 +50,7 @@ jobs:
     - name: Checkout Scripts Repo
       uses: actions/checkout@v4
       with:
-        path: ../ci-scripts
+        path: ${{ runner.temp }}/ci-scripts
         repository: pulumi/scripts
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
@@ -103,7 +103,7 @@ jobs:
     - name: Build Provider
       run: make provider
     - name: Check worktree clean
-      run: ../ci-scripts/ci/check-worktree-is-clean
+      run: ${{ runner.temp }}/ci-scripts/ci/check-worktree-is-clean
     - run: git status --porcelain
     - name: Tar provider binaries
       run: tar -zcf ${{ github.workspace }}/bin/provider.tar.gz -C ${{
@@ -148,7 +148,7 @@ jobs:
     - name: Checkout Scripts Repo
       uses: actions/checkout@v4
       with:
-        path: ../ci-scripts
+        path: ${{ runner.temp }}/ci-scripts
         repository: pulumi/scripts
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
@@ -202,7 +202,7 @@ jobs:
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
-      run: ../ci-scripts/ci/check-worktree-is-clean
+      run: ${{ runner.temp }}/ci-scripts/ci/check-worktree-is-clean
     - run: git status --porcelain
     - name: Tar SDK folder
       run: tar -zcf sdk/${{ matrix.language }}.tar.gz -C sdk/${{ matrix.language }} .
@@ -243,7 +243,7 @@ jobs:
     - name: Checkout Scripts Repo
       uses: actions/checkout@v4
       with:
-        path: ../ci-scripts
+        path: ${{ runner.temp }}/ci-scripts
         repository: pulumi/scripts
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
@@ -396,7 +396,7 @@ jobs:
     - name: Checkout Scripts Repo
       uses: actions/checkout@v4
       with:
-        path: ../ci-scripts
+        path: ${{ runner.temp }}/ci-scripts
         repository: pulumi/scripts
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
@@ -451,7 +451,8 @@ jobs:
     - name: Install Twine
       run: python -m pip install pip twine
     - name: Publish SDKs
-      run: ../ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
+      run: ${{ runner.temp }}/ci-scripts/ci/publish-tfgen-package ${{ github.workspace
+        }}
       env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         PYPI_PUBLISH_ARTIFACTS: all
@@ -475,7 +476,7 @@ jobs:
     - name: Checkout Scripts Repo
       uses: actions/checkout@v4
       with:
-        path: ../ci-scripts
+        path: ${{ runner.temp }}/ci-scripts
         repository: pulumi/scripts
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags

--- a/native-provider-ci/providers/kubernetes-cert-manager/repo/.github/workflows/prerelease.yml
+++ b/native-provider-ci/providers/kubernetes-cert-manager/repo/.github/workflows/prerelease.yml
@@ -52,8 +52,7 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
-      env:
-        GITHUB_WORKSPACE: ${{ runner.temp }}
+    - run: mv ci-scripts ../ci-scripts
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -105,7 +104,7 @@ jobs:
     - name: Build Provider
       run: make provider
     - name: Check worktree clean
-      run: ${{ runner.temp }}/ci-scripts/ci/check-worktree-is-clean
+      run: ../ci-scripts/ci/check-worktree-is-clean
     - run: git status --porcelain
     - name: Tar provider binaries
       run: tar -zcf ${{ github.workspace }}/bin/provider.tar.gz -C ${{
@@ -152,8 +151,7 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
-      env:
-        GITHUB_WORKSPACE: ${{ runner.temp }}
+    - run: mv ci-scripts ../ci-scripts
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -206,7 +204,7 @@ jobs:
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
-      run: ${{ runner.temp }}/ci-scripts/ci/check-worktree-is-clean
+      run: ../ci-scripts/ci/check-worktree-is-clean
     - run: git status --porcelain
     - name: Tar SDK folder
       run: tar -zcf sdk/${{ matrix.language }}.tar.gz -C sdk/${{ matrix.language }} .
@@ -249,8 +247,7 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
-      env:
-        GITHUB_WORKSPACE: ${{ runner.temp }}
+    - run: mv ci-scripts ../ci-scripts
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -404,8 +401,7 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
-      env:
-        GITHUB_WORKSPACE: ${{ runner.temp }}
+    - run: mv ci-scripts ../ci-scripts
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -459,8 +455,7 @@ jobs:
     - name: Install Twine
       run: python -m pip install pip twine
     - name: Publish SDKs
-      run: ${{ runner.temp }}/ci-scripts/ci/publish-tfgen-package ${{ github.workspace
-        }}
+      run: ../ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
       env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         PYPI_PUBLISH_ARTIFACTS: all
@@ -486,8 +481,7 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
-      env:
-        GITHUB_WORKSPACE: ${{ runner.temp }}
+    - run: mv ci-scripts ../ci-scripts
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/native-provider-ci/providers/kubernetes-cert-manager/repo/.github/workflows/prerelease.yml
+++ b/native-provider-ci/providers/kubernetes-cert-manager/repo/.github/workflows/prerelease.yml
@@ -52,7 +52,7 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
-    - run: mv ci-scripts ../ci-scripts
+    - run: echo "ci-scripts" >> .git/info/exclude
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -104,7 +104,7 @@ jobs:
     - name: Build Provider
       run: make provider
     - name: Check worktree clean
-      run: ../ci-scripts/ci/check-worktree-is-clean
+      run: ./ci-scripts/ci/check-worktree-is-clean
     - run: git status --porcelain
     - name: Tar provider binaries
       run: tar -zcf ${{ github.workspace }}/bin/provider.tar.gz -C ${{
@@ -151,7 +151,7 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
-    - run: mv ci-scripts ../ci-scripts
+    - run: echo "ci-scripts" >> .git/info/exclude
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -204,7 +204,7 @@ jobs:
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
-      run: ../ci-scripts/ci/check-worktree-is-clean
+      run: ./ci-scripts/ci/check-worktree-is-clean
     - run: git status --porcelain
     - name: Tar SDK folder
       run: tar -zcf sdk/${{ matrix.language }}.tar.gz -C sdk/${{ matrix.language }} .
@@ -247,7 +247,7 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
-    - run: mv ci-scripts ../ci-scripts
+    - run: echo "ci-scripts" >> .git/info/exclude
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -401,7 +401,7 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
-    - run: mv ci-scripts ../ci-scripts
+    - run: echo "ci-scripts" >> .git/info/exclude
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -455,7 +455,7 @@ jobs:
     - name: Install Twine
       run: python -m pip install pip twine
     - name: Publish SDKs
-      run: ../ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
+      run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
       env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         PYPI_PUBLISH_ARTIFACTS: all
@@ -481,7 +481,7 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
-    - run: mv ci-scripts ../ci-scripts
+    - run: echo "ci-scripts" >> .git/info/exclude
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/native-provider-ci/providers/kubernetes-cert-manager/repo/.github/workflows/prerelease.yml
+++ b/native-provider-ci/providers/kubernetes-cert-manager/repo/.github/workflows/prerelease.yml
@@ -50,7 +50,7 @@ jobs:
     - name: Checkout Scripts Repo
       uses: actions/checkout@v4
       with:
-        path: ci-scripts
+        path: ../ci-scripts
         repository: pulumi/scripts
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
@@ -103,7 +103,7 @@ jobs:
     - name: Build Provider
       run: make provider
     - name: Check worktree clean
-      run: ./ci-scripts/ci/check-worktree-is-clean
+      run: ../ci-scripts/ci/check-worktree-is-clean
     - run: git status --porcelain
     - name: Tar provider binaries
       run: tar -zcf ${{ github.workspace }}/bin/provider.tar.gz -C ${{
@@ -148,7 +148,7 @@ jobs:
     - name: Checkout Scripts Repo
       uses: actions/checkout@v4
       with:
-        path: ci-scripts
+        path: ../ci-scripts
         repository: pulumi/scripts
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
@@ -202,7 +202,7 @@ jobs:
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
-      run: ./ci-scripts/ci/check-worktree-is-clean
+      run: ../ci-scripts/ci/check-worktree-is-clean
     - run: git status --porcelain
     - name: Tar SDK folder
       run: tar -zcf sdk/${{ matrix.language }}.tar.gz -C sdk/${{ matrix.language }} .
@@ -243,7 +243,7 @@ jobs:
     - name: Checkout Scripts Repo
       uses: actions/checkout@v4
       with:
-        path: ci-scripts
+        path: ../ci-scripts
         repository: pulumi/scripts
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
@@ -396,7 +396,7 @@ jobs:
     - name: Checkout Scripts Repo
       uses: actions/checkout@v4
       with:
-        path: ci-scripts
+        path: ../ci-scripts
         repository: pulumi/scripts
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
@@ -451,7 +451,7 @@ jobs:
     - name: Install Twine
       run: python -m pip install pip twine
     - name: Publish SDKs
-      run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
+      run: ../ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
       env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         PYPI_PUBLISH_ARTIFACTS: all
@@ -475,7 +475,7 @@ jobs:
     - name: Checkout Scripts Repo
       uses: actions/checkout@v4
       with:
-        path: ci-scripts
+        path: ../ci-scripts
         repository: pulumi/scripts
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags

--- a/native-provider-ci/providers/kubernetes-cert-manager/repo/.github/workflows/release.yml
+++ b/native-provider-ci/providers/kubernetes-cert-manager/repo/.github/workflows/release.yml
@@ -50,8 +50,10 @@ jobs:
     - name: Checkout Scripts Repo
       uses: actions/checkout@v4
       with:
-        path: ${{ runner.temp }}/ci-scripts
+        path: ci-scripts
         repository: pulumi/scripts
+      env:
+        GITHUB_WORKSPACE: ${{ runner.temp }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -148,8 +150,10 @@ jobs:
     - name: Checkout Scripts Repo
       uses: actions/checkout@v4
       with:
-        path: ${{ runner.temp }}/ci-scripts
+        path: ci-scripts
         repository: pulumi/scripts
+      env:
+        GITHUB_WORKSPACE: ${{ runner.temp }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -243,8 +247,10 @@ jobs:
     - name: Checkout Scripts Repo
       uses: actions/checkout@v4
       with:
-        path: ${{ runner.temp }}/ci-scripts
+        path: ci-scripts
         repository: pulumi/scripts
+      env:
+        GITHUB_WORKSPACE: ${{ runner.temp }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -396,8 +402,10 @@ jobs:
     - name: Checkout Scripts Repo
       uses: actions/checkout@v4
       with:
-        path: ${{ runner.temp }}/ci-scripts
+        path: ci-scripts
         repository: pulumi/scripts
+      env:
+        GITHUB_WORKSPACE: ${{ runner.temp }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -476,8 +484,10 @@ jobs:
     - name: Checkout Scripts Repo
       uses: actions/checkout@v4
       with:
-        path: ${{ runner.temp }}/ci-scripts
+        path: ci-scripts
         repository: pulumi/scripts
+      env:
+        GITHUB_WORKSPACE: ${{ runner.temp }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/native-provider-ci/providers/kubernetes-cert-manager/repo/.github/workflows/release.yml
+++ b/native-provider-ci/providers/kubernetes-cert-manager/repo/.github/workflows/release.yml
@@ -50,7 +50,7 @@ jobs:
     - name: Checkout Scripts Repo
       uses: actions/checkout@v4
       with:
-        path: ../ci-scripts
+        path: ${{ runner.temp }}/ci-scripts
         repository: pulumi/scripts
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
@@ -103,7 +103,7 @@ jobs:
     - name: Build Provider
       run: make provider
     - name: Check worktree clean
-      run: ../ci-scripts/ci/check-worktree-is-clean
+      run: ${{ runner.temp }}/ci-scripts/ci/check-worktree-is-clean
     - run: git status --porcelain
     - name: Tar provider binaries
       run: tar -zcf ${{ github.workspace }}/bin/provider.tar.gz -C ${{
@@ -148,7 +148,7 @@ jobs:
     - name: Checkout Scripts Repo
       uses: actions/checkout@v4
       with:
-        path: ../ci-scripts
+        path: ${{ runner.temp }}/ci-scripts
         repository: pulumi/scripts
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
@@ -202,7 +202,7 @@ jobs:
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
-      run: ../ci-scripts/ci/check-worktree-is-clean
+      run: ${{ runner.temp }}/ci-scripts/ci/check-worktree-is-clean
     - run: git status --porcelain
     - name: Tar SDK folder
       run: tar -zcf sdk/${{ matrix.language }}.tar.gz -C sdk/${{ matrix.language }} .
@@ -243,7 +243,7 @@ jobs:
     - name: Checkout Scripts Repo
       uses: actions/checkout@v4
       with:
-        path: ../ci-scripts
+        path: ${{ runner.temp }}/ci-scripts
         repository: pulumi/scripts
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
@@ -396,7 +396,7 @@ jobs:
     - name: Checkout Scripts Repo
       uses: actions/checkout@v4
       with:
-        path: ../ci-scripts
+        path: ${{ runner.temp }}/ci-scripts
         repository: pulumi/scripts
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
@@ -451,7 +451,8 @@ jobs:
     - name: Install Twine
       run: python -m pip install pip twine
     - name: Publish SDKs
-      run: ../ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
+      run: ${{ runner.temp }}/ci-scripts/ci/publish-tfgen-package ${{ github.workspace
+        }}
       env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         PYPI_PUBLISH_ARTIFACTS: all
@@ -475,7 +476,7 @@ jobs:
     - name: Checkout Scripts Repo
       uses: actions/checkout@v4
       with:
-        path: ../ci-scripts
+        path: ${{ runner.temp }}/ci-scripts
         repository: pulumi/scripts
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags

--- a/native-provider-ci/providers/kubernetes-cert-manager/repo/.github/workflows/release.yml
+++ b/native-provider-ci/providers/kubernetes-cert-manager/repo/.github/workflows/release.yml
@@ -52,8 +52,7 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
-      env:
-        GITHUB_WORKSPACE: ${{ runner.temp }}
+    - run: mv ci-scripts ../ci-scripts
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -105,7 +104,7 @@ jobs:
     - name: Build Provider
       run: make provider
     - name: Check worktree clean
-      run: ${{ runner.temp }}/ci-scripts/ci/check-worktree-is-clean
+      run: ../ci-scripts/ci/check-worktree-is-clean
     - run: git status --porcelain
     - name: Tar provider binaries
       run: tar -zcf ${{ github.workspace }}/bin/provider.tar.gz -C ${{
@@ -152,8 +151,7 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
-      env:
-        GITHUB_WORKSPACE: ${{ runner.temp }}
+    - run: mv ci-scripts ../ci-scripts
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -206,7 +204,7 @@ jobs:
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
-      run: ${{ runner.temp }}/ci-scripts/ci/check-worktree-is-clean
+      run: ../ci-scripts/ci/check-worktree-is-clean
     - run: git status --porcelain
     - name: Tar SDK folder
       run: tar -zcf sdk/${{ matrix.language }}.tar.gz -C sdk/${{ matrix.language }} .
@@ -249,8 +247,7 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
-      env:
-        GITHUB_WORKSPACE: ${{ runner.temp }}
+    - run: mv ci-scripts ../ci-scripts
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -404,8 +401,7 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
-      env:
-        GITHUB_WORKSPACE: ${{ runner.temp }}
+    - run: mv ci-scripts ../ci-scripts
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -459,8 +455,7 @@ jobs:
     - name: Install Twine
       run: python -m pip install pip twine
     - name: Publish SDKs
-      run: ${{ runner.temp }}/ci-scripts/ci/publish-tfgen-package ${{ github.workspace
-        }}
+      run: ../ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
       env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         PYPI_PUBLISH_ARTIFACTS: all
@@ -486,8 +481,7 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
-      env:
-        GITHUB_WORKSPACE: ${{ runner.temp }}
+    - run: mv ci-scripts ../ci-scripts
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/native-provider-ci/providers/kubernetes-cert-manager/repo/.github/workflows/release.yml
+++ b/native-provider-ci/providers/kubernetes-cert-manager/repo/.github/workflows/release.yml
@@ -52,7 +52,7 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
-    - run: mv ci-scripts ../ci-scripts
+    - run: echo "ci-scripts" >> .git/info/exclude
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -104,7 +104,7 @@ jobs:
     - name: Build Provider
       run: make provider
     - name: Check worktree clean
-      run: ../ci-scripts/ci/check-worktree-is-clean
+      run: ./ci-scripts/ci/check-worktree-is-clean
     - run: git status --porcelain
     - name: Tar provider binaries
       run: tar -zcf ${{ github.workspace }}/bin/provider.tar.gz -C ${{
@@ -151,7 +151,7 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
-    - run: mv ci-scripts ../ci-scripts
+    - run: echo "ci-scripts" >> .git/info/exclude
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -204,7 +204,7 @@ jobs:
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
-      run: ../ci-scripts/ci/check-worktree-is-clean
+      run: ./ci-scripts/ci/check-worktree-is-clean
     - run: git status --porcelain
     - name: Tar SDK folder
       run: tar -zcf sdk/${{ matrix.language }}.tar.gz -C sdk/${{ matrix.language }} .
@@ -247,7 +247,7 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
-    - run: mv ci-scripts ../ci-scripts
+    - run: echo "ci-scripts" >> .git/info/exclude
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -401,7 +401,7 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
-    - run: mv ci-scripts ../ci-scripts
+    - run: echo "ci-scripts" >> .git/info/exclude
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -455,7 +455,7 @@ jobs:
     - name: Install Twine
       run: python -m pip install pip twine
     - name: Publish SDKs
-      run: ../ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
+      run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
       env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         PYPI_PUBLISH_ARTIFACTS: all
@@ -481,7 +481,7 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
-    - run: mv ci-scripts ../ci-scripts
+    - run: echo "ci-scripts" >> .git/info/exclude
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/native-provider-ci/providers/kubernetes-cert-manager/repo/.github/workflows/release.yml
+++ b/native-provider-ci/providers/kubernetes-cert-manager/repo/.github/workflows/release.yml
@@ -50,7 +50,7 @@ jobs:
     - name: Checkout Scripts Repo
       uses: actions/checkout@v4
       with:
-        path: ci-scripts
+        path: ../ci-scripts
         repository: pulumi/scripts
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
@@ -103,7 +103,7 @@ jobs:
     - name: Build Provider
       run: make provider
     - name: Check worktree clean
-      run: ./ci-scripts/ci/check-worktree-is-clean
+      run: ../ci-scripts/ci/check-worktree-is-clean
     - run: git status --porcelain
     - name: Tar provider binaries
       run: tar -zcf ${{ github.workspace }}/bin/provider.tar.gz -C ${{
@@ -148,7 +148,7 @@ jobs:
     - name: Checkout Scripts Repo
       uses: actions/checkout@v4
       with:
-        path: ci-scripts
+        path: ../ci-scripts
         repository: pulumi/scripts
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
@@ -202,7 +202,7 @@ jobs:
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
-      run: ./ci-scripts/ci/check-worktree-is-clean
+      run: ../ci-scripts/ci/check-worktree-is-clean
     - run: git status --porcelain
     - name: Tar SDK folder
       run: tar -zcf sdk/${{ matrix.language }}.tar.gz -C sdk/${{ matrix.language }} .
@@ -243,7 +243,7 @@ jobs:
     - name: Checkout Scripts Repo
       uses: actions/checkout@v4
       with:
-        path: ci-scripts
+        path: ../ci-scripts
         repository: pulumi/scripts
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
@@ -396,7 +396,7 @@ jobs:
     - name: Checkout Scripts Repo
       uses: actions/checkout@v4
       with:
-        path: ci-scripts
+        path: ../ci-scripts
         repository: pulumi/scripts
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
@@ -451,7 +451,7 @@ jobs:
     - name: Install Twine
       run: python -m pip install pip twine
     - name: Publish SDKs
-      run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
+      run: ../ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
       env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         PYPI_PUBLISH_ARTIFACTS: all
@@ -475,7 +475,7 @@ jobs:
     - name: Checkout Scripts Repo
       uses: actions/checkout@v4
       with:
-        path: ci-scripts
+        path: ../ci-scripts
         repository: pulumi/scripts
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags

--- a/native-provider-ci/providers/kubernetes-cert-manager/repo/.github/workflows/run-acceptance-tests.yml
+++ b/native-provider-ci/providers/kubernetes-cert-manager/repo/.github/workflows/run-acceptance-tests.yml
@@ -75,7 +75,7 @@ jobs:
     - name: Checkout Scripts Repo
       uses: actions/checkout@v4
       with:
-        path: ../ci-scripts
+        path: ${{ runner.temp }}/ci-scripts
         repository: pulumi/scripts
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
@@ -128,7 +128,7 @@ jobs:
     - name: Build Provider
       run: make provider
     - name: Check worktree clean
-      run: ../ci-scripts/ci/check-worktree-is-clean
+      run: ${{ runner.temp }}/ci-scripts/ci/check-worktree-is-clean
     - run: git status --porcelain
     - name: Tar provider binaries
       run: tar -zcf ${{ github.workspace }}/bin/provider.tar.gz -C ${{
@@ -176,7 +176,7 @@ jobs:
     - name: Checkout Scripts Repo
       uses: actions/checkout@v4
       with:
-        path: ../ci-scripts
+        path: ${{ runner.temp }}/ci-scripts
         repository: pulumi/scripts
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
@@ -230,7 +230,7 @@ jobs:
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
-      run: ../ci-scripts/ci/check-worktree-is-clean
+      run: ${{ runner.temp }}/ci-scripts/ci/check-worktree-is-clean
     - run: git status --porcelain
     - name: Tar SDK folder
       run: tar -zcf sdk/${{ matrix.language }}.tar.gz -C sdk/${{ matrix.language }} .
@@ -275,7 +275,7 @@ jobs:
     - name: Checkout Scripts Repo
       uses: actions/checkout@v4
       with:
-        path: ../ci-scripts
+        path: ${{ runner.temp }}/ci-scripts
         repository: pulumi/scripts
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags

--- a/native-provider-ci/providers/kubernetes-cert-manager/repo/.github/workflows/run-acceptance-tests.yml
+++ b/native-provider-ci/providers/kubernetes-cert-manager/repo/.github/workflows/run-acceptance-tests.yml
@@ -75,7 +75,7 @@ jobs:
     - name: Checkout Scripts Repo
       uses: actions/checkout@v4
       with:
-        path: ci-scripts
+        path: ../ci-scripts
         repository: pulumi/scripts
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
@@ -128,7 +128,7 @@ jobs:
     - name: Build Provider
       run: make provider
     - name: Check worktree clean
-      run: ./ci-scripts/ci/check-worktree-is-clean
+      run: ../ci-scripts/ci/check-worktree-is-clean
     - run: git status --porcelain
     - name: Tar provider binaries
       run: tar -zcf ${{ github.workspace }}/bin/provider.tar.gz -C ${{
@@ -176,7 +176,7 @@ jobs:
     - name: Checkout Scripts Repo
       uses: actions/checkout@v4
       with:
-        path: ci-scripts
+        path: ../ci-scripts
         repository: pulumi/scripts
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
@@ -230,7 +230,7 @@ jobs:
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
-      run: ./ci-scripts/ci/check-worktree-is-clean
+      run: ../ci-scripts/ci/check-worktree-is-clean
     - run: git status --porcelain
     - name: Tar SDK folder
       run: tar -zcf sdk/${{ matrix.language }}.tar.gz -C sdk/${{ matrix.language }} .
@@ -275,7 +275,7 @@ jobs:
     - name: Checkout Scripts Repo
       uses: actions/checkout@v4
       with:
-        path: ci-scripts
+        path: ../ci-scripts
         repository: pulumi/scripts
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags

--- a/native-provider-ci/providers/kubernetes-cert-manager/repo/.github/workflows/run-acceptance-tests.yml
+++ b/native-provider-ci/providers/kubernetes-cert-manager/repo/.github/workflows/run-acceptance-tests.yml
@@ -77,8 +77,7 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
-      env:
-        GITHUB_WORKSPACE: ${{ runner.temp }}
+    - run: mv ci-scripts ../ci-scripts
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -130,7 +129,7 @@ jobs:
     - name: Build Provider
       run: make provider
     - name: Check worktree clean
-      run: ${{ runner.temp }}/ci-scripts/ci/check-worktree-is-clean
+      run: ../ci-scripts/ci/check-worktree-is-clean
     - run: git status --porcelain
     - name: Tar provider binaries
       run: tar -zcf ${{ github.workspace }}/bin/provider.tar.gz -C ${{
@@ -180,8 +179,7 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
-      env:
-        GITHUB_WORKSPACE: ${{ runner.temp }}
+    - run: mv ci-scripts ../ci-scripts
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -234,7 +232,7 @@ jobs:
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
-      run: ${{ runner.temp }}/ci-scripts/ci/check-worktree-is-clean
+      run: ../ci-scripts/ci/check-worktree-is-clean
     - run: git status --porcelain
     - name: Tar SDK folder
       run: tar -zcf sdk/${{ matrix.language }}.tar.gz -C sdk/${{ matrix.language }} .
@@ -281,8 +279,7 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
-      env:
-        GITHUB_WORKSPACE: ${{ runner.temp }}
+    - run: mv ci-scripts ../ci-scripts
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/native-provider-ci/providers/kubernetes-cert-manager/repo/.github/workflows/run-acceptance-tests.yml
+++ b/native-provider-ci/providers/kubernetes-cert-manager/repo/.github/workflows/run-acceptance-tests.yml
@@ -75,8 +75,10 @@ jobs:
     - name: Checkout Scripts Repo
       uses: actions/checkout@v4
       with:
-        path: ${{ runner.temp }}/ci-scripts
+        path: ci-scripts
         repository: pulumi/scripts
+      env:
+        GITHUB_WORKSPACE: ${{ runner.temp }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -176,8 +178,10 @@ jobs:
     - name: Checkout Scripts Repo
       uses: actions/checkout@v4
       with:
-        path: ${{ runner.temp }}/ci-scripts
+        path: ci-scripts
         repository: pulumi/scripts
+      env:
+        GITHUB_WORKSPACE: ${{ runner.temp }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -275,8 +279,10 @@ jobs:
     - name: Checkout Scripts Repo
       uses: actions/checkout@v4
       with:
-        path: ${{ runner.temp }}/ci-scripts
+        path: ci-scripts
         repository: pulumi/scripts
+      env:
+        GITHUB_WORKSPACE: ${{ runner.temp }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/native-provider-ci/providers/kubernetes-cert-manager/repo/.github/workflows/run-acceptance-tests.yml
+++ b/native-provider-ci/providers/kubernetes-cert-manager/repo/.github/workflows/run-acceptance-tests.yml
@@ -77,7 +77,7 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
-    - run: mv ci-scripts ../ci-scripts
+    - run: echo "ci-scripts" >> .git/info/exclude
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -129,7 +129,7 @@ jobs:
     - name: Build Provider
       run: make provider
     - name: Check worktree clean
-      run: ../ci-scripts/ci/check-worktree-is-clean
+      run: ./ci-scripts/ci/check-worktree-is-clean
     - run: git status --porcelain
     - name: Tar provider binaries
       run: tar -zcf ${{ github.workspace }}/bin/provider.tar.gz -C ${{
@@ -179,7 +179,7 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
-    - run: mv ci-scripts ../ci-scripts
+    - run: echo "ci-scripts" >> .git/info/exclude
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -232,7 +232,7 @@ jobs:
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
-      run: ../ci-scripts/ci/check-worktree-is-clean
+      run: ./ci-scripts/ci/check-worktree-is-clean
     - run: git status --porcelain
     - name: Tar SDK folder
       run: tar -zcf sdk/${{ matrix.language }}.tar.gz -C sdk/${{ matrix.language }} .
@@ -279,7 +279,7 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
-    - run: mv ci-scripts ../ci-scripts
+    - run: echo "ci-scripts" >> .git/info/exclude
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/native-provider-ci/providers/kubernetes/repo/.github/workflows/build.yml
+++ b/native-provider-ci/providers/kubernetes/repo/.github/workflows/build.yml
@@ -58,8 +58,10 @@ jobs:
     - name: Checkout Scripts Repo
       uses: actions/checkout@v4
       with:
-        path: ${{ runner.temp }}/ci-scripts
+        path: ci-scripts
         repository: pulumi/scripts
+      env:
+        GITHUB_WORKSPACE: ${{ runner.temp }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -158,8 +160,10 @@ jobs:
     - name: Checkout Scripts Repo
       uses: actions/checkout@v4
       with:
-        path: ${{ runner.temp }}/ci-scripts
+        path: ci-scripts
         repository: pulumi/scripts
+      env:
+        GITHUB_WORKSPACE: ${{ runner.temp }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -253,8 +257,10 @@ jobs:
     - name: Checkout Scripts Repo
       uses: actions/checkout@v4
       with:
-        path: ${{ runner.temp }}/ci-scripts
+        path: ci-scripts
         repository: pulumi/scripts
+      env:
+        GITHUB_WORKSPACE: ${{ runner.temp }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -448,8 +454,10 @@ jobs:
     - name: Checkout Scripts Repo
       uses: actions/checkout@v4
       with:
-        path: ${{ runner.temp }}/ci-scripts
+        path: ci-scripts
         repository: pulumi/scripts
+      env:
+        GITHUB_WORKSPACE: ${{ runner.temp }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -528,8 +536,10 @@ jobs:
     - name: Checkout Scripts Repo
       uses: actions/checkout@v4
       with:
-        path: ${{ runner.temp }}/ci-scripts
+        path: ci-scripts
         repository: pulumi/scripts
+      env:
+        GITHUB_WORKSPACE: ${{ runner.temp }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/native-provider-ci/providers/kubernetes/repo/.github/workflows/build.yml
+++ b/native-provider-ci/providers/kubernetes/repo/.github/workflows/build.yml
@@ -58,7 +58,7 @@ jobs:
     - name: Checkout Scripts Repo
       uses: actions/checkout@v4
       with:
-        path: ci-scripts
+        path: ../ci-scripts
         repository: pulumi/scripts
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
@@ -113,7 +113,7 @@ jobs:
         number: ${{ github.event.issue.number }}
         github_token: ${{ secrets.GITHUB_TOKEN }}
     - name: Check worktree clean
-      run: ./ci-scripts/ci/check-worktree-is-clean
+      run: ../ci-scripts/ci/check-worktree-is-clean
     - run: git status --porcelain
     - name: Tar provider binaries
       run: tar -zcf ${{ github.workspace }}/bin/provider.tar.gz -C ${{
@@ -158,7 +158,7 @@ jobs:
     - name: Checkout Scripts Repo
       uses: actions/checkout@v4
       with:
-        path: ci-scripts
+        path: ../ci-scripts
         repository: pulumi/scripts
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
@@ -210,7 +210,7 @@ jobs:
     - name: Generate SDK
       run: make ${{ matrix.language }}_sdk
     - name: Check worktree clean
-      run: ./ci-scripts/ci/check-worktree-is-clean
+      run: ../ci-scripts/ci/check-worktree-is-clean
     - run: git status --porcelain
     - name: Tar SDK folder
       run: tar -zcf sdk/${{ matrix.language }}.tar.gz -C sdk/${{ matrix.language }} .
@@ -253,7 +253,7 @@ jobs:
     - name: Checkout Scripts Repo
       uses: actions/checkout@v4
       with:
-        path: ci-scripts
+        path: ../ci-scripts
         repository: pulumi/scripts
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
@@ -448,7 +448,7 @@ jobs:
     - name: Checkout Scripts Repo
       uses: actions/checkout@v4
       with:
-        path: ci-scripts
+        path: ../ci-scripts
         repository: pulumi/scripts
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
@@ -503,7 +503,7 @@ jobs:
     - name: Install Twine
       run: python -m pip install pip twine
     - name: Publish SDKs
-      run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
+      run: ../ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
       env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         PYPI_PUBLISH_ARTIFACTS: all
@@ -527,7 +527,7 @@ jobs:
     - name: Checkout Scripts Repo
       uses: actions/checkout@v4
       with:
-        path: ci-scripts
+        path: ../ci-scripts
         repository: pulumi/scripts
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags

--- a/native-provider-ci/providers/kubernetes/repo/.github/workflows/build.yml
+++ b/native-provider-ci/providers/kubernetes/repo/.github/workflows/build.yml
@@ -60,8 +60,7 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
-      env:
-        GITHUB_WORKSPACE: ${{ runner.temp }}
+    - run: mv ci-scripts ../ci-scripts
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -115,7 +114,7 @@ jobs:
         number: ${{ github.event.issue.number }}
         github_token: ${{ secrets.GITHUB_TOKEN }}
     - name: Check worktree clean
-      run: ${{ runner.temp }}/ci-scripts/ci/check-worktree-is-clean
+      run: ../ci-scripts/ci/check-worktree-is-clean
     - run: git status --porcelain
     - name: Tar provider binaries
       run: tar -zcf ${{ github.workspace }}/bin/provider.tar.gz -C ${{
@@ -162,8 +161,7 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
-      env:
-        GITHUB_WORKSPACE: ${{ runner.temp }}
+    - run: mv ci-scripts ../ci-scripts
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -214,7 +212,7 @@ jobs:
     - name: Generate SDK
       run: make ${{ matrix.language }}_sdk
     - name: Check worktree clean
-      run: ${{ runner.temp }}/ci-scripts/ci/check-worktree-is-clean
+      run: ../ci-scripts/ci/check-worktree-is-clean
     - run: git status --porcelain
     - name: Tar SDK folder
       run: tar -zcf sdk/${{ matrix.language }}.tar.gz -C sdk/${{ matrix.language }} .
@@ -259,8 +257,7 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
-      env:
-        GITHUB_WORKSPACE: ${{ runner.temp }}
+    - run: mv ci-scripts ../ci-scripts
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -456,8 +453,7 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
-      env:
-        GITHUB_WORKSPACE: ${{ runner.temp }}
+    - run: mv ci-scripts ../ci-scripts
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -511,8 +507,7 @@ jobs:
     - name: Install Twine
       run: python -m pip install pip twine
     - name: Publish SDKs
-      run: ${{ runner.temp }}/ci-scripts/ci/publish-tfgen-package ${{ github.workspace
-        }}
+      run: ../ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
       env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         PYPI_PUBLISH_ARTIFACTS: all
@@ -538,8 +533,7 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
-      env:
-        GITHUB_WORKSPACE: ${{ runner.temp }}
+    - run: mv ci-scripts ../ci-scripts
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/native-provider-ci/providers/kubernetes/repo/.github/workflows/build.yml
+++ b/native-provider-ci/providers/kubernetes/repo/.github/workflows/build.yml
@@ -60,7 +60,7 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
-    - run: mv ci-scripts ../ci-scripts
+    - run: echo "ci-scripts" >> .git/info/exclude
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -114,7 +114,7 @@ jobs:
         number: ${{ github.event.issue.number }}
         github_token: ${{ secrets.GITHUB_TOKEN }}
     - name: Check worktree clean
-      run: ../ci-scripts/ci/check-worktree-is-clean
+      run: ./ci-scripts/ci/check-worktree-is-clean
     - run: git status --porcelain
     - name: Tar provider binaries
       run: tar -zcf ${{ github.workspace }}/bin/provider.tar.gz -C ${{
@@ -161,7 +161,7 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
-    - run: mv ci-scripts ../ci-scripts
+    - run: echo "ci-scripts" >> .git/info/exclude
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -212,7 +212,7 @@ jobs:
     - name: Generate SDK
       run: make ${{ matrix.language }}_sdk
     - name: Check worktree clean
-      run: ../ci-scripts/ci/check-worktree-is-clean
+      run: ./ci-scripts/ci/check-worktree-is-clean
     - run: git status --porcelain
     - name: Tar SDK folder
       run: tar -zcf sdk/${{ matrix.language }}.tar.gz -C sdk/${{ matrix.language }} .
@@ -257,7 +257,7 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
-    - run: mv ci-scripts ../ci-scripts
+    - run: echo "ci-scripts" >> .git/info/exclude
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -453,7 +453,7 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
-    - run: mv ci-scripts ../ci-scripts
+    - run: echo "ci-scripts" >> .git/info/exclude
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -507,7 +507,7 @@ jobs:
     - name: Install Twine
       run: python -m pip install pip twine
     - name: Publish SDKs
-      run: ../ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
+      run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
       env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         PYPI_PUBLISH_ARTIFACTS: all
@@ -533,7 +533,7 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
-    - run: mv ci-scripts ../ci-scripts
+    - run: echo "ci-scripts" >> .git/info/exclude
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/native-provider-ci/providers/kubernetes/repo/.github/workflows/build.yml
+++ b/native-provider-ci/providers/kubernetes/repo/.github/workflows/build.yml
@@ -58,7 +58,7 @@ jobs:
     - name: Checkout Scripts Repo
       uses: actions/checkout@v4
       with:
-        path: ../ci-scripts
+        path: ${{ runner.temp }}/ci-scripts
         repository: pulumi/scripts
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
@@ -113,7 +113,7 @@ jobs:
         number: ${{ github.event.issue.number }}
         github_token: ${{ secrets.GITHUB_TOKEN }}
     - name: Check worktree clean
-      run: ../ci-scripts/ci/check-worktree-is-clean
+      run: ${{ runner.temp }}/ci-scripts/ci/check-worktree-is-clean
     - run: git status --porcelain
     - name: Tar provider binaries
       run: tar -zcf ${{ github.workspace }}/bin/provider.tar.gz -C ${{
@@ -158,7 +158,7 @@ jobs:
     - name: Checkout Scripts Repo
       uses: actions/checkout@v4
       with:
-        path: ../ci-scripts
+        path: ${{ runner.temp }}/ci-scripts
         repository: pulumi/scripts
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
@@ -210,7 +210,7 @@ jobs:
     - name: Generate SDK
       run: make ${{ matrix.language }}_sdk
     - name: Check worktree clean
-      run: ../ci-scripts/ci/check-worktree-is-clean
+      run: ${{ runner.temp }}/ci-scripts/ci/check-worktree-is-clean
     - run: git status --porcelain
     - name: Tar SDK folder
       run: tar -zcf sdk/${{ matrix.language }}.tar.gz -C sdk/${{ matrix.language }} .
@@ -253,7 +253,7 @@ jobs:
     - name: Checkout Scripts Repo
       uses: actions/checkout@v4
       with:
-        path: ../ci-scripts
+        path: ${{ runner.temp }}/ci-scripts
         repository: pulumi/scripts
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
@@ -448,7 +448,7 @@ jobs:
     - name: Checkout Scripts Repo
       uses: actions/checkout@v4
       with:
-        path: ../ci-scripts
+        path: ${{ runner.temp }}/ci-scripts
         repository: pulumi/scripts
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
@@ -503,7 +503,8 @@ jobs:
     - name: Install Twine
       run: python -m pip install pip twine
     - name: Publish SDKs
-      run: ../ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
+      run: ${{ runner.temp }}/ci-scripts/ci/publish-tfgen-package ${{ github.workspace
+        }}
       env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         PYPI_PUBLISH_ARTIFACTS: all
@@ -527,7 +528,7 @@ jobs:
     - name: Checkout Scripts Repo
       uses: actions/checkout@v4
       with:
-        path: ../ci-scripts
+        path: ${{ runner.temp }}/ci-scripts
         repository: pulumi/scripts
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags

--- a/native-provider-ci/providers/kubernetes/repo/.github/workflows/prerelease.yml
+++ b/native-provider-ci/providers/kubernetes/repo/.github/workflows/prerelease.yml
@@ -50,7 +50,7 @@ jobs:
     - name: Checkout Scripts Repo
       uses: actions/checkout@v4
       with:
-        path: ../ci-scripts
+        path: ${{ runner.temp }}/ci-scripts
         repository: pulumi/scripts
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
@@ -105,7 +105,7 @@ jobs:
         number: ${{ github.event.issue.number }}
         github_token: ${{ secrets.GITHUB_TOKEN }}
     - name: Check worktree clean
-      run: ../ci-scripts/ci/check-worktree-is-clean
+      run: ${{ runner.temp }}/ci-scripts/ci/check-worktree-is-clean
     - run: git status --porcelain
     - name: Tar provider binaries
       run: tar -zcf ${{ github.workspace }}/bin/provider.tar.gz -C ${{
@@ -150,7 +150,7 @@ jobs:
     - name: Checkout Scripts Repo
       uses: actions/checkout@v4
       with:
-        path: ../ci-scripts
+        path: ${{ runner.temp }}/ci-scripts
         repository: pulumi/scripts
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
@@ -202,7 +202,7 @@ jobs:
     - name: Generate SDK
       run: make ${{ matrix.language }}_sdk
     - name: Check worktree clean
-      run: ../ci-scripts/ci/check-worktree-is-clean
+      run: ${{ runner.temp }}/ci-scripts/ci/check-worktree-is-clean
     - run: git status --porcelain
     - name: Tar SDK folder
       run: tar -zcf sdk/${{ matrix.language }}.tar.gz -C sdk/${{ matrix.language }} .
@@ -244,7 +244,7 @@ jobs:
     - name: Checkout Scripts Repo
       uses: actions/checkout@v4
       with:
-        path: ../ci-scripts
+        path: ${{ runner.temp }}/ci-scripts
         repository: pulumi/scripts
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
@@ -439,7 +439,7 @@ jobs:
     - name: Checkout Scripts Repo
       uses: actions/checkout@v4
       with:
-        path: ../ci-scripts
+        path: ${{ runner.temp }}/ci-scripts
         repository: pulumi/scripts
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
@@ -494,7 +494,8 @@ jobs:
     - name: Install Twine
       run: python -m pip install pip twine
     - name: Publish SDKs
-      run: ../ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
+      run: ${{ runner.temp }}/ci-scripts/ci/publish-tfgen-package ${{ github.workspace
+        }}
       env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         PYPI_PUBLISH_ARTIFACTS: all
@@ -518,7 +519,7 @@ jobs:
     - name: Checkout Scripts Repo
       uses: actions/checkout@v4
       with:
-        path: ../ci-scripts
+        path: ${{ runner.temp }}/ci-scripts
         repository: pulumi/scripts
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags

--- a/native-provider-ci/providers/kubernetes/repo/.github/workflows/prerelease.yml
+++ b/native-provider-ci/providers/kubernetes/repo/.github/workflows/prerelease.yml
@@ -50,7 +50,7 @@ jobs:
     - name: Checkout Scripts Repo
       uses: actions/checkout@v4
       with:
-        path: ci-scripts
+        path: ../ci-scripts
         repository: pulumi/scripts
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
@@ -105,7 +105,7 @@ jobs:
         number: ${{ github.event.issue.number }}
         github_token: ${{ secrets.GITHUB_TOKEN }}
     - name: Check worktree clean
-      run: ./ci-scripts/ci/check-worktree-is-clean
+      run: ../ci-scripts/ci/check-worktree-is-clean
     - run: git status --porcelain
     - name: Tar provider binaries
       run: tar -zcf ${{ github.workspace }}/bin/provider.tar.gz -C ${{
@@ -150,7 +150,7 @@ jobs:
     - name: Checkout Scripts Repo
       uses: actions/checkout@v4
       with:
-        path: ci-scripts
+        path: ../ci-scripts
         repository: pulumi/scripts
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
@@ -202,7 +202,7 @@ jobs:
     - name: Generate SDK
       run: make ${{ matrix.language }}_sdk
     - name: Check worktree clean
-      run: ./ci-scripts/ci/check-worktree-is-clean
+      run: ../ci-scripts/ci/check-worktree-is-clean
     - run: git status --porcelain
     - name: Tar SDK folder
       run: tar -zcf sdk/${{ matrix.language }}.tar.gz -C sdk/${{ matrix.language }} .
@@ -244,7 +244,7 @@ jobs:
     - name: Checkout Scripts Repo
       uses: actions/checkout@v4
       with:
-        path: ci-scripts
+        path: ../ci-scripts
         repository: pulumi/scripts
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
@@ -439,7 +439,7 @@ jobs:
     - name: Checkout Scripts Repo
       uses: actions/checkout@v4
       with:
-        path: ci-scripts
+        path: ../ci-scripts
         repository: pulumi/scripts
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
@@ -494,7 +494,7 @@ jobs:
     - name: Install Twine
       run: python -m pip install pip twine
     - name: Publish SDKs
-      run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
+      run: ../ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
       env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         PYPI_PUBLISH_ARTIFACTS: all
@@ -518,7 +518,7 @@ jobs:
     - name: Checkout Scripts Repo
       uses: actions/checkout@v4
       with:
-        path: ci-scripts
+        path: ../ci-scripts
         repository: pulumi/scripts
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags

--- a/native-provider-ci/providers/kubernetes/repo/.github/workflows/prerelease.yml
+++ b/native-provider-ci/providers/kubernetes/repo/.github/workflows/prerelease.yml
@@ -52,8 +52,7 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
-      env:
-        GITHUB_WORKSPACE: ${{ runner.temp }}
+    - run: mv ci-scripts ../ci-scripts
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -107,7 +106,7 @@ jobs:
         number: ${{ github.event.issue.number }}
         github_token: ${{ secrets.GITHUB_TOKEN }}
     - name: Check worktree clean
-      run: ${{ runner.temp }}/ci-scripts/ci/check-worktree-is-clean
+      run: ../ci-scripts/ci/check-worktree-is-clean
     - run: git status --porcelain
     - name: Tar provider binaries
       run: tar -zcf ${{ github.workspace }}/bin/provider.tar.gz -C ${{
@@ -154,8 +153,7 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
-      env:
-        GITHUB_WORKSPACE: ${{ runner.temp }}
+    - run: mv ci-scripts ../ci-scripts
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -206,7 +204,7 @@ jobs:
     - name: Generate SDK
       run: make ${{ matrix.language }}_sdk
     - name: Check worktree clean
-      run: ${{ runner.temp }}/ci-scripts/ci/check-worktree-is-clean
+      run: ../ci-scripts/ci/check-worktree-is-clean
     - run: git status --porcelain
     - name: Tar SDK folder
       run: tar -zcf sdk/${{ matrix.language }}.tar.gz -C sdk/${{ matrix.language }} .
@@ -250,8 +248,7 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
-      env:
-        GITHUB_WORKSPACE: ${{ runner.temp }}
+    - run: mv ci-scripts ../ci-scripts
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -447,8 +444,7 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
-      env:
-        GITHUB_WORKSPACE: ${{ runner.temp }}
+    - run: mv ci-scripts ../ci-scripts
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -502,8 +498,7 @@ jobs:
     - name: Install Twine
       run: python -m pip install pip twine
     - name: Publish SDKs
-      run: ${{ runner.temp }}/ci-scripts/ci/publish-tfgen-package ${{ github.workspace
-        }}
+      run: ../ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
       env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         PYPI_PUBLISH_ARTIFACTS: all
@@ -529,8 +524,7 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
-      env:
-        GITHUB_WORKSPACE: ${{ runner.temp }}
+    - run: mv ci-scripts ../ci-scripts
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/native-provider-ci/providers/kubernetes/repo/.github/workflows/prerelease.yml
+++ b/native-provider-ci/providers/kubernetes/repo/.github/workflows/prerelease.yml
@@ -52,7 +52,7 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
-    - run: mv ci-scripts ../ci-scripts
+    - run: echo "ci-scripts" >> .git/info/exclude
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -106,7 +106,7 @@ jobs:
         number: ${{ github.event.issue.number }}
         github_token: ${{ secrets.GITHUB_TOKEN }}
     - name: Check worktree clean
-      run: ../ci-scripts/ci/check-worktree-is-clean
+      run: ./ci-scripts/ci/check-worktree-is-clean
     - run: git status --porcelain
     - name: Tar provider binaries
       run: tar -zcf ${{ github.workspace }}/bin/provider.tar.gz -C ${{
@@ -153,7 +153,7 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
-    - run: mv ci-scripts ../ci-scripts
+    - run: echo "ci-scripts" >> .git/info/exclude
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -204,7 +204,7 @@ jobs:
     - name: Generate SDK
       run: make ${{ matrix.language }}_sdk
     - name: Check worktree clean
-      run: ../ci-scripts/ci/check-worktree-is-clean
+      run: ./ci-scripts/ci/check-worktree-is-clean
     - run: git status --porcelain
     - name: Tar SDK folder
       run: tar -zcf sdk/${{ matrix.language }}.tar.gz -C sdk/${{ matrix.language }} .
@@ -248,7 +248,7 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
-    - run: mv ci-scripts ../ci-scripts
+    - run: echo "ci-scripts" >> .git/info/exclude
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -444,7 +444,7 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
-    - run: mv ci-scripts ../ci-scripts
+    - run: echo "ci-scripts" >> .git/info/exclude
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -498,7 +498,7 @@ jobs:
     - name: Install Twine
       run: python -m pip install pip twine
     - name: Publish SDKs
-      run: ../ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
+      run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
       env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         PYPI_PUBLISH_ARTIFACTS: all
@@ -524,7 +524,7 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
-    - run: mv ci-scripts ../ci-scripts
+    - run: echo "ci-scripts" >> .git/info/exclude
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/native-provider-ci/providers/kubernetes/repo/.github/workflows/prerelease.yml
+++ b/native-provider-ci/providers/kubernetes/repo/.github/workflows/prerelease.yml
@@ -50,8 +50,10 @@ jobs:
     - name: Checkout Scripts Repo
       uses: actions/checkout@v4
       with:
-        path: ${{ runner.temp }}/ci-scripts
+        path: ci-scripts
         repository: pulumi/scripts
+      env:
+        GITHUB_WORKSPACE: ${{ runner.temp }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -150,8 +152,10 @@ jobs:
     - name: Checkout Scripts Repo
       uses: actions/checkout@v4
       with:
-        path: ${{ runner.temp }}/ci-scripts
+        path: ci-scripts
         repository: pulumi/scripts
+      env:
+        GITHUB_WORKSPACE: ${{ runner.temp }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -244,8 +248,10 @@ jobs:
     - name: Checkout Scripts Repo
       uses: actions/checkout@v4
       with:
-        path: ${{ runner.temp }}/ci-scripts
+        path: ci-scripts
         repository: pulumi/scripts
+      env:
+        GITHUB_WORKSPACE: ${{ runner.temp }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -439,8 +445,10 @@ jobs:
     - name: Checkout Scripts Repo
       uses: actions/checkout@v4
       with:
-        path: ${{ runner.temp }}/ci-scripts
+        path: ci-scripts
         repository: pulumi/scripts
+      env:
+        GITHUB_WORKSPACE: ${{ runner.temp }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -519,8 +527,10 @@ jobs:
     - name: Checkout Scripts Repo
       uses: actions/checkout@v4
       with:
-        path: ${{ runner.temp }}/ci-scripts
+        path: ci-scripts
         repository: pulumi/scripts
+      env:
+        GITHUB_WORKSPACE: ${{ runner.temp }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/native-provider-ci/providers/kubernetes/repo/.github/workflows/release.yml
+++ b/native-provider-ci/providers/kubernetes/repo/.github/workflows/release.yml
@@ -50,7 +50,7 @@ jobs:
     - name: Checkout Scripts Repo
       uses: actions/checkout@v4
       with:
-        path: ../ci-scripts
+        path: ${{ runner.temp }}/ci-scripts
         repository: pulumi/scripts
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
@@ -105,7 +105,7 @@ jobs:
         number: ${{ github.event.issue.number }}
         github_token: ${{ secrets.GITHUB_TOKEN }}
     - name: Check worktree clean
-      run: ../ci-scripts/ci/check-worktree-is-clean
+      run: ${{ runner.temp }}/ci-scripts/ci/check-worktree-is-clean
     - run: git status --porcelain
     - name: Tar provider binaries
       run: tar -zcf ${{ github.workspace }}/bin/provider.tar.gz -C ${{
@@ -150,7 +150,7 @@ jobs:
     - name: Checkout Scripts Repo
       uses: actions/checkout@v4
       with:
-        path: ../ci-scripts
+        path: ${{ runner.temp }}/ci-scripts
         repository: pulumi/scripts
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
@@ -202,7 +202,7 @@ jobs:
     - name: Generate SDK
       run: make ${{ matrix.language }}_sdk
     - name: Check worktree clean
-      run: ../ci-scripts/ci/check-worktree-is-clean
+      run: ${{ runner.temp }}/ci-scripts/ci/check-worktree-is-clean
     - run: git status --porcelain
     - name: Tar SDK folder
       run: tar -zcf sdk/${{ matrix.language }}.tar.gz -C sdk/${{ matrix.language }} .
@@ -244,7 +244,7 @@ jobs:
     - name: Checkout Scripts Repo
       uses: actions/checkout@v4
       with:
-        path: ../ci-scripts
+        path: ${{ runner.temp }}/ci-scripts
         repository: pulumi/scripts
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
@@ -439,7 +439,7 @@ jobs:
     - name: Checkout Scripts Repo
       uses: actions/checkout@v4
       with:
-        path: ../ci-scripts
+        path: ${{ runner.temp }}/ci-scripts
         repository: pulumi/scripts
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
@@ -494,7 +494,8 @@ jobs:
     - name: Install Twine
       run: python -m pip install pip twine
     - name: Publish SDKs
-      run: ../ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
+      run: ${{ runner.temp }}/ci-scripts/ci/publish-tfgen-package ${{ github.workspace
+        }}
       env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         PYPI_PUBLISH_ARTIFACTS: all
@@ -518,7 +519,7 @@ jobs:
     - name: Checkout Scripts Repo
       uses: actions/checkout@v4
       with:
-        path: ../ci-scripts
+        path: ${{ runner.temp }}/ci-scripts
         repository: pulumi/scripts
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags

--- a/native-provider-ci/providers/kubernetes/repo/.github/workflows/release.yml
+++ b/native-provider-ci/providers/kubernetes/repo/.github/workflows/release.yml
@@ -50,7 +50,7 @@ jobs:
     - name: Checkout Scripts Repo
       uses: actions/checkout@v4
       with:
-        path: ci-scripts
+        path: ../ci-scripts
         repository: pulumi/scripts
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
@@ -105,7 +105,7 @@ jobs:
         number: ${{ github.event.issue.number }}
         github_token: ${{ secrets.GITHUB_TOKEN }}
     - name: Check worktree clean
-      run: ./ci-scripts/ci/check-worktree-is-clean
+      run: ../ci-scripts/ci/check-worktree-is-clean
     - run: git status --porcelain
     - name: Tar provider binaries
       run: tar -zcf ${{ github.workspace }}/bin/provider.tar.gz -C ${{
@@ -150,7 +150,7 @@ jobs:
     - name: Checkout Scripts Repo
       uses: actions/checkout@v4
       with:
-        path: ci-scripts
+        path: ../ci-scripts
         repository: pulumi/scripts
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
@@ -202,7 +202,7 @@ jobs:
     - name: Generate SDK
       run: make ${{ matrix.language }}_sdk
     - name: Check worktree clean
-      run: ./ci-scripts/ci/check-worktree-is-clean
+      run: ../ci-scripts/ci/check-worktree-is-clean
     - run: git status --porcelain
     - name: Tar SDK folder
       run: tar -zcf sdk/${{ matrix.language }}.tar.gz -C sdk/${{ matrix.language }} .
@@ -244,7 +244,7 @@ jobs:
     - name: Checkout Scripts Repo
       uses: actions/checkout@v4
       with:
-        path: ci-scripts
+        path: ../ci-scripts
         repository: pulumi/scripts
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
@@ -439,7 +439,7 @@ jobs:
     - name: Checkout Scripts Repo
       uses: actions/checkout@v4
       with:
-        path: ci-scripts
+        path: ../ci-scripts
         repository: pulumi/scripts
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
@@ -494,7 +494,7 @@ jobs:
     - name: Install Twine
       run: python -m pip install pip twine
     - name: Publish SDKs
-      run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
+      run: ../ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
       env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         PYPI_PUBLISH_ARTIFACTS: all
@@ -518,7 +518,7 @@ jobs:
     - name: Checkout Scripts Repo
       uses: actions/checkout@v4
       with:
-        path: ci-scripts
+        path: ../ci-scripts
         repository: pulumi/scripts
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags

--- a/native-provider-ci/providers/kubernetes/repo/.github/workflows/release.yml
+++ b/native-provider-ci/providers/kubernetes/repo/.github/workflows/release.yml
@@ -52,8 +52,7 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
-      env:
-        GITHUB_WORKSPACE: ${{ runner.temp }}
+    - run: mv ci-scripts ../ci-scripts
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -107,7 +106,7 @@ jobs:
         number: ${{ github.event.issue.number }}
         github_token: ${{ secrets.GITHUB_TOKEN }}
     - name: Check worktree clean
-      run: ${{ runner.temp }}/ci-scripts/ci/check-worktree-is-clean
+      run: ../ci-scripts/ci/check-worktree-is-clean
     - run: git status --porcelain
     - name: Tar provider binaries
       run: tar -zcf ${{ github.workspace }}/bin/provider.tar.gz -C ${{
@@ -154,8 +153,7 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
-      env:
-        GITHUB_WORKSPACE: ${{ runner.temp }}
+    - run: mv ci-scripts ../ci-scripts
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -206,7 +204,7 @@ jobs:
     - name: Generate SDK
       run: make ${{ matrix.language }}_sdk
     - name: Check worktree clean
-      run: ${{ runner.temp }}/ci-scripts/ci/check-worktree-is-clean
+      run: ../ci-scripts/ci/check-worktree-is-clean
     - run: git status --porcelain
     - name: Tar SDK folder
       run: tar -zcf sdk/${{ matrix.language }}.tar.gz -C sdk/${{ matrix.language }} .
@@ -250,8 +248,7 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
-      env:
-        GITHUB_WORKSPACE: ${{ runner.temp }}
+    - run: mv ci-scripts ../ci-scripts
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -447,8 +444,7 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
-      env:
-        GITHUB_WORKSPACE: ${{ runner.temp }}
+    - run: mv ci-scripts ../ci-scripts
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -502,8 +498,7 @@ jobs:
     - name: Install Twine
       run: python -m pip install pip twine
     - name: Publish SDKs
-      run: ${{ runner.temp }}/ci-scripts/ci/publish-tfgen-package ${{ github.workspace
-        }}
+      run: ../ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
       env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         PYPI_PUBLISH_ARTIFACTS: all
@@ -529,8 +524,7 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
-      env:
-        GITHUB_WORKSPACE: ${{ runner.temp }}
+    - run: mv ci-scripts ../ci-scripts
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/native-provider-ci/providers/kubernetes/repo/.github/workflows/release.yml
+++ b/native-provider-ci/providers/kubernetes/repo/.github/workflows/release.yml
@@ -52,7 +52,7 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
-    - run: mv ci-scripts ../ci-scripts
+    - run: echo "ci-scripts" >> .git/info/exclude
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -106,7 +106,7 @@ jobs:
         number: ${{ github.event.issue.number }}
         github_token: ${{ secrets.GITHUB_TOKEN }}
     - name: Check worktree clean
-      run: ../ci-scripts/ci/check-worktree-is-clean
+      run: ./ci-scripts/ci/check-worktree-is-clean
     - run: git status --porcelain
     - name: Tar provider binaries
       run: tar -zcf ${{ github.workspace }}/bin/provider.tar.gz -C ${{
@@ -153,7 +153,7 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
-    - run: mv ci-scripts ../ci-scripts
+    - run: echo "ci-scripts" >> .git/info/exclude
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -204,7 +204,7 @@ jobs:
     - name: Generate SDK
       run: make ${{ matrix.language }}_sdk
     - name: Check worktree clean
-      run: ../ci-scripts/ci/check-worktree-is-clean
+      run: ./ci-scripts/ci/check-worktree-is-clean
     - run: git status --porcelain
     - name: Tar SDK folder
       run: tar -zcf sdk/${{ matrix.language }}.tar.gz -C sdk/${{ matrix.language }} .
@@ -248,7 +248,7 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
-    - run: mv ci-scripts ../ci-scripts
+    - run: echo "ci-scripts" >> .git/info/exclude
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -444,7 +444,7 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
-    - run: mv ci-scripts ../ci-scripts
+    - run: echo "ci-scripts" >> .git/info/exclude
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -498,7 +498,7 @@ jobs:
     - name: Install Twine
       run: python -m pip install pip twine
     - name: Publish SDKs
-      run: ../ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
+      run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
       env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         PYPI_PUBLISH_ARTIFACTS: all
@@ -524,7 +524,7 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
-    - run: mv ci-scripts ../ci-scripts
+    - run: echo "ci-scripts" >> .git/info/exclude
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/native-provider-ci/providers/kubernetes/repo/.github/workflows/release.yml
+++ b/native-provider-ci/providers/kubernetes/repo/.github/workflows/release.yml
@@ -50,8 +50,10 @@ jobs:
     - name: Checkout Scripts Repo
       uses: actions/checkout@v4
       with:
-        path: ${{ runner.temp }}/ci-scripts
+        path: ci-scripts
         repository: pulumi/scripts
+      env:
+        GITHUB_WORKSPACE: ${{ runner.temp }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -150,8 +152,10 @@ jobs:
     - name: Checkout Scripts Repo
       uses: actions/checkout@v4
       with:
-        path: ${{ runner.temp }}/ci-scripts
+        path: ci-scripts
         repository: pulumi/scripts
+      env:
+        GITHUB_WORKSPACE: ${{ runner.temp }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -244,8 +248,10 @@ jobs:
     - name: Checkout Scripts Repo
       uses: actions/checkout@v4
       with:
-        path: ${{ runner.temp }}/ci-scripts
+        path: ci-scripts
         repository: pulumi/scripts
+      env:
+        GITHUB_WORKSPACE: ${{ runner.temp }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -439,8 +445,10 @@ jobs:
     - name: Checkout Scripts Repo
       uses: actions/checkout@v4
       with:
-        path: ${{ runner.temp }}/ci-scripts
+        path: ci-scripts
         repository: pulumi/scripts
+      env:
+        GITHUB_WORKSPACE: ${{ runner.temp }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -519,8 +527,10 @@ jobs:
     - name: Checkout Scripts Repo
       uses: actions/checkout@v4
       with:
-        path: ${{ runner.temp }}/ci-scripts
+        path: ci-scripts
         repository: pulumi/scripts
+      env:
+        GITHUB_WORKSPACE: ${{ runner.temp }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/native-provider-ci/providers/kubernetes/repo/.github/workflows/run-acceptance-tests.yml
+++ b/native-provider-ci/providers/kubernetes/repo/.github/workflows/run-acceptance-tests.yml
@@ -76,7 +76,7 @@ jobs:
     - name: Checkout Scripts Repo
       uses: actions/checkout@v4
       with:
-        path: ci-scripts
+        path: ../ci-scripts
         repository: pulumi/scripts
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
@@ -131,7 +131,7 @@ jobs:
         number: ${{ github.event.issue.number }}
         github_token: ${{ secrets.GITHUB_TOKEN }}
     - name: Check worktree clean
-      run: ./ci-scripts/ci/check-worktree-is-clean
+      run: ../ci-scripts/ci/check-worktree-is-clean
     - run: git status --porcelain
     - name: Tar provider binaries
       run: tar -zcf ${{ github.workspace }}/bin/provider.tar.gz -C ${{
@@ -179,7 +179,7 @@ jobs:
     - name: Checkout Scripts Repo
       uses: actions/checkout@v4
       with:
-        path: ci-scripts
+        path: ../ci-scripts
         repository: pulumi/scripts
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
@@ -231,7 +231,7 @@ jobs:
     - name: Generate SDK
       run: make ${{ matrix.language }}_sdk
     - name: Check worktree clean
-      run: ./ci-scripts/ci/check-worktree-is-clean
+      run: ../ci-scripts/ci/check-worktree-is-clean
     - run: git status --porcelain
     - name: Tar SDK folder
       run: tar -zcf sdk/${{ matrix.language }}.tar.gz -C sdk/${{ matrix.language }} .
@@ -276,7 +276,7 @@ jobs:
     - name: Checkout Scripts Repo
       uses: actions/checkout@v4
       with:
-        path: ci-scripts
+        path: ../ci-scripts
         repository: pulumi/scripts
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags

--- a/native-provider-ci/providers/kubernetes/repo/.github/workflows/run-acceptance-tests.yml
+++ b/native-provider-ci/providers/kubernetes/repo/.github/workflows/run-acceptance-tests.yml
@@ -76,8 +76,10 @@ jobs:
     - name: Checkout Scripts Repo
       uses: actions/checkout@v4
       with:
-        path: ${{ runner.temp }}/ci-scripts
+        path: ci-scripts
         repository: pulumi/scripts
+      env:
+        GITHUB_WORKSPACE: ${{ runner.temp }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -179,8 +181,10 @@ jobs:
     - name: Checkout Scripts Repo
       uses: actions/checkout@v4
       with:
-        path: ${{ runner.temp }}/ci-scripts
+        path: ci-scripts
         repository: pulumi/scripts
+      env:
+        GITHUB_WORKSPACE: ${{ runner.temp }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -276,8 +280,10 @@ jobs:
     - name: Checkout Scripts Repo
       uses: actions/checkout@v4
       with:
-        path: ${{ runner.temp }}/ci-scripts
+        path: ci-scripts
         repository: pulumi/scripts
+      env:
+        GITHUB_WORKSPACE: ${{ runner.temp }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/native-provider-ci/providers/kubernetes/repo/.github/workflows/run-acceptance-tests.yml
+++ b/native-provider-ci/providers/kubernetes/repo/.github/workflows/run-acceptance-tests.yml
@@ -78,8 +78,7 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
-      env:
-        GITHUB_WORKSPACE: ${{ runner.temp }}
+    - run: mv ci-scripts ../ci-scripts
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -133,7 +132,7 @@ jobs:
         number: ${{ github.event.issue.number }}
         github_token: ${{ secrets.GITHUB_TOKEN }}
     - name: Check worktree clean
-      run: ${{ runner.temp }}/ci-scripts/ci/check-worktree-is-clean
+      run: ../ci-scripts/ci/check-worktree-is-clean
     - run: git status --porcelain
     - name: Tar provider binaries
       run: tar -zcf ${{ github.workspace }}/bin/provider.tar.gz -C ${{
@@ -183,8 +182,7 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
-      env:
-        GITHUB_WORKSPACE: ${{ runner.temp }}
+    - run: mv ci-scripts ../ci-scripts
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -235,7 +233,7 @@ jobs:
     - name: Generate SDK
       run: make ${{ matrix.language }}_sdk
     - name: Check worktree clean
-      run: ${{ runner.temp }}/ci-scripts/ci/check-worktree-is-clean
+      run: ../ci-scripts/ci/check-worktree-is-clean
     - run: git status --porcelain
     - name: Tar SDK folder
       run: tar -zcf sdk/${{ matrix.language }}.tar.gz -C sdk/${{ matrix.language }} .
@@ -282,8 +280,7 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
-      env:
-        GITHUB_WORKSPACE: ${{ runner.temp }}
+    - run: mv ci-scripts ../ci-scripts
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/native-provider-ci/providers/kubernetes/repo/.github/workflows/run-acceptance-tests.yml
+++ b/native-provider-ci/providers/kubernetes/repo/.github/workflows/run-acceptance-tests.yml
@@ -76,7 +76,7 @@ jobs:
     - name: Checkout Scripts Repo
       uses: actions/checkout@v4
       with:
-        path: ../ci-scripts
+        path: ${{ runner.temp }}/ci-scripts
         repository: pulumi/scripts
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
@@ -131,7 +131,7 @@ jobs:
         number: ${{ github.event.issue.number }}
         github_token: ${{ secrets.GITHUB_TOKEN }}
     - name: Check worktree clean
-      run: ../ci-scripts/ci/check-worktree-is-clean
+      run: ${{ runner.temp }}/ci-scripts/ci/check-worktree-is-clean
     - run: git status --porcelain
     - name: Tar provider binaries
       run: tar -zcf ${{ github.workspace }}/bin/provider.tar.gz -C ${{
@@ -179,7 +179,7 @@ jobs:
     - name: Checkout Scripts Repo
       uses: actions/checkout@v4
       with:
-        path: ../ci-scripts
+        path: ${{ runner.temp }}/ci-scripts
         repository: pulumi/scripts
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
@@ -231,7 +231,7 @@ jobs:
     - name: Generate SDK
       run: make ${{ matrix.language }}_sdk
     - name: Check worktree clean
-      run: ../ci-scripts/ci/check-worktree-is-clean
+      run: ${{ runner.temp }}/ci-scripts/ci/check-worktree-is-clean
     - run: git status --porcelain
     - name: Tar SDK folder
       run: tar -zcf sdk/${{ matrix.language }}.tar.gz -C sdk/${{ matrix.language }} .
@@ -276,7 +276,7 @@ jobs:
     - name: Checkout Scripts Repo
       uses: actions/checkout@v4
       with:
-        path: ../ci-scripts
+        path: ${{ runner.temp }}/ci-scripts
         repository: pulumi/scripts
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags

--- a/native-provider-ci/providers/kubernetes/repo/.github/workflows/run-acceptance-tests.yml
+++ b/native-provider-ci/providers/kubernetes/repo/.github/workflows/run-acceptance-tests.yml
@@ -78,7 +78,7 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
-    - run: mv ci-scripts ../ci-scripts
+    - run: echo "ci-scripts" >> .git/info/exclude
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -132,7 +132,7 @@ jobs:
         number: ${{ github.event.issue.number }}
         github_token: ${{ secrets.GITHUB_TOKEN }}
     - name: Check worktree clean
-      run: ../ci-scripts/ci/check-worktree-is-clean
+      run: ./ci-scripts/ci/check-worktree-is-clean
     - run: git status --porcelain
     - name: Tar provider binaries
       run: tar -zcf ${{ github.workspace }}/bin/provider.tar.gz -C ${{
@@ -182,7 +182,7 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
-    - run: mv ci-scripts ../ci-scripts
+    - run: echo "ci-scripts" >> .git/info/exclude
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -233,7 +233,7 @@ jobs:
     - name: Generate SDK
       run: make ${{ matrix.language }}_sdk
     - name: Check worktree clean
-      run: ../ci-scripts/ci/check-worktree-is-clean
+      run: ./ci-scripts/ci/check-worktree-is-clean
     - run: git status --porcelain
     - name: Tar SDK folder
       run: tar -zcf sdk/${{ matrix.language }}.tar.gz -C sdk/${{ matrix.language }} .
@@ -280,7 +280,7 @@ jobs:
       with:
         path: ci-scripts
         repository: pulumi/scripts
-    - run: mv ci-scripts ../ci-scripts
+    - run: echo "ci-scripts" >> .git/info/exclude
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/native-provider-ci/src/steps.ts
+++ b/native-provider-ci/src/steps.ts
@@ -135,8 +135,11 @@ export function CheckoutScriptsRepoStep(): Step {
     name: "Checkout Scripts Repo",
     uses: action.checkout,
     with: {
-      path: "${{ runner.temp }}/ci-scripts",
+      path: "ci-scripts",
       repository: "pulumi/scripts",
+    },
+    env: {
+      GITHUB_WORKSPACE: "${{ runner.temp }}",
     },
   };
 }

--- a/native-provider-ci/src/steps.ts
+++ b/native-provider-ci/src/steps.ts
@@ -130,18 +130,20 @@ export function CheckoutRepoStepAtPR(): Step {
   };
 }
 
-export function CheckoutScriptsRepoStep(): Step {
-  return {
-    name: "Checkout Scripts Repo",
-    uses: action.checkout,
-    with: {
-      path: "ci-scripts",
-      repository: "pulumi/scripts",
+export function CheckoutScriptsRepoSteps(): Step[] {
+  return [
+    {
+      name: "Checkout Scripts Repo",
+      uses: action.checkout,
+      with: {
+        path: "ci-scripts",
+        repository: "pulumi/scripts",
+      },
     },
-    env: {
-      GITHUB_WORKSPACE: "${{ runner.temp }}",
+    {
+      run: "mv ci-scripts ../ci-scripts", // actions/checkout#197
     },
-  };
+  ];
 }
 
 export function CheckoutTagsStep(skipProvider?: string): Step {
@@ -468,7 +470,7 @@ export function ZipSDKsStep(): Step {
 export function CheckCleanWorkTree(): Step {
   return {
     name: "Check worktree clean",
-    run: "${{ runner.temp }}/ci-scripts/ci/check-worktree-is-clean",
+    run: "../ci-scripts/ci/check-worktree-is-clean",
   };
 }
 
@@ -1056,7 +1058,7 @@ export function InstallTwine(): Step {
 export function RunPublishSDK(): Step {
   return {
     name: "Publish SDKs",
-    run: "${{ runner.temp }}/ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}",
+    run: "../ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}",
     env: {
       NODE_AUTH_TOKEN: "${{ secrets.NPM_TOKEN }}",
       // See https://github.com/pulumi/scripts/pull/138/files

--- a/native-provider-ci/src/steps.ts
+++ b/native-provider-ci/src/steps.ts
@@ -141,7 +141,7 @@ export function CheckoutScriptsRepoSteps(): Step[] {
       },
     },
     {
-      run: "mv ci-scripts ../ci-scripts", // actions/checkout#197
+      run: 'echo "ci-scripts" >> .git/info/exclude', // actions/checkout#197
     },
   ];
 }
@@ -470,7 +470,7 @@ export function ZipSDKsStep(): Step {
 export function CheckCleanWorkTree(): Step {
   return {
     name: "Check worktree clean",
-    run: "../ci-scripts/ci/check-worktree-is-clean",
+    run: "./ci-scripts/ci/check-worktree-is-clean",
   };
 }
 
@@ -1058,7 +1058,7 @@ export function InstallTwine(): Step {
 export function RunPublishSDK(): Step {
   return {
     name: "Publish SDKs",
-    run: "../ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}",
+    run: "./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}",
     env: {
       NODE_AUTH_TOKEN: "${{ secrets.NPM_TOKEN }}",
       // See https://github.com/pulumi/scripts/pull/138/files

--- a/native-provider-ci/src/steps.ts
+++ b/native-provider-ci/src/steps.ts
@@ -135,7 +135,7 @@ export function CheckoutScriptsRepoStep(): Step {
     name: "Checkout Scripts Repo",
     uses: action.checkout,
     with: {
-      path: "ci-scripts",
+      path: "../ci-scripts",
       repository: "pulumi/scripts",
     },
   };
@@ -465,7 +465,7 @@ export function ZipSDKsStep(): Step {
 export function CheckCleanWorkTree(): Step {
   return {
     name: "Check worktree clean",
-    run: "./ci-scripts/ci/check-worktree-is-clean",
+    run: "../ci-scripts/ci/check-worktree-is-clean",
   };
 }
 
@@ -1053,7 +1053,7 @@ export function InstallTwine(): Step {
 export function RunPublishSDK(): Step {
   return {
     name: "Publish SDKs",
-    run: "./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}",
+    run: "../ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}",
     env: {
       NODE_AUTH_TOKEN: "${{ secrets.NPM_TOKEN }}",
       // See https://github.com/pulumi/scripts/pull/138/files

--- a/native-provider-ci/src/steps.ts
+++ b/native-provider-ci/src/steps.ts
@@ -135,7 +135,7 @@ export function CheckoutScriptsRepoStep(): Step {
     name: "Checkout Scripts Repo",
     uses: action.checkout,
     with: {
-      path: "../ci-scripts",
+      path: "${{ runner.temp }}/ci-scripts",
       repository: "pulumi/scripts",
     },
   };
@@ -465,7 +465,7 @@ export function ZipSDKsStep(): Step {
 export function CheckCleanWorkTree(): Step {
   return {
     name: "Check worktree clean",
-    run: "../ci-scripts/ci/check-worktree-is-clean",
+    run: "${{ runner.temp }}/ci-scripts/ci/check-worktree-is-clean",
   };
 }
 
@@ -1053,7 +1053,7 @@ export function InstallTwine(): Step {
 export function RunPublishSDK(): Step {
   return {
     name: "Publish SDKs",
-    run: "../ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}",
+    run: "${{ runner.temp }}/ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}",
     env: {
       NODE_AUTH_TOKEN: "${{ secrets.NPM_TOKEN }}",
       // See https://github.com/pulumi/scripts/pull/138/files

--- a/native-provider-ci/src/workflows.ts
+++ b/native-provider-ci/src/workflows.ts
@@ -451,7 +451,7 @@ export class BuildSdkJob implements NormalJob {
     this.name = name;
     this.steps = [
       steps.CheckoutRepoStep(),
-      steps.CheckoutScriptsRepoStep(),
+      ...steps.CheckoutScriptsRepoSteps(),
       steps.CheckoutTagsStep(),
       steps.InstallGo(),
       steps.InstallPulumiCtl(),
@@ -507,7 +507,7 @@ export class PrerequisitesJob implements NormalJob {
     this.name = name;
     this.steps = [
       steps.CheckoutRepoStep(),
-      steps.CheckoutScriptsRepoStep(),
+      ...steps.CheckoutScriptsRepoSteps(),
       steps.CheckoutTagsStep(),
       steps.InstallGo(),
       steps.InstallPulumiCtl(),
@@ -585,7 +585,7 @@ export class TestsJob implements NormalJob {
     };
     this.steps = [
       steps.CheckoutRepoStep(),
-      steps.CheckoutScriptsRepoStep(),
+      ...steps.CheckoutScriptsRepoSteps(),
       steps.CheckoutTagsStep(),
       steps.InstallGo(),
       steps.InstallPulumiCtl(),
@@ -811,7 +811,7 @@ export class PublishSDKJob implements NormalJob {
     Object.assign(this, { name });
     this.steps = [
       steps.CheckoutRepoStep(),
-      steps.CheckoutScriptsRepoStep(),
+      ...steps.CheckoutScriptsRepoSteps(),
       steps.CheckoutTagsStep(),
       steps.InstallGo(),
       steps.InstallPulumiCtl(),
@@ -844,7 +844,7 @@ export class PublishJavaSDKJob implements NormalJob {
     Object.assign(this, { name });
     this.steps = [
       steps.CheckoutRepoStep(),
-      steps.CheckoutScriptsRepoStep(),
+      ...steps.CheckoutScriptsRepoSteps(),
       steps.CheckoutTagsStep(),
       steps.InstallGo(),
       steps.InstallPulumiCtl(),

--- a/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/build_sdk.splice
+++ b/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/build_sdk.splice
@@ -1,9 +1,11 @@
     - name: Checkout Scripts Repo
       uses: #{{ .Config.actionVersions.checkout }}#
       with:
-        path: ${{ runner.temp }}/ci-scripts
+        path: ci-scripts
         repository: pulumi/scripts
         ref: #{{ .Config.pulumiScriptsRef }}#
+      env:
+        GITHUB_WORKSPACE: ${{ runner.temp }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
 #{{ .Config.actions.setupGo | toYaml | indent 4 }}#

--- a/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/build_sdk.splice
+++ b/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/build_sdk.splice
@@ -4,7 +4,7 @@
         path: ci-scripts
         repository: pulumi/scripts
         ref: #{{ .Config.pulumiScriptsRef }}#
-    - run: mv ci-scripts ../ci-scripts # actions/checkout#197
+    - run: echo "ci-scripts" >> .git/info/exclude # actions/checkout#197
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
 #{{ .Config.actions.setupGo | toYaml | indent 4 }}#
@@ -64,7 +64,7 @@
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
-      run: ../ci-scripts/ci/check-worktree-is-clean
+      run: ./ci-scripts/ci/check-worktree-is-clean
     - name: Compress SDK folder
       run: tar -zcf sdk/${{ matrix.language }}.tar.gz -C sdk/${{ matrix.language }} .
     - name: Upload artifacts

--- a/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/build_sdk.splice
+++ b/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/build_sdk.splice
@@ -4,8 +4,7 @@
         path: ci-scripts
         repository: pulumi/scripts
         ref: #{{ .Config.pulumiScriptsRef }}#
-      env:
-        GITHUB_WORKSPACE: ${{ runner.temp }}
+    - run: mv ci-scripts ../ci-scripts # actions/checkout#197
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
 #{{ .Config.actions.setupGo | toYaml | indent 4 }}#
@@ -65,7 +64,7 @@
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
-      run: ${{ runner.temp }}/ci-scripts/ci/check-worktree-is-clean
+      run: ../ci-scripts/ci/check-worktree-is-clean
     - name: Compress SDK folder
       run: tar -zcf sdk/${{ matrix.language }}.tar.gz -C sdk/${{ matrix.language }} .
     - name: Upload artifacts

--- a/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/build_sdk.splice
+++ b/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/build_sdk.splice
@@ -1,7 +1,7 @@
     - name: Checkout Scripts Repo
       uses: #{{ .Config.actionVersions.checkout }}#
       with:
-        path: ../ci-scripts
+        path: ${{ runner.temp }}/ci-scripts
         repository: pulumi/scripts
         ref: #{{ .Config.pulumiScriptsRef }}#
     - name: Unshallow clone for tags
@@ -63,7 +63,7 @@
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
-      run: ../ci-scripts/ci/check-worktree-is-clean
+      run: ${{ runner.temp }}/ci-scripts/ci/check-worktree-is-clean
     - name: Compress SDK folder
       run: tar -zcf sdk/${{ matrix.language }}.tar.gz -C sdk/${{ matrix.language }} .
     - name: Upload artifacts

--- a/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/build_sdk.splice
+++ b/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/build_sdk.splice
@@ -1,7 +1,7 @@
     - name: Checkout Scripts Repo
       uses: #{{ .Config.actionVersions.checkout }}#
       with:
-        path: ci-scripts
+        path: ../ci-scripts
         repository: pulumi/scripts
         ref: #{{ .Config.pulumiScriptsRef }}#
     - name: Unshallow clone for tags
@@ -63,7 +63,7 @@
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
-      run: ./ci-scripts/ci/check-worktree-is-clean
+      run: ../ci-scripts/ci/check-worktree-is-clean
     - name: Compress SDK folder
       run: tar -zcf sdk/${{ matrix.language }}.tar.gz -C sdk/${{ matrix.language }} .
     - name: Upload artifacts

--- a/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/main.yml
+++ b/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/main.yml
@@ -45,12 +45,6 @@ jobs:
         aws-access-key-id: ${{ secrets.AWS_CORP_S3_UPLOAD_ACCESS_KEY_ID }}
         aws-region: us-west-2
         aws-secret-access-key: ${{ secrets.AWS_CORP_S3_UPLOAD_SECRET_ACCESS_KEY }}
-    - name: Checkout Scripts Repo
-      uses: #{{ .Config.actionVersions.checkout }}#
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-        ref: #{{ .Config.pulumiScriptsRef }}#
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
 #{{ .Config.actions.setupGo | toYaml | indent 4 }}#
@@ -202,12 +196,6 @@ jobs:
       with:
         submodules: #{{ .Config.checkoutSubmodules }}#
 #{{- end }}#
-    - name: Checkout Scripts Repo
-      uses: #{{ .Config.actionVersions.checkout }}#
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-        ref: #{{ .Config.pulumiScriptsRef }}#
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
 #{{ .Config.actions.setupGo | toYaml | indent 4 }}#

--- a/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/nightly-test.yml
+++ b/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/nightly-test.yml
@@ -35,12 +35,6 @@ jobs:
       with:
         submodules: #{{ .Config.checkoutSubmodules }}#
 #{{- end }}#
-    - name: Checkout Scripts Repo
-      uses: #{{ .Config.actionVersions.checkout }}#
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-        ref: #{{ .Config.pulumiScriptsRef }}#
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
 #{{ .Config.actions.setupGo | toYaml | indent 4 }}#

--- a/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/prerelease.yml
+++ b/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/prerelease.yml
@@ -127,12 +127,6 @@ jobs:
       with:
         submodules: #{{ .Config.checkoutSubmodules }}#
 #{{- end }}#
-    - name: Checkout Scripts Repo
-      uses: #{{ .Config.actionVersions.checkout }}#
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-        ref: #{{ .Config.pulumiScriptsRef }}#
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
 #{{ .Config.actions.setupGo | toYaml | indent 4 }}#

--- a/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/prerequisites.splice
+++ b/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/prerequisites.splice
@@ -12,12 +12,6 @@
         path: |
           .pulumi/examples-cache
         key: ${{ runner.os }}-${{ hashFiles('provider/go.sum') }}
-    - name: Checkout Scripts Repo
-      uses: #{{ .Config.actionVersions.checkout }}#
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-        ref: #{{ .Config.pulumiScriptsRef }}#
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Prepare upstream code

--- a/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/release.yml
+++ b/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/release.yml
@@ -184,12 +184,6 @@ jobs:
       with:
         submodules: #{{ .Config.checkoutSubmodules }}#
 #{{- end }}#
-    - name: Checkout Scripts Repo
-      uses: #{{ .Config.actionVersions.checkout }}#
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-        ref: #{{ .Config.pulumiScriptsRef }}#
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
 #{{ .Config.actions.setupGo | toYaml | indent 4 }}#

--- a/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/run-acceptance-tests.yml
@@ -121,12 +121,6 @@ jobs:
         #{{- if .Config.checkoutSubmodules }}#
         submodules: #{{ .Config.checkoutSubmodules }}#
         #{{- end }}#
-    - name: Checkout Scripts Repo
-      uses: #{{ .Config.actionVersions.checkout }}#
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-        ref: #{{ .Config.pulumiScriptsRef }}#
     - name: Checkout p/examples
       if: matrix.testTarget == 'pulumiExamples'
       uses: #{{ .Config.actionVersions.checkout }}#

--- a/provider-ci/test-workflows/aws/.github/workflows/master.yml
+++ b/provider-ci/test-workflows/aws/.github/workflows/master.yml
@@ -43,7 +43,7 @@ jobs:
     - name: Checkout Scripts Repo
       uses: actions/checkout@v4
       with:
-        path: ci-scripts
+        path: ../ci-scripts
         repository: pulumi/scripts
         ref: deca2c5c6015ad7aaea6f572a1c2b198ca323592
     - name: Unshallow clone for tags
@@ -113,7 +113,7 @@ jobs:
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
-      run: ./ci-scripts/ci/check-worktree-is-clean
+      run: ../ci-scripts/ci/check-worktree-is-clean
     - name: Compress SDK folder
       run: tar -zcf sdk/${{ matrix.language }}.tar.gz -C sdk/${{ matrix.language }} .
     - name: Upload artifacts

--- a/provider-ci/test-workflows/aws/.github/workflows/master.yml
+++ b/provider-ci/test-workflows/aws/.github/workflows/master.yml
@@ -43,7 +43,7 @@ jobs:
     - name: Checkout Scripts Repo
       uses: actions/checkout@v4
       with:
-        path: ../ci-scripts
+        path: ${{ runner.temp }}/ci-scripts
         repository: pulumi/scripts
         ref: deca2c5c6015ad7aaea6f572a1c2b198ca323592
     - name: Unshallow clone for tags
@@ -113,7 +113,7 @@ jobs:
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
-      run: ../ci-scripts/ci/check-worktree-is-clean
+      run: ${{ runner.temp }}/ci-scripts/ci/check-worktree-is-clean
     - name: Compress SDK folder
       run: tar -zcf sdk/${{ matrix.language }}.tar.gz -C sdk/${{ matrix.language }} .
     - name: Upload artifacts
@@ -162,12 +162,6 @@ jobs:
         aws-access-key-id: ${{ secrets.AWS_CORP_S3_UPLOAD_ACCESS_KEY_ID }}
         aws-region: us-west-2
         aws-secret-access-key: ${{ secrets.AWS_CORP_S3_UPLOAD_SECRET_ACCESS_KEY }}
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v4
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-        ref: deca2c5c6015ad7aaea6f572a1c2b198ca323592
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -221,12 +215,6 @@ jobs:
         path: |
           .pulumi/examples-cache
         key: ${{ runner.os }}-${{ hashFiles('provider/go.sum') }}
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v4
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-        ref: deca2c5c6015ad7aaea6f572a1c2b198ca323592
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Prepare upstream code
@@ -449,12 +437,6 @@ jobs:
       uses: actions/checkout@v4
       with:
         submodules: true
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v4
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-        ref: deca2c5c6015ad7aaea6f572a1c2b198ca323592
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/provider-ci/test-workflows/aws/.github/workflows/master.yml
+++ b/provider-ci/test-workflows/aws/.github/workflows/master.yml
@@ -46,8 +46,7 @@ jobs:
         path: ci-scripts
         repository: pulumi/scripts
         ref: deca2c5c6015ad7aaea6f572a1c2b198ca323592
-      env:
-        GITHUB_WORKSPACE: ${{ runner.temp }}
+    - run: mv ci-scripts ../ci-scripts # actions/checkout#197
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -115,7 +114,7 @@ jobs:
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
-      run: ${{ runner.temp }}/ci-scripts/ci/check-worktree-is-clean
+      run: ../ci-scripts/ci/check-worktree-is-clean
     - name: Compress SDK folder
       run: tar -zcf sdk/${{ matrix.language }}.tar.gz -C sdk/${{ matrix.language }} .
     - name: Upload artifacts

--- a/provider-ci/test-workflows/aws/.github/workflows/master.yml
+++ b/provider-ci/test-workflows/aws/.github/workflows/master.yml
@@ -43,9 +43,11 @@ jobs:
     - name: Checkout Scripts Repo
       uses: actions/checkout@v4
       with:
-        path: ${{ runner.temp }}/ci-scripts
+        path: ci-scripts
         repository: pulumi/scripts
         ref: deca2c5c6015ad7aaea6f572a1c2b198ca323592
+      env:
+        GITHUB_WORKSPACE: ${{ runner.temp }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/provider-ci/test-workflows/aws/.github/workflows/master.yml
+++ b/provider-ci/test-workflows/aws/.github/workflows/master.yml
@@ -46,7 +46,7 @@ jobs:
         path: ci-scripts
         repository: pulumi/scripts
         ref: deca2c5c6015ad7aaea6f572a1c2b198ca323592
-    - run: mv ci-scripts ../ci-scripts # actions/checkout#197
+    - run: echo "ci-scripts" >> .git/info/exclude # actions/checkout#197
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -114,7 +114,7 @@ jobs:
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
-      run: ../ci-scripts/ci/check-worktree-is-clean
+      run: ./ci-scripts/ci/check-worktree-is-clean
     - name: Compress SDK folder
       run: tar -zcf sdk/${{ matrix.language }}.tar.gz -C sdk/${{ matrix.language }} .
     - name: Upload artifacts

--- a/provider-ci/test-workflows/aws/.github/workflows/nightly-test.yml
+++ b/provider-ci/test-workflows/aws/.github/workflows/nightly-test.yml
@@ -43,7 +43,7 @@ jobs:
     - name: Checkout Scripts Repo
       uses: actions/checkout@v4
       with:
-        path: ci-scripts
+        path: ../ci-scripts
         repository: pulumi/scripts
         ref: deca2c5c6015ad7aaea6f572a1c2b198ca323592
     - name: Unshallow clone for tags
@@ -113,7 +113,7 @@ jobs:
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
-      run: ./ci-scripts/ci/check-worktree-is-clean
+      run: ../ci-scripts/ci/check-worktree-is-clean
     - name: Compress SDK folder
       run: tar -zcf sdk/${{ matrix.language }}.tar.gz -C sdk/${{ matrix.language }} .
     - name: Upload artifacts

--- a/provider-ci/test-workflows/aws/.github/workflows/nightly-test.yml
+++ b/provider-ci/test-workflows/aws/.github/workflows/nightly-test.yml
@@ -46,8 +46,7 @@ jobs:
         path: ci-scripts
         repository: pulumi/scripts
         ref: deca2c5c6015ad7aaea6f572a1c2b198ca323592
-      env:
-        GITHUB_WORKSPACE: ${{ runner.temp }}
+    - run: mv ci-scripts ../ci-scripts # actions/checkout#197
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -115,7 +114,7 @@ jobs:
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
-      run: ${{ runner.temp }}/ci-scripts/ci/check-worktree-is-clean
+      run: ../ci-scripts/ci/check-worktree-is-clean
     - name: Compress SDK folder
       run: tar -zcf sdk/${{ matrix.language }}.tar.gz -C sdk/${{ matrix.language }} .
     - name: Upload artifacts

--- a/provider-ci/test-workflows/aws/.github/workflows/nightly-test.yml
+++ b/provider-ci/test-workflows/aws/.github/workflows/nightly-test.yml
@@ -43,7 +43,7 @@ jobs:
     - name: Checkout Scripts Repo
       uses: actions/checkout@v4
       with:
-        path: ../ci-scripts
+        path: ${{ runner.temp }}/ci-scripts
         repository: pulumi/scripts
         ref: deca2c5c6015ad7aaea6f572a1c2b198ca323592
     - name: Unshallow clone for tags
@@ -113,7 +113,7 @@ jobs:
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
-      run: ../ci-scripts/ci/check-worktree-is-clean
+      run: ${{ runner.temp }}/ci-scripts/ci/check-worktree-is-clean
     - name: Compress SDK folder
       run: tar -zcf sdk/${{ matrix.language }}.tar.gz -C sdk/${{ matrix.language }} .
     - name: Upload artifacts
@@ -153,12 +153,6 @@ jobs:
         path: |
           .pulumi/examples-cache
         key: ${{ runner.os }}-${{ hashFiles('provider/go.sum') }}
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v4
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-        ref: deca2c5c6015ad7aaea6f572a1c2b198ca323592
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Prepare upstream code
@@ -282,12 +276,6 @@ jobs:
       uses: actions/checkout@v4
       with:
         submodules: true
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v4
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-        ref: deca2c5c6015ad7aaea6f572a1c2b198ca323592
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/provider-ci/test-workflows/aws/.github/workflows/nightly-test.yml
+++ b/provider-ci/test-workflows/aws/.github/workflows/nightly-test.yml
@@ -43,9 +43,11 @@ jobs:
     - name: Checkout Scripts Repo
       uses: actions/checkout@v4
       with:
-        path: ${{ runner.temp }}/ci-scripts
+        path: ci-scripts
         repository: pulumi/scripts
         ref: deca2c5c6015ad7aaea6f572a1c2b198ca323592
+      env:
+        GITHUB_WORKSPACE: ${{ runner.temp }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/provider-ci/test-workflows/aws/.github/workflows/nightly-test.yml
+++ b/provider-ci/test-workflows/aws/.github/workflows/nightly-test.yml
@@ -46,7 +46,7 @@ jobs:
         path: ci-scripts
         repository: pulumi/scripts
         ref: deca2c5c6015ad7aaea6f572a1c2b198ca323592
-    - run: mv ci-scripts ../ci-scripts # actions/checkout#197
+    - run: echo "ci-scripts" >> .git/info/exclude # actions/checkout#197
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -114,7 +114,7 @@ jobs:
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
-      run: ../ci-scripts/ci/check-worktree-is-clean
+      run: ./ci-scripts/ci/check-worktree-is-clean
     - name: Compress SDK folder
       run: tar -zcf sdk/${{ matrix.language }}.tar.gz -C sdk/${{ matrix.language }} .
     - name: Upload artifacts

--- a/provider-ci/test-workflows/aws/.github/workflows/prerelease.yml
+++ b/provider-ci/test-workflows/aws/.github/workflows/prerelease.yml
@@ -47,7 +47,7 @@ jobs:
         path: ci-scripts
         repository: pulumi/scripts
         ref: deca2c5c6015ad7aaea6f572a1c2b198ca323592
-    - run: mv ci-scripts ../ci-scripts # actions/checkout#197
+    - run: echo "ci-scripts" >> .git/info/exclude # actions/checkout#197
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -115,7 +115,7 @@ jobs:
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
-      run: ../ci-scripts/ci/check-worktree-is-clean
+      run: ./ci-scripts/ci/check-worktree-is-clean
     - name: Compress SDK folder
       run: tar -zcf sdk/${{ matrix.language }}.tar.gz -C sdk/${{ matrix.language }} .
     - name: Upload artifacts

--- a/provider-ci/test-workflows/aws/.github/workflows/prerelease.yml
+++ b/provider-ci/test-workflows/aws/.github/workflows/prerelease.yml
@@ -44,7 +44,7 @@ jobs:
     - name: Checkout Scripts Repo
       uses: actions/checkout@v4
       with:
-        path: ../ci-scripts
+        path: ${{ runner.temp }}/ci-scripts
         repository: pulumi/scripts
         ref: deca2c5c6015ad7aaea6f572a1c2b198ca323592
     - name: Unshallow clone for tags
@@ -114,7 +114,7 @@ jobs:
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
-      run: ../ci-scripts/ci/check-worktree-is-clean
+      run: ${{ runner.temp }}/ci-scripts/ci/check-worktree-is-clean
     - name: Compress SDK folder
       run: tar -zcf sdk/${{ matrix.language }}.tar.gz -C sdk/${{ matrix.language }} .
     - name: Upload artifacts
@@ -158,12 +158,6 @@ jobs:
         path: |
           .pulumi/examples-cache
         key: ${{ runner.os }}-${{ hashFiles('provider/go.sum') }}
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v4
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-        ref: deca2c5c6015ad7aaea6f572a1c2b198ca323592
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Prepare upstream code
@@ -368,12 +362,6 @@ jobs:
       uses: actions/checkout@v4
       with:
         submodules: true
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v4
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-        ref: deca2c5c6015ad7aaea6f572a1c2b198ca323592
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/provider-ci/test-workflows/aws/.github/workflows/prerelease.yml
+++ b/provider-ci/test-workflows/aws/.github/workflows/prerelease.yml
@@ -47,8 +47,7 @@ jobs:
         path: ci-scripts
         repository: pulumi/scripts
         ref: deca2c5c6015ad7aaea6f572a1c2b198ca323592
-      env:
-        GITHUB_WORKSPACE: ${{ runner.temp }}
+    - run: mv ci-scripts ../ci-scripts # actions/checkout#197
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -116,7 +115,7 @@ jobs:
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
-      run: ${{ runner.temp }}/ci-scripts/ci/check-worktree-is-clean
+      run: ../ci-scripts/ci/check-worktree-is-clean
     - name: Compress SDK folder
       run: tar -zcf sdk/${{ matrix.language }}.tar.gz -C sdk/${{ matrix.language }} .
     - name: Upload artifacts

--- a/provider-ci/test-workflows/aws/.github/workflows/prerelease.yml
+++ b/provider-ci/test-workflows/aws/.github/workflows/prerelease.yml
@@ -44,7 +44,7 @@ jobs:
     - name: Checkout Scripts Repo
       uses: actions/checkout@v4
       with:
-        path: ci-scripts
+        path: ../ci-scripts
         repository: pulumi/scripts
         ref: deca2c5c6015ad7aaea6f572a1c2b198ca323592
     - name: Unshallow clone for tags
@@ -114,7 +114,7 @@ jobs:
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
-      run: ./ci-scripts/ci/check-worktree-is-clean
+      run: ../ci-scripts/ci/check-worktree-is-clean
     - name: Compress SDK folder
       run: tar -zcf sdk/${{ matrix.language }}.tar.gz -C sdk/${{ matrix.language }} .
     - name: Upload artifacts

--- a/provider-ci/test-workflows/aws/.github/workflows/prerelease.yml
+++ b/provider-ci/test-workflows/aws/.github/workflows/prerelease.yml
@@ -44,9 +44,11 @@ jobs:
     - name: Checkout Scripts Repo
       uses: actions/checkout@v4
       with:
-        path: ${{ runner.temp }}/ci-scripts
+        path: ci-scripts
         repository: pulumi/scripts
         ref: deca2c5c6015ad7aaea6f572a1c2b198ca323592
+      env:
+        GITHUB_WORKSPACE: ${{ runner.temp }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/provider-ci/test-workflows/aws/.github/workflows/release.yml
+++ b/provider-ci/test-workflows/aws/.github/workflows/release.yml
@@ -43,7 +43,7 @@ jobs:
     - name: Checkout Scripts Repo
       uses: actions/checkout@v4
       with:
-        path: ci-scripts
+        path: ../ci-scripts
         repository: pulumi/scripts
         ref: deca2c5c6015ad7aaea6f572a1c2b198ca323592
     - name: Unshallow clone for tags
@@ -113,7 +113,7 @@ jobs:
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
-      run: ./ci-scripts/ci/check-worktree-is-clean
+      run: ../ci-scripts/ci/check-worktree-is-clean
     - name: Compress SDK folder
       run: tar -zcf sdk/${{ matrix.language }}.tar.gz -C sdk/${{ matrix.language }} .
     - name: Upload artifacts

--- a/provider-ci/test-workflows/aws/.github/workflows/release.yml
+++ b/provider-ci/test-workflows/aws/.github/workflows/release.yml
@@ -46,8 +46,7 @@ jobs:
         path: ci-scripts
         repository: pulumi/scripts
         ref: deca2c5c6015ad7aaea6f572a1c2b198ca323592
-      env:
-        GITHUB_WORKSPACE: ${{ runner.temp }}
+    - run: mv ci-scripts ../ci-scripts # actions/checkout#197
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -115,7 +114,7 @@ jobs:
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
-      run: ${{ runner.temp }}/ci-scripts/ci/check-worktree-is-clean
+      run: ../ci-scripts/ci/check-worktree-is-clean
     - name: Compress SDK folder
       run: tar -zcf sdk/${{ matrix.language }}.tar.gz -C sdk/${{ matrix.language }} .
     - name: Upload artifacts

--- a/provider-ci/test-workflows/aws/.github/workflows/release.yml
+++ b/provider-ci/test-workflows/aws/.github/workflows/release.yml
@@ -43,7 +43,7 @@ jobs:
     - name: Checkout Scripts Repo
       uses: actions/checkout@v4
       with:
-        path: ../ci-scripts
+        path: ${{ runner.temp }}/ci-scripts
         repository: pulumi/scripts
         ref: deca2c5c6015ad7aaea6f572a1c2b198ca323592
     - name: Unshallow clone for tags
@@ -113,7 +113,7 @@ jobs:
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
-      run: ../ci-scripts/ci/check-worktree-is-clean
+      run: ${{ runner.temp }}/ci-scripts/ci/check-worktree-is-clean
     - name: Compress SDK folder
       run: tar -zcf sdk/${{ matrix.language }}.tar.gz -C sdk/${{ matrix.language }} .
     - name: Upload artifacts
@@ -172,12 +172,6 @@ jobs:
         path: |
           .pulumi/examples-cache
         key: ${{ runner.os }}-${{ hashFiles('provider/go.sum') }}
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v4
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-        ref: deca2c5c6015ad7aaea6f572a1c2b198ca323592
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Prepare upstream code
@@ -418,12 +412,6 @@ jobs:
       uses: actions/checkout@v4
       with:
         submodules: true
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v4
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-        ref: deca2c5c6015ad7aaea6f572a1c2b198ca323592
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/provider-ci/test-workflows/aws/.github/workflows/release.yml
+++ b/provider-ci/test-workflows/aws/.github/workflows/release.yml
@@ -43,9 +43,11 @@ jobs:
     - name: Checkout Scripts Repo
       uses: actions/checkout@v4
       with:
-        path: ${{ runner.temp }}/ci-scripts
+        path: ci-scripts
         repository: pulumi/scripts
         ref: deca2c5c6015ad7aaea6f572a1c2b198ca323592
+      env:
+        GITHUB_WORKSPACE: ${{ runner.temp }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/provider-ci/test-workflows/aws/.github/workflows/release.yml
+++ b/provider-ci/test-workflows/aws/.github/workflows/release.yml
@@ -46,7 +46,7 @@ jobs:
         path: ci-scripts
         repository: pulumi/scripts
         ref: deca2c5c6015ad7aaea6f572a1c2b198ca323592
-    - run: mv ci-scripts ../ci-scripts # actions/checkout#197
+    - run: echo "ci-scripts" >> .git/info/exclude # actions/checkout#197
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -114,7 +114,7 @@ jobs:
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
-      run: ../ci-scripts/ci/check-worktree-is-clean
+      run: ./ci-scripts/ci/check-worktree-is-clean
     - name: Compress SDK folder
       run: tar -zcf sdk/${{ matrix.language }}.tar.gz -C sdk/${{ matrix.language }} .
     - name: Upload artifacts

--- a/provider-ci/test-workflows/aws/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/test-workflows/aws/.github/workflows/run-acceptance-tests.yml
@@ -52,7 +52,7 @@ jobs:
     - name: Checkout Scripts Repo
       uses: actions/checkout@v4
       with:
-        path: ci-scripts
+        path: ../ci-scripts
         repository: pulumi/scripts
         ref: deca2c5c6015ad7aaea6f572a1c2b198ca323592
     - name: Unshallow clone for tags
@@ -122,7 +122,7 @@ jobs:
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
-      run: ./ci-scripts/ci/check-worktree-is-clean
+      run: ../ci-scripts/ci/check-worktree-is-clean
     - name: Compress SDK folder
       run: tar -zcf sdk/${{ matrix.language }}.tar.gz -C sdk/${{ matrix.language }} .
     - name: Upload artifacts

--- a/provider-ci/test-workflows/aws/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/test-workflows/aws/.github/workflows/run-acceptance-tests.yml
@@ -52,9 +52,11 @@ jobs:
     - name: Checkout Scripts Repo
       uses: actions/checkout@v4
       with:
-        path: ${{ runner.temp }}/ci-scripts
+        path: ci-scripts
         repository: pulumi/scripts
         ref: deca2c5c6015ad7aaea6f572a1c2b198ca323592
+      env:
+        GITHUB_WORKSPACE: ${{ runner.temp }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/provider-ci/test-workflows/aws/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/test-workflows/aws/.github/workflows/run-acceptance-tests.yml
@@ -52,7 +52,7 @@ jobs:
     - name: Checkout Scripts Repo
       uses: actions/checkout@v4
       with:
-        path: ../ci-scripts
+        path: ${{ runner.temp }}/ci-scripts
         repository: pulumi/scripts
         ref: deca2c5c6015ad7aaea6f572a1c2b198ca323592
     - name: Unshallow clone for tags
@@ -122,7 +122,7 @@ jobs:
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
-      run: ../ci-scripts/ci/check-worktree-is-clean
+      run: ${{ runner.temp }}/ci-scripts/ci/check-worktree-is-clean
     - name: Compress SDK folder
       run: tar -zcf sdk/${{ matrix.language }}.tar.gz -C sdk/${{ matrix.language }} .
     - name: Upload artifacts
@@ -179,12 +179,6 @@ jobs:
         path: |
           .pulumi/examples-cache
         key: ${{ runner.os }}-${{ hashFiles('provider/go.sum') }}
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v4
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-        ref: deca2c5c6015ad7aaea6f572a1c2b198ca323592
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Prepare upstream code
@@ -351,12 +345,6 @@ jobs:
       with:
         ref: ${{ env.PR_COMMIT_SHA }}
         submodules: true
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v4
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-        ref: deca2c5c6015ad7aaea6f572a1c2b198ca323592
     - name: Checkout p/examples
       if: matrix.testTarget == 'pulumiExamples'
       uses: actions/checkout@v4

--- a/provider-ci/test-workflows/aws/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/test-workflows/aws/.github/workflows/run-acceptance-tests.yml
@@ -55,8 +55,7 @@ jobs:
         path: ci-scripts
         repository: pulumi/scripts
         ref: deca2c5c6015ad7aaea6f572a1c2b198ca323592
-      env:
-        GITHUB_WORKSPACE: ${{ runner.temp }}
+    - run: mv ci-scripts ../ci-scripts # actions/checkout#197
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -124,7 +123,7 @@ jobs:
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
-      run: ${{ runner.temp }}/ci-scripts/ci/check-worktree-is-clean
+      run: ../ci-scripts/ci/check-worktree-is-clean
     - name: Compress SDK folder
       run: tar -zcf sdk/${{ matrix.language }}.tar.gz -C sdk/${{ matrix.language }} .
     - name: Upload artifacts

--- a/provider-ci/test-workflows/aws/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/test-workflows/aws/.github/workflows/run-acceptance-tests.yml
@@ -55,7 +55,7 @@ jobs:
         path: ci-scripts
         repository: pulumi/scripts
         ref: deca2c5c6015ad7aaea6f572a1c2b198ca323592
-    - run: mv ci-scripts ../ci-scripts # actions/checkout#197
+    - run: echo "ci-scripts" >> .git/info/exclude # actions/checkout#197
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -123,7 +123,7 @@ jobs:
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
-      run: ../ci-scripts/ci/check-worktree-is-clean
+      run: ./ci-scripts/ci/check-worktree-is-clean
     - name: Compress SDK folder
       run: tar -zcf sdk/${{ matrix.language }}.tar.gz -C sdk/${{ matrix.language }} .
     - name: Upload artifacts

--- a/provider-ci/test-workflows/cloudflare/.github/workflows/master.yml
+++ b/provider-ci/test-workflows/cloudflare/.github/workflows/master.yml
@@ -41,9 +41,11 @@ jobs:
     - name: Checkout Scripts Repo
       uses: actions/checkout@v4
       with:
-        path: ${{ runner.temp }}/ci-scripts
+        path: ci-scripts
         repository: pulumi/scripts
         ref: deca2c5c6015ad7aaea6f572a1c2b198ca323592
+      env:
+        GITHUB_WORKSPACE: ${{ runner.temp }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/provider-ci/test-workflows/cloudflare/.github/workflows/master.yml
+++ b/provider-ci/test-workflows/cloudflare/.github/workflows/master.yml
@@ -41,7 +41,7 @@ jobs:
     - name: Checkout Scripts Repo
       uses: actions/checkout@v4
       with:
-        path: ci-scripts
+        path: ../ci-scripts
         repository: pulumi/scripts
         ref: deca2c5c6015ad7aaea6f572a1c2b198ca323592
     - name: Unshallow clone for tags
@@ -111,7 +111,7 @@ jobs:
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
-      run: ./ci-scripts/ci/check-worktree-is-clean
+      run: ../ci-scripts/ci/check-worktree-is-clean
     - name: Compress SDK folder
       run: tar -zcf sdk/${{ matrix.language }}.tar.gz -C sdk/${{ matrix.language }} .
     - name: Upload artifacts

--- a/provider-ci/test-workflows/cloudflare/.github/workflows/master.yml
+++ b/provider-ci/test-workflows/cloudflare/.github/workflows/master.yml
@@ -44,7 +44,7 @@ jobs:
         path: ci-scripts
         repository: pulumi/scripts
         ref: deca2c5c6015ad7aaea6f572a1c2b198ca323592
-    - run: mv ci-scripts ../ci-scripts # actions/checkout#197
+    - run: echo "ci-scripts" >> .git/info/exclude # actions/checkout#197
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -112,7 +112,7 @@ jobs:
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
-      run: ../ci-scripts/ci/check-worktree-is-clean
+      run: ./ci-scripts/ci/check-worktree-is-clean
     - name: Compress SDK folder
       run: tar -zcf sdk/${{ matrix.language }}.tar.gz -C sdk/${{ matrix.language }} .
     - name: Upload artifacts

--- a/provider-ci/test-workflows/cloudflare/.github/workflows/master.yml
+++ b/provider-ci/test-workflows/cloudflare/.github/workflows/master.yml
@@ -41,7 +41,7 @@ jobs:
     - name: Checkout Scripts Repo
       uses: actions/checkout@v4
       with:
-        path: ../ci-scripts
+        path: ${{ runner.temp }}/ci-scripts
         repository: pulumi/scripts
         ref: deca2c5c6015ad7aaea6f572a1c2b198ca323592
     - name: Unshallow clone for tags
@@ -111,7 +111,7 @@ jobs:
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
-      run: ../ci-scripts/ci/check-worktree-is-clean
+      run: ${{ runner.temp }}/ci-scripts/ci/check-worktree-is-clean
     - name: Compress SDK folder
       run: tar -zcf sdk/${{ matrix.language }}.tar.gz -C sdk/${{ matrix.language }} .
     - name: Upload artifacts
@@ -158,12 +158,6 @@ jobs:
         aws-access-key-id: ${{ secrets.AWS_CORP_S3_UPLOAD_ACCESS_KEY_ID }}
         aws-region: us-west-2
         aws-secret-access-key: ${{ secrets.AWS_CORP_S3_UPLOAD_SECRET_ACCESS_KEY }}
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v4
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-        ref: deca2c5c6015ad7aaea6f572a1c2b198ca323592
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -219,12 +213,6 @@ jobs:
         path: |
           .pulumi/examples-cache
         key: ${{ runner.os }}-${{ hashFiles('provider/go.sum') }}
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v4
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-        ref: deca2c5c6015ad7aaea6f572a1c2b198ca323592
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Prepare upstream code
@@ -433,12 +421,6 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v4
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v4
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-        ref: deca2c5c6015ad7aaea6f572a1c2b198ca323592
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/provider-ci/test-workflows/cloudflare/.github/workflows/master.yml
+++ b/provider-ci/test-workflows/cloudflare/.github/workflows/master.yml
@@ -44,8 +44,7 @@ jobs:
         path: ci-scripts
         repository: pulumi/scripts
         ref: deca2c5c6015ad7aaea6f572a1c2b198ca323592
-      env:
-        GITHUB_WORKSPACE: ${{ runner.temp }}
+    - run: mv ci-scripts ../ci-scripts # actions/checkout#197
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -113,7 +112,7 @@ jobs:
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
-      run: ${{ runner.temp }}/ci-scripts/ci/check-worktree-is-clean
+      run: ../ci-scripts/ci/check-worktree-is-clean
     - name: Compress SDK folder
       run: tar -zcf sdk/${{ matrix.language }}.tar.gz -C sdk/${{ matrix.language }} .
     - name: Upload artifacts

--- a/provider-ci/test-workflows/cloudflare/.github/workflows/prerelease.yml
+++ b/provider-ci/test-workflows/cloudflare/.github/workflows/prerelease.yml
@@ -42,9 +42,11 @@ jobs:
     - name: Checkout Scripts Repo
       uses: actions/checkout@v4
       with:
-        path: ${{ runner.temp }}/ci-scripts
+        path: ci-scripts
         repository: pulumi/scripts
         ref: deca2c5c6015ad7aaea6f572a1c2b198ca323592
+      env:
+        GITHUB_WORKSPACE: ${{ runner.temp }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/provider-ci/test-workflows/cloudflare/.github/workflows/prerelease.yml
+++ b/provider-ci/test-workflows/cloudflare/.github/workflows/prerelease.yml
@@ -45,8 +45,7 @@ jobs:
         path: ci-scripts
         repository: pulumi/scripts
         ref: deca2c5c6015ad7aaea6f572a1c2b198ca323592
-      env:
-        GITHUB_WORKSPACE: ${{ runner.temp }}
+    - run: mv ci-scripts ../ci-scripts # actions/checkout#197
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -114,7 +113,7 @@ jobs:
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
-      run: ${{ runner.temp }}/ci-scripts/ci/check-worktree-is-clean
+      run: ../ci-scripts/ci/check-worktree-is-clean
     - name: Compress SDK folder
       run: tar -zcf sdk/${{ matrix.language }}.tar.gz -C sdk/${{ matrix.language }} .
     - name: Upload artifacts

--- a/provider-ci/test-workflows/cloudflare/.github/workflows/prerelease.yml
+++ b/provider-ci/test-workflows/cloudflare/.github/workflows/prerelease.yml
@@ -42,7 +42,7 @@ jobs:
     - name: Checkout Scripts Repo
       uses: actions/checkout@v4
       with:
-        path: ../ci-scripts
+        path: ${{ runner.temp }}/ci-scripts
         repository: pulumi/scripts
         ref: deca2c5c6015ad7aaea6f572a1c2b198ca323592
     - name: Unshallow clone for tags
@@ -112,7 +112,7 @@ jobs:
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
-      run: ../ci-scripts/ci/check-worktree-is-clean
+      run: ${{ runner.temp }}/ci-scripts/ci/check-worktree-is-clean
     - name: Compress SDK folder
       run: tar -zcf sdk/${{ matrix.language }}.tar.gz -C sdk/${{ matrix.language }} .
     - name: Upload artifacts
@@ -158,12 +158,6 @@ jobs:
         path: |
           .pulumi/examples-cache
         key: ${{ runner.os }}-${{ hashFiles('provider/go.sum') }}
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v4
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-        ref: deca2c5c6015ad7aaea6f572a1c2b198ca323592
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Prepare upstream code
@@ -354,12 +348,6 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v4
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v4
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-        ref: deca2c5c6015ad7aaea6f572a1c2b198ca323592
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/provider-ci/test-workflows/cloudflare/.github/workflows/prerelease.yml
+++ b/provider-ci/test-workflows/cloudflare/.github/workflows/prerelease.yml
@@ -45,7 +45,7 @@ jobs:
         path: ci-scripts
         repository: pulumi/scripts
         ref: deca2c5c6015ad7aaea6f572a1c2b198ca323592
-    - run: mv ci-scripts ../ci-scripts # actions/checkout#197
+    - run: echo "ci-scripts" >> .git/info/exclude # actions/checkout#197
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -113,7 +113,7 @@ jobs:
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
-      run: ../ci-scripts/ci/check-worktree-is-clean
+      run: ./ci-scripts/ci/check-worktree-is-clean
     - name: Compress SDK folder
       run: tar -zcf sdk/${{ matrix.language }}.tar.gz -C sdk/${{ matrix.language }} .
     - name: Upload artifacts

--- a/provider-ci/test-workflows/cloudflare/.github/workflows/prerelease.yml
+++ b/provider-ci/test-workflows/cloudflare/.github/workflows/prerelease.yml
@@ -42,7 +42,7 @@ jobs:
     - name: Checkout Scripts Repo
       uses: actions/checkout@v4
       with:
-        path: ci-scripts
+        path: ../ci-scripts
         repository: pulumi/scripts
         ref: deca2c5c6015ad7aaea6f572a1c2b198ca323592
     - name: Unshallow clone for tags
@@ -112,7 +112,7 @@ jobs:
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
-      run: ./ci-scripts/ci/check-worktree-is-clean
+      run: ../ci-scripts/ci/check-worktree-is-clean
     - name: Compress SDK folder
       run: tar -zcf sdk/${{ matrix.language }}.tar.gz -C sdk/${{ matrix.language }} .
     - name: Upload artifacts

--- a/provider-ci/test-workflows/cloudflare/.github/workflows/release.yml
+++ b/provider-ci/test-workflows/cloudflare/.github/workflows/release.yml
@@ -41,7 +41,7 @@ jobs:
     - name: Checkout Scripts Repo
       uses: actions/checkout@v4
       with:
-        path: ../ci-scripts
+        path: ${{ runner.temp }}/ci-scripts
         repository: pulumi/scripts
         ref: deca2c5c6015ad7aaea6f572a1c2b198ca323592
     - name: Unshallow clone for tags
@@ -111,7 +111,7 @@ jobs:
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
-      run: ../ci-scripts/ci/check-worktree-is-clean
+      run: ${{ runner.temp }}/ci-scripts/ci/check-worktree-is-clean
     - name: Compress SDK folder
       run: tar -zcf sdk/${{ matrix.language }}.tar.gz -C sdk/${{ matrix.language }} .
     - name: Upload artifacts
@@ -172,12 +172,6 @@ jobs:
         path: |
           .pulumi/examples-cache
         key: ${{ runner.os }}-${{ hashFiles('provider/go.sum') }}
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v4
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-        ref: deca2c5c6015ad7aaea6f572a1c2b198ca323592
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Prepare upstream code
@@ -402,12 +396,6 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v4
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v4
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-        ref: deca2c5c6015ad7aaea6f572a1c2b198ca323592
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/provider-ci/test-workflows/cloudflare/.github/workflows/release.yml
+++ b/provider-ci/test-workflows/cloudflare/.github/workflows/release.yml
@@ -41,9 +41,11 @@ jobs:
     - name: Checkout Scripts Repo
       uses: actions/checkout@v4
       with:
-        path: ${{ runner.temp }}/ci-scripts
+        path: ci-scripts
         repository: pulumi/scripts
         ref: deca2c5c6015ad7aaea6f572a1c2b198ca323592
+      env:
+        GITHUB_WORKSPACE: ${{ runner.temp }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/provider-ci/test-workflows/cloudflare/.github/workflows/release.yml
+++ b/provider-ci/test-workflows/cloudflare/.github/workflows/release.yml
@@ -41,7 +41,7 @@ jobs:
     - name: Checkout Scripts Repo
       uses: actions/checkout@v4
       with:
-        path: ci-scripts
+        path: ../ci-scripts
         repository: pulumi/scripts
         ref: deca2c5c6015ad7aaea6f572a1c2b198ca323592
     - name: Unshallow clone for tags
@@ -111,7 +111,7 @@ jobs:
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
-      run: ./ci-scripts/ci/check-worktree-is-clean
+      run: ../ci-scripts/ci/check-worktree-is-clean
     - name: Compress SDK folder
       run: tar -zcf sdk/${{ matrix.language }}.tar.gz -C sdk/${{ matrix.language }} .
     - name: Upload artifacts

--- a/provider-ci/test-workflows/cloudflare/.github/workflows/release.yml
+++ b/provider-ci/test-workflows/cloudflare/.github/workflows/release.yml
@@ -44,7 +44,7 @@ jobs:
         path: ci-scripts
         repository: pulumi/scripts
         ref: deca2c5c6015ad7aaea6f572a1c2b198ca323592
-    - run: mv ci-scripts ../ci-scripts # actions/checkout#197
+    - run: echo "ci-scripts" >> .git/info/exclude # actions/checkout#197
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -112,7 +112,7 @@ jobs:
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
-      run: ../ci-scripts/ci/check-worktree-is-clean
+      run: ./ci-scripts/ci/check-worktree-is-clean
     - name: Compress SDK folder
       run: tar -zcf sdk/${{ matrix.language }}.tar.gz -C sdk/${{ matrix.language }} .
     - name: Upload artifacts

--- a/provider-ci/test-workflows/cloudflare/.github/workflows/release.yml
+++ b/provider-ci/test-workflows/cloudflare/.github/workflows/release.yml
@@ -44,8 +44,7 @@ jobs:
         path: ci-scripts
         repository: pulumi/scripts
         ref: deca2c5c6015ad7aaea6f572a1c2b198ca323592
-      env:
-        GITHUB_WORKSPACE: ${{ runner.temp }}
+    - run: mv ci-scripts ../ci-scripts # actions/checkout#197
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -113,7 +112,7 @@ jobs:
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
-      run: ${{ runner.temp }}/ci-scripts/ci/check-worktree-is-clean
+      run: ../ci-scripts/ci/check-worktree-is-clean
     - name: Compress SDK folder
       run: tar -zcf sdk/${{ matrix.language }}.tar.gz -C sdk/${{ matrix.language }} .
     - name: Upload artifacts

--- a/provider-ci/test-workflows/cloudflare/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/test-workflows/cloudflare/.github/workflows/run-acceptance-tests.yml
@@ -51,9 +51,11 @@ jobs:
     - name: Checkout Scripts Repo
       uses: actions/checkout@v4
       with:
-        path: ${{ runner.temp }}/ci-scripts
+        path: ci-scripts
         repository: pulumi/scripts
         ref: deca2c5c6015ad7aaea6f572a1c2b198ca323592
+      env:
+        GITHUB_WORKSPACE: ${{ runner.temp }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/provider-ci/test-workflows/cloudflare/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/test-workflows/cloudflare/.github/workflows/run-acceptance-tests.yml
@@ -54,8 +54,7 @@ jobs:
         path: ci-scripts
         repository: pulumi/scripts
         ref: deca2c5c6015ad7aaea6f572a1c2b198ca323592
-      env:
-        GITHUB_WORKSPACE: ${{ runner.temp }}
+    - run: mv ci-scripts ../ci-scripts # actions/checkout#197
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -123,7 +122,7 @@ jobs:
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
-      run: ${{ runner.temp }}/ci-scripts/ci/check-worktree-is-clean
+      run: ../ci-scripts/ci/check-worktree-is-clean
     - name: Compress SDK folder
       run: tar -zcf sdk/${{ matrix.language }}.tar.gz -C sdk/${{ matrix.language }} .
     - name: Upload artifacts

--- a/provider-ci/test-workflows/cloudflare/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/test-workflows/cloudflare/.github/workflows/run-acceptance-tests.yml
@@ -54,7 +54,7 @@ jobs:
         path: ci-scripts
         repository: pulumi/scripts
         ref: deca2c5c6015ad7aaea6f572a1c2b198ca323592
-    - run: mv ci-scripts ../ci-scripts # actions/checkout#197
+    - run: echo "ci-scripts" >> .git/info/exclude # actions/checkout#197
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -122,7 +122,7 @@ jobs:
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
-      run: ../ci-scripts/ci/check-worktree-is-clean
+      run: ./ci-scripts/ci/check-worktree-is-clean
     - name: Compress SDK folder
       run: tar -zcf sdk/${{ matrix.language }}.tar.gz -C sdk/${{ matrix.language }} .
     - name: Upload artifacts

--- a/provider-ci/test-workflows/cloudflare/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/test-workflows/cloudflare/.github/workflows/run-acceptance-tests.yml
@@ -51,7 +51,7 @@ jobs:
     - name: Checkout Scripts Repo
       uses: actions/checkout@v4
       with:
-        path: ../ci-scripts
+        path: ${{ runner.temp }}/ci-scripts
         repository: pulumi/scripts
         ref: deca2c5c6015ad7aaea6f572a1c2b198ca323592
     - name: Unshallow clone for tags
@@ -121,7 +121,7 @@ jobs:
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
-      run: ../ci-scripts/ci/check-worktree-is-clean
+      run: ${{ runner.temp }}/ci-scripts/ci/check-worktree-is-clean
     - name: Compress SDK folder
       run: tar -zcf sdk/${{ matrix.language }}.tar.gz -C sdk/${{ matrix.language }} .
     - name: Upload artifacts
@@ -182,12 +182,6 @@ jobs:
         path: |
           .pulumi/examples-cache
         key: ${{ runner.os }}-${{ hashFiles('provider/go.sum') }}
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v4
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-        ref: deca2c5c6015ad7aaea6f572a1c2b198ca323592
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Prepare upstream code
@@ -344,12 +338,6 @@ jobs:
       uses: actions/checkout@v4
       with:
         ref: ${{ env.PR_COMMIT_SHA }}
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v4
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-        ref: deca2c5c6015ad7aaea6f572a1c2b198ca323592
     - name: Checkout p/examples
       if: matrix.testTarget == 'pulumiExamples'
       uses: actions/checkout@v4

--- a/provider-ci/test-workflows/cloudflare/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/test-workflows/cloudflare/.github/workflows/run-acceptance-tests.yml
@@ -51,7 +51,7 @@ jobs:
     - name: Checkout Scripts Repo
       uses: actions/checkout@v4
       with:
-        path: ci-scripts
+        path: ../ci-scripts
         repository: pulumi/scripts
         ref: deca2c5c6015ad7aaea6f572a1c2b198ca323592
     - name: Unshallow clone for tags
@@ -121,7 +121,7 @@ jobs:
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
-      run: ./ci-scripts/ci/check-worktree-is-clean
+      run: ../ci-scripts/ci/check-worktree-is-clean
     - name: Compress SDK folder
       run: tar -zcf sdk/${{ matrix.language }}.tar.gz -C sdk/${{ matrix.language }} .
     - name: Upload artifacts

--- a/provider-ci/test-workflows/docker/.github/workflows/master.yml
+++ b/provider-ci/test-workflows/docker/.github/workflows/master.yml
@@ -54,7 +54,7 @@ jobs:
     - name: Checkout Scripts Repo
       uses: actions/checkout@v4
       with:
-        path: ci-scripts
+        path: ../ci-scripts
         repository: pulumi/scripts
         ref: deca2c5c6015ad7aaea6f572a1c2b198ca323592
     - name: Unshallow clone for tags
@@ -124,7 +124,7 @@ jobs:
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
-      run: ./ci-scripts/ci/check-worktree-is-clean
+      run: ../ci-scripts/ci/check-worktree-is-clean
     - name: Compress SDK folder
       run: tar -zcf sdk/${{ matrix.language }}.tar.gz -C sdk/${{ matrix.language }} .
     - name: Upload artifacts

--- a/provider-ci/test-workflows/docker/.github/workflows/master.yml
+++ b/provider-ci/test-workflows/docker/.github/workflows/master.yml
@@ -57,7 +57,7 @@ jobs:
         path: ci-scripts
         repository: pulumi/scripts
         ref: deca2c5c6015ad7aaea6f572a1c2b198ca323592
-    - run: mv ci-scripts ../ci-scripts # actions/checkout#197
+    - run: echo "ci-scripts" >> .git/info/exclude # actions/checkout#197
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -125,7 +125,7 @@ jobs:
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
-      run: ../ci-scripts/ci/check-worktree-is-clean
+      run: ./ci-scripts/ci/check-worktree-is-clean
     - name: Compress SDK folder
       run: tar -zcf sdk/${{ matrix.language }}.tar.gz -C sdk/${{ matrix.language }} .
     - name: Upload artifacts

--- a/provider-ci/test-workflows/docker/.github/workflows/master.yml
+++ b/provider-ci/test-workflows/docker/.github/workflows/master.yml
@@ -54,9 +54,11 @@ jobs:
     - name: Checkout Scripts Repo
       uses: actions/checkout@v4
       with:
-        path: ${{ runner.temp }}/ci-scripts
+        path: ci-scripts
         repository: pulumi/scripts
         ref: deca2c5c6015ad7aaea6f572a1c2b198ca323592
+      env:
+        GITHUB_WORKSPACE: ${{ runner.temp }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/provider-ci/test-workflows/docker/.github/workflows/master.yml
+++ b/provider-ci/test-workflows/docker/.github/workflows/master.yml
@@ -57,8 +57,7 @@ jobs:
         path: ci-scripts
         repository: pulumi/scripts
         ref: deca2c5c6015ad7aaea6f572a1c2b198ca323592
-      env:
-        GITHUB_WORKSPACE: ${{ runner.temp }}
+    - run: mv ci-scripts ../ci-scripts # actions/checkout#197
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -126,7 +125,7 @@ jobs:
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
-      run: ${{ runner.temp }}/ci-scripts/ci/check-worktree-is-clean
+      run: ../ci-scripts/ci/check-worktree-is-clean
     - name: Compress SDK folder
       run: tar -zcf sdk/${{ matrix.language }}.tar.gz -C sdk/${{ matrix.language }} .
     - name: Upload artifacts

--- a/provider-ci/test-workflows/docker/.github/workflows/master.yml
+++ b/provider-ci/test-workflows/docker/.github/workflows/master.yml
@@ -54,7 +54,7 @@ jobs:
     - name: Checkout Scripts Repo
       uses: actions/checkout@v4
       with:
-        path: ../ci-scripts
+        path: ${{ runner.temp }}/ci-scripts
         repository: pulumi/scripts
         ref: deca2c5c6015ad7aaea6f572a1c2b198ca323592
     - name: Unshallow clone for tags
@@ -124,7 +124,7 @@ jobs:
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
-      run: ../ci-scripts/ci/check-worktree-is-clean
+      run: ${{ runner.temp }}/ci-scripts/ci/check-worktree-is-clean
     - name: Compress SDK folder
       run: tar -zcf sdk/${{ matrix.language }}.tar.gz -C sdk/${{ matrix.language }} .
     - name: Upload artifacts
@@ -171,12 +171,6 @@ jobs:
         aws-access-key-id: ${{ secrets.AWS_CORP_S3_UPLOAD_ACCESS_KEY_ID }}
         aws-region: us-west-2
         aws-secret-access-key: ${{ secrets.AWS_CORP_S3_UPLOAD_SECRET_ACCESS_KEY }}
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v4
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-        ref: deca2c5c6015ad7aaea6f572a1c2b198ca323592
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -232,12 +226,6 @@ jobs:
         path: |
           .pulumi/examples-cache
         key: ${{ runner.os }}-${{ hashFiles('provider/go.sum') }}
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v4
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-        ref: deca2c5c6015ad7aaea6f572a1c2b198ca323592
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Prepare upstream code
@@ -446,12 +434,6 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v4
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v4
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-        ref: deca2c5c6015ad7aaea6f572a1c2b198ca323592
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/provider-ci/test-workflows/docker/.github/workflows/prerelease.yml
+++ b/provider-ci/test-workflows/docker/.github/workflows/prerelease.yml
@@ -55,9 +55,11 @@ jobs:
     - name: Checkout Scripts Repo
       uses: actions/checkout@v4
       with:
-        path: ${{ runner.temp }}/ci-scripts
+        path: ci-scripts
         repository: pulumi/scripts
         ref: deca2c5c6015ad7aaea6f572a1c2b198ca323592
+      env:
+        GITHUB_WORKSPACE: ${{ runner.temp }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/provider-ci/test-workflows/docker/.github/workflows/prerelease.yml
+++ b/provider-ci/test-workflows/docker/.github/workflows/prerelease.yml
@@ -58,7 +58,7 @@ jobs:
         path: ci-scripts
         repository: pulumi/scripts
         ref: deca2c5c6015ad7aaea6f572a1c2b198ca323592
-    - run: mv ci-scripts ../ci-scripts # actions/checkout#197
+    - run: echo "ci-scripts" >> .git/info/exclude # actions/checkout#197
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -126,7 +126,7 @@ jobs:
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
-      run: ../ci-scripts/ci/check-worktree-is-clean
+      run: ./ci-scripts/ci/check-worktree-is-clean
     - name: Compress SDK folder
       run: tar -zcf sdk/${{ matrix.language }}.tar.gz -C sdk/${{ matrix.language }} .
     - name: Upload artifacts

--- a/provider-ci/test-workflows/docker/.github/workflows/prerelease.yml
+++ b/provider-ci/test-workflows/docker/.github/workflows/prerelease.yml
@@ -55,7 +55,7 @@ jobs:
     - name: Checkout Scripts Repo
       uses: actions/checkout@v4
       with:
-        path: ../ci-scripts
+        path: ${{ runner.temp }}/ci-scripts
         repository: pulumi/scripts
         ref: deca2c5c6015ad7aaea6f572a1c2b198ca323592
     - name: Unshallow clone for tags
@@ -125,7 +125,7 @@ jobs:
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
-      run: ../ci-scripts/ci/check-worktree-is-clean
+      run: ${{ runner.temp }}/ci-scripts/ci/check-worktree-is-clean
     - name: Compress SDK folder
       run: tar -zcf sdk/${{ matrix.language }}.tar.gz -C sdk/${{ matrix.language }} .
     - name: Upload artifacts
@@ -171,12 +171,6 @@ jobs:
         path: |
           .pulumi/examples-cache
         key: ${{ runner.os }}-${{ hashFiles('provider/go.sum') }}
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v4
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-        ref: deca2c5c6015ad7aaea6f572a1c2b198ca323592
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Prepare upstream code
@@ -367,12 +361,6 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v4
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v4
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-        ref: deca2c5c6015ad7aaea6f572a1c2b198ca323592
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/provider-ci/test-workflows/docker/.github/workflows/prerelease.yml
+++ b/provider-ci/test-workflows/docker/.github/workflows/prerelease.yml
@@ -58,8 +58,7 @@ jobs:
         path: ci-scripts
         repository: pulumi/scripts
         ref: deca2c5c6015ad7aaea6f572a1c2b198ca323592
-      env:
-        GITHUB_WORKSPACE: ${{ runner.temp }}
+    - run: mv ci-scripts ../ci-scripts # actions/checkout#197
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -127,7 +126,7 @@ jobs:
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
-      run: ${{ runner.temp }}/ci-scripts/ci/check-worktree-is-clean
+      run: ../ci-scripts/ci/check-worktree-is-clean
     - name: Compress SDK folder
       run: tar -zcf sdk/${{ matrix.language }}.tar.gz -C sdk/${{ matrix.language }} .
     - name: Upload artifacts

--- a/provider-ci/test-workflows/docker/.github/workflows/prerelease.yml
+++ b/provider-ci/test-workflows/docker/.github/workflows/prerelease.yml
@@ -55,7 +55,7 @@ jobs:
     - name: Checkout Scripts Repo
       uses: actions/checkout@v4
       with:
-        path: ci-scripts
+        path: ../ci-scripts
         repository: pulumi/scripts
         ref: deca2c5c6015ad7aaea6f572a1c2b198ca323592
     - name: Unshallow clone for tags
@@ -125,7 +125,7 @@ jobs:
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
-      run: ./ci-scripts/ci/check-worktree-is-clean
+      run: ../ci-scripts/ci/check-worktree-is-clean
     - name: Compress SDK folder
       run: tar -zcf sdk/${{ matrix.language }}.tar.gz -C sdk/${{ matrix.language }} .
     - name: Upload artifacts

--- a/provider-ci/test-workflows/docker/.github/workflows/release.yml
+++ b/provider-ci/test-workflows/docker/.github/workflows/release.yml
@@ -54,7 +54,7 @@ jobs:
     - name: Checkout Scripts Repo
       uses: actions/checkout@v4
       with:
-        path: ../ci-scripts
+        path: ${{ runner.temp }}/ci-scripts
         repository: pulumi/scripts
         ref: deca2c5c6015ad7aaea6f572a1c2b198ca323592
     - name: Unshallow clone for tags
@@ -124,7 +124,7 @@ jobs:
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
-      run: ../ci-scripts/ci/check-worktree-is-clean
+      run: ${{ runner.temp }}/ci-scripts/ci/check-worktree-is-clean
     - name: Compress SDK folder
       run: tar -zcf sdk/${{ matrix.language }}.tar.gz -C sdk/${{ matrix.language }} .
     - name: Upload artifacts
@@ -185,12 +185,6 @@ jobs:
         path: |
           .pulumi/examples-cache
         key: ${{ runner.os }}-${{ hashFiles('provider/go.sum') }}
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v4
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-        ref: deca2c5c6015ad7aaea6f572a1c2b198ca323592
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Prepare upstream code
@@ -415,12 +409,6 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v4
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v4
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-        ref: deca2c5c6015ad7aaea6f572a1c2b198ca323592
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/provider-ci/test-workflows/docker/.github/workflows/release.yml
+++ b/provider-ci/test-workflows/docker/.github/workflows/release.yml
@@ -54,7 +54,7 @@ jobs:
     - name: Checkout Scripts Repo
       uses: actions/checkout@v4
       with:
-        path: ci-scripts
+        path: ../ci-scripts
         repository: pulumi/scripts
         ref: deca2c5c6015ad7aaea6f572a1c2b198ca323592
     - name: Unshallow clone for tags
@@ -124,7 +124,7 @@ jobs:
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
-      run: ./ci-scripts/ci/check-worktree-is-clean
+      run: ../ci-scripts/ci/check-worktree-is-clean
     - name: Compress SDK folder
       run: tar -zcf sdk/${{ matrix.language }}.tar.gz -C sdk/${{ matrix.language }} .
     - name: Upload artifacts

--- a/provider-ci/test-workflows/docker/.github/workflows/release.yml
+++ b/provider-ci/test-workflows/docker/.github/workflows/release.yml
@@ -57,7 +57,7 @@ jobs:
         path: ci-scripts
         repository: pulumi/scripts
         ref: deca2c5c6015ad7aaea6f572a1c2b198ca323592
-    - run: mv ci-scripts ../ci-scripts # actions/checkout#197
+    - run: echo "ci-scripts" >> .git/info/exclude # actions/checkout#197
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -125,7 +125,7 @@ jobs:
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
-      run: ../ci-scripts/ci/check-worktree-is-clean
+      run: ./ci-scripts/ci/check-worktree-is-clean
     - name: Compress SDK folder
       run: tar -zcf sdk/${{ matrix.language }}.tar.gz -C sdk/${{ matrix.language }} .
     - name: Upload artifacts

--- a/provider-ci/test-workflows/docker/.github/workflows/release.yml
+++ b/provider-ci/test-workflows/docker/.github/workflows/release.yml
@@ -54,9 +54,11 @@ jobs:
     - name: Checkout Scripts Repo
       uses: actions/checkout@v4
       with:
-        path: ${{ runner.temp }}/ci-scripts
+        path: ci-scripts
         repository: pulumi/scripts
         ref: deca2c5c6015ad7aaea6f572a1c2b198ca323592
+      env:
+        GITHUB_WORKSPACE: ${{ runner.temp }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/provider-ci/test-workflows/docker/.github/workflows/release.yml
+++ b/provider-ci/test-workflows/docker/.github/workflows/release.yml
@@ -57,8 +57,7 @@ jobs:
         path: ci-scripts
         repository: pulumi/scripts
         ref: deca2c5c6015ad7aaea6f572a1c2b198ca323592
-      env:
-        GITHUB_WORKSPACE: ${{ runner.temp }}
+    - run: mv ci-scripts ../ci-scripts # actions/checkout#197
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -126,7 +125,7 @@ jobs:
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
-      run: ${{ runner.temp }}/ci-scripts/ci/check-worktree-is-clean
+      run: ../ci-scripts/ci/check-worktree-is-clean
     - name: Compress SDK folder
       run: tar -zcf sdk/${{ matrix.language }}.tar.gz -C sdk/${{ matrix.language }} .
     - name: Upload artifacts

--- a/provider-ci/test-workflows/docker/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/test-workflows/docker/.github/workflows/run-acceptance-tests.yml
@@ -64,7 +64,7 @@ jobs:
     - name: Checkout Scripts Repo
       uses: actions/checkout@v4
       with:
-        path: ../ci-scripts
+        path: ${{ runner.temp }}/ci-scripts
         repository: pulumi/scripts
         ref: deca2c5c6015ad7aaea6f572a1c2b198ca323592
     - name: Unshallow clone for tags
@@ -134,7 +134,7 @@ jobs:
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
-      run: ../ci-scripts/ci/check-worktree-is-clean
+      run: ${{ runner.temp }}/ci-scripts/ci/check-worktree-is-clean
     - name: Compress SDK folder
       run: tar -zcf sdk/${{ matrix.language }}.tar.gz -C sdk/${{ matrix.language }} .
     - name: Upload artifacts
@@ -195,12 +195,6 @@ jobs:
         path: |
           .pulumi/examples-cache
         key: ${{ runner.os }}-${{ hashFiles('provider/go.sum') }}
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v4
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-        ref: deca2c5c6015ad7aaea6f572a1c2b198ca323592
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Prepare upstream code
@@ -357,12 +351,6 @@ jobs:
       uses: actions/checkout@v4
       with:
         ref: ${{ env.PR_COMMIT_SHA }}
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v4
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-        ref: deca2c5c6015ad7aaea6f572a1c2b198ca323592
     - name: Checkout p/examples
       if: matrix.testTarget == 'pulumiExamples'
       uses: actions/checkout@v4

--- a/provider-ci/test-workflows/docker/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/test-workflows/docker/.github/workflows/run-acceptance-tests.yml
@@ -64,7 +64,7 @@ jobs:
     - name: Checkout Scripts Repo
       uses: actions/checkout@v4
       with:
-        path: ci-scripts
+        path: ../ci-scripts
         repository: pulumi/scripts
         ref: deca2c5c6015ad7aaea6f572a1c2b198ca323592
     - name: Unshallow clone for tags
@@ -134,7 +134,7 @@ jobs:
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
-      run: ./ci-scripts/ci/check-worktree-is-clean
+      run: ../ci-scripts/ci/check-worktree-is-clean
     - name: Compress SDK folder
       run: tar -zcf sdk/${{ matrix.language }}.tar.gz -C sdk/${{ matrix.language }} .
     - name: Upload artifacts

--- a/provider-ci/test-workflows/docker/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/test-workflows/docker/.github/workflows/run-acceptance-tests.yml
@@ -67,7 +67,7 @@ jobs:
         path: ci-scripts
         repository: pulumi/scripts
         ref: deca2c5c6015ad7aaea6f572a1c2b198ca323592
-    - run: mv ci-scripts ../ci-scripts # actions/checkout#197
+    - run: echo "ci-scripts" >> .git/info/exclude # actions/checkout#197
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -135,7 +135,7 @@ jobs:
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
-      run: ../ci-scripts/ci/check-worktree-is-clean
+      run: ./ci-scripts/ci/check-worktree-is-clean
     - name: Compress SDK folder
       run: tar -zcf sdk/${{ matrix.language }}.tar.gz -C sdk/${{ matrix.language }} .
     - name: Upload artifacts

--- a/provider-ci/test-workflows/docker/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/test-workflows/docker/.github/workflows/run-acceptance-tests.yml
@@ -67,8 +67,7 @@ jobs:
         path: ci-scripts
         repository: pulumi/scripts
         ref: deca2c5c6015ad7aaea6f572a1c2b198ca323592
-      env:
-        GITHUB_WORKSPACE: ${{ runner.temp }}
+    - run: mv ci-scripts ../ci-scripts # actions/checkout#197
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -136,7 +135,7 @@ jobs:
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
-      run: ${{ runner.temp }}/ci-scripts/ci/check-worktree-is-clean
+      run: ../ci-scripts/ci/check-worktree-is-clean
     - name: Compress SDK folder
       run: tar -zcf sdk/${{ matrix.language }}.tar.gz -C sdk/${{ matrix.language }} .
     - name: Upload artifacts

--- a/provider-ci/test-workflows/docker/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/test-workflows/docker/.github/workflows/run-acceptance-tests.yml
@@ -64,9 +64,11 @@ jobs:
     - name: Checkout Scripts Repo
       uses: actions/checkout@v4
       with:
-        path: ${{ runner.temp }}/ci-scripts
+        path: ci-scripts
         repository: pulumi/scripts
         ref: deca2c5c6015ad7aaea6f572a1c2b198ca323592
+      env:
+        GITHUB_WORKSPACE: ${{ runner.temp }}
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go


### PR DESCRIPTION
`ci-scripts` is flagging itself for being untracked, so let's ignore it. This seems more straightforward than updating `.gitignore` everywhere.

```
Run ./ci-scripts/ci/check-worktree-is-clean
error: working tree is not clean, aborting!
HEAD detached at pull/901/merge
Untracked files:
  (use "git add <file>..." to include in what will be committed)
	ci-scripts/
```