### PR TITLE
Allow empty patch in upstream script

### DIFF
--- a/provider-ci/internal/pkg/templates/bridged-provider/scripts/upstream.sh
+++ b/provider-ci/internal/pkg/templates/bridged-provider/scripts/upstream.sh
@@ -91,7 +91,7 @@ start_rebase() {
 
   for patch in ../patches/*.patch; do
     echo "Applying $patch"
-    if ! git am --3way "$patch"; then
+    if ! git am --3way "$patch" --allow-empty; then
       echo
       echo "Failed to apply ${patch}. Please run 'make upstream.rebase FROM=$TAG' where '$TAG' allows the patch set to apply cleanly"
       echo

--- a/provider-ci/test-workflows/aws/scripts/upstream.sh
+++ b/provider-ci/test-workflows/aws/scripts/upstream.sh
@@ -91,7 +91,7 @@ start_rebase() {
 
   for patch in ../patches/*.patch; do
     echo "Applying $patch"
-    if ! git am --3way "$patch"; then
+    if ! git am --3way "$patch" --allow-empty; then
       echo
       echo "Failed to apply ${patch}. Please run 'make upstream.rebase FROM=$TAG' where '$TAG' allows the patch set to apply cleanly"
       echo

--- a/provider-ci/test-workflows/cloudflare/scripts/upstream.sh
+++ b/provider-ci/test-workflows/cloudflare/scripts/upstream.sh
@@ -91,7 +91,7 @@ start_rebase() {
 
   for patch in ../patches/*.patch; do
     echo "Applying $patch"
-    if ! git am --3way "$patch"; then
+    if ! git am --3way "$patch" --allow-empty; then
       echo
       echo "Failed to apply ${patch}. Please run 'make upstream.rebase FROM=$TAG' where '$TAG' allows the patch set to apply cleanly"
       echo

--- a/provider-ci/test-workflows/docker/scripts/upstream.sh
+++ b/provider-ci/test-workflows/docker/scripts/upstream.sh
@@ -91,7 +91,7 @@ start_rebase() {
 
   for patch in ../patches/*.patch; do
     echo "Applying $patch"
-    if ! git am --3way "$patch"; then
+    if ! git am --3way "$patch" --allow-empty; then
       echo
       echo "Failed to apply ${patch}. Please run 'make upstream.rebase FROM=$TAG' where '$TAG' allows the patch set to apply cleanly"
       echo


### PR DESCRIPTION
This pull request allows us to have an empty patch file in such cases as https://github.com/pulumi/pulumi-pagerduty/pull/543, where all we need the submodule for is to make up for a lack of proper Go module versioning in an upstream provider.
This change is a minimal change to the script and setup, and we won't have to add additinal logic to ci-mgmt.yaml configs.

- **Allow empty patch for upstream apply**
- **Make test workflows**
