### PR TITLE
Add option for freeing disk space to sdk build and bridge upgrade

### DIFF
--- a/provider-ci/internal/pkg/templates/bridged-provider.config.yaml
+++ b/provider-ci/internal/pkg/templates/bridged-provider.config.yaml
@@ -69,6 +69,9 @@ freeDiskSpaceBeforeBuild: false
 # Set to true to clear disk space before running test jobs.
 freeDiskSpaceBeforeTest: false
 
+# Set to true to clear disk space before running sdk build jobs.
+freeDiskSpaceBeforeSdkBuild: false
+
 # Used for centrally managing tool versions.
 # This is not currently overridden by any providers: https://github.com/search?q=org%3Apulumi+path%3A.ci-mgmt.yaml+%22toolVersions%22&type=code
 toolVersions:

--- a/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/build_sdk.yml
+++ b/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/build_sdk.yml
@@ -25,6 +25,14 @@ jobs:
         - go
         - java
     steps:
+      #{{- if .Config.freeDiskSpaceBeforeSdkBuild }}#
+      # Run as first step so we don't delete things that have just been installed
+      - name: Free Disk Space (Ubuntu)
+        uses: #{{ .Config.actionVersions.freeDiskSpace }}#
+        with:
+          tool-cache: false
+          swap-storage: false
+      #{{- end }}#
       - name: Checkout Repo
         uses: #{{ .Config.actionVersions.checkout }}#
 #{{- if .Config.checkoutSubmodules }}#

--- a/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/upgrade-bridge.yml
+++ b/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/upgrade-bridge.yml
@@ -57,6 +57,14 @@ jobs:
     name: upgrade-provider
     runs-on: #{{ if .Config.runner.buildSdk }}##{{- .Config.runner.buildSdk }}##{{ else }}##{{- .Config.runner.default }}##{{ end }}#
     steps:
+    #{{- if .Config.freeDiskSpaceBeforeBuild }}#
+    # Run as first step so we don't delete things that have just been installed
+    - name: Free Disk Space (Ubuntu)
+      uses: #{{ .Config.actionVersions.freeDiskSpace }}#
+      with:
+        tool-cache: false
+        swap-storage: false
+    #{{- end }}#
     - name: Call upgrade provider action
       if: github.event_name == 'workflow_dispatch'
       uses: #{{ .Config.actionVersions.upgradeProviderAction }}#

--- a/provider-ci/test-providers/aws/.ci-mgmt.yaml
+++ b/provider-ci/test-providers/aws/.ci-mgmt.yaml
@@ -12,6 +12,7 @@ env:
 makeTemplate: bridged
 checkoutSubmodules: true
 freeDiskSpaceBeforeBuild: true
+freeDiskSpaceBeforeSdkBuild: true
 freeDiskSpaceBeforeTest: true
 # TODO: remove XrunUpstreamTools flag after work to add docs replacement strategies to resources.go is completed
 # Tracked in in https://github.com/pulumi/pulumi-aws/issues/2757

--- a/provider-ci/test-providers/aws/.github/workflows/build_sdk.yml
+++ b/provider-ci/test-providers/aws/.github/workflows/build_sdk.yml
@@ -43,6 +43,12 @@ jobs:
         - go
         - java
     steps:
+      # Run as first step so we don't delete things that have just been installed
+      - name: Free Disk Space (Ubuntu)
+        uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be
+        with:
+          tool-cache: false
+          swap-storage: false
       - name: Checkout Repo
         uses: actions/checkout@v4
         with:

--- a/provider-ci/test-providers/aws/.github/workflows/upgrade-bridge.yml
+++ b/provider-ci/test-providers/aws/.github/workflows/upgrade-bridge.yml
@@ -57,6 +57,12 @@ jobs:
     name: upgrade-provider
     runs-on: ubuntu-latest
     steps:
+    # Run as first step so we don't delete things that have just been installed
+    - name: Free Disk Space (Ubuntu)
+      uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be
+      with:
+        tool-cache: false
+        swap-storage: false
     - name: Call upgrade provider action
       if: github.event_name == 'workflow_dispatch'
       uses: pulumi/pulumi-upgrade-provider-action@v0.0.12


### PR DESCRIPTION
Some of the workflows on larger providers like aws started failing because they're running out of disk space (again.. sigh). Examples are:
- https://github.com/pulumi/pulumi-aws/issues/4379
- https://github.com/pulumi/pulumi-aws/actions/runs/10421649189/job/28864324845

This change adds a new configuration parameter (`freeDiskSpaceBeforeSdkBuild`) to free the disk space before SDK builds. Additionally it also adds the disk space cleaning to the upgrade-bridge workflow.

We should also explore using bigger runners, but this might be cost prohibitive (AWS alone had ~1.1k build hours within the last month, which would amount to ~1k$ for a larger runner).