### PR TITLE
Teach weekly-pulumi-update to create PRs with Pulumi version in the title

### DIFF
--- a/native-provider-ci/providers/aws-native/repo/.github/workflows/weekly-pulumi-update.yml
+++ b/native-provider-ci/providers/aws-native/repo/.github/workflows/weekly-pulumi-update.yml
@@ -117,12 +117,10 @@ jobs:
     - name: Create PR
       id: create-pr
       if: steps.gomod.outputs.changes != 0
-      uses: repo-sync/pull-request@v2.6.2
-      with:
-        source_branch: update-pulumi/${{ github.run_id }}-${{ github.run_number }}
-        destination_branch: master
-        pr_title: Automated Pulumi/Pulumi upgrade
-        github_token: ${{ secrets.PULUMI_BOT_TOKEN }}
+      run: |
+        ver=$(cat .pulumi.version)
+        msg="Automated upgrade: bump pulumi/pulumi to ${ver}"
+        gh pr create -t "$msg" -b "$msg" -B master
       env:
         GITHUB_TOKEN: ${{ secrets.PULUMI_BOT_TOKEN }}
     name: weekly-pulumi-update

--- a/native-provider-ci/providers/command/repo/.github/workflows/weekly-pulumi-update.yml
+++ b/native-provider-ci/providers/command/repo/.github/workflows/weekly-pulumi-update.yml
@@ -115,12 +115,10 @@ jobs:
     - name: Create PR
       id: create-pr
       if: steps.gomod.outputs.changes != 0
-      uses: repo-sync/pull-request@v2.6.2
-      with:
-        source_branch: update-pulumi/${{ github.run_id }}-${{ github.run_number }}
-        destination_branch: master
-        pr_title: Automated Pulumi/Pulumi upgrade
-        github_token: ${{ secrets.PULUMI_BOT_TOKEN }}
+      run: |
+        ver=$(cat .pulumi.version)
+        msg="Automated upgrade: bump pulumi/pulumi to ${ver}"
+        gh pr create -t "$msg" -b "$msg" -B master
       env:
         GITHUB_TOKEN: ${{ secrets.PULUMI_BOT_TOKEN }}
     name: weekly-pulumi-update

--- a/native-provider-ci/providers/docker-build/repo/.github/workflows/weekly-pulumi-update.yml
+++ b/native-provider-ci/providers/docker-build/repo/.github/workflows/weekly-pulumi-update.yml
@@ -127,12 +127,10 @@ jobs:
     - name: Create PR
       id: create-pr
       if: steps.gomod.outputs.changes != 0
-      uses: repo-sync/pull-request@v2.6.2
-      with:
-        source_branch: update-pulumi/${{ github.run_id }}-${{ github.run_number }}
-        destination_branch: main
-        pr_title: Automated Pulumi/Pulumi upgrade
-        github_token: ${{ secrets.PULUMI_BOT_TOKEN }}
+      run: |
+        ver=$(cat .pulumi.version)
+        msg="Automated upgrade: bump pulumi/pulumi to ${ver}"
+        gh pr create -t "$msg" -b "$msg" -B main
       env:
         GITHUB_TOKEN: ${{ secrets.PULUMI_BOT_TOKEN }}
     name: weekly-pulumi-update

--- a/native-provider-ci/providers/google-native/repo/.github/workflows/weekly-pulumi-update.yml
+++ b/native-provider-ci/providers/google-native/repo/.github/workflows/weekly-pulumi-update.yml
@@ -121,12 +121,10 @@ jobs:
     - name: Create PR
       id: create-pr
       if: steps.gomod.outputs.changes != 0
-      uses: repo-sync/pull-request@v2.6.2
-      with:
-        source_branch: update-pulumi/${{ github.run_id }}-${{ github.run_number }}
-        destination_branch: master
-        pr_title: Automated Pulumi/Pulumi upgrade
-        github_token: ${{ secrets.PULUMI_BOT_TOKEN }}
+      run: |
+        ver=$(cat .pulumi.version)
+        msg="Automated upgrade: bump pulumi/pulumi to ${ver}"
+        gh pr create -t "$msg" -b "$msg" -B master
       env:
         GITHUB_TOKEN: ${{ secrets.PULUMI_BOT_TOKEN }}
     name: weekly-pulumi-update

--- a/native-provider-ci/providers/kubernetes-cert-manager/repo/.github/workflows/weekly-pulumi-update.yml
+++ b/native-provider-ci/providers/kubernetes-cert-manager/repo/.github/workflows/weekly-pulumi-update.yml
@@ -120,12 +120,10 @@ jobs:
     - name: Create PR
       id: create-pr
       if: steps.gomod.outputs.changes != 0
-      uses: repo-sync/pull-request@v2.6.2
-      with:
-        source_branch: update-pulumi/${{ github.run_id }}-${{ github.run_number }}
-        destination_branch: master
-        pr_title: Automated Pulumi/Pulumi upgrade
-        github_token: ${{ secrets.PULUMI_BOT_TOKEN }}
+      run: |
+        ver=$(cat .pulumi.version)
+        msg="Automated upgrade: bump pulumi/pulumi to ${ver}"
+        gh pr create -t "$msg" -b "$msg" -B master
       env:
         GITHUB_TOKEN: ${{ secrets.PULUMI_BOT_TOKEN }}
     name: weekly-pulumi-update

--- a/native-provider-ci/providers/kubernetes/repo/.github/workflows/weekly-pulumi-update.yml
+++ b/native-provider-ci/providers/kubernetes/repo/.github/workflows/weekly-pulumi-update.yml
@@ -120,12 +120,10 @@ jobs:
     - name: Create PR
       id: create-pr
       if: steps.gomod.outputs.changes != 0
-      uses: repo-sync/pull-request@v2.6.2
-      with:
-        source_branch: update-pulumi/${{ github.run_id }}-${{ github.run_number }}
-        destination_branch: master
-        pr_title: Automated Pulumi/Pulumi upgrade
-        github_token: ${{ secrets.PULUMI_BOT_TOKEN }}
+      run: |
+        ver=$(cat .pulumi.version)
+        msg="Automated upgrade: bump pulumi/pulumi to ${ver}"
+        gh pr create -t "$msg" -b "$msg" -B master
       env:
         GITHUB_TOKEN: ${{ secrets.PULUMI_BOT_TOKEN }}
     name: weekly-pulumi-update

--- a/native-provider-ci/src/steps.ts
+++ b/native-provider-ci/src/steps.ts
@@ -982,14 +982,14 @@ export function CreateUpdatePulumiPR(branch: string): Step {
     name: "Create PR",
     id: "create-pr",
     if: "steps.gomod.outputs.changes != 0",
-    uses: action.pullRequest,
-    with: {
-      source_branch:
-        "update-pulumi/${{ github.run_id }}-${{ github.run_number }}",
-      destination_branch: branch,
-      pr_title: "Automated Pulumi/Pulumi upgrade",
-      github_token: "${{ secrets.PULUMI_BOT_TOKEN }}",
-    },
+    run:
+      "ver=$(cat .pulumi.version)" +
+      "\n" +
+      'msg="Automated upgrade: bump pulumi/pulumi to ${ver}"' +
+      "\n" +
+      'gh pr create -t "$msg" -b "$msg" -B ' +
+      branch +
+      "\n",
     env: {
       GITHUB_TOKEN: "${{ secrets.PULUMI_BOT_TOKEN }}",
     },


### PR DESCRIPTION
Here is an example of a PR created by the `weekly-pulumi-update` automation that includes the changes suggseted here:
https://github.com/pulumi/pulumi-aws-native/pull/1670

For comparison, here is the PR created by the automation before the changes:
https://github.com/pulumi/pulumi-aws-native/pull/1668

Note that Pulumi version is made prominent in the PR title.

And it uses the word "bump" inspired by Dependabot PRs.

It also removes repo-sync/pull-request@v2.6.2 dependency as this project is now archived.