### PR TITLE
Publish native provider prerelease Go SDKs

### DIFF
--- a/native-provider-ci/providers/aws-native/repo/.github/workflows/prerelease.yml
+++ b/native-provider-ci/providers/aws-native/repo/.github/workflows/prerelease.yml
@@ -540,3 +540,38 @@ jobs:
         arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
         build-root-directory: ./sdk/java
         gradle-version: 7.4.1
+  pubish_go_sdk:
+    runs-on: ubuntu-latest
+    name: publish-go-sdk
+    needs: publish-sdk
+    steps:
+    - name: Checkout Repo
+      uses: actions/checkout@v4
+      with:
+        lfs: true
+    - id: version
+      name: Set Provider Version
+      uses: pulumi/provider-version-action@v1
+      with:
+        set-env: PROVIDER_VERSION
+    - name: Download go SDK
+      uses: actions/download-artifact@v4
+      with:
+        name: go-sdk.tar.gz
+        path: ${{ github.workspace}}/sdk/
+    - name: Uncompress go SDK
+      run: tar -zxf ${{github.workspace}}/sdk/go.tar.gz -C
+        ${{github.workspace}}/sdk/go
+    - name: Publish Go SDK
+      uses: pulumi/publish-go-sdk-action@v1
+      with:
+        repository: ${{ github.repository }}
+        base-ref: ${{ github.sha }}
+        source: sdk
+        path: sdk
+        version: ${{ steps.version.outputs.version }}
+        additive: false
+        files: |-
+          go.*
+          go/**
+          !*.tar.gz

--- a/native-provider-ci/providers/command/repo/.github/workflows/prerelease.yml
+++ b/native-provider-ci/providers/command/repo/.github/workflows/prerelease.yml
@@ -509,3 +509,38 @@ jobs:
         arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
         build-root-directory: ./sdk/java
         gradle-version: 7.4.1
+  pubish_go_sdk:
+    runs-on: ubuntu-latest
+    name: publish-go-sdk
+    needs: publish-sdk
+    steps:
+    - name: Checkout Repo
+      uses: actions/checkout@v4
+      with:
+        lfs: true
+    - id: version
+      name: Set Provider Version
+      uses: pulumi/provider-version-action@v1
+      with:
+        set-env: PROVIDER_VERSION
+    - name: Download go SDK
+      uses: actions/download-artifact@v4
+      with:
+        name: go-sdk.tar.gz
+        path: ${{ github.workspace}}/sdk/
+    - name: Uncompress go SDK
+      run: tar -zxf ${{github.workspace}}/sdk/go.tar.gz -C
+        ${{github.workspace}}/sdk/go
+    - name: Publish Go SDK
+      uses: pulumi/publish-go-sdk-action@v1
+      with:
+        repository: ${{ github.repository }}
+        base-ref: ${{ github.sha }}
+        source: sdk
+        path: sdk
+        version: ${{ steps.version.outputs.version }}
+        additive: false
+        files: |-
+          go.*
+          go/**
+          !*.tar.gz

--- a/native-provider-ci/providers/docker-build/repo/.github/workflows/prerelease.yml
+++ b/native-provider-ci/providers/docker-build/repo/.github/workflows/prerelease.yml
@@ -571,3 +571,38 @@ jobs:
         arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
         build-root-directory: ./sdk/java
         gradle-version: 7.4.1
+  pubish_go_sdk:
+    runs-on: ubuntu-latest
+    name: publish-go-sdk
+    needs: publish-sdk
+    steps:
+    - name: Checkout Repo
+      uses: actions/checkout@v4
+      with:
+        lfs: true
+    - id: version
+      name: Set Provider Version
+      uses: pulumi/provider-version-action@v1
+      with:
+        set-env: PROVIDER_VERSION
+    - name: Download go SDK
+      uses: actions/download-artifact@v4
+      with:
+        name: go-sdk.tar.gz
+        path: ${{ github.workspace}}/sdk/
+    - name: Uncompress go SDK
+      run: tar -zxf ${{github.workspace}}/sdk/go.tar.gz -C
+        ${{github.workspace}}/sdk/go
+    - name: Publish Go SDK
+      uses: pulumi/publish-go-sdk-action@v1
+      with:
+        repository: ${{ github.repository }}
+        base-ref: ${{ github.sha }}
+        source: sdk
+        path: sdk
+        version: ${{ steps.version.outputs.version }}
+        additive: false
+        files: |-
+          go.*
+          go/**
+          !*.tar.gz

--- a/native-provider-ci/providers/google-native/repo/.github/workflows/prerelease.yml
+++ b/native-provider-ci/providers/google-native/repo/.github/workflows/prerelease.yml
@@ -558,3 +558,38 @@ jobs:
         arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
         build-root-directory: ./sdk/java
         gradle-version: 7.4.1
+  pubish_go_sdk:
+    runs-on: ubuntu-latest
+    name: publish-go-sdk
+    needs: publish-sdk
+    steps:
+    - name: Checkout Repo
+      uses: actions/checkout@v4
+      with:
+        lfs: true
+    - id: version
+      name: Set Provider Version
+      uses: pulumi/provider-version-action@v1
+      with:
+        set-env: PROVIDER_VERSION
+    - name: Download go SDK
+      uses: actions/download-artifact@v4
+      with:
+        name: go-sdk.tar.gz
+        path: ${{ github.workspace}}/sdk/
+    - name: Uncompress go SDK
+      run: tar -zxf ${{github.workspace}}/sdk/go.tar.gz -C
+        ${{github.workspace}}/sdk/go
+    - name: Publish Go SDK
+      uses: pulumi/publish-go-sdk-action@v1
+      with:
+        repository: ${{ github.repository }}
+        base-ref: ${{ github.sha }}
+        source: sdk
+        path: sdk
+        version: ${{ steps.version.outputs.version }}
+        additive: false
+        files: |-
+          go.*
+          go/**
+          !*.tar.gz

--- a/native-provider-ci/providers/kubernetes-cert-manager/repo/.github/workflows/prerelease.yml
+++ b/native-provider-ci/providers/kubernetes-cert-manager/repo/.github/workflows/prerelease.yml
@@ -541,3 +541,38 @@ jobs:
         arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
         build-root-directory: ./sdk/java
         gradle-version: 7.4.1
+  pubish_go_sdk:
+    runs-on: ubuntu-latest
+    name: publish-go-sdk
+    needs: publish-sdk
+    steps:
+    - name: Checkout Repo
+      uses: actions/checkout@v4
+      with:
+        lfs: true
+    - id: version
+      name: Set Provider Version
+      uses: pulumi/provider-version-action@v1
+      with:
+        set-env: PROVIDER_VERSION
+    - name: Download go SDK
+      uses: actions/download-artifact@v4
+      with:
+        name: go-sdk.tar.gz
+        path: ${{ github.workspace}}/sdk/
+    - name: Uncompress go SDK
+      run: tar -zxf ${{github.workspace}}/sdk/go.tar.gz -C
+        ${{github.workspace}}/sdk/go
+    - name: Publish Go SDK
+      uses: pulumi/publish-go-sdk-action@v1
+      with:
+        repository: ${{ github.repository }}
+        base-ref: ${{ github.sha }}
+        source: sdk
+        path: sdk
+        version: ${{ steps.version.outputs.version }}
+        additive: false
+        files: |-
+          go.*
+          go/**
+          !*.tar.gz

--- a/native-provider-ci/providers/kubernetes/repo/.github/workflows/prerelease.yml
+++ b/native-provider-ci/providers/kubernetes/repo/.github/workflows/prerelease.yml
@@ -584,6 +584,41 @@ jobs:
         arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
         build-root-directory: ./sdk/java
         gradle-version: 7.4.1
+  pubish_go_sdk:
+    runs-on: ubuntu-latest
+    name: publish-go-sdk
+    needs: publish-sdk
+    steps:
+    - name: Checkout Repo
+      uses: actions/checkout@v4
+      with:
+        lfs: true
+    - id: version
+      name: Set Provider Version
+      uses: pulumi/provider-version-action@v1
+      with:
+        set-env: PROVIDER_VERSION
+    - name: Download go SDK
+      uses: actions/download-artifact@v4
+      with:
+        name: go-sdk.tar.gz
+        path: ${{ github.workspace}}/sdk/
+    - name: Uncompress go SDK
+      run: tar -zxf ${{github.workspace}}/sdk/go.tar.gz -C
+        ${{github.workspace}}/sdk/go
+    - name: Publish Go SDK
+      uses: pulumi/publish-go-sdk-action@v1
+      with:
+        repository: ${{ github.repository }}
+        base-ref: ${{ github.sha }}
+        source: sdk
+        path: sdk
+        version: ${{ steps.version.outputs.version }}
+        additive: false
+        files: |-
+          go.*
+          go/**
+          !*.tar.gz
   build-test-cluster:
     runs-on: ubuntu-latest
     name: build-test-cluster

--- a/native-provider-ci/src/workflows.ts
+++ b/native-provider-ci/src/workflows.ts
@@ -253,6 +253,7 @@ export function PrereleaseWorkflow(
       publish: new PublishPrereleaseJob("publish", opts),
       publish_sdk: new PublishSDKJob("publish_sdk"),
       publish_java_sdk: new PublishJavaSDKJob("publish_java_sdk"),
+      pubish_go_sdk: new PublishGoSdkJob(),
     },
   };
   if (opts.provider === "kubernetes") {


### PR DESCRIPTION
This brings native providers in-line with bridged providers which publish tagged Go SDKs for pre-releases.