### PR TITLE
Always run tests on native provider PRs

### DIFF
--- a/native-provider-ci/providers/aws-native/repo/.github/workflows/run-acceptance-tests.yml
+++ b/native-provider-ci/providers/aws-native/repo/.github/workflows/run-acceptance-tests.yml
@@ -6,9 +6,6 @@ on:
     types:
     - run-acceptance-tests-command
   pull_request:
-    branches:
-    - master
-    - main
     paths-ignore:
     - CHANGELOG.md
   workflow_dispatch: {}

--- a/native-provider-ci/providers/command/repo/.github/workflows/run-acceptance-tests.yml
+++ b/native-provider-ci/providers/command/repo/.github/workflows/run-acceptance-tests.yml
@@ -6,9 +6,6 @@ on:
     types:
     - run-acceptance-tests-command
   pull_request:
-    branches:
-    - master
-    - main
     paths-ignore:
     - CHANGELOG.md
   workflow_dispatch: {}

--- a/native-provider-ci/providers/docker-build/repo/.github/workflows/run-acceptance-tests.yml
+++ b/native-provider-ci/providers/docker-build/repo/.github/workflows/run-acceptance-tests.yml
@@ -6,9 +6,6 @@ on:
     types:
     - run-acceptance-tests-command
   pull_request:
-    branches:
-    - master
-    - main
     paths-ignore:
     - CHANGELOG.md
   workflow_dispatch: {}

--- a/native-provider-ci/providers/google-native/repo/.github/workflows/run-acceptance-tests.yml
+++ b/native-provider-ci/providers/google-native/repo/.github/workflows/run-acceptance-tests.yml
@@ -6,9 +6,6 @@ on:
     types:
     - run-acceptance-tests-command
   pull_request:
-    branches:
-    - master
-    - main
     paths-ignore:
     - CHANGELOG.md
   workflow_dispatch: {}

--- a/native-provider-ci/providers/kubernetes-cert-manager/repo/.github/workflows/run-acceptance-tests.yml
+++ b/native-provider-ci/providers/kubernetes-cert-manager/repo/.github/workflows/run-acceptance-tests.yml
@@ -6,9 +6,6 @@ on:
     types:
     - run-acceptance-tests-command
   pull_request:
-    branches:
-    - master
-    - main
     paths-ignore:
     - CHANGELOG.md
   workflow_dispatch: {}

--- a/native-provider-ci/providers/kubernetes/repo/.github/workflows/run-acceptance-tests.yml
+++ b/native-provider-ci/providers/kubernetes/repo/.github/workflows/run-acceptance-tests.yml
@@ -6,10 +6,6 @@ on:
     types:
     - run-acceptance-tests-command
   pull_request:
-    branches:
-    - master
-    - main
-    - v4
     paths-ignore:
     - CHANGELOG.md
   workflow_dispatch: {}

--- a/native-provider-ci/src/workflows.ts
+++ b/native-provider-ci/src/workflows.ts
@@ -122,7 +122,6 @@ export function RunAcceptanceTestsWorkflow(
         types: ["run-acceptance-tests-command"],
       },
       pull_request: {
-        branches: ["master", "main"],
         "paths-ignore": ["CHANGELOG.md"],
       },
       workflow_dispatch: {},
@@ -155,14 +154,6 @@ export function RunAcceptanceTestsWorkflow(
   if (opts.lint) {
     workflow.jobs = Object.assign(workflow.jobs, {
       lint: new LintJob("lint").addDispatchConditional(true),
-    });
-  }
-  if (opts.provider === "kubernetes") {
-    workflow.on = Object.assign(workflow.on, {
-      pull_request: {
-        branches: ["master", "main", "v4"],
-        "paths-ignore": ["CHANGELOG.md"],
-      },
     });
   }
   return workflow;


### PR DESCRIPTION
This brings us to parity with bridged providers:
https://github.com/pulumi/ci-mgmt/blob/2d9cb9ebea04c3061453e60961ff347146fbdc26/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/run-acceptance-tests.yml#L234-L238