### PR TITLE
Encapsulate tool setup into a composite action

### DIFF
--- a/provider-ci/internal/pkg/templates/bridged-provider/.github/actions/setup-tools/action.yml
+++ b/provider-ci/internal/pkg/templates/bridged-provider/.github/actions/setup-tools/action.yml
@@ -1,0 +1,80 @@
+name: Setup tools
+description: Installs Go, Pulumi, pulumictl, schema-tools, Node.JS, Python, dotnet and Java.
+
+inputs:
+  tools:
+    description: |
+      Comma separated list of tools to install. The default of "all" installs all tools. Available tools are:
+        go
+        pulumicli
+        pulumictl
+        schema-tools
+        node
+        python
+        dotnet
+        java
+    default: all
+
+runs:
+  using: "composite"
+  steps:
+    - name: Install Go
+      if: inputs.tools == 'all' || contains(inputs.tools, 'go')
+      uses: #{{ .Config.actionVersions.setupGo }}#
+      with:
+        go-version: "#{{ .Config.toolVersions.go }}#"
+        cache-dependency-path: |
+          provider/*.sum
+          upstream/*.sum
+
+    - name: Install pulumictl
+      if: inputs.tools == 'all' || contains(inputs.tools, 'pulumictl')
+      uses: #{{ .Config.actionVersions.installGhRelease }}#
+      with:
+        tag: #{{ .Config.actionVersions.pulumictlTag }}#
+        repo: pulumi/pulumictl
+
+    - name: Install Pulumi CLI
+      if: inputs.tools == 'all' || contains(inputs.tools, 'pulumicli')
+      uses: #{{ .Config.actionVersions.setupPulumi }}#
+      with:
+        pulumi-version: "#{{ .Config.toolVersions.pulumi }}#"
+
+    - name: Install Schema Tools
+      if: inputs.tools == 'all' || contains(inputs.tools, 'schema-tools')
+      uses: #{{ .Config.actionVersions.installGhRelease }}#
+      with:
+        repo: pulumi/schema-tools
+
+    - name: Setup Node
+      if: inputs.tools == 'all' || contains(inputs.tools, 'node')
+      uses: #{{ .Config.actionVersions.setupNode }}#
+      with:
+        node-version: #{{ .Config.toolVersions.node }}#
+        registry-url: https://registry.npmjs.org
+
+    - name: Setup DotNet
+      if: inputs.tools == 'all' || contains(inputs.tools, 'dotnet')
+      uses: #{{ .Config.actionVersions.setupDotNet }}#
+      with:
+        dotnet-version: #{{ .Config.toolVersions.dotnet }}#
+
+    - name: Setup Python
+      if: inputs.tools == 'all' || contains(inputs.tools, 'python')
+      uses: #{{ .Config.actionVersions.setupPython }}#
+      with:
+        python-version: #{{ .Config.toolVersions.python }}#
+
+    - name: Setup Java
+      if: inputs.tools == 'all' || contains(inputs.tools, 'java')
+      uses: #{{ .Config.actionVersions.setupJava }}#
+      with:
+        cache: gradle
+        distribution: temurin
+        java-version: #{{ .Config.toolVersions.java }}#
+
+    - name: Setup Gradle
+      if: inputs.tools == 'all' || contains(inputs.tools, 'java')
+      uses: #{{ .Config.actionVersions.setupGradle }}#
+      with:
+        gradle-version: #{{ .Config.toolVersions.gradle }}#

--- a/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/build_sdk.yml
+++ b/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/build_sdk.yml
@@ -32,34 +32,10 @@ jobs:
           path: |
             .pulumi/examples-cache
           key: ${{ runner.os }}-${{ hashFiles('provider/go.sum') }}
-      - name: Install pulumictl
-        uses: #{{ .Config.actionVersions.installGhRelease }}#
+      - name: Setup tools
+        uses: ./.github/actions/setup-tools
         with:
-          tag: #{{ .Config.actionVersions.pulumictlTag }}#
-          repo: pulumi/pulumictl
-      - name: Setup Node
-        uses: #{{ .Config.actionVersions.setupNode }}#
-        with:
-          node-version: #{{ .Config.toolVersions.node }}#
-          registry-url: https://registry.npmjs.org
-      - name: Setup DotNet
-        uses: #{{ .Config.actionVersions.setupDotNet }}#
-        with:
-          dotnet-version: #{{ .Config.toolVersions.dotnet }}#
-      - name: Setup Python
-        uses: #{{ .Config.actionVersions.setupPython }}#
-        with:
-          python-version: #{{ .Config.toolVersions.python }}#
-      - name: Setup Java
-        uses: #{{ .Config.actionVersions.setupJava }}#
-        with:
-          cache: gradle
-          distribution: temurin
-          java-version: #{{ .Config.toolVersions.java }}#
-      - name: Setup Gradle
-        uses: #{{ .Config.actionVersions.setupGradle }}#
-        with:
-          gradle-version: #{{ .Config.toolVersions.gradle }}#
+          tools: pulumictl, pulumi, go, node, dotnet, python, java
       - name: Download provider + tfgen binaries
         uses: #{{ .Config.actionVersions.downloadArtifact }}#
         with:

--- a/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/prerequisites.yml
+++ b/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/prerequisites.yml
@@ -43,27 +43,10 @@ jobs:
         key: ${{ runner.os }}-${{ hashFiles('provider/go.sum') }}
     - name: Prepare upstream code
       run: make upstream
-    - name: Install Go
-      uses: #{{ .Config.actionVersions.setupGo }}#
+    - name: Setup tools
+      uses: ./.github/actions/setup-tools
       with:
-        go-version: "#{{ .Config.toolVersions.go }}#"
-        cache-dependency-path: |
-          provider/*.sum
-          upstream/*.sum
-    - name: Install pulumictl
-      uses: #{{ .Config.actionVersions.installGhRelease }}#
-      with:
-        tag: #{{ .Config.actionVersions.pulumictlTag }}#
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: #{{ .Config.actionVersions.setupPulumi }}#
-      with:
-        pulumi-version: "#{{ .Config.toolVersions.pulumi }}#"
-    - if: inputs.is_pr
-      name: Install Schema Tools
-      uses: #{{ .Config.actionVersions.installGhRelease }}#
-      with:
-        repo: pulumi/schema-tools
+        tools: go, pulumictl, pulumicli, schema-tools
 #{{- if .Config.actions.preBuild }}#
 #{{ .Config.actions.preBuild | toYaml | indent 4 }}#
 #{{- end }}#

--- a/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/run-acceptance-tests.yml
@@ -112,44 +112,10 @@ jobs:
       with:
         repository: pulumi/examples
         path: p-examples
-    - name: Install Go
-      uses: #{{ .Config.actionVersions.setupGo }}#
+    - name: Setup tools
+      uses: ./.github/actions/setup-tools
       with:
-        go-version: "#{{ .Config.toolVersions.go }}#"
-        cache-dependency-path: |
-          sdk/go.sum
-    - name: Install pulumictl
-      uses: #{{ .Config.actionVersions.installGhRelease }}#
-      with:
-        tag: #{{ .Config.actionVersions.pulumictlTag }}#
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: #{{ .Config.actionVersions.setupPulumi }}#
-      with:
-        pulumi-version: "#{{ .Config.toolVersions.pulumi }}#"
-    - name: Setup Node
-      uses: #{{ .Config.actionVersions.setupNode }}#
-      with:
-        node-version: "#{{ .Config.toolVersions.node }}#"
-        registry-url: https://registry.npmjs.org
-    - name: Setup DotNet
-      uses: #{{ .Config.actionVersions.setupDotNet }}#
-      with:
-        dotnet-version: "#{{ .Config.toolVersions.dotnet }}#"
-    - name: Setup Python
-      uses: #{{ .Config.actionVersions.setupPython }}#
-      with:
-        python-version: "#{{ .Config.toolVersions.python }}#"
-    - name: Setup Java
-      uses: #{{ .Config.actionVersions.setupJava }}#
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: "#{{ .Config.toolVersions.java }}#"
-    - name: Setup Gradle
-      uses: #{{ .Config.actionVersions.setupGradle }}#
-      with:
-        gradle-version: "#{{ .Config.toolVersions.gradle }}#"
+        tools: pulumictl, pulumi, go, node, dotnet, python, java
     - name: Download provider + tfgen binaries
       uses: #{{ .Config.actionVersions.downloadArtifact }}#
       with:

--- a/provider-ci/test-workflows/aws/.github/actions/setup-tools/action.yml
+++ b/provider-ci/test-workflows/aws/.github/actions/setup-tools/action.yml
@@ -1,0 +1,80 @@
+name: Setup tools
+description: Installs Go, Pulumi, pulumictl, schema-tools, Node.JS, Python, dotnet and Java.
+
+inputs:
+  tools:
+    description: |
+      Comma separated list of tools to install. The default of "all" installs all tools. Available tools are:
+        go
+        pulumicli
+        pulumictl
+        schema-tools
+        node
+        python
+        dotnet
+        java
+    default: all
+
+runs:
+  using: "composite"
+  steps:
+    - name: Install Go
+      if: inputs.tools == 'all' || contains(inputs.tools, 'go')
+      uses: actions/setup-go@v5
+      with:
+        go-version: "1.21.x"
+        cache-dependency-path: |
+          provider/*.sum
+          upstream/*.sum
+
+    - name: Install pulumictl
+      if: inputs.tools == 'all' || contains(inputs.tools, 'pulumictl')
+      uses: jaxxstorm/action-install-gh-release@v1.11.0
+      with:
+        tag: v0.0.46
+        repo: pulumi/pulumictl
+
+    - name: Install Pulumi CLI
+      if: inputs.tools == 'all' || contains(inputs.tools, 'pulumicli')
+      uses: pulumi/actions@v5
+      with:
+        pulumi-version: "^3"
+
+    - name: Install Schema Tools
+      if: inputs.tools == 'all' || contains(inputs.tools, 'schema-tools')
+      uses: jaxxstorm/action-install-gh-release@v1.11.0
+      with:
+        repo: pulumi/schema-tools
+
+    - name: Setup Node
+      if: inputs.tools == 'all' || contains(inputs.tools, 'node')
+      uses: actions/setup-node@v4
+      with:
+        node-version: 20.x
+        registry-url: https://registry.npmjs.org
+
+    - name: Setup DotNet
+      if: inputs.tools == 'all' || contains(inputs.tools, 'dotnet')
+      uses: actions/setup-dotnet@v4
+      with:
+        dotnet-version: 6.0.x
+
+    - name: Setup Python
+      if: inputs.tools == 'all' || contains(inputs.tools, 'python')
+      uses: actions/setup-python@v5
+      with:
+        python-version: 3.11.8
+
+    - name: Setup Java
+      if: inputs.tools == 'all' || contains(inputs.tools, 'java')
+      uses: actions/setup-java@v4
+      with:
+        cache: gradle
+        distribution: temurin
+        java-version: 11
+
+    - name: Setup Gradle
+      if: inputs.tools == 'all' || contains(inputs.tools, 'java')
+      uses: gradle/gradle-build-action@v3
+      with:
+        gradle-version: 7.6

--- a/provider-ci/test-workflows/aws/.github/workflows/build_sdk.yml
+++ b/provider-ci/test-workflows/aws/.github/workflows/build_sdk.yml
@@ -30,34 +30,10 @@ jobs:
           path: |
             .pulumi/examples-cache
           key: ${{ runner.os }}-${{ hashFiles('provider/go.sum') }}
-      - name: Install pulumictl
-        uses: jaxxstorm/action-install-gh-release@v1.11.0
+      - name: Setup tools
+        uses: ./.github/actions/setup-tools
         with:
-          tag: v0.0.46
-          repo: pulumi/pulumictl
-      - name: Setup Node
-        uses: actions/setup-node@v4
-        with:
-          node-version: 20.x
-          registry-url: https://registry.npmjs.org
-      - name: Setup DotNet
-        uses: actions/setup-dotnet@v4
-        with:
-          dotnet-version: 6.0.x
-      - name: Setup Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: 3.11.8
-      - name: Setup Java
-        uses: actions/setup-java@v4
-        with:
-          cache: gradle
-          distribution: temurin
-          java-version: 11
-      - name: Setup Gradle
-        uses: gradle/gradle-build-action@v3
-        with:
-          gradle-version: 7.6
+          tools: pulumictl, pulumi, go, node, dotnet, python, java
       - name: Download provider + tfgen binaries
         uses: actions/download-artifact@v4
         with:

--- a/provider-ci/test-workflows/aws/.github/workflows/prerequisites.yml
+++ b/provider-ci/test-workflows/aws/.github/workflows/prerequisites.yml
@@ -39,27 +39,10 @@ jobs:
         key: ${{ runner.os }}-${{ hashFiles('provider/go.sum') }}
     - name: Prepare upstream code
       run: make upstream
-    - name: Install Go
-      uses: actions/setup-go@v5
+    - name: Setup tools
+      uses: ./.github/actions/setup-tools
       with:
-        go-version: "1.21.x"
-        cache-dependency-path: |
-          provider/*.sum
-          upstream/*.sum
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.11.0
-      with:
-        tag: v0.0.46
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/actions@v5
-      with:
-        pulumi-version: "^3"
-    - if: inputs.is_pr
-      name: Install Schema Tools
-      uses: jaxxstorm/action-install-gh-release@v1.11.0
-      with:
-        repo: pulumi/schema-tools
+        tools: go, pulumictl, pulumicli, schema-tools
     - name: Clear GitHub Actions Ubuntu runner disk space
       uses: jlumbroso/free-disk-spacev@v1
       with:

--- a/provider-ci/test-workflows/aws/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/test-workflows/aws/.github/workflows/run-acceptance-tests.yml
@@ -112,44 +112,10 @@ jobs:
       with:
         repository: pulumi/examples
         path: p-examples
-    - name: Install Go
-      uses: actions/setup-go@v5
+    - name: Setup tools
+      uses: ./.github/actions/setup-tools
       with:
-        go-version: "1.21.x"
-        cache-dependency-path: |
-          sdk/go.sum
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.11.0
-      with:
-        tag: v0.0.46
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/actions@v5
-      with:
-        pulumi-version: "^3"
-    - name: Setup Node
-      uses: actions/setup-node@v4
-      with:
-        node-version: "20.x"
-        registry-url: https://registry.npmjs.org
-    - name: Setup DotNet
-      uses: actions/setup-dotnet@v4
-      with:
-        dotnet-version: "6.0.x"
-    - name: Setup Python
-      uses: actions/setup-python@v5
-      with:
-        python-version: "3.11.8"
-    - name: Setup Java
-      uses: actions/setup-java@v4
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: "11"
-    - name: Setup Gradle
-      uses: gradle/gradle-build-action@v3
-      with:
-        gradle-version: "7.6"
+        tools: pulumictl, pulumi, go, node, dotnet, python, java
     - name: Download provider + tfgen binaries
       uses: actions/download-artifact@v4
       with:

--- a/provider-ci/test-workflows/cloudflare/.github/actions/setup-tools/action.yml
+++ b/provider-ci/test-workflows/cloudflare/.github/actions/setup-tools/action.yml
@@ -1,0 +1,80 @@
+name: Setup tools
+description: Installs Go, Pulumi, pulumictl, schema-tools, Node.JS, Python, dotnet and Java.
+
+inputs:
+  tools:
+    description: |
+      Comma separated list of tools to install. The default of "all" installs all tools. Available tools are:
+        go
+        pulumicli
+        pulumictl
+        schema-tools
+        node
+        python
+        dotnet
+        java
+    default: all
+
+runs:
+  using: "composite"
+  steps:
+    - name: Install Go
+      if: inputs.tools == 'all' || contains(inputs.tools, 'go')
+      uses: actions/setup-go@v5
+      with:
+        go-version: "1.21.x"
+        cache-dependency-path: |
+          provider/*.sum
+          upstream/*.sum
+
+    - name: Install pulumictl
+      if: inputs.tools == 'all' || contains(inputs.tools, 'pulumictl')
+      uses: jaxxstorm/action-install-gh-release@v1.11.0
+      with:
+        tag: v0.0.46
+        repo: pulumi/pulumictl
+
+    - name: Install Pulumi CLI
+      if: inputs.tools == 'all' || contains(inputs.tools, 'pulumicli')
+      uses: pulumi/actions@v5
+      with:
+        pulumi-version: "^3"
+
+    - name: Install Schema Tools
+      if: inputs.tools == 'all' || contains(inputs.tools, 'schema-tools')
+      uses: jaxxstorm/action-install-gh-release@v1.11.0
+      with:
+        repo: pulumi/schema-tools
+
+    - name: Setup Node
+      if: inputs.tools == 'all' || contains(inputs.tools, 'node')
+      uses: actions/setup-node@v4
+      with:
+        node-version: 20.x
+        registry-url: https://registry.npmjs.org
+
+    - name: Setup DotNet
+      if: inputs.tools == 'all' || contains(inputs.tools, 'dotnet')
+      uses: actions/setup-dotnet@v4
+      with:
+        dotnet-version: 6.0.x
+
+    - name: Setup Python
+      if: inputs.tools == 'all' || contains(inputs.tools, 'python')
+      uses: actions/setup-python@v5
+      with:
+        python-version: 3.11.8
+
+    - name: Setup Java
+      if: inputs.tools == 'all' || contains(inputs.tools, 'java')
+      uses: actions/setup-java@v4
+      with:
+        cache: gradle
+        distribution: temurin
+        java-version: 11
+
+    - name: Setup Gradle
+      if: inputs.tools == 'all' || contains(inputs.tools, 'java')
+      uses: gradle/gradle-build-action@v3
+      with:
+        gradle-version: 7.6

--- a/provider-ci/test-workflows/cloudflare/.github/workflows/build_sdk.yml
+++ b/provider-ci/test-workflows/cloudflare/.github/workflows/build_sdk.yml
@@ -28,34 +28,10 @@ jobs:
           path: |
             .pulumi/examples-cache
           key: ${{ runner.os }}-${{ hashFiles('provider/go.sum') }}
-      - name: Install pulumictl
-        uses: jaxxstorm/action-install-gh-release@v1.11.0
+      - name: Setup tools
+        uses: ./.github/actions/setup-tools
         with:
-          tag: v0.0.46
-          repo: pulumi/pulumictl
-      - name: Setup Node
-        uses: actions/setup-node@v4
-        with:
-          node-version: 20.x
-          registry-url: https://registry.npmjs.org
-      - name: Setup DotNet
-        uses: actions/setup-dotnet@v4
-        with:
-          dotnet-version: 6.0.x
-      - name: Setup Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: 3.11.8
-      - name: Setup Java
-        uses: actions/setup-java@v4
-        with:
-          cache: gradle
-          distribution: temurin
-          java-version: 11
-      - name: Setup Gradle
-        uses: gradle/gradle-build-action@v3
-        with:
-          gradle-version: 7.6
+          tools: pulumictl, pulumi, go, node, dotnet, python, java
       - name: Download provider + tfgen binaries
         uses: actions/download-artifact@v4
         with:

--- a/provider-ci/test-workflows/cloudflare/.github/workflows/prerequisites.yml
+++ b/provider-ci/test-workflows/cloudflare/.github/workflows/prerequisites.yml
@@ -31,27 +31,10 @@ jobs:
         key: ${{ runner.os }}-${{ hashFiles('provider/go.sum') }}
     - name: Prepare upstream code
       run: make upstream
-    - name: Install Go
-      uses: actions/setup-go@v5
+    - name: Setup tools
+      uses: ./.github/actions/setup-tools
       with:
-        go-version: "1.21.x"
-        cache-dependency-path: |
-          provider/*.sum
-          upstream/*.sum
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.11.0
-      with:
-        tag: v0.0.46
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/actions@v5
-      with:
-        pulumi-version: "^3"
-    - if: inputs.is_pr
-      name: Install Schema Tools
-      uses: jaxxstorm/action-install-gh-release@v1.11.0
-      with:
-        repo: pulumi/schema-tools
+        tools: go, pulumictl, pulumicli, schema-tools
     - name: Build schema generator binary
       run: make tfgen_build_only
     - name: Install plugins

--- a/provider-ci/test-workflows/cloudflare/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/test-workflows/cloudflare/.github/workflows/run-acceptance-tests.yml
@@ -111,44 +111,10 @@ jobs:
       with:
         repository: pulumi/examples
         path: p-examples
-    - name: Install Go
-      uses: actions/setup-go@v5
+    - name: Setup tools
+      uses: ./.github/actions/setup-tools
       with:
-        go-version: "1.21.x"
-        cache-dependency-path: |
-          sdk/go.sum
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.11.0
-      with:
-        tag: v0.0.46
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/actions@v5
-      with:
-        pulumi-version: "^3"
-    - name: Setup Node
-      uses: actions/setup-node@v4
-      with:
-        node-version: "20.x"
-        registry-url: https://registry.npmjs.org
-    - name: Setup DotNet
-      uses: actions/setup-dotnet@v4
-      with:
-        dotnet-version: "6.0.x"
-    - name: Setup Python
-      uses: actions/setup-python@v5
-      with:
-        python-version: "3.11.8"
-    - name: Setup Java
-      uses: actions/setup-java@v4
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: "11"
-    - name: Setup Gradle
-      uses: gradle/gradle-build-action@v3
-      with:
-        gradle-version: "7.6"
+        tools: pulumictl, pulumi, go, node, dotnet, python, java
     - name: Download provider + tfgen binaries
       uses: actions/download-artifact@v4
       with:

--- a/provider-ci/test-workflows/docker/.github/actions/setup-tools/action.yml
+++ b/provider-ci/test-workflows/docker/.github/actions/setup-tools/action.yml
@@ -1,0 +1,80 @@
+name: Setup tools
+description: Installs Go, Pulumi, pulumictl, schema-tools, Node.JS, Python, dotnet and Java.
+
+inputs:
+  tools:
+    description: |
+      Comma separated list of tools to install. The default of "all" installs all tools. Available tools are:
+        go
+        pulumicli
+        pulumictl
+        schema-tools
+        node
+        python
+        dotnet
+        java
+    default: all
+
+runs:
+  using: "composite"
+  steps:
+    - name: Install Go
+      if: inputs.tools == 'all' || contains(inputs.tools, 'go')
+      uses: actions/setup-go@v5
+      with:
+        go-version: "1.21.x"
+        cache-dependency-path: |
+          provider/*.sum
+          upstream/*.sum
+
+    - name: Install pulumictl
+      if: inputs.tools == 'all' || contains(inputs.tools, 'pulumictl')
+      uses: jaxxstorm/action-install-gh-release@v1.11.0
+      with:
+        tag: v0.0.46
+        repo: pulumi/pulumictl
+
+    - name: Install Pulumi CLI
+      if: inputs.tools == 'all' || contains(inputs.tools, 'pulumicli')
+      uses: pulumi/actions@v5
+      with:
+        pulumi-version: "^3"
+
+    - name: Install Schema Tools
+      if: inputs.tools == 'all' || contains(inputs.tools, 'schema-tools')
+      uses: jaxxstorm/action-install-gh-release@v1.11.0
+      with:
+        repo: pulumi/schema-tools
+
+    - name: Setup Node
+      if: inputs.tools == 'all' || contains(inputs.tools, 'node')
+      uses: actions/setup-node@v4
+      with:
+        node-version: 20.x
+        registry-url: https://registry.npmjs.org
+
+    - name: Setup DotNet
+      if: inputs.tools == 'all' || contains(inputs.tools, 'dotnet')
+      uses: actions/setup-dotnet@v4
+      with:
+        dotnet-version: 6.0.x
+
+    - name: Setup Python
+      if: inputs.tools == 'all' || contains(inputs.tools, 'python')
+      uses: actions/setup-python@v5
+      with:
+        python-version: 3.11.8
+
+    - name: Setup Java
+      if: inputs.tools == 'all' || contains(inputs.tools, 'java')
+      uses: actions/setup-java@v4
+      with:
+        cache: gradle
+        distribution: temurin
+        java-version: 11
+
+    - name: Setup Gradle
+      if: inputs.tools == 'all' || contains(inputs.tools, 'java')
+      uses: gradle/gradle-build-action@v3
+      with:
+        gradle-version: 7.6

--- a/provider-ci/test-workflows/docker/.github/workflows/build_sdk.yml
+++ b/provider-ci/test-workflows/docker/.github/workflows/build_sdk.yml
@@ -28,34 +28,10 @@ jobs:
           path: |
             .pulumi/examples-cache
           key: ${{ runner.os }}-${{ hashFiles('provider/go.sum') }}
-      - name: Install pulumictl
-        uses: jaxxstorm/action-install-gh-release@v1.11.0
+      - name: Setup tools
+        uses: ./.github/actions/setup-tools
         with:
-          tag: v0.0.46
-          repo: pulumi/pulumictl
-      - name: Setup Node
-        uses: actions/setup-node@v4
-        with:
-          node-version: 20.x
-          registry-url: https://registry.npmjs.org
-      - name: Setup DotNet
-        uses: actions/setup-dotnet@v4
-        with:
-          dotnet-version: 6.0.x
-      - name: Setup Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: 3.11.8
-      - name: Setup Java
-        uses: actions/setup-java@v4
-        with:
-          cache: gradle
-          distribution: temurin
-          java-version: 11
-      - name: Setup Gradle
-        uses: gradle/gradle-build-action@v3
-        with:
-          gradle-version: 7.6
+          tools: pulumictl, pulumi, go, node, dotnet, python, java
       - name: Download provider + tfgen binaries
         uses: actions/download-artifact@v4
         with:

--- a/provider-ci/test-workflows/docker/.github/workflows/prerequisites.yml
+++ b/provider-ci/test-workflows/docker/.github/workflows/prerequisites.yml
@@ -31,27 +31,10 @@ jobs:
         key: ${{ runner.os }}-${{ hashFiles('provider/go.sum') }}
     - name: Prepare upstream code
       run: make upstream
-    - name: Install Go
-      uses: actions/setup-go@v5
+    - name: Setup tools
+      uses: ./.github/actions/setup-tools
       with:
-        go-version: "1.21.x"
-        cache-dependency-path: |
-          provider/*.sum
-          upstream/*.sum
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.11.0
-      with:
-        tag: v0.0.46
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/actions@v5
-      with:
-        pulumi-version: "^3"
-    - if: inputs.is_pr
-      name: Install Schema Tools
-      uses: jaxxstorm/action-install-gh-release@v1.11.0
-      with:
-        repo: pulumi/schema-tools
+        tools: go, pulumictl, pulumicli, schema-tools
     - name: Build schema generator binary
       run: make tfgen_build_only
     - name: Install plugins

--- a/provider-ci/test-workflows/docker/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/test-workflows/docker/.github/workflows/run-acceptance-tests.yml
@@ -124,44 +124,10 @@ jobs:
       with:
         repository: pulumi/examples
         path: p-examples
-    - name: Install Go
-      uses: actions/setup-go@v5
+    - name: Setup tools
+      uses: ./.github/actions/setup-tools
       with:
-        go-version: "1.21.x"
-        cache-dependency-path: |
-          sdk/go.sum
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.11.0
-      with:
-        tag: v0.0.46
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/actions@v5
-      with:
-        pulumi-version: "^3"
-    - name: Setup Node
-      uses: actions/setup-node@v4
-      with:
-        node-version: "20.x"
-        registry-url: https://registry.npmjs.org
-    - name: Setup DotNet
-      uses: actions/setup-dotnet@v4
-      with:
-        dotnet-version: "6.0.x"
-    - name: Setup Python
-      uses: actions/setup-python@v5
-      with:
-        python-version: "3.11.8"
-    - name: Setup Java
-      uses: actions/setup-java@v4
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: "11"
-    - name: Setup Gradle
-      uses: gradle/gradle-build-action@v3
-      with:
-        gradle-version: "7.6"
+        tools: pulumictl, pulumi, go, node, dotnet, python, java
     - name: Download provider + tfgen binaries
       uses: actions/download-artifact@v4
       with:


### PR DESCRIPTION
Stacked on top of https://github.com/pulumi/ci-mgmt/pull/942

Primary benefit is to reduce duplication within templates. This was not possible when using splices because splices cannot reference splices.

Additionally, we want to make installing our standard versions of our tools available for use from custom test jobs as used in AWS and other providers so they don't have to hard code their own install actions.

- Go was not previously explicitly installed during the build_sdk job but is used when running `make build_go`, so this adds it to ensure we're using a consistent version.