### PR TITLE
Add pulumi-junipermist to ci-mgmt

### DIFF
--- a/provider-ci/providers.json
+++ b/provider-ci/providers.json
@@ -32,6 +32,7 @@
     "hcloud",
     "http",
     "ise",
+    "junipermist",
     "kafka",
     "keycloak",
     "kong",


### PR DESCRIPTION
Adds the new bridged provider for Juniper Mist to ci-mgmt.