### PR TITLE
Implement new explicit sentinel check

### DIFF
--- a/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/run-acceptance-tests.yml
@@ -101,6 +101,18 @@ jobs:
     - name: Workflow is not a success
       if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') || contains(needs.*.result, 'skipped')
       run: exit 1
+    - uses: guibranco/github-status-action-v2@0849440ec82c5fa69b2377725b9b7852a3977e76
+      with: 
+        authToken: ${{secrets.GITHUB_TOKEN}}
+        # Write an explicit status check called "Sentinel" which will only pass if this code really runs.
+        # Once rolled out, we can make this the only required check for PRs,
+        # then remove the old conditionals on this job and remove the previous step.
+        context: 'Sentinel'
+        description: 'All required checks passed'
+        state: 'success'
+        # Write to the PR commit SHA if it's available as we don't want the merge commit sha,
+        # otherwise use the current SHA for any other type of build.
+        sha: ${{ github.event.pull_request.head.sha || github.sha }}
     - name: Workflow is a success
       run: echo "🎉🎈🎉🎈🎉"
 

--- a/provider-ci/test-workflows/aws/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/test-workflows/aws/.github/workflows/run-acceptance-tests.yml
@@ -300,6 +300,18 @@ jobs:
     - name: Workflow is not a success
       if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') || contains(needs.*.result, 'skipped')
       run: exit 1
+    - uses: guibranco/github-status-action-v2@0849440ec82c5fa69b2377725b9b7852a3977e76
+      with: 
+        authToken: ${{secrets.GITHUB_TOKEN}}
+        # Write an explicit status check called "Sentinel" which will only pass if this code really runs.
+        # Once rolled out, we can make this the only required check for PRs,
+        # then remove the old conditionals on this job and remove the previous step.
+        context: 'Sentinel'
+        description: 'All required checks passed'
+        state: 'success'
+        # Write to the PR commit SHA if it's available as we don't want the merge commit sha,
+        # otherwise use the current SHA for any other type of build.
+        sha: ${{ github.event.pull_request.head.sha || github.sha }}
     - name: Workflow is a success
       run: echo "🎉🎈🎉🎈🎉"
 

--- a/provider-ci/test-workflows/cloudflare/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/test-workflows/cloudflare/.github/workflows/run-acceptance-tests.yml
@@ -294,6 +294,18 @@ jobs:
     - name: Workflow is not a success
       if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') || contains(needs.*.result, 'skipped')
       run: exit 1
+    - uses: guibranco/github-status-action-v2@0849440ec82c5fa69b2377725b9b7852a3977e76
+      with: 
+        authToken: ${{secrets.GITHUB_TOKEN}}
+        # Write an explicit status check called "Sentinel" which will only pass if this code really runs.
+        # Once rolled out, we can make this the only required check for PRs,
+        # then remove the old conditionals on this job and remove the previous step.
+        context: 'Sentinel'
+        description: 'All required checks passed'
+        state: 'success'
+        # Write to the PR commit SHA if it's available as we don't want the merge commit sha,
+        # otherwise use the current SHA for any other type of build.
+        sha: ${{ github.event.pull_request.head.sha || github.sha }}
     - name: Workflow is a success
       run: echo "🎉🎈🎉🎈🎉"
 

--- a/provider-ci/test-workflows/docker/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/test-workflows/docker/.github/workflows/run-acceptance-tests.yml
@@ -307,6 +307,18 @@ jobs:
     - name: Workflow is not a success
       if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') || contains(needs.*.result, 'skipped')
       run: exit 1
+    - uses: guibranco/github-status-action-v2@0849440ec82c5fa69b2377725b9b7852a3977e76
+      with: 
+        authToken: ${{secrets.GITHUB_TOKEN}}
+        # Write an explicit status check called "Sentinel" which will only pass if this code really runs.
+        # Once rolled out, we can make this the only required check for PRs,
+        # then remove the old conditionals on this job and remove the previous step.
+        context: 'Sentinel'
+        description: 'All required checks passed'
+        state: 'success'
+        # Write to the PR commit SHA if it's available as we don't want the merge commit sha,
+        # otherwise use the current SHA for any other type of build.
+        sha: ${{ github.event.pull_request.head.sha || github.sha }}
     - name: Workflow is a success
       run: echo "🎉🎈🎉🎈🎉"
 


### PR DESCRIPTION
Write an explicit status check called "Sentinel" which will only pass if this code really runs. Once rolled out, we can make this the only required check for PRs, then remove the old conditionals on this job and remove the previous step.

This is a follow-up to the conversation https://github.com/pulumi/ci-mgmt/pull/942#issuecomment-2137523033 where we debated the merits of a single required check if we could simplify the current sentinel logic to make it more reliable.

Here's the test run in the xyz provider: https://github.com/pulumi/pulumi-xyz/actions/runs/9292939832?pr=145

Here's the old and new sentinel checks shown on the [test PR](https://github.com/pulumi/pulumi-xyz/pull/145):
![image](https://github.com/pulumi/ci-mgmt/assets/331676/2a9ac907-729e-415b-aac6-87ff29eb9d7b)
