### PR TITLE
Add option for freeing disk space

### DIFF
--- a/provider-ci/internal/pkg/templates/bridged-provider.config.yaml
+++ b/provider-ci/internal/pkg/templates/bridged-provider.config.yaml
@@ -10,6 +10,10 @@ fail-on-extra-mapping: true
 publishRegistry: true
 checkoutSubmodules: false
 testMasterAndReleaseWorkflows: false
+# Set to true to clear disk space before running prerequisites workflow.
+freeDiskSpaceBeforeBuild: false
+# Set to true to clear disk space before running test jobs.
+freeDiskSpaceBeforeTest: false
 toolVersions:
   dotnet: "6.0.x"
   go: "1.21.x"

--- a/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/prerequisites.yml
+++ b/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/prerequisites.yml
@@ -18,6 +18,14 @@ jobs:
     name: prerequisites
     runs-on: #{{ .Config.runner.prerequisites }}#
     steps:
+#{{- if .Config.freeDiskSpaceBeforeBuild }}#
+    # Run as first step so we don't delete things that have just been installed
+    - name: Free Disk Space (Ubuntu)
+      uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be
+      with:
+        tool-cache: false
+        swap-storage: false
+#{{- end }}#
     - name: Checkout Repo
       uses: #{{ .Config.actionVersions.checkout }}#
 #{{- if .Config.checkoutSubmodules }}#

--- a/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/run-acceptance-tests.yml
@@ -88,6 +88,14 @@ jobs:
       id-token: write
     runs-on: #{{ if .Config.runner.buildSdk }}##{{- .Config.runner.buildSdk }}##{{ else }}##{{- .Config.runner.default }}##{{ end }}#
     steps:
+#{{- if .Config.freeDiskSpaceBeforeTest }}#
+    # Run as first step so we don't delete things that have just been installed
+    - name: Free Disk Space (Ubuntu)
+      uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be
+      with:
+        tool-cache: false
+        swap-storage: false
+#{{- end }}#
     - name: Checkout Repo
       uses: #{{ .Config.actionVersions.checkout }}#
       with:

--- a/provider-ci/providers/aws/config.yaml
+++ b/provider-ci/providers/aws/config.yaml
@@ -12,6 +12,8 @@ env:
   PULUMI_MISSING_DOCS_ERROR: true
   AWS_REGION: "us-west-2"
 makeTemplate: bridged
+freeDiskSpaceBeforeBuild: true
+freeDiskSpaceBeforeTest: true
 checkoutSubmodules: true
 # TODO: remove XrunUpstreamTools flag after work to add docs replacement strategies to resources.go is completed
 # Tracked in in https://github.com/pulumi/pulumi-aws/issues/2757

--- a/provider-ci/test-workflows/aws/.github/workflows/prerequisites.yml
+++ b/provider-ci/test-workflows/aws/.github/workflows/prerequisites.yml
@@ -18,6 +18,12 @@ jobs:
     name: prerequisites
     runs-on: ubuntu-latest
     steps:
+    # Run as first step so we don't delete things that have just been installed
+    - name: Free Disk Space (Ubuntu)
+      uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be
+      with:
+        tool-cache: false
+        swap-storage: false
     - name: Checkout Repo
       uses: actions/checkout@v4
       with:

--- a/provider-ci/test-workflows/aws/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/test-workflows/aws/.github/workflows/run-acceptance-tests.yml
@@ -92,6 +92,12 @@ jobs:
       id-token: write
     runs-on: pulumi-ubuntu-8core
     steps:
+    # Run as first step so we don't delete things that have just been installed
+    - name: Free Disk Space (Ubuntu)
+      uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be
+      with:
+        tool-cache: false
+        swap-storage: false
     - name: Checkout Repo
       uses: actions/checkout@v4
       with:


### PR DESCRIPTION
Stacked on top of #942 

- Provide dedicated option instead of relying on providers to use custom steps which are run after tool installs.
- Run as first step so we don't delete things that have just been installed.
- Default to off to maintain existing behaviour. This can take around 3 minutes to run, so we should only run it if we're having issues.

```yaml
# Set to true to clear disk space before running prerequisites workflow.
freeDiskSpaceBeforeBuild: false
# Set to true to clear disk space before running test jobs.
freeDiskSpaceBeforeTest: false
```

This fixes oddities in Azure and AWS where we've added steps in the `preBuild` and `preTest` to clear disk space but then have to install tools (e.g. dotnet) a second time as they get deleted.