### PR TITLE
Install tools package publishing

### DIFF
--- a/provider-ci/internal/pkg/templates/bridged-provider.config.yaml
+++ b/provider-ci/internal/pkg/templates/bridged-provider.config.yaml
@@ -149,7 +149,7 @@ actionVersions:
 publish:
   # publisherAction is the version of the pulumi-package-publisher action to use.
   # This should be pinned to just the major version once v1 is released.
-  publisherAction: pulumi/pulumi-package-publisher@v0.0.18
+  publisherAction: pulumi/pulumi-package-publisher@v0.0.19
   # passed to the sdk input of pulumi-package-publisher
   # This is overridden in pulumi-local to disable python
   sdk: all

--- a/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/main.yml
+++ b/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/main.yml
@@ -128,10 +128,16 @@ jobs:
       - publish
     runs-on: #{{ .Config.runner.default }}#
     steps:
+    - name: Checkout Repo
+      uses: #{{ .Config.actionVersions.checkout }}#
+#{{- if .Config.checkoutSubmodules }}#
+      with:
+        submodules: #{{ .Config.checkoutSubmodules }}#
+#{{- end }}#
     - name: Setup tools
       uses: ./.github/actions/setup-tools
       with:
-        tools: pulumicli, go, node, dotnet, python, java
+        tools: pulumicli, pulumictl, go, node, dotnet, python, java
     - name: Publish SDKs
       uses: #{{ .Config.publish.publisherAction }}#
       with:

--- a/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/main.yml
+++ b/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/main.yml
@@ -128,15 +128,15 @@ jobs:
       - publish
     runs-on: #{{ .Config.runner.default }}#
     steps:
+    - name: Setup tools
+      uses: ./.github/actions/setup-tools
+      with:
+        tools: pulumicli, go, node, dotnet, python, java
     - name: Publish SDKs
       uses: #{{ .Config.publish.publisherAction }}#
       with:
         sdk: #{{ .Config.publish.sdk }}#
         version: ${{ needs.prerequisites.outputs.version }}
-        dotnet-version: "#{{ .Config.toolVersions.dotnet }}#"
-        java-version: "#{{ .Config.toolVersions.java }}#"
-        node-version: "#{{ .Config.toolVersions.node }}#"
-        python-version: "#{{ .Config.toolVersions.python }}#"
 
   tag_release_if_labeled_needs_release:
     name: Tag release if labeled as needs-release

--- a/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/prerelease.yml
+++ b/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/prerelease.yml
@@ -86,10 +86,16 @@ jobs:
       - publish
     runs-on: #{{ .Config.runner.default }}#
     steps:
+    - name: Checkout Repo
+      uses: #{{ .Config.actionVersions.checkout }}#
+#{{- if .Config.checkoutSubmodules }}#
+      with:
+        submodules: #{{ .Config.checkoutSubmodules }}#
+#{{- end }}#
     - name: Setup tools
       uses: ./.github/actions/setup-tools
       with:
-        tools: pulumicli, go, node, dotnet, python, java
+        tools: pulumicli, pulumictl, go, node, dotnet, python, java
     - name: Publish SDKs
       uses: #{{ .Config.publish.publisherAction }}#
       with:

--- a/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/prerelease.yml
+++ b/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/prerelease.yml
@@ -86,15 +86,15 @@ jobs:
       - publish
     runs-on: #{{ .Config.runner.default }}#
     steps:
+    - name: Setup tools
+      uses: ./.github/actions/setup-tools
+      with:
+        tools: pulumicli, go, node, dotnet, python, java
     - name: Publish SDKs
       uses: #{{ .Config.publish.publisherAction }}#
       with:
         sdk: #{{ .Config.publish.sdk }}#
         version: ${{ needs.prerequisites.outputs.version }}
-        dotnet-version: "#{{ .Config.toolVersions.dotnet }}#"
-        java-version: "#{{ .Config.toolVersions.java }}#"
-        node-version: "#{{ .Config.toolVersions.node }}#"
-        python-version: "#{{ .Config.toolVersions.python }}#"
   publish_go_sdk:
     name: publish_go_sdk
     needs: 

--- a/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/release.yml
+++ b/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/release.yml
@@ -103,15 +103,15 @@ jobs:
       - publish
     runs-on: #{{ .Config.runner.default }}#
     steps:
+    - name: Setup tools
+      uses: ./.github/actions/setup-tools
+      with:
+        tools: pulumicli, go, node, dotnet, python, java
     - name: Publish SDKs
       uses: #{{ .Config.publish.publisherAction }}#
       with:
         sdk: #{{ .Config.publish.sdk }}#
         version: ${{ needs.prerequisites.outputs.version }}
-        dotnet-version: "#{{ .Config.toolVersions.dotnet }}#"
-        java-version: "#{{ .Config.toolVersions.java }}#"
-        node-version: "#{{ .Config.toolVersions.node }}#"
-        python-version: "#{{ .Config.toolVersions.python }}#"
   publish_go_sdk:
     name: publish_go_sdk
     needs:

--- a/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/release.yml
+++ b/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/release.yml
@@ -103,10 +103,16 @@ jobs:
       - publish
     runs-on: #{{ .Config.runner.default }}#
     steps:
+    - name: Checkout Repo
+      uses: #{{ .Config.actionVersions.checkout }}#
+#{{- if .Config.checkoutSubmodules }}#
+      with:
+        submodules: #{{ .Config.checkoutSubmodules }}#
+#{{- end }}#
     - name: Setup tools
       uses: ./.github/actions/setup-tools
       with:
-        tools: pulumicli, go, node, dotnet, python, java
+        tools: pulumicli, pulumictl, go, node, dotnet, python, java
     - name: Publish SDKs
       uses: #{{ .Config.publish.publisherAction }}#
       with:

--- a/provider-ci/test-providers/aws/.github/workflows/master.yml
+++ b/provider-ci/test-providers/aws/.github/workflows/master.yml
@@ -135,15 +135,15 @@ jobs:
       - publish
     runs-on: ubuntu-latest
     steps:
+    - name: Setup tools
+      uses: ./.github/actions/setup-tools
+      with:
+        tools: pulumicli, go, node, dotnet, python, java
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.18
+      uses: pulumi/pulumi-package-publisher@v0.0.19
       with:
         sdk: all
         version: ${{ needs.prerequisites.outputs.version }}
-        dotnet-version: "6.0.x"
-        java-version: "11"
-        node-version: "20.x"
-        python-version: "3.11.8"
 
   tag_release_if_labeled_needs_release:
     name: Tag release if labeled as needs-release

--- a/provider-ci/test-providers/aws/.github/workflows/master.yml
+++ b/provider-ci/test-providers/aws/.github/workflows/master.yml
@@ -135,10 +135,14 @@ jobs:
       - publish
     runs-on: ubuntu-latest
     steps:
+    - name: Checkout Repo
+      uses: actions/checkout@v4
+      with:
+        submodules: true
     - name: Setup tools
       uses: ./.github/actions/setup-tools
       with:
-        tools: pulumicli, go, node, dotnet, python, java
+        tools: pulumicli, pulumictl, go, node, dotnet, python, java
     - name: Publish SDKs
       uses: pulumi/pulumi-package-publisher@v0.0.19
       with:

--- a/provider-ci/test-providers/aws/.github/workflows/prerelease.yml
+++ b/provider-ci/test-providers/aws/.github/workflows/prerelease.yml
@@ -95,10 +95,14 @@ jobs:
       - publish
     runs-on: ubuntu-latest
     steps:
+    - name: Checkout Repo
+      uses: actions/checkout@v4
+      with:
+        submodules: true
     - name: Setup tools
       uses: ./.github/actions/setup-tools
       with:
-        tools: pulumicli, go, node, dotnet, python, java
+        tools: pulumicli, pulumictl, go, node, dotnet, python, java
     - name: Publish SDKs
       uses: pulumi/pulumi-package-publisher@v0.0.19
       with:

--- a/provider-ci/test-providers/aws/.github/workflows/prerelease.yml
+++ b/provider-ci/test-providers/aws/.github/workflows/prerelease.yml
@@ -95,15 +95,15 @@ jobs:
       - publish
     runs-on: ubuntu-latest
     steps:
+    - name: Setup tools
+      uses: ./.github/actions/setup-tools
+      with:
+        tools: pulumicli, go, node, dotnet, python, java
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.18
+      uses: pulumi/pulumi-package-publisher@v0.0.19
       with:
         sdk: all
         version: ${{ needs.prerequisites.outputs.version }}
-        dotnet-version: "6.0.x"
-        java-version: "11"
-        node-version: "20.x"
-        python-version: "3.11.8"
   publish_go_sdk:
     name: publish_go_sdk
     needs: 

--- a/provider-ci/test-providers/aws/.github/workflows/release.yml
+++ b/provider-ci/test-providers/aws/.github/workflows/release.yml
@@ -110,15 +110,15 @@ jobs:
       - publish
     runs-on: ubuntu-latest
     steps:
+    - name: Setup tools
+      uses: ./.github/actions/setup-tools
+      with:
+        tools: pulumicli, go, node, dotnet, python, java
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.18
+      uses: pulumi/pulumi-package-publisher@v0.0.19
       with:
         sdk: all
         version: ${{ needs.prerequisites.outputs.version }}
-        dotnet-version: "6.0.x"
-        java-version: "11"
-        node-version: "20.x"
-        python-version: "3.11.8"
   publish_go_sdk:
     name: publish_go_sdk
     needs:

--- a/provider-ci/test-providers/aws/.github/workflows/release.yml
+++ b/provider-ci/test-providers/aws/.github/workflows/release.yml
@@ -110,10 +110,14 @@ jobs:
       - publish
     runs-on: ubuntu-latest
     steps:
+    - name: Checkout Repo
+      uses: actions/checkout@v4
+      with:
+        submodules: true
     - name: Setup tools
       uses: ./.github/actions/setup-tools
       with:
-        tools: pulumicli, go, node, dotnet, python, java
+        tools: pulumicli, pulumictl, go, node, dotnet, python, java
     - name: Publish SDKs
       uses: pulumi/pulumi-package-publisher@v0.0.19
       with:

--- a/provider-ci/test-providers/cloudflare/.github/workflows/master.yml
+++ b/provider-ci/test-providers/cloudflare/.github/workflows/master.yml
@@ -131,15 +131,15 @@ jobs:
       - publish
     runs-on: ubuntu-latest
     steps:
+    - name: Setup tools
+      uses: ./.github/actions/setup-tools
+      with:
+        tools: pulumicli, go, node, dotnet, python, java
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.18
+      uses: pulumi/pulumi-package-publisher@v0.0.19
       with:
         sdk: all
         version: ${{ needs.prerequisites.outputs.version }}
-        dotnet-version: "6.0.x"
-        java-version: "11"
-        node-version: "20.x"
-        python-version: "3.11.8"
 
   tag_release_if_labeled_needs_release:
     name: Tag release if labeled as needs-release

--- a/provider-ci/test-providers/cloudflare/.github/workflows/master.yml
+++ b/provider-ci/test-providers/cloudflare/.github/workflows/master.yml
@@ -131,10 +131,12 @@ jobs:
       - publish
     runs-on: ubuntu-latest
     steps:
+    - name: Checkout Repo
+      uses: actions/checkout@v4
     - name: Setup tools
       uses: ./.github/actions/setup-tools
       with:
-        tools: pulumicli, go, node, dotnet, python, java
+        tools: pulumicli, pulumictl, go, node, dotnet, python, java
     - name: Publish SDKs
       uses: pulumi/pulumi-package-publisher@v0.0.19
       with:

--- a/provider-ci/test-providers/cloudflare/.github/workflows/prerelease.yml
+++ b/provider-ci/test-providers/cloudflare/.github/workflows/prerelease.yml
@@ -93,15 +93,15 @@ jobs:
       - publish
     runs-on: ubuntu-latest
     steps:
+    - name: Setup tools
+      uses: ./.github/actions/setup-tools
+      with:
+        tools: pulumicli, go, node, dotnet, python, java
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.18
+      uses: pulumi/pulumi-package-publisher@v0.0.19
       with:
         sdk: all
         version: ${{ needs.prerequisites.outputs.version }}
-        dotnet-version: "6.0.x"
-        java-version: "11"
-        node-version: "20.x"
-        python-version: "3.11.8"
   publish_go_sdk:
     name: publish_go_sdk
     needs: 

--- a/provider-ci/test-providers/cloudflare/.github/workflows/prerelease.yml
+++ b/provider-ci/test-providers/cloudflare/.github/workflows/prerelease.yml
@@ -93,10 +93,12 @@ jobs:
       - publish
     runs-on: ubuntu-latest
     steps:
+    - name: Checkout Repo
+      uses: actions/checkout@v4
     - name: Setup tools
       uses: ./.github/actions/setup-tools
       with:
-        tools: pulumicli, go, node, dotnet, python, java
+        tools: pulumicli, pulumictl, go, node, dotnet, python, java
     - name: Publish SDKs
       uses: pulumi/pulumi-package-publisher@v0.0.19
       with:

--- a/provider-ci/test-providers/cloudflare/.github/workflows/release.yml
+++ b/provider-ci/test-providers/cloudflare/.github/workflows/release.yml
@@ -108,10 +108,12 @@ jobs:
       - publish
     runs-on: ubuntu-latest
     steps:
+    - name: Checkout Repo
+      uses: actions/checkout@v4
     - name: Setup tools
       uses: ./.github/actions/setup-tools
       with:
-        tools: pulumicli, go, node, dotnet, python, java
+        tools: pulumicli, pulumictl, go, node, dotnet, python, java
     - name: Publish SDKs
       uses: pulumi/pulumi-package-publisher@v0.0.19
       with:

--- a/provider-ci/test-providers/cloudflare/.github/workflows/release.yml
+++ b/provider-ci/test-providers/cloudflare/.github/workflows/release.yml
@@ -108,15 +108,15 @@ jobs:
       - publish
     runs-on: ubuntu-latest
     steps:
+    - name: Setup tools
+      uses: ./.github/actions/setup-tools
+      with:
+        tools: pulumicli, go, node, dotnet, python, java
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.18
+      uses: pulumi/pulumi-package-publisher@v0.0.19
       with:
         sdk: all
         version: ${{ needs.prerequisites.outputs.version }}
-        dotnet-version: "6.0.x"
-        java-version: "11"
-        node-version: "20.x"
-        python-version: "3.11.8"
   publish_go_sdk:
     name: publish_go_sdk
     needs:

--- a/provider-ci/test-providers/docker/.github/workflows/master.yml
+++ b/provider-ci/test-providers/docker/.github/workflows/master.yml
@@ -144,15 +144,15 @@ jobs:
       - publish
     runs-on: ubuntu-latest
     steps:
+    - name: Setup tools
+      uses: ./.github/actions/setup-tools
+      with:
+        tools: pulumicli, go, node, dotnet, python, java
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.18
+      uses: pulumi/pulumi-package-publisher@v0.0.19
       with:
         sdk: all
         version: ${{ needs.prerequisites.outputs.version }}
-        dotnet-version: "6.0.x"
-        java-version: "11"
-        node-version: "20.x"
-        python-version: "3.11.8"
 
   tag_release_if_labeled_needs_release:
     name: Tag release if labeled as needs-release

--- a/provider-ci/test-providers/docker/.github/workflows/master.yml
+++ b/provider-ci/test-providers/docker/.github/workflows/master.yml
@@ -144,10 +144,12 @@ jobs:
       - publish
     runs-on: ubuntu-latest
     steps:
+    - name: Checkout Repo
+      uses: actions/checkout@v4
     - name: Setup tools
       uses: ./.github/actions/setup-tools
       with:
-        tools: pulumicli, go, node, dotnet, python, java
+        tools: pulumicli, pulumictl, go, node, dotnet, python, java
     - name: Publish SDKs
       uses: pulumi/pulumi-package-publisher@v0.0.19
       with:

--- a/provider-ci/test-providers/docker/.github/workflows/prerelease.yml
+++ b/provider-ci/test-providers/docker/.github/workflows/prerelease.yml
@@ -106,10 +106,12 @@ jobs:
       - publish
     runs-on: ubuntu-latest
     steps:
+    - name: Checkout Repo
+      uses: actions/checkout@v4
     - name: Setup tools
       uses: ./.github/actions/setup-tools
       with:
-        tools: pulumicli, go, node, dotnet, python, java
+        tools: pulumicli, pulumictl, go, node, dotnet, python, java
     - name: Publish SDKs
       uses: pulumi/pulumi-package-publisher@v0.0.19
       with:

--- a/provider-ci/test-providers/docker/.github/workflows/prerelease.yml
+++ b/provider-ci/test-providers/docker/.github/workflows/prerelease.yml
@@ -106,15 +106,15 @@ jobs:
       - publish
     runs-on: ubuntu-latest
     steps:
+    - name: Setup tools
+      uses: ./.github/actions/setup-tools
+      with:
+        tools: pulumicli, go, node, dotnet, python, java
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.18
+      uses: pulumi/pulumi-package-publisher@v0.0.19
       with:
         sdk: all
         version: ${{ needs.prerequisites.outputs.version }}
-        dotnet-version: "6.0.x"
-        java-version: "11"
-        node-version: "20.x"
-        python-version: "3.11.8"
   publish_go_sdk:
     name: publish_go_sdk
     needs: 

--- a/provider-ci/test-providers/docker/.github/workflows/release.yml
+++ b/provider-ci/test-providers/docker/.github/workflows/release.yml
@@ -121,10 +121,12 @@ jobs:
       - publish
     runs-on: ubuntu-latest
     steps:
+    - name: Checkout Repo
+      uses: actions/checkout@v4
     - name: Setup tools
       uses: ./.github/actions/setup-tools
       with:
-        tools: pulumicli, go, node, dotnet, python, java
+        tools: pulumicli, pulumictl, go, node, dotnet, python, java
     - name: Publish SDKs
       uses: pulumi/pulumi-package-publisher@v0.0.19
       with:

--- a/provider-ci/test-providers/docker/.github/workflows/release.yml
+++ b/provider-ci/test-providers/docker/.github/workflows/release.yml
@@ -121,15 +121,15 @@ jobs:
       - publish
     runs-on: ubuntu-latest
     steps:
+    - name: Setup tools
+      uses: ./.github/actions/setup-tools
+      with:
+        tools: pulumicli, go, node, dotnet, python, java
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.18
+      uses: pulumi/pulumi-package-publisher@v0.0.19
       with:
         sdk: all
         version: ${{ needs.prerequisites.outputs.version }}
-        dotnet-version: "6.0.x"
-        java-version: "11"
-        node-version: "20.x"
-        python-version: "3.11.8"
   publish_go_sdk:
     name: publish_go_sdk
     needs:


### PR DESCRIPTION
Re-use our own tool setups which can include additional options for caching rather than duplicating the setup logic into the publishing action.

This depends on first merging:
- https://github.com/pulumi/pulumi-package-publisher/pull/32
- https://github.com/pulumi/ci-mgmt/pull/1003

This PR assumes that `pulumi/pulumi-package-publisher` will then be published as `v0.0.19` (the next version).