### PR TITLE
Remove use of actions hooks

### DIFF
--- a/provider-ci/internal/pkg/templates/bridged-provider.config.yaml
+++ b/provider-ci/internal/pkg/templates/bridged-provider.config.yaml
@@ -129,6 +129,9 @@ extraTests:
 #     name: My Test
 #     ...
 
+# Run e2e tests in the provider as well as in the examples directory
+integrationTestProvider: false
+
 # Run e2e tests using the examples and test suite in the pulumi/examples repo.
 # This is unused: https://github.com/search?q=org%3Apulumi+path%3A.ci-mgmt.yaml+%22testPulumiExamples%3A%22&type=code
 testPulumiExamples: false

--- a/provider-ci/internal/pkg/templates/bridged-provider.config.yaml
+++ b/provider-ci/internal/pkg/templates/bridged-provider.config.yaml
@@ -211,6 +211,11 @@ publish:
 # Used in 9 providers: https://github.com/search?q=org%3Apulumi+path%3A.ci-mgmt.yaml+%22docker%3A%22&type=code
 #docker: false
 
+# Setup SSH with specified private key before running tests in CI job.
+# This should be provided from a secret
+# Used by the docker provider only: https://github.com/search?q=org%3Apulumi+path%3A.ci-mgmt.yaml+%22sshPrivateKey%3A%22&type=code
+#sshPrivateKey: ${{ secrets.PRIVATE_SSH_KEY_FOR_DIGITALOCEAN }}
+
 # Authenticate with GCP before running tests in CI job
 # Used in gcp and docker: https://github.com/search?q=org%3Apulumi+path%3A.ci-mgmt.yaml+%22gcp%3A%22&type=code
 #gcp: false

--- a/provider-ci/internal/pkg/templates/bridged-provider.config.yaml
+++ b/provider-ci/internal/pkg/templates/bridged-provider.config.yaml
@@ -112,15 +112,6 @@ env:
   # Bridge-related - could be set in makefile instead?
   TF_APPEND_USER_AGENT: pulumi
 
-# actions can contain preBuild and preTest additional steps to be spliced into workflows.
-# The use of these hooks vary - quite a few just build upstream and run provider tests.
-# Usage: https://github.com/search?q=org%3Apulumi+path%3A.ci-mgmt.yaml+%22actions%3A%22&type=code
-actions: {}
-  # preBuild:
-  #  - Your action here
-  # preTest:
-  #  - Your action here
-
 # Additional tests run as part of `run-acceptance-tests.yml`, `master.yml`, `main.yml`,
 # `prerelease.yml` and `release.yml`.
 # Only used for aws: https://github.com/search?q=org%3Apulumi+path%3A.ci-mgmt.yaml+%22extraTests%3A%22&type=code

--- a/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/main.yml
+++ b/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/main.yml
@@ -211,9 +211,6 @@ jobs:
       with:
         token: ${{ secrets.GITHUB_TOKEN }}
         version: v2.5.0
-#{{- if .Config.actions.preTest }}#
-#{{ .Config.actions.preTest | toYaml | indent 4 }}#
-#{{- end }}#
     #{{- if .Config.integrationTestProvider }}#
     - name: Run provider tests
       working-directory: provider

--- a/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/main.yml
+++ b/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/main.yml
@@ -190,6 +190,10 @@ jobs:
     - name: Login to Google Cloud Registry
       run: gcloud --quiet auth configure-docker
     #{{- end }}#
+    #{{- if .Config.integrationTestProvider }}#
+    - name: Prepare upstream code
+      run: make upstream
+    #{{- end }}#
     #{{- if index .Config "setup-script" }}#
     - name: Run setup script
       run: #{{ index .Config "setup-script" }}#
@@ -204,9 +208,13 @@ jobs:
 #{{- if .Config.actions.preTest }}#
 #{{ .Config.actions.preTest | toYaml | indent 4 }}#
 #{{- end }}#
+    #{{- if .Config.integrationTestProvider }}#
+    - name: Run provider tests
+      working-directory: provider
+      run: go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt
+    #{{- end }}#
     - name: Run tests
-      run: cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{
-        matrix.language }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt
+      run: cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt
     strategy:
       fail-fast: false
       matrix:

--- a/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/main.yml
+++ b/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/main.yml
@@ -190,6 +190,12 @@ jobs:
     - name: Login to Google Cloud Registry
       run: gcloud --quiet auth configure-docker
     #{{- end }}#
+    #{{- if .Config.sshPrivateKey }}#
+    - name: Setup SSH key
+      uses: webfactory/ssh-agent@v0.7.0
+      with:
+        ssh-private-key: #{{ .Config.sshPrivateKey }}#
+    #{{- end }}#
     #{{- if .Config.integrationTestProvider }}#
     - name: Prepare upstream code
       run: make upstream

--- a/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/nightly-test.yml
+++ b/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/nightly-test.yml
@@ -124,9 +124,6 @@ jobs:
       with:
         token: ${{ secrets.GITHUB_TOKEN }}
         version: v2.5.0
-#{{- if .Config.actions.preTest }}#
-#{{ .Config.actions.preTest | toYaml | indent 4 }}#
-#{{- end }}#
     #{{- if .Config.integrationTestProvider }}#
     - name: Run provider tests
       if: matrix.testTarget == 'local'

--- a/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/nightly-test.yml
+++ b/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/nightly-test.yml
@@ -103,6 +103,16 @@ jobs:
     - name: Login to Google Cloud Registry
       run: gcloud --quiet auth configure-docker
     #{{- end }}#
+    #{{- if .Config.sshPrivateKey }}#
+    - name: Setup SSH key
+      uses: webfactory/ssh-agent@v0.7.0
+      with:
+        ssh-private-key: #{{ .Config.sshPrivateKey }}#
+    #{{- end }}#
+    #{{- if .Config.integrationTestProvider }}#
+    - name: Prepare upstream code
+      run: make upstream
+    #{{- end }}#
     #{{- if index .Config "setup-script" }}#
     - name: Run setup script
       run: #{{ index .Config "setup-script" }}#
@@ -117,6 +127,12 @@ jobs:
 #{{- if .Config.actions.preTest }}#
 #{{ .Config.actions.preTest | toYaml | indent 4 }}#
 #{{- end }}#
+    #{{- if .Config.integrationTestProvider }}#
+    - name: Run provider tests
+      if: matrix.testTarget == 'local'
+      working-directory: provider
+      run: go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt
+    #{{- end }}#
     - name: Run tests
       run: cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{
         matrix.language }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt

--- a/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/prerelease.yml
+++ b/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/prerelease.yml
@@ -131,6 +131,10 @@ jobs:
     - name: Login to Google Cloud Registry
       run: gcloud --quiet auth configure-docker
     #{{- end }}#
+    #{{- if .Config.integrationTestProvider }}#
+    - name: Prepare upstream code
+      run: make upstream
+    #{{- end }}#
     #{{- if index .Config "setup-script" }}#
     - name: Run setup script
       run: #{{ index .Config "setup-script" }}#
@@ -145,9 +149,13 @@ jobs:
 #{{- if .Config.actions.preTest }}#
 #{{ .Config.actions.preTest | toYaml | indent 4 }}#
 #{{- end }}#
+    #{{- if .Config.integrationTestProvider }}#
+    - name: Run provider tests
+      working-directory: provider
+      run: go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt
+    #{{- end }}#
     - name: Run tests
-      run: cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{
-        matrix.language }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt
+      run: cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt
     strategy:
       fail-fast: false
       matrix:

--- a/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/prerelease.yml
+++ b/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/prerelease.yml
@@ -152,9 +152,6 @@ jobs:
       with:
         token: ${{ secrets.GITHUB_TOKEN }}
         version: v2.5.0
-#{{- if .Config.actions.preTest }}#
-#{{ .Config.actions.preTest | toYaml | indent 4 }}#
-#{{- end }}#
     #{{- if .Config.integrationTestProvider }}#
     - name: Run provider tests
       working-directory: provider

--- a/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/prerelease.yml
+++ b/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/prerelease.yml
@@ -131,6 +131,12 @@ jobs:
     - name: Login to Google Cloud Registry
       run: gcloud --quiet auth configure-docker
     #{{- end }}#
+    #{{- if .Config.sshPrivateKey }}#
+    - name: Setup SSH key
+      uses: webfactory/ssh-agent@v0.7.0
+      with:
+        ssh-private-key: #{{ .Config.sshPrivateKey }}#
+    #{{- end }}#
     #{{- if .Config.integrationTestProvider }}#
     - name: Prepare upstream code
       run: make upstream

--- a/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/prerequisites.yml
+++ b/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/prerequisites.yml
@@ -57,9 +57,6 @@ jobs:
       uses: ./.github/actions/setup-tools
       with:
         tools: go, pulumictl, pulumicli, schema-tools
-#{{- if .Config.actions.preBuild }}#
-#{{ .Config.actions.preBuild | toYaml | indent 4 }}#
-#{{- end }}#
     - name: Build schema generator binary
       run: make tfgen_build_only
     - name: Install plugins

--- a/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/release.yml
+++ b/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/release.yml
@@ -130,6 +130,12 @@ jobs:
     - name: Login to Google Cloud Registry
       run: gcloud --quiet auth configure-docker
     #{{- end }}#
+    #{{- if .Config.sshPrivateKey }}#
+    - name: Setup SSH key
+      uses: webfactory/ssh-agent@v0.7.0
+      with:
+        ssh-private-key: #{{ .Config.sshPrivateKey }}#
+    #{{- end }}#
     #{{- if .Config.integrationTestProvider }}#
     - name: Prepare upstream code
       run: make upstream

--- a/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/release.yml
+++ b/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/release.yml
@@ -151,9 +151,6 @@ jobs:
       with:
         token: ${{ secrets.GITHUB_TOKEN }}
         version: v2.5.0
-#{{- if .Config.actions.preTest }}#
-#{{ .Config.actions.preTest | toYaml | indent 4 }}#
-#{{- end }}#
     #{{- if .Config.integrationTestProvider }}#
     - name: Run provider tests
       working-directory: provider

--- a/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/release.yml
+++ b/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/release.yml
@@ -130,6 +130,10 @@ jobs:
     - name: Login to Google Cloud Registry
       run: gcloud --quiet auth configure-docker
     #{{- end }}#
+    #{{- if .Config.integrationTestProvider }}#
+    - name: Prepare upstream code
+      run: make upstream
+    #{{- end }}#
     #{{- if index .Config "setup-script" }}#
     - name: Run setup script
       run: #{{ index .Config "setup-script" }}#
@@ -144,9 +148,13 @@ jobs:
 #{{- if .Config.actions.preTest }}#
 #{{ .Config.actions.preTest | toYaml | indent 4 }}#
 #{{- end }}#
+    #{{- if .Config.integrationTestProvider }}#
+    - name: Run provider tests
+      working-directory: provider
+      run: go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt
+    #{{- end }}#
     - name: Run tests
-      run: cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{
-        matrix.language }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt
+      run: cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt
     strategy:
       fail-fast: false
       matrix:

--- a/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/run-acceptance-tests.yml
@@ -194,9 +194,6 @@ jobs:
       with:
         token: ${{ secrets.GITHUB_TOKEN }}
         version: v2.5.0
-#{{- if .Config.actions.preTest }}#
-#{{ .Config.actions.preTest | toYaml | indent 4 }}#
-#{{- end }}#
     #{{- if .Config.integrationTestProvider }}#
     - name: Run provider tests
       if: matrix.testTarget == 'local'

--- a/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/run-acceptance-tests.yml
@@ -173,6 +173,10 @@ jobs:
     - name: Login to Google Cloud Registry
       run: gcloud --quiet auth configure-docker
     #{{- end }}#
+    #{{- if .Config.integrationTestProvider }}#
+    - name: Prepare upstream code
+      run: make upstream
+    #{{- end }}#
     #{{- if index .Config "setup-script" }}#
     - name: Run setup script
       run: #{{ index .Config "setup-script" }}#
@@ -187,10 +191,15 @@ jobs:
 #{{- if .Config.actions.preTest }}#
 #{{ .Config.actions.preTest | toYaml | indent 4 }}#
 #{{- end }}#
+    #{{- if .Config.integrationTestProvider }}#
+    - name: Run provider tests
+      if: matrix.testTarget == 'local'
+      working-directory: provider
+      run: go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt
+    #{{- end }}#
     - name: Run tests
       if: matrix.testTarget == 'local'
-      run: cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{
-        matrix.language }} -skip TestPulumiExamples -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt
+      run: cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language }} -skip TestPulumiExamples -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt
     - name: Run pulumi/examples tests
       if: matrix.testTarget == 'pulumiExamples'
       run: cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{

--- a/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/run-acceptance-tests.yml
@@ -173,6 +173,12 @@ jobs:
     - name: Login to Google Cloud Registry
       run: gcloud --quiet auth configure-docker
     #{{- end }}#
+    #{{- if .Config.sshPrivateKey }}#
+    - name: Setup SSH key
+      uses: webfactory/ssh-agent@v0.7.0
+      with:
+        ssh-private-key: #{{ .Config.sshPrivateKey }}#
+    #{{- end }}#
     #{{- if .Config.integrationTestProvider }}#
     - name: Prepare upstream code
       run: make upstream

--- a/provider-ci/test-providers/aws/.github/workflows/master.yml
+++ b/provider-ci/test-providers/aws/.github/workflows/master.yml
@@ -181,8 +181,7 @@ jobs:
     - name: Make upstream
       run: make upstream
     - name: Run tests
-      run: cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{
-        matrix.language }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt
+      run: cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt
     strategy:
       fail-fast: false
       matrix:

--- a/provider-ci/test-providers/aws/.github/workflows/prerelease.yml
+++ b/provider-ci/test-providers/aws/.github/workflows/prerelease.yml
@@ -124,8 +124,7 @@ jobs:
     - name: Make upstream
       run: make upstream
     - name: Run tests
-      run: cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{
-        matrix.language }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt
+      run: cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt
     strategy:
       fail-fast: false
       matrix:

--- a/provider-ci/test-providers/aws/.github/workflows/release.yml
+++ b/provider-ci/test-providers/aws/.github/workflows/release.yml
@@ -123,8 +123,7 @@ jobs:
     - name: Make upstream
       run: make upstream
     - name: Run tests
-      run: cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{
-        matrix.language }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt
+      run: cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt
     strategy:
       fail-fast: false
       matrix:

--- a/provider-ci/test-providers/aws/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/test-providers/aws/.github/workflows/run-acceptance-tests.yml
@@ -162,8 +162,7 @@ jobs:
       run: make upstream
     - name: Run tests
       if: matrix.testTarget == 'local'
-      run: cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{
-        matrix.language }} -skip TestPulumiExamples -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt
+      run: cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language }} -skip TestPulumiExamples -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt
     - name: Run pulumi/examples tests
       if: matrix.testTarget == 'pulumiExamples'
       run: cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{

--- a/provider-ci/test-providers/cloudflare/.github/workflows/master.yml
+++ b/provider-ci/test-providers/cloudflare/.github/workflows/master.yml
@@ -166,8 +166,7 @@ jobs:
       run: |
         cd provider && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt
     - name: Run tests
-      run: cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{
-        matrix.language }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt
+      run: cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt
     strategy:
       fail-fast: false
       matrix:

--- a/provider-ci/test-providers/cloudflare/.github/workflows/prerelease.yml
+++ b/provider-ci/test-providers/cloudflare/.github/workflows/prerelease.yml
@@ -111,8 +111,7 @@ jobs:
       run: |
         cd provider && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt
     - name: Run tests
-      run: cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{
-        matrix.language }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt
+      run: cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt
     strategy:
       fail-fast: false
       matrix:

--- a/provider-ci/test-providers/cloudflare/.github/workflows/release.yml
+++ b/provider-ci/test-providers/cloudflare/.github/workflows/release.yml
@@ -110,8 +110,7 @@ jobs:
       run: |
         cd provider && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt
     - name: Run tests
-      run: cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{
-        matrix.language }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt
+      run: cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt
     strategy:
       fail-fast: false
       matrix:

--- a/provider-ci/test-providers/cloudflare/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/test-providers/cloudflare/.github/workflows/run-acceptance-tests.yml
@@ -153,8 +153,7 @@ jobs:
         cd provider && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt
     - name: Run tests
       if: matrix.testTarget == 'local'
-      run: cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{
-        matrix.language }} -skip TestPulumiExamples -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt
+      run: cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language }} -skip TestPulumiExamples -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt
     - name: Run pulumi/examples tests
       if: matrix.testTarget == 'pulumiExamples'
       run: cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{

--- a/provider-ci/test-providers/docker/.github/workflows/master.yml
+++ b/provider-ci/test-providers/docker/.github/workflows/master.yml
@@ -200,8 +200,7 @@ jobs:
       with:
         ssh-private-key: ${{ secrets.PRIVATE_SSH_KEY_FOR_DIGITALOCEAN }}
     - name: Run tests
-      run: cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{
-        matrix.language }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt
+      run: cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt
     strategy:
       fail-fast: false
       matrix:

--- a/provider-ci/test-providers/docker/.github/workflows/prerelease.yml
+++ b/provider-ci/test-providers/docker/.github/workflows/prerelease.yml
@@ -145,8 +145,7 @@ jobs:
       with:
         ssh-private-key: ${{ secrets.PRIVATE_SSH_KEY_FOR_DIGITALOCEAN }}
     - name: Run tests
-      run: cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{
-        matrix.language }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt
+      run: cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt
     strategy:
       fail-fast: false
       matrix:

--- a/provider-ci/test-providers/docker/.github/workflows/release.yml
+++ b/provider-ci/test-providers/docker/.github/workflows/release.yml
@@ -144,8 +144,7 @@ jobs:
       with:
         ssh-private-key: ${{ secrets.PRIVATE_SSH_KEY_FOR_DIGITALOCEAN }}
     - name: Run tests
-      run: cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{
-        matrix.language }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt
+      run: cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt
     strategy:
       fail-fast: false
       matrix:

--- a/provider-ci/test-providers/docker/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/test-providers/docker/.github/workflows/run-acceptance-tests.yml
@@ -187,8 +187,7 @@ jobs:
         ssh-private-key: ${{ secrets.PRIVATE_SSH_KEY_FOR_DIGITALOCEAN }}
     - name: Run tests
       if: matrix.testTarget == 'local'
-      run: cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{
-        matrix.language }} -skip TestPulumiExamples -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt
+      run: cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language }} -skip TestPulumiExamples -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt
     - name: Run pulumi/examples tests
       if: matrix.testTarget == 'pulumiExamples'
       run: cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{


### PR DESCRIPTION
Stacked on top of #1038 

Related to https://github.com/pulumi/ci-mgmt/issues/936

Remove arbitary code injection hooks.

This can only be merged once no providers are using these actions: https://github.com/search?q=org%3Apulumi+path%3A.ci-mgmt.yaml+%22actions%3A%22&type=code