### PR TITLE
Revert pulumi-version-file for docker-build

### DIFF
--- a/native-provider-ci/providers/docker-build/config.yaml
+++ b/native-provider-ci/providers/docker-build/config.yaml
@@ -2,7 +2,6 @@ provider: docker-build
 major-version: 0
 defaultBranch: main
 providerVersion: github.com/pulumi/pulumi-docker-build/provider.Version
-pulumiVersionFile: .pulumi.version
 aws: true
 gcp: true
 sdkModuleDir: sdk/go/dockerbuild

--- a/native-provider-ci/providers/docker-build/repo/.github/workflows/build.yml
+++ b/native-provider-ci/providers/docker-build/repo/.github/workflows/build.yml
@@ -80,8 +80,6 @@ jobs:
         repo: pulumi/pulumictl
     - name: Install Pulumi CLI
       uses: pulumi/actions@v5
-      with:
-        pulumi-version-file: .pulumi.version
     - if: github.event_name == 'pull_request'
       name: Install Schema Tools
       uses: jaxxstorm/action-install-gh-release@v1.11.0
@@ -185,8 +183,6 @@ jobs:
         repo: pulumi/pulumictl
     - name: Install Pulumi CLI
       uses: pulumi/actions@v5
-      with:
-        pulumi-version-file: .pulumi.version
     - name: Setup Node
       uses: actions/setup-node@v4
       with:
@@ -288,8 +284,6 @@ jobs:
         repo: pulumi/pulumictl
     - name: Install Pulumi CLI
       uses: pulumi/actions@v5
-      with:
-        pulumi-version-file: .pulumi.version
     - name: Setup Node
       uses: actions/setup-node@v4
       with:
@@ -415,8 +409,6 @@ jobs:
         repo: pulumi/pulumictl
     - name: Install Pulumi CLI
       uses: pulumi/actions@v5
-      with:
-        pulumi-version-file: .pulumi.version
     - name: Configure AWS Credentials
       uses: aws-actions/configure-aws-credentials@v4
       with:

--- a/native-provider-ci/providers/docker-build/repo/.github/workflows/prerelease.yml
+++ b/native-provider-ci/providers/docker-build/repo/.github/workflows/prerelease.yml
@@ -72,8 +72,6 @@ jobs:
         repo: pulumi/pulumictl
     - name: Install Pulumi CLI
       uses: pulumi/actions@v5
-      with:
-        pulumi-version-file: .pulumi.version
     - if: github.event_name == 'pull_request'
       name: Install Schema Tools
       uses: jaxxstorm/action-install-gh-release@v1.11.0
@@ -177,8 +175,6 @@ jobs:
         repo: pulumi/pulumictl
     - name: Install Pulumi CLI
       uses: pulumi/actions@v5
-      with:
-        pulumi-version-file: .pulumi.version
     - name: Setup Node
       uses: actions/setup-node@v4
       with:
@@ -279,8 +275,6 @@ jobs:
         repo: pulumi/pulumictl
     - name: Install Pulumi CLI
       uses: pulumi/actions@v5
-      with:
-        pulumi-version-file: .pulumi.version
     - name: Setup Node
       uses: actions/setup-node@v4
       with:
@@ -406,8 +400,6 @@ jobs:
         repo: pulumi/pulumictl
     - name: Install Pulumi CLI
       uses: pulumi/actions@v5
-      with:
-        pulumi-version-file: .pulumi.version
     - name: Configure AWS Credentials
       uses: aws-actions/configure-aws-credentials@v4
       with:

--- a/native-provider-ci/providers/docker-build/repo/.github/workflows/release.yml
+++ b/native-provider-ci/providers/docker-build/repo/.github/workflows/release.yml
@@ -72,8 +72,6 @@ jobs:
         repo: pulumi/pulumictl
     - name: Install Pulumi CLI
       uses: pulumi/actions@v5
-      with:
-        pulumi-version-file: .pulumi.version
     - if: github.event_name == 'pull_request'
       name: Install Schema Tools
       uses: jaxxstorm/action-install-gh-release@v1.11.0
@@ -177,8 +175,6 @@ jobs:
         repo: pulumi/pulumictl
     - name: Install Pulumi CLI
       uses: pulumi/actions@v5
-      with:
-        pulumi-version-file: .pulumi.version
     - name: Setup Node
       uses: actions/setup-node@v4
       with:
@@ -279,8 +275,6 @@ jobs:
         repo: pulumi/pulumictl
     - name: Install Pulumi CLI
       uses: pulumi/actions@v5
-      with:
-        pulumi-version-file: .pulumi.version
     - name: Setup Node
       uses: actions/setup-node@v4
       with:
@@ -406,8 +400,6 @@ jobs:
         repo: pulumi/pulumictl
     - name: Install Pulumi CLI
       uses: pulumi/actions@v5
-      with:
-        pulumi-version-file: .pulumi.version
     - name: Configure AWS Credentials
       uses: aws-actions/configure-aws-credentials@v4
       with:

--- a/native-provider-ci/providers/docker-build/repo/.github/workflows/run-acceptance-tests.yml
+++ b/native-provider-ci/providers/docker-build/repo/.github/workflows/run-acceptance-tests.yml
@@ -97,8 +97,6 @@ jobs:
         repo: pulumi/pulumictl
     - name: Install Pulumi CLI
       uses: pulumi/actions@v5
-      with:
-        pulumi-version-file: .pulumi.version
     - if: github.event_name == 'pull_request'
       name: Install Schema Tools
       uses: jaxxstorm/action-install-gh-release@v1.11.0
@@ -205,8 +203,6 @@ jobs:
         repo: pulumi/pulumictl
     - name: Install Pulumi CLI
       uses: pulumi/actions@v5
-      with:
-        pulumi-version-file: .pulumi.version
     - name: Setup Node
       uses: actions/setup-node@v4
       with:
@@ -311,8 +307,6 @@ jobs:
         repo: pulumi/pulumictl
     - name: Install Pulumi CLI
       uses: pulumi/actions@v5
-      with:
-        pulumi-version-file: .pulumi.version
     - name: Setup Node
       uses: actions/setup-node@v4
       with:

--- a/native-provider-ci/providers/docker-build/repo/.github/workflows/weekly-pulumi-update.yml
+++ b/native-provider-ci/providers/docker-build/repo/.github/workflows/weekly-pulumi-update.yml
@@ -70,8 +70,6 @@ jobs:
         repo: pulumi/pulumictl
     - name: Install Pulumi CLI
       uses: pulumi/actions@v5
-      with:
-        pulumi-version-file: .pulumi.version
     - name: Setup DotNet
       uses: actions/setup-dotnet@v4
       with:


### PR DESCRIPTION
The `docker-build` provider uses `go.mod` as its source of truth for CLI dependencies and doesn't have a `.pulumi.version` file. 

We might be able to remove the entire "Install Pulumi CLI" step when this file is absent, but I'm debugging something else right now so I'm not able to confirm.