### PR TITLE
Download & restore Go SDK before pushing

### DIFF
--- a/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/release.yml
+++ b/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/release.yml
@@ -150,6 +150,15 @@ jobs:
     - id: version
       uses: pulumi/provider-version-action@v1
 #{{- if .Config.publish.goSdk.usePush }}#
+    - name: Download Go SDK
+      uses: actions/download-artifact@v4
+      with:
+        name: go-sdk.tar.gz
+        path: ${{ github.workspace }}/sdk/
+    - name: Uncompress Go SDK
+      run: tar -zxf ${{ github.workspace }}/sdk/go.tar.gz -C
+        ${{ github.workspace }}/sdk/go
+      shell: bash
     - uses: pulumi/publish-go-sdk-action@v1
       with:
         repository: #{{ .Config.publish.goSdk.repository }}#


### PR DESCRIPTION
- Ensure we have the SDK with the latest version number included before publishing.