### PR TITLE
Add ise provider to ci-mgmt 

### DIFF
--- a/provider-ci/providers.json
+++ b/provider-ci/providers.json
@@ -29,6 +29,7 @@
     "gitlab",
     "hcloud",
     "http",
+    "ise",
     "kafka",
     "keycloak",
     "kong",


### PR DESCRIPTION
Towards https://github.com/pulumi/home/issues/3395

Brings the pulumi-ise provider repository under ci-mgmt so we can maintain it with the rest of the bridged provider fleet. 