### PR TITLE
Fix new provider build when missing schema-embed

### DIFF
--- a/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/build_provider.yml
+++ b/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/build_provider.yml
@@ -50,7 +50,10 @@ jobs:
       - name: Download schema-embed.json
         uses: #{{ .Config.actionVersions.downloadArtifact }}#
         with:
-          name: schema-embed.json
+          # Use a pattern to avoid failing if the artifact doesn't exist
+          pattern: schema-embed.*
+          # Avoid creating directories for each artifact
+          merge-multiple: true
           path: provider/cmd/pulumi-resource-#{{ .Config.provider }}#/schema-embed.json
       - name: Prepare for build
         # This installs plugins and prepares upstream

--- a/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/run-acceptance-tests.yml
@@ -66,6 +66,7 @@ jobs:
       github.event.pull_request.head.repo.full_name == github.repository
     needs:
     - test
+    - build_provider
     - license_check
     #{{- if .Config.lint }}#
     - lint

--- a/provider-ci/internal/pkg/templates/bridged-provider/Makefile
+++ b/provider-ci/internal/pkg/templates/bridged-provider/Makefile
@@ -244,7 +244,7 @@ bin/linux-arm64/$(PROVIDER): TARGET := linux-arm64
 bin/darwin-amd64/$(PROVIDER): TARGET := darwin-amd64
 bin/darwin-arm64/$(PROVIDER): TARGET := darwin-arm64
 bin/windows-amd64/$(PROVIDER).exe: TARGET := windows-amd64
-bin/%/$(PROVIDER) bin/%/$(PROVIDER).exe: provider/cmd/$(PROVIDER)/schema-embed.json
+bin/%/$(PROVIDER) bin/%/$(PROVIDER).exe:
 	@# check the TARGET is set
 	test $(TARGET)
 	cd provider && \

--- a/provider-ci/test-providers/aws/.github/workflows/build_provider.yml
+++ b/provider-ci/test-providers/aws/.github/workflows/build_provider.yml
@@ -46,7 +46,10 @@ jobs:
       - name: Download schema-embed.json
         uses: actions/download-artifact@v4
         with:
-          name: schema-embed.json
+          # Use a pattern to avoid failing if the artifact doesn't exist
+          pattern: schema-embed.*
+          # Avoid creating directories for each artifact
+          merge-multiple: true
           path: provider/cmd/pulumi-resource-aws/schema-embed.json
       - name: Prepare for build
         # This installs plugins and prepares upstream

--- a/provider-ci/test-providers/aws/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/test-providers/aws/.github/workflows/run-acceptance-tests.yml
@@ -75,6 +75,7 @@ jobs:
       github.event.pull_request.head.repo.full_name == github.repository
     needs:
     - test
+    - build_provider
     - license_check
     - go_test_shim
     - provider_test

--- a/provider-ci/test-providers/aws/Makefile
+++ b/provider-ci/test-providers/aws/Makefile
@@ -225,7 +225,7 @@ bin/linux-arm64/$(PROVIDER): TARGET := linux-arm64
 bin/darwin-amd64/$(PROVIDER): TARGET := darwin-amd64
 bin/darwin-arm64/$(PROVIDER): TARGET := darwin-arm64
 bin/windows-amd64/$(PROVIDER).exe: TARGET := windows-amd64
-bin/%/$(PROVIDER) bin/%/$(PROVIDER).exe: provider/cmd/$(PROVIDER)/schema-embed.json
+bin/%/$(PROVIDER) bin/%/$(PROVIDER).exe:
 	@# check the TARGET is set
 	test $(TARGET)
 	cd provider && \

--- a/provider-ci/test-providers/cloudflare/.github/workflows/build_provider.yml
+++ b/provider-ci/test-providers/cloudflare/.github/workflows/build_provider.yml
@@ -38,7 +38,10 @@ jobs:
       - name: Download schema-embed.json
         uses: actions/download-artifact@v4
         with:
-          name: schema-embed.json
+          # Use a pattern to avoid failing if the artifact doesn't exist
+          pattern: schema-embed.*
+          # Avoid creating directories for each artifact
+          merge-multiple: true
           path: provider/cmd/pulumi-resource-cloudflare/schema-embed.json
       - name: Prepare for build
         # This installs plugins and prepares upstream

--- a/provider-ci/test-providers/cloudflare/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/test-providers/cloudflare/.github/workflows/run-acceptance-tests.yml
@@ -80,6 +80,7 @@ jobs:
       github.event.pull_request.head.repo.full_name == github.repository
     needs:
     - test
+    - build_provider
     - license_check
     - lint
     runs-on: ubuntu-latest

--- a/provider-ci/test-providers/cloudflare/Makefile
+++ b/provider-ci/test-providers/cloudflare/Makefile
@@ -214,7 +214,7 @@ bin/linux-arm64/$(PROVIDER): TARGET := linux-arm64
 bin/darwin-amd64/$(PROVIDER): TARGET := darwin-amd64
 bin/darwin-arm64/$(PROVIDER): TARGET := darwin-arm64
 bin/windows-amd64/$(PROVIDER).exe: TARGET := windows-amd64
-bin/%/$(PROVIDER) bin/%/$(PROVIDER).exe: provider/cmd/$(PROVIDER)/schema-embed.json
+bin/%/$(PROVIDER) bin/%/$(PROVIDER).exe:
 	@# check the TARGET is set
 	test $(TARGET)
 	cd provider && \

--- a/provider-ci/test-providers/docker/.github/workflows/build_provider.yml
+++ b/provider-ci/test-providers/docker/.github/workflows/build_provider.yml
@@ -38,7 +38,10 @@ jobs:
       - name: Download schema-embed.json
         uses: actions/download-artifact@v4
         with:
-          name: schema-embed.json
+          # Use a pattern to avoid failing if the artifact doesn't exist
+          pattern: schema-embed.*
+          # Avoid creating directories for each artifact
+          merge-multiple: true
           path: provider/cmd/pulumi-resource-docker/schema-embed.json
       - name: Prepare for build
         # This installs plugins and prepares upstream

--- a/provider-ci/test-providers/docker/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/test-providers/docker/.github/workflows/run-acceptance-tests.yml
@@ -93,6 +93,7 @@ jobs:
       github.event.pull_request.head.repo.full_name == github.repository
     needs:
     - test
+    - build_provider
     - license_check
     - lint
     runs-on: ubuntu-latest

--- a/provider-ci/test-providers/docker/Makefile
+++ b/provider-ci/test-providers/docker/Makefile
@@ -215,7 +215,7 @@ bin/linux-arm64/$(PROVIDER): TARGET := linux-arm64
 bin/darwin-amd64/$(PROVIDER): TARGET := darwin-amd64
 bin/darwin-arm64/$(PROVIDER): TARGET := darwin-arm64
 bin/windows-amd64/$(PROVIDER).exe: TARGET := windows-amd64
-bin/%/$(PROVIDER) bin/%/$(PROVIDER).exe: provider/cmd/$(PROVIDER)/schema-embed.json
+bin/%/$(PROVIDER) bin/%/$(PROVIDER).exe:
 	@# check the TARGET is set
 	test $(TARGET)
 	cd provider && \


### PR DESCRIPTION
Around 20 providers don't generate a `schema-embed.json` (e.g. because the schema is not massive). This causes 2 issues:
1. A named artifact download fails if not found.
2. The makefile target will fail if a dependency does not exist.

Example: https://github.com/pulumi/pulumi-azuredevops/pull/438
Note: this failed the PR builds for providers without the schema-embed.json file, but still got auto-merged by GitHub.

To make the `schema-embed.json` file optional we can:
1. Make the artifact download use a pattern which can validly match zero paths.
2. Remove the makefile target dependency.

This change has been manually tested via a PR to p-azuredevops: https://github.com/pulumi/pulumi-azuredevops/pull/440