### PR TITLE
Add worktreeAllowedChanges config option

### DIFF
--- a/provider-ci/internal/pkg/templates/bridged-provider.config.yaml
+++ b/provider-ci/internal/pkg/templates/bridged-provider.config.yaml
@@ -104,3 +104,4 @@ publish:
     source: sdk
     path: sdk
     additive: false
+worktreeAllowedChanges: ''

--- a/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/build_sdk.splice
+++ b/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/build_sdk.splice
@@ -56,6 +56,11 @@
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
       uses: pulumi/git-status-check-action@v1
+#{{- if .Config.worktreeAllowedChanges }}#
+      with:
+        allowed-changes: |
+#{{ .Config.worktreeAllowedChanges | indent 10 }}#
+#{{- end }}#
     - name: Compress SDK folder
       run: tar -zcf sdk/${{ matrix.language }}.tar.gz -C sdk/${{ matrix.language }} .
     - name: Upload artifacts


### PR DESCRIPTION
- Default to having no effect.
- This is needed as we start to onboard providers into embedding version numbers in SDKs.