### PR TITLE
Remove unshallow clone

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -14,8 +14,6 @@ jobs:
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v4
-      - name: Unshallow clone for tags
-        run: git fetch --prune --unshallow --tags
       - name: Install pulumictl
         uses: jaxxstorm/action-install-gh-release@v1.11.0
         with:
@@ -33,8 +31,6 @@ jobs:
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v4
-      - name: Unshallow clone for tags
-        run: git fetch --prune --unshallow --tags
       - name: Install pulumictl
         uses: jaxxstorm/action-install-gh-release@v1.11.0
         with:

--- a/.github/workflows/update-workflows.yml
+++ b/.github/workflows/update-workflows.yml
@@ -57,11 +57,6 @@ jobs:
           repository: pulumi/pulumi-${{ inputs.provider_name }}
           path: pulumi-${{ inputs.provider_name }}
           token: ${{ secrets.PULUMI_BOT_TOKEN }}
-      - name: Unshallow clone for tags
-        run: |
-          DIR="$PWD/pulumi-${{ inputs.provider_name }}"
-          cd "$DIR"
-          git fetch --prune --unshallow --tags
       - name: Initialize submodule in pulumi-${{ inputs.provider_name }}
         run: cd pulumi-${{ inputs.provider_name }} && make upstream && cd ..
         continue-on-error: true

--- a/native-provider-ci/providers/aws-native/repo/.github/workflows/build.yml
+++ b/native-provider-ci/providers/aws-native/repo/.github/workflows/build.yml
@@ -55,8 +55,6 @@ jobs:
       uses: pulumi/provider-version-action@v1
       with:
         set-env: PROVIDER_VERSION
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
     - name: Install Go
       uses: actions/setup-go@v5
       with:
@@ -162,8 +160,6 @@ jobs:
       uses: pulumi/provider-version-action@v1
       with:
         set-env: PROVIDER_VERSION
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
     - name: Install Go
       uses: actions/setup-go@v5
       with:
@@ -267,8 +263,6 @@ jobs:
       uses: pulumi/provider-version-action@v1
       with:
         set-env: PROVIDER_VERSION
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
     - name: Install Go
       uses: actions/setup-go@v5
       with:
@@ -373,8 +367,6 @@ jobs:
       uses: pulumi/provider-version-action@v1
       with:
         set-env: PROVIDER_VERSION
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
     - name: Install Go
       uses: actions/setup-go@v5
       with:
@@ -430,8 +422,6 @@ jobs:
         path: ci-scripts
         repository: pulumi/scripts
     - run: echo "ci-scripts" >> .git/info/exclude
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
     - name: Install Go
       uses: actions/setup-go@v5
       with:
@@ -509,8 +499,6 @@ jobs:
       uses: pulumi/provider-version-action@v1
       with:
         set-env: PROVIDER_VERSION
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
     - name: Install Go
       uses: actions/setup-go@v5
       with:

--- a/native-provider-ci/providers/aws-native/repo/.github/workflows/cf2pulumi-release.yml
+++ b/native-provider-ci/providers/aws-native/repo/.github/workflows/cf2pulumi-release.yml
@@ -46,8 +46,6 @@ jobs:
       uses: pulumi/provider-version-action@v1
       with:
         set-env: PROVIDER_VERSION
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
     - name: Install pulumictl
       uses: jaxxstorm/action-install-gh-release@v1.11.0
       with:

--- a/native-provider-ci/providers/aws-native/repo/.github/workflows/nightly-sdk-generation.yml
+++ b/native-provider-ci/providers/aws-native/repo/.github/workflows/nightly-sdk-generation.yml
@@ -46,8 +46,6 @@ jobs:
       uses: pulumi/provider-version-action@v1
       with:
         set-env: PROVIDER_VERSION
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
     - name: Install Go
       uses: actions/setup-go@v5
       with:

--- a/native-provider-ci/providers/aws-native/repo/.github/workflows/prerelease.yml
+++ b/native-provider-ci/providers/aws-native/repo/.github/workflows/prerelease.yml
@@ -47,8 +47,6 @@ jobs:
       uses: pulumi/provider-version-action@v1
       with:
         set-env: PROVIDER_VERSION
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
     - name: Install Go
       uses: actions/setup-go@v5
       with:
@@ -154,8 +152,6 @@ jobs:
       uses: pulumi/provider-version-action@v1
       with:
         set-env: PROVIDER_VERSION
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
     - name: Install Go
       uses: actions/setup-go@v5
       with:
@@ -258,8 +254,6 @@ jobs:
       uses: pulumi/provider-version-action@v1
       with:
         set-env: PROVIDER_VERSION
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
     - name: Install Go
       uses: actions/setup-go@v5
       with:
@@ -364,8 +358,6 @@ jobs:
       uses: pulumi/provider-version-action@v1
       with:
         set-env: PROVIDER_VERSION
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
     - name: Install Go
       uses: actions/setup-go@v5
       with:
@@ -421,8 +413,6 @@ jobs:
         path: ci-scripts
         repository: pulumi/scripts
     - run: echo "ci-scripts" >> .git/info/exclude
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
     - name: Install Go
       uses: actions/setup-go@v5
       with:
@@ -500,8 +490,6 @@ jobs:
       uses: pulumi/provider-version-action@v1
       with:
         set-env: PROVIDER_VERSION
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
     - name: Install Go
       uses: actions/setup-go@v5
       with:

--- a/native-provider-ci/providers/aws-native/repo/.github/workflows/release.yml
+++ b/native-provider-ci/providers/aws-native/repo/.github/workflows/release.yml
@@ -47,8 +47,6 @@ jobs:
       uses: pulumi/provider-version-action@v1
       with:
         set-env: PROVIDER_VERSION
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
     - name: Install Go
       uses: actions/setup-go@v5
       with:
@@ -154,8 +152,6 @@ jobs:
       uses: pulumi/provider-version-action@v1
       with:
         set-env: PROVIDER_VERSION
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
     - name: Install Go
       uses: actions/setup-go@v5
       with:
@@ -258,8 +254,6 @@ jobs:
       uses: pulumi/provider-version-action@v1
       with:
         set-env: PROVIDER_VERSION
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
     - name: Install Go
       uses: actions/setup-go@v5
       with:
@@ -364,8 +358,6 @@ jobs:
       uses: pulumi/provider-version-action@v1
       with:
         set-env: PROVIDER_VERSION
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
     - name: Install Go
       uses: actions/setup-go@v5
       with:
@@ -421,8 +413,6 @@ jobs:
         path: ci-scripts
         repository: pulumi/scripts
     - run: echo "ci-scripts" >> .git/info/exclude
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
     - name: Install Go
       uses: actions/setup-go@v5
       with:
@@ -500,8 +490,6 @@ jobs:
       uses: pulumi/provider-version-action@v1
       with:
         set-env: PROVIDER_VERSION
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
     - name: Install Go
       uses: actions/setup-go@v5
       with:

--- a/native-provider-ci/providers/aws-native/repo/.github/workflows/run-acceptance-tests.yml
+++ b/native-provider-ci/providers/aws-native/repo/.github/workflows/run-acceptance-tests.yml
@@ -72,8 +72,6 @@ jobs:
       uses: pulumi/provider-version-action@v1
       with:
         set-env: PROVIDER_VERSION
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
     - name: Install Go
       uses: actions/setup-go@v5
       with:
@@ -182,8 +180,6 @@ jobs:
       uses: pulumi/provider-version-action@v1
       with:
         set-env: PROVIDER_VERSION
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
     - name: Install Go
       uses: actions/setup-go@v5
       with:
@@ -290,8 +286,6 @@ jobs:
       uses: pulumi/provider-version-action@v1
       with:
         set-env: PROVIDER_VERSION
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
     - name: Install Go
       uses: actions/setup-go@v5
       with:

--- a/native-provider-ci/providers/aws-native/repo/.github/workflows/weekly-pulumi-update.yml
+++ b/native-provider-ci/providers/aws-native/repo/.github/workflows/weekly-pulumi-update.yml
@@ -45,8 +45,6 @@ jobs:
       uses: pulumi/provider-version-action@v1
       with:
         set-env: PROVIDER_VERSION
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
     - name: Install Go
       uses: actions/setup-go@v5
       with:

--- a/native-provider-ci/providers/command/repo/.github/workflows/build.yml
+++ b/native-provider-ci/providers/command/repo/.github/workflows/build.yml
@@ -55,8 +55,6 @@ jobs:
       uses: pulumi/provider-version-action@v1
       with:
         set-env: PROVIDER_VERSION
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
     - name: Install Go
       uses: actions/setup-go@v5
       with:
@@ -126,8 +124,6 @@ jobs:
       uses: pulumi/provider-version-action@v1
       with:
         set-env: PROVIDER_VERSION
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
     - name: Install Go
       uses: actions/setup-go@v5
       with:
@@ -227,8 +223,6 @@ jobs:
       uses: pulumi/provider-version-action@v1
       with:
         set-env: PROVIDER_VERSION
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
     - name: Install Go
       uses: actions/setup-go@v5
       with:
@@ -333,8 +327,6 @@ jobs:
       uses: pulumi/provider-version-action@v1
       with:
         set-env: PROVIDER_VERSION
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
     - name: Install Go
       uses: actions/setup-go@v5
       with:
@@ -399,8 +391,6 @@ jobs:
         path: ci-scripts
         repository: pulumi/scripts
     - run: echo "ci-scripts" >> .git/info/exclude
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
     - name: Install Go
       uses: actions/setup-go@v5
       with:
@@ -478,8 +468,6 @@ jobs:
       uses: pulumi/provider-version-action@v1
       with:
         set-env: PROVIDER_VERSION
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
     - name: Install Go
       uses: actions/setup-go@v5
       with:

--- a/native-provider-ci/providers/command/repo/.github/workflows/prerelease.yml
+++ b/native-provider-ci/providers/command/repo/.github/workflows/prerelease.yml
@@ -47,8 +47,6 @@ jobs:
       uses: pulumi/provider-version-action@v1
       with:
         set-env: PROVIDER_VERSION
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
     - name: Install Go
       uses: actions/setup-go@v5
       with:
@@ -118,8 +116,6 @@ jobs:
       uses: pulumi/provider-version-action@v1
       with:
         set-env: PROVIDER_VERSION
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
     - name: Install Go
       uses: actions/setup-go@v5
       with:
@@ -218,8 +214,6 @@ jobs:
       uses: pulumi/provider-version-action@v1
       with:
         set-env: PROVIDER_VERSION
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
     - name: Install Go
       uses: actions/setup-go@v5
       with:
@@ -324,8 +318,6 @@ jobs:
       uses: pulumi/provider-version-action@v1
       with:
         set-env: PROVIDER_VERSION
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
     - name: Install Go
       uses: actions/setup-go@v5
       with:
@@ -390,8 +382,6 @@ jobs:
         path: ci-scripts
         repository: pulumi/scripts
     - run: echo "ci-scripts" >> .git/info/exclude
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
     - name: Install Go
       uses: actions/setup-go@v5
       with:
@@ -469,8 +459,6 @@ jobs:
       uses: pulumi/provider-version-action@v1
       with:
         set-env: PROVIDER_VERSION
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
     - name: Install Go
       uses: actions/setup-go@v5
       with:

--- a/native-provider-ci/providers/command/repo/.github/workflows/release.yml
+++ b/native-provider-ci/providers/command/repo/.github/workflows/release.yml
@@ -47,8 +47,6 @@ jobs:
       uses: pulumi/provider-version-action@v1
       with:
         set-env: PROVIDER_VERSION
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
     - name: Install Go
       uses: actions/setup-go@v5
       with:
@@ -118,8 +116,6 @@ jobs:
       uses: pulumi/provider-version-action@v1
       with:
         set-env: PROVIDER_VERSION
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
     - name: Install Go
       uses: actions/setup-go@v5
       with:
@@ -218,8 +214,6 @@ jobs:
       uses: pulumi/provider-version-action@v1
       with:
         set-env: PROVIDER_VERSION
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
     - name: Install Go
       uses: actions/setup-go@v5
       with:
@@ -324,8 +318,6 @@ jobs:
       uses: pulumi/provider-version-action@v1
       with:
         set-env: PROVIDER_VERSION
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
     - name: Install Go
       uses: actions/setup-go@v5
       with:
@@ -390,8 +382,6 @@ jobs:
         path: ci-scripts
         repository: pulumi/scripts
     - run: echo "ci-scripts" >> .git/info/exclude
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
     - name: Install Go
       uses: actions/setup-go@v5
       with:
@@ -469,8 +459,6 @@ jobs:
       uses: pulumi/provider-version-action@v1
       with:
         set-env: PROVIDER_VERSION
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
     - name: Install Go
       uses: actions/setup-go@v5
       with:

--- a/native-provider-ci/providers/command/repo/.github/workflows/run-acceptance-tests.yml
+++ b/native-provider-ci/providers/command/repo/.github/workflows/run-acceptance-tests.yml
@@ -72,8 +72,6 @@ jobs:
       uses: pulumi/provider-version-action@v1
       with:
         set-env: PROVIDER_VERSION
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
     - name: Install Go
       uses: actions/setup-go@v5
       with:
@@ -146,8 +144,6 @@ jobs:
       uses: pulumi/provider-version-action@v1
       with:
         set-env: PROVIDER_VERSION
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
     - name: Install Go
       uses: actions/setup-go@v5
       with:
@@ -250,8 +246,6 @@ jobs:
       uses: pulumi/provider-version-action@v1
       with:
         set-env: PROVIDER_VERSION
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
     - name: Install Go
       uses: actions/setup-go@v5
       with:

--- a/native-provider-ci/providers/command/repo/.github/workflows/weekly-pulumi-update.yml
+++ b/native-provider-ci/providers/command/repo/.github/workflows/weekly-pulumi-update.yml
@@ -45,8 +45,6 @@ jobs:
       uses: pulumi/provider-version-action@v1
       with:
         set-env: PROVIDER_VERSION
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
     - name: Install Go
       uses: actions/setup-go@v5
       with:

--- a/native-provider-ci/providers/docker-build/repo/.github/workflows/build.yml
+++ b/native-provider-ci/providers/docker-build/repo/.github/workflows/build.yml
@@ -69,8 +69,6 @@ jobs:
       uses: pulumi/provider-version-action@v1
       with:
         set-env: PROVIDER_VERSION
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
     - name: Install Go
       uses: actions/setup-go@v5
       with:
@@ -174,8 +172,6 @@ jobs:
       uses: pulumi/provider-version-action@v1
       with:
         set-env: PROVIDER_VERSION
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
     - name: Install Go
       uses: actions/setup-go@v5
       with:
@@ -277,8 +273,6 @@ jobs:
       uses: pulumi/provider-version-action@v1
       with:
         set-env: PROVIDER_VERSION
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
     - name: Install Go
       uses: actions/setup-go@v5
       with:
@@ -395,8 +389,6 @@ jobs:
       uses: pulumi/provider-version-action@v1
       with:
         set-env: PROVIDER_VERSION
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
     - name: Install Go
       uses: actions/setup-go@v5
       with:
@@ -461,8 +453,6 @@ jobs:
         path: ci-scripts
         repository: pulumi/scripts
     - run: echo "ci-scripts" >> .git/info/exclude
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
     - name: Install Go
       uses: actions/setup-go@v5
       with:
@@ -540,8 +530,6 @@ jobs:
       uses: pulumi/provider-version-action@v1
       with:
         set-env: PROVIDER_VERSION
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
     - name: Install Go
       uses: actions/setup-go@v5
       with:

--- a/native-provider-ci/providers/docker-build/repo/.github/workflows/prerelease.yml
+++ b/native-provider-ci/providers/docker-build/repo/.github/workflows/prerelease.yml
@@ -61,8 +61,6 @@ jobs:
       uses: pulumi/provider-version-action@v1
       with:
         set-env: PROVIDER_VERSION
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
     - name: Install Go
       uses: actions/setup-go@v5
       with:
@@ -166,8 +164,6 @@ jobs:
       uses: pulumi/provider-version-action@v1
       with:
         set-env: PROVIDER_VERSION
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
     - name: Install Go
       uses: actions/setup-go@v5
       with:
@@ -268,8 +264,6 @@ jobs:
       uses: pulumi/provider-version-action@v1
       with:
         set-env: PROVIDER_VERSION
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
     - name: Install Go
       uses: actions/setup-go@v5
       with:
@@ -386,8 +380,6 @@ jobs:
       uses: pulumi/provider-version-action@v1
       with:
         set-env: PROVIDER_VERSION
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
     - name: Install Go
       uses: actions/setup-go@v5
       with:
@@ -452,8 +444,6 @@ jobs:
         path: ci-scripts
         repository: pulumi/scripts
     - run: echo "ci-scripts" >> .git/info/exclude
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
     - name: Install Go
       uses: actions/setup-go@v5
       with:
@@ -531,8 +521,6 @@ jobs:
       uses: pulumi/provider-version-action@v1
       with:
         set-env: PROVIDER_VERSION
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
     - name: Install Go
       uses: actions/setup-go@v5
       with:

--- a/native-provider-ci/providers/docker-build/repo/.github/workflows/release.yml
+++ b/native-provider-ci/providers/docker-build/repo/.github/workflows/release.yml
@@ -61,8 +61,6 @@ jobs:
       uses: pulumi/provider-version-action@v1
       with:
         set-env: PROVIDER_VERSION
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
     - name: Install Go
       uses: actions/setup-go@v5
       with:
@@ -166,8 +164,6 @@ jobs:
       uses: pulumi/provider-version-action@v1
       with:
         set-env: PROVIDER_VERSION
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
     - name: Install Go
       uses: actions/setup-go@v5
       with:
@@ -268,8 +264,6 @@ jobs:
       uses: pulumi/provider-version-action@v1
       with:
         set-env: PROVIDER_VERSION
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
     - name: Install Go
       uses: actions/setup-go@v5
       with:
@@ -386,8 +380,6 @@ jobs:
       uses: pulumi/provider-version-action@v1
       with:
         set-env: PROVIDER_VERSION
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
     - name: Install Go
       uses: actions/setup-go@v5
       with:
@@ -452,8 +444,6 @@ jobs:
         path: ci-scripts
         repository: pulumi/scripts
     - run: echo "ci-scripts" >> .git/info/exclude
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
     - name: Install Go
       uses: actions/setup-go@v5
       with:
@@ -531,8 +521,6 @@ jobs:
       uses: pulumi/provider-version-action@v1
       with:
         set-env: PROVIDER_VERSION
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
     - name: Install Go
       uses: actions/setup-go@v5
       with:

--- a/native-provider-ci/providers/docker-build/repo/.github/workflows/run-acceptance-tests.yml
+++ b/native-provider-ci/providers/docker-build/repo/.github/workflows/run-acceptance-tests.yml
@@ -86,8 +86,6 @@ jobs:
       uses: pulumi/provider-version-action@v1
       with:
         set-env: PROVIDER_VERSION
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
     - name: Install Go
       uses: actions/setup-go@v5
       with:
@@ -194,8 +192,6 @@ jobs:
       uses: pulumi/provider-version-action@v1
       with:
         set-env: PROVIDER_VERSION
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
     - name: Install Go
       uses: actions/setup-go@v5
       with:
@@ -300,8 +296,6 @@ jobs:
       uses: pulumi/provider-version-action@v1
       with:
         set-env: PROVIDER_VERSION
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
     - name: Install Go
       uses: actions/setup-go@v5
       with:

--- a/native-provider-ci/providers/docker-build/repo/.github/workflows/weekly-pulumi-update.yml
+++ b/native-provider-ci/providers/docker-build/repo/.github/workflows/weekly-pulumi-update.yml
@@ -59,8 +59,6 @@ jobs:
       uses: pulumi/provider-version-action@v1
       with:
         set-env: PROVIDER_VERSION
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
     - name: Install Go
       uses: actions/setup-go@v5
       with:

--- a/native-provider-ci/providers/google-native/repo/.github/workflows/build.yml
+++ b/native-provider-ci/providers/google-native/repo/.github/workflows/build.yml
@@ -61,8 +61,6 @@ jobs:
       uses: pulumi/provider-version-action@v1
       with:
         set-env: PROVIDER_VERSION
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
     - name: Install Go
       uses: actions/setup-go@v5
       with:
@@ -168,8 +166,6 @@ jobs:
       uses: pulumi/provider-version-action@v1
       with:
         set-env: PROVIDER_VERSION
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
     - name: Install Go
       uses: actions/setup-go@v5
       with:
@@ -273,8 +269,6 @@ jobs:
       uses: pulumi/provider-version-action@v1
       with:
         set-env: PROVIDER_VERSION
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
     - name: Install Go
       uses: actions/setup-go@v5
       with:
@@ -382,8 +376,6 @@ jobs:
       uses: pulumi/provider-version-action@v1
       with:
         set-env: PROVIDER_VERSION
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
     - name: Install Go
       uses: actions/setup-go@v5
       with:
@@ -448,8 +440,6 @@ jobs:
         path: ci-scripts
         repository: pulumi/scripts
     - run: echo "ci-scripts" >> .git/info/exclude
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
     - name: Install Go
       uses: actions/setup-go@v5
       with:
@@ -527,8 +517,6 @@ jobs:
       uses: pulumi/provider-version-action@v1
       with:
         set-env: PROVIDER_VERSION
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
     - name: Install Go
       uses: actions/setup-go@v5
       with:

--- a/native-provider-ci/providers/google-native/repo/.github/workflows/nightly-sdk-generation.yml
+++ b/native-provider-ci/providers/google-native/repo/.github/workflows/nightly-sdk-generation.yml
@@ -52,8 +52,6 @@ jobs:
       uses: pulumi/provider-version-action@v1
       with:
         set-env: PROVIDER_VERSION
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
     - name: Install Go
       uses: actions/setup-go@v5
       with:

--- a/native-provider-ci/providers/google-native/repo/.github/workflows/prerelease.yml
+++ b/native-provider-ci/providers/google-native/repo/.github/workflows/prerelease.yml
@@ -53,8 +53,6 @@ jobs:
       uses: pulumi/provider-version-action@v1
       with:
         set-env: PROVIDER_VERSION
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
     - name: Install Go
       uses: actions/setup-go@v5
       with:
@@ -160,8 +158,6 @@ jobs:
       uses: pulumi/provider-version-action@v1
       with:
         set-env: PROVIDER_VERSION
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
     - name: Install Go
       uses: actions/setup-go@v5
       with:
@@ -264,8 +260,6 @@ jobs:
       uses: pulumi/provider-version-action@v1
       with:
         set-env: PROVIDER_VERSION
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
     - name: Install Go
       uses: actions/setup-go@v5
       with:
@@ -373,8 +367,6 @@ jobs:
       uses: pulumi/provider-version-action@v1
       with:
         set-env: PROVIDER_VERSION
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
     - name: Install Go
       uses: actions/setup-go@v5
       with:
@@ -439,8 +431,6 @@ jobs:
         path: ci-scripts
         repository: pulumi/scripts
     - run: echo "ci-scripts" >> .git/info/exclude
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
     - name: Install Go
       uses: actions/setup-go@v5
       with:
@@ -518,8 +508,6 @@ jobs:
       uses: pulumi/provider-version-action@v1
       with:
         set-env: PROVIDER_VERSION
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
     - name: Install Go
       uses: actions/setup-go@v5
       with:

--- a/native-provider-ci/providers/google-native/repo/.github/workflows/release.yml
+++ b/native-provider-ci/providers/google-native/repo/.github/workflows/release.yml
@@ -53,8 +53,6 @@ jobs:
       uses: pulumi/provider-version-action@v1
       with:
         set-env: PROVIDER_VERSION
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
     - name: Install Go
       uses: actions/setup-go@v5
       with:
@@ -160,8 +158,6 @@ jobs:
       uses: pulumi/provider-version-action@v1
       with:
         set-env: PROVIDER_VERSION
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
     - name: Install Go
       uses: actions/setup-go@v5
       with:
@@ -264,8 +260,6 @@ jobs:
       uses: pulumi/provider-version-action@v1
       with:
         set-env: PROVIDER_VERSION
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
     - name: Install Go
       uses: actions/setup-go@v5
       with:
@@ -373,8 +367,6 @@ jobs:
       uses: pulumi/provider-version-action@v1
       with:
         set-env: PROVIDER_VERSION
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
     - name: Install Go
       uses: actions/setup-go@v5
       with:
@@ -439,8 +431,6 @@ jobs:
         path: ci-scripts
         repository: pulumi/scripts
     - run: echo "ci-scripts" >> .git/info/exclude
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
     - name: Install Go
       uses: actions/setup-go@v5
       with:
@@ -518,8 +508,6 @@ jobs:
       uses: pulumi/provider-version-action@v1
       with:
         set-env: PROVIDER_VERSION
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
     - name: Install Go
       uses: actions/setup-go@v5
       with:

--- a/native-provider-ci/providers/google-native/repo/.github/workflows/run-acceptance-tests.yml
+++ b/native-provider-ci/providers/google-native/repo/.github/workflows/run-acceptance-tests.yml
@@ -78,8 +78,6 @@ jobs:
       uses: pulumi/provider-version-action@v1
       with:
         set-env: PROVIDER_VERSION
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
     - name: Install Go
       uses: actions/setup-go@v5
       with:
@@ -188,8 +186,6 @@ jobs:
       uses: pulumi/provider-version-action@v1
       with:
         set-env: PROVIDER_VERSION
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
     - name: Install Go
       uses: actions/setup-go@v5
       with:
@@ -296,8 +292,6 @@ jobs:
       uses: pulumi/provider-version-action@v1
       with:
         set-env: PROVIDER_VERSION
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
     - name: Install Go
       uses: actions/setup-go@v5
       with:

--- a/native-provider-ci/providers/google-native/repo/.github/workflows/weekly-pulumi-update.yml
+++ b/native-provider-ci/providers/google-native/repo/.github/workflows/weekly-pulumi-update.yml
@@ -51,8 +51,6 @@ jobs:
       uses: pulumi/provider-version-action@v1
       with:
         set-env: PROVIDER_VERSION
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
     - name: Install Go
       uses: actions/setup-go@v5
       with:

--- a/native-provider-ci/providers/kubernetes-cert-manager/repo/.github/workflows/build.yml
+++ b/native-provider-ci/providers/kubernetes-cert-manager/repo/.github/workflows/build.yml
@@ -60,8 +60,6 @@ jobs:
       uses: pulumi/provider-version-action@v1
       with:
         set-env: PROVIDER_VERSION
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
     - name: Install Go
       uses: actions/setup-go@v5
       with:
@@ -165,8 +163,6 @@ jobs:
       uses: pulumi/provider-version-action@v1
       with:
         set-env: PROVIDER_VERSION
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
     - name: Install Go
       uses: actions/setup-go@v5
       with:
@@ -268,8 +264,6 @@ jobs:
       uses: pulumi/provider-version-action@v1
       with:
         set-env: PROVIDER_VERSION
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
     - name: Install Go
       uses: actions/setup-go@v5
       with:
@@ -365,8 +359,6 @@ jobs:
       uses: pulumi/provider-version-action@v1
       with:
         set-env: PROVIDER_VERSION
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
     - name: Install Go
       uses: actions/setup-go@v5
       with:
@@ -431,8 +423,6 @@ jobs:
         path: ci-scripts
         repository: pulumi/scripts
     - run: echo "ci-scripts" >> .git/info/exclude
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
     - name: Install Go
       uses: actions/setup-go@v5
       with:
@@ -510,8 +500,6 @@ jobs:
       uses: pulumi/provider-version-action@v1
       with:
         set-env: PROVIDER_VERSION
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
     - name: Install Go
       uses: actions/setup-go@v5
       with:

--- a/native-provider-ci/providers/kubernetes-cert-manager/repo/.github/workflows/prerelease.yml
+++ b/native-provider-ci/providers/kubernetes-cert-manager/repo/.github/workflows/prerelease.yml
@@ -52,8 +52,6 @@ jobs:
       uses: pulumi/provider-version-action@v1
       with:
         set-env: PROVIDER_VERSION
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
     - name: Install Go
       uses: actions/setup-go@v5
       with:
@@ -157,8 +155,6 @@ jobs:
       uses: pulumi/provider-version-action@v1
       with:
         set-env: PROVIDER_VERSION
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
     - name: Install Go
       uses: actions/setup-go@v5
       with:
@@ -259,8 +255,6 @@ jobs:
       uses: pulumi/provider-version-action@v1
       with:
         set-env: PROVIDER_VERSION
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
     - name: Install Go
       uses: actions/setup-go@v5
       with:
@@ -356,8 +350,6 @@ jobs:
       uses: pulumi/provider-version-action@v1
       with:
         set-env: PROVIDER_VERSION
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
     - name: Install Go
       uses: actions/setup-go@v5
       with:
@@ -422,8 +414,6 @@ jobs:
         path: ci-scripts
         repository: pulumi/scripts
     - run: echo "ci-scripts" >> .git/info/exclude
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
     - name: Install Go
       uses: actions/setup-go@v5
       with:
@@ -501,8 +491,6 @@ jobs:
       uses: pulumi/provider-version-action@v1
       with:
         set-env: PROVIDER_VERSION
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
     - name: Install Go
       uses: actions/setup-go@v5
       with:

--- a/native-provider-ci/providers/kubernetes-cert-manager/repo/.github/workflows/release.yml
+++ b/native-provider-ci/providers/kubernetes-cert-manager/repo/.github/workflows/release.yml
@@ -52,8 +52,6 @@ jobs:
       uses: pulumi/provider-version-action@v1
       with:
         set-env: PROVIDER_VERSION
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
     - name: Install Go
       uses: actions/setup-go@v5
       with:
@@ -157,8 +155,6 @@ jobs:
       uses: pulumi/provider-version-action@v1
       with:
         set-env: PROVIDER_VERSION
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
     - name: Install Go
       uses: actions/setup-go@v5
       with:
@@ -259,8 +255,6 @@ jobs:
       uses: pulumi/provider-version-action@v1
       with:
         set-env: PROVIDER_VERSION
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
     - name: Install Go
       uses: actions/setup-go@v5
       with:
@@ -356,8 +350,6 @@ jobs:
       uses: pulumi/provider-version-action@v1
       with:
         set-env: PROVIDER_VERSION
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
     - name: Install Go
       uses: actions/setup-go@v5
       with:
@@ -422,8 +414,6 @@ jobs:
         path: ci-scripts
         repository: pulumi/scripts
     - run: echo "ci-scripts" >> .git/info/exclude
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
     - name: Install Go
       uses: actions/setup-go@v5
       with:
@@ -501,8 +491,6 @@ jobs:
       uses: pulumi/provider-version-action@v1
       with:
         set-env: PROVIDER_VERSION
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
     - name: Install Go
       uses: actions/setup-go@v5
       with:

--- a/native-provider-ci/providers/kubernetes-cert-manager/repo/.github/workflows/run-acceptance-tests.yml
+++ b/native-provider-ci/providers/kubernetes-cert-manager/repo/.github/workflows/run-acceptance-tests.yml
@@ -77,8 +77,6 @@ jobs:
       uses: pulumi/provider-version-action@v1
       with:
         set-env: PROVIDER_VERSION
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
     - name: Install Go
       uses: actions/setup-go@v5
       with:
@@ -185,8 +183,6 @@ jobs:
       uses: pulumi/provider-version-action@v1
       with:
         set-env: PROVIDER_VERSION
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
     - name: Install Go
       uses: actions/setup-go@v5
       with:
@@ -291,8 +287,6 @@ jobs:
       uses: pulumi/provider-version-action@v1
       with:
         set-env: PROVIDER_VERSION
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
     - name: Install Go
       uses: actions/setup-go@v5
       with:

--- a/native-provider-ci/providers/kubernetes-cert-manager/repo/.github/workflows/weekly-pulumi-update.yml
+++ b/native-provider-ci/providers/kubernetes-cert-manager/repo/.github/workflows/weekly-pulumi-update.yml
@@ -50,8 +50,6 @@ jobs:
       uses: pulumi/provider-version-action@v1
       with:
         set-env: PROVIDER_VERSION
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
     - name: Install Go
       uses: actions/setup-go@v5
       with:

--- a/native-provider-ci/providers/kubernetes/repo/.github/workflows/build.yml
+++ b/native-provider-ci/providers/kubernetes/repo/.github/workflows/build.yml
@@ -60,8 +60,6 @@ jobs:
       uses: pulumi/provider-version-action@v1
       with:
         set-env: PROVIDER_VERSION
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
     - name: Install Go
       uses: actions/setup-go@v5
       with:
@@ -167,8 +165,6 @@ jobs:
       uses: pulumi/provider-version-action@v1
       with:
         set-env: PROVIDER_VERSION
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
     - name: Install Go
       uses: actions/setup-go@v5
       with:
@@ -269,8 +265,6 @@ jobs:
       uses: pulumi/provider-version-action@v1
       with:
         set-env: PROVIDER_VERSION
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
     - name: Install Go
       uses: actions/setup-go@v5
       with:
@@ -408,8 +402,6 @@ jobs:
       uses: pulumi/provider-version-action@v1
       with:
         set-env: PROVIDER_VERSION
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
     - name: Install Go
       uses: actions/setup-go@v5
       with:
@@ -474,8 +466,6 @@ jobs:
         path: ci-scripts
         repository: pulumi/scripts
     - run: echo "ci-scripts" >> .git/info/exclude
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
     - name: Install Go
       uses: actions/setup-go@v5
       with:
@@ -553,8 +543,6 @@ jobs:
       uses: pulumi/provider-version-action@v1
       with:
         set-env: PROVIDER_VERSION
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
     - name: Install Go
       uses: actions/setup-go@v5
       with:

--- a/native-provider-ci/providers/kubernetes/repo/.github/workflows/prerelease.yml
+++ b/native-provider-ci/providers/kubernetes/repo/.github/workflows/prerelease.yml
@@ -52,8 +52,6 @@ jobs:
       uses: pulumi/provider-version-action@v1
       with:
         set-env: PROVIDER_VERSION
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
     - name: Install Go
       uses: actions/setup-go@v5
       with:
@@ -159,8 +157,6 @@ jobs:
       uses: pulumi/provider-version-action@v1
       with:
         set-env: PROVIDER_VERSION
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
     - name: Install Go
       uses: actions/setup-go@v5
       with:
@@ -260,8 +256,6 @@ jobs:
       uses: pulumi/provider-version-action@v1
       with:
         set-env: PROVIDER_VERSION
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
     - name: Install Go
       uses: actions/setup-go@v5
       with:
@@ -399,8 +393,6 @@ jobs:
       uses: pulumi/provider-version-action@v1
       with:
         set-env: PROVIDER_VERSION
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
     - name: Install Go
       uses: actions/setup-go@v5
       with:
@@ -465,8 +457,6 @@ jobs:
         path: ci-scripts
         repository: pulumi/scripts
     - run: echo "ci-scripts" >> .git/info/exclude
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
     - name: Install Go
       uses: actions/setup-go@v5
       with:
@@ -544,8 +534,6 @@ jobs:
       uses: pulumi/provider-version-action@v1
       with:
         set-env: PROVIDER_VERSION
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
     - name: Install Go
       uses: actions/setup-go@v5
       with:

--- a/native-provider-ci/providers/kubernetes/repo/.github/workflows/release.yml
+++ b/native-provider-ci/providers/kubernetes/repo/.github/workflows/release.yml
@@ -52,8 +52,6 @@ jobs:
       uses: pulumi/provider-version-action@v1
       with:
         set-env: PROVIDER_VERSION
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
     - name: Install Go
       uses: actions/setup-go@v5
       with:
@@ -159,8 +157,6 @@ jobs:
       uses: pulumi/provider-version-action@v1
       with:
         set-env: PROVIDER_VERSION
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
     - name: Install Go
       uses: actions/setup-go@v5
       with:
@@ -260,8 +256,6 @@ jobs:
       uses: pulumi/provider-version-action@v1
       with:
         set-env: PROVIDER_VERSION
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
     - name: Install Go
       uses: actions/setup-go@v5
       with:
@@ -399,8 +393,6 @@ jobs:
       uses: pulumi/provider-version-action@v1
       with:
         set-env: PROVIDER_VERSION
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
     - name: Install Go
       uses: actions/setup-go@v5
       with:
@@ -465,8 +457,6 @@ jobs:
         path: ci-scripts
         repository: pulumi/scripts
     - run: echo "ci-scripts" >> .git/info/exclude
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
     - name: Install Go
       uses: actions/setup-go@v5
       with:
@@ -544,8 +534,6 @@ jobs:
       uses: pulumi/provider-version-action@v1
       with:
         set-env: PROVIDER_VERSION
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
     - name: Install Go
       uses: actions/setup-go@v5
       with:

--- a/native-provider-ci/providers/kubernetes/repo/.github/workflows/run-acceptance-tests.yml
+++ b/native-provider-ci/providers/kubernetes/repo/.github/workflows/run-acceptance-tests.yml
@@ -78,8 +78,6 @@ jobs:
       uses: pulumi/provider-version-action@v1
       with:
         set-env: PROVIDER_VERSION
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
     - name: Install Go
       uses: actions/setup-go@v5
       with:
@@ -188,8 +186,6 @@ jobs:
       uses: pulumi/provider-version-action@v1
       with:
         set-env: PROVIDER_VERSION
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
     - name: Install Go
       uses: actions/setup-go@v5
       with:
@@ -292,8 +288,6 @@ jobs:
       uses: pulumi/provider-version-action@v1
       with:
         set-env: PROVIDER_VERSION
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
     - name: Install Go
       uses: actions/setup-go@v5
       with:

--- a/native-provider-ci/providers/kubernetes/repo/.github/workflows/weekly-pulumi-update.yml
+++ b/native-provider-ci/providers/kubernetes/repo/.github/workflows/weekly-pulumi-update.yml
@@ -50,8 +50,6 @@ jobs:
       uses: pulumi/provider-version-action@v1
       with:
         set-env: PROVIDER_VERSION
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
     - name: Install Go
       uses: actions/setup-go@v5
       with:

--- a/native-provider-ci/src/steps.ts
+++ b/native-provider-ci/src/steps.ts
@@ -157,17 +157,6 @@ export function CheckoutScriptsRepoSteps(): Step[] {
   ];
 }
 
-export function CheckoutTagsStep(skipProvider?: string): Step {
-  // If a provider is not passed at all then this step will not be skipped.
-  if (skipProvider === "azure-native") {
-    return {};
-  }
-  return {
-    name: "Unshallow clone for tags",
-    run: "git fetch --prune --unshallow --tags",
-  };
-}
-
 export function GoogleAuth(requiresGcp?: boolean): Step {
   if (requiresGcp) {
     return {

--- a/native-provider-ci/src/workflows.ts
+++ b/native-provider-ci/src/workflows.ts
@@ -453,7 +453,6 @@ export class BuildSdkJob implements NormalJob {
     this.steps = [
       steps.CheckoutRepoStep(),
       steps.SetProviderVersionStep(),
-      steps.CheckoutTagsStep(),
       steps.InstallGo(),
       steps.InstallPulumiCtl(),
       steps.InstallPulumiCli(opts.pulumiCLIVersion),
@@ -509,7 +508,6 @@ export class PrerequisitesJob implements NormalJob {
     this.steps = [
       steps.CheckoutRepoStep(),
       steps.SetProviderVersionStep(),
-      steps.CheckoutTagsStep(),
       steps.InstallGo(),
       steps.InstallPulumiCtl(),
       steps.InstallPulumiCli(opts.pulumiCLIVersion),
@@ -587,7 +585,6 @@ export class TestsJob implements NormalJob {
     this.steps = [
       steps.CheckoutRepoStep(),
       steps.SetProviderVersionStep(),
-      steps.CheckoutTagsStep(),
       steps.InstallGo(),
       steps.InstallPulumiCtl(),
       steps.InstallPulumiCli(opts.pulumiCLIVersion),
@@ -757,7 +754,6 @@ export class PublishPrereleaseJob implements NormalJob {
     this.steps = [
       steps.CheckoutRepoStep(),
       steps.SetProviderVersionStep(),
-      steps.CheckoutTagsStep(),
       steps.InstallGo(),
       steps.FreeDiskSpace(this["runs-on"]),
       steps.InstallPulumiCtl(),
@@ -787,7 +783,6 @@ export class PublishJob implements NormalJob {
     this.steps = [
       steps.CheckoutRepoStep(),
       steps.SetProviderVersionStep(),
-      steps.CheckoutTagsStep(),
       steps.InstallGo(),
       steps.FreeDiskSpace(this["runs-on"]),
       steps.InstallPulumiCtl(),
@@ -814,7 +809,6 @@ export class PublishSDKJob implements NormalJob {
       steps.CheckoutRepoStep(),
       steps.SetProviderVersionStep(),
       ...steps.CheckoutScriptsRepoSteps(), // Required for RunPublishSDK
-      steps.CheckoutTagsStep(),
       steps.InstallGo(),
       steps.InstallPulumiCtl(),
       steps.InstallPulumiCli(),
@@ -847,7 +841,6 @@ export class PublishJavaSDKJob implements NormalJob {
     this.steps = [
       steps.CheckoutRepoStep(),
       steps.SetProviderVersionStep(),
-      steps.CheckoutTagsStep(),
       steps.InstallGo(),
       steps.InstallPulumiCtl(),
       steps.InstallPulumiCli(),
@@ -908,7 +901,6 @@ export class Cf2PulumiRelease implements NormalJob {
   steps = [
     steps.CheckoutRepoStep(),
     steps.SetProviderVersionStep(),
-    steps.CheckoutTagsStep(),
     steps.InstallPulumiCtl(),
     steps.InstallGo(goVersion),
     steps.RunGoReleaserWithArgs(
@@ -929,7 +921,6 @@ export class Arm2PulumiRelease implements NormalJob {
   steps = [
     steps.CheckoutRepoStep(),
     steps.SetProviderVersionStep(),
-    steps.CheckoutTagsStep(),
     steps.InstallPulumiCtl(),
     steps.InstallGo(goVersion),
     steps.RunGoReleaserWithArgs(
@@ -978,7 +969,6 @@ export class WeeklyPulumiUpdate implements NormalJob {
     this.steps = [
       steps.CheckoutRepoStep(),
       steps.SetProviderVersionStep(),
-      steps.CheckoutTagsStep(),
       steps.InstallGo(),
       steps.InstallPulumiCtl(),
       steps.InstallPulumiCli(opts.pulumiCLIVersion),
@@ -1007,7 +997,6 @@ export class NightlySdkGeneration implements NormalJob {
       steps.CheckoutRepoStep(),
       steps.SetProviderVersionStep(),
       // Pass the provider here as an option so that it can be skipped if not needed
-      steps.CheckoutTagsStep(opts.provider),
       steps.InstallGo(goVersion),
       steps.InstallPulumiCtl(),
       steps.InstallPulumiCli(opts.pulumiCLIVersion),


### PR DESCRIPTION
We no longer need all tags checked out locally for pulumictl to calculate versions because we now always calculate the version in CI via the provider version action.

Follow-up to #904 and #900 