### PR TITLE
Fix native Java & Go SDK publish

### DIFF
--- a/native-provider-ci/providers/aws-native/repo/.github/workflows/build.yml
+++ b/native-provider-ci/providers/aws-native/repo/.github/workflows/build.yml
@@ -528,11 +528,10 @@ jobs:
     - name: Uncompress java SDK
       run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
         ${{github.workspace}}/sdk/java
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
     - name: Publish Java SDK
       uses: gradle/gradle-build-action@v3
+      env:
+        PACKAGE_VERSION: ${{ env.PROVIDER_VERSION }}
       with:
         arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
         build-root-directory: ./sdk/java

--- a/native-provider-ci/providers/aws-native/repo/.github/workflows/cf2pulumi-release.yml
+++ b/native-provider-ci/providers/aws-native/repo/.github/workflows/cf2pulumi-release.yml
@@ -63,7 +63,7 @@ jobs:
         args: -p 1 -f .goreleaser.cf2pulumi.yml release --clean --timeout 60m0s
         version: latest
     - name: Chocolatey Package Deployment
-      run: |-
-        CURRENT_TAG=v$(pulumictl get version --language generic -o)
-        pulumictl create choco-deploy -a cf2pulumi ${CURRENT_TAG}
+      env:
+        CURRENT_TAG: ${{ env.PROVIDER_VERSION }}
+      run: pulumictl create choco-deploy -a cf2pulumi ${CURRENT_TAG}
     name: release

--- a/native-provider-ci/providers/aws-native/repo/.github/workflows/prerelease.yml
+++ b/native-provider-ci/providers/aws-native/repo/.github/workflows/prerelease.yml
@@ -519,11 +519,10 @@ jobs:
     - name: Uncompress java SDK
       run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
         ${{github.workspace}}/sdk/java
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
     - name: Publish Java SDK
       uses: gradle/gradle-build-action@v3
+      env:
+        PACKAGE_VERSION: ${{ env.PROVIDER_VERSION }}
       with:
         arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
         build-root-directory: ./sdk/java
@@ -531,7 +530,7 @@ jobs:
   pubish_go_sdk:
     runs-on: ubuntu-latest
     name: publish-go-sdk
-    needs: publish-sdk
+    needs: publish_sdk
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v4

--- a/native-provider-ci/providers/aws-native/repo/.github/workflows/release.yml
+++ b/native-provider-ci/providers/aws-native/repo/.github/workflows/release.yml
@@ -519,11 +519,10 @@ jobs:
     - name: Uncompress java SDK
       run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
         ${{github.workspace}}/sdk/java
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
     - name: Publish Java SDK
       uses: gradle/gradle-build-action@v3
+      env:
+        PACKAGE_VERSION: ${{ env.PROVIDER_VERSION }}
       with:
         arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
         build-root-directory: ./sdk/java
@@ -531,7 +530,7 @@ jobs:
   pubish_go_sdk:
     runs-on: ubuntu-latest
     name: publish-go-sdk
-    needs: publish-sdk
+    needs: publish_sdk
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v4

--- a/native-provider-ci/providers/command/repo/.github/workflows/build.yml
+++ b/native-provider-ci/providers/command/repo/.github/workflows/build.yml
@@ -497,11 +497,10 @@ jobs:
     - name: Uncompress java SDK
       run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
         ${{github.workspace}}/sdk/java
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
     - name: Publish Java SDK
       uses: gradle/gradle-build-action@v3
+      env:
+        PACKAGE_VERSION: ${{ env.PROVIDER_VERSION }}
       with:
         arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
         build-root-directory: ./sdk/java

--- a/native-provider-ci/providers/command/repo/.github/workflows/prerelease.yml
+++ b/native-provider-ci/providers/command/repo/.github/workflows/prerelease.yml
@@ -488,11 +488,10 @@ jobs:
     - name: Uncompress java SDK
       run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
         ${{github.workspace}}/sdk/java
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
     - name: Publish Java SDK
       uses: gradle/gradle-build-action@v3
+      env:
+        PACKAGE_VERSION: ${{ env.PROVIDER_VERSION }}
       with:
         arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
         build-root-directory: ./sdk/java
@@ -500,7 +499,7 @@ jobs:
   pubish_go_sdk:
     runs-on: ubuntu-latest
     name: publish-go-sdk
-    needs: publish-sdk
+    needs: publish_sdk
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v4

--- a/native-provider-ci/providers/command/repo/.github/workflows/release.yml
+++ b/native-provider-ci/providers/command/repo/.github/workflows/release.yml
@@ -488,11 +488,10 @@ jobs:
     - name: Uncompress java SDK
       run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
         ${{github.workspace}}/sdk/java
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
     - name: Publish Java SDK
       uses: gradle/gradle-build-action@v3
+      env:
+        PACKAGE_VERSION: ${{ env.PROVIDER_VERSION }}
       with:
         arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
         build-root-directory: ./sdk/java
@@ -500,7 +499,7 @@ jobs:
   pubish_go_sdk:
     runs-on: ubuntu-latest
     name: publish-go-sdk
-    needs: publish-sdk
+    needs: publish_sdk
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v4

--- a/native-provider-ci/providers/docker-build/repo/.github/workflows/build.yml
+++ b/native-provider-ci/providers/docker-build/repo/.github/workflows/build.yml
@@ -559,11 +559,10 @@ jobs:
     - name: Uncompress java SDK
       run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
         ${{github.workspace}}/sdk/java
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
     - name: Publish Java SDK
       uses: gradle/gradle-build-action@v3
+      env:
+        PACKAGE_VERSION: ${{ env.PROVIDER_VERSION }}
       with:
         arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
         build-root-directory: ./sdk/java

--- a/native-provider-ci/providers/docker-build/repo/.github/workflows/prerelease.yml
+++ b/native-provider-ci/providers/docker-build/repo/.github/workflows/prerelease.yml
@@ -550,11 +550,10 @@ jobs:
     - name: Uncompress java SDK
       run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
         ${{github.workspace}}/sdk/java
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
     - name: Publish Java SDK
       uses: gradle/gradle-build-action@v3
+      env:
+        PACKAGE_VERSION: ${{ env.PROVIDER_VERSION }}
       with:
         arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
         build-root-directory: ./sdk/java
@@ -562,7 +561,7 @@ jobs:
   pubish_go_sdk:
     runs-on: ubuntu-latest
     name: publish-go-sdk
-    needs: publish-sdk
+    needs: publish_sdk
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v4

--- a/native-provider-ci/providers/docker-build/repo/.github/workflows/release.yml
+++ b/native-provider-ci/providers/docker-build/repo/.github/workflows/release.yml
@@ -550,11 +550,10 @@ jobs:
     - name: Uncompress java SDK
       run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
         ${{github.workspace}}/sdk/java
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
     - name: Publish Java SDK
       uses: gradle/gradle-build-action@v3
+      env:
+        PACKAGE_VERSION: ${{ env.PROVIDER_VERSION }}
       with:
         arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
         build-root-directory: ./sdk/java
@@ -562,7 +561,7 @@ jobs:
   pubish_go_sdk:
     runs-on: ubuntu-latest
     name: publish-go-sdk
-    needs: publish-sdk
+    needs: publish_sdk
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v4

--- a/native-provider-ci/providers/google-native/repo/.github/workflows/build.yml
+++ b/native-provider-ci/providers/google-native/repo/.github/workflows/build.yml
@@ -546,11 +546,10 @@ jobs:
     - name: Uncompress java SDK
       run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
         ${{github.workspace}}/sdk/java
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
     - name: Publish Java SDK
       uses: gradle/gradle-build-action@v3
+      env:
+        PACKAGE_VERSION: ${{ env.PROVIDER_VERSION }}
       with:
         arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
         build-root-directory: ./sdk/java

--- a/native-provider-ci/providers/google-native/repo/.github/workflows/prerelease.yml
+++ b/native-provider-ci/providers/google-native/repo/.github/workflows/prerelease.yml
@@ -537,11 +537,10 @@ jobs:
     - name: Uncompress java SDK
       run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
         ${{github.workspace}}/sdk/java
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
     - name: Publish Java SDK
       uses: gradle/gradle-build-action@v3
+      env:
+        PACKAGE_VERSION: ${{ env.PROVIDER_VERSION }}
       with:
         arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
         build-root-directory: ./sdk/java
@@ -549,7 +548,7 @@ jobs:
   pubish_go_sdk:
     runs-on: ubuntu-latest
     name: publish-go-sdk
-    needs: publish-sdk
+    needs: publish_sdk
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v4

--- a/native-provider-ci/providers/google-native/repo/.github/workflows/release.yml
+++ b/native-provider-ci/providers/google-native/repo/.github/workflows/release.yml
@@ -537,11 +537,10 @@ jobs:
     - name: Uncompress java SDK
       run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
         ${{github.workspace}}/sdk/java
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
     - name: Publish Java SDK
       uses: gradle/gradle-build-action@v3
+      env:
+        PACKAGE_VERSION: ${{ env.PROVIDER_VERSION }}
       with:
         arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
         build-root-directory: ./sdk/java
@@ -549,7 +548,7 @@ jobs:
   pubish_go_sdk:
     runs-on: ubuntu-latest
     name: publish-go-sdk
-    needs: publish-sdk
+    needs: publish_sdk
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v4

--- a/native-provider-ci/providers/kubernetes-cert-manager/repo/.github/workflows/build.yml
+++ b/native-provider-ci/providers/kubernetes-cert-manager/repo/.github/workflows/build.yml
@@ -529,11 +529,10 @@ jobs:
     - name: Uncompress java SDK
       run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
         ${{github.workspace}}/sdk/java
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
     - name: Publish Java SDK
       uses: gradle/gradle-build-action@v3
+      env:
+        PACKAGE_VERSION: ${{ env.PROVIDER_VERSION }}
       with:
         arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
         build-root-directory: ./sdk/java

--- a/native-provider-ci/providers/kubernetes-cert-manager/repo/.github/workflows/prerelease.yml
+++ b/native-provider-ci/providers/kubernetes-cert-manager/repo/.github/workflows/prerelease.yml
@@ -520,11 +520,10 @@ jobs:
     - name: Uncompress java SDK
       run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
         ${{github.workspace}}/sdk/java
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
     - name: Publish Java SDK
       uses: gradle/gradle-build-action@v3
+      env:
+        PACKAGE_VERSION: ${{ env.PROVIDER_VERSION }}
       with:
         arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
         build-root-directory: ./sdk/java
@@ -532,7 +531,7 @@ jobs:
   pubish_go_sdk:
     runs-on: ubuntu-latest
     name: publish-go-sdk
-    needs: publish-sdk
+    needs: publish_sdk
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v4

--- a/native-provider-ci/providers/kubernetes-cert-manager/repo/.github/workflows/release.yml
+++ b/native-provider-ci/providers/kubernetes-cert-manager/repo/.github/workflows/release.yml
@@ -520,11 +520,10 @@ jobs:
     - name: Uncompress java SDK
       run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
         ${{github.workspace}}/sdk/java
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
     - name: Publish Java SDK
       uses: gradle/gradle-build-action@v3
+      env:
+        PACKAGE_VERSION: ${{ env.PROVIDER_VERSION }}
       with:
         arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
         build-root-directory: ./sdk/java
@@ -532,7 +531,7 @@ jobs:
   pubish_go_sdk:
     runs-on: ubuntu-latest
     name: publish-go-sdk
-    needs: publish-sdk
+    needs: publish_sdk
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v4

--- a/native-provider-ci/providers/kubernetes/repo/.github/workflows/build.yml
+++ b/native-provider-ci/providers/kubernetes/repo/.github/workflows/build.yml
@@ -572,11 +572,10 @@ jobs:
     - name: Uncompress java SDK
       run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
         ${{github.workspace}}/sdk/java
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
     - name: Publish Java SDK
       uses: gradle/gradle-build-action@v3
+      env:
+        PACKAGE_VERSION: ${{ env.PROVIDER_VERSION }}
       with:
         arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
         build-root-directory: ./sdk/java

--- a/native-provider-ci/providers/kubernetes/repo/.github/workflows/prerelease.yml
+++ b/native-provider-ci/providers/kubernetes/repo/.github/workflows/prerelease.yml
@@ -563,11 +563,10 @@ jobs:
     - name: Uncompress java SDK
       run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
         ${{github.workspace}}/sdk/java
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
     - name: Publish Java SDK
       uses: gradle/gradle-build-action@v3
+      env:
+        PACKAGE_VERSION: ${{ env.PROVIDER_VERSION }}
       with:
         arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
         build-root-directory: ./sdk/java
@@ -575,7 +574,7 @@ jobs:
   pubish_go_sdk:
     runs-on: ubuntu-latest
     name: publish-go-sdk
-    needs: publish-sdk
+    needs: publish_sdk
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v4

--- a/native-provider-ci/providers/kubernetes/repo/.github/workflows/release.yml
+++ b/native-provider-ci/providers/kubernetes/repo/.github/workflows/release.yml
@@ -563,11 +563,10 @@ jobs:
     - name: Uncompress java SDK
       run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
         ${{github.workspace}}/sdk/java
-    - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
     - name: Publish Java SDK
       uses: gradle/gradle-build-action@v3
+      env:
+        PACKAGE_VERSION: ${{ env.PROVIDER_VERSION }}
       with:
         arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
         build-root-directory: ./sdk/java
@@ -575,7 +574,7 @@ jobs:
   pubish_go_sdk:
     runs-on: ubuntu-latest
     name: publish-go-sdk
-    needs: publish-sdk
+    needs: publish_sdk
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v4

--- a/native-provider-ci/src/workflows.ts
+++ b/native-provider-ci/src/workflows.ts
@@ -849,33 +849,15 @@ export class PublishJavaSDKJob implements NormalJob {
       steps.InstallGradle("7.6"),
       steps.DownloadSpecificSDKStep("java"),
       steps.UnzipSpecificSDKStep("java"),
-      steps.SetPackageVersionToEnv(),
       steps.RunPublishJavaSDK(),
     ];
-  }
-}
-
-export class TagSDKJob implements NormalJob {
-  "runs-on" = "ubuntu-latest";
-  needs = "publish_sdk";
-  steps = [
-    steps.CheckoutRepoStep(),
-    steps.SetProviderVersionStep(),
-    steps.InstallPulumiCtl(),
-    steps.TagSDKTag(),
-  ];
-  name: string;
-
-  constructor(name: string) {
-    this.name = name;
-    Object.assign(this, { name });
   }
 }
 
 export class PublishGoSdkJob implements NormalJob {
   "runs-on" = "ubuntu-latest";
   name = "publish-go-sdk";
-  needs = "publish-sdk";
+  needs = "publish_sdk";
   steps = [
     steps.CheckoutRepoStep(),
     steps.SetProviderVersionStep(),


### PR DESCRIPTION
- Fix Publish Go Sdk dependency - typo between underscore and hyphen.
- Fix Java publish by using the consistent version rather than calling `pulumictl get version`.
- Fix cf2pulumi Chocolatey version - use consistent version rather than calling `pulumictl get version`.
- Remove unused steps and workflows.