### PR TITLE
Fix custom go utilities

### DIFF
--- a/native-provider-ci/providers/aws-native/repo/.github/workflows/build.yml
+++ b/native-provider-ci/providers/aws-native/repo/.github/workflows/build.yml
@@ -111,7 +111,7 @@ jobs:
         allowed-changes: |-
           sdk/**/pulumi-plugin.json
           sdk/dotnet/Pulumi.*.csproj
-          sdk/go/*/internal/pulumiUtilities.go
+          sdk/go/**/pulumiUtilities.go
           sdk/nodejs/package.json
           sdk/python/pyproject.toml
     - run: git status --porcelain
@@ -217,7 +217,7 @@ jobs:
         allowed-changes: |-
           sdk/**/pulumi-plugin.json
           sdk/dotnet/Pulumi.*.csproj
-          sdk/go/*/internal/pulumiUtilities.go
+          sdk/go/**/pulumiUtilities.go
           sdk/nodejs/package.json
           sdk/python/pyproject.toml
     - run: git status --porcelain

--- a/native-provider-ci/providers/aws-native/repo/.github/workflows/prerelease.yml
+++ b/native-provider-ci/providers/aws-native/repo/.github/workflows/prerelease.yml
@@ -103,7 +103,7 @@ jobs:
         allowed-changes: |-
           sdk/**/pulumi-plugin.json
           sdk/dotnet/Pulumi.*.csproj
-          sdk/go/*/internal/pulumiUtilities.go
+          sdk/go/**/pulumiUtilities.go
           sdk/nodejs/package.json
           sdk/python/pyproject.toml
     - run: git status --porcelain
@@ -209,7 +209,7 @@ jobs:
         allowed-changes: |-
           sdk/**/pulumi-plugin.json
           sdk/dotnet/Pulumi.*.csproj
-          sdk/go/*/internal/pulumiUtilities.go
+          sdk/go/**/pulumiUtilities.go
           sdk/nodejs/package.json
           sdk/python/pyproject.toml
     - run: git status --porcelain

--- a/native-provider-ci/providers/aws-native/repo/.github/workflows/release.yml
+++ b/native-provider-ci/providers/aws-native/repo/.github/workflows/release.yml
@@ -103,7 +103,7 @@ jobs:
         allowed-changes: |-
           sdk/**/pulumi-plugin.json
           sdk/dotnet/Pulumi.*.csproj
-          sdk/go/*/internal/pulumiUtilities.go
+          sdk/go/**/pulumiUtilities.go
           sdk/nodejs/package.json
           sdk/python/pyproject.toml
     - run: git status --porcelain
@@ -209,7 +209,7 @@ jobs:
         allowed-changes: |-
           sdk/**/pulumi-plugin.json
           sdk/dotnet/Pulumi.*.csproj
-          sdk/go/*/internal/pulumiUtilities.go
+          sdk/go/**/pulumiUtilities.go
           sdk/nodejs/package.json
           sdk/python/pyproject.toml
     - run: git status --porcelain

--- a/native-provider-ci/providers/aws-native/repo/.github/workflows/run-acceptance-tests.yml
+++ b/native-provider-ci/providers/aws-native/repo/.github/workflows/run-acceptance-tests.yml
@@ -128,7 +128,7 @@ jobs:
         allowed-changes: |-
           sdk/**/pulumi-plugin.json
           sdk/dotnet/Pulumi.*.csproj
-          sdk/go/*/internal/pulumiUtilities.go
+          sdk/go/**/pulumiUtilities.go
           sdk/nodejs/package.json
           sdk/python/pyproject.toml
     - run: git status --porcelain
@@ -237,7 +237,7 @@ jobs:
         allowed-changes: |-
           sdk/**/pulumi-plugin.json
           sdk/dotnet/Pulumi.*.csproj
-          sdk/go/*/internal/pulumiUtilities.go
+          sdk/go/**/pulumiUtilities.go
           sdk/nodejs/package.json
           sdk/python/pyproject.toml
     - run: git status --porcelain

--- a/native-provider-ci/providers/command/repo/.github/workflows/build.yml
+++ b/native-provider-ci/providers/command/repo/.github/workflows/build.yml
@@ -76,7 +76,7 @@ jobs:
         allowed-changes: |-
           sdk/**/pulumi-plugin.json
           sdk/dotnet/Pulumi.*.csproj
-          sdk/go/*/internal/pulumiUtilities.go
+          sdk/go/**/pulumiUtilities.go
           sdk/nodejs/package.json
           sdk/python/pyproject.toml
     - run: git status --porcelain
@@ -177,7 +177,7 @@ jobs:
         allowed-changes: |-
           sdk/**/pulumi-plugin.json
           sdk/dotnet/Pulumi.*.csproj
-          sdk/go/*/internal/pulumiUtilities.go
+          sdk/go/**/pulumiUtilities.go
           sdk/nodejs/package.json
           sdk/python/pyproject.toml
     - run: git status --porcelain

--- a/native-provider-ci/providers/command/repo/.github/workflows/prerelease.yml
+++ b/native-provider-ci/providers/command/repo/.github/workflows/prerelease.yml
@@ -68,7 +68,7 @@ jobs:
         allowed-changes: |-
           sdk/**/pulumi-plugin.json
           sdk/dotnet/Pulumi.*.csproj
-          sdk/go/*/internal/pulumiUtilities.go
+          sdk/go/**/pulumiUtilities.go
           sdk/nodejs/package.json
           sdk/python/pyproject.toml
     - run: git status --porcelain
@@ -169,7 +169,7 @@ jobs:
         allowed-changes: |-
           sdk/**/pulumi-plugin.json
           sdk/dotnet/Pulumi.*.csproj
-          sdk/go/*/internal/pulumiUtilities.go
+          sdk/go/**/pulumiUtilities.go
           sdk/nodejs/package.json
           sdk/python/pyproject.toml
     - run: git status --porcelain

--- a/native-provider-ci/providers/command/repo/.github/workflows/release.yml
+++ b/native-provider-ci/providers/command/repo/.github/workflows/release.yml
@@ -68,7 +68,7 @@ jobs:
         allowed-changes: |-
           sdk/**/pulumi-plugin.json
           sdk/dotnet/Pulumi.*.csproj
-          sdk/go/*/internal/pulumiUtilities.go
+          sdk/go/**/pulumiUtilities.go
           sdk/nodejs/package.json
           sdk/python/pyproject.toml
     - run: git status --porcelain
@@ -169,7 +169,7 @@ jobs:
         allowed-changes: |-
           sdk/**/pulumi-plugin.json
           sdk/dotnet/Pulumi.*.csproj
-          sdk/go/*/internal/pulumiUtilities.go
+          sdk/go/**/pulumiUtilities.go
           sdk/nodejs/package.json
           sdk/python/pyproject.toml
     - run: git status --porcelain

--- a/native-provider-ci/providers/command/repo/.github/workflows/run-acceptance-tests.yml
+++ b/native-provider-ci/providers/command/repo/.github/workflows/run-acceptance-tests.yml
@@ -93,7 +93,7 @@ jobs:
         allowed-changes: |-
           sdk/**/pulumi-plugin.json
           sdk/dotnet/Pulumi.*.csproj
-          sdk/go/*/internal/pulumiUtilities.go
+          sdk/go/**/pulumiUtilities.go
           sdk/nodejs/package.json
           sdk/python/pyproject.toml
     - run: git status --porcelain
@@ -197,7 +197,7 @@ jobs:
         allowed-changes: |-
           sdk/**/pulumi-plugin.json
           sdk/dotnet/Pulumi.*.csproj
-          sdk/go/*/internal/pulumiUtilities.go
+          sdk/go/**/pulumiUtilities.go
           sdk/nodejs/package.json
           sdk/python/pyproject.toml
     - run: git status --porcelain

--- a/native-provider-ci/providers/docker-build/repo/.github/workflows/build.yml
+++ b/native-provider-ci/providers/docker-build/repo/.github/workflows/build.yml
@@ -123,7 +123,7 @@ jobs:
         allowed-changes: |-
           sdk/**/pulumi-plugin.json
           sdk/dotnet/Pulumi.*.csproj
-          sdk/go/*/internal/pulumiUtilities.go
+          sdk/go/**/pulumiUtilities.go
           sdk/nodejs/package.json
           sdk/python/pyproject.toml
     - run: git status --porcelain
@@ -227,7 +227,7 @@ jobs:
         allowed-changes: |-
           sdk/**/pulumi-plugin.json
           sdk/dotnet/Pulumi.*.csproj
-          sdk/go/*/internal/pulumiUtilities.go
+          sdk/go/**/pulumiUtilities.go
           sdk/nodejs/package.json
           sdk/python/pyproject.toml
     - run: git status --porcelain

--- a/native-provider-ci/providers/docker-build/repo/.github/workflows/prerelease.yml
+++ b/native-provider-ci/providers/docker-build/repo/.github/workflows/prerelease.yml
@@ -115,7 +115,7 @@ jobs:
         allowed-changes: |-
           sdk/**/pulumi-plugin.json
           sdk/dotnet/Pulumi.*.csproj
-          sdk/go/*/internal/pulumiUtilities.go
+          sdk/go/**/pulumiUtilities.go
           sdk/nodejs/package.json
           sdk/python/pyproject.toml
     - run: git status --porcelain
@@ -219,7 +219,7 @@ jobs:
         allowed-changes: |-
           sdk/**/pulumi-plugin.json
           sdk/dotnet/Pulumi.*.csproj
-          sdk/go/*/internal/pulumiUtilities.go
+          sdk/go/**/pulumiUtilities.go
           sdk/nodejs/package.json
           sdk/python/pyproject.toml
     - run: git status --porcelain

--- a/native-provider-ci/providers/docker-build/repo/.github/workflows/release.yml
+++ b/native-provider-ci/providers/docker-build/repo/.github/workflows/release.yml
@@ -115,7 +115,7 @@ jobs:
         allowed-changes: |-
           sdk/**/pulumi-plugin.json
           sdk/dotnet/Pulumi.*.csproj
-          sdk/go/*/internal/pulumiUtilities.go
+          sdk/go/**/pulumiUtilities.go
           sdk/nodejs/package.json
           sdk/python/pyproject.toml
     - run: git status --porcelain
@@ -219,7 +219,7 @@ jobs:
         allowed-changes: |-
           sdk/**/pulumi-plugin.json
           sdk/dotnet/Pulumi.*.csproj
-          sdk/go/*/internal/pulumiUtilities.go
+          sdk/go/**/pulumiUtilities.go
           sdk/nodejs/package.json
           sdk/python/pyproject.toml
     - run: git status --porcelain

--- a/native-provider-ci/providers/docker-build/repo/.github/workflows/run-acceptance-tests.yml
+++ b/native-provider-ci/providers/docker-build/repo/.github/workflows/run-acceptance-tests.yml
@@ -140,7 +140,7 @@ jobs:
         allowed-changes: |-
           sdk/**/pulumi-plugin.json
           sdk/dotnet/Pulumi.*.csproj
-          sdk/go/*/internal/pulumiUtilities.go
+          sdk/go/**/pulumiUtilities.go
           sdk/nodejs/package.json
           sdk/python/pyproject.toml
     - run: git status --porcelain
@@ -247,7 +247,7 @@ jobs:
         allowed-changes: |-
           sdk/**/pulumi-plugin.json
           sdk/dotnet/Pulumi.*.csproj
-          sdk/go/*/internal/pulumiUtilities.go
+          sdk/go/**/pulumiUtilities.go
           sdk/nodejs/package.json
           sdk/python/pyproject.toml
     - run: git status --porcelain

--- a/native-provider-ci/providers/google-native/repo/.github/workflows/build.yml
+++ b/native-provider-ci/providers/google-native/repo/.github/workflows/build.yml
@@ -117,7 +117,7 @@ jobs:
         allowed-changes: |-
           sdk/**/pulumi-plugin.json
           sdk/dotnet/Pulumi.*.csproj
-          sdk/go/*/internal/pulumiUtilities.go
+          sdk/go/**/pulumiUtilities.go
           sdk/nodejs/package.json
           sdk/python/pyproject.toml
     - run: git status --porcelain
@@ -223,7 +223,7 @@ jobs:
         allowed-changes: |-
           sdk/**/pulumi-plugin.json
           sdk/dotnet/Pulumi.*.csproj
-          sdk/go/*/internal/pulumiUtilities.go
+          sdk/go/**/pulumiUtilities.go
           sdk/nodejs/package.json
           sdk/python/pyproject.toml
     - run: git status --porcelain

--- a/native-provider-ci/providers/google-native/repo/.github/workflows/prerelease.yml
+++ b/native-provider-ci/providers/google-native/repo/.github/workflows/prerelease.yml
@@ -109,7 +109,7 @@ jobs:
         allowed-changes: |-
           sdk/**/pulumi-plugin.json
           sdk/dotnet/Pulumi.*.csproj
-          sdk/go/*/internal/pulumiUtilities.go
+          sdk/go/**/pulumiUtilities.go
           sdk/nodejs/package.json
           sdk/python/pyproject.toml
     - run: git status --porcelain
@@ -215,7 +215,7 @@ jobs:
         allowed-changes: |-
           sdk/**/pulumi-plugin.json
           sdk/dotnet/Pulumi.*.csproj
-          sdk/go/*/internal/pulumiUtilities.go
+          sdk/go/**/pulumiUtilities.go
           sdk/nodejs/package.json
           sdk/python/pyproject.toml
     - run: git status --porcelain

--- a/native-provider-ci/providers/google-native/repo/.github/workflows/release.yml
+++ b/native-provider-ci/providers/google-native/repo/.github/workflows/release.yml
@@ -109,7 +109,7 @@ jobs:
         allowed-changes: |-
           sdk/**/pulumi-plugin.json
           sdk/dotnet/Pulumi.*.csproj
-          sdk/go/*/internal/pulumiUtilities.go
+          sdk/go/**/pulumiUtilities.go
           sdk/nodejs/package.json
           sdk/python/pyproject.toml
     - run: git status --porcelain
@@ -215,7 +215,7 @@ jobs:
         allowed-changes: |-
           sdk/**/pulumi-plugin.json
           sdk/dotnet/Pulumi.*.csproj
-          sdk/go/*/internal/pulumiUtilities.go
+          sdk/go/**/pulumiUtilities.go
           sdk/nodejs/package.json
           sdk/python/pyproject.toml
     - run: git status --porcelain

--- a/native-provider-ci/providers/google-native/repo/.github/workflows/run-acceptance-tests.yml
+++ b/native-provider-ci/providers/google-native/repo/.github/workflows/run-acceptance-tests.yml
@@ -134,7 +134,7 @@ jobs:
         allowed-changes: |-
           sdk/**/pulumi-plugin.json
           sdk/dotnet/Pulumi.*.csproj
-          sdk/go/*/internal/pulumiUtilities.go
+          sdk/go/**/pulumiUtilities.go
           sdk/nodejs/package.json
           sdk/python/pyproject.toml
     - run: git status --porcelain
@@ -243,7 +243,7 @@ jobs:
         allowed-changes: |-
           sdk/**/pulumi-plugin.json
           sdk/dotnet/Pulumi.*.csproj
-          sdk/go/*/internal/pulumiUtilities.go
+          sdk/go/**/pulumiUtilities.go
           sdk/nodejs/package.json
           sdk/python/pyproject.toml
     - run: git status --porcelain

--- a/native-provider-ci/providers/kubernetes-cert-manager/repo/.github/workflows/build.yml
+++ b/native-provider-ci/providers/kubernetes-cert-manager/repo/.github/workflows/build.yml
@@ -114,7 +114,7 @@ jobs:
         allowed-changes: |-
           sdk/**/pulumi-plugin.json
           sdk/dotnet/Pulumi.*.csproj
-          sdk/go/*/internal/pulumiUtilities.go
+          sdk/go/**/pulumiUtilities.go
           sdk/nodejs/package.json
           sdk/python/pyproject.toml
     - run: git status --porcelain
@@ -218,7 +218,7 @@ jobs:
         allowed-changes: |-
           sdk/**/pulumi-plugin.json
           sdk/dotnet/Pulumi.*.csproj
-          sdk/go/*/internal/pulumiUtilities.go
+          sdk/go/**/pulumiUtilities.go
           sdk/nodejs/package.json
           sdk/python/pyproject.toml
     - run: git status --porcelain

--- a/native-provider-ci/providers/kubernetes-cert-manager/repo/.github/workflows/prerelease.yml
+++ b/native-provider-ci/providers/kubernetes-cert-manager/repo/.github/workflows/prerelease.yml
@@ -106,7 +106,7 @@ jobs:
         allowed-changes: |-
           sdk/**/pulumi-plugin.json
           sdk/dotnet/Pulumi.*.csproj
-          sdk/go/*/internal/pulumiUtilities.go
+          sdk/go/**/pulumiUtilities.go
           sdk/nodejs/package.json
           sdk/python/pyproject.toml
     - run: git status --porcelain
@@ -210,7 +210,7 @@ jobs:
         allowed-changes: |-
           sdk/**/pulumi-plugin.json
           sdk/dotnet/Pulumi.*.csproj
-          sdk/go/*/internal/pulumiUtilities.go
+          sdk/go/**/pulumiUtilities.go
           sdk/nodejs/package.json
           sdk/python/pyproject.toml
     - run: git status --porcelain

--- a/native-provider-ci/providers/kubernetes-cert-manager/repo/.github/workflows/release.yml
+++ b/native-provider-ci/providers/kubernetes-cert-manager/repo/.github/workflows/release.yml
@@ -106,7 +106,7 @@ jobs:
         allowed-changes: |-
           sdk/**/pulumi-plugin.json
           sdk/dotnet/Pulumi.*.csproj
-          sdk/go/*/internal/pulumiUtilities.go
+          sdk/go/**/pulumiUtilities.go
           sdk/nodejs/package.json
           sdk/python/pyproject.toml
     - run: git status --porcelain
@@ -210,7 +210,7 @@ jobs:
         allowed-changes: |-
           sdk/**/pulumi-plugin.json
           sdk/dotnet/Pulumi.*.csproj
-          sdk/go/*/internal/pulumiUtilities.go
+          sdk/go/**/pulumiUtilities.go
           sdk/nodejs/package.json
           sdk/python/pyproject.toml
     - run: git status --porcelain

--- a/native-provider-ci/providers/kubernetes-cert-manager/repo/.github/workflows/run-acceptance-tests.yml
+++ b/native-provider-ci/providers/kubernetes-cert-manager/repo/.github/workflows/run-acceptance-tests.yml
@@ -131,7 +131,7 @@ jobs:
         allowed-changes: |-
           sdk/**/pulumi-plugin.json
           sdk/dotnet/Pulumi.*.csproj
-          sdk/go/*/internal/pulumiUtilities.go
+          sdk/go/**/pulumiUtilities.go
           sdk/nodejs/package.json
           sdk/python/pyproject.toml
     - run: git status --porcelain
@@ -238,7 +238,7 @@ jobs:
         allowed-changes: |-
           sdk/**/pulumi-plugin.json
           sdk/dotnet/Pulumi.*.csproj
-          sdk/go/*/internal/pulumiUtilities.go
+          sdk/go/**/pulumiUtilities.go
           sdk/nodejs/package.json
           sdk/python/pyproject.toml
     - run: git status --porcelain

--- a/native-provider-ci/providers/kubernetes/repo/.github/workflows/build.yml
+++ b/native-provider-ci/providers/kubernetes/repo/.github/workflows/build.yml
@@ -116,7 +116,7 @@ jobs:
         allowed-changes: |-
           sdk/**/pulumi-plugin.json
           sdk/dotnet/Pulumi.*.csproj
-          sdk/go/*/internal/pulumiUtilities.go
+          sdk/go/**/pulumiUtilities.go
           sdk/nodejs/package.json
           sdk/python/pyproject.toml
     - run: git status --porcelain
@@ -218,7 +218,7 @@ jobs:
         allowed-changes: |-
           sdk/**/pulumi-plugin.json
           sdk/dotnet/Pulumi.*.csproj
-          sdk/go/*/internal/pulumiUtilities.go
+          sdk/go/**/pulumiUtilities.go
           sdk/nodejs/package.json
           sdk/python/pyproject.toml
     - run: git status --porcelain

--- a/native-provider-ci/providers/kubernetes/repo/.github/workflows/prerelease.yml
+++ b/native-provider-ci/providers/kubernetes/repo/.github/workflows/prerelease.yml
@@ -108,7 +108,7 @@ jobs:
         allowed-changes: |-
           sdk/**/pulumi-plugin.json
           sdk/dotnet/Pulumi.*.csproj
-          sdk/go/*/internal/pulumiUtilities.go
+          sdk/go/**/pulumiUtilities.go
           sdk/nodejs/package.json
           sdk/python/pyproject.toml
     - run: git status --porcelain
@@ -210,7 +210,7 @@ jobs:
         allowed-changes: |-
           sdk/**/pulumi-plugin.json
           sdk/dotnet/Pulumi.*.csproj
-          sdk/go/*/internal/pulumiUtilities.go
+          sdk/go/**/pulumiUtilities.go
           sdk/nodejs/package.json
           sdk/python/pyproject.toml
     - run: git status --porcelain

--- a/native-provider-ci/providers/kubernetes/repo/.github/workflows/release.yml
+++ b/native-provider-ci/providers/kubernetes/repo/.github/workflows/release.yml
@@ -108,7 +108,7 @@ jobs:
         allowed-changes: |-
           sdk/**/pulumi-plugin.json
           sdk/dotnet/Pulumi.*.csproj
-          sdk/go/*/internal/pulumiUtilities.go
+          sdk/go/**/pulumiUtilities.go
           sdk/nodejs/package.json
           sdk/python/pyproject.toml
     - run: git status --porcelain
@@ -210,7 +210,7 @@ jobs:
         allowed-changes: |-
           sdk/**/pulumi-plugin.json
           sdk/dotnet/Pulumi.*.csproj
-          sdk/go/*/internal/pulumiUtilities.go
+          sdk/go/**/pulumiUtilities.go
           sdk/nodejs/package.json
           sdk/python/pyproject.toml
     - run: git status --porcelain

--- a/native-provider-ci/providers/kubernetes/repo/.github/workflows/run-acceptance-tests.yml
+++ b/native-provider-ci/providers/kubernetes/repo/.github/workflows/run-acceptance-tests.yml
@@ -134,7 +134,7 @@ jobs:
         allowed-changes: |-
           sdk/**/pulumi-plugin.json
           sdk/dotnet/Pulumi.*.csproj
-          sdk/go/*/internal/pulumiUtilities.go
+          sdk/go/**/pulumiUtilities.go
           sdk/nodejs/package.json
           sdk/python/pyproject.toml
     - run: git status --porcelain
@@ -239,7 +239,7 @@ jobs:
         allowed-changes: |-
           sdk/**/pulumi-plugin.json
           sdk/dotnet/Pulumi.*.csproj
-          sdk/go/*/internal/pulumiUtilities.go
+          sdk/go/**/pulumiUtilities.go
           sdk/nodejs/package.json
           sdk/python/pyproject.toml
     - run: git status --porcelain

--- a/native-provider-ci/src/steps.ts
+++ b/native-provider-ci/src/steps.ts
@@ -475,7 +475,7 @@ export function CheckCleanWorkTree(): Step {
       "allowed-changes": `\
 sdk/**/pulumi-plugin.json
 sdk/dotnet/Pulumi.*.csproj
-sdk/go/*/internal/pulumiUtilities.go
+sdk/go/**/pulumiUtilities.go
 sdk/nodejs/package.json
 sdk/python/pyproject.toml`,
     },

--- a/provider-ci/internal/pkg/templates/bridged-provider.config.yaml
+++ b/provider-ci/internal/pkg/templates/bridged-provider.config.yaml
@@ -107,6 +107,6 @@ publish:
 worktreeAllowedChanges: |-
   sdk/**/pulumi-plugin.json
   sdk/dotnet/Pulumi.*.csproj
-  sdk/go/*/internal/pulumiUtilities.go
+  sdk/go/**/pulumiUtilities.go
   sdk/nodejs/package.json
   sdk/python/pyproject.toml

--- a/provider-ci/test-workflows/aws/.github/workflows/master.yml
+++ b/provider-ci/test-workflows/aws/.github/workflows/master.yml
@@ -110,7 +110,7 @@ jobs:
         allowed-changes: |
           sdk/**/pulumi-plugin.json
           sdk/dotnet/Pulumi.*.csproj
-          sdk/go/*/internal/pulumiUtilities.go
+          sdk/go/**/pulumiUtilities.go
           sdk/nodejs/package.json
           sdk/python/pyproject.toml
     - name: Compress SDK folder

--- a/provider-ci/test-workflows/aws/.github/workflows/nightly-test.yml
+++ b/provider-ci/test-workflows/aws/.github/workflows/nightly-test.yml
@@ -110,7 +110,7 @@ jobs:
         allowed-changes: |
           sdk/**/pulumi-plugin.json
           sdk/dotnet/Pulumi.*.csproj
-          sdk/go/*/internal/pulumiUtilities.go
+          sdk/go/**/pulumiUtilities.go
           sdk/nodejs/package.json
           sdk/python/pyproject.toml
     - name: Compress SDK folder

--- a/provider-ci/test-workflows/aws/.github/workflows/prerelease.yml
+++ b/provider-ci/test-workflows/aws/.github/workflows/prerelease.yml
@@ -111,7 +111,7 @@ jobs:
         allowed-changes: |
           sdk/**/pulumi-plugin.json
           sdk/dotnet/Pulumi.*.csproj
-          sdk/go/*/internal/pulumiUtilities.go
+          sdk/go/**/pulumiUtilities.go
           sdk/nodejs/package.json
           sdk/python/pyproject.toml
     - name: Compress SDK folder

--- a/provider-ci/test-workflows/aws/.github/workflows/release.yml
+++ b/provider-ci/test-workflows/aws/.github/workflows/release.yml
@@ -110,7 +110,7 @@ jobs:
         allowed-changes: |
           sdk/**/pulumi-plugin.json
           sdk/dotnet/Pulumi.*.csproj
-          sdk/go/*/internal/pulumiUtilities.go
+          sdk/go/**/pulumiUtilities.go
           sdk/nodejs/package.json
           sdk/python/pyproject.toml
     - name: Compress SDK folder

--- a/provider-ci/test-workflows/aws/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/test-workflows/aws/.github/workflows/run-acceptance-tests.yml
@@ -119,7 +119,7 @@ jobs:
         allowed-changes: |
           sdk/**/pulumi-plugin.json
           sdk/dotnet/Pulumi.*.csproj
-          sdk/go/*/internal/pulumiUtilities.go
+          sdk/go/**/pulumiUtilities.go
           sdk/nodejs/package.json
           sdk/python/pyproject.toml
     - name: Compress SDK folder

--- a/provider-ci/test-workflows/cloudflare/.github/workflows/master.yml
+++ b/provider-ci/test-workflows/cloudflare/.github/workflows/master.yml
@@ -108,7 +108,7 @@ jobs:
         allowed-changes: |
           sdk/**/pulumi-plugin.json
           sdk/dotnet/Pulumi.*.csproj
-          sdk/go/*/internal/pulumiUtilities.go
+          sdk/go/**/pulumiUtilities.go
           sdk/nodejs/package.json
           sdk/python/pyproject.toml
     - name: Compress SDK folder

--- a/provider-ci/test-workflows/cloudflare/.github/workflows/prerelease.yml
+++ b/provider-ci/test-workflows/cloudflare/.github/workflows/prerelease.yml
@@ -109,7 +109,7 @@ jobs:
         allowed-changes: |
           sdk/**/pulumi-plugin.json
           sdk/dotnet/Pulumi.*.csproj
-          sdk/go/*/internal/pulumiUtilities.go
+          sdk/go/**/pulumiUtilities.go
           sdk/nodejs/package.json
           sdk/python/pyproject.toml
     - name: Compress SDK folder

--- a/provider-ci/test-workflows/cloudflare/.github/workflows/release.yml
+++ b/provider-ci/test-workflows/cloudflare/.github/workflows/release.yml
@@ -108,7 +108,7 @@ jobs:
         allowed-changes: |
           sdk/**/pulumi-plugin.json
           sdk/dotnet/Pulumi.*.csproj
-          sdk/go/*/internal/pulumiUtilities.go
+          sdk/go/**/pulumiUtilities.go
           sdk/nodejs/package.json
           sdk/python/pyproject.toml
     - name: Compress SDK folder

--- a/provider-ci/test-workflows/cloudflare/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/test-workflows/cloudflare/.github/workflows/run-acceptance-tests.yml
@@ -118,7 +118,7 @@ jobs:
         allowed-changes: |
           sdk/**/pulumi-plugin.json
           sdk/dotnet/Pulumi.*.csproj
-          sdk/go/*/internal/pulumiUtilities.go
+          sdk/go/**/pulumiUtilities.go
           sdk/nodejs/package.json
           sdk/python/pyproject.toml
     - name: Compress SDK folder

--- a/provider-ci/test-workflows/docker/.github/workflows/master.yml
+++ b/provider-ci/test-workflows/docker/.github/workflows/master.yml
@@ -121,7 +121,7 @@ jobs:
         allowed-changes: |
           sdk/**/pulumi-plugin.json
           sdk/dotnet/Pulumi.*.csproj
-          sdk/go/*/internal/pulumiUtilities.go
+          sdk/go/**/pulumiUtilities.go
           sdk/nodejs/package.json
           sdk/python/pyproject.toml
     - name: Compress SDK folder

--- a/provider-ci/test-workflows/docker/.github/workflows/prerelease.yml
+++ b/provider-ci/test-workflows/docker/.github/workflows/prerelease.yml
@@ -122,7 +122,7 @@ jobs:
         allowed-changes: |
           sdk/**/pulumi-plugin.json
           sdk/dotnet/Pulumi.*.csproj
-          sdk/go/*/internal/pulumiUtilities.go
+          sdk/go/**/pulumiUtilities.go
           sdk/nodejs/package.json
           sdk/python/pyproject.toml
     - name: Compress SDK folder

--- a/provider-ci/test-workflows/docker/.github/workflows/release.yml
+++ b/provider-ci/test-workflows/docker/.github/workflows/release.yml
@@ -121,7 +121,7 @@ jobs:
         allowed-changes: |
           sdk/**/pulumi-plugin.json
           sdk/dotnet/Pulumi.*.csproj
-          sdk/go/*/internal/pulumiUtilities.go
+          sdk/go/**/pulumiUtilities.go
           sdk/nodejs/package.json
           sdk/python/pyproject.toml
     - name: Compress SDK folder

--- a/provider-ci/test-workflows/docker/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/test-workflows/docker/.github/workflows/run-acceptance-tests.yml
@@ -131,7 +131,7 @@ jobs:
         allowed-changes: |
           sdk/**/pulumi-plugin.json
           sdk/dotnet/Pulumi.*.csproj
-          sdk/go/*/internal/pulumiUtilities.go
+          sdk/go/**/pulumiUtilities.go
           sdk/nodejs/package.json
           sdk/python/pyproject.toml
     - name: Compress SDK folder


### PR DESCRIPTION
Fix allowed changes for custom go utils dir - some providers customise the directory name containing the utilities.

See https://github.com/pulumi/pulumi-kubernetes/pull/3028 for example.