### PR TITLE
Allow empty patch in git apply

### DIFF
--- a/provider-ci/internal/pkg/templates/bridged-provider/scripts/upstream.sh
+++ b/provider-ci/internal/pkg/templates/bridged-provider/scripts/upstream.sh
@@ -138,7 +138,7 @@ apply() {
   # apply the patch using a 3-way merge strategy. This mirrors the default behavior of 'git merge'
   cd upstream
   for patch in ../patches/*.patch; do
-    if ! git apply --3way "$patch"; then
+    if ! git apply --3way "$patch" --allow-empty; then
       cat <<EOF
 
 make "$1"' failed to apply ${patch}. This is because there is a conflict between

--- a/provider-ci/test-providers/aws/scripts/upstream.sh
+++ b/provider-ci/test-providers/aws/scripts/upstream.sh
@@ -138,7 +138,7 @@ apply() {
   # apply the patch using a 3-way merge strategy. This mirrors the default behavior of 'git merge'
   cd upstream
   for patch in ../patches/*.patch; do
-    if ! git apply --3way "$patch"; then
+    if ! git apply --3way "$patch" --allow-empty; then
       cat <<EOF
 
 make "$1"' failed to apply ${patch}. This is because there is a conflict between

--- a/provider-ci/test-providers/cloudflare/scripts/upstream.sh
+++ b/provider-ci/test-providers/cloudflare/scripts/upstream.sh
@@ -138,7 +138,7 @@ apply() {
   # apply the patch using a 3-way merge strategy. This mirrors the default behavior of 'git merge'
   cd upstream
   for patch in ../patches/*.patch; do
-    if ! git apply --3way "$patch"; then
+    if ! git apply --3way "$patch" --allow-empty; then
       cat <<EOF
 
 make "$1"' failed to apply ${patch}. This is because there is a conflict between

--- a/provider-ci/test-providers/docker/scripts/upstream.sh
+++ b/provider-ci/test-providers/docker/scripts/upstream.sh
@@ -138,7 +138,7 @@ apply() {
   # apply the patch using a 3-way merge strategy. This mirrors the default behavior of 'git merge'
   cd upstream
   for patch in ../patches/*.patch; do
-    if ! git apply --3way "$patch"; then
+    if ! git apply --3way "$patch" --allow-empty; then
       cat <<EOF
 
 make "$1"' failed to apply ${patch}. This is because there is a conflict between


### PR DESCRIPTION
Fixes #991.

Previously, https://github.com/pulumi/ci-mgmt/pull/983 attempted to fix this behavior; however, the `--allow-empty` was erroneously appended to the `git am` command, not the `git apply` command, as it [should have been](https://github.com/pulumi/pulumi-vault/blob/master/scripts/upstream.sh#L141).

[Git documentation for `git apply --allow-empty`](https://git-scm.com/docs/git-apply#Documentation/git-apply.txt---allow-empty) is the behavior we want.