### PR TITLE
Refactor: Use GHA native dispatch for registry metadata build kickoff

### DIFF
--- a/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/release.yml
+++ b/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/release.yml
@@ -21,19 +21,18 @@ jobs:
     needs: tag_sdk
     runs-on: #{{ .Config.runner.default }}#
     steps:
-    - name: Dispatch Metadata build
-      uses: peter-evans/repository-dispatch@v3
-      with:
-    - env:
-        token: ${{ secrets.PULUMI_BOT_TOKEN }}
-        repository: pulumi/pulumi-${{ env.PROVIDER }}
-        event-type: resource-provider
-        client-payload: |-
-          {
-            "project": pulumi-${{ env.PROVIDER }},
-            "shortname": ${{ env.PROVIDER }},
-            "ref": ${{ env.GITHUB_REF_NAME }}
-          }
+      - name: Dispatch Metadata build
+        uses: peter-evans/repository-dispatch@v3
+        with:
+          token: ${{ secrets.PULUMI_BOT_TOKEN }}
+          repository: pulumi/registry
+          event-type: resource-provider
+          client-payload: |-
+            {
+              "project": "${{ github.repository }}",
+              "project-shortname": "#{{ .Config.provider }}#",
+              "ref": "${{ github.ref_name }}"
+            }
   #{{ end -}}#
   #{{ if .Config.lint -}}#
   lint:

--- a/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/release.yml
+++ b/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/release.yml
@@ -21,16 +21,19 @@ jobs:
     needs: tag_sdk
     runs-on: #{{ .Config.runner.default }}#
     steps:
-    - name: Install pulumictl
-      uses: #{{ .Config.actionVersions.installGhRelease }}#
+    - name: Dispatch Metadata build
+      uses: peter-evans/repository-dispatch@v3
       with:
-        tag: #{{ .Config.actionVersions.pulumictlTag }}#
-        repo: pulumi/pulumictl
     - env:
-        GITHUB_TOKEN: ${{ secrets.PULUMI_BOT_TOKEN }}
-      name: Dispatch Event
-      run: pulumictl create docs-build pulumi-#{{ .Config.provider }}#
-        "${GITHUB_REF#refs/tags/}"
+        token: ${{ secrets.PULUMI_BOT_TOKEN }}
+        repository: pulumi/pulumi-${{ env.PROVIDER }}
+        event-type: resource-provider
+        client-payload: |-
+          {
+            "project": pulumi-${{ env.PROVIDER }},
+            "shortname": ${{ env.PROVIDER }},
+            "ref": ${{ env.GITHUB_REF_NAME }}
+          }
   #{{ end -}}#
   #{{ if .Config.lint -}}#
   lint:

--- a/provider-ci/test-workflows/aws/.github/workflows/release.yml
+++ b/provider-ci/test-workflows/aws/.github/workflows/release.yml
@@ -133,16 +133,19 @@ jobs:
     needs: tag_sdk
     runs-on: ubuntu-latest
     steps:
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.11.0
+    - name: Dispatch Metadata build
+      uses: peter-evans/repository-dispatch@v3
       with:
-        tag: v0.0.46
-        repo: pulumi/pulumictl
     - env:
-        GITHUB_TOKEN: ${{ secrets.PULUMI_BOT_TOKEN }}
-      name: Dispatch Event
-      run: pulumictl create docs-build pulumi-aws
-        "${GITHUB_REF#refs/tags/}"
+        token: ${{ secrets.PULUMI_BOT_TOKEN }}
+        repository: pulumi/pulumi-${{ env.PROVIDER }}
+        event-type: resource-provider
+        client-payload: |-
+          {
+            "project": pulumi-${{ env.PROVIDER }},
+            "shortname": ${{ env.PROVIDER }},
+            "ref": ${{ env.GITHUB_REF_NAME }}
+          }
   license_check:
     name: License Check
     uses: ./.github/workflows/license.yml

--- a/provider-ci/test-workflows/aws/.github/workflows/release.yml
+++ b/provider-ci/test-workflows/aws/.github/workflows/release.yml
@@ -133,19 +133,18 @@ jobs:
     needs: tag_sdk
     runs-on: ubuntu-latest
     steps:
-    - name: Dispatch Metadata build
-      uses: peter-evans/repository-dispatch@v3
-      with:
-    - env:
-        token: ${{ secrets.PULUMI_BOT_TOKEN }}
-        repository: pulumi/pulumi-${{ env.PROVIDER }}
-        event-type: resource-provider
-        client-payload: |-
-          {
-            "project": pulumi-${{ env.PROVIDER }},
-            "shortname": ${{ env.PROVIDER }},
-            "ref": ${{ env.GITHUB_REF_NAME }}
-          }
+      - name: Dispatch Metadata build
+        uses: peter-evans/repository-dispatch@v3
+        with:
+          token: ${{ secrets.PULUMI_BOT_TOKEN }}
+          repository: pulumi/registry
+          event-type: resource-provider
+          client-payload: |-
+            {
+              "project": "${{ github.repository }}",
+              "project-shortname": "aws",
+              "ref": "${{ github.ref_name }}"
+            }
   license_check:
     name: License Check
     uses: ./.github/workflows/license.yml

--- a/provider-ci/test-workflows/cloudflare/.github/workflows/release.yml
+++ b/provider-ci/test-workflows/cloudflare/.github/workflows/release.yml
@@ -131,16 +131,19 @@ jobs:
     needs: tag_sdk
     runs-on: ubuntu-latest
     steps:
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.11.0
+    - name: Dispatch Metadata build
+      uses: peter-evans/repository-dispatch@v3
       with:
-        tag: v0.0.46
-        repo: pulumi/pulumictl
     - env:
-        GITHUB_TOKEN: ${{ secrets.PULUMI_BOT_TOKEN }}
-      name: Dispatch Event
-      run: pulumictl create docs-build pulumi-cloudflare
-        "${GITHUB_REF#refs/tags/}"
+        token: ${{ secrets.PULUMI_BOT_TOKEN }}
+        repository: pulumi/pulumi-${{ env.PROVIDER }}
+        event-type: resource-provider
+        client-payload: |-
+          {
+            "project": pulumi-${{ env.PROVIDER }},
+            "shortname": ${{ env.PROVIDER }},
+            "ref": ${{ env.GITHUB_REF_NAME }}
+          }
   lint:
     name: lint
     uses: ./.github/workflows/lint.yml

--- a/provider-ci/test-workflows/cloudflare/.github/workflows/release.yml
+++ b/provider-ci/test-workflows/cloudflare/.github/workflows/release.yml
@@ -131,19 +131,18 @@ jobs:
     needs: tag_sdk
     runs-on: ubuntu-latest
     steps:
-    - name: Dispatch Metadata build
-      uses: peter-evans/repository-dispatch@v3
-      with:
-    - env:
-        token: ${{ secrets.PULUMI_BOT_TOKEN }}
-        repository: pulumi/pulumi-${{ env.PROVIDER }}
-        event-type: resource-provider
-        client-payload: |-
-          {
-            "project": pulumi-${{ env.PROVIDER }},
-            "shortname": ${{ env.PROVIDER }},
-            "ref": ${{ env.GITHUB_REF_NAME }}
-          }
+      - name: Dispatch Metadata build
+        uses: peter-evans/repository-dispatch@v3
+        with:
+          token: ${{ secrets.PULUMI_BOT_TOKEN }}
+          repository: pulumi/registry
+          event-type: resource-provider
+          client-payload: |-
+            {
+              "project": "${{ github.repository }}",
+              "project-shortname": "cloudflare",
+              "ref": "${{ github.ref_name }}"
+            }
   lint:
     name: lint
     uses: ./.github/workflows/lint.yml

--- a/provider-ci/test-workflows/docker/.github/workflows/release.yml
+++ b/provider-ci/test-workflows/docker/.github/workflows/release.yml
@@ -144,16 +144,19 @@ jobs:
     needs: tag_sdk
     runs-on: ubuntu-latest
     steps:
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.11.0
+    - name: Dispatch Metadata build
+      uses: peter-evans/repository-dispatch@v3
       with:
-        tag: v0.0.46
-        repo: pulumi/pulumictl
     - env:
-        GITHUB_TOKEN: ${{ secrets.PULUMI_BOT_TOKEN }}
-      name: Dispatch Event
-      run: pulumictl create docs-build pulumi-docker
-        "${GITHUB_REF#refs/tags/}"
+        token: ${{ secrets.PULUMI_BOT_TOKEN }}
+        repository: pulumi/pulumi-${{ env.PROVIDER }}
+        event-type: resource-provider
+        client-payload: |-
+          {
+            "project": pulumi-${{ env.PROVIDER }},
+            "shortname": ${{ env.PROVIDER }},
+            "ref": ${{ env.GITHUB_REF_NAME }}
+          }
   lint:
     name: lint
     uses: ./.github/workflows/lint.yml

--- a/provider-ci/test-workflows/docker/.github/workflows/release.yml
+++ b/provider-ci/test-workflows/docker/.github/workflows/release.yml
@@ -144,19 +144,18 @@ jobs:
     needs: tag_sdk
     runs-on: ubuntu-latest
     steps:
-    - name: Dispatch Metadata build
-      uses: peter-evans/repository-dispatch@v3
-      with:
-    - env:
-        token: ${{ secrets.PULUMI_BOT_TOKEN }}
-        repository: pulumi/pulumi-${{ env.PROVIDER }}
-        event-type: resource-provider
-        client-payload: |-
-          {
-            "project": pulumi-${{ env.PROVIDER }},
-            "shortname": ${{ env.PROVIDER }},
-            "ref": ${{ env.GITHUB_REF_NAME }}
-          }
+      - name: Dispatch Metadata build
+        uses: peter-evans/repository-dispatch@v3
+        with:
+          token: ${{ secrets.PULUMI_BOT_TOKEN }}
+          repository: pulumi/registry
+          event-type: resource-provider
+          client-payload: |-
+            {
+              "project": "${{ github.repository }}",
+              "project-shortname": "docker",
+              "ref": "${{ github.ref_name }}"
+            }
   lint:
     name: lint
     uses: ./.github/workflows/lint.yml


### PR DESCRIPTION
This pull request removes the dependency on `pulumictl` for the bridged provider registry docs dispatch.

### Before this change
Currently, the [Create Docs Build](https://github.com/pulumi/ci-mgmt/blob/master/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/release.yml#L24) step in the Release Workflow calls into a [Pulumictl command](https://github.com/pulumi/pulumictl/blob/master/cmd/pulumictl/create/docs-build/cli.go) that triggers the [Publish Provider Update](https://github.com/pulumi/registry/blob/master/.github/workflows/publish-provider-update.yml) Workflow, building metadata, in pulumi/registry.

`publish.yml`(provider) -> `pulumictl`(bespoke command) -> `publish-provider-update`(registry)

### After this change
Use `peter-evans/repository-dispatch@v3` to dispatch the `resource-provider` event that [already exists on the registry `publish-provider-update` Workflow](https://github.com/pulumi/registry/blob/master/.github/workflows/publish-provider-update.yml#L16), removing the need for pulumictl.

The registry's Action has a few fields we do not use. See [example run](https://github.com/pulumi/registry/actions/runs/9350133653/job/25732951804#step:2:4). Filed https://github.com/pulumi/registry/issues/4671 to track. The repository dispatch payload therefore only contains:

```
"project": "${{ github.repository }}", - this is somewhat unnecessary but makes for a safe refactor without having to change the registry workflow file
"shortname": "#{{ .Config.provider }}#", - Just the provider name without `pulumi-` prefix
"ref": "${{ github.ref_name }}" - This is the tag name of the release.
```

*Note:* This pull request changes bridged providers only since we are currently working on unifying templating for native and bridged providers. I'm happy to add native provider changes to this effect if reviewers would prefer.

