### PR TITLE
Inline worktreeAllowedChanges

### DIFF
--- a/provider-ci/internal/pkg/templates/bridged-provider.config.yaml
+++ b/provider-ci/internal/pkg/templates/bridged-provider.config.yaml
@@ -179,15 +179,6 @@ publish:
     path: sdk
     additive: false
 
-# worktreeAllowedChanges defines which files we expect to find changes in when building in CI with a different version number
-# This could be in-lined as is not needed to be overridden: https://github.com/search?q=org%3Apulumi+path%3A.ci-mgmt.yaml+%22worktreeAllowedChanges%3A%22&type=code
-worktreeAllowedChanges: |-
-  sdk/**/pulumi-plugin.json
-  sdk/dotnet/Pulumi.*.csproj
-  sdk/go/**/pulumiUtilities.go
-  sdk/nodejs/package.json
-  sdk/python/pyproject.toml
-
 # Set a path for each language example to enable the test
 # releaseVerification:
   # nodejs: examples/simple-nodejs

--- a/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/build_sdk.yml
+++ b/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/build_sdk.yml
@@ -60,11 +60,13 @@ jobs:
         run: make build_${{ matrix.language }}
       - name: Check worktree clean
         uses: pulumi/git-status-check-action@v1
-#{{- if .Config.worktreeAllowedChanges }}#
         with:
           allowed-changes: |
-#{{ .Config.worktreeAllowedChanges | indent 12 }}#
-#{{- end }}#
+            sdk/**/pulumi-plugin.json
+            sdk/dotnet/Pulumi.*.csproj
+            sdk/go/**/pulumiUtilities.go
+            sdk/nodejs/package.json
+            sdk/python/pyproject.toml
       - name: Compress SDK folder
         run: tar -zcf sdk/${{ matrix.language }}.tar.gz -C sdk/${{ matrix.language }} .
       - name: Upload artifacts


### PR DESCRIPTION
This is not needed to be overridden now the rollout is complete.

Only use of override is also no longer needed: https://github.com/search?q=org%3Apulumi+path%3A.ci-mgmt.yaml+%22worktreeAllowedChanges%3A%22&type=code

PR to remove dangling use: https://github.com/pulumi/pulumi-kafka/pull/459