### PR TITLE
Add documentation for license check ignore option

### DIFF
--- a/provider-ci/internal/pkg/templates/bridged-provider.config.yaml
+++ b/provider-ci/internal/pkg/templates/bridged-provider.config.yaml
@@ -229,3 +229,12 @@ publish:
 #nixpkgs:
 # - name: foo
 #   version: 1.2.3
+
+# Package paths to ignore when running the license check
+#license:
+#  ignore:
+#    # Add comment to explain why skipping this license check is OK, e.g. "These projects don't have a LICENSE file,
+#    # but do say mention (in README.md) that they are under Apache-2.0."
+#    - github.com/alibabacloud-go/endpoint-util/service
+#    - github.com/alibabacloud-go/tea-roa-utils/service
+#    - github.com/alibabacloud-go/tea-roa/client


### PR DESCRIPTION
This field was missing in the config.yaml docs.

Real-world example: https://github.com/pulumi/pulumi-alicloud/blob/34d9dd0891282f9e0c4eb4d284ac1e560e2ea678/.ci-mgmt.yaml#L24