### PR TITLE
This prevents upstream from carrying un-tracked changes past `init`

### DIFF
--- a/provider-ci/internal/pkg/templates/bridged-provider/upstream.sh
+++ b/provider-ci/internal/pkg/templates/bridged-provider/upstream.sh
@@ -186,6 +186,8 @@ init() {
   fi
 
   git submodule update --force --init
+  cd upstream && git clean -fxd && cd ..
+
   if [[ "${force}" == "true" ]]; then
     clean_rebases
     clean_branches

--- a/provider-ci/test-providers/aws/upstream.sh
+++ b/provider-ci/test-providers/aws/upstream.sh
@@ -186,6 +186,8 @@ init() {
   fi
 
   git submodule update --force --init
+  cd upstream && git clean -fxd && cd ..
+
   if [[ "${force}" == "true" ]]; then
     clean_rebases
     clean_branches

--- a/provider-ci/test-providers/cloudflare/upstream.sh
+++ b/provider-ci/test-providers/cloudflare/upstream.sh
@@ -186,6 +186,8 @@ init() {
   fi
 
   git submodule update --force --init
+  cd upstream && git clean -fxd && cd ..
+
   if [[ "${force}" == "true" ]]; then
     clean_rebases
     clean_branches

--- a/provider-ci/test-providers/docker/upstream.sh
+++ b/provider-ci/test-providers/docker/upstream.sh
@@ -186,6 +186,8 @@ init() {
   fi
 
   git submodule update --force --init
+  cd upstream && git clean -fxd && cd ..
+
   if [[ "${force}" == "true" ]]; then
     clean_rebases
     clean_branches


### PR DESCRIPTION
This was motivated by an hour I spent tracking down a persistent diff between CI and my laptop when there was an un-tracked `website` folder in `upstream` that wasn't present in CI.