### PR TITLE
Add free-disk-space action to upgrade provider workflow

### DIFF
--- a/provider-ci/internal/pkg/templates/bridged-provider.config.yaml
+++ b/provider-ci/internal/pkg/templates/bridged-provider.config.yaml
@@ -69,6 +69,9 @@ freeDiskSpaceBeforeBuild: false
 # Set to true to clear disk space before running test jobs.
 freeDiskSpaceBeforeTest: false
 
+# The version of the jlumbroso/free-disk-space action to use.
+freeDiskSpaceActionVersion: 54081f138730dfa15788a46383842cd2f914a1be
+
 # Used for centrally managing tool versions.
 # This is not currently overridden by any providers: https://github.com/search?q=org%3Apulumi+path%3A.ci-mgmt.yaml+%22toolVersions%22&type=code
 toolVersions:

--- a/provider-ci/internal/pkg/templates/bridged-provider.config.yaml
+++ b/provider-ci/internal/pkg/templates/bridged-provider.config.yaml
@@ -69,9 +69,6 @@ freeDiskSpaceBeforeBuild: false
 # Set to true to clear disk space before running test jobs.
 freeDiskSpaceBeforeTest: false
 
-# The version of the jlumbroso/free-disk-space action to use.
-freeDiskSpaceActionVersion: 54081f138730dfa15788a46383842cd2f914a1be
-
 # Used for centrally managing tool versions.
 # This is not currently overridden by any providers: https://github.com/search?q=org%3Apulumi+path%3A.ci-mgmt.yaml+%22toolVersions%22&type=code
 toolVersions:
@@ -160,6 +157,7 @@ actionVersions:
   prComment: thollander/actions-comment-pull-request@v2
   uploadArtifact: actions/upload-artifact@v4
   upgradeProviderAction: pulumi/pulumi-upgrade-provider-action@v0.0.12
+  freeDiskSpace: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be
 
 # publish contains multiple properties relating to the publish jobs.
 # Used by 2 providers: https://github.com/search?q=org%3Apulumi+path%3A.ci-mgmt.yaml+%22publish%3A%22&type=code

--- a/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/build_provider.yml
+++ b/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/build_provider.yml
@@ -32,7 +32,7 @@ jobs:
       #{{- if .Config.freeDiskSpaceBeforeBuild }}#
       # Run as first step so we don't delete things that have just been installed
       - name: Free Disk Space (Ubuntu)
-        uses: jlumbroso/free-disk-space@#{{ .Config.freeDiskSpaceActionVersion }}#
+        uses: #{{ .Config.actionVersions.freeDiskSpace }}#
         with:
           tool-cache: false
           swap-storage: false

--- a/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/build_provider.yml
+++ b/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/build_provider.yml
@@ -32,7 +32,7 @@ jobs:
       #{{- if .Config.freeDiskSpaceBeforeBuild }}#
       # Run as first step so we don't delete things that have just been installed
       - name: Free Disk Space (Ubuntu)
-        uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be
+        uses: jlumbroso/free-disk-space@#{{ .Config.freeDiskSpaceActionVersion }}#
         with:
           tool-cache: false
           swap-storage: false

--- a/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/main.yml
+++ b/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/main.yml
@@ -129,7 +129,7 @@ jobs:
 #{{- if .Config.freeDiskSpaceBeforeTest }}#
     # Run as first step so we don't delete things that have just been installed
     - name: Free Disk Space (Ubuntu)
-      uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be
+      uses: jlumbroso/free-disk-space@#{{ .Config.freeDiskSpaceActionVersion }}#
       with:
         tool-cache: false
         swap-storage: false

--- a/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/main.yml
+++ b/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/main.yml
@@ -129,7 +129,7 @@ jobs:
 #{{- if .Config.freeDiskSpaceBeforeTest }}#
     # Run as first step so we don't delete things that have just been installed
     - name: Free Disk Space (Ubuntu)
-      uses: jlumbroso/free-disk-space@#{{ .Config.freeDiskSpaceActionVersion }}#
+      uses: #{{ .Config.actionVersions.freeDiskSpace }}#
       with:
         tool-cache: false
         swap-storage: false

--- a/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/nightly-test.yml
+++ b/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/nightly-test.yml
@@ -42,7 +42,7 @@ jobs:
 #{{- if .Config.freeDiskSpaceBeforeTest }}#
     # Run as first step so we don't delete things that have just been installed
     - name: Free Disk Space (Ubuntu)
-      uses: jlumbroso/free-disk-space@#{{ .Config.freeDiskSpaceActionVersion }}#
+      uses: #{{ .Config.actionVersions.freeDiskSpace }}#
       with:
         tool-cache: false
         swap-storage: false

--- a/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/nightly-test.yml
+++ b/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/nightly-test.yml
@@ -42,7 +42,7 @@ jobs:
 #{{- if .Config.freeDiskSpaceBeforeTest }}#
     # Run as first step so we don't delete things that have just been installed
     - name: Free Disk Space (Ubuntu)
-      uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be
+      uses: jlumbroso/free-disk-space@#{{ .Config.freeDiskSpaceActionVersion }}#
       with:
         tool-cache: false
         swap-storage: false

--- a/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/prerelease.yml
+++ b/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/prerelease.yml
@@ -70,7 +70,7 @@ jobs:
 #{{- if .Config.freeDiskSpaceBeforeTest }}#
     # Run as first step so we don't delete things that have just been installed
     - name: Free Disk Space (Ubuntu)
-      uses: jlumbroso/free-disk-space@#{{ .Config.freeDiskSpaceActionVersion }}#
+      uses: #{{ .Config.actionVersions.freeDiskSpace }}#
       with:
         tool-cache: false
         swap-storage: false

--- a/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/prerelease.yml
+++ b/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/prerelease.yml
@@ -70,7 +70,7 @@ jobs:
 #{{- if .Config.freeDiskSpaceBeforeTest }}#
     # Run as first step so we don't delete things that have just been installed
     - name: Free Disk Space (Ubuntu)
-      uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be
+      uses: jlumbroso/free-disk-space@#{{ .Config.freeDiskSpaceActionVersion }}#
       with:
         tool-cache: false
         swap-storage: false

--- a/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/prerequisites.yml
+++ b/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/prerequisites.yml
@@ -30,7 +30,7 @@ jobs:
 #{{- if .Config.freeDiskSpaceBeforeBuild }}#
     # Run as first step so we don't delete things that have just been installed
     - name: Free Disk Space (Ubuntu)
-      uses: jlumbroso/free-disk-space@#{{ .Config.freeDiskSpaceActionVersion }}#
+      uses: #{{ .Config.actionVersions.freeDiskSpace }}#
       with:
         tool-cache: false
         swap-storage: false

--- a/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/prerequisites.yml
+++ b/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/prerequisites.yml
@@ -30,7 +30,7 @@ jobs:
 #{{- if .Config.freeDiskSpaceBeforeBuild }}#
     # Run as first step so we don't delete things that have just been installed
     - name: Free Disk Space (Ubuntu)
-      uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be
+      uses: jlumbroso/free-disk-space@#{{ .Config.freeDiskSpaceActionVersion }}#
       with:
         tool-cache: false
         swap-storage: false

--- a/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/release.yml
+++ b/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/release.yml
@@ -69,7 +69,7 @@ jobs:
 #{{- if .Config.freeDiskSpaceBeforeTest }}#
     # Run as first step so we don't delete things that have just been installed
     - name: Free Disk Space (Ubuntu)
-      uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be
+      uses: jlumbroso/free-disk-space@#{{ .Config.freeDiskSpaceActionVersion }}#
       with:
         tool-cache: false
         swap-storage: false

--- a/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/release.yml
+++ b/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/release.yml
@@ -69,7 +69,7 @@ jobs:
 #{{- if .Config.freeDiskSpaceBeforeTest }}#
     # Run as first step so we don't delete things that have just been installed
     - name: Free Disk Space (Ubuntu)
-      uses: jlumbroso/free-disk-space@#{{ .Config.freeDiskSpaceActionVersion }}#
+      uses: #{{ .Config.actionVersions.freeDiskSpace }}#
       with:
         tool-cache: false
         swap-storage: false

--- a/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/run-acceptance-tests.yml
@@ -105,7 +105,7 @@ jobs:
 #{{- if .Config.freeDiskSpaceBeforeTest }}#
     # Run as first step so we don't delete things that have just been installed
     - name: Free Disk Space (Ubuntu)
-      uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be
+      uses: jlumbroso/free-disk-space@#{{ .Config.freeDiskSpaceActionVersion }}#
       with:
         tool-cache: false
         swap-storage: false

--- a/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/run-acceptance-tests.yml
@@ -105,7 +105,7 @@ jobs:
 #{{- if .Config.freeDiskSpaceBeforeTest }}#
     # Run as first step so we don't delete things that have just been installed
     - name: Free Disk Space (Ubuntu)
-      uses: jlumbroso/free-disk-space@#{{ .Config.freeDiskSpaceActionVersion }}#
+      uses: #{{ .Config.actionVersions.freeDiskSpace }}#
       with:
         tool-cache: false
         swap-storage: false

--- a/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/upgrade-provider.yml
+++ b/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/upgrade-provider.yml
@@ -9,6 +9,14 @@ jobs:
     name: upgrade-provider
     runs-on: #{{ .Config.runner.default }}#
     steps:
+    #{{- if .Config.freeDiskSpaceBeforeBuild }}#
+    # Run as first step so we don't delete things that have just been installed
+    - name: Free Disk Space (Ubuntu)
+      uses: jlumbroso/free-disk-space@#{{ .Config.freeDiskSpaceActionVersion }}#
+      with:
+        tool-cache: false
+        swap-storage: false
+    #{{- end }}#
     - name: Call upgrade provider action
       uses: #{{ .Config.actionVersions.upgradeProviderAction }}#
       with:

--- a/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/upgrade-provider.yml
+++ b/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/upgrade-provider.yml
@@ -12,7 +12,7 @@ jobs:
     #{{- if .Config.freeDiskSpaceBeforeBuild }}#
     # Run as first step so we don't delete things that have just been installed
     - name: Free Disk Space (Ubuntu)
-      uses: jlumbroso/free-disk-space@#{{ .Config.freeDiskSpaceActionVersion }}#
+      uses: #{{ .Config.actionVersions.freeDiskSpace }}#
       with:
         tool-cache: false
         swap-storage: false

--- a/provider-ci/test-providers/aws/.github/workflows/upgrade-provider.yml
+++ b/provider-ci/test-providers/aws/.github/workflows/upgrade-provider.yml
@@ -9,6 +9,12 @@ jobs:
     name: upgrade-provider
     runs-on: ubuntu-latest
     steps:
+    # Run as first step so we don't delete things that have just been installed
+    - name: Free Disk Space (Ubuntu)
+      uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be
+      with:
+        tool-cache: false
+        swap-storage: false
     - name: Call upgrade provider action
       uses: pulumi/pulumi-upgrade-provider-action@v0.0.12
       with:


### PR DESCRIPTION
This adds the `free-disk-space` action to the upgrade-provider workflow to prevent running out of disk space during compilation. It uses the existing `freeDiskSpaceBeforeBuild` config flag for controlling this.

Additionally this centralizes the config for the version of the `free-disk-space` action to use.