### PR TITLE
Use git worktree clean action

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -39,18 +39,12 @@ jobs:
         uses: jaxxstorm/action-install-gh-release@v1.11.0
         with:
           repo: pulumi/pulumictl
-      - name: Checkout Scripts Repo
-        uses: actions/checkout@v4
-        with:
-          path: ci-scripts
-          repository: pulumi/scripts
-      - run: echo "ci-scripts" >> .git/info/exclude # actions/checkout#197
       - name: Validate native-providers
         run: cd native-provider-ci && make all
       - name: Validate that our test workflows match checked in workflows
         run: cd provider-ci && make test-workflow-generation
       - name: Check worktree clean
-        run: ./ci-scripts/ci/check-worktree-is-clean
+        uses: pulumi/git-status-check-action@v1
 
   deploy:
     uses: ./.github/workflows/update-workflows.yml

--- a/native-provider-ci/providers/aws-native/repo/.github/workflows/build.yml
+++ b/native-provider-ci/providers/aws-native/repo/.github/workflows/build.yml
@@ -50,6 +50,10 @@ jobs:
       uses: actions/checkout@v4
       with:
         lfs: true
+    - name: Set Provider Version
+      uses: pulumi/provider-version-action@v1
+      with:
+        set-env: PROVIDER_VERSION
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -145,6 +149,10 @@ jobs:
       uses: actions/checkout@v4
       with:
         lfs: true
+    - name: Set Provider Version
+      uses: pulumi/provider-version-action@v1
+      with:
+        set-env: PROVIDER_VERSION
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -238,6 +246,10 @@ jobs:
       uses: actions/checkout@v4
       with:
         lfs: true
+    - name: Set Provider Version
+      uses: pulumi/provider-version-action@v1
+      with:
+        set-env: PROVIDER_VERSION
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -339,6 +351,10 @@ jobs:
       uses: actions/checkout@v4
       with:
         lfs: true
+    - name: Set Provider Version
+      uses: pulumi/provider-version-action@v1
+      with:
+        set-env: PROVIDER_VERSION
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -386,6 +402,10 @@ jobs:
       uses: actions/checkout@v4
       with:
         lfs: true
+    - name: Set Provider Version
+      uses: pulumi/provider-version-action@v1
+      with:
+        set-env: PROVIDER_VERSION
     - name: Checkout Scripts Repo
       uses: actions/checkout@v4
       with:
@@ -466,6 +486,10 @@ jobs:
       uses: actions/checkout@v4
       with:
         lfs: true
+    - name: Set Provider Version
+      uses: pulumi/provider-version-action@v1
+      with:
+        set-env: PROVIDER_VERSION
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/native-provider-ci/providers/aws-native/repo/.github/workflows/build.yml
+++ b/native-provider-ci/providers/aws-native/repo/.github/workflows/build.yml
@@ -50,12 +50,6 @@ jobs:
       uses: actions/checkout@v4
       with:
         lfs: true
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v4
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - run: echo "ci-scripts" >> .git/info/exclude
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -109,7 +103,7 @@ jobs:
     - name: Build Provider
       run: make provider
     - name: Check worktree clean
-      run: ./ci-scripts/ci/check-worktree-is-clean
+      uses: pulumi/git-status-check-action@v1
     - run: git status --porcelain
     - name: Tar provider binaries
       run: tar -zcf ${{ github.workspace }}/bin/provider.tar.gz -C ${{
@@ -151,12 +145,6 @@ jobs:
       uses: actions/checkout@v4
       with:
         lfs: true
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v4
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - run: echo "ci-scripts" >> .git/info/exclude
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -211,7 +199,7 @@ jobs:
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
-      run: ./ci-scripts/ci/check-worktree-is-clean
+      uses: pulumi/git-status-check-action@v1
     - run: git status --porcelain
     - name: Tar SDK folder
       run: tar -zcf sdk/${{ matrix.language }}.tar.gz -C sdk/${{ matrix.language }} .
@@ -250,12 +238,6 @@ jobs:
       uses: actions/checkout@v4
       with:
         lfs: true
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v4
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - run: echo "ci-scripts" >> .git/info/exclude
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -484,12 +466,6 @@ jobs:
       uses: actions/checkout@v4
       with:
         lfs: true
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v4
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - run: echo "ci-scripts" >> .git/info/exclude
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/native-provider-ci/providers/aws-native/repo/.github/workflows/cf2pulumi-release.yml
+++ b/native-provider-ci/providers/aws-native/repo/.github/workflows/cf2pulumi-release.yml
@@ -41,6 +41,10 @@ jobs:
       uses: actions/checkout@v4
       with:
         lfs: true
+    - name: Set Provider Version
+      uses: pulumi/provider-version-action@v1
+      with:
+        set-env: PROVIDER_VERSION
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install pulumictl

--- a/native-provider-ci/providers/aws-native/repo/.github/workflows/nightly-sdk-generation.yml
+++ b/native-provider-ci/providers/aws-native/repo/.github/workflows/nightly-sdk-generation.yml
@@ -41,6 +41,10 @@ jobs:
       uses: actions/checkout@v4
       with:
         lfs: true
+    - name: Set Provider Version
+      uses: pulumi/provider-version-action@v1
+      with:
+        set-env: PROVIDER_VERSION
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/native-provider-ci/providers/aws-native/repo/.github/workflows/prerelease.yml
+++ b/native-provider-ci/providers/aws-native/repo/.github/workflows/prerelease.yml
@@ -42,12 +42,6 @@ jobs:
       uses: actions/checkout@v4
       with:
         lfs: true
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v4
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - run: echo "ci-scripts" >> .git/info/exclude
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -101,7 +95,7 @@ jobs:
     - name: Build Provider
       run: make provider
     - name: Check worktree clean
-      run: ./ci-scripts/ci/check-worktree-is-clean
+      uses: pulumi/git-status-check-action@v1
     - run: git status --porcelain
     - name: Tar provider binaries
       run: tar -zcf ${{ github.workspace }}/bin/provider.tar.gz -C ${{
@@ -143,12 +137,6 @@ jobs:
       uses: actions/checkout@v4
       with:
         lfs: true
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v4
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - run: echo "ci-scripts" >> .git/info/exclude
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -203,7 +191,7 @@ jobs:
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
-      run: ./ci-scripts/ci/check-worktree-is-clean
+      uses: pulumi/git-status-check-action@v1
     - run: git status --porcelain
     - name: Tar SDK folder
       run: tar -zcf sdk/${{ matrix.language }}.tar.gz -C sdk/${{ matrix.language }} .
@@ -241,12 +229,6 @@ jobs:
       uses: actions/checkout@v4
       with:
         lfs: true
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v4
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - run: echo "ci-scripts" >> .git/info/exclude
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -475,12 +457,6 @@ jobs:
       uses: actions/checkout@v4
       with:
         lfs: true
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v4
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - run: echo "ci-scripts" >> .git/info/exclude
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/native-provider-ci/providers/aws-native/repo/.github/workflows/prerelease.yml
+++ b/native-provider-ci/providers/aws-native/repo/.github/workflows/prerelease.yml
@@ -42,6 +42,10 @@ jobs:
       uses: actions/checkout@v4
       with:
         lfs: true
+    - name: Set Provider Version
+      uses: pulumi/provider-version-action@v1
+      with:
+        set-env: PROVIDER_VERSION
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -137,6 +141,10 @@ jobs:
       uses: actions/checkout@v4
       with:
         lfs: true
+    - name: Set Provider Version
+      uses: pulumi/provider-version-action@v1
+      with:
+        set-env: PROVIDER_VERSION
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -229,6 +237,10 @@ jobs:
       uses: actions/checkout@v4
       with:
         lfs: true
+    - name: Set Provider Version
+      uses: pulumi/provider-version-action@v1
+      with:
+        set-env: PROVIDER_VERSION
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -330,6 +342,10 @@ jobs:
       uses: actions/checkout@v4
       with:
         lfs: true
+    - name: Set Provider Version
+      uses: pulumi/provider-version-action@v1
+      with:
+        set-env: PROVIDER_VERSION
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -377,6 +393,10 @@ jobs:
       uses: actions/checkout@v4
       with:
         lfs: true
+    - name: Set Provider Version
+      uses: pulumi/provider-version-action@v1
+      with:
+        set-env: PROVIDER_VERSION
     - name: Checkout Scripts Repo
       uses: actions/checkout@v4
       with:
@@ -457,6 +477,10 @@ jobs:
       uses: actions/checkout@v4
       with:
         lfs: true
+    - name: Set Provider Version
+      uses: pulumi/provider-version-action@v1
+      with:
+        set-env: PROVIDER_VERSION
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/native-provider-ci/providers/aws-native/repo/.github/workflows/release.yml
+++ b/native-provider-ci/providers/aws-native/repo/.github/workflows/release.yml
@@ -42,12 +42,6 @@ jobs:
       uses: actions/checkout@v4
       with:
         lfs: true
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v4
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - run: echo "ci-scripts" >> .git/info/exclude
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -101,7 +95,7 @@ jobs:
     - name: Build Provider
       run: make provider
     - name: Check worktree clean
-      run: ./ci-scripts/ci/check-worktree-is-clean
+      uses: pulumi/git-status-check-action@v1
     - run: git status --porcelain
     - name: Tar provider binaries
       run: tar -zcf ${{ github.workspace }}/bin/provider.tar.gz -C ${{
@@ -143,12 +137,6 @@ jobs:
       uses: actions/checkout@v4
       with:
         lfs: true
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v4
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - run: echo "ci-scripts" >> .git/info/exclude
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -203,7 +191,7 @@ jobs:
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
-      run: ./ci-scripts/ci/check-worktree-is-clean
+      uses: pulumi/git-status-check-action@v1
     - run: git status --porcelain
     - name: Tar SDK folder
       run: tar -zcf sdk/${{ matrix.language }}.tar.gz -C sdk/${{ matrix.language }} .
@@ -241,12 +229,6 @@ jobs:
       uses: actions/checkout@v4
       with:
         lfs: true
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v4
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - run: echo "ci-scripts" >> .git/info/exclude
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -475,12 +457,6 @@ jobs:
       uses: actions/checkout@v4
       with:
         lfs: true
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v4
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - run: echo "ci-scripts" >> .git/info/exclude
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/native-provider-ci/providers/aws-native/repo/.github/workflows/release.yml
+++ b/native-provider-ci/providers/aws-native/repo/.github/workflows/release.yml
@@ -42,6 +42,10 @@ jobs:
       uses: actions/checkout@v4
       with:
         lfs: true
+    - name: Set Provider Version
+      uses: pulumi/provider-version-action@v1
+      with:
+        set-env: PROVIDER_VERSION
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -137,6 +141,10 @@ jobs:
       uses: actions/checkout@v4
       with:
         lfs: true
+    - name: Set Provider Version
+      uses: pulumi/provider-version-action@v1
+      with:
+        set-env: PROVIDER_VERSION
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -229,6 +237,10 @@ jobs:
       uses: actions/checkout@v4
       with:
         lfs: true
+    - name: Set Provider Version
+      uses: pulumi/provider-version-action@v1
+      with:
+        set-env: PROVIDER_VERSION
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -330,6 +342,10 @@ jobs:
       uses: actions/checkout@v4
       with:
         lfs: true
+    - name: Set Provider Version
+      uses: pulumi/provider-version-action@v1
+      with:
+        set-env: PROVIDER_VERSION
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -377,6 +393,10 @@ jobs:
       uses: actions/checkout@v4
       with:
         lfs: true
+    - name: Set Provider Version
+      uses: pulumi/provider-version-action@v1
+      with:
+        set-env: PROVIDER_VERSION
     - name: Checkout Scripts Repo
       uses: actions/checkout@v4
       with:
@@ -457,6 +477,10 @@ jobs:
       uses: actions/checkout@v4
       with:
         lfs: true
+    - name: Set Provider Version
+      uses: pulumi/provider-version-action@v1
+      with:
+        set-env: PROVIDER_VERSION
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -505,6 +529,10 @@ jobs:
       uses: actions/checkout@v4
       with:
         lfs: true
+    - name: Set Provider Version
+      uses: pulumi/provider-version-action@v1
+      with:
+        set-env: PROVIDER_VERSION
     - name: Install pulumictl
       uses: jaxxstorm/action-install-gh-release@v1.11.0
       with:

--- a/native-provider-ci/providers/aws-native/repo/.github/workflows/run-acceptance-tests.yml
+++ b/native-provider-ci/providers/aws-native/repo/.github/workflows/run-acceptance-tests.yml
@@ -67,12 +67,6 @@ jobs:
       with:
         lfs: true
         ref: ${{ env.PR_COMMIT_SHA }}
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v4
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - run: echo "ci-scripts" >> .git/info/exclude
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -126,7 +120,7 @@ jobs:
     - name: Build Provider
       run: make provider
     - name: Check worktree clean
-      run: ./ci-scripts/ci/check-worktree-is-clean
+      uses: pulumi/git-status-check-action@v1
     - run: git status --porcelain
     - name: Tar provider binaries
       run: tar -zcf ${{ github.workspace }}/bin/provider.tar.gz -C ${{
@@ -171,12 +165,6 @@ jobs:
       with:
         lfs: true
         ref: ${{ env.PR_COMMIT_SHA }}
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v4
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - run: echo "ci-scripts" >> .git/info/exclude
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -231,7 +219,7 @@ jobs:
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
-      run: ./ci-scripts/ci/check-worktree-is-clean
+      uses: pulumi/git-status-check-action@v1
     - run: git status --porcelain
     - name: Tar SDK folder
       run: tar -zcf sdk/${{ matrix.language }}.tar.gz -C sdk/${{ matrix.language }} .
@@ -273,12 +261,6 @@ jobs:
       with:
         lfs: true
         ref: ${{ env.PR_COMMIT_SHA }}
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v4
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - run: echo "ci-scripts" >> .git/info/exclude
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/native-provider-ci/providers/aws-native/repo/.github/workflows/run-acceptance-tests.yml
+++ b/native-provider-ci/providers/aws-native/repo/.github/workflows/run-acceptance-tests.yml
@@ -67,6 +67,10 @@ jobs:
       with:
         lfs: true
         ref: ${{ env.PR_COMMIT_SHA }}
+    - name: Set Provider Version
+      uses: pulumi/provider-version-action@v1
+      with:
+        set-env: PROVIDER_VERSION
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -165,6 +169,10 @@ jobs:
       with:
         lfs: true
         ref: ${{ env.PR_COMMIT_SHA }}
+    - name: Set Provider Version
+      uses: pulumi/provider-version-action@v1
+      with:
+        set-env: PROVIDER_VERSION
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -261,6 +269,10 @@ jobs:
       with:
         lfs: true
         ref: ${{ env.PR_COMMIT_SHA }}
+    - name: Set Provider Version
+      uses: pulumi/provider-version-action@v1
+      with:
+        set-env: PROVIDER_VERSION
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/native-provider-ci/providers/aws-native/repo/.github/workflows/weekly-pulumi-update.yml
+++ b/native-provider-ci/providers/aws-native/repo/.github/workflows/weekly-pulumi-update.yml
@@ -40,6 +40,10 @@ jobs:
       uses: actions/checkout@v4
       with:
         lfs: true
+    - name: Set Provider Version
+      uses: pulumi/provider-version-action@v1
+      with:
+        set-env: PROVIDER_VERSION
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/native-provider-ci/providers/azure-native/repo/.github/workflows/arm2pulumi-release.yml
+++ b/native-provider-ci/providers/azure-native/repo/.github/workflows/arm2pulumi-release.yml
@@ -54,6 +54,10 @@ jobs:
       uses: actions/checkout@v4
       with:
         lfs: true
+    - name: Set Provider Version
+      uses: pulumi/provider-version-action@v1
+      with:
+        set-env: PROVIDER_VERSION
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install pulumictl

--- a/native-provider-ci/providers/azure-native/repo/.github/workflows/build.yml
+++ b/native-provider-ci/providers/azure-native/repo/.github/workflows/build.yml
@@ -56,6 +56,10 @@ jobs:
       uses: actions/checkout@v4
       with:
         lfs: true
+    - name: Set Provider Version
+      uses: pulumi/provider-version-action@v1
+      with:
+        set-env: PROVIDER_VERSION
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -151,6 +155,10 @@ jobs:
       uses: actions/checkout@v4
       with:
         lfs: true
+    - name: Set Provider Version
+      uses: pulumi/provider-version-action@v1
+      with:
+        set-env: PROVIDER_VERSION
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -250,6 +258,10 @@ jobs:
       uses: actions/checkout@v4
       with:
         lfs: true
+    - name: Set Provider Version
+      uses: pulumi/provider-version-action@v1
+      with:
+        set-env: PROVIDER_VERSION
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -342,6 +354,10 @@ jobs:
       uses: actions/checkout@v4
       with:
         lfs: true
+    - name: Set Provider Version
+      uses: pulumi/provider-version-action@v1
+      with:
+        set-env: PROVIDER_VERSION
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -389,6 +405,10 @@ jobs:
       uses: actions/checkout@v4
       with:
         lfs: true
+    - name: Set Provider Version
+      uses: pulumi/provider-version-action@v1
+      with:
+        set-env: PROVIDER_VERSION
     - name: Checkout Scripts Repo
       uses: actions/checkout@v4
       with:
@@ -469,6 +489,10 @@ jobs:
       uses: actions/checkout@v4
       with:
         lfs: true
+    - name: Set Provider Version
+      uses: pulumi/provider-version-action@v1
+      with:
+        set-env: PROVIDER_VERSION
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/native-provider-ci/providers/azure-native/repo/.github/workflows/build.yml
+++ b/native-provider-ci/providers/azure-native/repo/.github/workflows/build.yml
@@ -56,12 +56,6 @@ jobs:
       uses: actions/checkout@v4
       with:
         lfs: true
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v4
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - run: echo "ci-scripts" >> .git/info/exclude
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -115,7 +109,7 @@ jobs:
     - name: Build Provider
       run: make provider
     - name: Check worktree clean
-      run: ./ci-scripts/ci/check-worktree-is-clean
+      uses: pulumi/git-status-check-action@v1
     - run: git status --porcelain
     - name: Tar provider binaries
       run: tar -zcf ${{ github.workspace }}/bin/provider.tar.gz -C ${{
@@ -157,12 +151,6 @@ jobs:
       uses: actions/checkout@v4
       with:
         lfs: true
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v4
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - run: echo "ci-scripts" >> .git/info/exclude
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -223,7 +211,7 @@ jobs:
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
-      run: ./ci-scripts/ci/check-worktree-is-clean
+      uses: pulumi/git-status-check-action@v1
     - run: git status --porcelain
     - name: Tar SDK folder
       run: tar -zcf sdk/${{ matrix.language }}.tar.gz -C sdk/${{ matrix.language }} .
@@ -262,12 +250,6 @@ jobs:
       uses: actions/checkout@v4
       with:
         lfs: true
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v4
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - run: echo "ci-scripts" >> .git/info/exclude
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -487,12 +469,6 @@ jobs:
       uses: actions/checkout@v4
       with:
         lfs: true
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v4
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - run: echo "ci-scripts" >> .git/info/exclude
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/native-provider-ci/providers/azure-native/repo/.github/workflows/nightly-sdk-generation.yml
+++ b/native-provider-ci/providers/azure-native/repo/.github/workflows/nightly-sdk-generation.yml
@@ -47,6 +47,10 @@ jobs:
       uses: actions/checkout@v4
       with:
         lfs: true
+    - name: Set Provider Version
+      uses: pulumi/provider-version-action@v1
+      with:
+        set-env: PROVIDER_VERSION
     - name: Install Go
       uses: actions/setup-go@v5
       with:

--- a/native-provider-ci/providers/azure-native/repo/.github/workflows/prerelease.yml
+++ b/native-provider-ci/providers/azure-native/repo/.github/workflows/prerelease.yml
@@ -48,12 +48,6 @@ jobs:
       uses: actions/checkout@v4
       with:
         lfs: true
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v4
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - run: echo "ci-scripts" >> .git/info/exclude
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -107,7 +101,7 @@ jobs:
     - name: Build Provider
       run: make provider
     - name: Check worktree clean
-      run: ./ci-scripts/ci/check-worktree-is-clean
+      uses: pulumi/git-status-check-action@v1
     - run: git status --porcelain
     - name: Tar provider binaries
       run: tar -zcf ${{ github.workspace }}/bin/provider.tar.gz -C ${{
@@ -149,12 +143,6 @@ jobs:
       uses: actions/checkout@v4
       with:
         lfs: true
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v4
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - run: echo "ci-scripts" >> .git/info/exclude
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -215,7 +203,7 @@ jobs:
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
-      run: ./ci-scripts/ci/check-worktree-is-clean
+      uses: pulumi/git-status-check-action@v1
     - run: git status --porcelain
     - name: Tar SDK folder
       run: tar -zcf sdk/${{ matrix.language }}.tar.gz -C sdk/${{ matrix.language }} .
@@ -253,12 +241,6 @@ jobs:
       uses: actions/checkout@v4
       with:
         lfs: true
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v4
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - run: echo "ci-scripts" >> .git/info/exclude
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -478,12 +460,6 @@ jobs:
       uses: actions/checkout@v4
       with:
         lfs: true
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v4
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - run: echo "ci-scripts" >> .git/info/exclude
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/native-provider-ci/providers/azure-native/repo/.github/workflows/prerelease.yml
+++ b/native-provider-ci/providers/azure-native/repo/.github/workflows/prerelease.yml
@@ -48,6 +48,10 @@ jobs:
       uses: actions/checkout@v4
       with:
         lfs: true
+    - name: Set Provider Version
+      uses: pulumi/provider-version-action@v1
+      with:
+        set-env: PROVIDER_VERSION
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -143,6 +147,10 @@ jobs:
       uses: actions/checkout@v4
       with:
         lfs: true
+    - name: Set Provider Version
+      uses: pulumi/provider-version-action@v1
+      with:
+        set-env: PROVIDER_VERSION
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -241,6 +249,10 @@ jobs:
       uses: actions/checkout@v4
       with:
         lfs: true
+    - name: Set Provider Version
+      uses: pulumi/provider-version-action@v1
+      with:
+        set-env: PROVIDER_VERSION
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -333,6 +345,10 @@ jobs:
       uses: actions/checkout@v4
       with:
         lfs: true
+    - name: Set Provider Version
+      uses: pulumi/provider-version-action@v1
+      with:
+        set-env: PROVIDER_VERSION
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -380,6 +396,10 @@ jobs:
       uses: actions/checkout@v4
       with:
         lfs: true
+    - name: Set Provider Version
+      uses: pulumi/provider-version-action@v1
+      with:
+        set-env: PROVIDER_VERSION
     - name: Checkout Scripts Repo
       uses: actions/checkout@v4
       with:
@@ -460,6 +480,10 @@ jobs:
       uses: actions/checkout@v4
       with:
         lfs: true
+    - name: Set Provider Version
+      uses: pulumi/provider-version-action@v1
+      with:
+        set-env: PROVIDER_VERSION
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/native-provider-ci/providers/azure-native/repo/.github/workflows/release.yml
+++ b/native-provider-ci/providers/azure-native/repo/.github/workflows/release.yml
@@ -48,12 +48,6 @@ jobs:
       uses: actions/checkout@v4
       with:
         lfs: true
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v4
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - run: echo "ci-scripts" >> .git/info/exclude
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -107,7 +101,7 @@ jobs:
     - name: Build Provider
       run: make provider
     - name: Check worktree clean
-      run: ./ci-scripts/ci/check-worktree-is-clean
+      uses: pulumi/git-status-check-action@v1
     - run: git status --porcelain
     - name: Tar provider binaries
       run: tar -zcf ${{ github.workspace }}/bin/provider.tar.gz -C ${{
@@ -149,12 +143,6 @@ jobs:
       uses: actions/checkout@v4
       with:
         lfs: true
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v4
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - run: echo "ci-scripts" >> .git/info/exclude
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -215,7 +203,7 @@ jobs:
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
-      run: ./ci-scripts/ci/check-worktree-is-clean
+      uses: pulumi/git-status-check-action@v1
     - run: git status --porcelain
     - name: Tar SDK folder
       run: tar -zcf sdk/${{ matrix.language }}.tar.gz -C sdk/${{ matrix.language }} .
@@ -253,12 +241,6 @@ jobs:
       uses: actions/checkout@v4
       with:
         lfs: true
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v4
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - run: echo "ci-scripts" >> .git/info/exclude
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -478,12 +460,6 @@ jobs:
       uses: actions/checkout@v4
       with:
         lfs: true
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v4
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - run: echo "ci-scripts" >> .git/info/exclude
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/native-provider-ci/providers/azure-native/repo/.github/workflows/release.yml
+++ b/native-provider-ci/providers/azure-native/repo/.github/workflows/release.yml
@@ -48,6 +48,10 @@ jobs:
       uses: actions/checkout@v4
       with:
         lfs: true
+    - name: Set Provider Version
+      uses: pulumi/provider-version-action@v1
+      with:
+        set-env: PROVIDER_VERSION
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -143,6 +147,10 @@ jobs:
       uses: actions/checkout@v4
       with:
         lfs: true
+    - name: Set Provider Version
+      uses: pulumi/provider-version-action@v1
+      with:
+        set-env: PROVIDER_VERSION
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -241,6 +249,10 @@ jobs:
       uses: actions/checkout@v4
       with:
         lfs: true
+    - name: Set Provider Version
+      uses: pulumi/provider-version-action@v1
+      with:
+        set-env: PROVIDER_VERSION
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -333,6 +345,10 @@ jobs:
       uses: actions/checkout@v4
       with:
         lfs: true
+    - name: Set Provider Version
+      uses: pulumi/provider-version-action@v1
+      with:
+        set-env: PROVIDER_VERSION
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -380,6 +396,10 @@ jobs:
       uses: actions/checkout@v4
       with:
         lfs: true
+    - name: Set Provider Version
+      uses: pulumi/provider-version-action@v1
+      with:
+        set-env: PROVIDER_VERSION
     - name: Checkout Scripts Repo
       uses: actions/checkout@v4
       with:
@@ -460,6 +480,10 @@ jobs:
       uses: actions/checkout@v4
       with:
         lfs: true
+    - name: Set Provider Version
+      uses: pulumi/provider-version-action@v1
+      with:
+        set-env: PROVIDER_VERSION
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -508,6 +532,10 @@ jobs:
       uses: actions/checkout@v4
       with:
         lfs: true
+    - name: Set Provider Version
+      uses: pulumi/provider-version-action@v1
+      with:
+        set-env: PROVIDER_VERSION
     - name: Install pulumictl
       uses: jaxxstorm/action-install-gh-release@v1.11.0
       with:

--- a/native-provider-ci/providers/azure-native/repo/.github/workflows/run-acceptance-tests.yml
+++ b/native-provider-ci/providers/azure-native/repo/.github/workflows/run-acceptance-tests.yml
@@ -73,12 +73,6 @@ jobs:
       with:
         lfs: true
         ref: ${{ env.PR_COMMIT_SHA }}
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v4
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - run: echo "ci-scripts" >> .git/info/exclude
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -132,7 +126,7 @@ jobs:
     - name: Build Provider
       run: make provider
     - name: Check worktree clean
-      run: ./ci-scripts/ci/check-worktree-is-clean
+      uses: pulumi/git-status-check-action@v1
     - run: git status --porcelain
     - name: Tar provider binaries
       run: tar -zcf ${{ github.workspace }}/bin/provider.tar.gz -C ${{
@@ -177,12 +171,6 @@ jobs:
       with:
         lfs: true
         ref: ${{ env.PR_COMMIT_SHA }}
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v4
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - run: echo "ci-scripts" >> .git/info/exclude
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -243,7 +231,7 @@ jobs:
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
-      run: ./ci-scripts/ci/check-worktree-is-clean
+      uses: pulumi/git-status-check-action@v1
     - run: git status --porcelain
     - name: Tar SDK folder
       run: tar -zcf sdk/${{ matrix.language }}.tar.gz -C sdk/${{ matrix.language }} .
@@ -285,12 +273,6 @@ jobs:
       with:
         lfs: true
         ref: ${{ env.PR_COMMIT_SHA }}
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v4
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - run: echo "ci-scripts" >> .git/info/exclude
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/native-provider-ci/providers/azure-native/repo/.github/workflows/run-acceptance-tests.yml
+++ b/native-provider-ci/providers/azure-native/repo/.github/workflows/run-acceptance-tests.yml
@@ -73,6 +73,10 @@ jobs:
       with:
         lfs: true
         ref: ${{ env.PR_COMMIT_SHA }}
+    - name: Set Provider Version
+      uses: pulumi/provider-version-action@v1
+      with:
+        set-env: PROVIDER_VERSION
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -171,6 +175,10 @@ jobs:
       with:
         lfs: true
         ref: ${{ env.PR_COMMIT_SHA }}
+    - name: Set Provider Version
+      uses: pulumi/provider-version-action@v1
+      with:
+        set-env: PROVIDER_VERSION
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -273,6 +281,10 @@ jobs:
       with:
         lfs: true
         ref: ${{ env.PR_COMMIT_SHA }}
+    - name: Set Provider Version
+      uses: pulumi/provider-version-action@v1
+      with:
+        set-env: PROVIDER_VERSION
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/native-provider-ci/providers/azure-native/repo/.github/workflows/weekly-pulumi-update.yml
+++ b/native-provider-ci/providers/azure-native/repo/.github/workflows/weekly-pulumi-update.yml
@@ -46,6 +46,10 @@ jobs:
       uses: actions/checkout@v4
       with:
         lfs: true
+    - name: Set Provider Version
+      uses: pulumi/provider-version-action@v1
+      with:
+        set-env: PROVIDER_VERSION
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/native-provider-ci/providers/command/repo/.github/workflows/build.yml
+++ b/native-provider-ci/providers/command/repo/.github/workflows/build.yml
@@ -50,6 +50,10 @@ jobs:
       uses: actions/checkout@v4
       with:
         lfs: true
+    - name: Set Provider Version
+      uses: pulumi/provider-version-action@v1
+      with:
+        set-env: PROVIDER_VERSION
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -109,6 +113,10 @@ jobs:
       uses: actions/checkout@v4
       with:
         lfs: true
+    - name: Set Provider Version
+      uses: pulumi/provider-version-action@v1
+      with:
+        set-env: PROVIDER_VERSION
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -198,6 +206,10 @@ jobs:
       uses: actions/checkout@v4
       with:
         lfs: true
+    - name: Set Provider Version
+      uses: pulumi/provider-version-action@v1
+      with:
+        set-env: PROVIDER_VERSION
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -299,6 +311,10 @@ jobs:
       uses: actions/checkout@v4
       with:
         lfs: true
+    - name: Set Provider Version
+      uses: pulumi/provider-version-action@v1
+      with:
+        set-env: PROVIDER_VERSION
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -355,6 +371,10 @@ jobs:
       uses: actions/checkout@v4
       with:
         lfs: true
+    - name: Set Provider Version
+      uses: pulumi/provider-version-action@v1
+      with:
+        set-env: PROVIDER_VERSION
     - name: Checkout Scripts Repo
       uses: actions/checkout@v4
       with:
@@ -435,6 +455,10 @@ jobs:
       uses: actions/checkout@v4
       with:
         lfs: true
+    - name: Set Provider Version
+      uses: pulumi/provider-version-action@v1
+      with:
+        set-env: PROVIDER_VERSION
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/native-provider-ci/providers/command/repo/.github/workflows/build.yml
+++ b/native-provider-ci/providers/command/repo/.github/workflows/build.yml
@@ -50,12 +50,6 @@ jobs:
       uses: actions/checkout@v4
       with:
         lfs: true
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v4
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - run: echo "ci-scripts" >> .git/info/exclude
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -74,7 +68,7 @@ jobs:
     - name: Build Provider
       run: make provider
     - name: Check worktree clean
-      run: ./ci-scripts/ci/check-worktree-is-clean
+      uses: pulumi/git-status-check-action@v1
     - run: git status --porcelain
     - name: Tar provider binaries
       run: tar -zcf ${{ github.workspace }}/bin/provider.tar.gz -C ${{
@@ -115,12 +109,6 @@ jobs:
       uses: actions/checkout@v4
       with:
         lfs: true
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v4
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - run: echo "ci-scripts" >> .git/info/exclude
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -171,7 +159,7 @@ jobs:
     - name: Generate SDK
       run: make ${{ matrix.language }}_sdk
     - name: Check worktree clean
-      run: ./ci-scripts/ci/check-worktree-is-clean
+      uses: pulumi/git-status-check-action@v1
     - run: git status --porcelain
     - name: Tar SDK folder
       run: tar -zcf sdk/${{ matrix.language }}.tar.gz -C sdk/${{ matrix.language }} .
@@ -210,12 +198,6 @@ jobs:
       uses: actions/checkout@v4
       with:
         lfs: true
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v4
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - run: echo "ci-scripts" >> .git/info/exclude
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -453,12 +435,6 @@ jobs:
       uses: actions/checkout@v4
       with:
         lfs: true
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v4
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - run: echo "ci-scripts" >> .git/info/exclude
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/native-provider-ci/providers/command/repo/.github/workflows/prerelease.yml
+++ b/native-provider-ci/providers/command/repo/.github/workflows/prerelease.yml
@@ -42,12 +42,6 @@ jobs:
       uses: actions/checkout@v4
       with:
         lfs: true
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v4
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - run: echo "ci-scripts" >> .git/info/exclude
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -66,7 +60,7 @@ jobs:
     - name: Build Provider
       run: make provider
     - name: Check worktree clean
-      run: ./ci-scripts/ci/check-worktree-is-clean
+      uses: pulumi/git-status-check-action@v1
     - run: git status --porcelain
     - name: Tar provider binaries
       run: tar -zcf ${{ github.workspace }}/bin/provider.tar.gz -C ${{
@@ -107,12 +101,6 @@ jobs:
       uses: actions/checkout@v4
       with:
         lfs: true
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v4
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - run: echo "ci-scripts" >> .git/info/exclude
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -163,7 +151,7 @@ jobs:
     - name: Generate SDK
       run: make ${{ matrix.language }}_sdk
     - name: Check worktree clean
-      run: ./ci-scripts/ci/check-worktree-is-clean
+      uses: pulumi/git-status-check-action@v1
     - run: git status --porcelain
     - name: Tar SDK folder
       run: tar -zcf sdk/${{ matrix.language }}.tar.gz -C sdk/${{ matrix.language }} .
@@ -201,12 +189,6 @@ jobs:
       uses: actions/checkout@v4
       with:
         lfs: true
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v4
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - run: echo "ci-scripts" >> .git/info/exclude
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -444,12 +426,6 @@ jobs:
       uses: actions/checkout@v4
       with:
         lfs: true
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v4
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - run: echo "ci-scripts" >> .git/info/exclude
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/native-provider-ci/providers/command/repo/.github/workflows/prerelease.yml
+++ b/native-provider-ci/providers/command/repo/.github/workflows/prerelease.yml
@@ -42,6 +42,10 @@ jobs:
       uses: actions/checkout@v4
       with:
         lfs: true
+    - name: Set Provider Version
+      uses: pulumi/provider-version-action@v1
+      with:
+        set-env: PROVIDER_VERSION
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -101,6 +105,10 @@ jobs:
       uses: actions/checkout@v4
       with:
         lfs: true
+    - name: Set Provider Version
+      uses: pulumi/provider-version-action@v1
+      with:
+        set-env: PROVIDER_VERSION
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -189,6 +197,10 @@ jobs:
       uses: actions/checkout@v4
       with:
         lfs: true
+    - name: Set Provider Version
+      uses: pulumi/provider-version-action@v1
+      with:
+        set-env: PROVIDER_VERSION
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -290,6 +302,10 @@ jobs:
       uses: actions/checkout@v4
       with:
         lfs: true
+    - name: Set Provider Version
+      uses: pulumi/provider-version-action@v1
+      with:
+        set-env: PROVIDER_VERSION
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -346,6 +362,10 @@ jobs:
       uses: actions/checkout@v4
       with:
         lfs: true
+    - name: Set Provider Version
+      uses: pulumi/provider-version-action@v1
+      with:
+        set-env: PROVIDER_VERSION
     - name: Checkout Scripts Repo
       uses: actions/checkout@v4
       with:
@@ -426,6 +446,10 @@ jobs:
       uses: actions/checkout@v4
       with:
         lfs: true
+    - name: Set Provider Version
+      uses: pulumi/provider-version-action@v1
+      with:
+        set-env: PROVIDER_VERSION
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/native-provider-ci/providers/command/repo/.github/workflows/release.yml
+++ b/native-provider-ci/providers/command/repo/.github/workflows/release.yml
@@ -42,6 +42,10 @@ jobs:
       uses: actions/checkout@v4
       with:
         lfs: true
+    - name: Set Provider Version
+      uses: pulumi/provider-version-action@v1
+      with:
+        set-env: PROVIDER_VERSION
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -101,6 +105,10 @@ jobs:
       uses: actions/checkout@v4
       with:
         lfs: true
+    - name: Set Provider Version
+      uses: pulumi/provider-version-action@v1
+      with:
+        set-env: PROVIDER_VERSION
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -189,6 +197,10 @@ jobs:
       uses: actions/checkout@v4
       with:
         lfs: true
+    - name: Set Provider Version
+      uses: pulumi/provider-version-action@v1
+      with:
+        set-env: PROVIDER_VERSION
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -290,6 +302,10 @@ jobs:
       uses: actions/checkout@v4
       with:
         lfs: true
+    - name: Set Provider Version
+      uses: pulumi/provider-version-action@v1
+      with:
+        set-env: PROVIDER_VERSION
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -346,6 +362,10 @@ jobs:
       uses: actions/checkout@v4
       with:
         lfs: true
+    - name: Set Provider Version
+      uses: pulumi/provider-version-action@v1
+      with:
+        set-env: PROVIDER_VERSION
     - name: Checkout Scripts Repo
       uses: actions/checkout@v4
       with:
@@ -426,6 +446,10 @@ jobs:
       uses: actions/checkout@v4
       with:
         lfs: true
+    - name: Set Provider Version
+      uses: pulumi/provider-version-action@v1
+      with:
+        set-env: PROVIDER_VERSION
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -474,6 +498,10 @@ jobs:
       uses: actions/checkout@v4
       with:
         lfs: true
+    - name: Set Provider Version
+      uses: pulumi/provider-version-action@v1
+      with:
+        set-env: PROVIDER_VERSION
     - name: Install pulumictl
       uses: jaxxstorm/action-install-gh-release@v1.11.0
       with:

--- a/native-provider-ci/providers/command/repo/.github/workflows/release.yml
+++ b/native-provider-ci/providers/command/repo/.github/workflows/release.yml
@@ -42,12 +42,6 @@ jobs:
       uses: actions/checkout@v4
       with:
         lfs: true
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v4
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - run: echo "ci-scripts" >> .git/info/exclude
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -66,7 +60,7 @@ jobs:
     - name: Build Provider
       run: make provider
     - name: Check worktree clean
-      run: ./ci-scripts/ci/check-worktree-is-clean
+      uses: pulumi/git-status-check-action@v1
     - run: git status --porcelain
     - name: Tar provider binaries
       run: tar -zcf ${{ github.workspace }}/bin/provider.tar.gz -C ${{
@@ -107,12 +101,6 @@ jobs:
       uses: actions/checkout@v4
       with:
         lfs: true
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v4
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - run: echo "ci-scripts" >> .git/info/exclude
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -163,7 +151,7 @@ jobs:
     - name: Generate SDK
       run: make ${{ matrix.language }}_sdk
     - name: Check worktree clean
-      run: ./ci-scripts/ci/check-worktree-is-clean
+      uses: pulumi/git-status-check-action@v1
     - run: git status --porcelain
     - name: Tar SDK folder
       run: tar -zcf sdk/${{ matrix.language }}.tar.gz -C sdk/${{ matrix.language }} .
@@ -201,12 +189,6 @@ jobs:
       uses: actions/checkout@v4
       with:
         lfs: true
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v4
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - run: echo "ci-scripts" >> .git/info/exclude
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -444,12 +426,6 @@ jobs:
       uses: actions/checkout@v4
       with:
         lfs: true
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v4
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - run: echo "ci-scripts" >> .git/info/exclude
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/native-provider-ci/providers/command/repo/.github/workflows/run-acceptance-tests.yml
+++ b/native-provider-ci/providers/command/repo/.github/workflows/run-acceptance-tests.yml
@@ -67,12 +67,6 @@ jobs:
       with:
         lfs: true
         ref: ${{ env.PR_COMMIT_SHA }}
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v4
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - run: echo "ci-scripts" >> .git/info/exclude
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -91,7 +85,7 @@ jobs:
     - name: Build Provider
       run: make provider
     - name: Check worktree clean
-      run: ./ci-scripts/ci/check-worktree-is-clean
+      uses: pulumi/git-status-check-action@v1
     - run: git status --porcelain
     - name: Tar provider binaries
       run: tar -zcf ${{ github.workspace }}/bin/provider.tar.gz -C ${{
@@ -135,12 +129,6 @@ jobs:
       with:
         lfs: true
         ref: ${{ env.PR_COMMIT_SHA }}
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v4
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - run: echo "ci-scripts" >> .git/info/exclude
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -191,7 +179,7 @@ jobs:
     - name: Generate SDK
       run: make ${{ matrix.language }}_sdk
     - name: Check worktree clean
-      run: ./ci-scripts/ci/check-worktree-is-clean
+      uses: pulumi/git-status-check-action@v1
     - run: git status --porcelain
     - name: Tar SDK folder
       run: tar -zcf sdk/${{ matrix.language }}.tar.gz -C sdk/${{ matrix.language }} .
@@ -233,12 +221,6 @@ jobs:
       with:
         lfs: true
         ref: ${{ env.PR_COMMIT_SHA }}
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v4
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - run: echo "ci-scripts" >> .git/info/exclude
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/native-provider-ci/providers/command/repo/.github/workflows/run-acceptance-tests.yml
+++ b/native-provider-ci/providers/command/repo/.github/workflows/run-acceptance-tests.yml
@@ -67,6 +67,10 @@ jobs:
       with:
         lfs: true
         ref: ${{ env.PR_COMMIT_SHA }}
+    - name: Set Provider Version
+      uses: pulumi/provider-version-action@v1
+      with:
+        set-env: PROVIDER_VERSION
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -129,6 +133,10 @@ jobs:
       with:
         lfs: true
         ref: ${{ env.PR_COMMIT_SHA }}
+    - name: Set Provider Version
+      uses: pulumi/provider-version-action@v1
+      with:
+        set-env: PROVIDER_VERSION
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -221,6 +229,10 @@ jobs:
       with:
         lfs: true
         ref: ${{ env.PR_COMMIT_SHA }}
+    - name: Set Provider Version
+      uses: pulumi/provider-version-action@v1
+      with:
+        set-env: PROVIDER_VERSION
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/native-provider-ci/providers/command/repo/.github/workflows/weekly-pulumi-update.yml
+++ b/native-provider-ci/providers/command/repo/.github/workflows/weekly-pulumi-update.yml
@@ -40,6 +40,10 @@ jobs:
       uses: actions/checkout@v4
       with:
         lfs: true
+    - name: Set Provider Version
+      uses: pulumi/provider-version-action@v1
+      with:
+        set-env: PROVIDER_VERSION
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/native-provider-ci/providers/docker-build/repo/.github/workflows/build.yml
+++ b/native-provider-ci/providers/docker-build/repo/.github/workflows/build.yml
@@ -64,12 +64,6 @@ jobs:
       uses: actions/checkout@v4
       with:
         lfs: true
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v4
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - run: echo "ci-scripts" >> .git/info/exclude
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -121,7 +115,7 @@ jobs:
     - name: Build Provider
       run: make provider
     - name: Check worktree clean
-      run: ./ci-scripts/ci/check-worktree-is-clean
+      uses: pulumi/git-status-check-action@v1
     - run: git status --porcelain
     - name: Tar provider binaries
       run: tar -zcf ${{ github.workspace }}/bin/provider.tar.gz -C ${{
@@ -163,12 +157,6 @@ jobs:
       uses: actions/checkout@v4
       with:
         lfs: true
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v4
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - run: echo "ci-scripts" >> .git/info/exclude
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -221,7 +209,7 @@ jobs:
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
-      run: ./ci-scripts/ci/check-worktree-is-clean
+      uses: pulumi/git-status-check-action@v1
     - run: git status --porcelain
     - name: Tar SDK folder
       run: tar -zcf sdk/${{ matrix.language }}.tar.gz -C sdk/${{ matrix.language }} .
@@ -260,12 +248,6 @@ jobs:
       uses: actions/checkout@v4
       with:
         lfs: true
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v4
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - run: echo "ci-scripts" >> .git/info/exclude
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -515,12 +497,6 @@ jobs:
       uses: actions/checkout@v4
       with:
         lfs: true
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v4
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - run: echo "ci-scripts" >> .git/info/exclude
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/native-provider-ci/providers/docker-build/repo/.github/workflows/build.yml
+++ b/native-provider-ci/providers/docker-build/repo/.github/workflows/build.yml
@@ -64,6 +64,10 @@ jobs:
       uses: actions/checkout@v4
       with:
         lfs: true
+    - name: Set Provider Version
+      uses: pulumi/provider-version-action@v1
+      with:
+        set-env: PROVIDER_VERSION
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -157,6 +161,10 @@ jobs:
       uses: actions/checkout@v4
       with:
         lfs: true
+    - name: Set Provider Version
+      uses: pulumi/provider-version-action@v1
+      with:
+        set-env: PROVIDER_VERSION
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -248,6 +256,10 @@ jobs:
       uses: actions/checkout@v4
       with:
         lfs: true
+    - name: Set Provider Version
+      uses: pulumi/provider-version-action@v1
+      with:
+        set-env: PROVIDER_VERSION
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -361,6 +373,10 @@ jobs:
       uses: actions/checkout@v4
       with:
         lfs: true
+    - name: Set Provider Version
+      uses: pulumi/provider-version-action@v1
+      with:
+        set-env: PROVIDER_VERSION
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -417,6 +433,10 @@ jobs:
       uses: actions/checkout@v4
       with:
         lfs: true
+    - name: Set Provider Version
+      uses: pulumi/provider-version-action@v1
+      with:
+        set-env: PROVIDER_VERSION
     - name: Checkout Scripts Repo
       uses: actions/checkout@v4
       with:
@@ -497,6 +517,10 @@ jobs:
       uses: actions/checkout@v4
       with:
         lfs: true
+    - name: Set Provider Version
+      uses: pulumi/provider-version-action@v1
+      with:
+        set-env: PROVIDER_VERSION
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/native-provider-ci/providers/docker-build/repo/.github/workflows/prerelease.yml
+++ b/native-provider-ci/providers/docker-build/repo/.github/workflows/prerelease.yml
@@ -56,6 +56,10 @@ jobs:
       uses: actions/checkout@v4
       with:
         lfs: true
+    - name: Set Provider Version
+      uses: pulumi/provider-version-action@v1
+      with:
+        set-env: PROVIDER_VERSION
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -149,6 +153,10 @@ jobs:
       uses: actions/checkout@v4
       with:
         lfs: true
+    - name: Set Provider Version
+      uses: pulumi/provider-version-action@v1
+      with:
+        set-env: PROVIDER_VERSION
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -239,6 +247,10 @@ jobs:
       uses: actions/checkout@v4
       with:
         lfs: true
+    - name: Set Provider Version
+      uses: pulumi/provider-version-action@v1
+      with:
+        set-env: PROVIDER_VERSION
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -352,6 +364,10 @@ jobs:
       uses: actions/checkout@v4
       with:
         lfs: true
+    - name: Set Provider Version
+      uses: pulumi/provider-version-action@v1
+      with:
+        set-env: PROVIDER_VERSION
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -408,6 +424,10 @@ jobs:
       uses: actions/checkout@v4
       with:
         lfs: true
+    - name: Set Provider Version
+      uses: pulumi/provider-version-action@v1
+      with:
+        set-env: PROVIDER_VERSION
     - name: Checkout Scripts Repo
       uses: actions/checkout@v4
       with:
@@ -488,6 +508,10 @@ jobs:
       uses: actions/checkout@v4
       with:
         lfs: true
+    - name: Set Provider Version
+      uses: pulumi/provider-version-action@v1
+      with:
+        set-env: PROVIDER_VERSION
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/native-provider-ci/providers/docker-build/repo/.github/workflows/prerelease.yml
+++ b/native-provider-ci/providers/docker-build/repo/.github/workflows/prerelease.yml
@@ -56,12 +56,6 @@ jobs:
       uses: actions/checkout@v4
       with:
         lfs: true
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v4
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - run: echo "ci-scripts" >> .git/info/exclude
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -113,7 +107,7 @@ jobs:
     - name: Build Provider
       run: make provider
     - name: Check worktree clean
-      run: ./ci-scripts/ci/check-worktree-is-clean
+      uses: pulumi/git-status-check-action@v1
     - run: git status --porcelain
     - name: Tar provider binaries
       run: tar -zcf ${{ github.workspace }}/bin/provider.tar.gz -C ${{
@@ -155,12 +149,6 @@ jobs:
       uses: actions/checkout@v4
       with:
         lfs: true
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v4
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - run: echo "ci-scripts" >> .git/info/exclude
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -213,7 +201,7 @@ jobs:
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
-      run: ./ci-scripts/ci/check-worktree-is-clean
+      uses: pulumi/git-status-check-action@v1
     - run: git status --porcelain
     - name: Tar SDK folder
       run: tar -zcf sdk/${{ matrix.language }}.tar.gz -C sdk/${{ matrix.language }} .
@@ -251,12 +239,6 @@ jobs:
       uses: actions/checkout@v4
       with:
         lfs: true
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v4
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - run: echo "ci-scripts" >> .git/info/exclude
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -506,12 +488,6 @@ jobs:
       uses: actions/checkout@v4
       with:
         lfs: true
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v4
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - run: echo "ci-scripts" >> .git/info/exclude
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/native-provider-ci/providers/docker-build/repo/.github/workflows/release.yml
+++ b/native-provider-ci/providers/docker-build/repo/.github/workflows/release.yml
@@ -56,12 +56,6 @@ jobs:
       uses: actions/checkout@v4
       with:
         lfs: true
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v4
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - run: echo "ci-scripts" >> .git/info/exclude
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -113,7 +107,7 @@ jobs:
     - name: Build Provider
       run: make provider
     - name: Check worktree clean
-      run: ./ci-scripts/ci/check-worktree-is-clean
+      uses: pulumi/git-status-check-action@v1
     - run: git status --porcelain
     - name: Tar provider binaries
       run: tar -zcf ${{ github.workspace }}/bin/provider.tar.gz -C ${{
@@ -155,12 +149,6 @@ jobs:
       uses: actions/checkout@v4
       with:
         lfs: true
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v4
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - run: echo "ci-scripts" >> .git/info/exclude
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -213,7 +201,7 @@ jobs:
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
-      run: ./ci-scripts/ci/check-worktree-is-clean
+      uses: pulumi/git-status-check-action@v1
     - run: git status --porcelain
     - name: Tar SDK folder
       run: tar -zcf sdk/${{ matrix.language }}.tar.gz -C sdk/${{ matrix.language }} .
@@ -251,12 +239,6 @@ jobs:
       uses: actions/checkout@v4
       with:
         lfs: true
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v4
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - run: echo "ci-scripts" >> .git/info/exclude
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -506,12 +488,6 @@ jobs:
       uses: actions/checkout@v4
       with:
         lfs: true
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v4
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - run: echo "ci-scripts" >> .git/info/exclude
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/native-provider-ci/providers/docker-build/repo/.github/workflows/release.yml
+++ b/native-provider-ci/providers/docker-build/repo/.github/workflows/release.yml
@@ -56,6 +56,10 @@ jobs:
       uses: actions/checkout@v4
       with:
         lfs: true
+    - name: Set Provider Version
+      uses: pulumi/provider-version-action@v1
+      with:
+        set-env: PROVIDER_VERSION
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -149,6 +153,10 @@ jobs:
       uses: actions/checkout@v4
       with:
         lfs: true
+    - name: Set Provider Version
+      uses: pulumi/provider-version-action@v1
+      with:
+        set-env: PROVIDER_VERSION
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -239,6 +247,10 @@ jobs:
       uses: actions/checkout@v4
       with:
         lfs: true
+    - name: Set Provider Version
+      uses: pulumi/provider-version-action@v1
+      with:
+        set-env: PROVIDER_VERSION
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -352,6 +364,10 @@ jobs:
       uses: actions/checkout@v4
       with:
         lfs: true
+    - name: Set Provider Version
+      uses: pulumi/provider-version-action@v1
+      with:
+        set-env: PROVIDER_VERSION
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -408,6 +424,10 @@ jobs:
       uses: actions/checkout@v4
       with:
         lfs: true
+    - name: Set Provider Version
+      uses: pulumi/provider-version-action@v1
+      with:
+        set-env: PROVIDER_VERSION
     - name: Checkout Scripts Repo
       uses: actions/checkout@v4
       with:
@@ -488,6 +508,10 @@ jobs:
       uses: actions/checkout@v4
       with:
         lfs: true
+    - name: Set Provider Version
+      uses: pulumi/provider-version-action@v1
+      with:
+        set-env: PROVIDER_VERSION
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -536,6 +560,10 @@ jobs:
       uses: actions/checkout@v4
       with:
         lfs: true
+    - name: Set Provider Version
+      uses: pulumi/provider-version-action@v1
+      with:
+        set-env: PROVIDER_VERSION
     - name: Install pulumictl
       uses: jaxxstorm/action-install-gh-release@v1.11.0
       with:

--- a/native-provider-ci/providers/docker-build/repo/.github/workflows/run-acceptance-tests.yml
+++ b/native-provider-ci/providers/docker-build/repo/.github/workflows/run-acceptance-tests.yml
@@ -81,6 +81,10 @@ jobs:
       with:
         lfs: true
         ref: ${{ env.PR_COMMIT_SHA }}
+    - name: Set Provider Version
+      uses: pulumi/provider-version-action@v1
+      with:
+        set-env: PROVIDER_VERSION
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -177,6 +181,10 @@ jobs:
       with:
         lfs: true
         ref: ${{ env.PR_COMMIT_SHA }}
+    - name: Set Provider Version
+      uses: pulumi/provider-version-action@v1
+      with:
+        set-env: PROVIDER_VERSION
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -271,6 +279,10 @@ jobs:
       with:
         lfs: true
         ref: ${{ env.PR_COMMIT_SHA }}
+    - name: Set Provider Version
+      uses: pulumi/provider-version-action@v1
+      with:
+        set-env: PROVIDER_VERSION
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/native-provider-ci/providers/docker-build/repo/.github/workflows/run-acceptance-tests.yml
+++ b/native-provider-ci/providers/docker-build/repo/.github/workflows/run-acceptance-tests.yml
@@ -81,12 +81,6 @@ jobs:
       with:
         lfs: true
         ref: ${{ env.PR_COMMIT_SHA }}
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v4
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - run: echo "ci-scripts" >> .git/info/exclude
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -138,7 +132,7 @@ jobs:
     - name: Build Provider
       run: make provider
     - name: Check worktree clean
-      run: ./ci-scripts/ci/check-worktree-is-clean
+      uses: pulumi/git-status-check-action@v1
     - run: git status --porcelain
     - name: Tar provider binaries
       run: tar -zcf ${{ github.workspace }}/bin/provider.tar.gz -C ${{
@@ -183,12 +177,6 @@ jobs:
       with:
         lfs: true
         ref: ${{ env.PR_COMMIT_SHA }}
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v4
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - run: echo "ci-scripts" >> .git/info/exclude
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -241,7 +229,7 @@ jobs:
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
-      run: ./ci-scripts/ci/check-worktree-is-clean
+      uses: pulumi/git-status-check-action@v1
     - run: git status --porcelain
     - name: Tar SDK folder
       run: tar -zcf sdk/${{ matrix.language }}.tar.gz -C sdk/${{ matrix.language }} .
@@ -283,12 +271,6 @@ jobs:
       with:
         lfs: true
         ref: ${{ env.PR_COMMIT_SHA }}
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v4
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - run: echo "ci-scripts" >> .git/info/exclude
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/native-provider-ci/providers/docker-build/repo/.github/workflows/weekly-pulumi-update.yml
+++ b/native-provider-ci/providers/docker-build/repo/.github/workflows/weekly-pulumi-update.yml
@@ -54,6 +54,10 @@ jobs:
       uses: actions/checkout@v4
       with:
         lfs: true
+    - name: Set Provider Version
+      uses: pulumi/provider-version-action@v1
+      with:
+        set-env: PROVIDER_VERSION
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/native-provider-ci/providers/google-native/repo/.github/workflows/build.yml
+++ b/native-provider-ci/providers/google-native/repo/.github/workflows/build.yml
@@ -56,12 +56,6 @@ jobs:
       uses: actions/checkout@v4
       with:
         lfs: true
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v4
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - run: echo "ci-scripts" >> .git/info/exclude
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -115,7 +109,7 @@ jobs:
     - name: Build Provider
       run: make provider
     - name: Check worktree clean
-      run: ./ci-scripts/ci/check-worktree-is-clean
+      uses: pulumi/git-status-check-action@v1
     - run: git status --porcelain
     - name: Tar provider binaries
       run: tar -zcf ${{ github.workspace }}/bin/provider.tar.gz -C ${{
@@ -157,12 +151,6 @@ jobs:
       uses: actions/checkout@v4
       with:
         lfs: true
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v4
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - run: echo "ci-scripts" >> .git/info/exclude
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -217,7 +205,7 @@ jobs:
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
-      run: ./ci-scripts/ci/check-worktree-is-clean
+      uses: pulumi/git-status-check-action@v1
     - run: git status --porcelain
     - name: Tar SDK folder
       run: tar -zcf sdk/${{ matrix.language }}.tar.gz -C sdk/${{ matrix.language }} .
@@ -256,12 +244,6 @@ jobs:
       uses: actions/checkout@v4
       with:
         lfs: true
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v4
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - run: echo "ci-scripts" >> .git/info/exclude
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -502,12 +484,6 @@ jobs:
       uses: actions/checkout@v4
       with:
         lfs: true
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v4
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - run: echo "ci-scripts" >> .git/info/exclude
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/native-provider-ci/providers/google-native/repo/.github/workflows/build.yml
+++ b/native-provider-ci/providers/google-native/repo/.github/workflows/build.yml
@@ -56,6 +56,10 @@ jobs:
       uses: actions/checkout@v4
       with:
         lfs: true
+    - name: Set Provider Version
+      uses: pulumi/provider-version-action@v1
+      with:
+        set-env: PROVIDER_VERSION
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -151,6 +155,10 @@ jobs:
       uses: actions/checkout@v4
       with:
         lfs: true
+    - name: Set Provider Version
+      uses: pulumi/provider-version-action@v1
+      with:
+        set-env: PROVIDER_VERSION
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -244,6 +252,10 @@ jobs:
       uses: actions/checkout@v4
       with:
         lfs: true
+    - name: Set Provider Version
+      uses: pulumi/provider-version-action@v1
+      with:
+        set-env: PROVIDER_VERSION
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -348,6 +360,10 @@ jobs:
       uses: actions/checkout@v4
       with:
         lfs: true
+    - name: Set Provider Version
+      uses: pulumi/provider-version-action@v1
+      with:
+        set-env: PROVIDER_VERSION
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -404,6 +420,10 @@ jobs:
       uses: actions/checkout@v4
       with:
         lfs: true
+    - name: Set Provider Version
+      uses: pulumi/provider-version-action@v1
+      with:
+        set-env: PROVIDER_VERSION
     - name: Checkout Scripts Repo
       uses: actions/checkout@v4
       with:
@@ -484,6 +504,10 @@ jobs:
       uses: actions/checkout@v4
       with:
         lfs: true
+    - name: Set Provider Version
+      uses: pulumi/provider-version-action@v1
+      with:
+        set-env: PROVIDER_VERSION
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/native-provider-ci/providers/google-native/repo/.github/workflows/nightly-sdk-generation.yml
+++ b/native-provider-ci/providers/google-native/repo/.github/workflows/nightly-sdk-generation.yml
@@ -47,6 +47,10 @@ jobs:
       uses: actions/checkout@v4
       with:
         lfs: true
+    - name: Set Provider Version
+      uses: pulumi/provider-version-action@v1
+      with:
+        set-env: PROVIDER_VERSION
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/native-provider-ci/providers/google-native/repo/.github/workflows/prerelease.yml
+++ b/native-provider-ci/providers/google-native/repo/.github/workflows/prerelease.yml
@@ -48,6 +48,10 @@ jobs:
       uses: actions/checkout@v4
       with:
         lfs: true
+    - name: Set Provider Version
+      uses: pulumi/provider-version-action@v1
+      with:
+        set-env: PROVIDER_VERSION
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -143,6 +147,10 @@ jobs:
       uses: actions/checkout@v4
       with:
         lfs: true
+    - name: Set Provider Version
+      uses: pulumi/provider-version-action@v1
+      with:
+        set-env: PROVIDER_VERSION
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -235,6 +243,10 @@ jobs:
       uses: actions/checkout@v4
       with:
         lfs: true
+    - name: Set Provider Version
+      uses: pulumi/provider-version-action@v1
+      with:
+        set-env: PROVIDER_VERSION
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -339,6 +351,10 @@ jobs:
       uses: actions/checkout@v4
       with:
         lfs: true
+    - name: Set Provider Version
+      uses: pulumi/provider-version-action@v1
+      with:
+        set-env: PROVIDER_VERSION
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -395,6 +411,10 @@ jobs:
       uses: actions/checkout@v4
       with:
         lfs: true
+    - name: Set Provider Version
+      uses: pulumi/provider-version-action@v1
+      with:
+        set-env: PROVIDER_VERSION
     - name: Checkout Scripts Repo
       uses: actions/checkout@v4
       with:
@@ -475,6 +495,10 @@ jobs:
       uses: actions/checkout@v4
       with:
         lfs: true
+    - name: Set Provider Version
+      uses: pulumi/provider-version-action@v1
+      with:
+        set-env: PROVIDER_VERSION
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/native-provider-ci/providers/google-native/repo/.github/workflows/prerelease.yml
+++ b/native-provider-ci/providers/google-native/repo/.github/workflows/prerelease.yml
@@ -48,12 +48,6 @@ jobs:
       uses: actions/checkout@v4
       with:
         lfs: true
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v4
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - run: echo "ci-scripts" >> .git/info/exclude
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -107,7 +101,7 @@ jobs:
     - name: Build Provider
       run: make provider
     - name: Check worktree clean
-      run: ./ci-scripts/ci/check-worktree-is-clean
+      uses: pulumi/git-status-check-action@v1
     - run: git status --porcelain
     - name: Tar provider binaries
       run: tar -zcf ${{ github.workspace }}/bin/provider.tar.gz -C ${{
@@ -149,12 +143,6 @@ jobs:
       uses: actions/checkout@v4
       with:
         lfs: true
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v4
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - run: echo "ci-scripts" >> .git/info/exclude
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -209,7 +197,7 @@ jobs:
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
-      run: ./ci-scripts/ci/check-worktree-is-clean
+      uses: pulumi/git-status-check-action@v1
     - run: git status --porcelain
     - name: Tar SDK folder
       run: tar -zcf sdk/${{ matrix.language }}.tar.gz -C sdk/${{ matrix.language }} .
@@ -247,12 +235,6 @@ jobs:
       uses: actions/checkout@v4
       with:
         lfs: true
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v4
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - run: echo "ci-scripts" >> .git/info/exclude
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -493,12 +475,6 @@ jobs:
       uses: actions/checkout@v4
       with:
         lfs: true
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v4
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - run: echo "ci-scripts" >> .git/info/exclude
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/native-provider-ci/providers/google-native/repo/.github/workflows/release.yml
+++ b/native-provider-ci/providers/google-native/repo/.github/workflows/release.yml
@@ -48,6 +48,10 @@ jobs:
       uses: actions/checkout@v4
       with:
         lfs: true
+    - name: Set Provider Version
+      uses: pulumi/provider-version-action@v1
+      with:
+        set-env: PROVIDER_VERSION
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -143,6 +147,10 @@ jobs:
       uses: actions/checkout@v4
       with:
         lfs: true
+    - name: Set Provider Version
+      uses: pulumi/provider-version-action@v1
+      with:
+        set-env: PROVIDER_VERSION
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -235,6 +243,10 @@ jobs:
       uses: actions/checkout@v4
       with:
         lfs: true
+    - name: Set Provider Version
+      uses: pulumi/provider-version-action@v1
+      with:
+        set-env: PROVIDER_VERSION
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -339,6 +351,10 @@ jobs:
       uses: actions/checkout@v4
       with:
         lfs: true
+    - name: Set Provider Version
+      uses: pulumi/provider-version-action@v1
+      with:
+        set-env: PROVIDER_VERSION
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -395,6 +411,10 @@ jobs:
       uses: actions/checkout@v4
       with:
         lfs: true
+    - name: Set Provider Version
+      uses: pulumi/provider-version-action@v1
+      with:
+        set-env: PROVIDER_VERSION
     - name: Checkout Scripts Repo
       uses: actions/checkout@v4
       with:
@@ -475,6 +495,10 @@ jobs:
       uses: actions/checkout@v4
       with:
         lfs: true
+    - name: Set Provider Version
+      uses: pulumi/provider-version-action@v1
+      with:
+        set-env: PROVIDER_VERSION
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -523,6 +547,10 @@ jobs:
       uses: actions/checkout@v4
       with:
         lfs: true
+    - name: Set Provider Version
+      uses: pulumi/provider-version-action@v1
+      with:
+        set-env: PROVIDER_VERSION
     - name: Install pulumictl
       uses: jaxxstorm/action-install-gh-release@v1.11.0
       with:

--- a/native-provider-ci/providers/google-native/repo/.github/workflows/release.yml
+++ b/native-provider-ci/providers/google-native/repo/.github/workflows/release.yml
@@ -48,12 +48,6 @@ jobs:
       uses: actions/checkout@v4
       with:
         lfs: true
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v4
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - run: echo "ci-scripts" >> .git/info/exclude
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -107,7 +101,7 @@ jobs:
     - name: Build Provider
       run: make provider
     - name: Check worktree clean
-      run: ./ci-scripts/ci/check-worktree-is-clean
+      uses: pulumi/git-status-check-action@v1
     - run: git status --porcelain
     - name: Tar provider binaries
       run: tar -zcf ${{ github.workspace }}/bin/provider.tar.gz -C ${{
@@ -149,12 +143,6 @@ jobs:
       uses: actions/checkout@v4
       with:
         lfs: true
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v4
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - run: echo "ci-scripts" >> .git/info/exclude
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -209,7 +197,7 @@ jobs:
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
-      run: ./ci-scripts/ci/check-worktree-is-clean
+      uses: pulumi/git-status-check-action@v1
     - run: git status --porcelain
     - name: Tar SDK folder
       run: tar -zcf sdk/${{ matrix.language }}.tar.gz -C sdk/${{ matrix.language }} .
@@ -247,12 +235,6 @@ jobs:
       uses: actions/checkout@v4
       with:
         lfs: true
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v4
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - run: echo "ci-scripts" >> .git/info/exclude
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -493,12 +475,6 @@ jobs:
       uses: actions/checkout@v4
       with:
         lfs: true
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v4
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - run: echo "ci-scripts" >> .git/info/exclude
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/native-provider-ci/providers/google-native/repo/.github/workflows/run-acceptance-tests.yml
+++ b/native-provider-ci/providers/google-native/repo/.github/workflows/run-acceptance-tests.yml
@@ -73,6 +73,10 @@ jobs:
       with:
         lfs: true
         ref: ${{ env.PR_COMMIT_SHA }}
+    - name: Set Provider Version
+      uses: pulumi/provider-version-action@v1
+      with:
+        set-env: PROVIDER_VERSION
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -171,6 +175,10 @@ jobs:
       with:
         lfs: true
         ref: ${{ env.PR_COMMIT_SHA }}
+    - name: Set Provider Version
+      uses: pulumi/provider-version-action@v1
+      with:
+        set-env: PROVIDER_VERSION
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -267,6 +275,10 @@ jobs:
       with:
         lfs: true
         ref: ${{ env.PR_COMMIT_SHA }}
+    - name: Set Provider Version
+      uses: pulumi/provider-version-action@v1
+      with:
+        set-env: PROVIDER_VERSION
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/native-provider-ci/providers/google-native/repo/.github/workflows/run-acceptance-tests.yml
+++ b/native-provider-ci/providers/google-native/repo/.github/workflows/run-acceptance-tests.yml
@@ -73,12 +73,6 @@ jobs:
       with:
         lfs: true
         ref: ${{ env.PR_COMMIT_SHA }}
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v4
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - run: echo "ci-scripts" >> .git/info/exclude
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -132,7 +126,7 @@ jobs:
     - name: Build Provider
       run: make provider
     - name: Check worktree clean
-      run: ./ci-scripts/ci/check-worktree-is-clean
+      uses: pulumi/git-status-check-action@v1
     - run: git status --porcelain
     - name: Tar provider binaries
       run: tar -zcf ${{ github.workspace }}/bin/provider.tar.gz -C ${{
@@ -177,12 +171,6 @@ jobs:
       with:
         lfs: true
         ref: ${{ env.PR_COMMIT_SHA }}
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v4
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - run: echo "ci-scripts" >> .git/info/exclude
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -237,7 +225,7 @@ jobs:
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
-      run: ./ci-scripts/ci/check-worktree-is-clean
+      uses: pulumi/git-status-check-action@v1
     - run: git status --porcelain
     - name: Tar SDK folder
       run: tar -zcf sdk/${{ matrix.language }}.tar.gz -C sdk/${{ matrix.language }} .
@@ -279,12 +267,6 @@ jobs:
       with:
         lfs: true
         ref: ${{ env.PR_COMMIT_SHA }}
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v4
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - run: echo "ci-scripts" >> .git/info/exclude
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/native-provider-ci/providers/google-native/repo/.github/workflows/weekly-pulumi-update.yml
+++ b/native-provider-ci/providers/google-native/repo/.github/workflows/weekly-pulumi-update.yml
@@ -46,6 +46,10 @@ jobs:
       uses: actions/checkout@v4
       with:
         lfs: true
+    - name: Set Provider Version
+      uses: pulumi/provider-version-action@v1
+      with:
+        set-env: PROVIDER_VERSION
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/native-provider-ci/providers/kubernetes-cert-manager/repo/.github/workflows/build.yml
+++ b/native-provider-ci/providers/kubernetes-cert-manager/repo/.github/workflows/build.yml
@@ -55,12 +55,6 @@ jobs:
       uses: actions/checkout@v4
       with:
         lfs: true
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v4
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - run: echo "ci-scripts" >> .git/info/exclude
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -112,7 +106,7 @@ jobs:
     - name: Build Provider
       run: make provider
     - name: Check worktree clean
-      run: ./ci-scripts/ci/check-worktree-is-clean
+      uses: pulumi/git-status-check-action@v1
     - run: git status --porcelain
     - name: Tar provider binaries
       run: tar -zcf ${{ github.workspace }}/bin/provider.tar.gz -C ${{
@@ -154,12 +148,6 @@ jobs:
       uses: actions/checkout@v4
       with:
         lfs: true
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v4
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - run: echo "ci-scripts" >> .git/info/exclude
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -212,7 +200,7 @@ jobs:
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
-      run: ./ci-scripts/ci/check-worktree-is-clean
+      uses: pulumi/git-status-check-action@v1
     - run: git status --porcelain
     - name: Tar SDK folder
       run: tar -zcf sdk/${{ matrix.language }}.tar.gz -C sdk/${{ matrix.language }} .
@@ -251,12 +239,6 @@ jobs:
       uses: actions/checkout@v4
       with:
         lfs: true
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v4
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - run: echo "ci-scripts" >> .git/info/exclude
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -485,12 +467,6 @@ jobs:
       uses: actions/checkout@v4
       with:
         lfs: true
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v4
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - run: echo "ci-scripts" >> .git/info/exclude
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/native-provider-ci/providers/kubernetes-cert-manager/repo/.github/workflows/build.yml
+++ b/native-provider-ci/providers/kubernetes-cert-manager/repo/.github/workflows/build.yml
@@ -55,6 +55,10 @@ jobs:
       uses: actions/checkout@v4
       with:
         lfs: true
+    - name: Set Provider Version
+      uses: pulumi/provider-version-action@v1
+      with:
+        set-env: PROVIDER_VERSION
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -148,6 +152,10 @@ jobs:
       uses: actions/checkout@v4
       with:
         lfs: true
+    - name: Set Provider Version
+      uses: pulumi/provider-version-action@v1
+      with:
+        set-env: PROVIDER_VERSION
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -239,6 +247,10 @@ jobs:
       uses: actions/checkout@v4
       with:
         lfs: true
+    - name: Set Provider Version
+      uses: pulumi/provider-version-action@v1
+      with:
+        set-env: PROVIDER_VERSION
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -331,6 +343,10 @@ jobs:
       uses: actions/checkout@v4
       with:
         lfs: true
+    - name: Set Provider Version
+      uses: pulumi/provider-version-action@v1
+      with:
+        set-env: PROVIDER_VERSION
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -387,6 +403,10 @@ jobs:
       uses: actions/checkout@v4
       with:
         lfs: true
+    - name: Set Provider Version
+      uses: pulumi/provider-version-action@v1
+      with:
+        set-env: PROVIDER_VERSION
     - name: Checkout Scripts Repo
       uses: actions/checkout@v4
       with:
@@ -467,6 +487,10 @@ jobs:
       uses: actions/checkout@v4
       with:
         lfs: true
+    - name: Set Provider Version
+      uses: pulumi/provider-version-action@v1
+      with:
+        set-env: PROVIDER_VERSION
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/native-provider-ci/providers/kubernetes-cert-manager/repo/.github/workflows/prerelease.yml
+++ b/native-provider-ci/providers/kubernetes-cert-manager/repo/.github/workflows/prerelease.yml
@@ -47,6 +47,10 @@ jobs:
       uses: actions/checkout@v4
       with:
         lfs: true
+    - name: Set Provider Version
+      uses: pulumi/provider-version-action@v1
+      with:
+        set-env: PROVIDER_VERSION
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -140,6 +144,10 @@ jobs:
       uses: actions/checkout@v4
       with:
         lfs: true
+    - name: Set Provider Version
+      uses: pulumi/provider-version-action@v1
+      with:
+        set-env: PROVIDER_VERSION
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -230,6 +238,10 @@ jobs:
       uses: actions/checkout@v4
       with:
         lfs: true
+    - name: Set Provider Version
+      uses: pulumi/provider-version-action@v1
+      with:
+        set-env: PROVIDER_VERSION
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -322,6 +334,10 @@ jobs:
       uses: actions/checkout@v4
       with:
         lfs: true
+    - name: Set Provider Version
+      uses: pulumi/provider-version-action@v1
+      with:
+        set-env: PROVIDER_VERSION
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -378,6 +394,10 @@ jobs:
       uses: actions/checkout@v4
       with:
         lfs: true
+    - name: Set Provider Version
+      uses: pulumi/provider-version-action@v1
+      with:
+        set-env: PROVIDER_VERSION
     - name: Checkout Scripts Repo
       uses: actions/checkout@v4
       with:
@@ -458,6 +478,10 @@ jobs:
       uses: actions/checkout@v4
       with:
         lfs: true
+    - name: Set Provider Version
+      uses: pulumi/provider-version-action@v1
+      with:
+        set-env: PROVIDER_VERSION
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/native-provider-ci/providers/kubernetes-cert-manager/repo/.github/workflows/prerelease.yml
+++ b/native-provider-ci/providers/kubernetes-cert-manager/repo/.github/workflows/prerelease.yml
@@ -47,12 +47,6 @@ jobs:
       uses: actions/checkout@v4
       with:
         lfs: true
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v4
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - run: echo "ci-scripts" >> .git/info/exclude
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -104,7 +98,7 @@ jobs:
     - name: Build Provider
       run: make provider
     - name: Check worktree clean
-      run: ./ci-scripts/ci/check-worktree-is-clean
+      uses: pulumi/git-status-check-action@v1
     - run: git status --porcelain
     - name: Tar provider binaries
       run: tar -zcf ${{ github.workspace }}/bin/provider.tar.gz -C ${{
@@ -146,12 +140,6 @@ jobs:
       uses: actions/checkout@v4
       with:
         lfs: true
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v4
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - run: echo "ci-scripts" >> .git/info/exclude
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -204,7 +192,7 @@ jobs:
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
-      run: ./ci-scripts/ci/check-worktree-is-clean
+      uses: pulumi/git-status-check-action@v1
     - run: git status --porcelain
     - name: Tar SDK folder
       run: tar -zcf sdk/${{ matrix.language }}.tar.gz -C sdk/${{ matrix.language }} .
@@ -242,12 +230,6 @@ jobs:
       uses: actions/checkout@v4
       with:
         lfs: true
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v4
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - run: echo "ci-scripts" >> .git/info/exclude
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -476,12 +458,6 @@ jobs:
       uses: actions/checkout@v4
       with:
         lfs: true
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v4
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - run: echo "ci-scripts" >> .git/info/exclude
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/native-provider-ci/providers/kubernetes-cert-manager/repo/.github/workflows/release.yml
+++ b/native-provider-ci/providers/kubernetes-cert-manager/repo/.github/workflows/release.yml
@@ -47,6 +47,10 @@ jobs:
       uses: actions/checkout@v4
       with:
         lfs: true
+    - name: Set Provider Version
+      uses: pulumi/provider-version-action@v1
+      with:
+        set-env: PROVIDER_VERSION
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -140,6 +144,10 @@ jobs:
       uses: actions/checkout@v4
       with:
         lfs: true
+    - name: Set Provider Version
+      uses: pulumi/provider-version-action@v1
+      with:
+        set-env: PROVIDER_VERSION
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -230,6 +238,10 @@ jobs:
       uses: actions/checkout@v4
       with:
         lfs: true
+    - name: Set Provider Version
+      uses: pulumi/provider-version-action@v1
+      with:
+        set-env: PROVIDER_VERSION
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -322,6 +334,10 @@ jobs:
       uses: actions/checkout@v4
       with:
         lfs: true
+    - name: Set Provider Version
+      uses: pulumi/provider-version-action@v1
+      with:
+        set-env: PROVIDER_VERSION
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -378,6 +394,10 @@ jobs:
       uses: actions/checkout@v4
       with:
         lfs: true
+    - name: Set Provider Version
+      uses: pulumi/provider-version-action@v1
+      with:
+        set-env: PROVIDER_VERSION
     - name: Checkout Scripts Repo
       uses: actions/checkout@v4
       with:
@@ -458,6 +478,10 @@ jobs:
       uses: actions/checkout@v4
       with:
         lfs: true
+    - name: Set Provider Version
+      uses: pulumi/provider-version-action@v1
+      with:
+        set-env: PROVIDER_VERSION
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -506,6 +530,10 @@ jobs:
       uses: actions/checkout@v4
       with:
         lfs: true
+    - name: Set Provider Version
+      uses: pulumi/provider-version-action@v1
+      with:
+        set-env: PROVIDER_VERSION
     - name: Install pulumictl
       uses: jaxxstorm/action-install-gh-release@v1.11.0
       with:

--- a/native-provider-ci/providers/kubernetes-cert-manager/repo/.github/workflows/release.yml
+++ b/native-provider-ci/providers/kubernetes-cert-manager/repo/.github/workflows/release.yml
@@ -47,12 +47,6 @@ jobs:
       uses: actions/checkout@v4
       with:
         lfs: true
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v4
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - run: echo "ci-scripts" >> .git/info/exclude
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -104,7 +98,7 @@ jobs:
     - name: Build Provider
       run: make provider
     - name: Check worktree clean
-      run: ./ci-scripts/ci/check-worktree-is-clean
+      uses: pulumi/git-status-check-action@v1
     - run: git status --porcelain
     - name: Tar provider binaries
       run: tar -zcf ${{ github.workspace }}/bin/provider.tar.gz -C ${{
@@ -146,12 +140,6 @@ jobs:
       uses: actions/checkout@v4
       with:
         lfs: true
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v4
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - run: echo "ci-scripts" >> .git/info/exclude
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -204,7 +192,7 @@ jobs:
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
-      run: ./ci-scripts/ci/check-worktree-is-clean
+      uses: pulumi/git-status-check-action@v1
     - run: git status --porcelain
     - name: Tar SDK folder
       run: tar -zcf sdk/${{ matrix.language }}.tar.gz -C sdk/${{ matrix.language }} .
@@ -242,12 +230,6 @@ jobs:
       uses: actions/checkout@v4
       with:
         lfs: true
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v4
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - run: echo "ci-scripts" >> .git/info/exclude
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -476,12 +458,6 @@ jobs:
       uses: actions/checkout@v4
       with:
         lfs: true
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v4
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - run: echo "ci-scripts" >> .git/info/exclude
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/native-provider-ci/providers/kubernetes-cert-manager/repo/.github/workflows/run-acceptance-tests.yml
+++ b/native-provider-ci/providers/kubernetes-cert-manager/repo/.github/workflows/run-acceptance-tests.yml
@@ -72,6 +72,10 @@ jobs:
       with:
         lfs: true
         ref: ${{ env.PR_COMMIT_SHA }}
+    - name: Set Provider Version
+      uses: pulumi/provider-version-action@v1
+      with:
+        set-env: PROVIDER_VERSION
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -168,6 +172,10 @@ jobs:
       with:
         lfs: true
         ref: ${{ env.PR_COMMIT_SHA }}
+    - name: Set Provider Version
+      uses: pulumi/provider-version-action@v1
+      with:
+        set-env: PROVIDER_VERSION
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -262,6 +270,10 @@ jobs:
       with:
         lfs: true
         ref: ${{ env.PR_COMMIT_SHA }}
+    - name: Set Provider Version
+      uses: pulumi/provider-version-action@v1
+      with:
+        set-env: PROVIDER_VERSION
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/native-provider-ci/providers/kubernetes-cert-manager/repo/.github/workflows/run-acceptance-tests.yml
+++ b/native-provider-ci/providers/kubernetes-cert-manager/repo/.github/workflows/run-acceptance-tests.yml
@@ -72,12 +72,6 @@ jobs:
       with:
         lfs: true
         ref: ${{ env.PR_COMMIT_SHA }}
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v4
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - run: echo "ci-scripts" >> .git/info/exclude
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -129,7 +123,7 @@ jobs:
     - name: Build Provider
       run: make provider
     - name: Check worktree clean
-      run: ./ci-scripts/ci/check-worktree-is-clean
+      uses: pulumi/git-status-check-action@v1
     - run: git status --porcelain
     - name: Tar provider binaries
       run: tar -zcf ${{ github.workspace }}/bin/provider.tar.gz -C ${{
@@ -174,12 +168,6 @@ jobs:
       with:
         lfs: true
         ref: ${{ env.PR_COMMIT_SHA }}
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v4
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - run: echo "ci-scripts" >> .git/info/exclude
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -232,7 +220,7 @@ jobs:
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
-      run: ./ci-scripts/ci/check-worktree-is-clean
+      uses: pulumi/git-status-check-action@v1
     - run: git status --porcelain
     - name: Tar SDK folder
       run: tar -zcf sdk/${{ matrix.language }}.tar.gz -C sdk/${{ matrix.language }} .
@@ -274,12 +262,6 @@ jobs:
       with:
         lfs: true
         ref: ${{ env.PR_COMMIT_SHA }}
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v4
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - run: echo "ci-scripts" >> .git/info/exclude
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/native-provider-ci/providers/kubernetes-cert-manager/repo/.github/workflows/weekly-pulumi-update.yml
+++ b/native-provider-ci/providers/kubernetes-cert-manager/repo/.github/workflows/weekly-pulumi-update.yml
@@ -45,6 +45,10 @@ jobs:
       uses: actions/checkout@v4
       with:
         lfs: true
+    - name: Set Provider Version
+      uses: pulumi/provider-version-action@v1
+      with:
+        set-env: PROVIDER_VERSION
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/native-provider-ci/providers/kubernetes/repo/.github/workflows/build.yml
+++ b/native-provider-ci/providers/kubernetes/repo/.github/workflows/build.yml
@@ -55,6 +55,10 @@ jobs:
       uses: actions/checkout@v4
       with:
         lfs: true
+    - name: Set Provider Version
+      uses: pulumi/provider-version-action@v1
+      with:
+        set-env: PROVIDER_VERSION
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -150,6 +154,10 @@ jobs:
       uses: actions/checkout@v4
       with:
         lfs: true
+    - name: Set Provider Version
+      uses: pulumi/provider-version-action@v1
+      with:
+        set-env: PROVIDER_VERSION
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -240,6 +248,10 @@ jobs:
       uses: actions/checkout@v4
       with:
         lfs: true
+    - name: Set Provider Version
+      uses: pulumi/provider-version-action@v1
+      with:
+        set-env: PROVIDER_VERSION
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -374,6 +386,10 @@ jobs:
       uses: actions/checkout@v4
       with:
         lfs: true
+    - name: Set Provider Version
+      uses: pulumi/provider-version-action@v1
+      with:
+        set-env: PROVIDER_VERSION
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -430,6 +446,10 @@ jobs:
       uses: actions/checkout@v4
       with:
         lfs: true
+    - name: Set Provider Version
+      uses: pulumi/provider-version-action@v1
+      with:
+        set-env: PROVIDER_VERSION
     - name: Checkout Scripts Repo
       uses: actions/checkout@v4
       with:
@@ -510,6 +530,10 @@ jobs:
       uses: actions/checkout@v4
       with:
         lfs: true
+    - name: Set Provider Version
+      uses: pulumi/provider-version-action@v1
+      with:
+        set-env: PROVIDER_VERSION
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/native-provider-ci/providers/kubernetes/repo/.github/workflows/build.yml
+++ b/native-provider-ci/providers/kubernetes/repo/.github/workflows/build.yml
@@ -55,12 +55,6 @@ jobs:
       uses: actions/checkout@v4
       with:
         lfs: true
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v4
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - run: echo "ci-scripts" >> .git/info/exclude
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -114,7 +108,7 @@ jobs:
         number: ${{ github.event.issue.number }}
         github_token: ${{ secrets.GITHUB_TOKEN }}
     - name: Check worktree clean
-      run: ./ci-scripts/ci/check-worktree-is-clean
+      uses: pulumi/git-status-check-action@v1
     - run: git status --porcelain
     - name: Tar provider binaries
       run: tar -zcf ${{ github.workspace }}/bin/provider.tar.gz -C ${{
@@ -156,12 +150,6 @@ jobs:
       uses: actions/checkout@v4
       with:
         lfs: true
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v4
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - run: echo "ci-scripts" >> .git/info/exclude
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -212,7 +200,7 @@ jobs:
     - name: Generate SDK
       run: make ${{ matrix.language }}_sdk
     - name: Check worktree clean
-      run: ./ci-scripts/ci/check-worktree-is-clean
+      uses: pulumi/git-status-check-action@v1
     - run: git status --porcelain
     - name: Tar SDK folder
       run: tar -zcf sdk/${{ matrix.language }}.tar.gz -C sdk/${{ matrix.language }} .
@@ -252,12 +240,6 @@ jobs:
       uses: actions/checkout@v4
       with:
         lfs: true
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v4
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - run: echo "ci-scripts" >> .git/info/exclude
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -528,12 +510,6 @@ jobs:
       uses: actions/checkout@v4
       with:
         lfs: true
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v4
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - run: echo "ci-scripts" >> .git/info/exclude
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/native-provider-ci/providers/kubernetes/repo/.github/workflows/prerelease.yml
+++ b/native-provider-ci/providers/kubernetes/repo/.github/workflows/prerelease.yml
@@ -47,6 +47,10 @@ jobs:
       uses: actions/checkout@v4
       with:
         lfs: true
+    - name: Set Provider Version
+      uses: pulumi/provider-version-action@v1
+      with:
+        set-env: PROVIDER_VERSION
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -142,6 +146,10 @@ jobs:
       uses: actions/checkout@v4
       with:
         lfs: true
+    - name: Set Provider Version
+      uses: pulumi/provider-version-action@v1
+      with:
+        set-env: PROVIDER_VERSION
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -231,6 +239,10 @@ jobs:
       uses: actions/checkout@v4
       with:
         lfs: true
+    - name: Set Provider Version
+      uses: pulumi/provider-version-action@v1
+      with:
+        set-env: PROVIDER_VERSION
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -365,6 +377,10 @@ jobs:
       uses: actions/checkout@v4
       with:
         lfs: true
+    - name: Set Provider Version
+      uses: pulumi/provider-version-action@v1
+      with:
+        set-env: PROVIDER_VERSION
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -421,6 +437,10 @@ jobs:
       uses: actions/checkout@v4
       with:
         lfs: true
+    - name: Set Provider Version
+      uses: pulumi/provider-version-action@v1
+      with:
+        set-env: PROVIDER_VERSION
     - name: Checkout Scripts Repo
       uses: actions/checkout@v4
       with:
@@ -501,6 +521,10 @@ jobs:
       uses: actions/checkout@v4
       with:
         lfs: true
+    - name: Set Provider Version
+      uses: pulumi/provider-version-action@v1
+      with:
+        set-env: PROVIDER_VERSION
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/native-provider-ci/providers/kubernetes/repo/.github/workflows/prerelease.yml
+++ b/native-provider-ci/providers/kubernetes/repo/.github/workflows/prerelease.yml
@@ -47,12 +47,6 @@ jobs:
       uses: actions/checkout@v4
       with:
         lfs: true
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v4
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - run: echo "ci-scripts" >> .git/info/exclude
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -106,7 +100,7 @@ jobs:
         number: ${{ github.event.issue.number }}
         github_token: ${{ secrets.GITHUB_TOKEN }}
     - name: Check worktree clean
-      run: ./ci-scripts/ci/check-worktree-is-clean
+      uses: pulumi/git-status-check-action@v1
     - run: git status --porcelain
     - name: Tar provider binaries
       run: tar -zcf ${{ github.workspace }}/bin/provider.tar.gz -C ${{
@@ -148,12 +142,6 @@ jobs:
       uses: actions/checkout@v4
       with:
         lfs: true
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v4
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - run: echo "ci-scripts" >> .git/info/exclude
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -204,7 +192,7 @@ jobs:
     - name: Generate SDK
       run: make ${{ matrix.language }}_sdk
     - name: Check worktree clean
-      run: ./ci-scripts/ci/check-worktree-is-clean
+      uses: pulumi/git-status-check-action@v1
     - run: git status --porcelain
     - name: Tar SDK folder
       run: tar -zcf sdk/${{ matrix.language }}.tar.gz -C sdk/${{ matrix.language }} .
@@ -243,12 +231,6 @@ jobs:
       uses: actions/checkout@v4
       with:
         lfs: true
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v4
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - run: echo "ci-scripts" >> .git/info/exclude
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -519,12 +501,6 @@ jobs:
       uses: actions/checkout@v4
       with:
         lfs: true
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v4
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - run: echo "ci-scripts" >> .git/info/exclude
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/native-provider-ci/providers/kubernetes/repo/.github/workflows/release.yml
+++ b/native-provider-ci/providers/kubernetes/repo/.github/workflows/release.yml
@@ -47,6 +47,10 @@ jobs:
       uses: actions/checkout@v4
       with:
         lfs: true
+    - name: Set Provider Version
+      uses: pulumi/provider-version-action@v1
+      with:
+        set-env: PROVIDER_VERSION
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -142,6 +146,10 @@ jobs:
       uses: actions/checkout@v4
       with:
         lfs: true
+    - name: Set Provider Version
+      uses: pulumi/provider-version-action@v1
+      with:
+        set-env: PROVIDER_VERSION
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -231,6 +239,10 @@ jobs:
       uses: actions/checkout@v4
       with:
         lfs: true
+    - name: Set Provider Version
+      uses: pulumi/provider-version-action@v1
+      with:
+        set-env: PROVIDER_VERSION
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -365,6 +377,10 @@ jobs:
       uses: actions/checkout@v4
       with:
         lfs: true
+    - name: Set Provider Version
+      uses: pulumi/provider-version-action@v1
+      with:
+        set-env: PROVIDER_VERSION
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -421,6 +437,10 @@ jobs:
       uses: actions/checkout@v4
       with:
         lfs: true
+    - name: Set Provider Version
+      uses: pulumi/provider-version-action@v1
+      with:
+        set-env: PROVIDER_VERSION
     - name: Checkout Scripts Repo
       uses: actions/checkout@v4
       with:
@@ -501,6 +521,10 @@ jobs:
       uses: actions/checkout@v4
       with:
         lfs: true
+    - name: Set Provider Version
+      uses: pulumi/provider-version-action@v1
+      with:
+        set-env: PROVIDER_VERSION
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -549,6 +573,10 @@ jobs:
       uses: actions/checkout@v4
       with:
         lfs: true
+    - name: Set Provider Version
+      uses: pulumi/provider-version-action@v1
+      with:
+        set-env: PROVIDER_VERSION
     - name: Install pulumictl
       uses: jaxxstorm/action-install-gh-release@v1.11.0
       with:

--- a/native-provider-ci/providers/kubernetes/repo/.github/workflows/release.yml
+++ b/native-provider-ci/providers/kubernetes/repo/.github/workflows/release.yml
@@ -47,12 +47,6 @@ jobs:
       uses: actions/checkout@v4
       with:
         lfs: true
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v4
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - run: echo "ci-scripts" >> .git/info/exclude
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -106,7 +100,7 @@ jobs:
         number: ${{ github.event.issue.number }}
         github_token: ${{ secrets.GITHUB_TOKEN }}
     - name: Check worktree clean
-      run: ./ci-scripts/ci/check-worktree-is-clean
+      uses: pulumi/git-status-check-action@v1
     - run: git status --porcelain
     - name: Tar provider binaries
       run: tar -zcf ${{ github.workspace }}/bin/provider.tar.gz -C ${{
@@ -148,12 +142,6 @@ jobs:
       uses: actions/checkout@v4
       with:
         lfs: true
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v4
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - run: echo "ci-scripts" >> .git/info/exclude
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -204,7 +192,7 @@ jobs:
     - name: Generate SDK
       run: make ${{ matrix.language }}_sdk
     - name: Check worktree clean
-      run: ./ci-scripts/ci/check-worktree-is-clean
+      uses: pulumi/git-status-check-action@v1
     - run: git status --porcelain
     - name: Tar SDK folder
       run: tar -zcf sdk/${{ matrix.language }}.tar.gz -C sdk/${{ matrix.language }} .
@@ -243,12 +231,6 @@ jobs:
       uses: actions/checkout@v4
       with:
         lfs: true
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v4
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - run: echo "ci-scripts" >> .git/info/exclude
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -519,12 +501,6 @@ jobs:
       uses: actions/checkout@v4
       with:
         lfs: true
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v4
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - run: echo "ci-scripts" >> .git/info/exclude
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/native-provider-ci/providers/kubernetes/repo/.github/workflows/run-acceptance-tests.yml
+++ b/native-provider-ci/providers/kubernetes/repo/.github/workflows/run-acceptance-tests.yml
@@ -73,12 +73,6 @@ jobs:
       with:
         lfs: true
         ref: ${{ env.PR_COMMIT_SHA }}
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v4
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - run: echo "ci-scripts" >> .git/info/exclude
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -132,7 +126,7 @@ jobs:
         number: ${{ github.event.issue.number }}
         github_token: ${{ secrets.GITHUB_TOKEN }}
     - name: Check worktree clean
-      run: ./ci-scripts/ci/check-worktree-is-clean
+      uses: pulumi/git-status-check-action@v1
     - run: git status --porcelain
     - name: Tar provider binaries
       run: tar -zcf ${{ github.workspace }}/bin/provider.tar.gz -C ${{
@@ -177,12 +171,6 @@ jobs:
       with:
         lfs: true
         ref: ${{ env.PR_COMMIT_SHA }}
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v4
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - run: echo "ci-scripts" >> .git/info/exclude
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -233,7 +221,7 @@ jobs:
     - name: Generate SDK
       run: make ${{ matrix.language }}_sdk
     - name: Check worktree clean
-      run: ./ci-scripts/ci/check-worktree-is-clean
+      uses: pulumi/git-status-check-action@v1
     - run: git status --porcelain
     - name: Tar SDK folder
       run: tar -zcf sdk/${{ matrix.language }}.tar.gz -C sdk/${{ matrix.language }} .
@@ -275,12 +263,6 @@ jobs:
       with:
         lfs: true
         ref: ${{ env.PR_COMMIT_SHA }}
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v4
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - run: echo "ci-scripts" >> .git/info/exclude
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/native-provider-ci/providers/kubernetes/repo/.github/workflows/run-acceptance-tests.yml
+++ b/native-provider-ci/providers/kubernetes/repo/.github/workflows/run-acceptance-tests.yml
@@ -73,6 +73,10 @@ jobs:
       with:
         lfs: true
         ref: ${{ env.PR_COMMIT_SHA }}
+    - name: Set Provider Version
+      uses: pulumi/provider-version-action@v1
+      with:
+        set-env: PROVIDER_VERSION
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -171,6 +175,10 @@ jobs:
       with:
         lfs: true
         ref: ${{ env.PR_COMMIT_SHA }}
+    - name: Set Provider Version
+      uses: pulumi/provider-version-action@v1
+      with:
+        set-env: PROVIDER_VERSION
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
@@ -263,6 +271,10 @@ jobs:
       with:
         lfs: true
         ref: ${{ env.PR_COMMIT_SHA }}
+    - name: Set Provider Version
+      uses: pulumi/provider-version-action@v1
+      with:
+        set-env: PROVIDER_VERSION
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/native-provider-ci/providers/kubernetes/repo/.github/workflows/weekly-pulumi-update.yml
+++ b/native-provider-ci/providers/kubernetes/repo/.github/workflows/weekly-pulumi-update.yml
@@ -45,6 +45,10 @@ jobs:
       uses: actions/checkout@v4
       with:
         lfs: true
+    - name: Set Provider Version
+      uses: pulumi/provider-version-action@v1
+      with:
+        set-env: PROVIDER_VERSION
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go

--- a/native-provider-ci/src/action-versions.ts
+++ b/native-provider-ci/src/action-versions.ts
@@ -26,6 +26,7 @@ export const addAndCommit = "EndBug/add-and-commit@v7";
 export const addLabel = "actions-ecosystem/action-add-labels@v1.1.0";
 export const autoMerge = "peter-evans/enable-pull-request-automerge@v1";
 export const checkout = "actions/checkout@v4";
+export const gitStatusCheck = "pulumi/git-status-check-action@v1";
 export const cleanupArtifact = "c-hive/gha-remove-artifacts@v1";
 export const createOrUpdateComment = "peter-evans/create-or-update-comment@v1";
 export const deleteArtifact = "geekyeggo/delete-artifact@v1";

--- a/native-provider-ci/src/action-versions.ts
+++ b/native-provider-ci/src/action-versions.ts
@@ -20,6 +20,7 @@ export const gradleBuildAction = "gradle/gradle-build-action@v3";
 export const installGhRelease = "jaxxstorm/action-install-gh-release@v1.11.0";
 export const installPulumiCli = "pulumi/actions@v5";
 export const codecov = "codecov/codecov-action@v4";
+export const providerVersion = "pulumi/provider-version-action@v1";
 
 // GHA Utilities
 export const addAndCommit = "EndBug/add-and-commit@v7";

--- a/native-provider-ci/src/steps.ts
+++ b/native-provider-ci/src/steps.ts
@@ -13,6 +13,16 @@ export function CheckoutRepoStep(): Step {
   };
 }
 
+export function SetProviderVersionStep(): Step {
+  return {
+    name: "Set Provider Version",
+    uses: action.providerVersion,
+    with: {
+      "set-env": "PROVIDER_VERSION",
+    },
+  };
+}
+
 export function CommandDispatchStep(providerName: string): Step {
   return {
     uses: action.slashCommand,

--- a/native-provider-ci/src/steps.ts
+++ b/native-provider-ci/src/steps.ts
@@ -470,7 +470,7 @@ export function ZipSDKsStep(): Step {
 export function CheckCleanWorkTree(): Step {
   return {
     name: "Check worktree clean",
-    run: "./ci-scripts/ci/check-worktree-is-clean",
+    uses: action.gitStatusCheck,
   };
 }
 

--- a/native-provider-ci/src/workflows.ts
+++ b/native-provider-ci/src/workflows.ts
@@ -452,7 +452,6 @@ export class BuildSdkJob implements NormalJob {
     this.name = name;
     this.steps = [
       steps.CheckoutRepoStep(),
-      ...steps.CheckoutScriptsRepoSteps(),
       steps.CheckoutTagsStep(),
       steps.InstallGo(),
       steps.InstallPulumiCtl(),
@@ -508,7 +507,6 @@ export class PrerequisitesJob implements NormalJob {
     this.name = name;
     this.steps = [
       steps.CheckoutRepoStep(),
-      ...steps.CheckoutScriptsRepoSteps(),
       steps.CheckoutTagsStep(),
       steps.InstallGo(),
       steps.InstallPulumiCtl(),
@@ -586,7 +584,6 @@ export class TestsJob implements NormalJob {
     };
     this.steps = [
       steps.CheckoutRepoStep(),
-      ...steps.CheckoutScriptsRepoSteps(),
       steps.CheckoutTagsStep(),
       steps.InstallGo(),
       steps.InstallPulumiCtl(),
@@ -812,7 +809,7 @@ export class PublishSDKJob implements NormalJob {
     Object.assign(this, { name });
     this.steps = [
       steps.CheckoutRepoStep(),
-      ...steps.CheckoutScriptsRepoSteps(),
+      ...steps.CheckoutScriptsRepoSteps(), // Required for RunPublishSDK
       steps.CheckoutTagsStep(),
       steps.InstallGo(),
       steps.InstallPulumiCtl(),
@@ -845,7 +842,6 @@ export class PublishJavaSDKJob implements NormalJob {
     Object.assign(this, { name });
     this.steps = [
       steps.CheckoutRepoStep(),
-      ...steps.CheckoutScriptsRepoSteps(),
       steps.CheckoutTagsStep(),
       steps.InstallGo(),
       steps.InstallPulumiCtl(),

--- a/native-provider-ci/src/workflows.ts
+++ b/native-provider-ci/src/workflows.ts
@@ -452,6 +452,7 @@ export class BuildSdkJob implements NormalJob {
     this.name = name;
     this.steps = [
       steps.CheckoutRepoStep(),
+      steps.SetProviderVersionStep(),
       steps.CheckoutTagsStep(),
       steps.InstallGo(),
       steps.InstallPulumiCtl(),
@@ -507,6 +508,7 @@ export class PrerequisitesJob implements NormalJob {
     this.name = name;
     this.steps = [
       steps.CheckoutRepoStep(),
+      steps.SetProviderVersionStep(),
       steps.CheckoutTagsStep(),
       steps.InstallGo(),
       steps.InstallPulumiCtl(),
@@ -584,6 +586,7 @@ export class TestsJob implements NormalJob {
     };
     this.steps = [
       steps.CheckoutRepoStep(),
+      steps.SetProviderVersionStep(),
       steps.CheckoutTagsStep(),
       steps.InstallGo(),
       steps.InstallPulumiCtl(),
@@ -753,6 +756,7 @@ export class PublishPrereleaseJob implements NormalJob {
     this.name = name;
     this.steps = [
       steps.CheckoutRepoStep(),
+      steps.SetProviderVersionStep(),
       steps.CheckoutTagsStep(),
       steps.InstallGo(),
       steps.FreeDiskSpace(this["runs-on"]),
@@ -783,6 +787,7 @@ export class PublishJob implements NormalJob {
     }
     this.steps = [
       steps.CheckoutRepoStep(),
+      steps.SetProviderVersionStep(),
       steps.CheckoutTagsStep(),
       steps.InstallGo(),
       steps.FreeDiskSpace(this["runs-on"]),
@@ -809,6 +814,7 @@ export class PublishSDKJob implements NormalJob {
     Object.assign(this, { name });
     this.steps = [
       steps.CheckoutRepoStep(),
+      steps.SetProviderVersionStep(),
       ...steps.CheckoutScriptsRepoSteps(), // Required for RunPublishSDK
       steps.CheckoutTagsStep(),
       steps.InstallGo(),
@@ -842,6 +848,7 @@ export class PublishJavaSDKJob implements NormalJob {
     Object.assign(this, { name });
     this.steps = [
       steps.CheckoutRepoStep(),
+      steps.SetProviderVersionStep(),
       steps.CheckoutTagsStep(),
       steps.InstallGo(),
       steps.InstallPulumiCtl(),
@@ -861,6 +868,7 @@ export class TagSDKJob implements NormalJob {
   needs = "publish_sdk";
   steps = [
     steps.CheckoutRepoStep(),
+    steps.SetProviderVersionStep(),
     steps.InstallPulumiCtl(),
     steps.TagSDKTag(),
   ];
@@ -888,6 +896,7 @@ export class Cf2PulumiRelease implements NormalJob {
   "runs-on" = "macos-11";
   steps = [
     steps.CheckoutRepoStep(),
+    steps.SetProviderVersionStep(),
     steps.CheckoutTagsStep(),
     steps.InstallPulumiCtl(),
     steps.InstallGo(goVersion),
@@ -908,6 +917,7 @@ export class Arm2PulumiRelease implements NormalJob {
   "runs-on" = "macos-11";
   steps = [
     steps.CheckoutRepoStep(),
+    steps.SetProviderVersionStep(),
     steps.CheckoutTagsStep(),
     steps.InstallPulumiCtl(),
     steps.InstallGo(goVersion),
@@ -957,6 +967,7 @@ export class WeeklyPulumiUpdate implements NormalJob {
   constructor(name: string, opts: WorkflowOpts) {
     this.steps = [
       steps.CheckoutRepoStep(),
+      steps.SetProviderVersionStep(),
       steps.CheckoutTagsStep(),
       steps.InstallGo(),
       steps.InstallPulumiCtl(),
@@ -984,6 +995,7 @@ export class NightlySdkGeneration implements NormalJob {
     this.name = name;
     this.steps = [
       steps.CheckoutRepoStep(),
+      steps.SetProviderVersionStep(),
       // Pass the provider here as an option so that it can be skipped if not needed
       steps.CheckoutTagsStep(opts.provider),
       steps.InstallGo(goVersion),

--- a/provider-ci/internal/pkg/templates/bridged-provider.config.yaml
+++ b/provider-ci/internal/pkg/templates/bridged-provider.config.yaml
@@ -9,7 +9,6 @@ fail-on-missing-mapping: true
 fail-on-extra-mapping: true
 publishRegistry: true
 checkoutSubmodules: false
-pulumiScriptsRef: deca2c5c6015ad7aaea6f572a1c2b198ca323592
 testMasterAndReleaseWorkflows: false
 env:
   DOTNETVERSION: |

--- a/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/build_sdk.splice
+++ b/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/build_sdk.splice
@@ -1,13 +1,6 @@
     - uses: pulumi/provider-version-action@v1
       with:
         set-env: 'PROVIDER_VERSION'
-    - name: Checkout Scripts Repo
-      uses: #{{ .Config.actionVersions.checkout }}#
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-        ref: #{{ .Config.pulumiScriptsRef }}#
-    - run: echo "ci-scripts" >> .git/info/exclude # actions/checkout#197
 #{{ .Config.actions.setupGo | toYaml | indent 4 }}#
     - name: Cache examples generation
       uses: actions/cache@v4
@@ -62,7 +55,7 @@
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
-      run: ./ci-scripts/ci/check-worktree-is-clean
+      uses: pulumi/git-status-check-action@v1
     - name: Compress SDK folder
       run: tar -zcf sdk/${{ matrix.language }}.tar.gz -C sdk/${{ matrix.language }} .
     - name: Upload artifacts

--- a/provider-ci/test-workflows/aws/.github/workflows/master.yml
+++ b/provider-ci/test-workflows/aws/.github/workflows/master.yml
@@ -43,13 +43,6 @@ jobs:
     - uses: pulumi/provider-version-action@v1
       with:
         set-env: 'PROVIDER_VERSION'
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v4
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-        ref: deca2c5c6015ad7aaea6f572a1c2b198ca323592
-    - run: echo "ci-scripts" >> .git/info/exclude # actions/checkout#197
     - name: Install Go
       uses: actions/setup-go@v5
       with:
@@ -112,7 +105,7 @@ jobs:
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
-      run: ./ci-scripts/ci/check-worktree-is-clean
+      uses: pulumi/git-status-check-action@v1
     - name: Compress SDK folder
       run: tar -zcf sdk/${{ matrix.language }}.tar.gz -C sdk/${{ matrix.language }} .
     - name: Upload artifacts

--- a/provider-ci/test-workflows/aws/.github/workflows/nightly-test.yml
+++ b/provider-ci/test-workflows/aws/.github/workflows/nightly-test.yml
@@ -43,13 +43,6 @@ jobs:
     - uses: pulumi/provider-version-action@v1
       with:
         set-env: 'PROVIDER_VERSION'
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v4
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-        ref: deca2c5c6015ad7aaea6f572a1c2b198ca323592
-    - run: echo "ci-scripts" >> .git/info/exclude # actions/checkout#197
     - name: Install Go
       uses: actions/setup-go@v5
       with:
@@ -112,7 +105,7 @@ jobs:
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
-      run: ./ci-scripts/ci/check-worktree-is-clean
+      uses: pulumi/git-status-check-action@v1
     - name: Compress SDK folder
       run: tar -zcf sdk/${{ matrix.language }}.tar.gz -C sdk/${{ matrix.language }} .
     - name: Upload artifacts

--- a/provider-ci/test-workflows/aws/.github/workflows/prerelease.yml
+++ b/provider-ci/test-workflows/aws/.github/workflows/prerelease.yml
@@ -44,13 +44,6 @@ jobs:
     - uses: pulumi/provider-version-action@v1
       with:
         set-env: 'PROVIDER_VERSION'
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v4
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-        ref: deca2c5c6015ad7aaea6f572a1c2b198ca323592
-    - run: echo "ci-scripts" >> .git/info/exclude # actions/checkout#197
     - name: Install Go
       uses: actions/setup-go@v5
       with:
@@ -113,7 +106,7 @@ jobs:
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
-      run: ./ci-scripts/ci/check-worktree-is-clean
+      uses: pulumi/git-status-check-action@v1
     - name: Compress SDK folder
       run: tar -zcf sdk/${{ matrix.language }}.tar.gz -C sdk/${{ matrix.language }} .
     - name: Upload artifacts

--- a/provider-ci/test-workflows/aws/.github/workflows/release.yml
+++ b/provider-ci/test-workflows/aws/.github/workflows/release.yml
@@ -43,13 +43,6 @@ jobs:
     - uses: pulumi/provider-version-action@v1
       with:
         set-env: 'PROVIDER_VERSION'
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v4
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-        ref: deca2c5c6015ad7aaea6f572a1c2b198ca323592
-    - run: echo "ci-scripts" >> .git/info/exclude # actions/checkout#197
     - name: Install Go
       uses: actions/setup-go@v5
       with:
@@ -112,7 +105,7 @@ jobs:
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
-      run: ./ci-scripts/ci/check-worktree-is-clean
+      uses: pulumi/git-status-check-action@v1
     - name: Compress SDK folder
       run: tar -zcf sdk/${{ matrix.language }}.tar.gz -C sdk/${{ matrix.language }} .
     - name: Upload artifacts

--- a/provider-ci/test-workflows/aws/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/test-workflows/aws/.github/workflows/run-acceptance-tests.yml
@@ -52,13 +52,6 @@ jobs:
     - uses: pulumi/provider-version-action@v1
       with:
         set-env: 'PROVIDER_VERSION'
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v4
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-        ref: deca2c5c6015ad7aaea6f572a1c2b198ca323592
-    - run: echo "ci-scripts" >> .git/info/exclude # actions/checkout#197
     - name: Install Go
       uses: actions/setup-go@v5
       with:
@@ -121,7 +114,7 @@ jobs:
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
-      run: ./ci-scripts/ci/check-worktree-is-clean
+      uses: pulumi/git-status-check-action@v1
     - name: Compress SDK folder
       run: tar -zcf sdk/${{ matrix.language }}.tar.gz -C sdk/${{ matrix.language }} .
     - name: Upload artifacts

--- a/provider-ci/test-workflows/cloudflare/.github/workflows/master.yml
+++ b/provider-ci/test-workflows/cloudflare/.github/workflows/master.yml
@@ -41,13 +41,6 @@ jobs:
     - uses: pulumi/provider-version-action@v1
       with:
         set-env: 'PROVIDER_VERSION'
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v4
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-        ref: deca2c5c6015ad7aaea6f572a1c2b198ca323592
-    - run: echo "ci-scripts" >> .git/info/exclude # actions/checkout#197
     - name: Install Go
       uses: actions/setup-go@v5
       with:
@@ -110,7 +103,7 @@ jobs:
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
-      run: ./ci-scripts/ci/check-worktree-is-clean
+      uses: pulumi/git-status-check-action@v1
     - name: Compress SDK folder
       run: tar -zcf sdk/${{ matrix.language }}.tar.gz -C sdk/${{ matrix.language }} .
     - name: Upload artifacts

--- a/provider-ci/test-workflows/cloudflare/.github/workflows/prerelease.yml
+++ b/provider-ci/test-workflows/cloudflare/.github/workflows/prerelease.yml
@@ -42,13 +42,6 @@ jobs:
     - uses: pulumi/provider-version-action@v1
       with:
         set-env: 'PROVIDER_VERSION'
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v4
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-        ref: deca2c5c6015ad7aaea6f572a1c2b198ca323592
-    - run: echo "ci-scripts" >> .git/info/exclude # actions/checkout#197
     - name: Install Go
       uses: actions/setup-go@v5
       with:
@@ -111,7 +104,7 @@ jobs:
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
-      run: ./ci-scripts/ci/check-worktree-is-clean
+      uses: pulumi/git-status-check-action@v1
     - name: Compress SDK folder
       run: tar -zcf sdk/${{ matrix.language }}.tar.gz -C sdk/${{ matrix.language }} .
     - name: Upload artifacts

--- a/provider-ci/test-workflows/cloudflare/.github/workflows/release.yml
+++ b/provider-ci/test-workflows/cloudflare/.github/workflows/release.yml
@@ -41,13 +41,6 @@ jobs:
     - uses: pulumi/provider-version-action@v1
       with:
         set-env: 'PROVIDER_VERSION'
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v4
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-        ref: deca2c5c6015ad7aaea6f572a1c2b198ca323592
-    - run: echo "ci-scripts" >> .git/info/exclude # actions/checkout#197
     - name: Install Go
       uses: actions/setup-go@v5
       with:
@@ -110,7 +103,7 @@ jobs:
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
-      run: ./ci-scripts/ci/check-worktree-is-clean
+      uses: pulumi/git-status-check-action@v1
     - name: Compress SDK folder
       run: tar -zcf sdk/${{ matrix.language }}.tar.gz -C sdk/${{ matrix.language }} .
     - name: Upload artifacts

--- a/provider-ci/test-workflows/cloudflare/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/test-workflows/cloudflare/.github/workflows/run-acceptance-tests.yml
@@ -51,13 +51,6 @@ jobs:
     - uses: pulumi/provider-version-action@v1
       with:
         set-env: 'PROVIDER_VERSION'
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v4
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-        ref: deca2c5c6015ad7aaea6f572a1c2b198ca323592
-    - run: echo "ci-scripts" >> .git/info/exclude # actions/checkout#197
     - name: Install Go
       uses: actions/setup-go@v5
       with:
@@ -120,7 +113,7 @@ jobs:
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
-      run: ./ci-scripts/ci/check-worktree-is-clean
+      uses: pulumi/git-status-check-action@v1
     - name: Compress SDK folder
       run: tar -zcf sdk/${{ matrix.language }}.tar.gz -C sdk/${{ matrix.language }} .
     - name: Upload artifacts

--- a/provider-ci/test-workflows/docker/.github/workflows/master.yml
+++ b/provider-ci/test-workflows/docker/.github/workflows/master.yml
@@ -54,13 +54,6 @@ jobs:
     - uses: pulumi/provider-version-action@v1
       with:
         set-env: 'PROVIDER_VERSION'
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v4
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-        ref: deca2c5c6015ad7aaea6f572a1c2b198ca323592
-    - run: echo "ci-scripts" >> .git/info/exclude # actions/checkout#197
     - name: Install Go
       uses: actions/setup-go@v5
       with:
@@ -123,7 +116,7 @@ jobs:
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
-      run: ./ci-scripts/ci/check-worktree-is-clean
+      uses: pulumi/git-status-check-action@v1
     - name: Compress SDK folder
       run: tar -zcf sdk/${{ matrix.language }}.tar.gz -C sdk/${{ matrix.language }} .
     - name: Upload artifacts

--- a/provider-ci/test-workflows/docker/.github/workflows/prerelease.yml
+++ b/provider-ci/test-workflows/docker/.github/workflows/prerelease.yml
@@ -55,13 +55,6 @@ jobs:
     - uses: pulumi/provider-version-action@v1
       with:
         set-env: 'PROVIDER_VERSION'
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v4
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-        ref: deca2c5c6015ad7aaea6f572a1c2b198ca323592
-    - run: echo "ci-scripts" >> .git/info/exclude # actions/checkout#197
     - name: Install Go
       uses: actions/setup-go@v5
       with:
@@ -124,7 +117,7 @@ jobs:
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
-      run: ./ci-scripts/ci/check-worktree-is-clean
+      uses: pulumi/git-status-check-action@v1
     - name: Compress SDK folder
       run: tar -zcf sdk/${{ matrix.language }}.tar.gz -C sdk/${{ matrix.language }} .
     - name: Upload artifacts

--- a/provider-ci/test-workflows/docker/.github/workflows/release.yml
+++ b/provider-ci/test-workflows/docker/.github/workflows/release.yml
@@ -54,13 +54,6 @@ jobs:
     - uses: pulumi/provider-version-action@v1
       with:
         set-env: 'PROVIDER_VERSION'
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v4
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-        ref: deca2c5c6015ad7aaea6f572a1c2b198ca323592
-    - run: echo "ci-scripts" >> .git/info/exclude # actions/checkout#197
     - name: Install Go
       uses: actions/setup-go@v5
       with:
@@ -123,7 +116,7 @@ jobs:
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
-      run: ./ci-scripts/ci/check-worktree-is-clean
+      uses: pulumi/git-status-check-action@v1
     - name: Compress SDK folder
       run: tar -zcf sdk/${{ matrix.language }}.tar.gz -C sdk/${{ matrix.language }} .
     - name: Upload artifacts

--- a/provider-ci/test-workflows/docker/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/test-workflows/docker/.github/workflows/run-acceptance-tests.yml
@@ -64,13 +64,6 @@ jobs:
     - uses: pulumi/provider-version-action@v1
       with:
         set-env: 'PROVIDER_VERSION'
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v4
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-        ref: deca2c5c6015ad7aaea6f572a1c2b198ca323592
-    - run: echo "ci-scripts" >> .git/info/exclude # actions/checkout#197
     - name: Install Go
       uses: actions/setup-go@v5
       with:
@@ -133,7 +126,7 @@ jobs:
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
-      run: ./ci-scripts/ci/check-worktree-is-clean
+      uses: pulumi/git-status-check-action@v1
     - name: Compress SDK folder
       run: tar -zcf sdk/${{ matrix.language }}.tar.gz -C sdk/${{ matrix.language }} .
     - name: Upload artifacts


### PR DESCRIPTION
Avoid using ci-scripts for checking if the worktree is clean - use the new dedicated action instead.

The motivation for this change is to make it easier to allow specific changes to be allowed once we start injecting versions into SDKs during generation.

This leaves our only usage of ci-scripts for running `ci-scripts/ci/publish-tfgen-package`.

Use new version action in native providers too (missed from https://github.com/pulumi/ci-mgmt/pull/900). Once this is merged, each native provider can update its makefile to use the version variable rather than calling `pulumictl get version`. Then we can can remove the fetching of tags.