### PR TITLE
Make log outputs optional in the issue template

### DIFF
--- a/provider-ci/internal/pkg/templates/provider/.github/ISSUE_TEMPLATE/bug.yaml
+++ b/provider-ci/internal/pkg/templates/provider/.github/ISSUE_TEMPLATE/bug.yaml
@@ -39,8 +39,6 @@ body:
         We may also ask you to supply us with debug output following [these steps](https://www.pulumi.com/docs/using-pulumi/pulumi-packages/debugging-provider-packages/).
         **Note:** If the log output is more than a few lines, please send us a Gist or a link to a file.
         </details>
-    validations:
-      required: true
   - type: textarea
     id: resources
     attributes:

--- a/provider-ci/test-providers/aws/.github/ISSUE_TEMPLATE/bug.yaml
+++ b/provider-ci/test-providers/aws/.github/ISSUE_TEMPLATE/bug.yaml
@@ -39,8 +39,6 @@ body:
         We may also ask you to supply us with debug output following [these steps](https://www.pulumi.com/docs/using-pulumi/pulumi-packages/debugging-provider-packages/).
         **Note:** If the log output is more than a few lines, please send us a Gist or a link to a file.
         </details>
-    validations:
-      required: true
   - type: textarea
     id: resources
     attributes:

--- a/provider-ci/test-providers/cloudflare/.github/ISSUE_TEMPLATE/bug.yaml
+++ b/provider-ci/test-providers/cloudflare/.github/ISSUE_TEMPLATE/bug.yaml
@@ -39,8 +39,6 @@ body:
         We may also ask you to supply us with debug output following [these steps](https://www.pulumi.com/docs/using-pulumi/pulumi-packages/debugging-provider-packages/).
         **Note:** If the log output is more than a few lines, please send us a Gist or a link to a file.
         </details>
-    validations:
-      required: true
   - type: textarea
     id: resources
     attributes:

--- a/provider-ci/test-providers/docker/.github/ISSUE_TEMPLATE/bug.yaml
+++ b/provider-ci/test-providers/docker/.github/ISSUE_TEMPLATE/bug.yaml
@@ -39,8 +39,6 @@ body:
         We may also ask you to supply us with debug output following [these steps](https://www.pulumi.com/docs/using-pulumi/pulumi-packages/debugging-provider-packages/).
         **Note:** If the log output is more than a few lines, please send us a Gist or a link to a file.
         </details>
-    validations:
-      required: true
   - type: textarea
     id: resources
     attributes:


### PR DESCRIPTION
We don't need log outputs if a clear repro is given for an issue, so it's unnecessary to require that. It raises the barrier to reporting an issue, possibly costing us bug reports.

I haven't seen a pulumi engineer add logs when reporting an issue, except when that's meaningful, so we shouldn't expect outside contributors to do that.