### PR TITLE
Update native provider CI

### DIFF
--- a/native-provider-ci/providers/aws-native/repo/.github/workflows/run-acceptance-tests.yml
+++ b/native-provider-ci/providers/aws-native/repo/.github/workflows/run-acceptance-tests.yml
@@ -382,8 +382,14 @@ jobs:
     runs-on: ubuntu-latest
     name: sentinel
     steps:
-    - name: Is workflow a success
-      run: echo yes
+    - name: Mark workflow as successful
+      uses: guibranco/github-status-action-v2@0849440ec82c5fa69b2377725b9b7852a3977e76
+      with:
+        authToken: ${{ secrets.GITHUB_TOKEN }}
+        context: Sentinel
+        state: success
+        description: Sentinel checks passed
+        sha: ${{ github.event.pull_request.head.sha || github.sha }}
     if: github.event_name == 'repository_dispatch' ||
       github.event.pull_request.head.repo.full_name == github.repository
     needs:

--- a/native-provider-ci/providers/command/repo/.github/workflows/run-acceptance-tests.yml
+++ b/native-provider-ci/providers/command/repo/.github/workflows/run-acceptance-tests.yml
@@ -342,8 +342,14 @@ jobs:
     runs-on: ubuntu-latest
     name: sentinel
     steps:
-    - name: Is workflow a success
-      run: echo yes
+    - name: Mark workflow as successful
+      uses: guibranco/github-status-action-v2@0849440ec82c5fa69b2377725b9b7852a3977e76
+      with:
+        authToken: ${{ secrets.GITHUB_TOKEN }}
+        context: Sentinel
+        state: success
+        description: Sentinel checks passed
+        sha: ${{ github.event.pull_request.head.sha || github.sha }}
     if: github.event_name == 'repository_dispatch' ||
       github.event.pull_request.head.repo.full_name == github.repository
     needs:

--- a/native-provider-ci/providers/docker-build/repo/.github/workflows/run-acceptance-tests.yml
+++ b/native-provider-ci/providers/docker-build/repo/.github/workflows/run-acceptance-tests.yml
@@ -404,8 +404,14 @@ jobs:
     runs-on: ubuntu-latest
     name: sentinel
     steps:
-    - name: Is workflow a success
-      run: echo yes
+    - name: Mark workflow as successful
+      uses: guibranco/github-status-action-v2@0849440ec82c5fa69b2377725b9b7852a3977e76
+      with:
+        authToken: ${{ secrets.GITHUB_TOKEN }}
+        context: Sentinel
+        state: success
+        description: Sentinel checks passed
+        sha: ${{ github.event.pull_request.head.sha || github.sha }}
     if: github.event_name == 'repository_dispatch' ||
       github.event.pull_request.head.repo.full_name == github.repository
     needs:

--- a/native-provider-ci/providers/google-native/repo/.github/workflows/run-acceptance-tests.yml
+++ b/native-provider-ci/providers/google-native/repo/.github/workflows/run-acceptance-tests.yml
@@ -391,8 +391,14 @@ jobs:
     runs-on: ubuntu-latest
     name: sentinel
     steps:
-    - name: Is workflow a success
-      run: echo yes
+    - name: Mark workflow as successful
+      uses: guibranco/github-status-action-v2@0849440ec82c5fa69b2377725b9b7852a3977e76
+      with:
+        authToken: ${{ secrets.GITHUB_TOKEN }}
+        context: Sentinel
+        state: success
+        description: Sentinel checks passed
+        sha: ${{ github.event.pull_request.head.sha || github.sha }}
     if: github.event_name == 'repository_dispatch' ||
       github.event.pull_request.head.repo.full_name == github.repository
     needs:

--- a/native-provider-ci/providers/kubernetes-cert-manager/repo/.github/workflows/run-acceptance-tests.yml
+++ b/native-provider-ci/providers/kubernetes-cert-manager/repo/.github/workflows/run-acceptance-tests.yml
@@ -374,8 +374,14 @@ jobs:
     runs-on: ubuntu-latest
     name: sentinel
     steps:
-    - name: Is workflow a success
-      run: echo yes
+    - name: Mark workflow as successful
+      uses: guibranco/github-status-action-v2@0849440ec82c5fa69b2377725b9b7852a3977e76
+      with:
+        authToken: ${{ secrets.GITHUB_TOKEN }}
+        context: Sentinel
+        state: success
+        description: Sentinel checks passed
+        sha: ${{ github.event.pull_request.head.sha || github.sha }}
     if: github.event_name == 'repository_dispatch' ||
       github.event.pull_request.head.repo.full_name == github.repository
     needs:

--- a/native-provider-ci/providers/kubernetes/repo/.github/workflows/run-acceptance-tests.yml
+++ b/native-provider-ci/providers/kubernetes/repo/.github/workflows/run-acceptance-tests.yml
@@ -415,8 +415,14 @@ jobs:
     runs-on: ubuntu-latest
     name: sentinel
     steps:
-    - name: Is workflow a success
-      run: echo yes
+    - name: Mark workflow as successful
+      uses: guibranco/github-status-action-v2@0849440ec82c5fa69b2377725b9b7852a3977e76
+      with:
+        authToken: ${{ secrets.GITHUB_TOKEN }}
+        context: Sentinel
+        state: success
+        description: Sentinel checks passed
+        sha: ${{ github.event.pull_request.head.sha || github.sha }}
     if: github.event_name == 'repository_dispatch' ||
       github.event.pull_request.head.repo.full_name == github.repository
     needs:

--- a/native-provider-ci/src/action-versions.ts
+++ b/native-provider-ci/src/action-versions.ts
@@ -44,3 +44,5 @@ export const upgradeProviderAction =
 export const slackNotification = "rtCamp/action-slack-notify@v2";
 export const freeDiskSpace = "jlumbroso/free-disk-space@v1.3.1"; // action does not support major version pinning, so we need to pin to exact version
 export const createKindCluster = "helm/kind-action@v1";
+export const githubStatusAction =
+  "guibranco/github-status-action-v2@0849440ec82c5fa69b2377725b9b7852a3977e76";

--- a/native-provider-ci/src/steps.ts
+++ b/native-provider-ci/src/steps.ts
@@ -115,6 +115,20 @@ export function EchoSuccessStep(): Step {
   };
 }
 
+export function SentinelStep(): Step {
+  return {
+    name: "Mark workflow as successful",
+    uses: action.githubStatusAction,
+    with: {
+      authToken: "${{ secrets.GITHUB_TOKEN }}",
+      context: "Sentinel",
+      state: "success",
+      description: "Sentinel checks passed",
+      sha: "${{ github.event.pull_request.head.sha || github.sha }}",
+    },
+  };
+}
+
 export function UpdatePRWithResultsStep(): Step {
   return {
     name: "Update with Result",

--- a/native-provider-ci/src/workflows.ts
+++ b/native-provider-ci/src/workflows.ts
@@ -146,7 +146,7 @@ export function RunAcceptanceTestsWorkflow(
         .addConditional(
           "github.event_name == 'repository_dispatch' || github.event.pull_request.head.repo.full_name == github.repository"
         )
-        .addStep(steps.EchoSuccessStep())
+        .addStep(steps.SentinelStep())
         .addNeeds(calculateSentinelNeeds(name, opts.lint, opts.provider)),
     },
   };


### PR DESCRIPTION
The existing native providers still require the existing sentinel job name as well as the build and test steps. This adds an additional check which we can then switch to be the only step we depend on once it's rolled out. The existing sentinel job check had the issue where if previous jobs failed, it would be skipped which is considered complete by the branch protection.

This mirrors the change from #944 for native providers.

This provides us the ability to restructure jobs within the workflows without breaking required checks.