### PR TITLE
Make generate cli arguments optional

### DIFF
--- a/provider-ci/internal/cmd/generate.go
+++ b/provider-ci/internal/cmd/generate.go
@@ -1,22 +1,63 @@
 package cmd
 
 import (
+	"fmt"
+
 	"github.com/pulumi/ci-mgmt/provider-ci/internal/pkg"
 	"github.com/spf13/cobra"
 )
 
-var generateOpts = &pkg.GenerateOpts{}
+type generateArguments struct {
+	RepositoryName string
+	OutDir         string
+	TemplateName   string
+	ConfigPath     string
+}
+
+var generateArgs generateArguments
 
 // generateCmd represents the generate command
 var generateCmd = &cobra.Command{
 	Use:   "generate",
 	Short: "Generate repository files.",
 	RunE: func(cmd *cobra.Command, args []string) error {
-		err := pkg.GeneratePackage(pkg.GenerateOpts{
-			RepositoryName: generateOpts.RepositoryName,
-			OutDir:         generateOpts.OutDir,
-			TemplateName:   generateOpts.TemplateName,
-			ConfigPath:     generateOpts.ConfigPath,
+		localConfig, err := pkg.LoadLocalConfig(generateArgs.ConfigPath)
+		if err != nil {
+			return err
+		}
+		// Template name priority: CLI flag > config file > "bridged-provider"
+		if generateArgs.TemplateName == "" {
+			if templateName, ok := localConfig["template"].(string); ok {
+				generateArgs.TemplateName = templateName
+			}
+		}
+		if generateArgs.TemplateName == "" {
+			generateArgs.TemplateName = "bridged-provider"
+		}
+
+		// Name priority: CLI flag > config file ("repository", then "name" field)
+		if generateArgs.RepositoryName == "" {
+			if repositoryName, ok := localConfig["repository"].(string); ok {
+				generateArgs.RepositoryName = repositoryName
+			} else if name, ok := localConfig["name"].(string); ok {
+				generateArgs.RepositoryName = name
+			}
+		}
+
+		if generateArgs.RepositoryName == "" {
+			return fmt.Errorf("repository name must be set either in the config file or via the --name flag")
+		}
+
+		// Merge local config with template defaults
+		templateConfig, err := localConfig.WithTemplateDefaults(generateArgs.TemplateName)
+		if err != nil {
+			return err
+		}
+		err = pkg.GeneratePackage(pkg.GenerateOpts{
+			RepositoryName: generateArgs.RepositoryName,
+			OutDir:         generateArgs.OutDir,
+			TemplateName:   generateArgs.TemplateName,
+			Config:         templateConfig,
 		})
 		return err
 	},
@@ -25,15 +66,8 @@ var generateCmd = &cobra.Command{
 func init() {
 	rootCmd.AddCommand(generateCmd)
 
-	generateCmd.Flags().StringVarP(&generateOpts.RepositoryName, "name", "n", "", "repository name to generate, e.g.: pulumi/pulumi-aws")
-	_ = generateCmd.MarkFlagRequired("name")
-
-	generateCmd.Flags().StringVarP(&generateOpts.OutDir, "out", "o", ".", "directory to generate files to")
-	_ = generateCmd.MarkFlagRequired("out")
-
-	generateCmd.Flags().StringVarP(&generateOpts.TemplateName, "template", "t", "", "template name to use, e.g.: bridged-provider")
-	_ = generateCmd.MarkFlagRequired("template")
-
-	generateCmd.Flags().StringVarP(&generateOpts.ConfigPath, "config", "c", "", "config file to use, e.g.: config.yaml")
-	_ = generateCmd.MarkFlagRequired("config")
+	generateCmd.Flags().StringVarP(&generateArgs.RepositoryName, "name", "n", "", "repository name to generate (default \"{config.repository}\" or otherwise \"pulumi/pulumi-{config.provider}\")")
+	generateCmd.Flags().StringVarP(&generateArgs.OutDir, "out", "o", ".", "directory to write generate files to")
+	generateCmd.Flags().StringVarP(&generateArgs.TemplateName, "template", "t", "", "template name to generate (default \"{config.template}\" or otherwise \"bridged-provider\")")
+	generateCmd.Flags().StringVarP(&generateArgs.ConfigPath, "config", "c", ".ci-mgmt.yaml", "local config file to use")
 }

--- a/provider-ci/internal/pkg/config.go
+++ b/provider-ci/internal/pkg/config.go
@@ -1,0 +1,55 @@
+package pkg
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/imdario/mergo"
+	"gopkg.in/yaml.v3"
+)
+
+type Config map[string]any
+
+func LoadLocalConfig(path string) (Config, error) {
+	localConfigBytes, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("error reading config file %s: %w", path, err)
+	}
+
+	var localConfig map[string]interface{}
+	err = yaml.Unmarshal(localConfigBytes, &localConfig)
+	if err != nil {
+		return nil, err
+	}
+	return localConfig, nil
+}
+
+func (c Config) WithTemplateDefaults(templateName string) (Config, error) {
+	configForTemplate, err := loadDefaultConfig(templateName)
+	if err != nil {
+		return nil, err
+	}
+	err = mergo.Merge(&configForTemplate, &c, mergo.WithOverride)
+	if err != nil {
+		return nil, err
+	}
+	return configForTemplate, nil
+}
+
+func loadDefaultConfig(templateName string) (Config, error) {
+	var config map[string]interface{}
+
+	configBytes, err := templateFS.ReadFile(filepath.Join("templates", templateName+".config.yaml"))
+	if err != nil {
+		if !os.IsNotExist(err) {
+			return nil, fmt.Errorf("error reading embedded config file for template %s: %w", templateName, err)
+		}
+	} else {
+		err = yaml.Unmarshal(configBytes, &config)
+		if err != nil {
+			return nil, fmt.Errorf("error parsing embedded config file for template %s: %w", templateName, err)
+		}
+	}
+	return config, nil
+}


### PR DESCRIPTION
Related to https://github.com/pulumi/ci-mgmt/issues/936 - this is a pre-cursor to building out composable templates.

## Unbundle the config parsing from the generate method

We need to parse the config before calling generate.

## Make it simpler to run the provider-ci binary directly

Make the 4 required arguments to `provider-ci` optional:

```
Usage:
  provider-ci generate [flags]

Flags:
  -c, --config string     local config file to use (default ".ci-mgmt.yaml")
  -h, --help              help for generate
  -n, --name string       repository name to generate (default "{config.repository}" or otherwise "pulumi/pulumi-{config.provider}")
  -o, --out string        directory to write generate files to (default ".")
  -t, --template string   template name to generate (default "{config.template}" or otherwise "bridged-provider")
```

This avoids the need to generate a makefile template to make it easier to run the tool to pull templates:

```diff
- go run github.com/pulumi/ci-mgmt/provider-ci@master generate \
-		--name pulumi/pulumi-$(PACK) \
-		--out . \
-		--template bridged-provider \
-		--config $<
+ go run github.com/pulumi/ci-mgmt/provider-ci@master generate
```

Existing providers have all the required information available except for the `template` field.