### PR TITLE
Remove unused publish.goSdk config

### DIFF
--- a/provider-ci/internal/pkg/templates/bridged-provider.config.yaml
+++ b/provider-ci/internal/pkg/templates/bridged-provider.config.yaml
@@ -153,16 +153,6 @@ publish:
   # passed to the sdk input of pulumi-package-publisher
   # This is overridden in pulumi-local to disable python
   sdk: all
-  # goSdk is no longer needed as is not overridden in specific providers.
-  goSdk:
-    # Set to `true` to use the below configuration to push a new commit somewhere else.
-    usePush: true
-    # By default we'll push back to its own repository as a standalone, tagged commit.
-    repository: ${{ github.repository }}
-    baseRef: ${{ github.sha }}
-    source: sdk
-    path: sdk
-    additive: false
 
 # Set a path for each language example to enable the test
 # releaseVerification:

--- a/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/prerelease.yml
+++ b/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/prerelease.yml
@@ -95,7 +95,6 @@ jobs:
         java-version: "#{{ .Config.toolVersions.java }}#"
         node-version: "#{{ .Config.toolVersions.node }}#"
         python-version: "#{{ .Config.toolVersions.python }}#"
-#{{- if .Config.publish.goSdk.usePush }}#
   publish_go_sdk:
     name: publish_go_sdk
     needs: 
@@ -120,18 +119,17 @@ jobs:
       shell: bash
     - uses: pulumi/publish-go-sdk-action@v1
       with:
-        repository: #{{ .Config.publish.goSdk.repository }}#
-        base-ref: #{{ .Config.publish.goSdk.baseRef }}#
-        source: #{{ .Config.publish.goSdk.source }}#
-        path: #{{ .Config.publish.goSdk.path }}#
+        repository: ${{ github.repository }}
+        base-ref: ${{ github.sha }}
+        source: sdk
+        path: sdk
         version: ${{ needs.prerequisites.outputs.version }}
-        additive: #{{ .Config.publish.goSdk.additive }}#
+        additive: false
         # Avoid including other language SDKs & artifacts in the commit
         files: |
           go.*
           go/**
           !*.tar.gz
-#{{- end }}#
   test:
     name: test
     needs: 

--- a/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/release.yml
+++ b/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/release.yml
@@ -125,7 +125,6 @@ jobs:
       with:
         submodules: #{{ .Config.checkoutSubmodules }}#
 #{{- end }}#
-#{{- if .Config.publish.goSdk.usePush }}#
     - name: Download Go SDK
       uses: actions/download-artifact@v4
       with:
@@ -137,22 +136,17 @@ jobs:
       shell: bash
     - uses: pulumi/publish-go-sdk-action@v1
       with:
-        repository: #{{ .Config.publish.goSdk.repository }}#
-        base-ref: #{{ .Config.publish.goSdk.baseRef }}#
-        source: #{{ .Config.publish.goSdk.source }}#
-        path: #{{ .Config.publish.goSdk.path }}#
+        repository: ${{ github.repository }}
+        base-ref: ${{ github.sha }}
+        source: sdk
+        path: sdk
         version: ${{ needs.prerequisites.outputs.version }}
-        additive: #{{ .Config.publish.goSdk.additive }}#
+        additive: false
         # Avoid including other language SDKs & artifacts in the commit
         files: |
           go.*
           go/**
           !*.tar.gz
-#{{- else }}#
-    - name: Add SDK version tag
-      run: git tag "sdk/v${{ needs.prerequisites.outputs.version }}" && git push origin
-        "sdk/v${{ needs.prerequisites.outputs.version }}"
-#{{- end }}#
 
   clean_up_release_labels:
     name: Clean up release labels


### PR DESCRIPTION
These are never actually overridden so can be inlined to reduce complexity of possible conditons.

Single reference to goSdk was in pulumi-kafka which had no effect. PR to remove: https://github.com/pulumi/pulumi-kafka/pull/459

Stacked on top of:
- https://github.com/pulumi/ci-mgmt/pull/1003