### PR TITLE
Revert "Allow empty patch in upstream script (#983)"

### DIFF
--- a/provider-ci/internal/pkg/templates/bridged-provider/scripts/upstream.sh
+++ b/provider-ci/internal/pkg/templates/bridged-provider/scripts/upstream.sh
@@ -91,7 +91,7 @@ start_rebase() {
 
   for patch in ../patches/*.patch; do
     echo "Applying $patch"
-    if ! git am --3way "$patch" --allow-empty; then
+    if ! git am --3way "$patch"; then
       echo
       echo "Failed to apply ${patch}. Please run 'make upstream.rebase FROM=$TAG' where '$TAG' allows the patch set to apply cleanly"
       echo

--- a/provider-ci/test-workflows/aws/scripts/upstream.sh
+++ b/provider-ci/test-workflows/aws/scripts/upstream.sh
@@ -91,7 +91,7 @@ start_rebase() {
 
   for patch in ../patches/*.patch; do
     echo "Applying $patch"
-    if ! git am --3way "$patch" --allow-empty; then
+    if ! git am --3way "$patch"; then
       echo
       echo "Failed to apply ${patch}. Please run 'make upstream.rebase FROM=$TAG' where '$TAG' allows the patch set to apply cleanly"
       echo

--- a/provider-ci/test-workflows/cloudflare/scripts/upstream.sh
+++ b/provider-ci/test-workflows/cloudflare/scripts/upstream.sh
@@ -91,7 +91,7 @@ start_rebase() {
 
   for patch in ../patches/*.patch; do
     echo "Applying $patch"
-    if ! git am --3way "$patch" --allow-empty; then
+    if ! git am --3way "$patch"; then
       echo
       echo "Failed to apply ${patch}. Please run 'make upstream.rebase FROM=$TAG' where '$TAG' allows the patch set to apply cleanly"
       echo

--- a/provider-ci/test-workflows/docker/scripts/upstream.sh
+++ b/provider-ci/test-workflows/docker/scripts/upstream.sh
@@ -91,7 +91,7 @@ start_rebase() {
 
   for patch in ../patches/*.patch; do
     echo "Applying $patch"
-    if ! git am --3way "$patch" --allow-empty; then
+    if ! git am --3way "$patch"; then
       echo
       echo "Failed to apply ${patch}. Please run 'make upstream.rebase FROM=$TAG' where '$TAG' allows the patch set to apply cleanly"
       echo


### PR DESCRIPTION
This reverts commit 13b894e0e3ea580291d037ee7dbd563fb57b67df.

This introduced a regression that caused `make upstream.rebase` to fail in AWS, GCP and other providers.

E.g. AWS:
```
Applying ../patches/0001-Add-TagsSchemaTrulyComputed-definition.patch
fatal: Resolve operation not in progress, we are not resuming
```

E.g. GCP:
```
Applying ../patches/0001-Allow-disabling-the-partner-name.patch
fatal: Resolve operation not in progress, we are not resuming.
```