### PR TITLE
Update golangci-lint version

### DIFF
--- a/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/lint.yml
+++ b/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/lint.yml
@@ -24,7 +24,7 @@ jobs:
       uses: actions/setup-go@v5
       with:
         # The versions of golangci-lint and setup-go here cross-depend and need to update together.
-        go-version: 1.21
+        go-version: 1.22
         # Either this action or golangci-lint needs to disable the cache
         cache: false
     - name: disarm go:embed directives to enable lint
@@ -37,7 +37,7 @@ jobs:
     - name: golangci-lint
       uses: golangci/golangci-lint-action@v4
       with:
-        version: v1.55.2
+        version: v1.58.0
         working-directory: provider
     - if: failure() && github.event_name == 'push'
       name: Notify Slack

--- a/provider-ci/test-workflows/aws/.github/workflows/lint.yml
+++ b/provider-ci/test-workflows/aws/.github/workflows/lint.yml
@@ -49,7 +49,7 @@ jobs:
       uses: actions/setup-go@v5
       with:
         # The versions of golangci-lint and setup-go here cross-depend and need to update together.
-        go-version: 1.21
+        go-version: 1.22
         # Either this action or golangci-lint needs to disable the cache
         cache: false
     - name: disarm go:embed directives to enable lint
@@ -62,7 +62,7 @@ jobs:
     - name: golangci-lint
       uses: golangci/golangci-lint-action@v4
       with:
-        version: v1.55.2
+        version: v1.58.0
         working-directory: provider
     - if: failure() && github.event_name == 'push'
       name: Notify Slack

--- a/provider-ci/test-workflows/cloudflare/.github/workflows/lint.yml
+++ b/provider-ci/test-workflows/cloudflare/.github/workflows/lint.yml
@@ -47,7 +47,7 @@ jobs:
       uses: actions/setup-go@v5
       with:
         # The versions of golangci-lint and setup-go here cross-depend and need to update together.
-        go-version: 1.21
+        go-version: 1.22
         # Either this action or golangci-lint needs to disable the cache
         cache: false
     - name: disarm go:embed directives to enable lint
@@ -60,7 +60,7 @@ jobs:
     - name: golangci-lint
       uses: golangci/golangci-lint-action@v4
       with:
-        version: v1.55.2
+        version: v1.58.0
         working-directory: provider
     - if: failure() && github.event_name == 'push'
       name: Notify Slack

--- a/provider-ci/test-workflows/docker/.github/workflows/lint.yml
+++ b/provider-ci/test-workflows/docker/.github/workflows/lint.yml
@@ -60,7 +60,7 @@ jobs:
       uses: actions/setup-go@v5
       with:
         # The versions of golangci-lint and setup-go here cross-depend and need to update together.
-        go-version: 1.21
+        go-version: 1.22
         # Either this action or golangci-lint needs to disable the cache
         cache: false
     - name: disarm go:embed directives to enable lint
@@ -73,7 +73,7 @@ jobs:
     - name: golangci-lint
       uses: golangci/golangci-lint-action@v4
       with:
-        version: v1.55.2
+        version: v1.58.0
         working-directory: provider
     - if: failure() && github.event_name == 'push'
       name: Notify Slack


### PR DESCRIPTION
This is necessary to merge https://github.com/pulumi/pulumi-tailscale/pull/408, since
before we were seeing spurious lint errors:

```
 Running [/home/runner/golangci-lint-1.55.2-linux-amd64/golangci-lint run --out-format=github-actions --path-prefix=provider] in [/home/runner/work/pulumi-tailscale/pulumi-tailscale/provider] ...
  Error: cannot range over addrs.Len() (value of type int) (typecheck)
  Error: cannot range over rr.Len() (value of type int) (typecheck)
  Error: cannot range over rr.Len() (value of type int) (typecheck)
  Error: cannot range over in.Len() (value of type int) (typecheck)

  Error: issues found
```

https://github.com/pulumi/pulumi-tailscale/actions/runs/8946537237/job/24577325007?pr=408
shows that this change runs as expected.