### PR TITLE
Only calculate version once in prerequisites

### DIFF
--- a/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/build_sdk.yml
+++ b/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/build_sdk.yml
@@ -1,10 +1,15 @@
 name: "Build SDK"
 
 on:
-  workflow_call: {}
+  workflow_call:
+    inputs:
+      version:
+        required: true
+        type: string
 
 env:
 #{{ .Config.env | toYaml | indent 2 }}#
+  PROVIDER_VERSION: ${{ inputs.version }}
 
 jobs:
   build_sdk:
@@ -26,9 +31,6 @@ jobs:
         with:
           submodules: #{{ .Config.checkoutSubmodules }}#
 #{{- end }}#
-      - uses: pulumi/provider-version-action@v1
-        with:
-          set-env: 'PROVIDER_VERSION'
       - name: Cache examples generation
         uses: actions/cache@v4
         with:

--- a/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/main.yml
+++ b/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/main.yml
@@ -3,11 +3,21 @@
 env:
 #{{ .Config.env | toYaml | indent 2 }}#
 jobs:
+  prerequisites:
+    uses: ./.github/workflows/prerequisites.yml
+    secrets: inherit
+    with:
+      default_branch: ${{ github.event.repository.default_branch }}
+      is_pr: ${{ github.event_name == 'pull_request' }}
+      is_automated: ${{ github.actor == 'dependabot[bot]' }}
+
   build_sdk:
     name: build_sdk
     needs: prerequisites
     uses: ./.github/workflows/build_sdk.yml
     secrets: inherit
+    with:
+      version: ${{ needs.prerequisites.outputs.version }}
 
   generate_coverage_data:
     continue-on-error: true
@@ -78,17 +88,11 @@ jobs:
     name: License Check
     uses: ./.github/workflows/license.yml
     secrets: inherit
-  prerequisites:
-    uses: ./.github/workflows/prerequisites.yml
-    secrets: inherit
-    with:
-      default_branch: ${{ github.event.repository.default_branch }}
-      is_pr: ${{ github.event_name == 'pull_request' }}
-      is_automated: ${{ github.actor == 'dependabot[bot]' }}
 
   publish:
     name: publish
     needs:
+      - prerequisites
       - test
       - license_check
       #{{- range $action, $_ := .Config.extraTests }}#
@@ -134,13 +138,11 @@ jobs:
         role-external-id: upload-pulumi-release
         role-session-name: #{{ .Config.provider }}#@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
-    - id: version
-      uses: pulumi/provider-version-action@v1
     - name: Run GoReleaser
       uses: #{{ .Config.actionVersions.goReleaser }}#
       env:
-        GORELEASER_CURRENT_TAG: v${{ steps.version.outputs.version }}
-        PROVIDER_VERSION: ${{ steps.version.outputs.version }}
+        GORELEASER_CURRENT_TAG: v${{ needs.prerequisites.outputs.version }}
+        PROVIDER_VERSION: ${{ needs.prerequisites.outputs.version }}
       with:
         args: -p #{{ .Config.parallel }}# -f .goreleaser.prerelease.yml --rm-dist --skip-validate --timeout
           #{{ .Config.timeout }}#m0s
@@ -154,16 +156,16 @@ jobs:
         status: ${{ job.status }}
   publish_sdk:
     name: publish_sdk
-    needs: publish
+    needs:
+      - prerequisites
+      - publish
     runs-on: #{{ .Config.runner.default }}#
     steps:
-    - id: version
-      uses: pulumi/provider-version-action@v1
     - name: Publish SDKs
       uses: #{{ .Config.publish.publisherAction }}#
       with:
         sdk: #{{ .Config.publish.sdk }}#
-        version: ${{ steps.version.outputs.version }}
+        version: ${{ needs.prerequisites.outputs.version }}
         dotnet-version: "#{{ .Config.toolVersions.dotnet }}#"
         java-version: "#{{ .Config.toolVersions.java }}#"
         node-version: "#{{ .Config.toolVersions.node }}#"
@@ -199,11 +201,15 @@ jobs:
 
   test:
     name: test
-    needs: build_sdk
+    needs: 
+      - prerequisites
+      - build_sdk
     permissions:
       contents: read
       id-token: write
     runs-on: #{{ if .Config.runner.buildSdk }}##{{- .Config.runner.buildSdk }}##{{ else }}##{{- .Config.runner.default }}##{{ end }}#
+    env:
+      PROVIDER_VERSION: ${{ needs.prerequisites.outputs.version }}
     steps:
 #{{- if .Config.freeDiskSpaceBeforeTest }}#
     # Run as first step so we don't delete things that have just been installed
@@ -219,9 +225,6 @@ jobs:
       with:
         submodules: #{{ .Config.checkoutSubmodules }}#
 #{{- end }}#
-    - uses: pulumi/provider-version-action@v1
-      with:
-        set-env: 'PROVIDER_VERSION'
     - name: Install Go
       uses: #{{ .Config.actionVersions.setupGo }}#
       with:

--- a/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/nightly-test.yml
+++ b/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/nightly-test.yml
@@ -4,12 +4,6 @@
 env:
 #{{ .Config.env | toYaml | indent 2 }}#
 jobs:
-  build_sdk:
-    name: build_sdk
-    needs: prerequisites
-    uses: ./.github/workflows/build_sdk.yml
-    secrets: inherit
-
   prerequisites:
     uses: ./.github/workflows/prerequisites.yml
     secrets: inherit
@@ -18,13 +12,25 @@ jobs:
       is_pr: ${{ github.event_name == 'pull_request' }}
       is_automated: ${{ github.actor == 'dependabot[bot]' }}
 
+  build_sdk:
+    name: build_sdk
+    needs: prerequisites
+    uses: ./.github/workflows/build_sdk.yml
+    secrets: inherit
+    with:
+      version: ${{ needs.prerequisites.outputs.version }}
+
   test:
     name: test
-    needs: build_sdk
+    needs: 
+      - prerequisites
+      - build_sdk
     permissions:
       contents: read
       id-token: write
     runs-on: #{{ if .Config.runner.buildSdk }}##{{- .Config.runner.buildSdk }}##{{ else }}##{{- .Config.runner.default }}##{{ end }}#
+    env:
+      PROVIDER_VERSION: ${{ needs.prerequisites.outputs.version }}
     steps:
 #{{- if .Config.freeDiskSpaceBeforeTest }}#
     # Run as first step so we don't delete things that have just been installed
@@ -40,9 +46,6 @@ jobs:
       with:
         submodules: #{{ .Config.checkoutSubmodules }}#
 #{{- end }}#
-    - uses: pulumi/provider-version-action@v1
-      with:
-        set-env: 'PROVIDER_VERSION'
     - name: Install Go
       uses: #{{ .Config.actionVersions.setupGo }}#
       with:

--- a/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/prerelease.yml
+++ b/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/prerelease.yml
@@ -4,11 +4,21 @@ env:
   IS_PRERELEASE: true
 #{{ .Config.env | toYaml | indent 2 }}#
 jobs:
+  prerequisites:
+    uses: ./.github/workflows/prerequisites.yml
+    secrets: inherit
+    with:
+      default_branch: ${{ github.event.repository.default_branch }}
+      is_pr: ${{ github.event_name == 'pull_request' }}
+      is_automated: ${{ github.actor == 'dependabot[bot]' }}
+
   build_sdk:
     name: build_sdk
     needs: prerequisites
     uses: ./.github/workflows/build_sdk.yml
     secrets: inherit
+    with:
+      version: ${{ needs.prerequisites.outputs.version }}
 
   #{{ if .Config.lint -}}#
   lint:
@@ -21,17 +31,11 @@ jobs:
     name: License Check
     uses: ./.github/workflows/license.yml
     secrets: inherit
-  prerequisites:
-    uses: ./.github/workflows/prerequisites.yml
-    secrets: inherit
-    with:
-      default_branch: ${{ github.event.repository.default_branch }}
-      is_pr: ${{ github.event_name == 'pull_request' }}
-      is_automated: ${{ github.actor == 'dependabot[bot]' }}
 
   publish:
     name: publish
     needs:
+      - prerequisites
       - test
       - license_check
       #{{- range $action, $_ := .Config.extraTests }}#
@@ -77,13 +81,11 @@ jobs:
         role-external-id: upload-pulumi-release
         role-session-name: #{{ .Config.provider }}#@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
-    - id: version
-      uses: pulumi/provider-version-action@v1
     - name: Run GoReleaser
       uses: #{{ .Config.actionVersions.goReleaser }}#
       env:
-        GORELEASER_CURRENT_TAG: v${{ steps.version.outputs.version }}
-        PROVIDER_VERSION: ${{ steps.version.outputs.version }}
+        GORELEASER_CURRENT_TAG: v${{ needs.prerequisites.outputs.version }}
+        PROVIDER_VERSION: ${{ needs.prerequisites.outputs.version }}
       with:
         args: -p #{{ .Config.parallel }}# -f .goreleaser.prerelease.yml --rm-dist --skip-validate --timeout
           #{{ .Config.timeout }}#m0s
@@ -97,16 +99,16 @@ jobs:
         status: ${{ job.status }}
   publish_sdk:
     name: publish_sdk
-    needs: publish
+    needs: 
+      - prerequisites
+      - publish
     runs-on: #{{ .Config.runner.default }}#
     steps:
-    - id: version
-      uses: pulumi/provider-version-action@v1
     - name: Publish SDKs
       uses: #{{ .Config.publish.publisherAction }}#
       with:
         sdk: #{{ .Config.publish.sdk }}#
-        version: ${{ steps.version.outputs.version }}
+        version: ${{ needs.prerequisites.outputs.version }}
         dotnet-version: "#{{ .Config.toolVersions.dotnet }}#"
         java-version: "#{{ .Config.toolVersions.java }}#"
         node-version: "#{{ .Config.toolVersions.node }}#"
@@ -125,7 +127,9 @@ jobs:
 #{{- if .Config.publish.goSdk.usePush }}#
   publish_go_sdk:
     name: publish_go_sdk
-    needs: publish_sdk
+    needs: 
+      - prerequisites
+      - publish_sdk
     runs-on: #{{ .Config.runner.default }}#
     steps:
     - name: Checkout Repo
@@ -139,8 +143,6 @@ jobs:
       with:
         tag: #{{ .Config.actionVersions.pulumictlTag }}#
         repo: pulumi/pulumictl
-    - id: version
-      uses: pulumi/provider-version-action@v1
     - name: Download Go SDK
       uses: actions/download-artifact@v4
       with:
@@ -156,7 +158,7 @@ jobs:
         base-ref: #{{ .Config.publish.goSdk.baseRef }}#
         source: #{{ .Config.publish.goSdk.source }}#
         path: #{{ .Config.publish.goSdk.path }}#
-        version: ${{ steps.version.outputs.version }}
+        version: ${{ needs.prerequisites.outputs.version }}
         additive: #{{ .Config.publish.goSdk.additive }}#
         # Avoid including other language SDKs & artifacts in the commit
         files: |
@@ -166,11 +168,15 @@ jobs:
 #{{- end }}#
   test:
     name: test
-    needs: build_sdk
+    needs: 
+      - prerequisites
+      - build_sdk
     permissions:
       contents: read
       id-token: write
     runs-on: #{{ if .Config.runner.buildSdk }}##{{- .Config.runner.buildSdk }}##{{ else }}##{{- .Config.runner.default }}##{{ end }}#
+    env:
+      PROVIDER_VERSION: ${{ needs.prerequisites.outputs.version }}
     steps:
 #{{- if .Config.freeDiskSpaceBeforeTest }}#
     # Run as first step so we don't delete things that have just been installed
@@ -186,9 +192,6 @@ jobs:
       with:
         submodules: #{{ .Config.checkoutSubmodules }}#
 #{{- end }}#
-    - uses: pulumi/provider-version-action@v1
-      with:
-        set-env: 'PROVIDER_VERSION'
     - name: Install Go
       uses: #{{ .Config.actionVersions.setupGo }}#
       with:

--- a/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/prerequisites.yml
+++ b/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/prerequisites.yml
@@ -12,6 +12,10 @@ on:
       default_branch:
         type: string
         required: true
+    outputs:
+      version:
+        description: "Provider version being built"
+        value: ${{ jobs.prerequisites.outputs.version }}
 
 env:
 #{{ .Config.env | toYaml | indent 2 }}#
@@ -20,6 +24,8 @@ jobs:
   prerequisites:
     name: prerequisites
     runs-on: #{{ .Config.runner.prerequisites }}#
+    outputs:
+      version: ${{ steps.provider-version.outputs.version }}
     steps:
 #{{- if .Config.freeDiskSpaceBeforeBuild }}#
     # Run as first step so we don't delete things that have just been installed
@@ -36,6 +42,7 @@ jobs:
         submodules: #{{ .Config.checkoutSubmodules }}#
 #{{- end }}#
     - uses: pulumi/provider-version-action@v1
+      id: provider-version
       with:
         set-env: 'PROVIDER_VERSION'
     - name: Cache examples generation

--- a/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/release.yml
+++ b/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/release.yml
@@ -3,11 +3,21 @@
 env:
 #{{ .Config.env | toYaml | indent 2 }}#
 jobs:
+  prerequisites:
+    uses: ./.github/workflows/prerequisites.yml
+    secrets: inherit
+    with:
+      default_branch: ${{ github.event.repository.default_branch }}
+      is_pr: ${{ github.event_name == 'pull_request' }}
+      is_automated: ${{ github.actor == 'dependabot[bot]' }}
+
   build_sdk:
     name: build_sdk
     needs: prerequisites
     uses: ./.github/workflows/build_sdk.yml
     secrets: inherit
+    with:
+      version: ${{ needs.prerequisites.outputs.version }}
 
   #{{ if .Config.publishRegistry -}}#
   create_docs_build:
@@ -39,17 +49,11 @@ jobs:
     name: License Check
     uses: ./.github/workflows/license.yml
     secrets: inherit
-  prerequisites:
-    uses: ./.github/workflows/prerequisites.yml
-    secrets: inherit
-    with:
-      default_branch: ${{ github.event.repository.default_branch }}
-      is_pr: ${{ github.event_name == 'pull_request' }}
-      is_automated: ${{ github.actor == 'dependabot[bot]' }}
 
   publish:
     name: publish
     needs:
+      - prerequisites
       - test
       - license_check
       #{{- range $action, $_ := .Config.extraTests }}#
@@ -95,13 +99,11 @@ jobs:
         role-external-id: upload-pulumi-release
         role-session-name: #{{ .Config.provider }}#@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
-    - id: version
-      uses: pulumi/provider-version-action@v1
     - name: Run GoReleaser
       uses: #{{ .Config.actionVersions.goReleaser }}#
       env:
-        GORELEASER_CURRENT_TAG: v${{ steps.version.outputs.version }}
-        PROVIDER_VERSION: ${{ steps.version.outputs.version }}
+        GORELEASER_CURRENT_TAG: v${{ needs.prerequisites.outputs.version }}
+        PROVIDER_VERSION: ${{ needs.prerequisites.outputs.version }}
       with:
         args: -p #{{ .Config.parallel }}# release --rm-dist --timeout #{{ .Config.timeout }}#m0s
         version: latest
@@ -114,16 +116,16 @@ jobs:
         status: ${{ job.status }}
   publish_sdk:
     name: publish_sdk
-    needs: publish
+    needs:
+      - prerequisites
+      - publish
     runs-on: #{{ .Config.runner.default }}#
     steps:
-    - id: version
-      uses: pulumi/provider-version-action@v1
     - name: Publish SDKs
       uses: #{{ .Config.publish.publisherAction }}#
       with:
         sdk: #{{ .Config.publish.sdk }}#
-        version: ${{ steps.version.outputs.version }}
+        version: ${{ needs.prerequisites.outputs.version }}
         dotnet-version: "#{{ .Config.toolVersions.dotnet }}#"
         java-version: "#{{ .Config.toolVersions.java }}#"
         node-version: "#{{ .Config.toolVersions.node }}#"
@@ -141,7 +143,9 @@ jobs:
       uses: #{{ .Config.actionVersions.slackNotification }}#
   tag_sdk:
     name: tag_sdk
-    needs: publish_sdk
+    needs:
+      - prerequisites
+      - publish_sdk
     runs-on: #{{ .Config.runner.default }}#
     steps:
     - name: Checkout Repo
@@ -155,8 +159,6 @@ jobs:
       with:
         tag: #{{ .Config.actionVersions.pulumictlTag }}#
         repo: pulumi/pulumictl
-    - id: version
-      uses: pulumi/provider-version-action@v1
 #{{- if .Config.publish.goSdk.usePush }}#
     - name: Download Go SDK
       uses: actions/download-artifact@v4
@@ -173,7 +175,7 @@ jobs:
         base-ref: #{{ .Config.publish.goSdk.baseRef }}#
         source: #{{ .Config.publish.goSdk.source }}#
         path: #{{ .Config.publish.goSdk.path }}#
-        version: ${{ steps.version.outputs.version }}
+        version: ${{ needs.prerequisites.outputs.version }}
         additive: #{{ .Config.publish.goSdk.additive }}#
         # Avoid including other language SDKs & artifacts in the commit
         files: |
@@ -182,8 +184,8 @@ jobs:
           !*.tar.gz
 #{{- else }}#
     - name: Add SDK version tag
-      run: git tag "sdk/v${{ steps.version.outputs.version }}" && git push origin
-        "sdk/v${{ steps.version.outputs.version }}"
+      run: git tag "sdk/v${{ needs.prerequisites.outputs.version }}" && git push origin
+        "sdk/v${{ needs.prerequisites.outputs.version }}"
 #{{- end }}#
 
   clean_up_release_labels:
@@ -208,11 +210,15 @@ jobs:
 
   test:
     name: test
-    needs: build_sdk
+    needs:
+      - prerequisites
+      - build_sdk
     permissions:
       contents: read
       id-token: write
     runs-on: #{{ if .Config.runner.buildSdk }}##{{- .Config.runner.buildSdk }}##{{ else }}##{{- .Config.runner.default }}##{{ end }}#
+    env:
+      PROVIDER_VERSION: ${{ needs.prerequisites.outputs.version }}
     steps:
 #{{- if .Config.freeDiskSpaceBeforeTest }}#
     # Run as first step so we don't delete things that have just been installed
@@ -228,9 +234,6 @@ jobs:
       with:
         submodules: #{{ .Config.checkoutSubmodules }}#
 #{{- end }}#
-    - uses: pulumi/provider-version-action@v1
-      with:
-        set-env: 'PROVIDER_VERSION'
     - name: Install Go
       uses: #{{ .Config.actionVersions.setupGo }}#
       with:

--- a/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/run-acceptance-tests.yml
@@ -9,6 +9,16 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 jobs:
+  prerequisites:
+    if: github.event_name == 'repository_dispatch' ||
+      github.event.pull_request.head.repo.full_name == github.repository
+    uses: ./.github/workflows/prerequisites.yml
+    secrets: inherit
+    with:
+      default_branch: ${{ github.event.repository.default_branch }}
+      is_pr: ${{ github.event_name == 'pull_request' }}
+      is_automated: ${{ github.actor == 'dependabot[bot]' }}
+
   build_sdk:
     if: github.event_name == 'repository_dispatch' ||
       github.event.pull_request.head.repo.full_name == github.repository
@@ -16,6 +26,8 @@ jobs:
     needs: prerequisites
     uses: ./.github/workflows/build_sdk.yml
     secrets: inherit
+    with:
+      version: ${{ needs.prerequisites.outputs.version }}
 
   comment-notification:
     if: github.event_name == 'repository_dispatch'
@@ -40,16 +52,6 @@ jobs:
     uses: ./.github/workflows/lint.yml
     secrets: inherit
   #{{ end -}}#
-
-  prerequisites:
-    if: github.event_name == 'repository_dispatch' ||
-      github.event.pull_request.head.repo.full_name == github.repository
-    uses: ./.github/workflows/prerequisites.yml
-    secrets: inherit
-    with:
-      default_branch: ${{ github.event.repository.default_branch }}
-      is_pr: ${{ github.event_name == 'pull_request' }}
-      is_automated: ${{ github.actor == 'dependabot[bot]' }}
 
   sentinel:
     name: sentinel
@@ -82,11 +84,15 @@ jobs:
     if: github.event_name == 'repository_dispatch' ||
       github.event.pull_request.head.repo.full_name == github.repository
     name: test
-    needs: build_sdk
+    needs:
+      - prerequisites
+      - build_sdk
     permissions:
       contents: read
       id-token: write
     runs-on: #{{ if .Config.runner.buildSdk }}##{{- .Config.runner.buildSdk }}##{{ else }}##{{- .Config.runner.default }}##{{ end }}#
+    env:
+      PROVIDER_VERSION: ${{ needs.prerequisites.outputs.version }}
     steps:
 #{{- if .Config.freeDiskSpaceBeforeTest }}#
     # Run as first step so we don't delete things that have just been installed
@@ -103,9 +109,6 @@ jobs:
         #{{- if .Config.checkoutSubmodules }}#
         submodules: #{{ .Config.checkoutSubmodules }}#
         #{{- end }}#
-    - uses: pulumi/provider-version-action@v1
-      with:
-        set-env: 'PROVIDER_VERSION'
     - name: Checkout p/examples
       if: matrix.testTarget == 'pulumiExamples'
       uses: #{{ .Config.actionVersions.checkout }}#

--- a/provider-ci/test-workflows/aws/.github/workflows/build_sdk.yml
+++ b/provider-ci/test-workflows/aws/.github/workflows/build_sdk.yml
@@ -1,7 +1,11 @@
 name: "Build SDK"
 
 on:
-  workflow_call: {}
+  workflow_call:
+    inputs:
+      version:
+        required: true
+        type: string
 
 env:
   AWS_REGION: us-west-2
@@ -23,6 +27,7 @@ env:
   SIGNING_PASSWORD: ${{ secrets.JAVA_SIGNING_PASSWORD }}
   SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
   TF_APPEND_USER_AGENT: pulumi
+  PROVIDER_VERSION: ${{ inputs.version }}
 
 jobs:
   build_sdk:
@@ -42,9 +47,6 @@ jobs:
         uses: actions/checkout@v4
         with:
           submodules: true
-      - uses: pulumi/provider-version-action@v1
-        with:
-          set-env: 'PROVIDER_VERSION'
       - name: Cache examples generation
         uses: actions/cache@v4
         with:

--- a/provider-ci/test-workflows/aws/.github/workflows/master.yml
+++ b/provider-ci/test-workflows/aws/.github/workflows/master.yml
@@ -21,11 +21,21 @@ env:
   SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
   TF_APPEND_USER_AGENT: pulumi
 jobs:
+  prerequisites:
+    uses: ./.github/workflows/prerequisites.yml
+    secrets: inherit
+    with:
+      default_branch: ${{ github.event.repository.default_branch }}
+      is_pr: ${{ github.event_name == 'pull_request' }}
+      is_automated: ${{ github.actor == 'dependabot[bot]' }}
+
   build_sdk:
     name: build_sdk
     needs: prerequisites
     uses: ./.github/workflows/build_sdk.yml
     secrets: inherit
+    with:
+      version: ${{ needs.prerequisites.outputs.version }}
 
   generate_coverage_data:
     continue-on-error: true
@@ -87,17 +97,11 @@ jobs:
     name: License Check
     uses: ./.github/workflows/license.yml
     secrets: inherit
-  prerequisites:
-    uses: ./.github/workflows/prerequisites.yml
-    secrets: inherit
-    with:
-      default_branch: ${{ github.event.repository.default_branch }}
-      is_pr: ${{ github.event_name == 'pull_request' }}
-      is_automated: ${{ github.actor == 'dependabot[bot]' }}
 
   publish:
     name: publish
     needs:
+      - prerequisites
       - test
       - license_check
       - go_test_shim
@@ -139,13 +143,11 @@ jobs:
         role-external-id: upload-pulumi-release
         role-session-name: aws@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
-    - id: version
-      uses: pulumi/provider-version-action@v1
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v5
       env:
-        GORELEASER_CURRENT_TAG: v${{ steps.version.outputs.version }}
-        PROVIDER_VERSION: ${{ steps.version.outputs.version }}
+        GORELEASER_CURRENT_TAG: v${{ needs.prerequisites.outputs.version }}
+        PROVIDER_VERSION: ${{ needs.prerequisites.outputs.version }}
       with:
         args: -p 1 -f .goreleaser.prerelease.yml --rm-dist --skip-validate --timeout
           150m0s
@@ -159,16 +161,16 @@ jobs:
         status: ${{ job.status }}
   publish_sdk:
     name: publish_sdk
-    needs: publish
+    needs:
+      - prerequisites
+      - publish
     runs-on: ubuntu-latest
     steps:
-    - id: version
-      uses: pulumi/provider-version-action@v1
     - name: Publish SDKs
       uses: pulumi/pulumi-package-publisher@v0.0.17
       with:
         sdk: all
-        version: ${{ steps.version.outputs.version }}
+        version: ${{ needs.prerequisites.outputs.version }}
         dotnet-version: "6.0.x"
         java-version: "11"
         node-version: "20.x"
@@ -204,11 +206,15 @@ jobs:
 
   test:
     name: test
-    needs: build_sdk
+    needs: 
+      - prerequisites
+      - build_sdk
     permissions:
       contents: read
       id-token: write
     runs-on: pulumi-ubuntu-8core
+    env:
+      PROVIDER_VERSION: ${{ needs.prerequisites.outputs.version }}
     steps:
     # Run as first step so we don't delete things that have just been installed
     - name: Free Disk Space (Ubuntu)
@@ -220,9 +226,6 @@ jobs:
       uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: pulumi/provider-version-action@v1
-      with:
-        set-env: 'PROVIDER_VERSION'
     - name: Install Go
       uses: actions/setup-go@v5
       with:

--- a/provider-ci/test-workflows/aws/.github/workflows/nightly-test.yml
+++ b/provider-ci/test-workflows/aws/.github/workflows/nightly-test.yml
@@ -21,12 +21,6 @@ env:
   SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
   TF_APPEND_USER_AGENT: pulumi
 jobs:
-  build_sdk:
-    name: build_sdk
-    needs: prerequisites
-    uses: ./.github/workflows/build_sdk.yml
-    secrets: inherit
-
   prerequisites:
     uses: ./.github/workflows/prerequisites.yml
     secrets: inherit
@@ -35,13 +29,25 @@ jobs:
       is_pr: ${{ github.event_name == 'pull_request' }}
       is_automated: ${{ github.actor == 'dependabot[bot]' }}
 
+  build_sdk:
+    name: build_sdk
+    needs: prerequisites
+    uses: ./.github/workflows/build_sdk.yml
+    secrets: inherit
+    with:
+      version: ${{ needs.prerequisites.outputs.version }}
+
   test:
     name: test
-    needs: build_sdk
+    needs: 
+      - prerequisites
+      - build_sdk
     permissions:
       contents: read
       id-token: write
     runs-on: pulumi-ubuntu-8core
+    env:
+      PROVIDER_VERSION: ${{ needs.prerequisites.outputs.version }}
     steps:
     # Run as first step so we don't delete things that have just been installed
     - name: Free Disk Space (Ubuntu)
@@ -53,9 +59,6 @@ jobs:
       uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: pulumi/provider-version-action@v1
-      with:
-        set-env: 'PROVIDER_VERSION'
     - name: Install Go
       uses: actions/setup-go@v5
       with:

--- a/provider-ci/test-workflows/aws/.github/workflows/prerelease.yml
+++ b/provider-ci/test-workflows/aws/.github/workflows/prerelease.yml
@@ -22,16 +22,6 @@ env:
   SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
   TF_APPEND_USER_AGENT: pulumi
 jobs:
-  build_sdk:
-    name: build_sdk
-    needs: prerequisites
-    uses: ./.github/workflows/build_sdk.yml
-    secrets: inherit
-
-  license_check:
-    name: License Check
-    uses: ./.github/workflows/license.yml
-    secrets: inherit
   prerequisites:
     uses: ./.github/workflows/prerequisites.yml
     secrets: inherit
@@ -40,9 +30,23 @@ jobs:
       is_pr: ${{ github.event_name == 'pull_request' }}
       is_automated: ${{ github.actor == 'dependabot[bot]' }}
 
+  build_sdk:
+    name: build_sdk
+    needs: prerequisites
+    uses: ./.github/workflows/build_sdk.yml
+    secrets: inherit
+    with:
+      version: ${{ needs.prerequisites.outputs.version }}
+
+  license_check:
+    name: License Check
+    uses: ./.github/workflows/license.yml
+    secrets: inherit
+
   publish:
     name: publish
     needs:
+      - prerequisites
       - test
       - license_check
       - go_test_shim
@@ -84,13 +88,11 @@ jobs:
         role-external-id: upload-pulumi-release
         role-session-name: aws@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
-    - id: version
-      uses: pulumi/provider-version-action@v1
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v5
       env:
-        GORELEASER_CURRENT_TAG: v${{ steps.version.outputs.version }}
-        PROVIDER_VERSION: ${{ steps.version.outputs.version }}
+        GORELEASER_CURRENT_TAG: v${{ needs.prerequisites.outputs.version }}
+        PROVIDER_VERSION: ${{ needs.prerequisites.outputs.version }}
       with:
         args: -p 1 -f .goreleaser.prerelease.yml --rm-dist --skip-validate --timeout
           150m0s
@@ -104,16 +106,16 @@ jobs:
         status: ${{ job.status }}
   publish_sdk:
     name: publish_sdk
-    needs: publish
+    needs: 
+      - prerequisites
+      - publish
     runs-on: ubuntu-latest
     steps:
-    - id: version
-      uses: pulumi/provider-version-action@v1
     - name: Publish SDKs
       uses: pulumi/pulumi-package-publisher@v0.0.17
       with:
         sdk: all
-        version: ${{ steps.version.outputs.version }}
+        version: ${{ needs.prerequisites.outputs.version }}
         dotnet-version: "6.0.x"
         java-version: "11"
         node-version: "20.x"
@@ -131,7 +133,9 @@ jobs:
       uses: rtCamp/action-slack-notify@v2
   publish_go_sdk:
     name: publish_go_sdk
-    needs: publish_sdk
+    needs: 
+      - prerequisites
+      - publish_sdk
     runs-on: ubuntu-latest
     steps:
     - name: Checkout Repo
@@ -143,8 +147,6 @@ jobs:
       with:
         tag: v0.0.46
         repo: pulumi/pulumictl
-    - id: version
-      uses: pulumi/provider-version-action@v1
     - name: Download Go SDK
       uses: actions/download-artifact@v4
       with:
@@ -160,7 +162,7 @@ jobs:
         base-ref: ${{ github.sha }}
         source: sdk
         path: sdk
-        version: ${{ steps.version.outputs.version }}
+        version: ${{ needs.prerequisites.outputs.version }}
         additive: false
         # Avoid including other language SDKs & artifacts in the commit
         files: |
@@ -169,11 +171,15 @@ jobs:
           !*.tar.gz
   test:
     name: test
-    needs: build_sdk
+    needs: 
+      - prerequisites
+      - build_sdk
     permissions:
       contents: read
       id-token: write
     runs-on: pulumi-ubuntu-8core
+    env:
+      PROVIDER_VERSION: ${{ needs.prerequisites.outputs.version }}
     steps:
     # Run as first step so we don't delete things that have just been installed
     - name: Free Disk Space (Ubuntu)
@@ -185,9 +191,6 @@ jobs:
       uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: pulumi/provider-version-action@v1
-      with:
-        set-env: 'PROVIDER_VERSION'
     - name: Install Go
       uses: actions/setup-go@v5
       with:

--- a/provider-ci/test-workflows/aws/.github/workflows/prerequisites.yml
+++ b/provider-ci/test-workflows/aws/.github/workflows/prerequisites.yml
@@ -12,6 +12,10 @@ on:
       default_branch:
         type: string
         required: true
+    outputs:
+      version:
+        description: "Provider version being built"
+        value: ${{ jobs.prerequisites.outputs.version }}
 
 env:
   AWS_REGION: us-west-2
@@ -38,6 +42,8 @@ jobs:
   prerequisites:
     name: prerequisites
     runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.provider-version.outputs.version }}
     steps:
     # Run as first step so we don't delete things that have just been installed
     - name: Free Disk Space (Ubuntu)
@@ -50,6 +56,7 @@ jobs:
       with:
         submodules: true
     - uses: pulumi/provider-version-action@v1
+      id: provider-version
       with:
         set-env: 'PROVIDER_VERSION'
     - name: Cache examples generation

--- a/provider-ci/test-workflows/aws/.github/workflows/release.yml
+++ b/provider-ci/test-workflows/aws/.github/workflows/release.yml
@@ -21,11 +21,21 @@ env:
   SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
   TF_APPEND_USER_AGENT: pulumi
 jobs:
+  prerequisites:
+    uses: ./.github/workflows/prerequisites.yml
+    secrets: inherit
+    with:
+      default_branch: ${{ github.event.repository.default_branch }}
+      is_pr: ${{ github.event_name == 'pull_request' }}
+      is_automated: ${{ github.actor == 'dependabot[bot]' }}
+
   build_sdk:
     name: build_sdk
     needs: prerequisites
     uses: ./.github/workflows/build_sdk.yml
     secrets: inherit
+    with:
+      version: ${{ needs.prerequisites.outputs.version }}
 
   create_docs_build:
     name: create_docs_build
@@ -48,17 +58,11 @@ jobs:
     name: License Check
     uses: ./.github/workflows/license.yml
     secrets: inherit
-  prerequisites:
-    uses: ./.github/workflows/prerequisites.yml
-    secrets: inherit
-    with:
-      default_branch: ${{ github.event.repository.default_branch }}
-      is_pr: ${{ github.event_name == 'pull_request' }}
-      is_automated: ${{ github.actor == 'dependabot[bot]' }}
 
   publish:
     name: publish
     needs:
+      - prerequisites
       - test
       - license_check
       - go_test_shim
@@ -100,13 +104,11 @@ jobs:
         role-external-id: upload-pulumi-release
         role-session-name: aws@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
-    - id: version
-      uses: pulumi/provider-version-action@v1
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v5
       env:
-        GORELEASER_CURRENT_TAG: v${{ steps.version.outputs.version }}
-        PROVIDER_VERSION: ${{ steps.version.outputs.version }}
+        GORELEASER_CURRENT_TAG: v${{ needs.prerequisites.outputs.version }}
+        PROVIDER_VERSION: ${{ needs.prerequisites.outputs.version }}
       with:
         args: -p 1 release --rm-dist --timeout 150m0s
         version: latest
@@ -119,16 +121,16 @@ jobs:
         status: ${{ job.status }}
   publish_sdk:
     name: publish_sdk
-    needs: publish
+    needs:
+      - prerequisites
+      - publish
     runs-on: ubuntu-latest
     steps:
-    - id: version
-      uses: pulumi/provider-version-action@v1
     - name: Publish SDKs
       uses: pulumi/pulumi-package-publisher@v0.0.17
       with:
         sdk: all
-        version: ${{ steps.version.outputs.version }}
+        version: ${{ needs.prerequisites.outputs.version }}
         dotnet-version: "6.0.x"
         java-version: "11"
         node-version: "20.x"
@@ -146,7 +148,9 @@ jobs:
       uses: rtCamp/action-slack-notify@v2
   tag_sdk:
     name: tag_sdk
-    needs: publish_sdk
+    needs:
+      - prerequisites
+      - publish_sdk
     runs-on: ubuntu-latest
     steps:
     - name: Checkout Repo
@@ -158,8 +162,6 @@ jobs:
       with:
         tag: v0.0.46
         repo: pulumi/pulumictl
-    - id: version
-      uses: pulumi/provider-version-action@v1
     - name: Download Go SDK
       uses: actions/download-artifact@v4
       with:
@@ -175,7 +177,7 @@ jobs:
         base-ref: ${{ github.sha }}
         source: sdk
         path: sdk
-        version: ${{ steps.version.outputs.version }}
+        version: ${{ needs.prerequisites.outputs.version }}
         additive: false
         # Avoid including other language SDKs & artifacts in the commit
         files: |
@@ -202,11 +204,15 @@ jobs:
 
   test:
     name: test
-    needs: build_sdk
+    needs:
+      - prerequisites
+      - build_sdk
     permissions:
       contents: read
       id-token: write
     runs-on: pulumi-ubuntu-8core
+    env:
+      PROVIDER_VERSION: ${{ needs.prerequisites.outputs.version }}
     steps:
     # Run as first step so we don't delete things that have just been installed
     - name: Free Disk Space (Ubuntu)
@@ -218,9 +224,6 @@ jobs:
       uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: pulumi/provider-version-action@v1
-      with:
-        set-env: 'PROVIDER_VERSION'
     - name: Install Go
       uses: actions/setup-go@v5
       with:

--- a/provider-ci/test-workflows/aws/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/test-workflows/aws/.github/workflows/run-acceptance-tests.yml
@@ -27,6 +27,16 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 jobs:
+  prerequisites:
+    if: github.event_name == 'repository_dispatch' ||
+      github.event.pull_request.head.repo.full_name == github.repository
+    uses: ./.github/workflows/prerequisites.yml
+    secrets: inherit
+    with:
+      default_branch: ${{ github.event.repository.default_branch }}
+      is_pr: ${{ github.event_name == 'pull_request' }}
+      is_automated: ${{ github.actor == 'dependabot[bot]' }}
+
   build_sdk:
     if: github.event_name == 'repository_dispatch' ||
       github.event.pull_request.head.repo.full_name == github.repository
@@ -34,6 +44,8 @@ jobs:
     needs: prerequisites
     uses: ./.github/workflows/build_sdk.yml
     secrets: inherit
+    with:
+      version: ${{ needs.prerequisites.outputs.version }}
 
   comment-notification:
     if: github.event_name == 'repository_dispatch'
@@ -50,16 +62,6 @@ jobs:
         issue-number: ${{ github.event.client_payload.github.payload.issue.number }}
         repository: ${{ github.event.client_payload.github.payload.repository.full_name }}
         token: ${{ secrets.PULUMI_BOT_TOKEN }}
-  prerequisites:
-    if: github.event_name == 'repository_dispatch' ||
-      github.event.pull_request.head.repo.full_name == github.repository
-    uses: ./.github/workflows/prerequisites.yml
-    secrets: inherit
-    with:
-      default_branch: ${{ github.event.repository.default_branch }}
-      is_pr: ${{ github.event_name == 'pull_request' }}
-      is_automated: ${{ github.actor == 'dependabot[bot]' }}
-
   sentinel:
     name: sentinel
     if: github.event_name == 'repository_dispatch' ||
@@ -86,11 +88,15 @@ jobs:
     if: github.event_name == 'repository_dispatch' ||
       github.event.pull_request.head.repo.full_name == github.repository
     name: test
-    needs: build_sdk
+    needs:
+      - prerequisites
+      - build_sdk
     permissions:
       contents: read
       id-token: write
     runs-on: pulumi-ubuntu-8core
+    env:
+      PROVIDER_VERSION: ${{ needs.prerequisites.outputs.version }}
     steps:
     # Run as first step so we don't delete things that have just been installed
     - name: Free Disk Space (Ubuntu)
@@ -103,9 +109,6 @@ jobs:
       with:
         ref: ${{ env.PR_COMMIT_SHA }}
         submodules: true
-    - uses: pulumi/provider-version-action@v1
-      with:
-        set-env: 'PROVIDER_VERSION'
     - name: Checkout p/examples
       if: matrix.testTarget == 'pulumiExamples'
       uses: actions/checkout@v4

--- a/provider-ci/test-workflows/cloudflare/.github/workflows/build_sdk.yml
+++ b/provider-ci/test-workflows/cloudflare/.github/workflows/build_sdk.yml
@@ -1,7 +1,11 @@
 name: "Build SDK"
 
 on:
-  workflow_call: {}
+  workflow_call:
+    inputs:
+      version:
+        required: true
+        type: string
 
 env:
   CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
@@ -23,6 +27,7 @@ env:
   SIGNING_PASSWORD: ${{ secrets.JAVA_SIGNING_PASSWORD }}
   SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
   TF_APPEND_USER_AGENT: pulumi
+  PROVIDER_VERSION: ${{ inputs.version }}
 
 jobs:
   build_sdk:
@@ -40,9 +45,6 @@ jobs:
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v4
-      - uses: pulumi/provider-version-action@v1
-        with:
-          set-env: 'PROVIDER_VERSION'
       - name: Cache examples generation
         uses: actions/cache@v4
         with:

--- a/provider-ci/test-workflows/cloudflare/.github/workflows/master.yml
+++ b/provider-ci/test-workflows/cloudflare/.github/workflows/master.yml
@@ -21,11 +21,21 @@ env:
   SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
   TF_APPEND_USER_AGENT: pulumi
 jobs:
+  prerequisites:
+    uses: ./.github/workflows/prerequisites.yml
+    secrets: inherit
+    with:
+      default_branch: ${{ github.event.repository.default_branch }}
+      is_pr: ${{ github.event_name == 'pull_request' }}
+      is_automated: ${{ github.actor == 'dependabot[bot]' }}
+
   build_sdk:
     name: build_sdk
     needs: prerequisites
     uses: ./.github/workflows/build_sdk.yml
     secrets: inherit
+    with:
+      version: ${{ needs.prerequisites.outputs.version }}
 
   generate_coverage_data:
     continue-on-error: true
@@ -89,17 +99,11 @@ jobs:
     name: License Check
     uses: ./.github/workflows/license.yml
     secrets: inherit
-  prerequisites:
-    uses: ./.github/workflows/prerequisites.yml
-    secrets: inherit
-    with:
-      default_branch: ${{ github.event.repository.default_branch }}
-      is_pr: ${{ github.event_name == 'pull_request' }}
-      is_automated: ${{ github.actor == 'dependabot[bot]' }}
 
   publish:
     name: publish
     needs:
+      - prerequisites
       - test
       - license_check
     runs-on: ubuntu-latest
@@ -138,13 +142,11 @@ jobs:
         role-external-id: upload-pulumi-release
         role-session-name: cloudflare@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
-    - id: version
-      uses: pulumi/provider-version-action@v1
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v5
       env:
-        GORELEASER_CURRENT_TAG: v${{ steps.version.outputs.version }}
-        PROVIDER_VERSION: ${{ steps.version.outputs.version }}
+        GORELEASER_CURRENT_TAG: v${{ needs.prerequisites.outputs.version }}
+        PROVIDER_VERSION: ${{ needs.prerequisites.outputs.version }}
       with:
         args: -p 3 -f .goreleaser.prerelease.yml --rm-dist --skip-validate --timeout
           60m0s
@@ -158,16 +160,16 @@ jobs:
         status: ${{ job.status }}
   publish_sdk:
     name: publish_sdk
-    needs: publish
+    needs:
+      - prerequisites
+      - publish
     runs-on: ubuntu-latest
     steps:
-    - id: version
-      uses: pulumi/provider-version-action@v1
     - name: Publish SDKs
       uses: pulumi/pulumi-package-publisher@v0.0.17
       with:
         sdk: all
-        version: ${{ steps.version.outputs.version }}
+        version: ${{ needs.prerequisites.outputs.version }}
         dotnet-version: "6.0.x"
         java-version: "11"
         node-version: "20.x"
@@ -203,17 +205,18 @@ jobs:
 
   test:
     name: test
-    needs: build_sdk
+    needs: 
+      - prerequisites
+      - build_sdk
     permissions:
       contents: read
       id-token: write
     runs-on: ubuntu-latest
+    env:
+      PROVIDER_VERSION: ${{ needs.prerequisites.outputs.version }}
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v4
-    - uses: pulumi/provider-version-action@v1
-      with:
-        set-env: 'PROVIDER_VERSION'
     - name: Install Go
       uses: actions/setup-go@v5
       with:

--- a/provider-ci/test-workflows/cloudflare/.github/workflows/prerelease.yml
+++ b/provider-ci/test-workflows/cloudflare/.github/workflows/prerelease.yml
@@ -22,11 +22,21 @@ env:
   SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
   TF_APPEND_USER_AGENT: pulumi
 jobs:
+  prerequisites:
+    uses: ./.github/workflows/prerequisites.yml
+    secrets: inherit
+    with:
+      default_branch: ${{ github.event.repository.default_branch }}
+      is_pr: ${{ github.event_name == 'pull_request' }}
+      is_automated: ${{ github.actor == 'dependabot[bot]' }}
+
   build_sdk:
     name: build_sdk
     needs: prerequisites
     uses: ./.github/workflows/build_sdk.yml
     secrets: inherit
+    with:
+      version: ${{ needs.prerequisites.outputs.version }}
 
   lint:
     name: lint
@@ -36,17 +46,11 @@ jobs:
     name: License Check
     uses: ./.github/workflows/license.yml
     secrets: inherit
-  prerequisites:
-    uses: ./.github/workflows/prerequisites.yml
-    secrets: inherit
-    with:
-      default_branch: ${{ github.event.repository.default_branch }}
-      is_pr: ${{ github.event_name == 'pull_request' }}
-      is_automated: ${{ github.actor == 'dependabot[bot]' }}
 
   publish:
     name: publish
     needs:
+      - prerequisites
       - test
       - license_check
     runs-on: ubuntu-latest
@@ -85,13 +89,11 @@ jobs:
         role-external-id: upload-pulumi-release
         role-session-name: cloudflare@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
-    - id: version
-      uses: pulumi/provider-version-action@v1
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v5
       env:
-        GORELEASER_CURRENT_TAG: v${{ steps.version.outputs.version }}
-        PROVIDER_VERSION: ${{ steps.version.outputs.version }}
+        GORELEASER_CURRENT_TAG: v${{ needs.prerequisites.outputs.version }}
+        PROVIDER_VERSION: ${{ needs.prerequisites.outputs.version }}
       with:
         args: -p 3 -f .goreleaser.prerelease.yml --rm-dist --skip-validate --timeout
           60m0s
@@ -105,16 +107,16 @@ jobs:
         status: ${{ job.status }}
   publish_sdk:
     name: publish_sdk
-    needs: publish
+    needs: 
+      - prerequisites
+      - publish
     runs-on: ubuntu-latest
     steps:
-    - id: version
-      uses: pulumi/provider-version-action@v1
     - name: Publish SDKs
       uses: pulumi/pulumi-package-publisher@v0.0.17
       with:
         sdk: all
-        version: ${{ steps.version.outputs.version }}
+        version: ${{ needs.prerequisites.outputs.version }}
         dotnet-version: "6.0.x"
         java-version: "11"
         node-version: "20.x"
@@ -132,7 +134,9 @@ jobs:
       uses: rtCamp/action-slack-notify@v2
   publish_go_sdk:
     name: publish_go_sdk
-    needs: publish_sdk
+    needs: 
+      - prerequisites
+      - publish_sdk
     runs-on: ubuntu-latest
     steps:
     - name: Checkout Repo
@@ -142,8 +146,6 @@ jobs:
       with:
         tag: v0.0.46
         repo: pulumi/pulumictl
-    - id: version
-      uses: pulumi/provider-version-action@v1
     - name: Download Go SDK
       uses: actions/download-artifact@v4
       with:
@@ -159,7 +161,7 @@ jobs:
         base-ref: ${{ github.sha }}
         source: sdk
         path: sdk
-        version: ${{ steps.version.outputs.version }}
+        version: ${{ needs.prerequisites.outputs.version }}
         additive: false
         # Avoid including other language SDKs & artifacts in the commit
         files: |
@@ -168,17 +170,18 @@ jobs:
           !*.tar.gz
   test:
     name: test
-    needs: build_sdk
+    needs: 
+      - prerequisites
+      - build_sdk
     permissions:
       contents: read
       id-token: write
     runs-on: ubuntu-latest
+    env:
+      PROVIDER_VERSION: ${{ needs.prerequisites.outputs.version }}
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v4
-    - uses: pulumi/provider-version-action@v1
-      with:
-        set-env: 'PROVIDER_VERSION'
     - name: Install Go
       uses: actions/setup-go@v5
       with:

--- a/provider-ci/test-workflows/cloudflare/.github/workflows/prerequisites.yml
+++ b/provider-ci/test-workflows/cloudflare/.github/workflows/prerequisites.yml
@@ -12,6 +12,10 @@ on:
       default_branch:
         type: string
         required: true
+    outputs:
+      version:
+        description: "Provider version being built"
+        value: ${{ jobs.prerequisites.outputs.version }}
 
 env:
   CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
@@ -38,10 +42,13 @@ jobs:
   prerequisites:
     name: prerequisites
     runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.provider-version.outputs.version }}
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v4
     - uses: pulumi/provider-version-action@v1
+      id: provider-version
       with:
         set-env: 'PROVIDER_VERSION'
     - name: Cache examples generation

--- a/provider-ci/test-workflows/cloudflare/.github/workflows/release.yml
+++ b/provider-ci/test-workflows/cloudflare/.github/workflows/release.yml
@@ -21,11 +21,21 @@ env:
   SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
   TF_APPEND_USER_AGENT: pulumi
 jobs:
+  prerequisites:
+    uses: ./.github/workflows/prerequisites.yml
+    secrets: inherit
+    with:
+      default_branch: ${{ github.event.repository.default_branch }}
+      is_pr: ${{ github.event_name == 'pull_request' }}
+      is_automated: ${{ github.actor == 'dependabot[bot]' }}
+
   build_sdk:
     name: build_sdk
     needs: prerequisites
     uses: ./.github/workflows/build_sdk.yml
     secrets: inherit
+    with:
+      version: ${{ needs.prerequisites.outputs.version }}
 
   create_docs_build:
     name: create_docs_build
@@ -52,17 +62,11 @@ jobs:
     name: License Check
     uses: ./.github/workflows/license.yml
     secrets: inherit
-  prerequisites:
-    uses: ./.github/workflows/prerequisites.yml
-    secrets: inherit
-    with:
-      default_branch: ${{ github.event.repository.default_branch }}
-      is_pr: ${{ github.event_name == 'pull_request' }}
-      is_automated: ${{ github.actor == 'dependabot[bot]' }}
 
   publish:
     name: publish
     needs:
+      - prerequisites
       - test
       - license_check
     runs-on: ubuntu-latest
@@ -101,13 +105,11 @@ jobs:
         role-external-id: upload-pulumi-release
         role-session-name: cloudflare@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
-    - id: version
-      uses: pulumi/provider-version-action@v1
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v5
       env:
-        GORELEASER_CURRENT_TAG: v${{ steps.version.outputs.version }}
-        PROVIDER_VERSION: ${{ steps.version.outputs.version }}
+        GORELEASER_CURRENT_TAG: v${{ needs.prerequisites.outputs.version }}
+        PROVIDER_VERSION: ${{ needs.prerequisites.outputs.version }}
       with:
         args: -p 3 release --rm-dist --timeout 60m0s
         version: latest
@@ -120,16 +122,16 @@ jobs:
         status: ${{ job.status }}
   publish_sdk:
     name: publish_sdk
-    needs: publish
+    needs:
+      - prerequisites
+      - publish
     runs-on: ubuntu-latest
     steps:
-    - id: version
-      uses: pulumi/provider-version-action@v1
     - name: Publish SDKs
       uses: pulumi/pulumi-package-publisher@v0.0.17
       with:
         sdk: all
-        version: ${{ steps.version.outputs.version }}
+        version: ${{ needs.prerequisites.outputs.version }}
         dotnet-version: "6.0.x"
         java-version: "11"
         node-version: "20.x"
@@ -147,7 +149,9 @@ jobs:
       uses: rtCamp/action-slack-notify@v2
   tag_sdk:
     name: tag_sdk
-    needs: publish_sdk
+    needs:
+      - prerequisites
+      - publish_sdk
     runs-on: ubuntu-latest
     steps:
     - name: Checkout Repo
@@ -157,8 +161,6 @@ jobs:
       with:
         tag: v0.0.46
         repo: pulumi/pulumictl
-    - id: version
-      uses: pulumi/provider-version-action@v1
     - name: Download Go SDK
       uses: actions/download-artifact@v4
       with:
@@ -174,7 +176,7 @@ jobs:
         base-ref: ${{ github.sha }}
         source: sdk
         path: sdk
-        version: ${{ steps.version.outputs.version }}
+        version: ${{ needs.prerequisites.outputs.version }}
         additive: false
         # Avoid including other language SDKs & artifacts in the commit
         files: |
@@ -201,17 +203,18 @@ jobs:
 
   test:
     name: test
-    needs: build_sdk
+    needs:
+      - prerequisites
+      - build_sdk
     permissions:
       contents: read
       id-token: write
     runs-on: ubuntu-latest
+    env:
+      PROVIDER_VERSION: ${{ needs.prerequisites.outputs.version }}
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v4
-    - uses: pulumi/provider-version-action@v1
-      with:
-        set-env: 'PROVIDER_VERSION'
     - name: Install Go
       uses: actions/setup-go@v5
       with:

--- a/provider-ci/test-workflows/cloudflare/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/test-workflows/cloudflare/.github/workflows/run-acceptance-tests.yml
@@ -27,6 +27,16 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 jobs:
+  prerequisites:
+    if: github.event_name == 'repository_dispatch' ||
+      github.event.pull_request.head.repo.full_name == github.repository
+    uses: ./.github/workflows/prerequisites.yml
+    secrets: inherit
+    with:
+      default_branch: ${{ github.event.repository.default_branch }}
+      is_pr: ${{ github.event_name == 'pull_request' }}
+      is_automated: ${{ github.actor == 'dependabot[bot]' }}
+
   build_sdk:
     if: github.event_name == 'repository_dispatch' ||
       github.event.pull_request.head.repo.full_name == github.repository
@@ -34,6 +44,8 @@ jobs:
     needs: prerequisites
     uses: ./.github/workflows/build_sdk.yml
     secrets: inherit
+    with:
+      version: ${{ needs.prerequisites.outputs.version }}
 
   comment-notification:
     if: github.event_name == 'repository_dispatch'
@@ -56,16 +68,6 @@ jobs:
     name: lint
     uses: ./.github/workflows/lint.yml
     secrets: inherit
-  prerequisites:
-    if: github.event_name == 'repository_dispatch' ||
-      github.event.pull_request.head.repo.full_name == github.repository
-    uses: ./.github/workflows/prerequisites.yml
-    secrets: inherit
-    with:
-      default_branch: ${{ github.event.repository.default_branch }}
-      is_pr: ${{ github.event_name == 'pull_request' }}
-      is_automated: ${{ github.actor == 'dependabot[bot]' }}
-
   sentinel:
     name: sentinel
     if: github.event_name == 'repository_dispatch' ||
@@ -92,19 +94,20 @@ jobs:
     if: github.event_name == 'repository_dispatch' ||
       github.event.pull_request.head.repo.full_name == github.repository
     name: test
-    needs: build_sdk
+    needs:
+      - prerequisites
+      - build_sdk
     permissions:
       contents: read
       id-token: write
     runs-on: ubuntu-latest
+    env:
+      PROVIDER_VERSION: ${{ needs.prerequisites.outputs.version }}
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v4
       with:
         ref: ${{ env.PR_COMMIT_SHA }}
-    - uses: pulumi/provider-version-action@v1
-      with:
-        set-env: 'PROVIDER_VERSION'
     - name: Checkout p/examples
       if: matrix.testTarget == 'pulumiExamples'
       uses: actions/checkout@v4

--- a/provider-ci/test-workflows/docker/.github/workflows/build_sdk.yml
+++ b/provider-ci/test-workflows/docker/.github/workflows/build_sdk.yml
@@ -1,7 +1,11 @@
 name: "Build SDK"
 
 on:
-  workflow_call: {}
+  workflow_call:
+    inputs:
+      version:
+        required: true
+        type: string
 
 env:
   ARM_CLIENT_ID: 30e520fa-12b4-4e21-b473-9426c5ac2e1e
@@ -36,6 +40,7 @@ env:
   SIGNING_PASSWORD: ${{ secrets.JAVA_SIGNING_PASSWORD }}
   SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
   TF_APPEND_USER_AGENT: pulumi
+  PROVIDER_VERSION: ${{ inputs.version }}
 
 jobs:
   build_sdk:
@@ -53,9 +58,6 @@ jobs:
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v4
-      - uses: pulumi/provider-version-action@v1
-        with:
-          set-env: 'PROVIDER_VERSION'
       - name: Cache examples generation
         uses: actions/cache@v4
         with:

--- a/provider-ci/test-workflows/docker/.github/workflows/master.yml
+++ b/provider-ci/test-workflows/docker/.github/workflows/master.yml
@@ -34,11 +34,21 @@ env:
   SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
   TF_APPEND_USER_AGENT: pulumi
 jobs:
+  prerequisites:
+    uses: ./.github/workflows/prerequisites.yml
+    secrets: inherit
+    with:
+      default_branch: ${{ github.event.repository.default_branch }}
+      is_pr: ${{ github.event_name == 'pull_request' }}
+      is_automated: ${{ github.actor == 'dependabot[bot]' }}
+
   build_sdk:
     name: build_sdk
     needs: prerequisites
     uses: ./.github/workflows/build_sdk.yml
     secrets: inherit
+    with:
+      version: ${{ needs.prerequisites.outputs.version }}
 
   generate_coverage_data:
     continue-on-error: true
@@ -102,17 +112,11 @@ jobs:
     name: License Check
     uses: ./.github/workflows/license.yml
     secrets: inherit
-  prerequisites:
-    uses: ./.github/workflows/prerequisites.yml
-    secrets: inherit
-    with:
-      default_branch: ${{ github.event.repository.default_branch }}
-      is_pr: ${{ github.event_name == 'pull_request' }}
-      is_automated: ${{ github.actor == 'dependabot[bot]' }}
 
   publish:
     name: publish
     needs:
+      - prerequisites
       - test
       - license_check
     runs-on: ubuntu-latest
@@ -151,13 +155,11 @@ jobs:
         role-external-id: upload-pulumi-release
         role-session-name: docker@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
-    - id: version
-      uses: pulumi/provider-version-action@v1
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v5
       env:
-        GORELEASER_CURRENT_TAG: v${{ steps.version.outputs.version }}
-        PROVIDER_VERSION: ${{ steps.version.outputs.version }}
+        GORELEASER_CURRENT_TAG: v${{ needs.prerequisites.outputs.version }}
+        PROVIDER_VERSION: ${{ needs.prerequisites.outputs.version }}
       with:
         args: -p 3 -f .goreleaser.prerelease.yml --rm-dist --skip-validate --timeout
           60m0s
@@ -171,16 +173,16 @@ jobs:
         status: ${{ job.status }}
   publish_sdk:
     name: publish_sdk
-    needs: publish
+    needs:
+      - prerequisites
+      - publish
     runs-on: ubuntu-latest
     steps:
-    - id: version
-      uses: pulumi/provider-version-action@v1
     - name: Publish SDKs
       uses: pulumi/pulumi-package-publisher@v0.0.17
       with:
         sdk: all
-        version: ${{ steps.version.outputs.version }}
+        version: ${{ needs.prerequisites.outputs.version }}
         dotnet-version: "6.0.x"
         java-version: "11"
         node-version: "20.x"
@@ -216,17 +218,18 @@ jobs:
 
   test:
     name: test
-    needs: build_sdk
+    needs: 
+      - prerequisites
+      - build_sdk
     permissions:
       contents: read
       id-token: write
     runs-on: ubuntu-latest
+    env:
+      PROVIDER_VERSION: ${{ needs.prerequisites.outputs.version }}
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v4
-    - uses: pulumi/provider-version-action@v1
-      with:
-        set-env: 'PROVIDER_VERSION'
     - name: Install Go
       uses: actions/setup-go@v5
       with:

--- a/provider-ci/test-workflows/docker/.github/workflows/prerelease.yml
+++ b/provider-ci/test-workflows/docker/.github/workflows/prerelease.yml
@@ -35,11 +35,21 @@ env:
   SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
   TF_APPEND_USER_AGENT: pulumi
 jobs:
+  prerequisites:
+    uses: ./.github/workflows/prerequisites.yml
+    secrets: inherit
+    with:
+      default_branch: ${{ github.event.repository.default_branch }}
+      is_pr: ${{ github.event_name == 'pull_request' }}
+      is_automated: ${{ github.actor == 'dependabot[bot]' }}
+
   build_sdk:
     name: build_sdk
     needs: prerequisites
     uses: ./.github/workflows/build_sdk.yml
     secrets: inherit
+    with:
+      version: ${{ needs.prerequisites.outputs.version }}
 
   lint:
     name: lint
@@ -49,17 +59,11 @@ jobs:
     name: License Check
     uses: ./.github/workflows/license.yml
     secrets: inherit
-  prerequisites:
-    uses: ./.github/workflows/prerequisites.yml
-    secrets: inherit
-    with:
-      default_branch: ${{ github.event.repository.default_branch }}
-      is_pr: ${{ github.event_name == 'pull_request' }}
-      is_automated: ${{ github.actor == 'dependabot[bot]' }}
 
   publish:
     name: publish
     needs:
+      - prerequisites
       - test
       - license_check
     runs-on: ubuntu-latest
@@ -98,13 +102,11 @@ jobs:
         role-external-id: upload-pulumi-release
         role-session-name: docker@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
-    - id: version
-      uses: pulumi/provider-version-action@v1
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v5
       env:
-        GORELEASER_CURRENT_TAG: v${{ steps.version.outputs.version }}
-        PROVIDER_VERSION: ${{ steps.version.outputs.version }}
+        GORELEASER_CURRENT_TAG: v${{ needs.prerequisites.outputs.version }}
+        PROVIDER_VERSION: ${{ needs.prerequisites.outputs.version }}
       with:
         args: -p 3 -f .goreleaser.prerelease.yml --rm-dist --skip-validate --timeout
           60m0s
@@ -118,16 +120,16 @@ jobs:
         status: ${{ job.status }}
   publish_sdk:
     name: publish_sdk
-    needs: publish
+    needs: 
+      - prerequisites
+      - publish
     runs-on: ubuntu-latest
     steps:
-    - id: version
-      uses: pulumi/provider-version-action@v1
     - name: Publish SDKs
       uses: pulumi/pulumi-package-publisher@v0.0.17
       with:
         sdk: all
-        version: ${{ steps.version.outputs.version }}
+        version: ${{ needs.prerequisites.outputs.version }}
         dotnet-version: "6.0.x"
         java-version: "11"
         node-version: "20.x"
@@ -145,7 +147,9 @@ jobs:
       uses: rtCamp/action-slack-notify@v2
   publish_go_sdk:
     name: publish_go_sdk
-    needs: publish_sdk
+    needs: 
+      - prerequisites
+      - publish_sdk
     runs-on: ubuntu-latest
     steps:
     - name: Checkout Repo
@@ -155,8 +159,6 @@ jobs:
       with:
         tag: v0.0.46
         repo: pulumi/pulumictl
-    - id: version
-      uses: pulumi/provider-version-action@v1
     - name: Download Go SDK
       uses: actions/download-artifact@v4
       with:
@@ -172,7 +174,7 @@ jobs:
         base-ref: ${{ github.sha }}
         source: sdk
         path: sdk
-        version: ${{ steps.version.outputs.version }}
+        version: ${{ needs.prerequisites.outputs.version }}
         additive: false
         # Avoid including other language SDKs & artifacts in the commit
         files: |
@@ -181,17 +183,18 @@ jobs:
           !*.tar.gz
   test:
     name: test
-    needs: build_sdk
+    needs: 
+      - prerequisites
+      - build_sdk
     permissions:
       contents: read
       id-token: write
     runs-on: ubuntu-latest
+    env:
+      PROVIDER_VERSION: ${{ needs.prerequisites.outputs.version }}
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v4
-    - uses: pulumi/provider-version-action@v1
-      with:
-        set-env: 'PROVIDER_VERSION'
     - name: Install Go
       uses: actions/setup-go@v5
       with:

--- a/provider-ci/test-workflows/docker/.github/workflows/prerequisites.yml
+++ b/provider-ci/test-workflows/docker/.github/workflows/prerequisites.yml
@@ -12,6 +12,10 @@ on:
       default_branch:
         type: string
         required: true
+    outputs:
+      version:
+        description: "Provider version being built"
+        value: ${{ jobs.prerequisites.outputs.version }}
 
 env:
   ARM_CLIENT_ID: 30e520fa-12b4-4e21-b473-9426c5ac2e1e
@@ -51,10 +55,13 @@ jobs:
   prerequisites:
     name: prerequisites
     runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.provider-version.outputs.version }}
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v4
     - uses: pulumi/provider-version-action@v1
+      id: provider-version
       with:
         set-env: 'PROVIDER_VERSION'
     - name: Cache examples generation

--- a/provider-ci/test-workflows/docker/.github/workflows/release.yml
+++ b/provider-ci/test-workflows/docker/.github/workflows/release.yml
@@ -34,11 +34,21 @@ env:
   SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
   TF_APPEND_USER_AGENT: pulumi
 jobs:
+  prerequisites:
+    uses: ./.github/workflows/prerequisites.yml
+    secrets: inherit
+    with:
+      default_branch: ${{ github.event.repository.default_branch }}
+      is_pr: ${{ github.event_name == 'pull_request' }}
+      is_automated: ${{ github.actor == 'dependabot[bot]' }}
+
   build_sdk:
     name: build_sdk
     needs: prerequisites
     uses: ./.github/workflows/build_sdk.yml
     secrets: inherit
+    with:
+      version: ${{ needs.prerequisites.outputs.version }}
 
   create_docs_build:
     name: create_docs_build
@@ -65,17 +75,11 @@ jobs:
     name: License Check
     uses: ./.github/workflows/license.yml
     secrets: inherit
-  prerequisites:
-    uses: ./.github/workflows/prerequisites.yml
-    secrets: inherit
-    with:
-      default_branch: ${{ github.event.repository.default_branch }}
-      is_pr: ${{ github.event_name == 'pull_request' }}
-      is_automated: ${{ github.actor == 'dependabot[bot]' }}
 
   publish:
     name: publish
     needs:
+      - prerequisites
       - test
       - license_check
     runs-on: ubuntu-latest
@@ -114,13 +118,11 @@ jobs:
         role-external-id: upload-pulumi-release
         role-session-name: docker@githubActions
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
-    - id: version
-      uses: pulumi/provider-version-action@v1
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v5
       env:
-        GORELEASER_CURRENT_TAG: v${{ steps.version.outputs.version }}
-        PROVIDER_VERSION: ${{ steps.version.outputs.version }}
+        GORELEASER_CURRENT_TAG: v${{ needs.prerequisites.outputs.version }}
+        PROVIDER_VERSION: ${{ needs.prerequisites.outputs.version }}
       with:
         args: -p 3 release --rm-dist --timeout 60m0s
         version: latest
@@ -133,16 +135,16 @@ jobs:
         status: ${{ job.status }}
   publish_sdk:
     name: publish_sdk
-    needs: publish
+    needs:
+      - prerequisites
+      - publish
     runs-on: ubuntu-latest
     steps:
-    - id: version
-      uses: pulumi/provider-version-action@v1
     - name: Publish SDKs
       uses: pulumi/pulumi-package-publisher@v0.0.17
       with:
         sdk: all
-        version: ${{ steps.version.outputs.version }}
+        version: ${{ needs.prerequisites.outputs.version }}
         dotnet-version: "6.0.x"
         java-version: "11"
         node-version: "20.x"
@@ -160,7 +162,9 @@ jobs:
       uses: rtCamp/action-slack-notify@v2
   tag_sdk:
     name: tag_sdk
-    needs: publish_sdk
+    needs:
+      - prerequisites
+      - publish_sdk
     runs-on: ubuntu-latest
     steps:
     - name: Checkout Repo
@@ -170,8 +174,6 @@ jobs:
       with:
         tag: v0.0.46
         repo: pulumi/pulumictl
-    - id: version
-      uses: pulumi/provider-version-action@v1
     - name: Download Go SDK
       uses: actions/download-artifact@v4
       with:
@@ -187,7 +189,7 @@ jobs:
         base-ref: ${{ github.sha }}
         source: sdk
         path: sdk
-        version: ${{ steps.version.outputs.version }}
+        version: ${{ needs.prerequisites.outputs.version }}
         additive: false
         # Avoid including other language SDKs & artifacts in the commit
         files: |
@@ -214,17 +216,18 @@ jobs:
 
   test:
     name: test
-    needs: build_sdk
+    needs:
+      - prerequisites
+      - build_sdk
     permissions:
       contents: read
       id-token: write
     runs-on: ubuntu-latest
+    env:
+      PROVIDER_VERSION: ${{ needs.prerequisites.outputs.version }}
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v4
-    - uses: pulumi/provider-version-action@v1
-      with:
-        set-env: 'PROVIDER_VERSION'
     - name: Install Go
       uses: actions/setup-go@v5
       with:

--- a/provider-ci/test-workflows/docker/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/test-workflows/docker/.github/workflows/run-acceptance-tests.yml
@@ -40,6 +40,16 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 jobs:
+  prerequisites:
+    if: github.event_name == 'repository_dispatch' ||
+      github.event.pull_request.head.repo.full_name == github.repository
+    uses: ./.github/workflows/prerequisites.yml
+    secrets: inherit
+    with:
+      default_branch: ${{ github.event.repository.default_branch }}
+      is_pr: ${{ github.event_name == 'pull_request' }}
+      is_automated: ${{ github.actor == 'dependabot[bot]' }}
+
   build_sdk:
     if: github.event_name == 'repository_dispatch' ||
       github.event.pull_request.head.repo.full_name == github.repository
@@ -47,6 +57,8 @@ jobs:
     needs: prerequisites
     uses: ./.github/workflows/build_sdk.yml
     secrets: inherit
+    with:
+      version: ${{ needs.prerequisites.outputs.version }}
 
   comment-notification:
     if: github.event_name == 'repository_dispatch'
@@ -69,16 +81,6 @@ jobs:
     name: lint
     uses: ./.github/workflows/lint.yml
     secrets: inherit
-  prerequisites:
-    if: github.event_name == 'repository_dispatch' ||
-      github.event.pull_request.head.repo.full_name == github.repository
-    uses: ./.github/workflows/prerequisites.yml
-    secrets: inherit
-    with:
-      default_branch: ${{ github.event.repository.default_branch }}
-      is_pr: ${{ github.event_name == 'pull_request' }}
-      is_automated: ${{ github.actor == 'dependabot[bot]' }}
-
   sentinel:
     name: sentinel
     if: github.event_name == 'repository_dispatch' ||
@@ -105,19 +107,20 @@ jobs:
     if: github.event_name == 'repository_dispatch' ||
       github.event.pull_request.head.repo.full_name == github.repository
     name: test
-    needs: build_sdk
+    needs:
+      - prerequisites
+      - build_sdk
     permissions:
       contents: read
       id-token: write
     runs-on: ubuntu-latest
+    env:
+      PROVIDER_VERSION: ${{ needs.prerequisites.outputs.version }}
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v4
       with:
         ref: ${{ env.PR_COMMIT_SHA }}
-    - uses: pulumi/provider-version-action@v1
-      with:
-        set-env: 'PROVIDER_VERSION'
     - name: Checkout p/examples
       if: matrix.testTarget == 'pulumiExamples'
       uses: actions/checkout@v4


### PR DESCRIPTION
This ensures that the version is always consistent between different jobs within the workflow even if external dependencies change (e.g. a new release goes out half way through).

This is also required for us to be able to call a new re-usable workflow which requires the version to be available as a job output.

Tidy up the job ordering so prerequisites is the first job in the workflow (as it's the first to run).