### PR TITLE
Provide better instructions when upstream is modified

### DIFF
--- a/provider-ci/internal/pkg/templates/bridged-provider/Makefile
+++ b/provider-ci/internal/pkg/templates/bridged-provider/Makefile
@@ -187,7 +187,7 @@ tfgen_build_only:
 
 upstream:
 ifneq ("$(wildcard upstream)","")
-	./upstream.sh init -f
+	./upstream.sh init
 endif
 
 #{{- if .Config.XrunUpstreamTools }}#

--- a/provider-ci/internal/pkg/templates/bridged-provider/Makefile
+++ b/provider-ci/internal/pkg/templates/bridged-provider/Makefile
@@ -238,7 +238,7 @@ ci-mgmt: .ci-mgmt.yaml
 debug_tfgen:
 	dlv  --listen=:2345 --headless=true --api-version=2  exec $(WORKING_DIR)/bin/$(TFGEN) -- schema --out provider/cmd/$(PROVIDER)
 
-.PHONY: development build build_sdks install_go_sdk install_java_sdk install_python_sdk install_sdks only_build build_dotnet build_go build_java build_nodejs build_python clean cleanup#{{ if .Config.docsCmd }}# docs#{{end}}# help install_dotnet_sdk install_nodejs_sdk install_plugins lint_provider provider provider_no_deps test tfgen upstream upstream.finalize upstream.rebase ci-mgmt test_provider debug_tfgen tfgen_build_only
+.PHONY: development build build_sdks install_go_sdk install_java_sdk install_python_sdk install_sdks only_build build_dotnet build_go build_java build_nodejs build_python clean cleanup#{{ if .Config.docsCmd }}# docs#{{end}}# help install_dotnet_sdk install_nodejs_sdk install_plugins lint_provider provider provider_no_deps test tfgen upstream ci-mgmt test_provider debug_tfgen tfgen_build_only
 
 # Provider cross-platform build & packaging
 

--- a/provider-ci/internal/pkg/templates/bridged-provider/upstream.sh
+++ b/provider-ci/internal/pkg/templates/bridged-provider/upstream.sh
@@ -56,6 +56,12 @@ EXAMPLES
     ${original_exec} checkout
     ${original_exec} rebase -i
     ${original_exec} check_in
+
+  Add a new patch:
+    ${original_exec} checkout
+    # Make changes to the upstream repository
+    git commit -am "Add new feature"
+    ${original_exec} check_in
 EOF
 }
 

--- a/provider-ci/internal/pkg/templates/bridged-provider/upstream.sh
+++ b/provider-ci/internal/pkg/templates/bridged-provider/upstream.sh
@@ -349,7 +349,7 @@ case ${original_cmd} in
   init)
     init "$@"
     ;;
-  checkout)
+  checkout|check_out)
     checkout "$@"
     ;;
   rebase)
@@ -358,7 +358,7 @@ case ${original_cmd} in
   format_patches)
     format_patches "$@"
     ;;
-  check_in)
+  check_in|checkin)
     check_in "$@"
     ;;
   *)

--- a/provider-ci/test-providers/aws/Makefile
+++ b/provider-ci/test-providers/aws/Makefile
@@ -219,7 +219,7 @@ ci-mgmt: .ci-mgmt.yaml
 debug_tfgen:
 	dlv  --listen=:2345 --headless=true --api-version=2  exec $(WORKING_DIR)/bin/$(TFGEN) -- schema --out provider/cmd/$(PROVIDER)
 
-.PHONY: development build build_sdks install_go_sdk install_java_sdk install_python_sdk install_sdks only_build build_dotnet build_go build_java build_nodejs build_python clean cleanup help install_dotnet_sdk install_nodejs_sdk install_plugins lint_provider provider provider_no_deps test tfgen upstream upstream.finalize upstream.rebase ci-mgmt test_provider debug_tfgen tfgen_build_only
+.PHONY: development build build_sdks install_go_sdk install_java_sdk install_python_sdk install_sdks only_build build_dotnet build_go build_java build_nodejs build_python clean cleanup help install_dotnet_sdk install_nodejs_sdk install_plugins lint_provider provider provider_no_deps test tfgen upstream ci-mgmt test_provider debug_tfgen tfgen_build_only
 
 # Provider cross-platform build & packaging
 

--- a/provider-ci/test-providers/aws/Makefile
+++ b/provider-ci/test-providers/aws/Makefile
@@ -172,7 +172,7 @@ tfgen_build_only:
 
 upstream:
 ifneq ("$(wildcard upstream)","")
-	./upstream.sh init -f
+	./upstream.sh init
 endif
 
 	# Ensure tool is installed

--- a/provider-ci/test-providers/aws/upstream.sh
+++ b/provider-ci/test-providers/aws/upstream.sh
@@ -56,6 +56,12 @@ EXAMPLES
     ${original_exec} checkout
     ${original_exec} rebase -i
     ${original_exec} check_in
+
+  Add a new patch:
+    ${original_exec} checkout
+    # Make changes to the upstream repository
+    git commit -am "Add new feature"
+    ${original_exec} check_in
 EOF
 }
 

--- a/provider-ci/test-providers/cloudflare/Makefile
+++ b/provider-ci/test-providers/cloudflare/Makefile
@@ -166,7 +166,7 @@ tfgen_build_only:
 
 upstream:
 ifneq ("$(wildcard upstream)","")
-	./upstream.sh init -f
+	./upstream.sh init
 endif
 
 bin/pulumi-java-gen: .pulumi-java-gen.version

--- a/provider-ci/test-providers/cloudflare/Makefile
+++ b/provider-ci/test-providers/cloudflare/Makefile
@@ -208,7 +208,7 @@ ci-mgmt: .ci-mgmt.yaml
 debug_tfgen:
 	dlv  --listen=:2345 --headless=true --api-version=2  exec $(WORKING_DIR)/bin/$(TFGEN) -- schema --out provider/cmd/$(PROVIDER)
 
-.PHONY: development build build_sdks install_go_sdk install_java_sdk install_python_sdk install_sdks only_build build_dotnet build_go build_java build_nodejs build_python clean cleanup help install_dotnet_sdk install_nodejs_sdk install_plugins lint_provider provider provider_no_deps test tfgen upstream upstream.finalize upstream.rebase ci-mgmt test_provider debug_tfgen tfgen_build_only
+.PHONY: development build build_sdks install_go_sdk install_java_sdk install_python_sdk install_sdks only_build build_dotnet build_go build_java build_nodejs build_python clean cleanup help install_dotnet_sdk install_nodejs_sdk install_plugins lint_provider provider provider_no_deps test tfgen upstream ci-mgmt test_provider debug_tfgen tfgen_build_only
 
 # Provider cross-platform build & packaging
 

--- a/provider-ci/test-providers/cloudflare/upstream.sh
+++ b/provider-ci/test-providers/cloudflare/upstream.sh
@@ -56,6 +56,12 @@ EXAMPLES
     ${original_exec} checkout
     ${original_exec} rebase -i
     ${original_exec} check_in
+
+  Add a new patch:
+    ${original_exec} checkout
+    # Make changes to the upstream repository
+    git commit -am "Add new feature"
+    ${original_exec} check_in
 EOF
 }
 

--- a/provider-ci/test-providers/docker/Makefile
+++ b/provider-ci/test-providers/docker/Makefile
@@ -209,7 +209,7 @@ ci-mgmt: .ci-mgmt.yaml
 debug_tfgen:
 	dlv  --listen=:2345 --headless=true --api-version=2  exec $(WORKING_DIR)/bin/$(TFGEN) -- schema --out provider/cmd/$(PROVIDER)
 
-.PHONY: development build build_sdks install_go_sdk install_java_sdk install_python_sdk install_sdks only_build build_dotnet build_go build_java build_nodejs build_python clean cleanup docs help install_dotnet_sdk install_nodejs_sdk install_plugins lint_provider provider provider_no_deps test tfgen upstream upstream.finalize upstream.rebase ci-mgmt test_provider debug_tfgen tfgen_build_only
+.PHONY: development build build_sdks install_go_sdk install_java_sdk install_python_sdk install_sdks only_build build_dotnet build_go build_java build_nodejs build_python clean cleanup docs help install_dotnet_sdk install_nodejs_sdk install_plugins lint_provider provider provider_no_deps test tfgen upstream ci-mgmt test_provider debug_tfgen tfgen_build_only
 
 # Provider cross-platform build & packaging
 

--- a/provider-ci/test-providers/docker/Makefile
+++ b/provider-ci/test-providers/docker/Makefile
@@ -167,7 +167,7 @@ tfgen_build_only:
 
 upstream:
 ifneq ("$(wildcard upstream)","")
-	./upstream.sh init -f
+	./upstream.sh init
 endif
 
 bin/pulumi-java-gen: .pulumi-java-gen.version

--- a/provider-ci/test-providers/docker/upstream.sh
+++ b/provider-ci/test-providers/docker/upstream.sh
@@ -56,6 +56,12 @@ EXAMPLES
     ${original_exec} checkout
     ${original_exec} rebase -i
     ${original_exec} check_in
+
+  Add a new patch:
+    ${original_exec} checkout
+    # Make changes to the upstream repository
+    git commit -am "Add new feature"
+    ${original_exec} check_in
 EOF
 }
 


### PR DESCRIPTION
- Recommend adding `-f` rather than custom git checkout commands.
- Hide the `format_patches` command as `check_in` is a much less confusing version of the command.
- Don't use the force option from the makefile as we don't want to wipe out any uncommitted work by accident.
- Relax validation for running 'init' and 'checkout' without the force option. Only require upstream to not be checked out on the 'pulumi/patch-checkout' branch, but don't require it to be tracked in git. This allows the unforced init to be used after pulling changes but not having yet updated the submodule.
- Assert we're not mid-rebase if force not provided (avoids accidentally loosing progress if switched to our own branch).
- Clean up old branches and rebases when using the force option with either init or checkout.

Example error (for init):
```
Error: 'upstream' submodule checked out on the 'pulumi/patch-checkout' branch.
This was likely caused by running a 'checkout' command but not running
'check_in' afterwards.

To turn the commits in the 'pulumi/patch-checkout' branch back into patches, run:
  ./upstream.sh check_in

To disgard changes in the 'pulumi/patch-checkout' branch, use the 'force' flag (-f):
  ./upstream.sh init -f
```