### PR TITLE
Do not calculate version for native provider nightly/weekly jobs

### DIFF
--- a/native-provider-ci/providers/aws-native/repo/.github/workflows/nightly-sdk-generation.yml
+++ b/native-provider-ci/providers/aws-native/repo/.github/workflows/nightly-sdk-generation.yml
@@ -41,11 +41,6 @@ jobs:
       uses: actions/checkout@v4
       with:
         lfs: true
-    - id: version
-      name: Set Provider Version
-      uses: pulumi/provider-version-action@v1
-      with:
-        set-env: PROVIDER_VERSION
     - name: Install Go
       uses: actions/setup-go@v5
       with:

--- a/native-provider-ci/providers/aws-native/repo/.github/workflows/weekly-pulumi-update.yml
+++ b/native-provider-ci/providers/aws-native/repo/.github/workflows/weekly-pulumi-update.yml
@@ -40,11 +40,6 @@ jobs:
       uses: actions/checkout@v4
       with:
         lfs: true
-    - id: version
-      name: Set Provider Version
-      uses: pulumi/provider-version-action@v1
-      with:
-        set-env: PROVIDER_VERSION
     - name: Install Go
       uses: actions/setup-go@v5
       with:

--- a/native-provider-ci/providers/command/repo/.github/workflows/weekly-pulumi-update.yml
+++ b/native-provider-ci/providers/command/repo/.github/workflows/weekly-pulumi-update.yml
@@ -40,11 +40,6 @@ jobs:
       uses: actions/checkout@v4
       with:
         lfs: true
-    - id: version
-      name: Set Provider Version
-      uses: pulumi/provider-version-action@v1
-      with:
-        set-env: PROVIDER_VERSION
     - name: Install Go
       uses: actions/setup-go@v5
       with:

--- a/native-provider-ci/providers/docker-build/repo/.github/workflows/weekly-pulumi-update.yml
+++ b/native-provider-ci/providers/docker-build/repo/.github/workflows/weekly-pulumi-update.yml
@@ -54,11 +54,6 @@ jobs:
       uses: actions/checkout@v4
       with:
         lfs: true
-    - id: version
-      name: Set Provider Version
-      uses: pulumi/provider-version-action@v1
-      with:
-        set-env: PROVIDER_VERSION
     - name: Install Go
       uses: actions/setup-go@v5
       with:

--- a/native-provider-ci/providers/google-native/repo/.github/workflows/nightly-sdk-generation.yml
+++ b/native-provider-ci/providers/google-native/repo/.github/workflows/nightly-sdk-generation.yml
@@ -47,11 +47,6 @@ jobs:
       uses: actions/checkout@v4
       with:
         lfs: true
-    - id: version
-      name: Set Provider Version
-      uses: pulumi/provider-version-action@v1
-      with:
-        set-env: PROVIDER_VERSION
     - name: Install Go
       uses: actions/setup-go@v5
       with:

--- a/native-provider-ci/providers/google-native/repo/.github/workflows/weekly-pulumi-update.yml
+++ b/native-provider-ci/providers/google-native/repo/.github/workflows/weekly-pulumi-update.yml
@@ -46,11 +46,6 @@ jobs:
       uses: actions/checkout@v4
       with:
         lfs: true
-    - id: version
-      name: Set Provider Version
-      uses: pulumi/provider-version-action@v1
-      with:
-        set-env: PROVIDER_VERSION
     - name: Install Go
       uses: actions/setup-go@v5
       with:

--- a/native-provider-ci/providers/kubernetes-cert-manager/repo/.github/workflows/weekly-pulumi-update.yml
+++ b/native-provider-ci/providers/kubernetes-cert-manager/repo/.github/workflows/weekly-pulumi-update.yml
@@ -45,11 +45,6 @@ jobs:
       uses: actions/checkout@v4
       with:
         lfs: true
-    - id: version
-      name: Set Provider Version
-      uses: pulumi/provider-version-action@v1
-      with:
-        set-env: PROVIDER_VERSION
     - name: Install Go
       uses: actions/setup-go@v5
       with:

--- a/native-provider-ci/providers/kubernetes/repo/.github/workflows/weekly-pulumi-update.yml
+++ b/native-provider-ci/providers/kubernetes/repo/.github/workflows/weekly-pulumi-update.yml
@@ -45,11 +45,6 @@ jobs:
       uses: actions/checkout@v4
       with:
         lfs: true
-    - id: version
-      name: Set Provider Version
-      uses: pulumi/provider-version-action@v1
-      with:
-        set-env: PROVIDER_VERSION
     - name: Install Go
       uses: actions/setup-go@v5
       with:

--- a/native-provider-ci/src/workflows.ts
+++ b/native-provider-ci/src/workflows.ts
@@ -957,7 +957,7 @@ export class WeeklyPulumiUpdate implements NormalJob {
   constructor(name: string, opts: WorkflowOpts) {
     this.steps = [
       steps.CheckoutRepoStep(),
-      steps.SetProviderVersionStep(),
+      // Do not calculate version here since we only want version embedded during releases.
       steps.InstallGo(),
       steps.InstallPulumiCtl(),
       steps.InstallPulumiCli(opts.pulumiCLIVersion, opts.pulumiVersionFile),
@@ -984,7 +984,7 @@ export class NightlySdkGeneration implements NormalJob {
     this.name = name;
     this.steps = [
       steps.CheckoutRepoStep(),
-      steps.SetProviderVersionStep(),
+      // Do not calculate version here since we only want version embedded during releases.
       // Pass the provider here as an option so that it can be skipped if not needed
       steps.InstallGo(goVersion),
       steps.InstallPulumiCtl(),


### PR DESCRIPTION
This PR stops the checked out SDK version in Git from drifting between the dev and tentative versions.

Fixes: #1009 