### PR TITLE
Install pulumi cli in jobs

### DIFF
--- a/provider-ci/internal/pkg/templates/bridged-provider.config.yaml
+++ b/provider-ci/internal/pkg/templates/bridged-provider.config.yaml
@@ -20,7 +20,7 @@ toolVersions:
   java: "11"
   gradle: "7.6"
   node: "20.x"
-  pulumi: "^3"
+  pulumi: "dev"
   python: "3.11.8"
 env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/build_sdk.yml
+++ b/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/build_sdk.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Setup tools
         uses: ./.github/actions/setup-tools
         with:
-          tools: pulumictl, pulumi, go, node, dotnet, python, java
+          tools: pulumictl, pulumicli, go, node, dotnet, python, java
       - name: Download provider + tfgen binaries
         uses: #{{ .Config.actionVersions.downloadArtifact }}#
         with:

--- a/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/run-acceptance-tests.yml
@@ -115,7 +115,7 @@ jobs:
     - name: Setup tools
       uses: ./.github/actions/setup-tools
       with:
-        tools: pulumictl, pulumi, go, node, dotnet, python, java
+        tools: pulumictl, pulumicli, go, node, dotnet, python, java
     - name: Download provider + tfgen binaries
       uses: #{{ .Config.actionVersions.downloadArtifact }}#
       with:

--- a/provider-ci/test-workflows/aws/.github/actions/setup-tools/action.yml
+++ b/provider-ci/test-workflows/aws/.github/actions/setup-tools/action.yml
@@ -38,7 +38,7 @@ runs:
       if: inputs.tools == 'all' || contains(inputs.tools, 'pulumicli')
       uses: pulumi/actions@v5
       with:
-        pulumi-version: "^3"
+        pulumi-version: "dev"
 
     - name: Install Schema Tools
       if: inputs.tools == 'all' || contains(inputs.tools, 'schema-tools')

--- a/provider-ci/test-workflows/aws/.github/workflows/build_sdk.yml
+++ b/provider-ci/test-workflows/aws/.github/workflows/build_sdk.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Setup tools
         uses: ./.github/actions/setup-tools
         with:
-          tools: pulumictl, pulumi, go, node, dotnet, python, java
+          tools: pulumictl, pulumicli, go, node, dotnet, python, java
       - name: Download provider + tfgen binaries
         uses: actions/download-artifact@v4
         with:

--- a/provider-ci/test-workflows/aws/.github/workflows/master.yml
+++ b/provider-ci/test-workflows/aws/.github/workflows/master.yml
@@ -64,7 +64,7 @@ jobs:
     - name: Install Pulumi CLI
       uses: pulumi/actions@v5
       with:
-        pulumi-version: "^3"
+        pulumi-version: "dev"
     - if: github.event_name == 'pull_request'
       name: Install Schema Tools
       uses: jaxxstorm/action-install-gh-release@v1.11.0
@@ -128,7 +128,7 @@ jobs:
     - name: Install Pulumi CLI
       uses: pulumi/actions@v5
       with:
-        pulumi-version: "^3"
+        pulumi-version: "dev"
     - name: Configure AWS Credentials
       uses: aws-actions/configure-aws-credentials@v4
       with:
@@ -237,7 +237,7 @@ jobs:
     - name: Install Pulumi CLI
       uses: pulumi/actions@v5
       with:
-        pulumi-version: "^3"
+        pulumi-version: "dev"
     - name: Setup Node
       uses: actions/setup-node@v4
       with:

--- a/provider-ci/test-workflows/aws/.github/workflows/nightly-test.yml
+++ b/provider-ci/test-workflows/aws/.github/workflows/nightly-test.yml
@@ -70,7 +70,7 @@ jobs:
     - name: Install Pulumi CLI
       uses: pulumi/actions@v5
       with:
-        pulumi-version: "^3"
+        pulumi-version: "dev"
     - name: Setup Node
       uses: actions/setup-node@v4
       with:

--- a/provider-ci/test-workflows/aws/.github/workflows/prerelease.yml
+++ b/provider-ci/test-workflows/aws/.github/workflows/prerelease.yml
@@ -73,7 +73,7 @@ jobs:
     - name: Install Pulumi CLI
       uses: pulumi/actions@v5
       with:
-        pulumi-version: "^3"
+        pulumi-version: "dev"
     - name: Configure AWS Credentials
       uses: aws-actions/configure-aws-credentials@v4
       with:
@@ -202,7 +202,7 @@ jobs:
     - name: Install Pulumi CLI
       uses: pulumi/actions@v5
       with:
-        pulumi-version: "^3"
+        pulumi-version: "dev"
     - name: Setup Node
       uses: actions/setup-node@v4
       with:

--- a/provider-ci/test-workflows/aws/.github/workflows/release.yml
+++ b/provider-ci/test-workflows/aws/.github/workflows/release.yml
@@ -89,7 +89,7 @@ jobs:
     - name: Install Pulumi CLI
       uses: pulumi/actions@v5
       with:
-        pulumi-version: "^3"
+        pulumi-version: "dev"
     - name: Configure AWS Credentials
       uses: aws-actions/configure-aws-credentials@v4
       with:
@@ -235,7 +235,7 @@ jobs:
     - name: Install Pulumi CLI
       uses: pulumi/actions@v5
       with:
-        pulumi-version: "^3"
+        pulumi-version: "dev"
     - name: Setup Node
       uses: actions/setup-node@v4
       with:

--- a/provider-ci/test-workflows/aws/.github/workflows/resync-build.yml
+++ b/provider-ci/test-workflows/aws/.github/workflows/resync-build.yml
@@ -53,7 +53,7 @@ jobs:
     - name: Install Pulumi CLI
       uses: pulumi/actions@v5
       with:
-        pulumi-version: "^3"
+        pulumi-version: "dev"
     - name: Setup DotNet
       uses: actions/setup-dotnet@v4
       with:

--- a/provider-ci/test-workflows/aws/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/test-workflows/aws/.github/workflows/run-acceptance-tests.yml
@@ -115,7 +115,7 @@ jobs:
     - name: Setup tools
       uses: ./.github/actions/setup-tools
       with:
-        tools: pulumictl, pulumi, go, node, dotnet, python, java
+        tools: pulumictl, pulumicli, go, node, dotnet, python, java
     - name: Download provider + tfgen binaries
       uses: actions/download-artifact@v4
       with:

--- a/provider-ci/test-workflows/cloudflare/.github/actions/setup-tools/action.yml
+++ b/provider-ci/test-workflows/cloudflare/.github/actions/setup-tools/action.yml
@@ -38,7 +38,7 @@ runs:
       if: inputs.tools == 'all' || contains(inputs.tools, 'pulumicli')
       uses: pulumi/actions@v5
       with:
-        pulumi-version: "^3"
+        pulumi-version: "dev"
 
     - name: Install Schema Tools
       if: inputs.tools == 'all' || contains(inputs.tools, 'schema-tools')

--- a/provider-ci/test-workflows/cloudflare/.github/workflows/build_sdk.yml
+++ b/provider-ci/test-workflows/cloudflare/.github/workflows/build_sdk.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Setup tools
         uses: ./.github/actions/setup-tools
         with:
-          tools: pulumictl, pulumi, go, node, dotnet, python, java
+          tools: pulumictl, pulumicli, go, node, dotnet, python, java
       - name: Download provider + tfgen binaries
         uses: actions/download-artifact@v4
         with:

--- a/provider-ci/test-workflows/cloudflare/.github/workflows/master.yml
+++ b/provider-ci/test-workflows/cloudflare/.github/workflows/master.yml
@@ -62,7 +62,7 @@ jobs:
     - name: Install Pulumi CLI
       uses: pulumi/actions@v5
       with:
-        pulumi-version: "^3"
+        pulumi-version: "dev"
     - if: github.event_name == 'pull_request'
       name: Install Schema Tools
       uses: jaxxstorm/action-install-gh-release@v1.11.0
@@ -127,7 +127,7 @@ jobs:
     - name: Install Pulumi CLI
       uses: pulumi/actions@v5
       with:
-        pulumi-version: "^3"
+        pulumi-version: "dev"
     - name: Configure AWS Credentials
       uses: aws-actions/configure-aws-credentials@v4
       with:
@@ -228,7 +228,7 @@ jobs:
     - name: Install Pulumi CLI
       uses: pulumi/actions@v5
       with:
-        pulumi-version: "^3"
+        pulumi-version: "dev"
     - name: Setup Node
       uses: actions/setup-node@v4
       with:

--- a/provider-ci/test-workflows/cloudflare/.github/workflows/prerelease.yml
+++ b/provider-ci/test-workflows/cloudflare/.github/workflows/prerelease.yml
@@ -74,7 +74,7 @@ jobs:
     - name: Install Pulumi CLI
       uses: pulumi/actions@v5
       with:
-        pulumi-version: "^3"
+        pulumi-version: "dev"
     - name: Configure AWS Credentials
       uses: aws-actions/configure-aws-credentials@v4
       with:
@@ -193,7 +193,7 @@ jobs:
     - name: Install Pulumi CLI
       uses: pulumi/actions@v5
       with:
-        pulumi-version: "^3"
+        pulumi-version: "dev"
     - name: Setup Node
       uses: actions/setup-node@v4
       with:

--- a/provider-ci/test-workflows/cloudflare/.github/workflows/release.yml
+++ b/provider-ci/test-workflows/cloudflare/.github/workflows/release.yml
@@ -90,7 +90,7 @@ jobs:
     - name: Install Pulumi CLI
       uses: pulumi/actions@v5
       with:
-        pulumi-version: "^3"
+        pulumi-version: "dev"
     - name: Configure AWS Credentials
       uses: aws-actions/configure-aws-credentials@v4
       with:
@@ -226,7 +226,7 @@ jobs:
     - name: Install Pulumi CLI
       uses: pulumi/actions@v5
       with:
-        pulumi-version: "^3"
+        pulumi-version: "dev"
     - name: Setup Node
       uses: actions/setup-node@v4
       with:

--- a/provider-ci/test-workflows/cloudflare/.github/workflows/resync-build.yml
+++ b/provider-ci/test-workflows/cloudflare/.github/workflows/resync-build.yml
@@ -51,7 +51,7 @@ jobs:
     - name: Install Pulumi CLI
       uses: pulumi/actions@v5
       with:
-        pulumi-version: "^3"
+        pulumi-version: "dev"
     - name: Setup DotNet
       uses: actions/setup-dotnet@v4
       with:

--- a/provider-ci/test-workflows/cloudflare/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/test-workflows/cloudflare/.github/workflows/run-acceptance-tests.yml
@@ -114,7 +114,7 @@ jobs:
     - name: Setup tools
       uses: ./.github/actions/setup-tools
       with:
-        tools: pulumictl, pulumi, go, node, dotnet, python, java
+        tools: pulumictl, pulumicli, go, node, dotnet, python, java
     - name: Download provider + tfgen binaries
       uses: actions/download-artifact@v4
       with:

--- a/provider-ci/test-workflows/docker/.github/actions/setup-tools/action.yml
+++ b/provider-ci/test-workflows/docker/.github/actions/setup-tools/action.yml
@@ -38,7 +38,7 @@ runs:
       if: inputs.tools == 'all' || contains(inputs.tools, 'pulumicli')
       uses: pulumi/actions@v5
       with:
-        pulumi-version: "^3"
+        pulumi-version: "dev"
 
     - name: Install Schema Tools
       if: inputs.tools == 'all' || contains(inputs.tools, 'schema-tools')

--- a/provider-ci/test-workflows/docker/.github/workflows/build_sdk.yml
+++ b/provider-ci/test-workflows/docker/.github/workflows/build_sdk.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Setup tools
         uses: ./.github/actions/setup-tools
         with:
-          tools: pulumictl, pulumi, go, node, dotnet, python, java
+          tools: pulumictl, pulumicli, go, node, dotnet, python, java
       - name: Download provider + tfgen binaries
         uses: actions/download-artifact@v4
         with:

--- a/provider-ci/test-workflows/docker/.github/workflows/master.yml
+++ b/provider-ci/test-workflows/docker/.github/workflows/master.yml
@@ -75,7 +75,7 @@ jobs:
     - name: Install Pulumi CLI
       uses: pulumi/actions@v5
       with:
-        pulumi-version: "^3"
+        pulumi-version: "dev"
     - if: github.event_name == 'pull_request'
       name: Install Schema Tools
       uses: jaxxstorm/action-install-gh-release@v1.11.0
@@ -140,7 +140,7 @@ jobs:
     - name: Install Pulumi CLI
       uses: pulumi/actions@v5
       with:
-        pulumi-version: "^3"
+        pulumi-version: "dev"
     - name: Configure AWS Credentials
       uses: aws-actions/configure-aws-credentials@v4
       with:
@@ -241,7 +241,7 @@ jobs:
     - name: Install Pulumi CLI
       uses: pulumi/actions@v5
       with:
-        pulumi-version: "^3"
+        pulumi-version: "dev"
     - name: Setup Node
       uses: actions/setup-node@v4
       with:

--- a/provider-ci/test-workflows/docker/.github/workflows/prerelease.yml
+++ b/provider-ci/test-workflows/docker/.github/workflows/prerelease.yml
@@ -87,7 +87,7 @@ jobs:
     - name: Install Pulumi CLI
       uses: pulumi/actions@v5
       with:
-        pulumi-version: "^3"
+        pulumi-version: "dev"
     - name: Configure AWS Credentials
       uses: aws-actions/configure-aws-credentials@v4
       with:
@@ -206,7 +206,7 @@ jobs:
     - name: Install Pulumi CLI
       uses: pulumi/actions@v5
       with:
-        pulumi-version: "^3"
+        pulumi-version: "dev"
     - name: Setup Node
       uses: actions/setup-node@v4
       with:

--- a/provider-ci/test-workflows/docker/.github/workflows/release.yml
+++ b/provider-ci/test-workflows/docker/.github/workflows/release.yml
@@ -103,7 +103,7 @@ jobs:
     - name: Install Pulumi CLI
       uses: pulumi/actions@v5
       with:
-        pulumi-version: "^3"
+        pulumi-version: "dev"
     - name: Configure AWS Credentials
       uses: aws-actions/configure-aws-credentials@v4
       with:
@@ -239,7 +239,7 @@ jobs:
     - name: Install Pulumi CLI
       uses: pulumi/actions@v5
       with:
-        pulumi-version: "^3"
+        pulumi-version: "dev"
     - name: Setup Node
       uses: actions/setup-node@v4
       with:

--- a/provider-ci/test-workflows/docker/.github/workflows/resync-build.yml
+++ b/provider-ci/test-workflows/docker/.github/workflows/resync-build.yml
@@ -64,7 +64,7 @@ jobs:
     - name: Install Pulumi CLI
       uses: pulumi/actions@v5
       with:
-        pulumi-version: "^3"
+        pulumi-version: "dev"
     - name: Setup DotNet
       uses: actions/setup-dotnet@v4
       with:

--- a/provider-ci/test-workflows/docker/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/test-workflows/docker/.github/workflows/run-acceptance-tests.yml
@@ -127,7 +127,7 @@ jobs:
     - name: Setup tools
       uses: ./.github/actions/setup-tools
       with:
-        tools: pulumictl, pulumi, go, node, dotnet, python, java
+        tools: pulumictl, pulumicli, go, node, dotnet, python, java
     - name: Download provider + tfgen binaries
       uses: actions/download-artifact@v4
       with:


### PR DESCRIPTION
We were not actually installing the CLI and just using the ambient GHA version = (

setup-tools expects pulumicli as a string: https://github.com/pulumi/pulumi-github/blob/43b283d3734a435d5c714723ab8c1ddefc2be3c3/.github/actions/setup-tools/action.yml#L38

We also now install the dev version