### PR TITLE
Add option to enable go-sdk push publishing

### DIFF
--- a/provider-ci/Makefile
+++ b/provider-ci/Makefile
@@ -39,7 +39,7 @@ providers/%/config.yaml:
 	curl "https://raw.githubusercontent.com/pulumi/pulumi-$*/$B/.ci-mgmt.yaml" > $F
 
 providers/%/repo: bin/provider-ci providers/%/config.yaml
-	@./bin/provider-ci generate \
+	./bin/provider-ci generate \
 		--name pulumi/pulumi-$* \
 		--out ./providers/$*/repo \
 		--template bridged-provider \

--- a/provider-ci/internal/pkg/templates/bridged-provider.config.yaml
+++ b/provider-ci/internal/pkg/templates/bridged-provider.config.yaml
@@ -95,3 +95,12 @@ actionVersions:
 publish:
   publisherAction: pulumi/pulumi-package-publisher@v0.0.15
   sdk: all
+  goSdk:
+    # Set to `true` to use the below configuration to push a new commit somewhere else.
+    usePush: false
+    # By default we'll push back to its own repository as a standalone, tagged commit.
+    repository: ${{ github.repository }}
+    baseRef: ${{ github.sha }}
+    source: sdk
+    path: sdk
+    additive: false

--- a/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/release.yml
+++ b/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/release.yml
@@ -149,9 +149,20 @@ jobs:
         repo: pulumi/pulumictl
     - id: version
       uses: pulumi/provider-version-action@v1
+#{{- if .Config.publish.goSdk.usePush }}#
+    - uses: pulumi/publish-go-sdk-action@v1
+      with:
+        repository: #{{ .Config.publish.goSdk.repository }}#
+        base-ref: #{{ .Config.publish.goSdk.baseRef }}#
+        source: #{{ .Config.publish.goSdk.source }}#
+        path: #{{ .Config.publish.goSdk.path }}#
+        version: ${{ steps.version.outputs.version }}
+        additive: #{{ .Config.publish.goSdk.additive }}#
+#{{- else }}#
     - name: Add SDK version tag
       run: git tag "sdk/v${{ steps.version.outputs.version }}" && git push origin
         "sdk/v${{ steps.version.outputs.version }}"
+#{{- end }}#
 
   clean_up_release_labels:
     name: Clean up release labels


### PR DESCRIPTION
- Add option `publish.goSdk.usePush` which can be set to `true` to push a standalone commit for the Go SDK.
- Add options for underlying action properties to control where the SDK is pushed to.

This is disabled for the initial roll-out resulting in no change, but can be enabled on a per-provider basis as we also enable embedding the provider version number in the generated SDK.

Uses https://github.com/pulumi/publish-go-sdk-action for Go SDK publishing