### PR TITLE
Configurable SDK module directory

### DIFF
--- a/native-provider-ci/providers/docker-build/config.yaml
+++ b/native-provider-ci/providers/docker-build/config.yaml
@@ -4,6 +4,7 @@ defaultBranch: main
 providerVersion: github.com/pulumi/pulumi-docker-build/provider.Version
 aws: true
 gcp: true
+sdkModuleDir: sdk/go/dockerbuild
 env:
   AWS_REGION: us-west-2
   PULUMI_API: "https://api.pulumi-staging.io"

--- a/native-provider-ci/providers/docker-build/repo/.github/workflows/prerelease.yml
+++ b/native-provider-ci/providers/docker-build/repo/.github/workflows/prerelease.yml
@@ -585,8 +585,8 @@ jobs:
       with:
         repository: ${{ github.repository }}
         base-ref: ${{ github.sha }}
-        source: sdk
-        path: sdk
+        source: sdk/go/dockerbuild
+        path: sdk/go/dockerbuild
         version: ${{ steps.version.outputs.version }}
         additive: false
         files: |-

--- a/native-provider-ci/providers/docker-build/repo/.github/workflows/release.yml
+++ b/native-provider-ci/providers/docker-build/repo/.github/workflows/release.yml
@@ -585,8 +585,8 @@ jobs:
       with:
         repository: ${{ github.repository }}
         base-ref: ${{ github.sha }}
-        source: sdk
-        path: sdk
+        source: sdk/go/dockerbuild
+        path: sdk/go/dockerbuild
         version: ${{ steps.version.outputs.version }}
         additive: false
         files: |-

--- a/native-provider-ci/src/steps.ts
+++ b/native-provider-ci/src/steps.ts
@@ -1017,15 +1017,15 @@ export function RunGoReleaserWithArgs(args?: string): Step {
   };
 }
 
-export function PublishGoSdk(): Step {
+export function PublishGoSdk(sdkModuleDir: string): Step {
   return {
     name: "Publish Go SDK",
     uses: "pulumi/publish-go-sdk-action@v1",
     with: {
       repository: "${{ github.repository }}",
       "base-ref": "${{ github.sha }}",
-      source: "sdk",
-      path: "sdk",
+      source: sdkModuleDir,
+      path: sdkModuleDir,
       version: "${{ steps.version.outputs.version }}",
       additive: false,
       files: `\


### PR DESCRIPTION
This persists the fix in https://github.com/pulumi/pulumi-docker-build/pull/106.

This also makes it possible to eventually not need a separate `go.mod` under the `sdk` directory at all.