### PR TITLE
Force initialize the submodule on `make upstream`

### DIFF
--- a/provider-ci/internal/pkg/templates/bridged-provider/Makefile
+++ b/provider-ci/internal/pkg/templates/bridged-provider/Makefile
@@ -187,7 +187,7 @@ tfgen_build_only:
 
 upstream:
 ifneq ("$(wildcard upstream)","")
-	./upstream.sh init
+	./upstream.sh init -f
 endif
 
 #{{- if .Config.XrunUpstreamTools }}#

--- a/provider-ci/internal/pkg/templates/bridged-provider/upstream.sh
+++ b/provider-ci/internal/pkg/templates/bridged-provider/upstream.sh
@@ -97,7 +97,7 @@ Either stage or reset the 'upstream' submodule changes before continuing:
 
     git add upstream
     # or #
-    git checkout upstream
+    (cd upstream && git checkout <current submodule commit of origin/default> && cd -)
 
 EOF
     exit 1

--- a/provider-ci/test-providers/aws/Makefile
+++ b/provider-ci/test-providers/aws/Makefile
@@ -172,7 +172,7 @@ tfgen_build_only:
 
 upstream:
 ifneq ("$(wildcard upstream)","")
-	./upstream.sh init
+	./upstream.sh init -f
 endif
 
 	# Ensure tool is installed

--- a/provider-ci/test-providers/aws/upstream.sh
+++ b/provider-ci/test-providers/aws/upstream.sh
@@ -97,7 +97,7 @@ Either stage or reset the 'upstream' submodule changes before continuing:
 
     git add upstream
     # or #
-    git checkout upstream
+    (cd upstream && git checkout <current submodule commit of origin/default> && cd -)
 
 EOF
     exit 1

--- a/provider-ci/test-providers/cloudflare/Makefile
+++ b/provider-ci/test-providers/cloudflare/Makefile
@@ -166,7 +166,7 @@ tfgen_build_only:
 
 upstream:
 ifneq ("$(wildcard upstream)","")
-	./upstream.sh init
+	./upstream.sh init -f
 endif
 
 bin/pulumi-java-gen: .pulumi-java-gen.version

--- a/provider-ci/test-providers/cloudflare/upstream.sh
+++ b/provider-ci/test-providers/cloudflare/upstream.sh
@@ -97,7 +97,7 @@ Either stage or reset the 'upstream' submodule changes before continuing:
 
     git add upstream
     # or #
-    git checkout upstream
+    (cd upstream && git checkout <current submodule commit of origin/default> && cd -)
 
 EOF
     exit 1

--- a/provider-ci/test-providers/docker/Makefile
+++ b/provider-ci/test-providers/docker/Makefile
@@ -167,7 +167,7 @@ tfgen_build_only:
 
 upstream:
 ifneq ("$(wildcard upstream)","")
-	./upstream.sh init
+	./upstream.sh init -f
 endif
 
 bin/pulumi-java-gen: .pulumi-java-gen.version

--- a/provider-ci/test-providers/docker/upstream.sh
+++ b/provider-ci/test-providers/docker/upstream.sh
@@ -97,7 +97,7 @@ Either stage or reset the 'upstream' submodule changes before continuing:
 
     git add upstream
     # or #
-    git checkout upstream
+    (cd upstream && git checkout <current submodule commit of origin/default> && cd -)
 
 EOF
     exit 1


### PR DESCRIPTION
When `upstream` locally gets out of sync with the current default branch tip, any run of `make upstream` will exit 1 on `assert_upstream`tracked` in the `upstream.sh` script, because it will have been detected as modified. 
This happens whenever anyone pulls in upstream changes to work on a feature or bug fix. The instructions [provided](https://github.com/pulumi/ci-mgmt/blob/master/provider-ci/internal/pkg/templates/bridged-provider/upstream.sh#L96) do not work.

This pull request defaults to pass `-f` to the `init` command run via `make upstream`.

Since the [upgrade provider tool](https://github.com/pulumi/upgrade-provider/blob/main/upgrade/steps.go#L163) always force resets the submodule as well, this should be a safe change.

It is dubious why we'd need the non-force option at all, and the fact that the remedial instructions do not work is another issue as well.