### PR TITLE
Upgrade golangci-lint-action to latest v6

### DIFF
--- a/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/lint.yml
+++ b/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/lint.yml
@@ -35,7 +35,7 @@ jobs:
       continue-on-error: true
       run: make upstream
     - name: golangci-lint
-      uses: golangci/golangci-lint-action@v4
+      uses: golangci/golangci-lint-action@v6
       with:
         version: v1.58.0
         working-directory: provider

--- a/provider-ci/test-workflows/aws/.github/workflows/lint.yml
+++ b/provider-ci/test-workflows/aws/.github/workflows/lint.yml
@@ -60,7 +60,7 @@ jobs:
       continue-on-error: true
       run: make upstream
     - name: golangci-lint
-      uses: golangci/golangci-lint-action@v4
+      uses: golangci/golangci-lint-action@v6
       with:
         version: v1.58.0
         working-directory: provider

--- a/provider-ci/test-workflows/cloudflare/.github/workflows/lint.yml
+++ b/provider-ci/test-workflows/cloudflare/.github/workflows/lint.yml
@@ -58,7 +58,7 @@ jobs:
       continue-on-error: true
       run: make upstream
     - name: golangci-lint
-      uses: golangci/golangci-lint-action@v4
+      uses: golangci/golangci-lint-action@v6
       with:
         version: v1.58.0
         working-directory: provider

--- a/provider-ci/test-workflows/docker/.github/workflows/lint.yml
+++ b/provider-ci/test-workflows/docker/.github/workflows/lint.yml
@@ -71,7 +71,7 @@ jobs:
       continue-on-error: true
       run: make upstream
     - name: golangci-lint
-      uses: golangci/golangci-lint-action@v4
+      uses: golangci/golangci-lint-action@v6
       with:
         version: v1.58.0
         working-directory: provider


### PR DESCRIPTION
Motivated by a failure of the [lint step of the pulumi-azure build](https://github.com/pulumi/pulumi-azure/actions/runs/8980005852/job/24662960390?pr=2007).
> level=error msg=“Running error: can’t run linter goanalysis_metalinter\nbuildir: failed to load package integration: could not load export data: no export data for \“[github.com/pulumi/pulumi/pkg/v3/testing/integration](http://github.com/pulumi/pulumi/pkg/v3/testing/integration)\“”

This error message can have several causes. One of them is issues with the Go module cache. golangci/golangci-lint-action and  actions/setup-go compete in their default settings for which one is going to be installing the dependencies, potentially causing a "cache race". 

However, [v5 of golangci-lint-action](https://github.com/golangci/golangci-lint-action/releases) has
> feat: remove Go cache management

in the changelog. So, let's try to upgrade.