### PR TITLE
Remove slack notifications

### DIFF
--- a/provider-ci/internal/pkg/templates/bridged-provider.config.yaml
+++ b/provider-ci/internal/pkg/templates/bridged-provider.config.yaml
@@ -99,7 +99,6 @@ env:
   SIGNING_KEY: ${{ secrets.JAVA_SIGNING_KEY }}
   SIGNING_KEY_ID: ${{ secrets.JAVA_SIGNING_KEY_ID }}
   SIGNING_PASSWORD: ${{ secrets.JAVA_SIGNING_PASSWORD }}
-  SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
   TF_APPEND_USER_AGENT: pulumi
 
 # actions can contain preBuild and preTest additional steps to be spliced into workflows.
@@ -157,7 +156,6 @@ actionVersions:
   slashCommand: peter-evans/slash-command-dispatch@v2
   uploadArtifact: actions/upload-artifact@v4
   upgradeProviderAction: pulumi/pulumi-upgrade-provider-action@v0.0.12
-  slackNotification: rtCamp/action-slack-notify@v2
 
 # publish contains multiple properties relating to the publish jobs.
 # Used by 2 providers: https://github.com/search?q=org%3Apulumi+path%3A.ci-mgmt.yaml+%22publish%3A%22&type=code

--- a/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/check-upstream-upgrade.yml
+++ b/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/check-upstream-upgrade.yml
@@ -36,17 +36,6 @@ jobs:
       env:
         REPO: ${{ github.repository }}
       shell: bash
-    - name: Send Check Version Failure To Slack
-      if: failure()
-      uses: #{{ .Config.actionVersions.slackNotification }}#
-      env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
-        SLACK_COLOR: "#FF0000"
-        SLACK_ICON_EMOJI: ":owl:"
-        SLACK_MESSAGE: " Failed to check upstream for a new version "
-        SLACK_TITLE: ${{ github.event.repository.name }} upstream version check
-        SLACK_USERNAME: provider-bot
-        SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_URL }}
 name: Check upstream upgrade
 on:
   workflow_dispatch: {} #so we can run this manually if necessary.

--- a/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/main.yml
+++ b/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/main.yml
@@ -164,17 +164,6 @@ jobs:
         java-version: "#{{ .Config.toolVersions.java }}#"
         node-version: "#{{ .Config.toolVersions.node }}#"
         python-version: "#{{ .Config.toolVersions.python }}#"
-    - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
-        SLACK_COLOR: "#FF0000"
-        SLACK_ICON_EMOJI: ":taco:"
-        SLACK_MESSAGE: "Publish failed :x:"
-        SLACK_TITLE: ${{ github.event.repository.name }} upgrade result
-        SLACK_USERNAME: provider-bot
-        SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_URL }}
-      if: failure()
-      name: Send Publish Failure To Slack
-      uses: #{{ .Config.actionVersions.slackNotification }}#
 
   tag_release_if_labeled_needs_release:
     name: Tag release if labeled as needs-release

--- a/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/prerelease.yml
+++ b/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/prerelease.yml
@@ -106,17 +106,6 @@ jobs:
         java-version: "#{{ .Config.toolVersions.java }}#"
         node-version: "#{{ .Config.toolVersions.node }}#"
         python-version: "#{{ .Config.toolVersions.python }}#"
-    - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
-        SLACK_COLOR: "#FF0000"
-        SLACK_ICON_EMOJI: ":taco:"
-        SLACK_MESSAGE: "Publish failed :x:"
-        SLACK_TITLE: ${{ github.event.repository.name }} upgrade result
-        SLACK_USERNAME: provider-bot
-        SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_URL }}
-      if: failure()
-      name: Send Publish Failure To Slack
-      uses: #{{ .Config.actionVersions.slackNotification }}#
 #{{- if .Config.publish.goSdk.usePush }}#
   publish_go_sdk:
     name: publish_go_sdk

--- a/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/release.yml
+++ b/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/release.yml
@@ -123,17 +123,6 @@ jobs:
         java-version: "#{{ .Config.toolVersions.java }}#"
         node-version: "#{{ .Config.toolVersions.node }}#"
         python-version: "#{{ .Config.toolVersions.python }}#"
-    - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
-        SLACK_COLOR: "#FF0000"
-        SLACK_ICON_EMOJI: ":taco:"
-        SLACK_MESSAGE: "Publish failed :x:"
-        SLACK_TITLE: ${{ github.event.repository.name }} upgrade result
-        SLACK_USERNAME: provider-bot
-        SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_URL }}
-      if: failure()
-      name: Send Publish Failure To Slack
-      uses: #{{ .Config.actionVersions.slackNotification }}#
   publish_go_sdk:
     name: publish_go_sdk
     needs:

--- a/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/upgrade-bridge.yml
+++ b/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/upgrade-bridge.yml
@@ -86,27 +86,3 @@ jobs:
         pr-reviewers: ${{ github.event.client_payload.pr-reviewers }}
         pr-description: ${{ github.event.client_payload.pr-description }}
         pr-title-prefix: ${{ github.event.client_payload.pr-title-prefix }}
-    - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
-        SLACK_COLOR: "#7CFC00"
-        SLACK_ICON_EMOJI: ":taco:"
-        SLACK_MESSAGE: >-
-          Upgrade succeeded :heart_decoration:
-
-          PR opened at github.com/pulumi/${{ github.event.repository.name }}/pulls
-        SLACK_TITLE: ${{ github.event.repository.name }} upgrade result
-        SLACK_USERNAME: provider-bot
-        SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_URL }}
-      name: Send Upgrade Success To Slack
-      uses: #{{ .Config.actionVersions.slackNotification }}#
-    - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
-        SLACK_COLOR: "#FF0000"
-        SLACK_ICON_EMOJI: ":taco:"
-        SLACK_MESSAGE: " Upgrade failed :x:"
-        SLACK_TITLE: ${{ github.event.repository.name }} upgrade result
-        SLACK_USERNAME: provider-bot
-        SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_URL }}
-      if: failure()
-      name: Send Upgrade Failure To Slack
-      uses: #{{ .Config.actionVersions.slackNotification }}#

--- a/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/upgrade-provider.yml
+++ b/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/upgrade-provider.yml
@@ -18,30 +18,6 @@ jobs:
         #{{- end }}#
         email: bot@pulumi.com
         username: pulumi-bot
-    - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
-        SLACK_COLOR: "#7CFC00"
-        SLACK_ICON_EMOJI: ":taco:"
-        SLACK_MESSAGE: >-
-          Upgrade succeeded :heart_decoration:
-
-          PR opened at github.com/pulumi/${{ github.event.repository.name }}/pulls
-        SLACK_TITLE: ${{ github.event.repository.name }} upgrade result
-        SLACK_USERNAME: provider-bot
-        SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_URL }}
-      name: Send Upgrade Success To Slack
-      uses: #{{ .Config.actionVersions.slackNotification }}#
-    - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
-        SLACK_COLOR: "#FF0000"
-        SLACK_ICON_EMOJI: ":taco:"
-        SLACK_MESSAGE: " Upgrade failed :x:"
-        SLACK_TITLE: ${{ github.event.repository.name }} upgrade result
-        SLACK_USERNAME: provider-bot
-        SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_URL }}
-      if: failure()
-      name: Send Upgrade Failure To Slack
-      uses: #{{ .Config.actionVersions.slackNotification }}#
 name: Upgrade provider
 on:
   issues:

--- a/provider-ci/test-providers/aws/.github/workflows/build_sdk.yml
+++ b/provider-ci/test-providers/aws/.github/workflows/build_sdk.yml
@@ -26,7 +26,6 @@ env:
   SIGNING_KEY: ${{ secrets.JAVA_SIGNING_KEY }}
   SIGNING_KEY_ID: ${{ secrets.JAVA_SIGNING_KEY_ID }}
   SIGNING_PASSWORD: ${{ secrets.JAVA_SIGNING_PASSWORD }}
-  SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
   TF_APPEND_USER_AGENT: pulumi
   PROVIDER_VERSION: ${{ inputs.version }}
 

--- a/provider-ci/test-providers/aws/.github/workflows/check-upstream-upgrade.yml
+++ b/provider-ci/test-providers/aws/.github/workflows/check-upstream-upgrade.yml
@@ -34,17 +34,6 @@ jobs:
       env:
         REPO: ${{ github.repository }}
       shell: bash
-    - name: Send Check Version Failure To Slack
-      if: failure()
-      uses: rtCamp/action-slack-notify@v2
-      env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
-        SLACK_COLOR: "#FF0000"
-        SLACK_ICON_EMOJI: ":owl:"
-        SLACK_MESSAGE: " Failed to check upstream for a new version "
-        SLACK_TITLE: ${{ github.event.repository.name }} upstream version check
-        SLACK_USERNAME: provider-bot
-        SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_URL }}
 name: Check upstream upgrade
 on:
   workflow_dispatch: {} #so we can run this manually if necessary.

--- a/provider-ci/test-providers/aws/.github/workflows/command-dispatch.yml
+++ b/provider-ci/test-providers/aws/.github/workflows/command-dispatch.yml
@@ -19,7 +19,6 @@ env:
   SIGNING_KEY: ${{ secrets.JAVA_SIGNING_KEY }}
   SIGNING_KEY_ID: ${{ secrets.JAVA_SIGNING_KEY_ID }}
   SIGNING_PASSWORD: ${{ secrets.JAVA_SIGNING_PASSWORD }}
-  SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
   TF_APPEND_USER_AGENT: pulumi
 jobs:
   command-dispatch-for-testing:

--- a/provider-ci/test-providers/aws/.github/workflows/license.yml
+++ b/provider-ci/test-providers/aws/.github/workflows/license.yml
@@ -26,7 +26,6 @@ env:
   SIGNING_KEY: ${{ secrets.JAVA_SIGNING_KEY }}
   SIGNING_KEY_ID: ${{ secrets.JAVA_SIGNING_KEY_ID }}
   SIGNING_PASSWORD: ${{ secrets.JAVA_SIGNING_PASSWORD }}
-  SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
   TF_APPEND_USER_AGENT: pulumi
 
 jobs:

--- a/provider-ci/test-providers/aws/.github/workflows/lint.yml
+++ b/provider-ci/test-providers/aws/.github/workflows/lint.yml
@@ -25,7 +25,6 @@ env:
   SIGNING_KEY: ${{ secrets.JAVA_SIGNING_KEY }}
   SIGNING_KEY_ID: ${{ secrets.JAVA_SIGNING_KEY_ID }}
   SIGNING_PASSWORD: ${{ secrets.JAVA_SIGNING_PASSWORD }}
-  SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
   TF_APPEND_USER_AGENT: pulumi
 
 jobs:

--- a/provider-ci/test-providers/aws/.github/workflows/master.yml
+++ b/provider-ci/test-providers/aws/.github/workflows/master.yml
@@ -172,17 +172,6 @@ jobs:
         java-version: "11"
         node-version: "20.x"
         python-version: "3.11.8"
-    - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
-        SLACK_COLOR: "#FF0000"
-        SLACK_ICON_EMOJI: ":taco:"
-        SLACK_MESSAGE: "Publish failed :x:"
-        SLACK_TITLE: ${{ github.event.repository.name }} upgrade result
-        SLACK_USERNAME: provider-bot
-        SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_URL }}
-      if: failure()
-      name: Send Publish Failure To Slack
-      uses: rtCamp/action-slack-notify@v2
 
   tag_release_if_labeled_needs_release:
     name: Tag release if labeled as needs-release

--- a/provider-ci/test-providers/aws/.github/workflows/master.yml
+++ b/provider-ci/test-providers/aws/.github/workflows/master.yml
@@ -19,7 +19,6 @@ env:
   SIGNING_KEY: ${{ secrets.JAVA_SIGNING_KEY }}
   SIGNING_KEY_ID: ${{ secrets.JAVA_SIGNING_KEY_ID }}
   SIGNING_PASSWORD: ${{ secrets.JAVA_SIGNING_PASSWORD }}
-  SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
   TF_APPEND_USER_AGENT: pulumi
 jobs:
   prerequisites:

--- a/provider-ci/test-providers/aws/.github/workflows/nightly-test.yml
+++ b/provider-ci/test-providers/aws/.github/workflows/nightly-test.yml
@@ -19,7 +19,6 @@ env:
   SIGNING_KEY: ${{ secrets.JAVA_SIGNING_KEY }}
   SIGNING_KEY_ID: ${{ secrets.JAVA_SIGNING_KEY_ID }}
   SIGNING_PASSWORD: ${{ secrets.JAVA_SIGNING_PASSWORD }}
-  SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
   TF_APPEND_USER_AGENT: pulumi
 jobs:
   prerequisites:

--- a/provider-ci/test-providers/aws/.github/workflows/prerelease.yml
+++ b/provider-ci/test-providers/aws/.github/workflows/prerelease.yml
@@ -20,7 +20,6 @@ env:
   SIGNING_KEY: ${{ secrets.JAVA_SIGNING_KEY }}
   SIGNING_KEY_ID: ${{ secrets.JAVA_SIGNING_KEY_ID }}
   SIGNING_PASSWORD: ${{ secrets.JAVA_SIGNING_PASSWORD }}
-  SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
   TF_APPEND_USER_AGENT: pulumi
 jobs:
   prerequisites:

--- a/provider-ci/test-providers/aws/.github/workflows/prerelease.yml
+++ b/provider-ci/test-providers/aws/.github/workflows/prerelease.yml
@@ -116,17 +116,6 @@ jobs:
         java-version: "11"
         node-version: "20.x"
         python-version: "3.11.8"
-    - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
-        SLACK_COLOR: "#FF0000"
-        SLACK_ICON_EMOJI: ":taco:"
-        SLACK_MESSAGE: "Publish failed :x:"
-        SLACK_TITLE: ${{ github.event.repository.name }} upgrade result
-        SLACK_USERNAME: provider-bot
-        SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_URL }}
-      if: failure()
-      name: Send Publish Failure To Slack
-      uses: rtCamp/action-slack-notify@v2
   publish_go_sdk:
     name: publish_go_sdk
     needs: 

--- a/provider-ci/test-providers/aws/.github/workflows/prerequisites.yml
+++ b/provider-ci/test-providers/aws/.github/workflows/prerequisites.yml
@@ -36,7 +36,6 @@ env:
   SIGNING_KEY: ${{ secrets.JAVA_SIGNING_KEY }}
   SIGNING_KEY_ID: ${{ secrets.JAVA_SIGNING_KEY_ID }}
   SIGNING_PASSWORD: ${{ secrets.JAVA_SIGNING_PASSWORD }}
-  SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
   TF_APPEND_USER_AGENT: pulumi
 
 jobs:

--- a/provider-ci/test-providers/aws/.github/workflows/pull-request.yml
+++ b/provider-ci/test-providers/aws/.github/workflows/pull-request.yml
@@ -19,7 +19,6 @@ env:
   SIGNING_KEY: ${{ secrets.JAVA_SIGNING_KEY }}
   SIGNING_KEY_ID: ${{ secrets.JAVA_SIGNING_KEY_ID }}
   SIGNING_PASSWORD: ${{ secrets.JAVA_SIGNING_PASSWORD }}
-  SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
   TF_APPEND_USER_AGENT: pulumi
 jobs:
   comment-on-pr:

--- a/provider-ci/test-providers/aws/.github/workflows/release.yml
+++ b/provider-ci/test-providers/aws/.github/workflows/release.yml
@@ -131,17 +131,6 @@ jobs:
         java-version: "11"
         node-version: "20.x"
         python-version: "3.11.8"
-    - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
-        SLACK_COLOR: "#FF0000"
-        SLACK_ICON_EMOJI: ":taco:"
-        SLACK_MESSAGE: "Publish failed :x:"
-        SLACK_TITLE: ${{ github.event.repository.name }} upgrade result
-        SLACK_USERNAME: provider-bot
-        SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_URL }}
-      if: failure()
-      name: Send Publish Failure To Slack
-      uses: rtCamp/action-slack-notify@v2
   publish_go_sdk:
     name: publish_go_sdk
     needs:

--- a/provider-ci/test-providers/aws/.github/workflows/release.yml
+++ b/provider-ci/test-providers/aws/.github/workflows/release.yml
@@ -19,7 +19,6 @@ env:
   SIGNING_KEY: ${{ secrets.JAVA_SIGNING_KEY }}
   SIGNING_KEY_ID: ${{ secrets.JAVA_SIGNING_KEY_ID }}
   SIGNING_PASSWORD: ${{ secrets.JAVA_SIGNING_PASSWORD }}
-  SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
   TF_APPEND_USER_AGENT: pulumi
 jobs:
   prerequisites:

--- a/provider-ci/test-providers/aws/.github/workflows/resync-build.yml
+++ b/provider-ci/test-providers/aws/.github/workflows/resync-build.yml
@@ -21,7 +21,6 @@ env:
   SIGNING_KEY: ${{ secrets.JAVA_SIGNING_KEY }}
   SIGNING_KEY_ID: ${{ secrets.JAVA_SIGNING_KEY_ID }}
   SIGNING_PASSWORD: ${{ secrets.JAVA_SIGNING_PASSWORD }}
-  SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
   TF_APPEND_USER_AGENT: pulumi
 jobs:
   resync_build:

--- a/provider-ci/test-providers/aws/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/test-providers/aws/.github/workflows/run-acceptance-tests.yml
@@ -20,7 +20,6 @@ env:
   SIGNING_KEY: ${{ secrets.JAVA_SIGNING_KEY }}
   SIGNING_KEY_ID: ${{ secrets.JAVA_SIGNING_KEY_ID }}
   SIGNING_PASSWORD: ${{ secrets.JAVA_SIGNING_PASSWORD }}
-  SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
   TF_APPEND_USER_AGENT: pulumi
 
 # This should cancel any previous runs of the same workflow on the same branch which are still running.

--- a/provider-ci/test-providers/aws/.github/workflows/upgrade-bridge.yml
+++ b/provider-ci/test-providers/aws/.github/workflows/upgrade-bridge.yml
@@ -83,27 +83,3 @@ jobs:
         pr-reviewers: ${{ github.event.client_payload.pr-reviewers }}
         pr-description: ${{ github.event.client_payload.pr-description }}
         pr-title-prefix: ${{ github.event.client_payload.pr-title-prefix }}
-    - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
-        SLACK_COLOR: "#7CFC00"
-        SLACK_ICON_EMOJI: ":taco:"
-        SLACK_MESSAGE: >-
-          Upgrade succeeded :heart_decoration:
-
-          PR opened at github.com/pulumi/${{ github.event.repository.name }}/pulls
-        SLACK_TITLE: ${{ github.event.repository.name }} upgrade result
-        SLACK_USERNAME: provider-bot
-        SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_URL }}
-      name: Send Upgrade Success To Slack
-      uses: rtCamp/action-slack-notify@v2
-    - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
-        SLACK_COLOR: "#FF0000"
-        SLACK_ICON_EMOJI: ":taco:"
-        SLACK_MESSAGE: " Upgrade failed :x:"
-        SLACK_TITLE: ${{ github.event.repository.name }} upgrade result
-        SLACK_USERNAME: provider-bot
-        SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_URL }}
-      if: failure()
-      name: Send Upgrade Failure To Slack
-      uses: rtCamp/action-slack-notify@v2

--- a/provider-ci/test-providers/aws/.github/workflows/upgrade-provider.yml
+++ b/provider-ci/test-providers/aws/.github/workflows/upgrade-provider.yml
@@ -15,30 +15,6 @@ jobs:
         kind: all
         email: bot@pulumi.com
         username: pulumi-bot
-    - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
-        SLACK_COLOR: "#7CFC00"
-        SLACK_ICON_EMOJI: ":taco:"
-        SLACK_MESSAGE: >-
-          Upgrade succeeded :heart_decoration:
-
-          PR opened at github.com/pulumi/${{ github.event.repository.name }}/pulls
-        SLACK_TITLE: ${{ github.event.repository.name }} upgrade result
-        SLACK_USERNAME: provider-bot
-        SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_URL }}
-      name: Send Upgrade Success To Slack
-      uses: rtCamp/action-slack-notify@v2
-    - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
-        SLACK_COLOR: "#FF0000"
-        SLACK_ICON_EMOJI: ":taco:"
-        SLACK_MESSAGE: " Upgrade failed :x:"
-        SLACK_TITLE: ${{ github.event.repository.name }} upgrade result
-        SLACK_USERNAME: provider-bot
-        SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_URL }}
-      if: failure()
-      name: Send Upgrade Failure To Slack
-      uses: rtCamp/action-slack-notify@v2
 name: Upgrade provider
 on:
   issues:

--- a/provider-ci/test-providers/aws/.github/workflows/verify-release.yml
+++ b/provider-ci/test-providers/aws/.github/workflows/verify-release.yml
@@ -42,7 +42,6 @@ env:
   SIGNING_KEY: ${{ secrets.JAVA_SIGNING_KEY }}
   SIGNING_KEY_ID: ${{ secrets.JAVA_SIGNING_KEY_ID }}
   SIGNING_PASSWORD: ${{ secrets.JAVA_SIGNING_PASSWORD }}
-  SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
   TF_APPEND_USER_AGENT: pulumi
 
 jobs:

--- a/provider-ci/test-providers/cloudflare/.github/workflows/build_sdk.yml
+++ b/provider-ci/test-providers/cloudflare/.github/workflows/build_sdk.yml
@@ -25,7 +25,6 @@ env:
   SIGNING_KEY: ${{ secrets.JAVA_SIGNING_KEY }}
   SIGNING_KEY_ID: ${{ secrets.JAVA_SIGNING_KEY_ID }}
   SIGNING_PASSWORD: ${{ secrets.JAVA_SIGNING_PASSWORD }}
-  SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
   TF_APPEND_USER_AGENT: pulumi
   PROVIDER_VERSION: ${{ inputs.version }}
 

--- a/provider-ci/test-providers/cloudflare/.github/workflows/check-upstream-upgrade.yml
+++ b/provider-ci/test-providers/cloudflare/.github/workflows/check-upstream-upgrade.yml
@@ -32,17 +32,6 @@ jobs:
       env:
         REPO: ${{ github.repository }}
       shell: bash
-    - name: Send Check Version Failure To Slack
-      if: failure()
-      uses: rtCamp/action-slack-notify@v2
-      env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
-        SLACK_COLOR: "#FF0000"
-        SLACK_ICON_EMOJI: ":owl:"
-        SLACK_MESSAGE: " Failed to check upstream for a new version "
-        SLACK_TITLE: ${{ github.event.repository.name }} upstream version check
-        SLACK_USERNAME: provider-bot
-        SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_URL }}
 name: Check upstream upgrade
 on:
   workflow_dispatch: {} #so we can run this manually if necessary.

--- a/provider-ci/test-providers/cloudflare/.github/workflows/command-dispatch.yml
+++ b/provider-ci/test-providers/cloudflare/.github/workflows/command-dispatch.yml
@@ -18,7 +18,6 @@ env:
   SIGNING_KEY: ${{ secrets.JAVA_SIGNING_KEY }}
   SIGNING_KEY_ID: ${{ secrets.JAVA_SIGNING_KEY_ID }}
   SIGNING_PASSWORD: ${{ secrets.JAVA_SIGNING_PASSWORD }}
-  SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
   TF_APPEND_USER_AGENT: pulumi
 jobs:
   command-dispatch-for-testing:

--- a/provider-ci/test-providers/cloudflare/.github/workflows/license.yml
+++ b/provider-ci/test-providers/cloudflare/.github/workflows/license.yml
@@ -25,7 +25,6 @@ env:
   SIGNING_KEY: ${{ secrets.JAVA_SIGNING_KEY }}
   SIGNING_KEY_ID: ${{ secrets.JAVA_SIGNING_KEY_ID }}
   SIGNING_PASSWORD: ${{ secrets.JAVA_SIGNING_PASSWORD }}
-  SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
   TF_APPEND_USER_AGENT: pulumi
 
 jobs:

--- a/provider-ci/test-providers/cloudflare/.github/workflows/lint.yml
+++ b/provider-ci/test-providers/cloudflare/.github/workflows/lint.yml
@@ -24,7 +24,6 @@ env:
   SIGNING_KEY: ${{ secrets.JAVA_SIGNING_KEY }}
   SIGNING_KEY_ID: ${{ secrets.JAVA_SIGNING_KEY_ID }}
   SIGNING_PASSWORD: ${{ secrets.JAVA_SIGNING_PASSWORD }}
-  SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
   TF_APPEND_USER_AGENT: pulumi
 
 jobs:

--- a/provider-ci/test-providers/cloudflare/.github/workflows/master.yml
+++ b/provider-ci/test-providers/cloudflare/.github/workflows/master.yml
@@ -168,17 +168,6 @@ jobs:
         java-version: "11"
         node-version: "20.x"
         python-version: "3.11.8"
-    - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
-        SLACK_COLOR: "#FF0000"
-        SLACK_ICON_EMOJI: ":taco:"
-        SLACK_MESSAGE: "Publish failed :x:"
-        SLACK_TITLE: ${{ github.event.repository.name }} upgrade result
-        SLACK_USERNAME: provider-bot
-        SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_URL }}
-      if: failure()
-      name: Send Publish Failure To Slack
-      uses: rtCamp/action-slack-notify@v2
 
   tag_release_if_labeled_needs_release:
     name: Tag release if labeled as needs-release

--- a/provider-ci/test-providers/cloudflare/.github/workflows/master.yml
+++ b/provider-ci/test-providers/cloudflare/.github/workflows/master.yml
@@ -18,7 +18,6 @@ env:
   SIGNING_KEY: ${{ secrets.JAVA_SIGNING_KEY }}
   SIGNING_KEY_ID: ${{ secrets.JAVA_SIGNING_KEY_ID }}
   SIGNING_PASSWORD: ${{ secrets.JAVA_SIGNING_PASSWORD }}
-  SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
   TF_APPEND_USER_AGENT: pulumi
 jobs:
   prerequisites:

--- a/provider-ci/test-providers/cloudflare/.github/workflows/prerelease.yml
+++ b/provider-ci/test-providers/cloudflare/.github/workflows/prerelease.yml
@@ -114,17 +114,6 @@ jobs:
         java-version: "11"
         node-version: "20.x"
         python-version: "3.11.8"
-    - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
-        SLACK_COLOR: "#FF0000"
-        SLACK_ICON_EMOJI: ":taco:"
-        SLACK_MESSAGE: "Publish failed :x:"
-        SLACK_TITLE: ${{ github.event.repository.name }} upgrade result
-        SLACK_USERNAME: provider-bot
-        SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_URL }}
-      if: failure()
-      name: Send Publish Failure To Slack
-      uses: rtCamp/action-slack-notify@v2
   publish_go_sdk:
     name: publish_go_sdk
     needs: 

--- a/provider-ci/test-providers/cloudflare/.github/workflows/prerelease.yml
+++ b/provider-ci/test-providers/cloudflare/.github/workflows/prerelease.yml
@@ -19,7 +19,6 @@ env:
   SIGNING_KEY: ${{ secrets.JAVA_SIGNING_KEY }}
   SIGNING_KEY_ID: ${{ secrets.JAVA_SIGNING_KEY_ID }}
   SIGNING_PASSWORD: ${{ secrets.JAVA_SIGNING_PASSWORD }}
-  SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
   TF_APPEND_USER_AGENT: pulumi
 jobs:
   prerequisites:

--- a/provider-ci/test-providers/cloudflare/.github/workflows/prerequisites.yml
+++ b/provider-ci/test-providers/cloudflare/.github/workflows/prerequisites.yml
@@ -35,7 +35,6 @@ env:
   SIGNING_KEY: ${{ secrets.JAVA_SIGNING_KEY }}
   SIGNING_KEY_ID: ${{ secrets.JAVA_SIGNING_KEY_ID }}
   SIGNING_PASSWORD: ${{ secrets.JAVA_SIGNING_PASSWORD }}
-  SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
   TF_APPEND_USER_AGENT: pulumi
 
 jobs:

--- a/provider-ci/test-providers/cloudflare/.github/workflows/pull-request.yml
+++ b/provider-ci/test-providers/cloudflare/.github/workflows/pull-request.yml
@@ -18,7 +18,6 @@ env:
   SIGNING_KEY: ${{ secrets.JAVA_SIGNING_KEY }}
   SIGNING_KEY_ID: ${{ secrets.JAVA_SIGNING_KEY_ID }}
   SIGNING_PASSWORD: ${{ secrets.JAVA_SIGNING_PASSWORD }}
-  SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
   TF_APPEND_USER_AGENT: pulumi
 jobs:
   comment-on-pr:

--- a/provider-ci/test-providers/cloudflare/.github/workflows/release.yml
+++ b/provider-ci/test-providers/cloudflare/.github/workflows/release.yml
@@ -129,17 +129,6 @@ jobs:
         java-version: "11"
         node-version: "20.x"
         python-version: "3.11.8"
-    - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
-        SLACK_COLOR: "#FF0000"
-        SLACK_ICON_EMOJI: ":taco:"
-        SLACK_MESSAGE: "Publish failed :x:"
-        SLACK_TITLE: ${{ github.event.repository.name }} upgrade result
-        SLACK_USERNAME: provider-bot
-        SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_URL }}
-      if: failure()
-      name: Send Publish Failure To Slack
-      uses: rtCamp/action-slack-notify@v2
   publish_go_sdk:
     name: publish_go_sdk
     needs:

--- a/provider-ci/test-providers/cloudflare/.github/workflows/release.yml
+++ b/provider-ci/test-providers/cloudflare/.github/workflows/release.yml
@@ -18,7 +18,6 @@ env:
   SIGNING_KEY: ${{ secrets.JAVA_SIGNING_KEY }}
   SIGNING_KEY_ID: ${{ secrets.JAVA_SIGNING_KEY_ID }}
   SIGNING_PASSWORD: ${{ secrets.JAVA_SIGNING_PASSWORD }}
-  SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
   TF_APPEND_USER_AGENT: pulumi
 jobs:
   prerequisites:

--- a/provider-ci/test-providers/cloudflare/.github/workflows/resync-build.yml
+++ b/provider-ci/test-providers/cloudflare/.github/workflows/resync-build.yml
@@ -20,7 +20,6 @@ env:
   SIGNING_KEY: ${{ secrets.JAVA_SIGNING_KEY }}
   SIGNING_KEY_ID: ${{ secrets.JAVA_SIGNING_KEY_ID }}
   SIGNING_PASSWORD: ${{ secrets.JAVA_SIGNING_PASSWORD }}
-  SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
   TF_APPEND_USER_AGENT: pulumi
 jobs:
   resync_build:

--- a/provider-ci/test-providers/cloudflare/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/test-providers/cloudflare/.github/workflows/run-acceptance-tests.yml
@@ -19,7 +19,6 @@ env:
   SIGNING_KEY: ${{ secrets.JAVA_SIGNING_KEY }}
   SIGNING_KEY_ID: ${{ secrets.JAVA_SIGNING_KEY_ID }}
   SIGNING_PASSWORD: ${{ secrets.JAVA_SIGNING_PASSWORD }}
-  SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
   TF_APPEND_USER_AGENT: pulumi
 
 # This should cancel any previous runs of the same workflow on the same branch which are still running.

--- a/provider-ci/test-providers/cloudflare/.github/workflows/upgrade-bridge.yml
+++ b/provider-ci/test-providers/cloudflare/.github/workflows/upgrade-bridge.yml
@@ -83,27 +83,3 @@ jobs:
         pr-reviewers: ${{ github.event.client_payload.pr-reviewers }}
         pr-description: ${{ github.event.client_payload.pr-description }}
         pr-title-prefix: ${{ github.event.client_payload.pr-title-prefix }}
-    - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
-        SLACK_COLOR: "#7CFC00"
-        SLACK_ICON_EMOJI: ":taco:"
-        SLACK_MESSAGE: >-
-          Upgrade succeeded :heart_decoration:
-
-          PR opened at github.com/pulumi/${{ github.event.repository.name }}/pulls
-        SLACK_TITLE: ${{ github.event.repository.name }} upgrade result
-        SLACK_USERNAME: provider-bot
-        SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_URL }}
-      name: Send Upgrade Success To Slack
-      uses: rtCamp/action-slack-notify@v2
-    - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
-        SLACK_COLOR: "#FF0000"
-        SLACK_ICON_EMOJI: ":taco:"
-        SLACK_MESSAGE: " Upgrade failed :x:"
-        SLACK_TITLE: ${{ github.event.repository.name }} upgrade result
-        SLACK_USERNAME: provider-bot
-        SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_URL }}
-      if: failure()
-      name: Send Upgrade Failure To Slack
-      uses: rtCamp/action-slack-notify@v2

--- a/provider-ci/test-providers/cloudflare/.github/workflows/upgrade-provider.yml
+++ b/provider-ci/test-providers/cloudflare/.github/workflows/upgrade-provider.yml
@@ -15,30 +15,6 @@ jobs:
         kind: all
         email: bot@pulumi.com
         username: pulumi-bot
-    - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
-        SLACK_COLOR: "#7CFC00"
-        SLACK_ICON_EMOJI: ":taco:"
-        SLACK_MESSAGE: >-
-          Upgrade succeeded :heart_decoration:
-
-          PR opened at github.com/pulumi/${{ github.event.repository.name }}/pulls
-        SLACK_TITLE: ${{ github.event.repository.name }} upgrade result
-        SLACK_USERNAME: provider-bot
-        SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_URL }}
-      name: Send Upgrade Success To Slack
-      uses: rtCamp/action-slack-notify@v2
-    - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
-        SLACK_COLOR: "#FF0000"
-        SLACK_ICON_EMOJI: ":taco:"
-        SLACK_MESSAGE: " Upgrade failed :x:"
-        SLACK_TITLE: ${{ github.event.repository.name }} upgrade result
-        SLACK_USERNAME: provider-bot
-        SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_URL }}
-      if: failure()
-      name: Send Upgrade Failure To Slack
-      uses: rtCamp/action-slack-notify@v2
 name: Upgrade provider
 on:
   issues:

--- a/provider-ci/test-providers/cloudflare/.github/workflows/verify-release.yml
+++ b/provider-ci/test-providers/cloudflare/.github/workflows/verify-release.yml
@@ -41,7 +41,6 @@ env:
   SIGNING_KEY: ${{ secrets.JAVA_SIGNING_KEY }}
   SIGNING_KEY_ID: ${{ secrets.JAVA_SIGNING_KEY_ID }}
   SIGNING_PASSWORD: ${{ secrets.JAVA_SIGNING_PASSWORD }}
-  SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
   TF_APPEND_USER_AGENT: pulumi
 
 jobs:

--- a/provider-ci/test-providers/docker/.github/workflows/build_sdk.yml
+++ b/provider-ci/test-providers/docker/.github/workflows/build_sdk.yml
@@ -38,7 +38,6 @@ env:
   SIGNING_KEY: ${{ secrets.JAVA_SIGNING_KEY }}
   SIGNING_KEY_ID: ${{ secrets.JAVA_SIGNING_KEY_ID }}
   SIGNING_PASSWORD: ${{ secrets.JAVA_SIGNING_PASSWORD }}
-  SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
   TF_APPEND_USER_AGENT: pulumi
   PROVIDER_VERSION: ${{ inputs.version }}
 

--- a/provider-ci/test-providers/docker/.github/workflows/check-upstream-upgrade.yml
+++ b/provider-ci/test-providers/docker/.github/workflows/check-upstream-upgrade.yml
@@ -32,17 +32,6 @@ jobs:
       env:
         REPO: ${{ github.repository }}
       shell: bash
-    - name: Send Check Version Failure To Slack
-      if: failure()
-      uses: rtCamp/action-slack-notify@v2
-      env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
-        SLACK_COLOR: "#FF0000"
-        SLACK_ICON_EMOJI: ":owl:"
-        SLACK_MESSAGE: " Failed to check upstream for a new version "
-        SLACK_TITLE: ${{ github.event.repository.name }} upstream version check
-        SLACK_USERNAME: provider-bot
-        SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_URL }}
 name: Check upstream upgrade
 on:
   workflow_dispatch: {} #so we can run this manually if necessary.

--- a/provider-ci/test-providers/docker/.github/workflows/command-dispatch.yml
+++ b/provider-ci/test-providers/docker/.github/workflows/command-dispatch.yml
@@ -31,7 +31,6 @@ env:
   SIGNING_KEY: ${{ secrets.JAVA_SIGNING_KEY }}
   SIGNING_KEY_ID: ${{ secrets.JAVA_SIGNING_KEY_ID }}
   SIGNING_PASSWORD: ${{ secrets.JAVA_SIGNING_PASSWORD }}
-  SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
   TF_APPEND_USER_AGENT: pulumi
 jobs:
   command-dispatch-for-testing:

--- a/provider-ci/test-providers/docker/.github/workflows/license.yml
+++ b/provider-ci/test-providers/docker/.github/workflows/license.yml
@@ -38,7 +38,6 @@ env:
   SIGNING_KEY: ${{ secrets.JAVA_SIGNING_KEY }}
   SIGNING_KEY_ID: ${{ secrets.JAVA_SIGNING_KEY_ID }}
   SIGNING_PASSWORD: ${{ secrets.JAVA_SIGNING_PASSWORD }}
-  SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
   TF_APPEND_USER_AGENT: pulumi
 
 jobs:

--- a/provider-ci/test-providers/docker/.github/workflows/lint.yml
+++ b/provider-ci/test-providers/docker/.github/workflows/lint.yml
@@ -37,7 +37,6 @@ env:
   SIGNING_KEY: ${{ secrets.JAVA_SIGNING_KEY }}
   SIGNING_KEY_ID: ${{ secrets.JAVA_SIGNING_KEY_ID }}
   SIGNING_PASSWORD: ${{ secrets.JAVA_SIGNING_PASSWORD }}
-  SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
   TF_APPEND_USER_AGENT: pulumi
 
 jobs:

--- a/provider-ci/test-providers/docker/.github/workflows/master.yml
+++ b/provider-ci/test-providers/docker/.github/workflows/master.yml
@@ -31,7 +31,6 @@ env:
   SIGNING_KEY: ${{ secrets.JAVA_SIGNING_KEY }}
   SIGNING_KEY_ID: ${{ secrets.JAVA_SIGNING_KEY_ID }}
   SIGNING_PASSWORD: ${{ secrets.JAVA_SIGNING_PASSWORD }}
-  SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
   TF_APPEND_USER_AGENT: pulumi
 jobs:
   prerequisites:

--- a/provider-ci/test-providers/docker/.github/workflows/master.yml
+++ b/provider-ci/test-providers/docker/.github/workflows/master.yml
@@ -181,17 +181,6 @@ jobs:
         java-version: "11"
         node-version: "20.x"
         python-version: "3.11.8"
-    - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
-        SLACK_COLOR: "#FF0000"
-        SLACK_ICON_EMOJI: ":taco:"
-        SLACK_MESSAGE: "Publish failed :x:"
-        SLACK_TITLE: ${{ github.event.repository.name }} upgrade result
-        SLACK_USERNAME: provider-bot
-        SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_URL }}
-      if: failure()
-      name: Send Publish Failure To Slack
-      uses: rtCamp/action-slack-notify@v2
 
   tag_release_if_labeled_needs_release:
     name: Tag release if labeled as needs-release

--- a/provider-ci/test-providers/docker/.github/workflows/prerelease.yml
+++ b/provider-ci/test-providers/docker/.github/workflows/prerelease.yml
@@ -127,17 +127,6 @@ jobs:
         java-version: "11"
         node-version: "20.x"
         python-version: "3.11.8"
-    - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
-        SLACK_COLOR: "#FF0000"
-        SLACK_ICON_EMOJI: ":taco:"
-        SLACK_MESSAGE: "Publish failed :x:"
-        SLACK_TITLE: ${{ github.event.repository.name }} upgrade result
-        SLACK_USERNAME: provider-bot
-        SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_URL }}
-      if: failure()
-      name: Send Publish Failure To Slack
-      uses: rtCamp/action-slack-notify@v2
   publish_go_sdk:
     name: publish_go_sdk
     needs: 

--- a/provider-ci/test-providers/docker/.github/workflows/prerelease.yml
+++ b/provider-ci/test-providers/docker/.github/workflows/prerelease.yml
@@ -32,7 +32,6 @@ env:
   SIGNING_KEY: ${{ secrets.JAVA_SIGNING_KEY }}
   SIGNING_KEY_ID: ${{ secrets.JAVA_SIGNING_KEY_ID }}
   SIGNING_PASSWORD: ${{ secrets.JAVA_SIGNING_PASSWORD }}
-  SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
   TF_APPEND_USER_AGENT: pulumi
 jobs:
   prerequisites:

--- a/provider-ci/test-providers/docker/.github/workflows/prerequisites.yml
+++ b/provider-ci/test-providers/docker/.github/workflows/prerequisites.yml
@@ -48,7 +48,6 @@ env:
   SIGNING_KEY: ${{ secrets.JAVA_SIGNING_KEY }}
   SIGNING_KEY_ID: ${{ secrets.JAVA_SIGNING_KEY_ID }}
   SIGNING_PASSWORD: ${{ secrets.JAVA_SIGNING_PASSWORD }}
-  SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
   TF_APPEND_USER_AGENT: pulumi
 
 jobs:

--- a/provider-ci/test-providers/docker/.github/workflows/pull-request.yml
+++ b/provider-ci/test-providers/docker/.github/workflows/pull-request.yml
@@ -31,7 +31,6 @@ env:
   SIGNING_KEY: ${{ secrets.JAVA_SIGNING_KEY }}
   SIGNING_KEY_ID: ${{ secrets.JAVA_SIGNING_KEY_ID }}
   SIGNING_PASSWORD: ${{ secrets.JAVA_SIGNING_PASSWORD }}
-  SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
   TF_APPEND_USER_AGENT: pulumi
 jobs:
   comment-on-pr:

--- a/provider-ci/test-providers/docker/.github/workflows/release.yml
+++ b/provider-ci/test-providers/docker/.github/workflows/release.yml
@@ -31,7 +31,6 @@ env:
   SIGNING_KEY: ${{ secrets.JAVA_SIGNING_KEY }}
   SIGNING_KEY_ID: ${{ secrets.JAVA_SIGNING_KEY_ID }}
   SIGNING_PASSWORD: ${{ secrets.JAVA_SIGNING_PASSWORD }}
-  SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
   TF_APPEND_USER_AGENT: pulumi
 jobs:
   prerequisites:

--- a/provider-ci/test-providers/docker/.github/workflows/release.yml
+++ b/provider-ci/test-providers/docker/.github/workflows/release.yml
@@ -142,17 +142,6 @@ jobs:
         java-version: "11"
         node-version: "20.x"
         python-version: "3.11.8"
-    - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
-        SLACK_COLOR: "#FF0000"
-        SLACK_ICON_EMOJI: ":taco:"
-        SLACK_MESSAGE: "Publish failed :x:"
-        SLACK_TITLE: ${{ github.event.repository.name }} upgrade result
-        SLACK_USERNAME: provider-bot
-        SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_URL }}
-      if: failure()
-      name: Send Publish Failure To Slack
-      uses: rtCamp/action-slack-notify@v2
   publish_go_sdk:
     name: publish_go_sdk
     needs:

--- a/provider-ci/test-providers/docker/.github/workflows/resync-build.yml
+++ b/provider-ci/test-providers/docker/.github/workflows/resync-build.yml
@@ -33,7 +33,6 @@ env:
   SIGNING_KEY: ${{ secrets.JAVA_SIGNING_KEY }}
   SIGNING_KEY_ID: ${{ secrets.JAVA_SIGNING_KEY_ID }}
   SIGNING_PASSWORD: ${{ secrets.JAVA_SIGNING_PASSWORD }}
-  SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
   TF_APPEND_USER_AGENT: pulumi
 jobs:
   resync_build:

--- a/provider-ci/test-providers/docker/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/test-providers/docker/.github/workflows/run-acceptance-tests.yml
@@ -32,7 +32,6 @@ env:
   SIGNING_KEY: ${{ secrets.JAVA_SIGNING_KEY }}
   SIGNING_KEY_ID: ${{ secrets.JAVA_SIGNING_KEY_ID }}
   SIGNING_PASSWORD: ${{ secrets.JAVA_SIGNING_PASSWORD }}
-  SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
   TF_APPEND_USER_AGENT: pulumi
 
 # This should cancel any previous runs of the same workflow on the same branch which are still running.

--- a/provider-ci/test-providers/docker/.github/workflows/upgrade-bridge.yml
+++ b/provider-ci/test-providers/docker/.github/workflows/upgrade-bridge.yml
@@ -83,27 +83,3 @@ jobs:
         pr-reviewers: ${{ github.event.client_payload.pr-reviewers }}
         pr-description: ${{ github.event.client_payload.pr-description }}
         pr-title-prefix: ${{ github.event.client_payload.pr-title-prefix }}
-    - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
-        SLACK_COLOR: "#7CFC00"
-        SLACK_ICON_EMOJI: ":taco:"
-        SLACK_MESSAGE: >-
-          Upgrade succeeded :heart_decoration:
-
-          PR opened at github.com/pulumi/${{ github.event.repository.name }}/pulls
-        SLACK_TITLE: ${{ github.event.repository.name }} upgrade result
-        SLACK_USERNAME: provider-bot
-        SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_URL }}
-      name: Send Upgrade Success To Slack
-      uses: rtCamp/action-slack-notify@v2
-    - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
-        SLACK_COLOR: "#FF0000"
-        SLACK_ICON_EMOJI: ":taco:"
-        SLACK_MESSAGE: " Upgrade failed :x:"
-        SLACK_TITLE: ${{ github.event.repository.name }} upgrade result
-        SLACK_USERNAME: provider-bot
-        SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_URL }}
-      if: failure()
-      name: Send Upgrade Failure To Slack
-      uses: rtCamp/action-slack-notify@v2

--- a/provider-ci/test-providers/docker/.github/workflows/upgrade-provider.yml
+++ b/provider-ci/test-providers/docker/.github/workflows/upgrade-provider.yml
@@ -15,30 +15,6 @@ jobs:
         kind: all
         email: bot@pulumi.com
         username: pulumi-bot
-    - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
-        SLACK_COLOR: "#7CFC00"
-        SLACK_ICON_EMOJI: ":taco:"
-        SLACK_MESSAGE: >-
-          Upgrade succeeded :heart_decoration:
-
-          PR opened at github.com/pulumi/${{ github.event.repository.name }}/pulls
-        SLACK_TITLE: ${{ github.event.repository.name }} upgrade result
-        SLACK_USERNAME: provider-bot
-        SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_URL }}
-      name: Send Upgrade Success To Slack
-      uses: rtCamp/action-slack-notify@v2
-    - env:
-        SLACK_CHANNEL: provider-upgrade-publish-status
-        SLACK_COLOR: "#FF0000"
-        SLACK_ICON_EMOJI: ":taco:"
-        SLACK_MESSAGE: " Upgrade failed :x:"
-        SLACK_TITLE: ${{ github.event.repository.name }} upgrade result
-        SLACK_USERNAME: provider-bot
-        SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_URL }}
-      if: failure()
-      name: Send Upgrade Failure To Slack
-      uses: rtCamp/action-slack-notify@v2
 name: Upgrade provider
 on:
   issues:

--- a/provider-ci/test-providers/docker/.github/workflows/verify-release.yml
+++ b/provider-ci/test-providers/docker/.github/workflows/verify-release.yml
@@ -54,7 +54,6 @@ env:
   SIGNING_KEY: ${{ secrets.JAVA_SIGNING_KEY }}
   SIGNING_KEY_ID: ${{ secrets.JAVA_SIGNING_KEY_ID }}
   SIGNING_PASSWORD: ${{ secrets.JAVA_SIGNING_PASSWORD }}
-  SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
   TF_APPEND_USER_AGENT: pulumi
 
 jobs:


### PR DESCRIPTION
fixes https://github.com/pulumi/ci-mgmt/issues/956

The slack notifications are no longer used - we now have automation which opens issues for failures instead.