### PR TITLE
Add pulumi-harness to providers.json

### DIFF
--- a/provider-ci/providers.json
+++ b/provider-ci/providers.json
@@ -28,6 +28,7 @@
     "gcp",
     "github",
     "gitlab",
+    "harness",
     "hcloud",
     "http",
     "ise",


### PR DESCRIPTION
with [Update build and package names · pulumi-harness/59](https://github.com/pulumi/pulumi-harness/pull/59), the harness provider should be ready to add to the fleet.