### PR TITLE
hotfix: run lint-actions.yml on all pull requests to master

### DIFF
--- a/.github/workflows/lint-actions.yml
+++ b/.github/workflows/lint-actions.yml
@@ -2,9 +2,6 @@ on:
   pull_request:
     branches:
       - master
-    paths:
-      - .github/**
-
 env:
   GITHUB_TOKEN: ${{ secrets.PULUMI_BOT_TOKEN }}
 concurrency:

--- a/.github/workflows/test-provider-ci.yml
+++ b/.github/workflows/test-provider-ci.yml
@@ -2,8 +2,6 @@ on:
   pull_request:
     branches:
       - master
-    paths:
-      - provider-ci/**
 
 env:
   GITHUB_TOKEN: ${{ secrets.PULUMI_BOT_TOKEN }}


### PR DESCRIPTION
#993 refactored the Required "Run actionlint and shellcheck" job, limiting it to top-level `.github` paths.
This caused #995 and #996 to hang indefinitely.

This pull request re-enables this check to run on every pull request.

