### PR TITLE
Add pulumi-meraki to ci-mgmt

### DIFF
--- a/provider-ci/providers.json
+++ b/provider-ci/providers.json
@@ -37,6 +37,7 @@
     "linode",
     "local",
     "mailgun",
+    "meraki",
     "minio",
     "mongodbatlas",
     "mysql",


### PR DESCRIPTION
Towards https://github.com/pulumi/home/issues/3396

Brings the pulumi-meraki provider repository under ci-mgmt so we can maintain it with the rest of the bridged provider fleet.