### PR TITLE
Auto-update local pulumi cli version

### DIFF
--- a/native-provider-ci/providers/aws-native/repo/.github/workflows/weekly-pulumi-update.yml
+++ b/native-provider-ci/providers/aws-native/repo/.github/workflows/weekly-pulumi-update.yml
@@ -80,6 +80,8 @@ jobs:
 
         for MODFILE in $(find . -name go.mod); do pushd $(dirname $MODFILE); go get github.com/pulumi/pulumi/pkg/v3 github.com/pulumi/pulumi/sdk/v3; go mod tidy; popd; done
 
+        gh repo view pulumi/pulumi --json latestRelease --jq .latestRelease.tagName | sed 's/^v//' > .pulumi.version
+
         git update-index -q --refresh
 
         if ! git diff-files --quiet; then echo changes=1 >> "$GITHUB_OUTPUT"; fi

--- a/native-provider-ci/providers/command/repo/.github/workflows/weekly-pulumi-update.yml
+++ b/native-provider-ci/providers/command/repo/.github/workflows/weekly-pulumi-update.yml
@@ -80,6 +80,8 @@ jobs:
 
         for MODFILE in $(find . -name go.mod); do pushd $(dirname $MODFILE); go get github.com/pulumi/pulumi/pkg/v3 github.com/pulumi/pulumi/sdk/v3; go mod tidy; popd; done
 
+        gh repo view pulumi/pulumi --json latestRelease --jq .latestRelease.tagName | sed 's/^v//' > .pulumi.version
+
         git update-index -q --refresh
 
         if ! git diff-files --quiet; then echo changes=1 >> "$GITHUB_OUTPUT"; fi

--- a/native-provider-ci/providers/docker-build/repo/.github/workflows/weekly-pulumi-update.yml
+++ b/native-provider-ci/providers/docker-build/repo/.github/workflows/weekly-pulumi-update.yml
@@ -94,6 +94,8 @@ jobs:
 
         for MODFILE in $(find . -name go.mod); do pushd $(dirname $MODFILE); go get github.com/pulumi/pulumi/pkg/v3 github.com/pulumi/pulumi/sdk/v3; go mod tidy; popd; done
 
+        gh repo view pulumi/pulumi --json latestRelease --jq .latestRelease.tagName | sed 's/^v//' > .pulumi.version
+
         git update-index -q --refresh
 
         if ! git diff-files --quiet; then echo changes=1 >> "$GITHUB_OUTPUT"; fi

--- a/native-provider-ci/providers/google-native/repo/.github/workflows/weekly-pulumi-update.yml
+++ b/native-provider-ci/providers/google-native/repo/.github/workflows/weekly-pulumi-update.yml
@@ -86,6 +86,8 @@ jobs:
 
         for MODFILE in $(find . -name go.mod); do pushd $(dirname $MODFILE); go get github.com/pulumi/pulumi/pkg/v3 github.com/pulumi/pulumi/sdk/v3; go mod tidy; popd; done
 
+        gh repo view pulumi/pulumi --json latestRelease --jq .latestRelease.tagName | sed 's/^v//' > .pulumi.version
+
         git update-index -q --refresh
 
         if ! git diff-files --quiet; then echo changes=1 >> "$GITHUB_OUTPUT"; fi

--- a/native-provider-ci/providers/kubernetes-cert-manager/repo/.github/workflows/weekly-pulumi-update.yml
+++ b/native-provider-ci/providers/kubernetes-cert-manager/repo/.github/workflows/weekly-pulumi-update.yml
@@ -85,6 +85,8 @@ jobs:
 
         for MODFILE in $(find . -name go.mod); do pushd $(dirname $MODFILE); go get github.com/pulumi/pulumi/pkg/v3 github.com/pulumi/pulumi/sdk/v3; go mod tidy; popd; done
 
+        gh repo view pulumi/pulumi --json latestRelease --jq .latestRelease.tagName | sed 's/^v//' > .pulumi.version
+
         git update-index -q --refresh
 
         if ! git diff-files --quiet; then echo changes=1 >> "$GITHUB_OUTPUT"; fi

--- a/native-provider-ci/providers/kubernetes/repo/.github/workflows/weekly-pulumi-update.yml
+++ b/native-provider-ci/providers/kubernetes/repo/.github/workflows/weekly-pulumi-update.yml
@@ -85,6 +85,8 @@ jobs:
 
         for MODFILE in $(find . -name go.mod); do pushd $(dirname $MODFILE); go get github.com/pulumi/pulumi/pkg/v3 github.com/pulumi/pulumi/sdk/v3; go mod tidy; popd; done
 
+        gh repo view pulumi/pulumi --json latestRelease --jq .latestRelease.tagName | sed 's/^v//' > .pulumi.version
+
         git update-index -q --refresh
 
         if ! git diff-files --quiet; then echo changes=1 >> "$GITHUB_OUTPUT"; fi

--- a/native-provider-ci/src/steps.ts
+++ b/native-provider-ci/src/steps.ts
@@ -919,6 +919,8 @@ export function UpdatePulumi(): Step {
       "git config --local user.name 'pulumi-bot'\n" +
       "git checkout -b update-pulumi/${{ github.run_id }}-${{ github.run_number }}\n" +
       "for MODFILE in $(find . -name go.mod); do pushd $(dirname $MODFILE); go get github.com/pulumi/pulumi/pkg/v3 github.com/pulumi/pulumi/sdk/v3; go mod tidy; popd; done\n" +
+      // Fetch latest release version of Pulumi, remove the leading 'v' and store it to the `.pulumi.version` file.
+      "gh repo view pulumi/pulumi --json latestRelease --jq .latestRelease.tagName | sed 's/^v//' > .pulumi.version\n" +
       "git update-index -q --refresh\n" +
       'if ! git diff-files --quiet; then echo changes=1 >> "$GITHUB_OUTPUT"; fi',
   };


### PR DESCRIPTION
Fixes #940

This doesn't yet apply to bridged providers because they still have to build their own TF Gen binary for now until https://github.com/pulumi/pulumi/issues/16099 is fixed.