### PR TITLE
Bump package publisher version and update inputs

### DIFF
--- a/provider-ci/internal/pkg/templates/bridged-provider.config.yaml
+++ b/provider-ci/internal/pkg/templates/bridged-provider.config.yaml
@@ -82,7 +82,7 @@ actionVersions:
   upgradeProviderAction: pulumi/pulumi-upgrade-provider-action@v0.0.12
   slackNotification: rtCamp/action-slack-notify@v2
 publish:
-  publisherAction: pulumi/pulumi-package-publisher@v0.0.16
+  publisherAction: pulumi/pulumi-package-publisher@v0.0.17
   sdk: all
   goSdk:
     # Set to `true` to use the below configuration to push a new commit somewhere else.

--- a/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/main.yml
+++ b/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/main.yml
@@ -166,6 +166,10 @@ jobs:
       with:
         sdk: #{{ .Config.publish.sdk }}#
         version: ${{ steps.version.outputs.version }}
+        dotnet-version: "#{{ .Config.toolVersions.dotnet }}#"
+        java-version: "#{{ .Config.toolVersions.java }}#"
+        node-version: "#{{ .Config.toolVersions.node }}#"
+        python-version: "#{{ .Config.toolVersions.python }}#"
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/prerelease.yml
+++ b/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/prerelease.yml
@@ -109,6 +109,10 @@ jobs:
       with:
         sdk: #{{ .Config.publish.sdk }}#
         version: ${{ steps.version.outputs.version }}
+        dotnet-version: "#{{ .Config.toolVersions.dotnet }}#"
+        java-version: "#{{ .Config.toolVersions.java }}#"
+        node-version: "#{{ .Config.toolVersions.node }}#"
+        python-version: "#{{ .Config.toolVersions.python }}#"
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/release.yml
+++ b/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/release.yml
@@ -124,6 +124,10 @@ jobs:
       with:
         sdk: #{{ .Config.publish.sdk }}#
         version: ${{ steps.version.outputs.version }}
+        dotnet-version: "#{{ .Config.toolVersions.dotnet }}#"
+        java-version: "#{{ .Config.toolVersions.java }}#"
+        node-version: "#{{ .Config.toolVersions.node }}#"
+        python-version: "#{{ .Config.toolVersions.python }}#"
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/test-workflows/aws/.github/workflows/master.yml
+++ b/provider-ci/test-workflows/aws/.github/workflows/master.yml
@@ -357,10 +357,14 @@ jobs:
     - id: version
       uses: pulumi/provider-version-action@v1
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.16
+      uses: pulumi/pulumi-package-publisher@v0.0.17
       with:
         sdk: all
         version: ${{ steps.version.outputs.version }}
+        dotnet-version: "6.0.x"
+        java-version: "11"
+        node-version: "20.x"
+        python-version: "3.11.8"
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/test-workflows/aws/.github/workflows/prerelease.yml
+++ b/provider-ci/test-workflows/aws/.github/workflows/prerelease.yml
@@ -302,10 +302,14 @@ jobs:
     - id: version
       uses: pulumi/provider-version-action@v1
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.16
+      uses: pulumi/pulumi-package-publisher@v0.0.17
       with:
         sdk: all
         version: ${{ steps.version.outputs.version }}
+        dotnet-version: "6.0.x"
+        java-version: "11"
+        node-version: "20.x"
+        python-version: "3.11.8"
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/test-workflows/aws/.github/workflows/release.yml
+++ b/provider-ci/test-workflows/aws/.github/workflows/release.yml
@@ -315,10 +315,14 @@ jobs:
     - id: version
       uses: pulumi/provider-version-action@v1
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.16
+      uses: pulumi/pulumi-package-publisher@v0.0.17
       with:
         sdk: all
         version: ${{ steps.version.outputs.version }}
+        dotnet-version: "6.0.x"
+        java-version: "11"
+        node-version: "20.x"
+        python-version: "3.11.8"
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/test-workflows/cloudflare/.github/workflows/master.yml
+++ b/provider-ci/test-workflows/cloudflare/.github/workflows/master.yml
@@ -343,10 +343,14 @@ jobs:
     - id: version
       uses: pulumi/provider-version-action@v1
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.16
+      uses: pulumi/pulumi-package-publisher@v0.0.17
       with:
         sdk: all
         version: ${{ steps.version.outputs.version }}
+        dotnet-version: "6.0.x"
+        java-version: "11"
+        node-version: "20.x"
+        python-version: "3.11.8"
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/test-workflows/cloudflare/.github/workflows/prerelease.yml
+++ b/provider-ci/test-workflows/cloudflare/.github/workflows/prerelease.yml
@@ -290,10 +290,14 @@ jobs:
     - id: version
       uses: pulumi/provider-version-action@v1
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.16
+      uses: pulumi/pulumi-package-publisher@v0.0.17
       with:
         sdk: all
         version: ${{ steps.version.outputs.version }}
+        dotnet-version: "6.0.x"
+        java-version: "11"
+        node-version: "20.x"
+        python-version: "3.11.8"
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/test-workflows/cloudflare/.github/workflows/release.yml
+++ b/provider-ci/test-workflows/cloudflare/.github/workflows/release.yml
@@ -303,10 +303,14 @@ jobs:
     - id: version
       uses: pulumi/provider-version-action@v1
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.16
+      uses: pulumi/pulumi-package-publisher@v0.0.17
       with:
         sdk: all
         version: ${{ steps.version.outputs.version }}
+        dotnet-version: "6.0.x"
+        java-version: "11"
+        node-version: "20.x"
+        python-version: "3.11.8"
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/test-workflows/docker/.github/workflows/master.yml
+++ b/provider-ci/test-workflows/docker/.github/workflows/master.yml
@@ -356,10 +356,14 @@ jobs:
     - id: version
       uses: pulumi/provider-version-action@v1
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.16
+      uses: pulumi/pulumi-package-publisher@v0.0.17
       with:
         sdk: all
         version: ${{ steps.version.outputs.version }}
+        dotnet-version: "6.0.x"
+        java-version: "11"
+        node-version: "20.x"
+        python-version: "3.11.8"
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/test-workflows/docker/.github/workflows/prerelease.yml
+++ b/provider-ci/test-workflows/docker/.github/workflows/prerelease.yml
@@ -303,10 +303,14 @@ jobs:
     - id: version
       uses: pulumi/provider-version-action@v1
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.16
+      uses: pulumi/pulumi-package-publisher@v0.0.17
       with:
         sdk: all
         version: ${{ steps.version.outputs.version }}
+        dotnet-version: "6.0.x"
+        java-version: "11"
+        node-version: "20.x"
+        python-version: "3.11.8"
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/provider-ci/test-workflows/docker/.github/workflows/release.yml
+++ b/provider-ci/test-workflows/docker/.github/workflows/release.yml
@@ -316,10 +316,14 @@ jobs:
     - id: version
       uses: pulumi/provider-version-action@v1
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.16
+      uses: pulumi/pulumi-package-publisher@v0.0.17
       with:
         sdk: all
         version: ${{ steps.version.outputs.version }}
+        dotnet-version: "6.0.x"
+        java-version: "11"
+        node-version: "20.x"
+        python-version: "3.11.8"
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"


### PR DESCRIPTION
Part of #961.

We can close #961 when all Workflows have updated to this publisher.