### PR TITLE
Use setup-tools everywhere

### DIFF
--- a/provider-ci/internal/pkg/templates/bridged-provider.config.yaml
+++ b/provider-ci/internal/pkg/templates/bridged-provider.config.yaml
@@ -139,7 +139,6 @@ actionVersions:
   googleAuth: google-github-actions/auth@v2
   goReleaser: goreleaser/goreleaser-action@v5
   checkout: actions/checkout@v4
-  createOrUpdateComment: peter-evans/create-or-update-comment@v1
   downloadArtifact: actions/download-artifact@v4
   pathsFilter: dorny/paths-filter@v2
   prComment: thollander/actions-comment-pull-request@v2

--- a/provider-ci/internal/pkg/templates/bridged-provider.config.yaml
+++ b/provider-ci/internal/pkg/templates/bridged-provider.config.yaml
@@ -134,22 +134,11 @@ runner:
 # actionVersions should be used wherever we use external actions to make upgrading easier.
 # These are never overridden by providers: https://github.com/search?q=org%3Apulumi+path%3A.ci-mgmt.yaml+%22actionVersions%3A%22&type=code
 actionVersions:
-  setupGo: actions/setup-go@v5
-  setupDotNet: actions/setup-dotnet@v4
-  setupJava: actions/setup-java@v4
-  setupGradle: gradle/gradle-build-action@v3
-  setupNode: actions/setup-node@v4
-  setupPulumi: pulumi/actions@v5
-  setupPython: actions/setup-python@v5
-
   configureAwsCredentials: aws-actions/configure-aws-credentials@v4
   setupGcloud: google-github-actions/setup-gcloud@v2
   googleAuth: google-github-actions/auth@v2
   goReleaser: goreleaser/goreleaser-action@v5
-  installGhRelease: jaxxstorm/action-install-gh-release@v1.11.0
   checkout: actions/checkout@v4
-  pulumictlTag: v0.0.46
-  cleanupArtifact: c-hive/gha-remove-artifacts@v1
   createOrUpdateComment: peter-evans/create-or-update-comment@v1
   downloadArtifact: actions/download-artifact@v4
   pathsFilter: dorny/paths-filter@v2

--- a/provider-ci/internal/pkg/templates/bridged-provider.config.yaml
+++ b/provider-ci/internal/pkg/templates/bridged-provider.config.yaml
@@ -143,7 +143,6 @@ actionVersions:
   downloadArtifact: actions/download-artifact@v4
   pathsFilter: dorny/paths-filter@v2
   prComment: thollander/actions-comment-pull-request@v2
-  slashCommand: peter-evans/slash-command-dispatch@v2
   uploadArtifact: actions/upload-artifact@v4
   upgradeProviderAction: pulumi/pulumi-upgrade-provider-action@v0.0.12
   slackNotification: rtCamp/action-slack-notify@v2

--- a/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/check-upstream-upgrade.yml
+++ b/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/check-upstream-upgrade.yml
@@ -8,18 +8,16 @@ jobs:
     name: Check for upstream provider upgrades
     runs-on: #{{ .Config.runner.default }}#
     steps:
-    - name: Install Go
-      uses: #{{ .Config.actionVersions.setupGo }}#
-      with:
-        go-version: "#{{ .Config.toolVersions.go }}#"
-        cache-dependency-path: |
-          sdk/go.sum
     - name: Checkout Repo
       uses: #{{ .Config.actionVersions.checkout }}#
         #{{- if .Config.checkoutSubmodules }}#
       with:
         submodules: #{{ .Config.checkoutSubmodules }}#
     #{{- end }}#
+    - name: Setup tools
+      uses: ./.github/actions/setup-tools
+      with:
+        tools: go
     - name: Install upgrade-provider
       run: go install github.com/pulumi/upgrade-provider@main
       shell: bash

--- a/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/main.yml
+++ b/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/main.yml
@@ -44,26 +44,10 @@ jobs:
         aws-access-key-id: ${{ secrets.AWS_CORP_S3_UPLOAD_ACCESS_KEY_ID }}
         aws-region: us-west-2
         aws-secret-access-key: ${{ secrets.AWS_CORP_S3_UPLOAD_SECRET_ACCESS_KEY }}
-    - name: Install Go
-      uses: #{{ .Config.actionVersions.setupGo }}#
+    - name: Setup tools
+      uses: ./.github/actions/setup-tools
       with:
-        go-version: "#{{ .Config.toolVersions.go }}#"
-        cache-dependency-path: |
-          sdk/go.sum
-    - name: Install pulumictl
-      uses: #{{ .Config.actionVersions.installGhRelease }}#
-      with:
-        tag: #{{ .Config.actionVersions.pulumictlTag }}#
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: #{{ .Config.actionVersions.setupPulumi }}#
-      with:
-        pulumi-version: "#{{ .Config.toolVersions.pulumi }}#"
-    - if: github.event_name == 'pull_request'
-      name: Install Schema Tools
-      uses: #{{ .Config.actionVersions.installGhRelease }}#
-      with:
-        repo: pulumi/schema-tools
+        tools: pulumictl, pulumicli, go, schema-tools
     - name: Echo Coverage Output Dir
       run: 'echo "Coverage output directory: ${{ env.COVERAGE_OUTPUT_DIR }}"'
     - name: Generate Coverage Data
@@ -113,21 +97,10 @@ jobs:
       with:
         submodules: #{{ .Config.checkoutSubmodules }}#
 #{{- end }}#
-    - name: Install Go
-      uses: #{{ .Config.actionVersions.setupGo }}#
+    - name: Setup tools
+      uses: ./.github/actions/setup-tools
       with:
-        go-version: "#{{ .Config.toolVersions.go }}#"
-        cache-dependency-path: |
-          sdk/go.sum
-    - name: Install pulumictl
-      uses: #{{ .Config.actionVersions.installGhRelease }}#
-      with:
-        tag: #{{ .Config.actionVersions.pulumictlTag }}#
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: #{{ .Config.actionVersions.setupPulumi }}#
-      with:
-        pulumi-version: "#{{ .Config.toolVersions.pulumi }}#"
+        tools: pulumictl, pulumicli, go
     - name: Configure AWS Credentials
       uses: #{{ .Config.actionVersions.configureAwsCredentials }}#
       with:
@@ -219,44 +192,10 @@ jobs:
       with:
         submodules: #{{ .Config.checkoutSubmodules }}#
 #{{- end }}#
-    - name: Install Go
-      uses: #{{ .Config.actionVersions.setupGo }}#
+    - name: Setup tools
+      uses: ./.github/actions/setup-tools
       with:
-        go-version: "#{{ .Config.toolVersions.go }}#"
-        cache-dependency-path: |
-          sdk/go.sum
-    - name: Install pulumictl
-      uses: #{{ .Config.actionVersions.installGhRelease }}#
-      with:
-        tag: #{{ .Config.actionVersions.pulumictlTag }}#
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: #{{ .Config.actionVersions.setupPulumi }}#
-      with:
-        pulumi-version: "#{{ .Config.toolVersions.pulumi }}#"
-    - name: Setup Node
-      uses: #{{ .Config.actionVersions.setupNode }}#
-      with:
-        node-version: "#{{ .Config.toolVersions.node }}#"
-        registry-url: https://registry.npmjs.org
-    - name: Setup DotNet
-      uses: #{{ .Config.actionVersions.setupDotNet }}#
-      with:
-        dotnet-version: "#{{ .Config.toolVersions.dotnet }}#"
-    - name: Setup Python
-      uses: #{{ .Config.actionVersions.setupPython }}#
-      with:
-        python-version: "#{{ .Config.toolVersions.python }}#"
-    - name: Setup Java
-      uses: #{{ .Config.actionVersions.setupJava }}#
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: "#{{ .Config.toolVersions.java }}#"
-    - name: Setup Gradle
-      uses: #{{ .Config.actionVersions.setupGradle }}#
-      with:
-        gradle-version: "#{{ .Config.toolVersions.gradle }}#"
+        tools: pulumictl, pulumicli, go, node, dotnet, python, java
     - name: Download provider + tfgen binaries
       uses: #{{ .Config.actionVersions.downloadArtifact }}#
       with:

--- a/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/nightly-test.yml
+++ b/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/nightly-test.yml
@@ -46,44 +46,10 @@ jobs:
       with:
         submodules: #{{ .Config.checkoutSubmodules }}#
 #{{- end }}#
-    - name: Install Go
-      uses: #{{ .Config.actionVersions.setupGo }}#
+    - name: Setup tools
+      uses: ./.github/actions/setup-tools
       with:
-        go-version: "#{{ .Config.toolVersions.go }}#"
-        cache-dependency-path: |
-          sdk/go.sum
-    - name: Install pulumictl
-      uses: #{{ .Config.actionVersions.installGhRelease }}#
-      with:
-        tag: #{{ .Config.actionVersions.pulumictlTag }}#
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: #{{ .Config.actionVersions.setupPulumi }}#
-      with:
-        pulumi-version: "#{{ .Config.toolVersions.pulumi }}#"
-    - name: Setup Node
-      uses: #{{ .Config.actionVersions.setupNode }}#
-      with:
-        node-version: "#{{ .Config.toolVersions.node }}#"
-        registry-url: https://registry.npmjs.org
-    - name: Setup DotNet
-      uses: #{{ .Config.actionVersions.setupDotNet }}#
-      with:
-        dotnet-version: "#{{ .Config.toolVersions.dotnet }}#"
-    - name: Setup Python
-      uses: #{{ .Config.actionVersions.setupPython }}#
-      with:
-        python-version: "#{{ .Config.toolVersions.python }}#"
-    - name: Setup Java
-      uses: #{{ .Config.actionVersions.setupJava }}#
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: "#{{ .Config.toolVersions.java }}#"
-    - name: Setup Gradle
-      uses: #{{ .Config.actionVersions.setupGradle }}#
-      with:
-        gradle-version: "#{{ .Config.toolVersions.gradle }}#"
+        tools: pulumictl, pulumicli, go, node, dotnet, python, java
     - name: Download provider + tfgen binaries
       uses: #{{ .Config.actionVersions.downloadArtifact }}#
       with:

--- a/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/prerelease.yml
+++ b/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/prerelease.yml
@@ -120,11 +120,6 @@ jobs:
       with:
         submodules: #{{ .Config.checkoutSubmodules }}#
 #{{- end }}#
-    - name: Install pulumictl
-      uses: #{{ .Config.actionVersions.installGhRelease }}#
-      with:
-        tag: #{{ .Config.actionVersions.pulumictlTag }}#
-        repo: pulumi/pulumictl
     - name: Download Go SDK
       uses: actions/download-artifact@v4
       with:

--- a/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/prerelease.yml
+++ b/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/prerelease.yml
@@ -56,21 +56,10 @@ jobs:
       with:
         submodules: #{{ .Config.checkoutSubmodules }}#
 #{{- end }}#
-    - name: Install Go
-      uses: #{{ .Config.actionVersions.setupGo }}#
+    - name: Setup tools
+      uses: ./.github/actions/setup-tools
       with:
-        go-version: "#{{ .Config.toolVersions.go }}#"
-        cache-dependency-path: |
-          sdk/go.sum
-    - name: Install pulumictl
-      uses: #{{ .Config.actionVersions.installGhRelease }}#
-      with:
-        tag: #{{ .Config.actionVersions.pulumictlTag }}#
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: #{{ .Config.actionVersions.setupPulumi }}#
-      with:
-        pulumi-version: "#{{ .Config.toolVersions.pulumi }}#"
+        tools: pulumictl, pulumicli, go
     - name: Configure AWS Credentials
       uses: #{{ .Config.actionVersions.configureAwsCredentials }}#
       with:
@@ -185,44 +174,10 @@ jobs:
       with:
         submodules: #{{ .Config.checkoutSubmodules }}#
 #{{- end }}#
-    - name: Install Go
-      uses: #{{ .Config.actionVersions.setupGo }}#
+    - name: Setup tools
+      uses: ./.github/actions/setup-tools
       with:
-        go-version: "#{{ .Config.toolVersions.go }}#"
-        cache-dependency-path: |
-          sdk/go.sum
-    - name: Install pulumictl
-      uses: #{{ .Config.actionVersions.installGhRelease }}#
-      with:
-        tag: #{{ .Config.actionVersions.pulumictlTag }}#
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: #{{ .Config.actionVersions.setupPulumi }}#
-      with:
-        pulumi-version: "#{{ .Config.toolVersions.pulumi }}#"
-    - name: Setup Node
-      uses: #{{ .Config.actionVersions.setupNode }}#
-      with:
-        node-version: "#{{ .Config.toolVersions.node }}#"
-        registry-url: https://registry.npmjs.org
-    - name: Setup DotNet
-      uses: #{{ .Config.actionVersions.setupDotNet }}#
-      with:
-        dotnet-version: "#{{ .Config.toolVersions.dotnet }}#"
-    - name: Setup Python
-      uses: #{{ .Config.actionVersions.setupPython }}#
-      with:
-        python-version: "#{{ .Config.toolVersions.python }}#"
-    - name: Setup Java
-      uses: #{{ .Config.actionVersions.setupJava }}#
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: "#{{ .Config.toolVersions.java }}#"
-    - name: Setup Gradle
-      uses: #{{ .Config.actionVersions.setupGradle }}#
-      with:
-        gradle-version: "#{{ .Config.toolVersions.gradle }}#"
+        tools: pulumictl, pulumicli, go, node, dotnet, python, java
     - name: Download provider + tfgen binaries
       uses: #{{ .Config.actionVersions.downloadArtifact }}#
       with:

--- a/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/release.yml
+++ b/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/release.yml
@@ -136,11 +136,6 @@ jobs:
       with:
         submodules: #{{ .Config.checkoutSubmodules }}#
 #{{- end }}#
-    - name: Install pulumictl
-      uses: #{{ .Config.actionVersions.installGhRelease }}#
-      with:
-        tag: #{{ .Config.actionVersions.pulumictlTag }}#
-        repo: pulumi/pulumictl
 #{{- if .Config.publish.goSdk.usePush }}#
     - name: Download Go SDK
       uses: actions/download-artifact@v4

--- a/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/release.yml
+++ b/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/release.yml
@@ -74,21 +74,10 @@ jobs:
       with:
         submodules: #{{ .Config.checkoutSubmodules }}#
 #{{- end }}#
-    - name: Install Go
-      uses: #{{ .Config.actionVersions.setupGo }}#
+    - name: Setup tools
+      uses: ./.github/actions/setup-tools
       with:
-        go-version: "#{{ .Config.toolVersions.go }}#"
-        cache-dependency-path: |
-          sdk/go.sum
-    - name: Install pulumictl
-      uses: #{{ .Config.actionVersions.installGhRelease }}#
-      with:
-        tag: #{{ .Config.actionVersions.pulumictlTag }}#
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: #{{ .Config.actionVersions.setupPulumi }}#
-      with:
-        pulumi-version: "#{{ .Config.toolVersions.pulumi }}#"
+        tools: pulumictl, pulumicli, go
     - name: Configure AWS Credentials
       uses: #{{ .Config.actionVersions.configureAwsCredentials }}#
       with:
@@ -227,44 +216,10 @@ jobs:
       with:
         submodules: #{{ .Config.checkoutSubmodules }}#
 #{{- end }}#
-    - name: Install Go
-      uses: #{{ .Config.actionVersions.setupGo }}#
+    - name: Setup tools
+      uses: ./.github/actions/setup-tools
       with:
-        go-version: "#{{ .Config.toolVersions.go }}#"
-        cache-dependency-path: |
-          sdk/go.sum
-    - name: Install pulumictl
-      uses: #{{ .Config.actionVersions.installGhRelease }}#
-      with:
-        tag: #{{ .Config.actionVersions.pulumictlTag }}#
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: #{{ .Config.actionVersions.setupPulumi }}#
-      with:
-        pulumi-version: "#{{ .Config.toolVersions.pulumi }}#"
-    - name: Setup Node
-      uses: #{{ .Config.actionVersions.setupNode }}#
-      with:
-        node-version: "#{{ .Config.toolVersions.node }}#"
-        registry-url: https://registry.npmjs.org
-    - name: Setup DotNet
-      uses: #{{ .Config.actionVersions.setupDotNet }}#
-      with:
-        dotnet-version: "#{{ .Config.toolVersions.dotnet }}#"
-    - name: Setup Python
-      uses: #{{ .Config.actionVersions.setupPython }}#
-      with:
-        python-version: "#{{ .Config.toolVersions.python }}#"
-    - name: Setup Java
-      uses: #{{ .Config.actionVersions.setupJava }}#
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: "#{{ .Config.toolVersions.java }}#"
-    - name: Setup Gradle
-      uses: #{{ .Config.actionVersions.setupGradle }}#
-      with:
-        gradle-version: "#{{ .Config.toolVersions.gradle }}#"
+        tools: pulumictl, pulumicli, go, node, dotnet, python, java
     - name: Download provider + tfgen binaries
       uses: #{{ .Config.actionVersions.downloadArtifact }}#
       with:

--- a/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/resync-build.yml
+++ b/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/resync-build.yml
@@ -23,34 +23,10 @@ jobs:
     - id: run-url
       name: Create URL to the run output
       run:  echo "run-url=https://github.com/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID" >> "$GITHUB_OUTPUT"
-    - name: Install Go
-      uses: #{{ .Config.actionVersions.setupGo }}#
+    - name: Setup tools
+      uses: ./.github/actions/setup-tools
       with:
-        go-version: "#{{ .Config.toolVersions.go }}#"
-        cache-dependency-path: |
-          sdk/go.sum
-    - name: Install pulumictl
-      uses: #{{ .Config.actionVersions.installGhRelease }}#
-      with:
-        tag: #{{ .Config.actionVersions.pulumictlTag }}#
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: #{{ .Config.actionVersions.setupPulumi }}#
-      with:
-        pulumi-version: "#{{ .Config.toolVersions.pulumi }}#"
-    - name: Setup DotNet
-      uses: #{{ .Config.actionVersions.setupDotNet }}#
-      with:
-        dotnet-version: "#{{ .Config.toolVersions.dotnet }}#"
-    - name: Setup Node
-      uses: #{{ .Config.actionVersions.setupNode }}#
-      with:
-        node-version: "#{{ .Config.toolVersions.node }}#"
-        registry-url: https://registry.npmjs.org
-    - name: Setup Python
-      uses: #{{ .Config.actionVersions.setupPython }}#
-      with:
-        python-version: "#{{ .Config.toolVersions.python }}#"
+        tools: pulumictl, pulumicli, go, node, dotnet, python
     - name: Sync with ci-mgmt
       run: cp -r "ci-mgmt/provider-ci/providers/$PROVIDER/repo/." .
     - name: Remove ci-mgmt directory

--- a/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/run-acceptance-tests.yml
@@ -38,7 +38,7 @@ jobs:
       name: Create URL to the run output
       run: echo "run-url=https://github.com/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID" >> "$GITHUB_OUTPUT"
     - name: Update with Result
-      uses: #{{ .Config.actionVersions.createOrUpdateComment }}#
+      uses: peter-evans/create-or-update-comment@v1
       with:
         body: "Please view the PR build: ${{ steps.run-url.outputs.run-url }}"
         issue-number: ${{ github.event.client_payload.github.payload.issue.number }}

--- a/provider-ci/internal/pkg/templates/provider/.github/actions/setup-tools/action.yml
+++ b/provider-ci/internal/pkg/templates/provider/.github/actions/setup-tools/action.yml
@@ -26,6 +26,7 @@ runs:
         cache-dependency-path: |
           provider/*.sum
           upstream/*.sum
+          sdk/*.sum
 
     - name: Install pulumictl
       if: inputs.tools == 'all' || contains(inputs.tools, 'pulumictl')

--- a/provider-ci/internal/pkg/templates/provider/.github/actions/setup-tools/action.yml
+++ b/provider-ci/internal/pkg/templates/provider/.github/actions/setup-tools/action.yml
@@ -20,7 +20,7 @@ runs:
   steps:
     - name: Install Go
       if: inputs.tools == 'all' || contains(inputs.tools, 'go')
-      uses: #{{ .Config.actionVersions.setupGo }}#
+      uses: actions/setup-go@v5
       with:
         go-version: "#{{ .Config.toolVersions.go }}#"
         cache-dependency-path: |
@@ -30,45 +30,45 @@ runs:
 
     - name: Install pulumictl
       if: inputs.tools == 'all' || contains(inputs.tools, 'pulumictl')
-      uses: #{{ .Config.actionVersions.installGhRelease }}#
+      uses: jaxxstorm/action-install-gh-release@v1.11.0
       with:
-        tag: #{{ .Config.actionVersions.pulumictlTag }}#
+        tag: v0.0.46
         repo: pulumi/pulumictl
 
     - name: Install Pulumi CLI
       if: inputs.tools == 'all' || contains(inputs.tools, 'pulumicli')
-      uses: #{{ .Config.actionVersions.setupPulumi }}#
+      uses: pulumi/actions@v5
       with:
         pulumi-version: "#{{ .Config.toolVersions.pulumi }}#"
 
     - name: Install Schema Tools
       if: inputs.tools == 'all' || contains(inputs.tools, 'schema-tools')
-      uses: #{{ .Config.actionVersions.installGhRelease }}#
+      uses: jaxxstorm/action-install-gh-release@v1.11.0
       with:
         repo: pulumi/schema-tools
 
     - name: Setup Node
       if: inputs.tools == 'all' || contains(inputs.tools, 'node')
-      uses: #{{ .Config.actionVersions.setupNode }}#
+      uses: actions/setup-node@v4
       with:
         node-version: #{{ .Config.toolVersions.node }}#
         registry-url: https://registry.npmjs.org
 
     - name: Setup DotNet
       if: inputs.tools == 'all' || contains(inputs.tools, 'dotnet')
-      uses: #{{ .Config.actionVersions.setupDotNet }}#
+      uses: actions/setup-dotnet@v4
       with:
         dotnet-version: #{{ .Config.toolVersions.dotnet }}#
 
     - name: Setup Python
       if: inputs.tools == 'all' || contains(inputs.tools, 'python')
-      uses: #{{ .Config.actionVersions.setupPython }}#
+      uses: actions/setup-python@v5
       with:
         python-version: #{{ .Config.toolVersions.python }}#
 
     - name: Setup Java
       if: inputs.tools == 'all' || contains(inputs.tools, 'java')
-      uses: #{{ .Config.actionVersions.setupJava }}#
+      uses: actions/setup-java@v4
       with:
         cache: gradle
         distribution: temurin
@@ -76,6 +76,6 @@ runs:
 
     - name: Setup Gradle
       if: inputs.tools == 'all' || contains(inputs.tools, 'java')
-      uses: #{{ .Config.actionVersions.setupGradle }}#
+      uses: gradle/gradle-build-action@v3
       with:
         gradle-version: #{{ .Config.toolVersions.gradle }}#

--- a/provider-ci/internal/pkg/templates/provider/.github/workflows/command-dispatch.yml
+++ b/provider-ci/internal/pkg/templates/provider/.github/workflows/command-dispatch.yml
@@ -13,7 +13,7 @@ jobs:
       with:
         submodules: #{{ .Config.checkoutSubmodules }}#
 #{{- end }}#
-    - uses: #{{ .Config.actionVersions.slashCommand }}#
+    - uses: peter-evans/slash-command-dispatch@v2
       with:
         commands: |
           run-acceptance-tests

--- a/provider-ci/internal/pkg/templates/provider/.github/workflows/license.yml
+++ b/provider-ci/internal/pkg/templates/provider/.github/workflows/license.yml
@@ -19,12 +19,10 @@ jobs:
       uses: actions/checkout@v4
       with:
         ref: ${{ env.PR_COMMIT_SHA }}
-    - name: Install Go
-      uses: actions/setup-go@v5
+    - name: Setup tools
+      uses: ./.github/actions/setup-tools
       with:
-        cache-dependency-path: |
-            sdk/go.sum
-        go-version: "#{{ .Config.toolVersions.go }}#"
+        tools: go
     - run: make upstream
     - uses: pulumi/license-check-action@main
       with:

--- a/provider-ci/internal/pkg/templates/provider/.github/workflows/verify-release.yml
+++ b/provider-ci/internal/pkg/templates/provider/.github/workflows/verify-release.yml
@@ -57,6 +57,8 @@ jobs:
         uses: actions/checkout@v4
       - name: Setup tools
         uses: ./.github/actions/setup-tools
+        with:
+          tools: pulumicli, go, node, dotnet, python, java
 #{{- if .Config.releaseVerification.nodejs }}#
       - name: Verify nodejs release
         uses: pulumi/verify-provider-release@v1

--- a/provider-ci/test-providers/aws/.github/actions/setup-tools/action.yml
+++ b/provider-ci/test-providers/aws/.github/actions/setup-tools/action.yml
@@ -26,6 +26,7 @@ runs:
         cache-dependency-path: |
           provider/*.sum
           upstream/*.sum
+          sdk/*.sum
 
     - name: Install pulumictl
       if: inputs.tools == 'all' || contains(inputs.tools, 'pulumictl')

--- a/provider-ci/test-providers/aws/.github/workflows/check-upstream-upgrade.yml
+++ b/provider-ci/test-providers/aws/.github/workflows/check-upstream-upgrade.yml
@@ -8,16 +8,14 @@ jobs:
     name: Check for upstream provider upgrades
     runs-on: ubuntu-latest
     steps:
-    - name: Install Go
-      uses: actions/setup-go@v5
-      with:
-        go-version: "1.21.x"
-        cache-dependency-path: |
-          sdk/go.sum
     - name: Checkout Repo
       uses: actions/checkout@v4
       with:
         submodules: true
+    - name: Setup tools
+      uses: ./.github/actions/setup-tools
+      with:
+        tools: go
     - name: Install upgrade-provider
       run: go install github.com/pulumi/upgrade-provider@main
       shell: bash

--- a/provider-ci/test-providers/aws/.github/workflows/license.yml
+++ b/provider-ci/test-providers/aws/.github/workflows/license.yml
@@ -38,12 +38,10 @@ jobs:
       uses: actions/checkout@v4
       with:
         ref: ${{ env.PR_COMMIT_SHA }}
-    - name: Install Go
-      uses: actions/setup-go@v5
+    - name: Setup tools
+      uses: ./.github/actions/setup-tools
       with:
-        cache-dependency-path: |
-            sdk/go.sum
-        go-version: "1.21.x"
+        tools: go
     - run: make upstream
     - uses: pulumi/license-check-action@main
       with:

--- a/provider-ci/test-providers/aws/.github/workflows/master.yml
+++ b/provider-ci/test-providers/aws/.github/workflows/master.yml
@@ -61,26 +61,10 @@ jobs:
         aws-access-key-id: ${{ secrets.AWS_CORP_S3_UPLOAD_ACCESS_KEY_ID }}
         aws-region: us-west-2
         aws-secret-access-key: ${{ secrets.AWS_CORP_S3_UPLOAD_SECRET_ACCESS_KEY }}
-    - name: Install Go
-      uses: actions/setup-go@v5
+    - name: Setup tools
+      uses: ./.github/actions/setup-tools
       with:
-        go-version: "1.21.x"
-        cache-dependency-path: |
-          sdk/go.sum
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.11.0
-      with:
-        tag: v0.0.46
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/actions@v5
-      with:
-        pulumi-version: "dev"
-    - if: github.event_name == 'pull_request'
-      name: Install Schema Tools
-      uses: jaxxstorm/action-install-gh-release@v1.11.0
-      with:
-        repo: pulumi/schema-tools
+        tools: pulumictl, pulumicli, go, schema-tools
     - name: Echo Coverage Output Dir
       run: 'echo "Coverage output directory: ${{ env.COVERAGE_OUTPUT_DIR }}"'
     - name: Generate Coverage Data
@@ -121,21 +105,10 @@ jobs:
       uses: actions/checkout@v4
       with:
         submodules: true
-    - name: Install Go
-      uses: actions/setup-go@v5
+    - name: Setup tools
+      uses: ./.github/actions/setup-tools
       with:
-        go-version: "1.21.x"
-        cache-dependency-path: |
-          sdk/go.sum
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.11.0
-      with:
-        tag: v0.0.46
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/actions@v5
-      with:
-        pulumi-version: "dev"
+        tools: pulumictl, pulumicli, go
     - name: Configure AWS Credentials
       uses: aws-actions/configure-aws-credentials@v4
       with:
@@ -223,44 +196,10 @@ jobs:
       uses: actions/checkout@v4
       with:
         submodules: true
-    - name: Install Go
-      uses: actions/setup-go@v5
+    - name: Setup tools
+      uses: ./.github/actions/setup-tools
       with:
-        go-version: "1.21.x"
-        cache-dependency-path: |
-          sdk/go.sum
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.11.0
-      with:
-        tag: v0.0.46
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/actions@v5
-      with:
-        pulumi-version: "dev"
-    - name: Setup Node
-      uses: actions/setup-node@v4
-      with:
-        node-version: "20.x"
-        registry-url: https://registry.npmjs.org
-    - name: Setup DotNet
-      uses: actions/setup-dotnet@v4
-      with:
-        dotnet-version: "6.0.x"
-    - name: Setup Python
-      uses: actions/setup-python@v5
-      with:
-        python-version: "3.11.8"
-    - name: Setup Java
-      uses: actions/setup-java@v4
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: "11"
-    - name: Setup Gradle
-      uses: gradle/gradle-build-action@v3
-      with:
-        gradle-version: "7.6"
+        tools: pulumictl, pulumicli, go, node, dotnet, python, java
     - name: Download provider + tfgen binaries
       uses: actions/download-artifact@v4
       with:

--- a/provider-ci/test-providers/aws/.github/workflows/nightly-test.yml
+++ b/provider-ci/test-providers/aws/.github/workflows/nightly-test.yml
@@ -60,44 +60,10 @@ jobs:
       uses: actions/checkout@v4
       with:
         submodules: true
-    - name: Install Go
-      uses: actions/setup-go@v5
+    - name: Setup tools
+      uses: ./.github/actions/setup-tools
       with:
-        go-version: "1.21.x"
-        cache-dependency-path: |
-          sdk/go.sum
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.11.0
-      with:
-        tag: v0.0.46
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/actions@v5
-      with:
-        pulumi-version: "dev"
-    - name: Setup Node
-      uses: actions/setup-node@v4
-      with:
-        node-version: "20.x"
-        registry-url: https://registry.npmjs.org
-    - name: Setup DotNet
-      uses: actions/setup-dotnet@v4
-      with:
-        dotnet-version: "6.0.x"
-    - name: Setup Python
-      uses: actions/setup-python@v5
-      with:
-        python-version: "3.11.8"
-    - name: Setup Java
-      uses: actions/setup-java@v4
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: "11"
-    - name: Setup Gradle
-      uses: gradle/gradle-build-action@v3
-      with:
-        gradle-version: "7.6"
+        tools: pulumictl, pulumicli, go, node, dotnet, python, java
     - name: Download provider + tfgen binaries
       uses: actions/download-artifact@v4
       with:

--- a/provider-ci/test-providers/aws/.github/workflows/prerelease.yml
+++ b/provider-ci/test-providers/aws/.github/workflows/prerelease.yml
@@ -66,21 +66,10 @@ jobs:
       uses: actions/checkout@v4
       with:
         submodules: true
-    - name: Install Go
-      uses: actions/setup-go@v5
+    - name: Setup tools
+      uses: ./.github/actions/setup-tools
       with:
-        go-version: "1.21.x"
-        cache-dependency-path: |
-          sdk/go.sum
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.11.0
-      with:
-        tag: v0.0.46
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/actions@v5
-      with:
-        pulumi-version: "dev"
+        tools: pulumictl, pulumicli, go
     - name: Configure AWS Credentials
       uses: aws-actions/configure-aws-credentials@v4
       with:
@@ -138,11 +127,6 @@ jobs:
       uses: actions/checkout@v4
       with:
         submodules: true
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.11.0
-      with:
-        tag: v0.0.46
-        repo: pulumi/pulumictl
     - name: Download Go SDK
       uses: actions/download-artifact@v4
       with:
@@ -187,44 +171,10 @@ jobs:
       uses: actions/checkout@v4
       with:
         submodules: true
-    - name: Install Go
-      uses: actions/setup-go@v5
+    - name: Setup tools
+      uses: ./.github/actions/setup-tools
       with:
-        go-version: "1.21.x"
-        cache-dependency-path: |
-          sdk/go.sum
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.11.0
-      with:
-        tag: v0.0.46
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/actions@v5
-      with:
-        pulumi-version: "dev"
-    - name: Setup Node
-      uses: actions/setup-node@v4
-      with:
-        node-version: "20.x"
-        registry-url: https://registry.npmjs.org
-    - name: Setup DotNet
-      uses: actions/setup-dotnet@v4
-      with:
-        dotnet-version: "6.0.x"
-    - name: Setup Python
-      uses: actions/setup-python@v5
-      with:
-        python-version: "3.11.8"
-    - name: Setup Java
-      uses: actions/setup-java@v4
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: "11"
-    - name: Setup Gradle
-      uses: gradle/gradle-build-action@v3
-      with:
-        gradle-version: "7.6"
+        tools: pulumictl, pulumicli, go, node, dotnet, python, java
     - name: Download provider + tfgen binaries
       uses: actions/download-artifact@v4
       with:

--- a/provider-ci/test-providers/aws/.github/workflows/release.yml
+++ b/provider-ci/test-providers/aws/.github/workflows/release.yml
@@ -82,21 +82,10 @@ jobs:
       uses: actions/checkout@v4
       with:
         submodules: true
-    - name: Install Go
-      uses: actions/setup-go@v5
+    - name: Setup tools
+      uses: ./.github/actions/setup-tools
       with:
-        go-version: "1.21.x"
-        cache-dependency-path: |
-          sdk/go.sum
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.11.0
-      with:
-        tag: v0.0.46
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/actions@v5
-      with:
-        pulumi-version: "dev"
+        tools: pulumictl, pulumicli, go
     - name: Configure AWS Credentials
       uses: aws-actions/configure-aws-credentials@v4
       with:
@@ -153,11 +142,6 @@ jobs:
       uses: actions/checkout@v4
       with:
         submodules: true
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.11.0
-      with:
-        tag: v0.0.46
-        repo: pulumi/pulumictl
     - name: Download Go SDK
       uses: actions/download-artifact@v4
       with:
@@ -220,44 +204,10 @@ jobs:
       uses: actions/checkout@v4
       with:
         submodules: true
-    - name: Install Go
-      uses: actions/setup-go@v5
+    - name: Setup tools
+      uses: ./.github/actions/setup-tools
       with:
-        go-version: "1.21.x"
-        cache-dependency-path: |
-          sdk/go.sum
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.11.0
-      with:
-        tag: v0.0.46
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/actions@v5
-      with:
-        pulumi-version: "dev"
-    - name: Setup Node
-      uses: actions/setup-node@v4
-      with:
-        node-version: "20.x"
-        registry-url: https://registry.npmjs.org
-    - name: Setup DotNet
-      uses: actions/setup-dotnet@v4
-      with:
-        dotnet-version: "6.0.x"
-    - name: Setup Python
-      uses: actions/setup-python@v5
-      with:
-        python-version: "3.11.8"
-    - name: Setup Java
-      uses: actions/setup-java@v4
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: "11"
-    - name: Setup Gradle
-      uses: gradle/gradle-build-action@v3
-      with:
-        gradle-version: "7.6"
+        tools: pulumictl, pulumicli, go, node, dotnet, python, java
     - name: Download provider + tfgen binaries
       uses: actions/download-artifact@v4
       with:

--- a/provider-ci/test-providers/aws/.github/workflows/resync-build.yml
+++ b/provider-ci/test-providers/aws/.github/workflows/resync-build.yml
@@ -40,34 +40,10 @@ jobs:
     - id: run-url
       name: Create URL to the run output
       run:  echo "run-url=https://github.com/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID" >> "$GITHUB_OUTPUT"
-    - name: Install Go
-      uses: actions/setup-go@v5
+    - name: Setup tools
+      uses: ./.github/actions/setup-tools
       with:
-        go-version: "1.21.x"
-        cache-dependency-path: |
-          sdk/go.sum
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.11.0
-      with:
-        tag: v0.0.46
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/actions@v5
-      with:
-        pulumi-version: "dev"
-    - name: Setup DotNet
-      uses: actions/setup-dotnet@v4
-      with:
-        dotnet-version: "6.0.x"
-    - name: Setup Node
-      uses: actions/setup-node@v4
-      with:
-        node-version: "20.x"
-        registry-url: https://registry.npmjs.org
-    - name: Setup Python
-      uses: actions/setup-python@v5
-      with:
-        python-version: "3.11.8"
+        tools: pulumictl, pulumicli, go, node, dotnet, python
     - name: Sync with ci-mgmt
       run: cp -r "ci-mgmt/provider-ci/providers/$PROVIDER/repo/." .
     - name: Remove ci-mgmt directory

--- a/provider-ci/test-providers/aws/.github/workflows/verify-release.yml
+++ b/provider-ci/test-providers/aws/.github/workflows/verify-release.yml
@@ -66,3 +66,5 @@ jobs:
         uses: actions/checkout@v4
       - name: Setup tools
         uses: ./.github/actions/setup-tools
+        with:
+          tools: pulumicli, go, node, dotnet, python, java

--- a/provider-ci/test-providers/cloudflare/.github/actions/setup-tools/action.yml
+++ b/provider-ci/test-providers/cloudflare/.github/actions/setup-tools/action.yml
@@ -26,6 +26,7 @@ runs:
         cache-dependency-path: |
           provider/*.sum
           upstream/*.sum
+          sdk/*.sum
 
     - name: Install pulumictl
       if: inputs.tools == 'all' || contains(inputs.tools, 'pulumictl')

--- a/provider-ci/test-providers/cloudflare/.github/workflows/check-upstream-upgrade.yml
+++ b/provider-ci/test-providers/cloudflare/.github/workflows/check-upstream-upgrade.yml
@@ -8,14 +8,12 @@ jobs:
     name: Check for upstream provider upgrades
     runs-on: ubuntu-latest
     steps:
-    - name: Install Go
-      uses: actions/setup-go@v5
-      with:
-        go-version: "1.21.x"
-        cache-dependency-path: |
-          sdk/go.sum
     - name: Checkout Repo
       uses: actions/checkout@v4
+    - name: Setup tools
+      uses: ./.github/actions/setup-tools
+      with:
+        tools: go
     - name: Install upgrade-provider
       run: go install github.com/pulumi/upgrade-provider@main
       shell: bash

--- a/provider-ci/test-providers/cloudflare/.github/workflows/license.yml
+++ b/provider-ci/test-providers/cloudflare/.github/workflows/license.yml
@@ -37,12 +37,10 @@ jobs:
       uses: actions/checkout@v4
       with:
         ref: ${{ env.PR_COMMIT_SHA }}
-    - name: Install Go
-      uses: actions/setup-go@v5
+    - name: Setup tools
+      uses: ./.github/actions/setup-tools
       with:
-        cache-dependency-path: |
-            sdk/go.sum
-        go-version: "1.21.x"
+        tools: go
     - run: make upstream
     - uses: pulumi/license-check-action@main
       with:

--- a/provider-ci/test-providers/cloudflare/.github/workflows/master.yml
+++ b/provider-ci/test-providers/cloudflare/.github/workflows/master.yml
@@ -58,26 +58,10 @@ jobs:
         aws-access-key-id: ${{ secrets.AWS_CORP_S3_UPLOAD_ACCESS_KEY_ID }}
         aws-region: us-west-2
         aws-secret-access-key: ${{ secrets.AWS_CORP_S3_UPLOAD_SECRET_ACCESS_KEY }}
-    - name: Install Go
-      uses: actions/setup-go@v5
+    - name: Setup tools
+      uses: ./.github/actions/setup-tools
       with:
-        go-version: "1.21.x"
-        cache-dependency-path: |
-          sdk/go.sum
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.11.0
-      with:
-        tag: v0.0.46
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/actions@v5
-      with:
-        pulumi-version: "dev"
-    - if: github.event_name == 'pull_request'
-      name: Install Schema Tools
-      uses: jaxxstorm/action-install-gh-release@v1.11.0
-      with:
-        repo: pulumi/schema-tools
+        tools: pulumictl, pulumicli, go, schema-tools
     - name: Echo Coverage Output Dir
       run: 'echo "Coverage output directory: ${{ env.COVERAGE_OUTPUT_DIR }}"'
     - name: Generate Coverage Data
@@ -117,21 +101,10 @@ jobs:
         swap-storage: false
     - name: Checkout Repo
       uses: actions/checkout@v4
-    - name: Install Go
-      uses: actions/setup-go@v5
+    - name: Setup tools
+      uses: ./.github/actions/setup-tools
       with:
-        go-version: "1.21.x"
-        cache-dependency-path: |
-          sdk/go.sum
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.11.0
-      with:
-        tag: v0.0.46
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/actions@v5
-      with:
-        pulumi-version: "dev"
+        tools: pulumictl, pulumicli, go
     - name: Configure AWS Credentials
       uses: aws-actions/configure-aws-credentials@v4
       with:
@@ -211,44 +184,10 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v4
-    - name: Install Go
-      uses: actions/setup-go@v5
+    - name: Setup tools
+      uses: ./.github/actions/setup-tools
       with:
-        go-version: "1.21.x"
-        cache-dependency-path: |
-          sdk/go.sum
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.11.0
-      with:
-        tag: v0.0.46
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/actions@v5
-      with:
-        pulumi-version: "dev"
-    - name: Setup Node
-      uses: actions/setup-node@v4
-      with:
-        node-version: "20.x"
-        registry-url: https://registry.npmjs.org
-    - name: Setup DotNet
-      uses: actions/setup-dotnet@v4
-      with:
-        dotnet-version: "6.0.x"
-    - name: Setup Python
-      uses: actions/setup-python@v5
-      with:
-        python-version: "3.11.8"
-    - name: Setup Java
-      uses: actions/setup-java@v4
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: "11"
-    - name: Setup Gradle
-      uses: gradle/gradle-build-action@v3
-      with:
-        gradle-version: "7.6"
+        tools: pulumictl, pulumicli, go, node, dotnet, python, java
     - name: Download provider + tfgen binaries
       uses: actions/download-artifact@v4
       with:

--- a/provider-ci/test-providers/cloudflare/.github/workflows/prerelease.yml
+++ b/provider-ci/test-providers/cloudflare/.github/workflows/prerelease.yml
@@ -64,21 +64,10 @@ jobs:
         swap-storage: false
     - name: Checkout Repo
       uses: actions/checkout@v4
-    - name: Install Go
-      uses: actions/setup-go@v5
+    - name: Setup tools
+      uses: ./.github/actions/setup-tools
       with:
-        go-version: "1.21.x"
-        cache-dependency-path: |
-          sdk/go.sum
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.11.0
-      with:
-        tag: v0.0.46
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/actions@v5
-      with:
-        pulumi-version: "dev"
+        tools: pulumictl, pulumicli, go
     - name: Configure AWS Credentials
       uses: aws-actions/configure-aws-credentials@v4
       with:
@@ -134,11 +123,6 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v4
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.11.0
-      with:
-        tag: v0.0.46
-        repo: pulumi/pulumictl
     - name: Download Go SDK
       uses: actions/download-artifact@v4
       with:
@@ -175,44 +159,10 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v4
-    - name: Install Go
-      uses: actions/setup-go@v5
+    - name: Setup tools
+      uses: ./.github/actions/setup-tools
       with:
-        go-version: "1.21.x"
-        cache-dependency-path: |
-          sdk/go.sum
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.11.0
-      with:
-        tag: v0.0.46
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/actions@v5
-      with:
-        pulumi-version: "dev"
-    - name: Setup Node
-      uses: actions/setup-node@v4
-      with:
-        node-version: "20.x"
-        registry-url: https://registry.npmjs.org
-    - name: Setup DotNet
-      uses: actions/setup-dotnet@v4
-      with:
-        dotnet-version: "6.0.x"
-    - name: Setup Python
-      uses: actions/setup-python@v5
-      with:
-        python-version: "3.11.8"
-    - name: Setup Java
-      uses: actions/setup-java@v4
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: "11"
-    - name: Setup Gradle
-      uses: gradle/gradle-build-action@v3
-      with:
-        gradle-version: "7.6"
+        tools: pulumictl, pulumicli, go, node, dotnet, python, java
     - name: Download provider + tfgen binaries
       uses: actions/download-artifact@v4
       with:

--- a/provider-ci/test-providers/cloudflare/.github/workflows/release.yml
+++ b/provider-ci/test-providers/cloudflare/.github/workflows/release.yml
@@ -80,21 +80,10 @@ jobs:
         swap-storage: false
     - name: Checkout Repo
       uses: actions/checkout@v4
-    - name: Install Go
-      uses: actions/setup-go@v5
+    - name: Setup tools
+      uses: ./.github/actions/setup-tools
       with:
-        go-version: "1.21.x"
-        cache-dependency-path: |
-          sdk/go.sum
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.11.0
-      with:
-        tag: v0.0.46
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/actions@v5
-      with:
-        pulumi-version: "dev"
+        tools: pulumictl, pulumicli, go
     - name: Configure AWS Credentials
       uses: aws-actions/configure-aws-credentials@v4
       with:
@@ -149,11 +138,6 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v4
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.11.0
-      with:
-        tag: v0.0.46
-        repo: pulumi/pulumictl
     - name: Download Go SDK
       uses: actions/download-artifact@v4
       with:
@@ -208,44 +192,10 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v4
-    - name: Install Go
-      uses: actions/setup-go@v5
+    - name: Setup tools
+      uses: ./.github/actions/setup-tools
       with:
-        go-version: "1.21.x"
-        cache-dependency-path: |
-          sdk/go.sum
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.11.0
-      with:
-        tag: v0.0.46
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/actions@v5
-      with:
-        pulumi-version: "dev"
-    - name: Setup Node
-      uses: actions/setup-node@v4
-      with:
-        node-version: "20.x"
-        registry-url: https://registry.npmjs.org
-    - name: Setup DotNet
-      uses: actions/setup-dotnet@v4
-      with:
-        dotnet-version: "6.0.x"
-    - name: Setup Python
-      uses: actions/setup-python@v5
-      with:
-        python-version: "3.11.8"
-    - name: Setup Java
-      uses: actions/setup-java@v4
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: "11"
-    - name: Setup Gradle
-      uses: gradle/gradle-build-action@v3
-      with:
-        gradle-version: "7.6"
+        tools: pulumictl, pulumicli, go, node, dotnet, python, java
     - name: Download provider + tfgen binaries
       uses: actions/download-artifact@v4
       with:

--- a/provider-ci/test-providers/cloudflare/.github/workflows/resync-build.yml
+++ b/provider-ci/test-providers/cloudflare/.github/workflows/resync-build.yml
@@ -37,34 +37,10 @@ jobs:
     - id: run-url
       name: Create URL to the run output
       run:  echo "run-url=https://github.com/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID" >> "$GITHUB_OUTPUT"
-    - name: Install Go
-      uses: actions/setup-go@v5
+    - name: Setup tools
+      uses: ./.github/actions/setup-tools
       with:
-        go-version: "1.21.x"
-        cache-dependency-path: |
-          sdk/go.sum
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.11.0
-      with:
-        tag: v0.0.46
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/actions@v5
-      with:
-        pulumi-version: "dev"
-    - name: Setup DotNet
-      uses: actions/setup-dotnet@v4
-      with:
-        dotnet-version: "6.0.x"
-    - name: Setup Node
-      uses: actions/setup-node@v4
-      with:
-        node-version: "20.x"
-        registry-url: https://registry.npmjs.org
-    - name: Setup Python
-      uses: actions/setup-python@v5
-      with:
-        python-version: "3.11.8"
+        tools: pulumictl, pulumicli, go, node, dotnet, python
     - name: Sync with ci-mgmt
       run: cp -r "ci-mgmt/provider-ci/providers/$PROVIDER/repo/." .
     - name: Remove ci-mgmt directory

--- a/provider-ci/test-providers/cloudflare/.github/workflows/verify-release.yml
+++ b/provider-ci/test-providers/cloudflare/.github/workflows/verify-release.yml
@@ -65,3 +65,5 @@ jobs:
         uses: actions/checkout@v4
       - name: Setup tools
         uses: ./.github/actions/setup-tools
+        with:
+          tools: pulumicli, go, node, dotnet, python, java

--- a/provider-ci/test-providers/docker/.github/actions/setup-tools/action.yml
+++ b/provider-ci/test-providers/docker/.github/actions/setup-tools/action.yml
@@ -26,6 +26,7 @@ runs:
         cache-dependency-path: |
           provider/*.sum
           upstream/*.sum
+          sdk/*.sum
 
     - name: Install pulumictl
       if: inputs.tools == 'all' || contains(inputs.tools, 'pulumictl')

--- a/provider-ci/test-providers/docker/.github/workflows/check-upstream-upgrade.yml
+++ b/provider-ci/test-providers/docker/.github/workflows/check-upstream-upgrade.yml
@@ -8,14 +8,12 @@ jobs:
     name: Check for upstream provider upgrades
     runs-on: ubuntu-latest
     steps:
-    - name: Install Go
-      uses: actions/setup-go@v5
-      with:
-        go-version: "1.21.x"
-        cache-dependency-path: |
-          sdk/go.sum
     - name: Checkout Repo
       uses: actions/checkout@v4
+    - name: Setup tools
+      uses: ./.github/actions/setup-tools
+      with:
+        tools: go
     - name: Install upgrade-provider
       run: go install github.com/pulumi/upgrade-provider@main
       shell: bash

--- a/provider-ci/test-providers/docker/.github/workflows/license.yml
+++ b/provider-ci/test-providers/docker/.github/workflows/license.yml
@@ -50,12 +50,10 @@ jobs:
       uses: actions/checkout@v4
       with:
         ref: ${{ env.PR_COMMIT_SHA }}
-    - name: Install Go
-      uses: actions/setup-go@v5
+    - name: Setup tools
+      uses: ./.github/actions/setup-tools
       with:
-        cache-dependency-path: |
-            sdk/go.sum
-        go-version: "1.21.x"
+        tools: go
     - run: make upstream
     - uses: pulumi/license-check-action@main
       with:

--- a/provider-ci/test-providers/docker/.github/workflows/master.yml
+++ b/provider-ci/test-providers/docker/.github/workflows/master.yml
@@ -71,26 +71,10 @@ jobs:
         aws-access-key-id: ${{ secrets.AWS_CORP_S3_UPLOAD_ACCESS_KEY_ID }}
         aws-region: us-west-2
         aws-secret-access-key: ${{ secrets.AWS_CORP_S3_UPLOAD_SECRET_ACCESS_KEY }}
-    - name: Install Go
-      uses: actions/setup-go@v5
+    - name: Setup tools
+      uses: ./.github/actions/setup-tools
       with:
-        go-version: "1.21.x"
-        cache-dependency-path: |
-          sdk/go.sum
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.11.0
-      with:
-        tag: v0.0.46
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/actions@v5
-      with:
-        pulumi-version: "dev"
-    - if: github.event_name == 'pull_request'
-      name: Install Schema Tools
-      uses: jaxxstorm/action-install-gh-release@v1.11.0
-      with:
-        repo: pulumi/schema-tools
+        tools: pulumictl, pulumicli, go, schema-tools
     - name: Echo Coverage Output Dir
       run: 'echo "Coverage output directory: ${{ env.COVERAGE_OUTPUT_DIR }}"'
     - name: Generate Coverage Data
@@ -130,21 +114,10 @@ jobs:
         swap-storage: false
     - name: Checkout Repo
       uses: actions/checkout@v4
-    - name: Install Go
-      uses: actions/setup-go@v5
+    - name: Setup tools
+      uses: ./.github/actions/setup-tools
       with:
-        go-version: "1.21.x"
-        cache-dependency-path: |
-          sdk/go.sum
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.11.0
-      with:
-        tag: v0.0.46
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/actions@v5
-      with:
-        pulumi-version: "dev"
+        tools: pulumictl, pulumicli, go
     - name: Configure AWS Credentials
       uses: aws-actions/configure-aws-credentials@v4
       with:
@@ -224,44 +197,10 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v4
-    - name: Install Go
-      uses: actions/setup-go@v5
+    - name: Setup tools
+      uses: ./.github/actions/setup-tools
       with:
-        go-version: "1.21.x"
-        cache-dependency-path: |
-          sdk/go.sum
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.11.0
-      with:
-        tag: v0.0.46
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/actions@v5
-      with:
-        pulumi-version: "dev"
-    - name: Setup Node
-      uses: actions/setup-node@v4
-      with:
-        node-version: "20.x"
-        registry-url: https://registry.npmjs.org
-    - name: Setup DotNet
-      uses: actions/setup-dotnet@v4
-      with:
-        dotnet-version: "6.0.x"
-    - name: Setup Python
-      uses: actions/setup-python@v5
-      with:
-        python-version: "3.11.8"
-    - name: Setup Java
-      uses: actions/setup-java@v4
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: "11"
-    - name: Setup Gradle
-      uses: gradle/gradle-build-action@v3
-      with:
-        gradle-version: "7.6"
+        tools: pulumictl, pulumicli, go, node, dotnet, python, java
     - name: Download provider + tfgen binaries
       uses: actions/download-artifact@v4
       with:

--- a/provider-ci/test-providers/docker/.github/workflows/prerelease.yml
+++ b/provider-ci/test-providers/docker/.github/workflows/prerelease.yml
@@ -77,21 +77,10 @@ jobs:
         swap-storage: false
     - name: Checkout Repo
       uses: actions/checkout@v4
-    - name: Install Go
-      uses: actions/setup-go@v5
+    - name: Setup tools
+      uses: ./.github/actions/setup-tools
       with:
-        go-version: "1.21.x"
-        cache-dependency-path: |
-          sdk/go.sum
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.11.0
-      with:
-        tag: v0.0.46
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/actions@v5
-      with:
-        pulumi-version: "dev"
+        tools: pulumictl, pulumicli, go
     - name: Configure AWS Credentials
       uses: aws-actions/configure-aws-credentials@v4
       with:
@@ -147,11 +136,6 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v4
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.11.0
-      with:
-        tag: v0.0.46
-        repo: pulumi/pulumictl
     - name: Download Go SDK
       uses: actions/download-artifact@v4
       with:
@@ -188,44 +172,10 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v4
-    - name: Install Go
-      uses: actions/setup-go@v5
+    - name: Setup tools
+      uses: ./.github/actions/setup-tools
       with:
-        go-version: "1.21.x"
-        cache-dependency-path: |
-          sdk/go.sum
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.11.0
-      with:
-        tag: v0.0.46
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/actions@v5
-      with:
-        pulumi-version: "dev"
-    - name: Setup Node
-      uses: actions/setup-node@v4
-      with:
-        node-version: "20.x"
-        registry-url: https://registry.npmjs.org
-    - name: Setup DotNet
-      uses: actions/setup-dotnet@v4
-      with:
-        dotnet-version: "6.0.x"
-    - name: Setup Python
-      uses: actions/setup-python@v5
-      with:
-        python-version: "3.11.8"
-    - name: Setup Java
-      uses: actions/setup-java@v4
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: "11"
-    - name: Setup Gradle
-      uses: gradle/gradle-build-action@v3
-      with:
-        gradle-version: "7.6"
+        tools: pulumictl, pulumicli, go, node, dotnet, python, java
     - name: Download provider + tfgen binaries
       uses: actions/download-artifact@v4
       with:

--- a/provider-ci/test-providers/docker/.github/workflows/release.yml
+++ b/provider-ci/test-providers/docker/.github/workflows/release.yml
@@ -93,21 +93,10 @@ jobs:
         swap-storage: false
     - name: Checkout Repo
       uses: actions/checkout@v4
-    - name: Install Go
-      uses: actions/setup-go@v5
+    - name: Setup tools
+      uses: ./.github/actions/setup-tools
       with:
-        go-version: "1.21.x"
-        cache-dependency-path: |
-          sdk/go.sum
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.11.0
-      with:
-        tag: v0.0.46
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/actions@v5
-      with:
-        pulumi-version: "dev"
+        tools: pulumictl, pulumicli, go
     - name: Configure AWS Credentials
       uses: aws-actions/configure-aws-credentials@v4
       with:
@@ -162,11 +151,6 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v4
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.11.0
-      with:
-        tag: v0.0.46
-        repo: pulumi/pulumictl
     - name: Download Go SDK
       uses: actions/download-artifact@v4
       with:
@@ -221,44 +205,10 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v4
-    - name: Install Go
-      uses: actions/setup-go@v5
+    - name: Setup tools
+      uses: ./.github/actions/setup-tools
       with:
-        go-version: "1.21.x"
-        cache-dependency-path: |
-          sdk/go.sum
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.11.0
-      with:
-        tag: v0.0.46
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/actions@v5
-      with:
-        pulumi-version: "dev"
-    - name: Setup Node
-      uses: actions/setup-node@v4
-      with:
-        node-version: "20.x"
-        registry-url: https://registry.npmjs.org
-    - name: Setup DotNet
-      uses: actions/setup-dotnet@v4
-      with:
-        dotnet-version: "6.0.x"
-    - name: Setup Python
-      uses: actions/setup-python@v5
-      with:
-        python-version: "3.11.8"
-    - name: Setup Java
-      uses: actions/setup-java@v4
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: "11"
-    - name: Setup Gradle
-      uses: gradle/gradle-build-action@v3
-      with:
-        gradle-version: "7.6"
+        tools: pulumictl, pulumicli, go, node, dotnet, python, java
     - name: Download provider + tfgen binaries
       uses: actions/download-artifact@v4
       with:

--- a/provider-ci/test-providers/docker/.github/workflows/resync-build.yml
+++ b/provider-ci/test-providers/docker/.github/workflows/resync-build.yml
@@ -50,34 +50,10 @@ jobs:
     - id: run-url
       name: Create URL to the run output
       run:  echo "run-url=https://github.com/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID" >> "$GITHUB_OUTPUT"
-    - name: Install Go
-      uses: actions/setup-go@v5
+    - name: Setup tools
+      uses: ./.github/actions/setup-tools
       with:
-        go-version: "1.21.x"
-        cache-dependency-path: |
-          sdk/go.sum
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.11.0
-      with:
-        tag: v0.0.46
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/actions@v5
-      with:
-        pulumi-version: "dev"
-    - name: Setup DotNet
-      uses: actions/setup-dotnet@v4
-      with:
-        dotnet-version: "6.0.x"
-    - name: Setup Node
-      uses: actions/setup-node@v4
-      with:
-        node-version: "20.x"
-        registry-url: https://registry.npmjs.org
-    - name: Setup Python
-      uses: actions/setup-python@v5
-      with:
-        python-version: "3.11.8"
+        tools: pulumictl, pulumicli, go, node, dotnet, python
     - name: Sync with ci-mgmt
       run: cp -r "ci-mgmt/provider-ci/providers/$PROVIDER/repo/." .
     - name: Remove ci-mgmt directory

--- a/provider-ci/test-providers/docker/.github/workflows/verify-release.yml
+++ b/provider-ci/test-providers/docker/.github/workflows/verify-release.yml
@@ -78,3 +78,5 @@ jobs:
         uses: actions/checkout@v4
       - name: Setup tools
         uses: ./.github/actions/setup-tools
+        with:
+          tools: pulumicli, go, node, dotnet, python, java


### PR DESCRIPTION
Commits are factored for review:

1. Use setup-tools anywhere we're installing go, pulumicli, pulumictl
2. Remove unused pulumictl install for Go SDK release job
3. Now we only have one use of each setup step, inline the tool versions and remove from the config.
4. Also inline `slash-command` and `create-or-update-comment` actions as they're only used once.
5. Specify tools explicitly for the verify-release job.
6. Re-generate test-providers.