### PR TITLE
Bump package publisher

### DIFF
--- a/provider-ci/internal/pkg/templates/bridged-provider.config.yaml
+++ b/provider-ci/internal/pkg/templates/bridged-provider.config.yaml
@@ -93,7 +93,7 @@ actionVersions:
   upgradeProviderAction: pulumi/pulumi-upgrade-provider-action@v0.0.12
   slackNotification: rtCamp/action-slack-notify@v2
 publish:
-  publisherAction: pulumi/pulumi-package-publisher@v0.0.15
+  publisherAction: pulumi/pulumi-package-publisher@v0.0.16
   sdk: all
   goSdk:
     # Set to `true` to use the below configuration to push a new commit somewhere else.

--- a/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/upgrade-bridge.yml
+++ b/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/upgrade-bridge.yml
@@ -49,6 +49,11 @@ on:
         required: false
         type: boolean
         default: false
+      release-patch:
+        description: Release a patch version of the provider
+        required: false
+        type: boolean
+        default: false
 env:
   GH_TOKEN: ${{ secrets.PULUMI_BOT_TOKEN }}
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/upgrade-bridge.yml
+++ b/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/upgrade-bridge.yml
@@ -49,11 +49,6 @@ on:
         required: false
         type: boolean
         default: false
-      release-patch:
-        description: Release a patch version of the provider
-        required: false
-        type: boolean
-        default: false
 env:
   GH_TOKEN: ${{ secrets.PULUMI_BOT_TOKEN }}
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/provider-ci/test-workflows/aws/.github/workflows/master.yml
+++ b/provider-ci/test-workflows/aws/.github/workflows/master.yml
@@ -367,7 +367,7 @@ jobs:
     - id: version
       uses: pulumi/provider-version-action@v1
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.15
+      uses: pulumi/pulumi-package-publisher@v0.0.16
       with:
         sdk: all
         version: ${{ steps.version.outputs.version }}

--- a/provider-ci/test-workflows/aws/.github/workflows/prerelease.yml
+++ b/provider-ci/test-workflows/aws/.github/workflows/prerelease.yml
@@ -312,7 +312,7 @@ jobs:
     - id: version
       uses: pulumi/provider-version-action@v1
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.15
+      uses: pulumi/pulumi-package-publisher@v0.0.16
       with:
         sdk: all
         version: ${{ steps.version.outputs.version }}

--- a/provider-ci/test-workflows/aws/.github/workflows/release.yml
+++ b/provider-ci/test-workflows/aws/.github/workflows/release.yml
@@ -325,7 +325,7 @@ jobs:
     - id: version
       uses: pulumi/provider-version-action@v1
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.15
+      uses: pulumi/pulumi-package-publisher@v0.0.16
       with:
         sdk: all
         version: ${{ steps.version.outputs.version }}

--- a/provider-ci/test-workflows/cloudflare/.github/workflows/master.yml
+++ b/provider-ci/test-workflows/cloudflare/.github/workflows/master.yml
@@ -353,7 +353,7 @@ jobs:
     - id: version
       uses: pulumi/provider-version-action@v1
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.15
+      uses: pulumi/pulumi-package-publisher@v0.0.16
       with:
         sdk: all
         version: ${{ steps.version.outputs.version }}

--- a/provider-ci/test-workflows/cloudflare/.github/workflows/prerelease.yml
+++ b/provider-ci/test-workflows/cloudflare/.github/workflows/prerelease.yml
@@ -300,7 +300,7 @@ jobs:
     - id: version
       uses: pulumi/provider-version-action@v1
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.15
+      uses: pulumi/pulumi-package-publisher@v0.0.16
       with:
         sdk: all
         version: ${{ steps.version.outputs.version }}

--- a/provider-ci/test-workflows/cloudflare/.github/workflows/release.yml
+++ b/provider-ci/test-workflows/cloudflare/.github/workflows/release.yml
@@ -313,7 +313,7 @@ jobs:
     - id: version
       uses: pulumi/provider-version-action@v1
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.15
+      uses: pulumi/pulumi-package-publisher@v0.0.16
       with:
         sdk: all
         version: ${{ steps.version.outputs.version }}

--- a/provider-ci/test-workflows/docker/.github/workflows/master.yml
+++ b/provider-ci/test-workflows/docker/.github/workflows/master.yml
@@ -366,7 +366,7 @@ jobs:
     - id: version
       uses: pulumi/provider-version-action@v1
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.15
+      uses: pulumi/pulumi-package-publisher@v0.0.16
       with:
         sdk: all
         version: ${{ steps.version.outputs.version }}

--- a/provider-ci/test-workflows/docker/.github/workflows/prerelease.yml
+++ b/provider-ci/test-workflows/docker/.github/workflows/prerelease.yml
@@ -313,7 +313,7 @@ jobs:
     - id: version
       uses: pulumi/provider-version-action@v1
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.15
+      uses: pulumi/pulumi-package-publisher@v0.0.16
       with:
         sdk: all
         version: ${{ steps.version.outputs.version }}

--- a/provider-ci/test-workflows/docker/.github/workflows/release.yml
+++ b/provider-ci/test-workflows/docker/.github/workflows/release.yml
@@ -326,7 +326,7 @@ jobs:
     - id: version
       uses: pulumi/provider-version-action@v1
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.15
+      uses: pulumi/pulumi-package-publisher@v0.0.16
       with:
         sdk: all
         version: ${{ steps.version.outputs.version }}


### PR DESCRIPTION
propagates https://github.com/pulumi/pulumi-package-publisher/pull/26 to ci-mgmt.

We should now catch dotnet publishing failures correctly.

The changes were tested in https://github.com/pulumi/pulumi-random/pull/960