### PR TITLE
Remove missing PR_COMMIT_SHA from license check

### DIFF
--- a/provider-ci/internal/pkg/templates/provider/.github/workflows/license.yml
+++ b/provider-ci/internal/pkg/templates/provider/.github/workflows/license.yml
@@ -6,7 +6,6 @@ on:
   workflow_call:
     inputs: {}
 
-
 env:
 #{{ .Config.env | toYaml | indent 2 }}#
 
@@ -15,36 +14,34 @@ jobs:
     name: License Check
     runs-on: #{{ .Config.runner.default }}#
     steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v4
-      with:
-        ref: ${{ env.PR_COMMIT_SHA }}
-    - name: Setup tools
-      uses: ./.github/actions/setup-tools
-      with:
-        tools: go
-    - run: make upstream
-    - uses: pulumi/license-check-action@main
-      with:
-        module-path: provider
-        ignore-modules: >-
-          #{{ range $ignore := .Config.license.ignore }}#
-          #{{- $ignore -}}#,
-          #{{ end -}}#
-          github.com/aead/chacha20,
-          github.com/apache/arrow/go/v12,
-          github.com/apache/thrift/lib/go/thrift,
-          github.com/cloudflare/circl,
-          github.com/golang,
-          github.com/gorhill/cronexpr,
-          github.com/in-toto/in-toto-golang,
-          github.com/jmespath/go-jmespath,
-          github.com/keybase/go-crypto,
-          github.com/klauspost/compress,
-          github.com/mattn/go-localereader,
-          github.com/modern-go/reflect2,
-          github.com/pierrec/lz4,
-          github.com/pjbgf/sha1cd,
-          github.com/pulumi,
-          github.com/segmentio/asm,
-          golang.org
+      - name: Checkout Repo
+        uses: actions/checkout@v4
+      - name: Setup tools
+        uses: ./.github/actions/setup-tools
+        with:
+          tools: go
+      - run: make upstream
+      - uses: pulumi/license-check-action@main
+        with:
+          module-path: provider
+          ignore-modules: >-
+            #{{ range $ignore := .Config.license.ignore }}#
+            #{{- $ignore -}}#,
+            #{{ end -}}#
+            github.com/aead/chacha20,
+            github.com/apache/arrow/go/v12,
+            github.com/apache/thrift/lib/go/thrift,
+            github.com/cloudflare/circl,
+            github.com/golang,
+            github.com/gorhill/cronexpr,
+            github.com/in-toto/in-toto-golang,
+            github.com/jmespath/go-jmespath,
+            github.com/keybase/go-crypto,
+            github.com/klauspost/compress,
+            github.com/mattn/go-localereader,
+            github.com/modern-go/reflect2,
+            github.com/pierrec/lz4,
+            github.com/pjbgf/sha1cd,
+            github.com/pulumi,
+            github.com/segmentio/asm,
+            golang.org

--- a/provider-ci/test-providers/aws/.github/workflows/license.yml
+++ b/provider-ci/test-providers/aws/.github/workflows/license.yml
@@ -6,7 +6,6 @@ on:
   workflow_call:
     inputs: {}
 
-
 env:
   AWS_REGION: us-west-2
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -33,33 +32,31 @@ jobs:
     name: License Check
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v4
-      with:
-        ref: ${{ env.PR_COMMIT_SHA }}
-    - name: Setup tools
-      uses: ./.github/actions/setup-tools
-      with:
-        tools: go
-    - run: make upstream
-    - uses: pulumi/license-check-action@main
-      with:
-        module-path: provider
-        ignore-modules: >-
-          github.com/aead/chacha20,
-          github.com/apache/arrow/go/v12,
-          github.com/apache/thrift/lib/go/thrift,
-          github.com/cloudflare/circl,
-          github.com/golang,
-          github.com/gorhill/cronexpr,
-          github.com/in-toto/in-toto-golang,
-          github.com/jmespath/go-jmespath,
-          github.com/keybase/go-crypto,
-          github.com/klauspost/compress,
-          github.com/mattn/go-localereader,
-          github.com/modern-go/reflect2,
-          github.com/pierrec/lz4,
-          github.com/pjbgf/sha1cd,
-          github.com/pulumi,
-          github.com/segmentio/asm,
-          golang.org
+      - name: Checkout Repo
+        uses: actions/checkout@v4
+      - name: Setup tools
+        uses: ./.github/actions/setup-tools
+        with:
+          tools: go
+      - run: make upstream
+      - uses: pulumi/license-check-action@main
+        with:
+          module-path: provider
+          ignore-modules: >-
+            github.com/aead/chacha20,
+            github.com/apache/arrow/go/v12,
+            github.com/apache/thrift/lib/go/thrift,
+            github.com/cloudflare/circl,
+            github.com/golang,
+            github.com/gorhill/cronexpr,
+            github.com/in-toto/in-toto-golang,
+            github.com/jmespath/go-jmespath,
+            github.com/keybase/go-crypto,
+            github.com/klauspost/compress,
+            github.com/mattn/go-localereader,
+            github.com/modern-go/reflect2,
+            github.com/pierrec/lz4,
+            github.com/pjbgf/sha1cd,
+            github.com/pulumi,
+            github.com/segmentio/asm,
+            golang.org

--- a/provider-ci/test-providers/cloudflare/.github/workflows/license.yml
+++ b/provider-ci/test-providers/cloudflare/.github/workflows/license.yml
@@ -6,7 +6,6 @@ on:
   workflow_call:
     inputs: {}
 
-
 env:
   CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
   CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
@@ -32,33 +31,31 @@ jobs:
     name: License Check
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v4
-      with:
-        ref: ${{ env.PR_COMMIT_SHA }}
-    - name: Setup tools
-      uses: ./.github/actions/setup-tools
-      with:
-        tools: go
-    - run: make upstream
-    - uses: pulumi/license-check-action@main
-      with:
-        module-path: provider
-        ignore-modules: >-
-          github.com/aead/chacha20,
-          github.com/apache/arrow/go/v12,
-          github.com/apache/thrift/lib/go/thrift,
-          github.com/cloudflare/circl,
-          github.com/golang,
-          github.com/gorhill/cronexpr,
-          github.com/in-toto/in-toto-golang,
-          github.com/jmespath/go-jmespath,
-          github.com/keybase/go-crypto,
-          github.com/klauspost/compress,
-          github.com/mattn/go-localereader,
-          github.com/modern-go/reflect2,
-          github.com/pierrec/lz4,
-          github.com/pjbgf/sha1cd,
-          github.com/pulumi,
-          github.com/segmentio/asm,
-          golang.org
+      - name: Checkout Repo
+        uses: actions/checkout@v4
+      - name: Setup tools
+        uses: ./.github/actions/setup-tools
+        with:
+          tools: go
+      - run: make upstream
+      - uses: pulumi/license-check-action@main
+        with:
+          module-path: provider
+          ignore-modules: >-
+            github.com/aead/chacha20,
+            github.com/apache/arrow/go/v12,
+            github.com/apache/thrift/lib/go/thrift,
+            github.com/cloudflare/circl,
+            github.com/golang,
+            github.com/gorhill/cronexpr,
+            github.com/in-toto/in-toto-golang,
+            github.com/jmespath/go-jmespath,
+            github.com/keybase/go-crypto,
+            github.com/klauspost/compress,
+            github.com/mattn/go-localereader,
+            github.com/modern-go/reflect2,
+            github.com/pierrec/lz4,
+            github.com/pjbgf/sha1cd,
+            github.com/pulumi,
+            github.com/segmentio/asm,
+            golang.org

--- a/provider-ci/test-providers/docker/.github/workflows/license.yml
+++ b/provider-ci/test-providers/docker/.github/workflows/license.yml
@@ -6,7 +6,6 @@ on:
   workflow_call:
     inputs: {}
 
-
 env:
   ARM_CLIENT_ID: 30e520fa-12b4-4e21-b473-9426c5ac2e1e
   ARM_CLIENT_SECRET: ${{ secrets.ARM_CLIENT_SECRET }}
@@ -45,33 +44,31 @@ jobs:
     name: License Check
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v4
-      with:
-        ref: ${{ env.PR_COMMIT_SHA }}
-    - name: Setup tools
-      uses: ./.github/actions/setup-tools
-      with:
-        tools: go
-    - run: make upstream
-    - uses: pulumi/license-check-action@main
-      with:
-        module-path: provider
-        ignore-modules: >-
-          github.com/aead/chacha20,
-          github.com/apache/arrow/go/v12,
-          github.com/apache/thrift/lib/go/thrift,
-          github.com/cloudflare/circl,
-          github.com/golang,
-          github.com/gorhill/cronexpr,
-          github.com/in-toto/in-toto-golang,
-          github.com/jmespath/go-jmespath,
-          github.com/keybase/go-crypto,
-          github.com/klauspost/compress,
-          github.com/mattn/go-localereader,
-          github.com/modern-go/reflect2,
-          github.com/pierrec/lz4,
-          github.com/pjbgf/sha1cd,
-          github.com/pulumi,
-          github.com/segmentio/asm,
-          golang.org
+      - name: Checkout Repo
+        uses: actions/checkout@v4
+      - name: Setup tools
+        uses: ./.github/actions/setup-tools
+        with:
+          tools: go
+      - run: make upstream
+      - uses: pulumi/license-check-action@main
+        with:
+          module-path: provider
+          ignore-modules: >-
+            github.com/aead/chacha20,
+            github.com/apache/arrow/go/v12,
+            github.com/apache/thrift/lib/go/thrift,
+            github.com/cloudflare/circl,
+            github.com/golang,
+            github.com/gorhill/cronexpr,
+            github.com/in-toto/in-toto-golang,
+            github.com/jmespath/go-jmespath,
+            github.com/keybase/go-crypto,
+            github.com/klauspost/compress,
+            github.com/mattn/go-localereader,
+            github.com/modern-go/reflect2,
+            github.com/pierrec/lz4,
+            github.com/pjbgf/sha1cd,
+            github.com/pulumi,
+            github.com/segmentio/asm,
+            golang.org


### PR DESCRIPTION
- This is a left-over from the old acceptance test setup - this ENV variable is no longer set in this context.
- Just use the default checkout behaviour.
- Reformat YAML (add indent on list items & remove duplicate line breaks). See [diff ignoring whitespace](https://github.com/pulumi/ci-mgmt/pull/1036/files?w=1)