### PR TITLE
Simplify sentinel check

### DIFF
--- a/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/run-acceptance-tests.yml
@@ -56,6 +56,8 @@ jobs:
 
   sentinel:
     name: sentinel
+    if: github.event_name == 'repository_dispatch' ||
+      github.event.pull_request.head.repo.full_name == github.repository
     needs:
     - test
     - license_check

--- a/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/run-acceptance-tests.yml
@@ -56,32 +56,6 @@ jobs:
 
   sentinel:
     name: sentinel
-    # We would like to be able to specify `sentinel` as the only required job for this
-    # workflow. To do that, we need `sentinel` to succeed only when it is safe to
-    # merge and fail in all other cases.
-    #
-    # We can't use the default `if: success()`, since GitHub interprets a skipped job as a
-    # success, and by default a dependee job failing will skip a dependent job. That means
-    # if a test step fails, then it will skip `sentinel` so GitHub will register
-    # `sentinel` as succeeded.
-    #
-    # GitHub documents `jobs.result` as:
-    #
-    # The result of a job in the reusable workflow. Possible values are success,
-    # failure, cancelled, or skipped.
-    #
-    # GitHub documents `cancelled()` as:
-    #
-    # Returns true if the workflow was canceled.
-    #
-    # Combining these terms gives us an intuitive definition of success:
-    #
-    # We have succeeded when no dependent workflow has failed and the job was
-    # not cancelled.
-    #
-    if: (github.event_name == 'repository_dispatch' ||
-      github.event.pull_request.head.repo.full_name == github.repository) &&
-      ! cancelled()
     needs:
     - test
     - license_check
@@ -93,23 +67,17 @@ jobs:
     #{{- end }}#
     runs-on: #{{ .Config.runner.default }}#
     steps:
-    - name: Workflow is not a success
-      if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') || contains(needs.*.result, 'skipped')
-      run: exit 1
     - uses: guibranco/github-status-action-v2@0849440ec82c5fa69b2377725b9b7852a3977e76
       with: 
         authToken: ${{secrets.GITHUB_TOKEN}}
         # Write an explicit status check called "Sentinel" which will only pass if this code really runs.
-        # Once rolled out, we can make this the only required check for PRs,
-        # then remove the old conditionals on this job and remove the previous step.
+        # This should always be a required check for PRs.
         context: 'Sentinel'
         description: 'All required checks passed'
         state: 'success'
         # Write to the PR commit SHA if it's available as we don't want the merge commit sha,
         # otherwise use the current SHA for any other type of build.
         sha: ${{ github.event.pull_request.head.sha || github.sha }}
-    - name: Workflow is a success
-      run: echo "🎉🎈🎉🎈🎉"
 
   test:
     if: github.event_name == 'repository_dispatch' ||

--- a/provider-ci/test-workflows/aws/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/test-workflows/aws/.github/workflows/run-acceptance-tests.yml
@@ -255,6 +255,8 @@ jobs:
 
   sentinel:
     name: sentinel
+    if: github.event_name == 'repository_dispatch' ||
+      github.event.pull_request.head.repo.full_name == github.repository
     needs:
     - test
     - license_check

--- a/provider-ci/test-workflows/aws/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/test-workflows/aws/.github/workflows/run-acceptance-tests.yml
@@ -255,55 +255,23 @@ jobs:
 
   sentinel:
     name: sentinel
-    # We would like to be able to specify `sentinel` as the only required job for this
-    # workflow. To do that, we need `sentinel` to succeed only when it is safe to
-    # merge and fail in all other cases.
-    #
-    # We can't use the default `if: success()`, since GitHub interprets a skipped job as a
-    # success, and by default a dependee job failing will skip a dependent job. That means
-    # if a test step fails, then it will skip `sentinel` so GitHub will register
-    # `sentinel` as succeeded.
-    #
-    # GitHub documents `jobs.result` as:
-    #
-    # The result of a job in the reusable workflow. Possible values are success,
-    # failure, cancelled, or skipped.
-    #
-    # GitHub documents `cancelled()` as:
-    #
-    # Returns true if the workflow was canceled.
-    #
-    # Combining these terms gives us an intuitive definition of success:
-    #
-    # We have succeeded when no dependent workflow has failed and the job was
-    # not cancelled.
-    #
-    if: (github.event_name == 'repository_dispatch' ||
-      github.event.pull_request.head.repo.full_name == github.repository) &&
-      ! cancelled()
     needs:
     - test
     - license_check
     - go_test_shim
     runs-on: ubuntu-latest
     steps:
-    - name: Workflow is not a success
-      if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') || contains(needs.*.result, 'skipped')
-      run: exit 1
     - uses: guibranco/github-status-action-v2@0849440ec82c5fa69b2377725b9b7852a3977e76
       with: 
         authToken: ${{secrets.GITHUB_TOKEN}}
         # Write an explicit status check called "Sentinel" which will only pass if this code really runs.
-        # Once rolled out, we can make this the only required check for PRs,
-        # then remove the old conditionals on this job and remove the previous step.
+        # This should always be a required check for PRs.
         context: 'Sentinel'
         description: 'All required checks passed'
         state: 'success'
         # Write to the PR commit SHA if it's available as we don't want the merge commit sha,
         # otherwise use the current SHA for any other type of build.
         sha: ${{ github.event.pull_request.head.sha || github.sha }}
-    - name: Workflow is a success
-      run: echo "🎉🎈🎉🎈🎉"
 
   test:
     if: github.event_name == 'repository_dispatch' ||

--- a/provider-ci/test-workflows/cloudflare/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/test-workflows/cloudflare/.github/workflows/run-acceptance-tests.yml
@@ -249,6 +249,8 @@ jobs:
 
   sentinel:
     name: sentinel
+    if: github.event_name == 'repository_dispatch' ||
+      github.event.pull_request.head.repo.full_name == github.repository
     needs:
     - test
     - license_check

--- a/provider-ci/test-workflows/cloudflare/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/test-workflows/cloudflare/.github/workflows/run-acceptance-tests.yml
@@ -249,55 +249,23 @@ jobs:
 
   sentinel:
     name: sentinel
-    # We would like to be able to specify `sentinel` as the only required job for this
-    # workflow. To do that, we need `sentinel` to succeed only when it is safe to
-    # merge and fail in all other cases.
-    #
-    # We can't use the default `if: success()`, since GitHub interprets a skipped job as a
-    # success, and by default a dependee job failing will skip a dependent job. That means
-    # if a test step fails, then it will skip `sentinel` so GitHub will register
-    # `sentinel` as succeeded.
-    #
-    # GitHub documents `jobs.result` as:
-    #
-    # The result of a job in the reusable workflow. Possible values are success,
-    # failure, cancelled, or skipped.
-    #
-    # GitHub documents `cancelled()` as:
-    #
-    # Returns true if the workflow was canceled.
-    #
-    # Combining these terms gives us an intuitive definition of success:
-    #
-    # We have succeeded when no dependent workflow has failed and the job was
-    # not cancelled.
-    #
-    if: (github.event_name == 'repository_dispatch' ||
-      github.event.pull_request.head.repo.full_name == github.repository) &&
-      ! cancelled()
     needs:
     - test
     - license_check
     - lint
     runs-on: ubuntu-latest
     steps:
-    - name: Workflow is not a success
-      if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') || contains(needs.*.result, 'skipped')
-      run: exit 1
     - uses: guibranco/github-status-action-v2@0849440ec82c5fa69b2377725b9b7852a3977e76
       with: 
         authToken: ${{secrets.GITHUB_TOKEN}}
         # Write an explicit status check called "Sentinel" which will only pass if this code really runs.
-        # Once rolled out, we can make this the only required check for PRs,
-        # then remove the old conditionals on this job and remove the previous step.
+        # This should always be a required check for PRs.
         context: 'Sentinel'
         description: 'All required checks passed'
         state: 'success'
         # Write to the PR commit SHA if it's available as we don't want the merge commit sha,
         # otherwise use the current SHA for any other type of build.
         sha: ${{ github.event.pull_request.head.sha || github.sha }}
-    - name: Workflow is a success
-      run: echo "🎉🎈🎉🎈🎉"
 
   test:
     if: github.event_name == 'repository_dispatch' ||

--- a/provider-ci/test-workflows/docker/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/test-workflows/docker/.github/workflows/run-acceptance-tests.yml
@@ -262,55 +262,23 @@ jobs:
 
   sentinel:
     name: sentinel
-    # We would like to be able to specify `sentinel` as the only required job for this
-    # workflow. To do that, we need `sentinel` to succeed only when it is safe to
-    # merge and fail in all other cases.
-    #
-    # We can't use the default `if: success()`, since GitHub interprets a skipped job as a
-    # success, and by default a dependee job failing will skip a dependent job. That means
-    # if a test step fails, then it will skip `sentinel` so GitHub will register
-    # `sentinel` as succeeded.
-    #
-    # GitHub documents `jobs.result` as:
-    #
-    # The result of a job in the reusable workflow. Possible values are success,
-    # failure, cancelled, or skipped.
-    #
-    # GitHub documents `cancelled()` as:
-    #
-    # Returns true if the workflow was canceled.
-    #
-    # Combining these terms gives us an intuitive definition of success:
-    #
-    # We have succeeded when no dependent workflow has failed and the job was
-    # not cancelled.
-    #
-    if: (github.event_name == 'repository_dispatch' ||
-      github.event.pull_request.head.repo.full_name == github.repository) &&
-      ! cancelled()
     needs:
     - test
     - license_check
     - lint
     runs-on: ubuntu-latest
     steps:
-    - name: Workflow is not a success
-      if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') || contains(needs.*.result, 'skipped')
-      run: exit 1
     - uses: guibranco/github-status-action-v2@0849440ec82c5fa69b2377725b9b7852a3977e76
       with: 
         authToken: ${{secrets.GITHUB_TOKEN}}
         # Write an explicit status check called "Sentinel" which will only pass if this code really runs.
-        # Once rolled out, we can make this the only required check for PRs,
-        # then remove the old conditionals on this job and remove the previous step.
+        # This should always be a required check for PRs.
         context: 'Sentinel'
         description: 'All required checks passed'
         state: 'success'
         # Write to the PR commit SHA if it's available as we don't want the merge commit sha,
         # otherwise use the current SHA for any other type of build.
         sha: ${{ github.event.pull_request.head.sha || github.sha }}
-    - name: Workflow is a success
-      run: echo "🎉🎈🎉🎈🎉"
 
   test:
     if: github.event_name == 'repository_dispatch' ||

--- a/provider-ci/test-workflows/docker/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/test-workflows/docker/.github/workflows/run-acceptance-tests.yml
@@ -262,6 +262,8 @@ jobs:
 
   sentinel:
     name: sentinel
+    if: github.event_name == 'repository_dispatch' ||
+      github.event.pull_request.head.repo.full_name == github.repository
     needs:
     - test
     - license_check


### PR DESCRIPTION
Depends on #947 being merged and deployed.

- Remove complex conditionals. These were previously required to avoid the issue of this job being skipped due to failures in previous jobs but a skip being considered as the required check completed.
- The "Sentinel" check will only be considered as success if it's explicitly run which can naturally only happen if this step actually runs.