### PR TITLE
Don't hit GitHub API for schema comparisons

### DIFF
--- a/native-provider-ci/providers/aws-native/repo/.github/workflows/build.yml
+++ b/native-provider-ci/providers/aws-native/repo/.github/workflows/build.yml
@@ -71,6 +71,7 @@ jobs:
       uses: jaxxstorm/action-install-gh-release@v1.11.0
       with:
         repo: pulumi/schema-tools
+        tag: master
     - name: Initialize submodules
       run: make init_submodules
     - name: Build codegen binaries
@@ -80,13 +81,15 @@ jobs:
     - if: github.event_name == 'pull_request'
       name: Check Schema is Valid
       run: >-
+        git show ${{ github.event.repository.default_branch
+        }}:provider/cmd/pulumi-resource-${{ env.PROVIDER }}/schema.json > ${{
+        runner.temp }}/schema.json;
+
         echo 'SCHEMA_CHANGES<<EOF' >> $GITHUB_ENV
 
-        schema-tools compare -p ${{ env.PROVIDER }} -o ${{ github.event.repository.default_branch }} -n --local-path=provider/cmd/pulumi-resource-${{ env.PROVIDER }}/schema.json >> $GITHUB_ENV
+        schema-tools compare -p ${{ env.PROVIDER }} -n --local-path=provider/cmd/pulumi-resource-${{ env.PROVIDER }}/schema.json -r file:${{ runner.temp }}/schema.json;
 
         echo 'EOF' >> $GITHUB_ENV
-      env:
-        GITHUB_TOKEN: ${{ secrets.PULUMI_BOT_TOKEN }}
     - if: github.event_name == 'pull_request'
       name: Comment on PR with Details of Schema Check
       uses: thollander/actions-comment-pull-request@v2

--- a/native-provider-ci/providers/aws-native/repo/.github/workflows/prerelease.yml
+++ b/native-provider-ci/providers/aws-native/repo/.github/workflows/prerelease.yml
@@ -63,6 +63,7 @@ jobs:
       uses: jaxxstorm/action-install-gh-release@v1.11.0
       with:
         repo: pulumi/schema-tools
+        tag: master
     - name: Initialize submodules
       run: make init_submodules
     - name: Build codegen binaries
@@ -72,13 +73,15 @@ jobs:
     - if: github.event_name == 'pull_request'
       name: Check Schema is Valid
       run: >-
+        git show ${{ github.event.repository.default_branch
+        }}:provider/cmd/pulumi-resource-${{ env.PROVIDER }}/schema.json > ${{
+        runner.temp }}/schema.json;
+
         echo 'SCHEMA_CHANGES<<EOF' >> $GITHUB_ENV
 
-        schema-tools compare -p ${{ env.PROVIDER }} -o ${{ github.event.repository.default_branch }} -n --local-path=provider/cmd/pulumi-resource-${{ env.PROVIDER }}/schema.json >> $GITHUB_ENV
+        schema-tools compare -p ${{ env.PROVIDER }} -n --local-path=provider/cmd/pulumi-resource-${{ env.PROVIDER }}/schema.json -r file:${{ runner.temp }}/schema.json;
 
         echo 'EOF' >> $GITHUB_ENV
-      env:
-        GITHUB_TOKEN: ${{ secrets.PULUMI_BOT_TOKEN }}
     - if: github.event_name == 'pull_request'
       name: Comment on PR with Details of Schema Check
       uses: thollander/actions-comment-pull-request@v2

--- a/native-provider-ci/providers/aws-native/repo/.github/workflows/release.yml
+++ b/native-provider-ci/providers/aws-native/repo/.github/workflows/release.yml
@@ -63,6 +63,7 @@ jobs:
       uses: jaxxstorm/action-install-gh-release@v1.11.0
       with:
         repo: pulumi/schema-tools
+        tag: master
     - name: Initialize submodules
       run: make init_submodules
     - name: Build codegen binaries
@@ -72,13 +73,15 @@ jobs:
     - if: github.event_name == 'pull_request'
       name: Check Schema is Valid
       run: >-
+        git show ${{ github.event.repository.default_branch
+        }}:provider/cmd/pulumi-resource-${{ env.PROVIDER }}/schema.json > ${{
+        runner.temp }}/schema.json;
+
         echo 'SCHEMA_CHANGES<<EOF' >> $GITHUB_ENV
 
-        schema-tools compare -p ${{ env.PROVIDER }} -o ${{ github.event.repository.default_branch }} -n --local-path=provider/cmd/pulumi-resource-${{ env.PROVIDER }}/schema.json >> $GITHUB_ENV
+        schema-tools compare -p ${{ env.PROVIDER }} -n --local-path=provider/cmd/pulumi-resource-${{ env.PROVIDER }}/schema.json -r file:${{ runner.temp }}/schema.json;
 
         echo 'EOF' >> $GITHUB_ENV
-      env:
-        GITHUB_TOKEN: ${{ secrets.PULUMI_BOT_TOKEN }}
     - if: github.event_name == 'pull_request'
       name: Comment on PR with Details of Schema Check
       uses: thollander/actions-comment-pull-request@v2

--- a/native-provider-ci/providers/aws-native/repo/.github/workflows/run-acceptance-tests.yml
+++ b/native-provider-ci/providers/aws-native/repo/.github/workflows/run-acceptance-tests.yml
@@ -88,6 +88,7 @@ jobs:
       uses: jaxxstorm/action-install-gh-release@v1.11.0
       with:
         repo: pulumi/schema-tools
+        tag: master
     - name: Initialize submodules
       run: make init_submodules
     - name: Build codegen binaries
@@ -97,13 +98,15 @@ jobs:
     - if: github.event_name == 'pull_request'
       name: Check Schema is Valid
       run: >-
+        git show ${{ github.event.repository.default_branch
+        }}:provider/cmd/pulumi-resource-${{ env.PROVIDER }}/schema.json > ${{
+        runner.temp }}/schema.json;
+
         echo 'SCHEMA_CHANGES<<EOF' >> $GITHUB_ENV
 
-        schema-tools compare -p ${{ env.PROVIDER }} -o ${{ github.event.repository.default_branch }} -n --local-path=provider/cmd/pulumi-resource-${{ env.PROVIDER }}/schema.json >> $GITHUB_ENV
+        schema-tools compare -p ${{ env.PROVIDER }} -n --local-path=provider/cmd/pulumi-resource-${{ env.PROVIDER }}/schema.json -r file:${{ runner.temp }}/schema.json;
 
         echo 'EOF' >> $GITHUB_ENV
-      env:
-        GITHUB_TOKEN: ${{ secrets.PULUMI_BOT_TOKEN }}
     - if: github.event_name == 'pull_request'
       name: Comment on PR with Details of Schema Check
       uses: thollander/actions-comment-pull-request@v2

--- a/native-provider-ci/providers/docker-build/repo/.github/workflows/build.yml
+++ b/native-provider-ci/providers/docker-build/repo/.github/workflows/build.yml
@@ -85,6 +85,7 @@ jobs:
       uses: jaxxstorm/action-install-gh-release@v1.11.0
       with:
         repo: pulumi/schema-tools
+        tag: master
     - name: Build codegen binaries
       run: make codegen
     - name: Build Schema
@@ -92,13 +93,15 @@ jobs:
     - if: github.event_name == 'pull_request'
       name: Check Schema is Valid
       run: >-
+        git show ${{ github.event.repository.default_branch
+        }}:provider/cmd/pulumi-resource-${{ env.PROVIDER }}/schema.json > ${{
+        runner.temp }}/schema.json;
+
         echo 'SCHEMA_CHANGES<<EOF' >> $GITHUB_ENV
 
-        schema-tools compare -p ${{ env.PROVIDER }} -o ${{ github.event.repository.default_branch }} -n --local-path=provider/cmd/pulumi-resource-${{ env.PROVIDER }}/schema.json >> $GITHUB_ENV
+        schema-tools compare -p ${{ env.PROVIDER }} -n --local-path=provider/cmd/pulumi-resource-${{ env.PROVIDER }}/schema.json -r file:${{ runner.temp }}/schema.json;
 
         echo 'EOF' >> $GITHUB_ENV
-      env:
-        GITHUB_TOKEN: ${{ secrets.PULUMI_BOT_TOKEN }}
     - if: github.event_name == 'pull_request'
       name: Comment on PR with Details of Schema Check
       uses: thollander/actions-comment-pull-request@v2

--- a/native-provider-ci/providers/docker-build/repo/.github/workflows/prerelease.yml
+++ b/native-provider-ci/providers/docker-build/repo/.github/workflows/prerelease.yml
@@ -77,6 +77,7 @@ jobs:
       uses: jaxxstorm/action-install-gh-release@v1.11.0
       with:
         repo: pulumi/schema-tools
+        tag: master
     - name: Build codegen binaries
       run: make codegen
     - name: Build Schema
@@ -84,13 +85,15 @@ jobs:
     - if: github.event_name == 'pull_request'
       name: Check Schema is Valid
       run: >-
+        git show ${{ github.event.repository.default_branch
+        }}:provider/cmd/pulumi-resource-${{ env.PROVIDER }}/schema.json > ${{
+        runner.temp }}/schema.json;
+
         echo 'SCHEMA_CHANGES<<EOF' >> $GITHUB_ENV
 
-        schema-tools compare -p ${{ env.PROVIDER }} -o ${{ github.event.repository.default_branch }} -n --local-path=provider/cmd/pulumi-resource-${{ env.PROVIDER }}/schema.json >> $GITHUB_ENV
+        schema-tools compare -p ${{ env.PROVIDER }} -n --local-path=provider/cmd/pulumi-resource-${{ env.PROVIDER }}/schema.json -r file:${{ runner.temp }}/schema.json;
 
         echo 'EOF' >> $GITHUB_ENV
-      env:
-        GITHUB_TOKEN: ${{ secrets.PULUMI_BOT_TOKEN }}
     - if: github.event_name == 'pull_request'
       name: Comment on PR with Details of Schema Check
       uses: thollander/actions-comment-pull-request@v2

--- a/native-provider-ci/providers/docker-build/repo/.github/workflows/release.yml
+++ b/native-provider-ci/providers/docker-build/repo/.github/workflows/release.yml
@@ -77,6 +77,7 @@ jobs:
       uses: jaxxstorm/action-install-gh-release@v1.11.0
       with:
         repo: pulumi/schema-tools
+        tag: master
     - name: Build codegen binaries
       run: make codegen
     - name: Build Schema
@@ -84,13 +85,15 @@ jobs:
     - if: github.event_name == 'pull_request'
       name: Check Schema is Valid
       run: >-
+        git show ${{ github.event.repository.default_branch
+        }}:provider/cmd/pulumi-resource-${{ env.PROVIDER }}/schema.json > ${{
+        runner.temp }}/schema.json;
+
         echo 'SCHEMA_CHANGES<<EOF' >> $GITHUB_ENV
 
-        schema-tools compare -p ${{ env.PROVIDER }} -o ${{ github.event.repository.default_branch }} -n --local-path=provider/cmd/pulumi-resource-${{ env.PROVIDER }}/schema.json >> $GITHUB_ENV
+        schema-tools compare -p ${{ env.PROVIDER }} -n --local-path=provider/cmd/pulumi-resource-${{ env.PROVIDER }}/schema.json -r file:${{ runner.temp }}/schema.json;
 
         echo 'EOF' >> $GITHUB_ENV
-      env:
-        GITHUB_TOKEN: ${{ secrets.PULUMI_BOT_TOKEN }}
     - if: github.event_name == 'pull_request'
       name: Comment on PR with Details of Schema Check
       uses: thollander/actions-comment-pull-request@v2

--- a/native-provider-ci/providers/docker-build/repo/.github/workflows/run-acceptance-tests.yml
+++ b/native-provider-ci/providers/docker-build/repo/.github/workflows/run-acceptance-tests.yml
@@ -102,6 +102,7 @@ jobs:
       uses: jaxxstorm/action-install-gh-release@v1.11.0
       with:
         repo: pulumi/schema-tools
+        tag: master
     - name: Build codegen binaries
       run: make codegen
     - name: Build Schema
@@ -109,13 +110,15 @@ jobs:
     - if: github.event_name == 'pull_request'
       name: Check Schema is Valid
       run: >-
+        git show ${{ github.event.repository.default_branch
+        }}:provider/cmd/pulumi-resource-${{ env.PROVIDER }}/schema.json > ${{
+        runner.temp }}/schema.json;
+
         echo 'SCHEMA_CHANGES<<EOF' >> $GITHUB_ENV
 
-        schema-tools compare -p ${{ env.PROVIDER }} -o ${{ github.event.repository.default_branch }} -n --local-path=provider/cmd/pulumi-resource-${{ env.PROVIDER }}/schema.json >> $GITHUB_ENV
+        schema-tools compare -p ${{ env.PROVIDER }} -n --local-path=provider/cmd/pulumi-resource-${{ env.PROVIDER }}/schema.json -r file:${{ runner.temp }}/schema.json;
 
         echo 'EOF' >> $GITHUB_ENV
-      env:
-        GITHUB_TOKEN: ${{ secrets.PULUMI_BOT_TOKEN }}
     - if: github.event_name == 'pull_request'
       name: Comment on PR with Details of Schema Check
       uses: thollander/actions-comment-pull-request@v2

--- a/native-provider-ci/providers/google-native/repo/.github/workflows/build.yml
+++ b/native-provider-ci/providers/google-native/repo/.github/workflows/build.yml
@@ -77,6 +77,7 @@ jobs:
       uses: jaxxstorm/action-install-gh-release@v1.11.0
       with:
         repo: pulumi/schema-tools
+        tag: master
     - name: Initialize submodules
       run: make init_submodules
     - name: Build codegen binaries
@@ -86,13 +87,15 @@ jobs:
     - if: github.event_name == 'pull_request'
       name: Check Schema is Valid
       run: >-
+        git show ${{ github.event.repository.default_branch
+        }}:provider/cmd/pulumi-resource-${{ env.PROVIDER }}/schema.json > ${{
+        runner.temp }}/schema.json;
+
         echo 'SCHEMA_CHANGES<<EOF' >> $GITHUB_ENV
 
-        schema-tools compare -p ${{ env.PROVIDER }} -o ${{ github.event.repository.default_branch }} -n --local-path=provider/cmd/pulumi-resource-${{ env.PROVIDER }}/schema.json >> $GITHUB_ENV
+        schema-tools compare -p ${{ env.PROVIDER }} -n --local-path=provider/cmd/pulumi-resource-${{ env.PROVIDER }}/schema.json -r file:${{ runner.temp }}/schema.json;
 
         echo 'EOF' >> $GITHUB_ENV
-      env:
-        GITHUB_TOKEN: ${{ secrets.PULUMI_BOT_TOKEN }}
     - if: github.event_name == 'pull_request'
       name: Comment on PR with Details of Schema Check
       uses: thollander/actions-comment-pull-request@v2

--- a/native-provider-ci/providers/google-native/repo/.github/workflows/prerelease.yml
+++ b/native-provider-ci/providers/google-native/repo/.github/workflows/prerelease.yml
@@ -69,6 +69,7 @@ jobs:
       uses: jaxxstorm/action-install-gh-release@v1.11.0
       with:
         repo: pulumi/schema-tools
+        tag: master
     - name: Initialize submodules
       run: make init_submodules
     - name: Build codegen binaries
@@ -78,13 +79,15 @@ jobs:
     - if: github.event_name == 'pull_request'
       name: Check Schema is Valid
       run: >-
+        git show ${{ github.event.repository.default_branch
+        }}:provider/cmd/pulumi-resource-${{ env.PROVIDER }}/schema.json > ${{
+        runner.temp }}/schema.json;
+
         echo 'SCHEMA_CHANGES<<EOF' >> $GITHUB_ENV
 
-        schema-tools compare -p ${{ env.PROVIDER }} -o ${{ github.event.repository.default_branch }} -n --local-path=provider/cmd/pulumi-resource-${{ env.PROVIDER }}/schema.json >> $GITHUB_ENV
+        schema-tools compare -p ${{ env.PROVIDER }} -n --local-path=provider/cmd/pulumi-resource-${{ env.PROVIDER }}/schema.json -r file:${{ runner.temp }}/schema.json;
 
         echo 'EOF' >> $GITHUB_ENV
-      env:
-        GITHUB_TOKEN: ${{ secrets.PULUMI_BOT_TOKEN }}
     - if: github.event_name == 'pull_request'
       name: Comment on PR with Details of Schema Check
       uses: thollander/actions-comment-pull-request@v2

--- a/native-provider-ci/providers/google-native/repo/.github/workflows/release.yml
+++ b/native-provider-ci/providers/google-native/repo/.github/workflows/release.yml
@@ -69,6 +69,7 @@ jobs:
       uses: jaxxstorm/action-install-gh-release@v1.11.0
       with:
         repo: pulumi/schema-tools
+        tag: master
     - name: Initialize submodules
       run: make init_submodules
     - name: Build codegen binaries
@@ -78,13 +79,15 @@ jobs:
     - if: github.event_name == 'pull_request'
       name: Check Schema is Valid
       run: >-
+        git show ${{ github.event.repository.default_branch
+        }}:provider/cmd/pulumi-resource-${{ env.PROVIDER }}/schema.json > ${{
+        runner.temp }}/schema.json;
+
         echo 'SCHEMA_CHANGES<<EOF' >> $GITHUB_ENV
 
-        schema-tools compare -p ${{ env.PROVIDER }} -o ${{ github.event.repository.default_branch }} -n --local-path=provider/cmd/pulumi-resource-${{ env.PROVIDER }}/schema.json >> $GITHUB_ENV
+        schema-tools compare -p ${{ env.PROVIDER }} -n --local-path=provider/cmd/pulumi-resource-${{ env.PROVIDER }}/schema.json -r file:${{ runner.temp }}/schema.json;
 
         echo 'EOF' >> $GITHUB_ENV
-      env:
-        GITHUB_TOKEN: ${{ secrets.PULUMI_BOT_TOKEN }}
     - if: github.event_name == 'pull_request'
       name: Comment on PR with Details of Schema Check
       uses: thollander/actions-comment-pull-request@v2

--- a/native-provider-ci/providers/google-native/repo/.github/workflows/run-acceptance-tests.yml
+++ b/native-provider-ci/providers/google-native/repo/.github/workflows/run-acceptance-tests.yml
@@ -94,6 +94,7 @@ jobs:
       uses: jaxxstorm/action-install-gh-release@v1.11.0
       with:
         repo: pulumi/schema-tools
+        tag: master
     - name: Initialize submodules
       run: make init_submodules
     - name: Build codegen binaries
@@ -103,13 +104,15 @@ jobs:
     - if: github.event_name == 'pull_request'
       name: Check Schema is Valid
       run: >-
+        git show ${{ github.event.repository.default_branch
+        }}:provider/cmd/pulumi-resource-${{ env.PROVIDER }}/schema.json > ${{
+        runner.temp }}/schema.json;
+
         echo 'SCHEMA_CHANGES<<EOF' >> $GITHUB_ENV
 
-        schema-tools compare -p ${{ env.PROVIDER }} -o ${{ github.event.repository.default_branch }} -n --local-path=provider/cmd/pulumi-resource-${{ env.PROVIDER }}/schema.json >> $GITHUB_ENV
+        schema-tools compare -p ${{ env.PROVIDER }} -n --local-path=provider/cmd/pulumi-resource-${{ env.PROVIDER }}/schema.json -r file:${{ runner.temp }}/schema.json;
 
         echo 'EOF' >> $GITHUB_ENV
-      env:
-        GITHUB_TOKEN: ${{ secrets.PULUMI_BOT_TOKEN }}
     - if: github.event_name == 'pull_request'
       name: Comment on PR with Details of Schema Check
       uses: thollander/actions-comment-pull-request@v2

--- a/native-provider-ci/providers/kubernetes-cert-manager/repo/.github/workflows/build.yml
+++ b/native-provider-ci/providers/kubernetes-cert-manager/repo/.github/workflows/build.yml
@@ -76,6 +76,7 @@ jobs:
       uses: jaxxstorm/action-install-gh-release@v1.11.0
       with:
         repo: pulumi/schema-tools
+        tag: master
     - name: Build codegen binaries
       run: make codegen
     - name: Build Schema
@@ -83,13 +84,15 @@ jobs:
     - if: github.event_name == 'pull_request'
       name: Check Schema is Valid
       run: >-
+        git show ${{ github.event.repository.default_branch
+        }}:provider/cmd/pulumi-resource-${{ env.PROVIDER }}/schema.json > ${{
+        runner.temp }}/schema.json;
+
         echo 'SCHEMA_CHANGES<<EOF' >> $GITHUB_ENV
 
-        schema-tools compare -p ${{ env.PROVIDER }} -o ${{ github.event.repository.default_branch }} -n --local-path=provider/cmd/pulumi-resource-${{ env.PROVIDER }}/schema.json >> $GITHUB_ENV
+        schema-tools compare -p ${{ env.PROVIDER }} -n --local-path=provider/cmd/pulumi-resource-${{ env.PROVIDER }}/schema.json -r file:${{ runner.temp }}/schema.json;
 
         echo 'EOF' >> $GITHUB_ENV
-      env:
-        GITHUB_TOKEN: ${{ secrets.PULUMI_BOT_TOKEN }}
     - if: github.event_name == 'pull_request'
       name: Comment on PR with Details of Schema Check
       uses: thollander/actions-comment-pull-request@v2

--- a/native-provider-ci/providers/kubernetes-cert-manager/repo/.github/workflows/prerelease.yml
+++ b/native-provider-ci/providers/kubernetes-cert-manager/repo/.github/workflows/prerelease.yml
@@ -68,6 +68,7 @@ jobs:
       uses: jaxxstorm/action-install-gh-release@v1.11.0
       with:
         repo: pulumi/schema-tools
+        tag: master
     - name: Build codegen binaries
       run: make codegen
     - name: Build Schema
@@ -75,13 +76,15 @@ jobs:
     - if: github.event_name == 'pull_request'
       name: Check Schema is Valid
       run: >-
+        git show ${{ github.event.repository.default_branch
+        }}:provider/cmd/pulumi-resource-${{ env.PROVIDER }}/schema.json > ${{
+        runner.temp }}/schema.json;
+
         echo 'SCHEMA_CHANGES<<EOF' >> $GITHUB_ENV
 
-        schema-tools compare -p ${{ env.PROVIDER }} -o ${{ github.event.repository.default_branch }} -n --local-path=provider/cmd/pulumi-resource-${{ env.PROVIDER }}/schema.json >> $GITHUB_ENV
+        schema-tools compare -p ${{ env.PROVIDER }} -n --local-path=provider/cmd/pulumi-resource-${{ env.PROVIDER }}/schema.json -r file:${{ runner.temp }}/schema.json;
 
         echo 'EOF' >> $GITHUB_ENV
-      env:
-        GITHUB_TOKEN: ${{ secrets.PULUMI_BOT_TOKEN }}
     - if: github.event_name == 'pull_request'
       name: Comment on PR with Details of Schema Check
       uses: thollander/actions-comment-pull-request@v2

--- a/native-provider-ci/providers/kubernetes-cert-manager/repo/.github/workflows/release.yml
+++ b/native-provider-ci/providers/kubernetes-cert-manager/repo/.github/workflows/release.yml
@@ -68,6 +68,7 @@ jobs:
       uses: jaxxstorm/action-install-gh-release@v1.11.0
       with:
         repo: pulumi/schema-tools
+        tag: master
     - name: Build codegen binaries
       run: make codegen
     - name: Build Schema
@@ -75,13 +76,15 @@ jobs:
     - if: github.event_name == 'pull_request'
       name: Check Schema is Valid
       run: >-
+        git show ${{ github.event.repository.default_branch
+        }}:provider/cmd/pulumi-resource-${{ env.PROVIDER }}/schema.json > ${{
+        runner.temp }}/schema.json;
+
         echo 'SCHEMA_CHANGES<<EOF' >> $GITHUB_ENV
 
-        schema-tools compare -p ${{ env.PROVIDER }} -o ${{ github.event.repository.default_branch }} -n --local-path=provider/cmd/pulumi-resource-${{ env.PROVIDER }}/schema.json >> $GITHUB_ENV
+        schema-tools compare -p ${{ env.PROVIDER }} -n --local-path=provider/cmd/pulumi-resource-${{ env.PROVIDER }}/schema.json -r file:${{ runner.temp }}/schema.json;
 
         echo 'EOF' >> $GITHUB_ENV
-      env:
-        GITHUB_TOKEN: ${{ secrets.PULUMI_BOT_TOKEN }}
     - if: github.event_name == 'pull_request'
       name: Comment on PR with Details of Schema Check
       uses: thollander/actions-comment-pull-request@v2

--- a/native-provider-ci/providers/kubernetes-cert-manager/repo/.github/workflows/run-acceptance-tests.yml
+++ b/native-provider-ci/providers/kubernetes-cert-manager/repo/.github/workflows/run-acceptance-tests.yml
@@ -93,6 +93,7 @@ jobs:
       uses: jaxxstorm/action-install-gh-release@v1.11.0
       with:
         repo: pulumi/schema-tools
+        tag: master
     - name: Build codegen binaries
       run: make codegen
     - name: Build Schema
@@ -100,13 +101,15 @@ jobs:
     - if: github.event_name == 'pull_request'
       name: Check Schema is Valid
       run: >-
+        git show ${{ github.event.repository.default_branch
+        }}:provider/cmd/pulumi-resource-${{ env.PROVIDER }}/schema.json > ${{
+        runner.temp }}/schema.json;
+
         echo 'SCHEMA_CHANGES<<EOF' >> $GITHUB_ENV
 
-        schema-tools compare -p ${{ env.PROVIDER }} -o ${{ github.event.repository.default_branch }} -n --local-path=provider/cmd/pulumi-resource-${{ env.PROVIDER }}/schema.json >> $GITHUB_ENV
+        schema-tools compare -p ${{ env.PROVIDER }} -n --local-path=provider/cmd/pulumi-resource-${{ env.PROVIDER }}/schema.json -r file:${{ runner.temp }}/schema.json;
 
         echo 'EOF' >> $GITHUB_ENV
-      env:
-        GITHUB_TOKEN: ${{ secrets.PULUMI_BOT_TOKEN }}
     - if: github.event_name == 'pull_request'
       name: Comment on PR with Details of Schema Check
       uses: thollander/actions-comment-pull-request@v2

--- a/native-provider-ci/providers/kubernetes/repo/.github/workflows/build.yml
+++ b/native-provider-ci/providers/kubernetes/repo/.github/workflows/build.yml
@@ -76,6 +76,7 @@ jobs:
       uses: jaxxstorm/action-install-gh-release@v1.11.0
       with:
         repo: pulumi/schema-tools
+        tag: master
     - name: Build K8sgen
       run: make k8sgen
     - name: Prepare OpenAPI file
@@ -87,13 +88,15 @@ jobs:
     - if: github.event_name == 'pull_request'
       name: Check Schema is Valid
       run: >-
+        git show ${{ github.event.repository.default_branch
+        }}:provider/cmd/pulumi-resource-${{ env.PROVIDER }}/schema.json > ${{
+        runner.temp }}/schema.json;
+
         echo 'SCHEMA_CHANGES<<EOF' >> $GITHUB_ENV
 
-        schema-tools compare -p ${{ env.PROVIDER }} -o ${{ github.event.repository.default_branch }} -n --local-path=provider/cmd/pulumi-resource-${{ env.PROVIDER }}/schema.json >> $GITHUB_ENV
+        schema-tools compare -p ${{ env.PROVIDER }} -n --local-path=provider/cmd/pulumi-resource-${{ env.PROVIDER }}/schema.json -r file:${{ runner.temp }}/schema.json;
 
         echo 'EOF' >> $GITHUB_ENV
-      env:
-        GITHUB_TOKEN: ${{ secrets.PULUMI_BOT_TOKEN }}
     - if: github.event_name == 'pull_request'
       name: Comment on PR with Details of Schema Check
       uses: thollander/actions-comment-pull-request@v2

--- a/native-provider-ci/providers/kubernetes/repo/.github/workflows/prerelease.yml
+++ b/native-provider-ci/providers/kubernetes/repo/.github/workflows/prerelease.yml
@@ -68,6 +68,7 @@ jobs:
       uses: jaxxstorm/action-install-gh-release@v1.11.0
       with:
         repo: pulumi/schema-tools
+        tag: master
     - name: Build K8sgen
       run: make k8sgen
     - name: Prepare OpenAPI file
@@ -79,13 +80,15 @@ jobs:
     - if: github.event_name == 'pull_request'
       name: Check Schema is Valid
       run: >-
+        git show ${{ github.event.repository.default_branch
+        }}:provider/cmd/pulumi-resource-${{ env.PROVIDER }}/schema.json > ${{
+        runner.temp }}/schema.json;
+
         echo 'SCHEMA_CHANGES<<EOF' >> $GITHUB_ENV
 
-        schema-tools compare -p ${{ env.PROVIDER }} -o ${{ github.event.repository.default_branch }} -n --local-path=provider/cmd/pulumi-resource-${{ env.PROVIDER }}/schema.json >> $GITHUB_ENV
+        schema-tools compare -p ${{ env.PROVIDER }} -n --local-path=provider/cmd/pulumi-resource-${{ env.PROVIDER }}/schema.json -r file:${{ runner.temp }}/schema.json;
 
         echo 'EOF' >> $GITHUB_ENV
-      env:
-        GITHUB_TOKEN: ${{ secrets.PULUMI_BOT_TOKEN }}
     - if: github.event_name == 'pull_request'
       name: Comment on PR with Details of Schema Check
       uses: thollander/actions-comment-pull-request@v2

--- a/native-provider-ci/providers/kubernetes/repo/.github/workflows/release.yml
+++ b/native-provider-ci/providers/kubernetes/repo/.github/workflows/release.yml
@@ -68,6 +68,7 @@ jobs:
       uses: jaxxstorm/action-install-gh-release@v1.11.0
       with:
         repo: pulumi/schema-tools
+        tag: master
     - name: Build K8sgen
       run: make k8sgen
     - name: Prepare OpenAPI file
@@ -79,13 +80,15 @@ jobs:
     - if: github.event_name == 'pull_request'
       name: Check Schema is Valid
       run: >-
+        git show ${{ github.event.repository.default_branch
+        }}:provider/cmd/pulumi-resource-${{ env.PROVIDER }}/schema.json > ${{
+        runner.temp }}/schema.json;
+
         echo 'SCHEMA_CHANGES<<EOF' >> $GITHUB_ENV
 
-        schema-tools compare -p ${{ env.PROVIDER }} -o ${{ github.event.repository.default_branch }} -n --local-path=provider/cmd/pulumi-resource-${{ env.PROVIDER }}/schema.json >> $GITHUB_ENV
+        schema-tools compare -p ${{ env.PROVIDER }} -n --local-path=provider/cmd/pulumi-resource-${{ env.PROVIDER }}/schema.json -r file:${{ runner.temp }}/schema.json;
 
         echo 'EOF' >> $GITHUB_ENV
-      env:
-        GITHUB_TOKEN: ${{ secrets.PULUMI_BOT_TOKEN }}
     - if: github.event_name == 'pull_request'
       name: Comment on PR with Details of Schema Check
       uses: thollander/actions-comment-pull-request@v2

--- a/native-provider-ci/providers/kubernetes/repo/.github/workflows/run-acceptance-tests.yml
+++ b/native-provider-ci/providers/kubernetes/repo/.github/workflows/run-acceptance-tests.yml
@@ -94,6 +94,7 @@ jobs:
       uses: jaxxstorm/action-install-gh-release@v1.11.0
       with:
         repo: pulumi/schema-tools
+        tag: master
     - name: Build K8sgen
       run: make k8sgen
     - name: Prepare OpenAPI file
@@ -105,13 +106,15 @@ jobs:
     - if: github.event_name == 'pull_request'
       name: Check Schema is Valid
       run: >-
+        git show ${{ github.event.repository.default_branch
+        }}:provider/cmd/pulumi-resource-${{ env.PROVIDER }}/schema.json > ${{
+        runner.temp }}/schema.json;
+
         echo 'SCHEMA_CHANGES<<EOF' >> $GITHUB_ENV
 
-        schema-tools compare -p ${{ env.PROVIDER }} -o ${{ github.event.repository.default_branch }} -n --local-path=provider/cmd/pulumi-resource-${{ env.PROVIDER }}/schema.json >> $GITHUB_ENV
+        schema-tools compare -p ${{ env.PROVIDER }} -n --local-path=provider/cmd/pulumi-resource-${{ env.PROVIDER }}/schema.json -r file:${{ runner.temp }}/schema.json;
 
         echo 'EOF' >> $GITHUB_ENV
-      env:
-        GITHUB_TOKEN: ${{ secrets.PULUMI_BOT_TOKEN }}
     - if: github.event_name == 'pull_request'
       name: Comment on PR with Details of Schema Check
       uses: thollander/actions-comment-pull-request@v2

--- a/native-provider-ci/src/steps.ts
+++ b/native-provider-ci/src/steps.ts
@@ -324,6 +324,7 @@ export function InstallSchemaChecker(provider: string): Step {
     uses: action.installGhRelease,
     with: {
       repo: "pulumi/schema-tools",
+      tag: "master",
     },
   };
 }
@@ -553,12 +554,10 @@ export function CheckSchemaChanges(provider: string): Step {
     if: "github.event_name == 'pull_request'",
     name: "Check Schema is Valid",
     run:
+      "git show ${{ github.event.repository.default_branch }}:provider/cmd/pulumi-resource-${{ env.PROVIDER }}/schema.json > ${{ runner.temp }}/schema.json;\n" +
       "echo 'SCHEMA_CHANGES<<EOF' >> $GITHUB_ENV\n" +
-      "schema-tools compare -p ${{ env.PROVIDER }} -o ${{ github.event.repository.default_branch }} -n --local-path=provider/cmd/pulumi-resource-${{ env.PROVIDER }}/schema.json >> $GITHUB_ENV\n" +
+      "schema-tools compare -p ${{ env.PROVIDER }} -n --local-path=provider/cmd/pulumi-resource-${{ env.PROVIDER }}/schema.json -r file:${{ runner.temp }}/schema.json;\n" +
       "echo 'EOF' >> $GITHUB_ENV",
-    env: {
-      GITHUB_TOKEN: "${{ secrets.PULUMI_BOT_TOKEN }}",
-    },
   };
 }
 


### PR DESCRIPTION
The latest `schema-tools` supports reading from disk instead of fetching from GitHub.