### PR TITLE
Try to fix first releases

### DIFF
--- a/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/publish.yml
+++ b/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/publish.yml
@@ -67,10 +67,12 @@ jobs:
       shell: bash
       run: |
         # Get latest stable release. Return only first column from result (tag).
-        LAST_VERSION=$(gh release view --repo pulumi/pulumi-#{{ .Config.provider }}# --json tagName -q .tagName)
+        LAST_VERSION=$(gh release view --repo pulumi/pulumi-#{{ .Config.provider }}# --json tagName -q .tagName || echo "No stable release" )
         {
           echo 'summary<<EOF'
-          schema-tools compare --provider="#{{ .Config.provider }}#" --old-commit="$LAST_VERSION" --new-commit="--local-path=provider/cmd/pulumi-resource-#{{ .Config.provider }}#/schema.json"
+          if [[ "$LAST_VERSION" != "No stable release" ]]; then
+            schema-tools compare --provider="#{{ .Config.provider }}#" --old-commit="$LAST_VERSION" --new-commit="--local-path=provider/cmd/pulumi-resource-#{{ .Config.provider }}#/schema.json"
+          fi
           echo 'EOF'
         } >> "$GITHUB_OUTPUT"
     - name: Upload Provider Binaries

--- a/provider-ci/test-providers/aws/.github/workflows/publish.yml
+++ b/provider-ci/test-providers/aws/.github/workflows/publish.yml
@@ -83,10 +83,12 @@ jobs:
       shell: bash
       run: |
         # Get latest stable release. Return only first column from result (tag).
-        LAST_VERSION=$(gh release view --repo pulumi/pulumi-aws --json tagName -q .tagName)
+        LAST_VERSION=$(gh release view --repo pulumi/pulumi-aws --json tagName -q .tagName || echo "No stable release" )
         {
           echo 'summary<<EOF'
-          schema-tools compare --provider="aws" --old-commit="$LAST_VERSION" --new-commit="--local-path=provider/cmd/pulumi-resource-aws/schema.json"
+          if [[ "$LAST_VERSION" != "No stable release" ]]; then
+            schema-tools compare --provider="aws" --old-commit="$LAST_VERSION" --new-commit="--local-path=provider/cmd/pulumi-resource-aws/schema.json"
+          fi
           echo 'EOF'
         } >> "$GITHUB_OUTPUT"
     - name: Upload Provider Binaries

--- a/provider-ci/test-providers/cloudflare/.github/workflows/publish.yml
+++ b/provider-ci/test-providers/cloudflare/.github/workflows/publish.yml
@@ -80,10 +80,12 @@ jobs:
       shell: bash
       run: |
         # Get latest stable release. Return only first column from result (tag).
-        LAST_VERSION=$(gh release view --repo pulumi/pulumi-cloudflare --json tagName -q .tagName)
+        LAST_VERSION=$(gh release view --repo pulumi/pulumi-cloudflare --json tagName -q .tagName || echo "No stable release" )
         {
           echo 'summary<<EOF'
-          schema-tools compare --provider="cloudflare" --old-commit="$LAST_VERSION" --new-commit="--local-path=provider/cmd/pulumi-resource-cloudflare/schema.json"
+          if [[ "$LAST_VERSION" != "No stable release" ]]; then
+            schema-tools compare --provider="cloudflare" --old-commit="$LAST_VERSION" --new-commit="--local-path=provider/cmd/pulumi-resource-cloudflare/schema.json"
+          fi
           echo 'EOF'
         } >> "$GITHUB_OUTPUT"
     - name: Upload Provider Binaries

--- a/provider-ci/test-providers/docker/.github/workflows/publish.yml
+++ b/provider-ci/test-providers/docker/.github/workflows/publish.yml
@@ -93,10 +93,12 @@ jobs:
       shell: bash
       run: |
         # Get latest stable release. Return only first column from result (tag).
-        LAST_VERSION=$(gh release view --repo pulumi/pulumi-docker --json tagName -q .tagName)
+        LAST_VERSION=$(gh release view --repo pulumi/pulumi-docker --json tagName -q .tagName || echo "No stable release" )
         {
           echo 'summary<<EOF'
-          schema-tools compare --provider="docker" --old-commit="$LAST_VERSION" --new-commit="--local-path=provider/cmd/pulumi-resource-docker/schema.json"
+          if [[ "$LAST_VERSION" != "No stable release" ]]; then
+            schema-tools compare --provider="docker" --old-commit="$LAST_VERSION" --new-commit="--local-path=provider/cmd/pulumi-resource-docker/schema.json"
+          fi
           echo 'EOF'
         } >> "$GITHUB_OUTPUT"
     - name: Upload Provider Binaries


### PR DESCRIPTION
The publish job currently fails if there are no stable GH releases for the repo yet, which breaks any brand new provider. This change leaves the release notes empty for the first release which should allow the publish job to complete.