### PR TITLE
Turn on test sharding for k8s and docker-build

### DIFF
--- a/native-provider-ci/providers/aws-native/repo/.github/workflows/build.yml
+++ b/native-provider-ci/providers/aws-native/repo/.github/workflows/build.yml
@@ -320,8 +320,8 @@ jobs:
         name: ${{ matrix.language }}-sdk.tar.gz
         path: ${{ github.workspace}}/sdk/
     - name: UnTar SDK folder
-      run: tar -zxf ${{ github.workspace}}/sdk/${{ matrix.language}}.tar.gz -C ${{
-        github.workspace}}/sdk/${{ matrix.language}}
+      run: for f in *.tar.gz; do tar -zxf "$f" -C "${f%.tar.gz}"; done
+      working-directory: ${{ github.workspace}}/sdk
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Install Node dependencies
@@ -332,7 +332,7 @@ jobs:
         pip3 install virtualenv==20.0.23
         pip3 install pipenv
     - name: Install dependencies
-      run: make install_${{ matrix.language}}_sdk
+      run: make install_sdks
     - name: Configure AWS Credentials
       uses: aws-actions/configure-aws-credentials@v4
       with:

--- a/native-provider-ci/providers/aws-native/repo/.github/workflows/prerelease.yml
+++ b/native-provider-ci/providers/aws-native/repo/.github/workflows/prerelease.yml
@@ -311,8 +311,8 @@ jobs:
         name: ${{ matrix.language }}-sdk.tar.gz
         path: ${{ github.workspace}}/sdk/
     - name: UnTar SDK folder
-      run: tar -zxf ${{ github.workspace}}/sdk/${{ matrix.language}}.tar.gz -C ${{
-        github.workspace}}/sdk/${{ matrix.language}}
+      run: for f in *.tar.gz; do tar -zxf "$f" -C "${f%.tar.gz}"; done
+      working-directory: ${{ github.workspace}}/sdk
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Install Node dependencies
@@ -323,7 +323,7 @@ jobs:
         pip3 install virtualenv==20.0.23
         pip3 install pipenv
     - name: Install dependencies
-      run: make install_${{ matrix.language}}_sdk
+      run: make install_sdks
     - name: Configure AWS Credentials
       uses: aws-actions/configure-aws-credentials@v4
       with:

--- a/native-provider-ci/providers/aws-native/repo/.github/workflows/release.yml
+++ b/native-provider-ci/providers/aws-native/repo/.github/workflows/release.yml
@@ -311,8 +311,8 @@ jobs:
         name: ${{ matrix.language }}-sdk.tar.gz
         path: ${{ github.workspace}}/sdk/
     - name: UnTar SDK folder
-      run: tar -zxf ${{ github.workspace}}/sdk/${{ matrix.language}}.tar.gz -C ${{
-        github.workspace}}/sdk/${{ matrix.language}}
+      run: for f in *.tar.gz; do tar -zxf "$f" -C "${f%.tar.gz}"; done
+      working-directory: ${{ github.workspace}}/sdk
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Install Node dependencies
@@ -323,7 +323,7 @@ jobs:
         pip3 install virtualenv==20.0.23
         pip3 install pipenv
     - name: Install dependencies
-      run: make install_${{ matrix.language}}_sdk
+      run: make install_sdks
     - name: Configure AWS Credentials
       uses: aws-actions/configure-aws-credentials@v4
       with:

--- a/native-provider-ci/providers/aws-native/repo/.github/workflows/run-acceptance-tests.yml
+++ b/native-provider-ci/providers/aws-native/repo/.github/workflows/run-acceptance-tests.yml
@@ -340,8 +340,8 @@ jobs:
         name: ${{ matrix.language }}-sdk.tar.gz
         path: ${{ github.workspace}}/sdk/
     - name: UnTar SDK folder
-      run: tar -zxf ${{ github.workspace}}/sdk/${{ matrix.language}}.tar.gz -C ${{
-        github.workspace}}/sdk/${{ matrix.language}}
+      run: for f in *.tar.gz; do tar -zxf "$f" -C "${f%.tar.gz}"; done
+      working-directory: ${{ github.workspace}}/sdk
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Install Node dependencies
@@ -352,7 +352,7 @@ jobs:
         pip3 install virtualenv==20.0.23
         pip3 install pipenv
     - name: Install dependencies
-      run: make install_${{ matrix.language}}_sdk
+      run: make install_sdks
     - name: Configure AWS Credentials
       uses: aws-actions/configure-aws-credentials@v4
       with:

--- a/native-provider-ci/providers/command/repo/.github/workflows/build.yml
+++ b/native-provider-ci/providers/command/repo/.github/workflows/build.yml
@@ -280,8 +280,8 @@ jobs:
         name: ${{ matrix.language }}-sdk.tar.gz
         path: ${{ github.workspace}}/sdk/
     - name: UnTar SDK folder
-      run: tar -zxf ${{ github.workspace}}/sdk/${{ matrix.language}}.tar.gz -C ${{
-        github.workspace}}/sdk/${{ matrix.language}}
+      run: for f in *.tar.gz; do tar -zxf "$f" -C "${f%.tar.gz}"; done
+      working-directory: ${{ github.workspace}}/sdk
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Install Node dependencies
@@ -292,7 +292,7 @@ jobs:
         pip3 install virtualenv==20.0.23
         pip3 install pipenv
     - name: Install dependencies
-      run: make install_${{ matrix.language}}_sdk
+      run: make install_sdks
     - name: Configure AWS Credentials
       uses: aws-actions/configure-aws-credentials@v4
       with:

--- a/native-provider-ci/providers/command/repo/.github/workflows/prerelease.yml
+++ b/native-provider-ci/providers/command/repo/.github/workflows/prerelease.yml
@@ -271,8 +271,8 @@ jobs:
         name: ${{ matrix.language }}-sdk.tar.gz
         path: ${{ github.workspace}}/sdk/
     - name: UnTar SDK folder
-      run: tar -zxf ${{ github.workspace}}/sdk/${{ matrix.language}}.tar.gz -C ${{
-        github.workspace}}/sdk/${{ matrix.language}}
+      run: for f in *.tar.gz; do tar -zxf "$f" -C "${f%.tar.gz}"; done
+      working-directory: ${{ github.workspace}}/sdk
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Install Node dependencies
@@ -283,7 +283,7 @@ jobs:
         pip3 install virtualenv==20.0.23
         pip3 install pipenv
     - name: Install dependencies
-      run: make install_${{ matrix.language}}_sdk
+      run: make install_sdks
     - name: Configure AWS Credentials
       uses: aws-actions/configure-aws-credentials@v4
       with:

--- a/native-provider-ci/providers/command/repo/.github/workflows/release.yml
+++ b/native-provider-ci/providers/command/repo/.github/workflows/release.yml
@@ -271,8 +271,8 @@ jobs:
         name: ${{ matrix.language }}-sdk.tar.gz
         path: ${{ github.workspace}}/sdk/
     - name: UnTar SDK folder
-      run: tar -zxf ${{ github.workspace}}/sdk/${{ matrix.language}}.tar.gz -C ${{
-        github.workspace}}/sdk/${{ matrix.language}}
+      run: for f in *.tar.gz; do tar -zxf "$f" -C "${f%.tar.gz}"; done
+      working-directory: ${{ github.workspace}}/sdk
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Install Node dependencies
@@ -283,7 +283,7 @@ jobs:
         pip3 install virtualenv==20.0.23
         pip3 install pipenv
     - name: Install dependencies
-      run: make install_${{ matrix.language}}_sdk
+      run: make install_sdks
     - name: Configure AWS Credentials
       uses: aws-actions/configure-aws-credentials@v4
       with:

--- a/native-provider-ci/providers/command/repo/.github/workflows/run-acceptance-tests.yml
+++ b/native-provider-ci/providers/command/repo/.github/workflows/run-acceptance-tests.yml
@@ -300,8 +300,8 @@ jobs:
         name: ${{ matrix.language }}-sdk.tar.gz
         path: ${{ github.workspace}}/sdk/
     - name: UnTar SDK folder
-      run: tar -zxf ${{ github.workspace}}/sdk/${{ matrix.language}}.tar.gz -C ${{
-        github.workspace}}/sdk/${{ matrix.language}}
+      run: for f in *.tar.gz; do tar -zxf "$f" -C "${f%.tar.gz}"; done
+      working-directory: ${{ github.workspace}}/sdk
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Install Node dependencies
@@ -312,7 +312,7 @@ jobs:
         pip3 install virtualenv==20.0.23
         pip3 install pipenv
     - name: Install dependencies
-      run: make install_${{ matrix.language}}_sdk
+      run: make install_sdks
     - name: Configure AWS Credentials
       uses: aws-actions/configure-aws-credentials@v4
       with:

--- a/native-provider-ci/providers/docker-build/config.yaml
+++ b/native-provider-ci/providers/docker-build/config.yaml
@@ -5,6 +5,8 @@ providerVersion: github.com/pulumi/pulumi-docker-build/provider.Version
 aws: true
 gcp: true
 sdkModuleDir: sdk/go/dockerbuild
+testShards: 5
+testShardDir: examples
 env:
   AWS_REGION: us-west-2
   PULUMI_API: "https://api.pulumi-staging.io"

--- a/native-provider-ci/providers/docker-build/repo/.github/workflows/build.yml
+++ b/native-provider-ci/providers/docker-build/repo/.github/workflows/build.yml
@@ -253,12 +253,12 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        language:
-        - nodejs
-        - python
-        - dotnet
-        - go
-        - java
+        shard:
+        - 0
+        - 1
+        - 2
+        - 3
+        - 4
     name: test
     permissions:
       contents: read
@@ -318,14 +318,34 @@ jobs:
     - name: Restore Binary Permissions
       run: find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print
         -exec chmod +x {} \;
-    - name: Download SDK
+    - name: Download nodejs SDK
       uses: actions/download-artifact@v4
       with:
-        name: ${{ matrix.language }}-sdk.tar.gz
+        name: nodejs-sdk.tar.gz
+        path: ${{ github.workspace}}/sdk/
+    - name: Download go SDK
+      uses: actions/download-artifact@v4
+      with:
+        name: go-sdk.tar.gz
+        path: ${{ github.workspace}}/sdk/
+    - name: Download dotnet SDK
+      uses: actions/download-artifact@v4
+      with:
+        name: dotnet-sdk.tar.gz
+        path: ${{ github.workspace}}/sdk/
+    - name: Download python SDK
+      uses: actions/download-artifact@v4
+      with:
+        name: python-sdk.tar.gz
+        path: ${{ github.workspace}}/sdk/
+    - name: Download java SDK
+      uses: actions/download-artifact@v4
+      with:
+        name: java-sdk.tar.gz
         path: ${{ github.workspace}}/sdk/
     - name: UnTar SDK folder
-      run: tar -zxf ${{ github.workspace}}/sdk/${{ matrix.language}}.tar.gz -C ${{
-        github.workspace}}/sdk/${{ matrix.language}}
+      run: for f in *.tar.gz; do tar -zxf "$f" -C "${f%.tar.gz}"; done
+      working-directory: ${{ github.workspace}}/sdk
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Install Node dependencies
@@ -336,7 +356,7 @@ jobs:
         pip3 install virtualenv==20.0.23
         pip3 install pipenv
     - name: Install dependencies
-      run: make install_${{ matrix.language}}_sdk
+      run: make install_sdks
     - name: Configure AWS Credentials
       uses: aws-actions/configure-aws-credentials@v4
       with:
@@ -363,11 +383,15 @@ jobs:
       with:
         version: v2.5.0
         token: ${{ secrets.GITHUB_TOKEN }}
+    - name: Shard tests
+      run: echo go test -v -count=1 -cover -timeout 2h -parallel 4 "$(go run
+        github.com/blampe/shard@b251cf8da6a83022628496125f285095772ebe86 --total
+        ${{ strategy.job-total }} --index ${{ strategy.job-index }})" >
+        test-command
+      working-directory: examples
     - name: Run tests
-      run: >-
-        set -euo pipefail
-
-        cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt
+      run: cat test-command && $(cat test-command)
+      working-directory: examples
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3

--- a/native-provider-ci/providers/docker-build/repo/.github/workflows/prerelease.yml
+++ b/native-provider-ci/providers/docker-build/repo/.github/workflows/prerelease.yml
@@ -244,12 +244,12 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        language:
-        - nodejs
-        - python
-        - dotnet
-        - go
-        - java
+        shard:
+        - 0
+        - 1
+        - 2
+        - 3
+        - 4
     name: test
     permissions:
       contents: read
@@ -309,14 +309,34 @@ jobs:
     - name: Restore Binary Permissions
       run: find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print
         -exec chmod +x {} \;
-    - name: Download SDK
+    - name: Download nodejs SDK
       uses: actions/download-artifact@v4
       with:
-        name: ${{ matrix.language }}-sdk.tar.gz
+        name: nodejs-sdk.tar.gz
+        path: ${{ github.workspace}}/sdk/
+    - name: Download go SDK
+      uses: actions/download-artifact@v4
+      with:
+        name: go-sdk.tar.gz
+        path: ${{ github.workspace}}/sdk/
+    - name: Download dotnet SDK
+      uses: actions/download-artifact@v4
+      with:
+        name: dotnet-sdk.tar.gz
+        path: ${{ github.workspace}}/sdk/
+    - name: Download python SDK
+      uses: actions/download-artifact@v4
+      with:
+        name: python-sdk.tar.gz
+        path: ${{ github.workspace}}/sdk/
+    - name: Download java SDK
+      uses: actions/download-artifact@v4
+      with:
+        name: java-sdk.tar.gz
         path: ${{ github.workspace}}/sdk/
     - name: UnTar SDK folder
-      run: tar -zxf ${{ github.workspace}}/sdk/${{ matrix.language}}.tar.gz -C ${{
-        github.workspace}}/sdk/${{ matrix.language}}
+      run: for f in *.tar.gz; do tar -zxf "$f" -C "${f%.tar.gz}"; done
+      working-directory: ${{ github.workspace}}/sdk
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Install Node dependencies
@@ -327,7 +347,7 @@ jobs:
         pip3 install virtualenv==20.0.23
         pip3 install pipenv
     - name: Install dependencies
-      run: make install_${{ matrix.language}}_sdk
+      run: make install_sdks
     - name: Configure AWS Credentials
       uses: aws-actions/configure-aws-credentials@v4
       with:
@@ -354,11 +374,15 @@ jobs:
       with:
         version: v2.5.0
         token: ${{ secrets.GITHUB_TOKEN }}
+    - name: Shard tests
+      run: echo go test -v -count=1 -cover -timeout 2h -parallel 4 "$(go run
+        github.com/blampe/shard@b251cf8da6a83022628496125f285095772ebe86 --total
+        ${{ strategy.job-total }} --index ${{ strategy.job-index }})" >
+        test-command
+      working-directory: examples
     - name: Run tests
-      run: >-
-        set -euo pipefail
-
-        cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt
+      run: cat test-command && $(cat test-command)
+      working-directory: examples
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3

--- a/native-provider-ci/providers/docker-build/repo/.github/workflows/release.yml
+++ b/native-provider-ci/providers/docker-build/repo/.github/workflows/release.yml
@@ -244,12 +244,12 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        language:
-        - nodejs
-        - python
-        - dotnet
-        - go
-        - java
+        shard:
+        - 0
+        - 1
+        - 2
+        - 3
+        - 4
     name: test
     permissions:
       contents: read
@@ -309,14 +309,34 @@ jobs:
     - name: Restore Binary Permissions
       run: find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print
         -exec chmod +x {} \;
-    - name: Download SDK
+    - name: Download nodejs SDK
       uses: actions/download-artifact@v4
       with:
-        name: ${{ matrix.language }}-sdk.tar.gz
+        name: nodejs-sdk.tar.gz
+        path: ${{ github.workspace}}/sdk/
+    - name: Download go SDK
+      uses: actions/download-artifact@v4
+      with:
+        name: go-sdk.tar.gz
+        path: ${{ github.workspace}}/sdk/
+    - name: Download dotnet SDK
+      uses: actions/download-artifact@v4
+      with:
+        name: dotnet-sdk.tar.gz
+        path: ${{ github.workspace}}/sdk/
+    - name: Download python SDK
+      uses: actions/download-artifact@v4
+      with:
+        name: python-sdk.tar.gz
+        path: ${{ github.workspace}}/sdk/
+    - name: Download java SDK
+      uses: actions/download-artifact@v4
+      with:
+        name: java-sdk.tar.gz
         path: ${{ github.workspace}}/sdk/
     - name: UnTar SDK folder
-      run: tar -zxf ${{ github.workspace}}/sdk/${{ matrix.language}}.tar.gz -C ${{
-        github.workspace}}/sdk/${{ matrix.language}}
+      run: for f in *.tar.gz; do tar -zxf "$f" -C "${f%.tar.gz}"; done
+      working-directory: ${{ github.workspace}}/sdk
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Install Node dependencies
@@ -327,7 +347,7 @@ jobs:
         pip3 install virtualenv==20.0.23
         pip3 install pipenv
     - name: Install dependencies
-      run: make install_${{ matrix.language}}_sdk
+      run: make install_sdks
     - name: Configure AWS Credentials
       uses: aws-actions/configure-aws-credentials@v4
       with:
@@ -354,11 +374,15 @@ jobs:
       with:
         version: v2.5.0
         token: ${{ secrets.GITHUB_TOKEN }}
+    - name: Shard tests
+      run: echo go test -v -count=1 -cover -timeout 2h -parallel 4 "$(go run
+        github.com/blampe/shard@b251cf8da6a83022628496125f285095772ebe86 --total
+        ${{ strategy.job-total }} --index ${{ strategy.job-index }})" >
+        test-command
+      working-directory: examples
     - name: Run tests
-      run: >-
-        set -euo pipefail
-
-        cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt
+      run: cat test-command && $(cat test-command)
+      working-directory: examples
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3

--- a/native-provider-ci/providers/docker-build/repo/.github/workflows/run-acceptance-tests.yml
+++ b/native-provider-ci/providers/docker-build/repo/.github/workflows/run-acceptance-tests.yml
@@ -272,12 +272,12 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        language:
-        - nodejs
-        - python
-        - dotnet
-        - go
-        - java
+        shard:
+        - 0
+        - 1
+        - 2
+        - 3
+        - 4
     name: test
     permissions:
       contents: read
@@ -338,14 +338,34 @@ jobs:
     - name: Restore Binary Permissions
       run: find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print
         -exec chmod +x {} \;
-    - name: Download SDK
+    - name: Download nodejs SDK
       uses: actions/download-artifact@v4
       with:
-        name: ${{ matrix.language }}-sdk.tar.gz
+        name: nodejs-sdk.tar.gz
+        path: ${{ github.workspace}}/sdk/
+    - name: Download go SDK
+      uses: actions/download-artifact@v4
+      with:
+        name: go-sdk.tar.gz
+        path: ${{ github.workspace}}/sdk/
+    - name: Download dotnet SDK
+      uses: actions/download-artifact@v4
+      with:
+        name: dotnet-sdk.tar.gz
+        path: ${{ github.workspace}}/sdk/
+    - name: Download python SDK
+      uses: actions/download-artifact@v4
+      with:
+        name: python-sdk.tar.gz
+        path: ${{ github.workspace}}/sdk/
+    - name: Download java SDK
+      uses: actions/download-artifact@v4
+      with:
+        name: java-sdk.tar.gz
         path: ${{ github.workspace}}/sdk/
     - name: UnTar SDK folder
-      run: tar -zxf ${{ github.workspace}}/sdk/${{ matrix.language}}.tar.gz -C ${{
-        github.workspace}}/sdk/${{ matrix.language}}
+      run: for f in *.tar.gz; do tar -zxf "$f" -C "${f%.tar.gz}"; done
+      working-directory: ${{ github.workspace}}/sdk
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Install Node dependencies
@@ -356,7 +376,7 @@ jobs:
         pip3 install virtualenv==20.0.23
         pip3 install pipenv
     - name: Install dependencies
-      run: make install_${{ matrix.language}}_sdk
+      run: make install_sdks
     - name: Configure AWS Credentials
       uses: aws-actions/configure-aws-credentials@v4
       with:
@@ -383,11 +403,15 @@ jobs:
       with:
         version: v2.5.0
         token: ${{ secrets.GITHUB_TOKEN }}
+    - name: Shard tests
+      run: echo go test -v -count=1 -cover -timeout 2h -parallel 4 -short "$(go run
+        github.com/blampe/shard@b251cf8da6a83022628496125f285095772ebe86 --total
+        ${{ strategy.job-total }} --index ${{ strategy.job-index }})" >
+        test-command
+      working-directory: examples
     - name: Run tests
-      run: >-
-        set -euo pipefail
-
-        cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt
+      run: cat test-command && $(cat test-command)
+      working-directory: examples
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3

--- a/native-provider-ci/providers/google-native/repo/.github/workflows/build.yml
+++ b/native-provider-ci/providers/google-native/repo/.github/workflows/build.yml
@@ -320,8 +320,8 @@ jobs:
         name: ${{ matrix.language }}-sdk.tar.gz
         path: ${{ github.workspace}}/sdk/
     - name: UnTar SDK folder
-      run: tar -zxf ${{ github.workspace}}/sdk/${{ matrix.language}}.tar.gz -C ${{
-        github.workspace}}/sdk/${{ matrix.language}}
+      run: for f in *.tar.gz; do tar -zxf "$f" -C "${f%.tar.gz}"; done
+      working-directory: ${{ github.workspace}}/sdk
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Install Node dependencies
@@ -332,7 +332,7 @@ jobs:
         pip3 install virtualenv==20.0.23
         pip3 install pipenv
     - name: Install dependencies
-      run: make install_${{ matrix.language}}_sdk
+      run: make install_sdks
     - name: Authenticate to Google Cloud
       uses: google-github-actions/auth@v0
       with:

--- a/native-provider-ci/providers/google-native/repo/.github/workflows/prerelease.yml
+++ b/native-provider-ci/providers/google-native/repo/.github/workflows/prerelease.yml
@@ -311,8 +311,8 @@ jobs:
         name: ${{ matrix.language }}-sdk.tar.gz
         path: ${{ github.workspace}}/sdk/
     - name: UnTar SDK folder
-      run: tar -zxf ${{ github.workspace}}/sdk/${{ matrix.language}}.tar.gz -C ${{
-        github.workspace}}/sdk/${{ matrix.language}}
+      run: for f in *.tar.gz; do tar -zxf "$f" -C "${f%.tar.gz}"; done
+      working-directory: ${{ github.workspace}}/sdk
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Install Node dependencies
@@ -323,7 +323,7 @@ jobs:
         pip3 install virtualenv==20.0.23
         pip3 install pipenv
     - name: Install dependencies
-      run: make install_${{ matrix.language}}_sdk
+      run: make install_sdks
     - name: Authenticate to Google Cloud
       uses: google-github-actions/auth@v0
       with:

--- a/native-provider-ci/providers/google-native/repo/.github/workflows/release.yml
+++ b/native-provider-ci/providers/google-native/repo/.github/workflows/release.yml
@@ -311,8 +311,8 @@ jobs:
         name: ${{ matrix.language }}-sdk.tar.gz
         path: ${{ github.workspace}}/sdk/
     - name: UnTar SDK folder
-      run: tar -zxf ${{ github.workspace}}/sdk/${{ matrix.language}}.tar.gz -C ${{
-        github.workspace}}/sdk/${{ matrix.language}}
+      run: for f in *.tar.gz; do tar -zxf "$f" -C "${f%.tar.gz}"; done
+      working-directory: ${{ github.workspace}}/sdk
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Install Node dependencies
@@ -323,7 +323,7 @@ jobs:
         pip3 install virtualenv==20.0.23
         pip3 install pipenv
     - name: Install dependencies
-      run: make install_${{ matrix.language}}_sdk
+      run: make install_sdks
     - name: Authenticate to Google Cloud
       uses: google-github-actions/auth@v0
       with:

--- a/native-provider-ci/providers/google-native/repo/.github/workflows/run-acceptance-tests.yml
+++ b/native-provider-ci/providers/google-native/repo/.github/workflows/run-acceptance-tests.yml
@@ -340,8 +340,8 @@ jobs:
         name: ${{ matrix.language }}-sdk.tar.gz
         path: ${{ github.workspace}}/sdk/
     - name: UnTar SDK folder
-      run: tar -zxf ${{ github.workspace}}/sdk/${{ matrix.language}}.tar.gz -C ${{
-        github.workspace}}/sdk/${{ matrix.language}}
+      run: for f in *.tar.gz; do tar -zxf "$f" -C "${f%.tar.gz}"; done
+      working-directory: ${{ github.workspace}}/sdk
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Install Node dependencies
@@ -352,7 +352,7 @@ jobs:
         pip3 install virtualenv==20.0.23
         pip3 install pipenv
     - name: Install dependencies
-      run: make install_${{ matrix.language}}_sdk
+      run: make install_sdks
     - name: Authenticate to Google Cloud
       uses: google-github-actions/auth@v0
       with:

--- a/native-provider-ci/providers/kubernetes-cert-manager/repo/.github/workflows/build.yml
+++ b/native-provider-ci/providers/kubernetes-cert-manager/repo/.github/workflows/build.yml
@@ -321,8 +321,8 @@ jobs:
         name: ${{ matrix.language }}-sdk.tar.gz
         path: ${{ github.workspace}}/sdk/
     - name: UnTar SDK folder
-      run: tar -zxf ${{ github.workspace}}/sdk/${{ matrix.language}}.tar.gz -C ${{
-        github.workspace}}/sdk/${{ matrix.language}}
+      run: for f in *.tar.gz; do tar -zxf "$f" -C "${f%.tar.gz}"; done
+      working-directory: ${{ github.workspace}}/sdk
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Install Node dependencies
@@ -333,7 +333,7 @@ jobs:
         pip3 install virtualenv==20.0.23
         pip3 install pipenv
     - name: Install dependencies
-      run: make install_${{ matrix.language}}_sdk
+      run: make install_sdks
     - name: Install gotestfmt
       uses: GoTestTools/gotestfmt-action@v2
       with:

--- a/native-provider-ci/providers/kubernetes-cert-manager/repo/.github/workflows/prerelease.yml
+++ b/native-provider-ci/providers/kubernetes-cert-manager/repo/.github/workflows/prerelease.yml
@@ -312,8 +312,8 @@ jobs:
         name: ${{ matrix.language }}-sdk.tar.gz
         path: ${{ github.workspace}}/sdk/
     - name: UnTar SDK folder
-      run: tar -zxf ${{ github.workspace}}/sdk/${{ matrix.language}}.tar.gz -C ${{
-        github.workspace}}/sdk/${{ matrix.language}}
+      run: for f in *.tar.gz; do tar -zxf "$f" -C "${f%.tar.gz}"; done
+      working-directory: ${{ github.workspace}}/sdk
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Install Node dependencies
@@ -324,7 +324,7 @@ jobs:
         pip3 install virtualenv==20.0.23
         pip3 install pipenv
     - name: Install dependencies
-      run: make install_${{ matrix.language}}_sdk
+      run: make install_sdks
     - name: Install gotestfmt
       uses: GoTestTools/gotestfmt-action@v2
       with:

--- a/native-provider-ci/providers/kubernetes-cert-manager/repo/.github/workflows/release.yml
+++ b/native-provider-ci/providers/kubernetes-cert-manager/repo/.github/workflows/release.yml
@@ -312,8 +312,8 @@ jobs:
         name: ${{ matrix.language }}-sdk.tar.gz
         path: ${{ github.workspace}}/sdk/
     - name: UnTar SDK folder
-      run: tar -zxf ${{ github.workspace}}/sdk/${{ matrix.language}}.tar.gz -C ${{
-        github.workspace}}/sdk/${{ matrix.language}}
+      run: for f in *.tar.gz; do tar -zxf "$f" -C "${f%.tar.gz}"; done
+      working-directory: ${{ github.workspace}}/sdk
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Install Node dependencies
@@ -324,7 +324,7 @@ jobs:
         pip3 install virtualenv==20.0.23
         pip3 install pipenv
     - name: Install dependencies
-      run: make install_${{ matrix.language}}_sdk
+      run: make install_sdks
     - name: Install gotestfmt
       uses: GoTestTools/gotestfmt-action@v2
       with:

--- a/native-provider-ci/providers/kubernetes-cert-manager/repo/.github/workflows/run-acceptance-tests.yml
+++ b/native-provider-ci/providers/kubernetes-cert-manager/repo/.github/workflows/run-acceptance-tests.yml
@@ -341,8 +341,8 @@ jobs:
         name: ${{ matrix.language }}-sdk.tar.gz
         path: ${{ github.workspace}}/sdk/
     - name: UnTar SDK folder
-      run: tar -zxf ${{ github.workspace}}/sdk/${{ matrix.language}}.tar.gz -C ${{
-        github.workspace}}/sdk/${{ matrix.language}}
+      run: for f in *.tar.gz; do tar -zxf "$f" -C "${f%.tar.gz}"; done
+      working-directory: ${{ github.workspace}}/sdk
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Install Node dependencies
@@ -353,7 +353,7 @@ jobs:
         pip3 install virtualenv==20.0.23
         pip3 install pipenv
     - name: Install dependencies
-      run: make install_${{ matrix.language}}_sdk
+      run: make install_sdks
     - name: Install gotestfmt
       uses: GoTestTools/gotestfmt-action@v2
       with:

--- a/native-provider-ci/providers/kubernetes/config.yaml
+++ b/native-provider-ci/providers/kubernetes/config.yaml
@@ -4,11 +4,13 @@ aws: true
 gcp: true
 pulumiVersionFile: .pulumi.version
 major-version: 4
+testShards: 10
+testShardDir: tests/sdk
 env:
   AWS_REGION: us-west-2
   PULUMI_TEST_OWNER: moolumi
   GOLANGCI_LINT_VERSION: v1.55.2
-  GOOGLE_CI_SERVICE_ACCOUNT_EMAIL:  pulumi-ci@pulumi-k8s-provider.iam.gserviceaccount.com
+  GOOGLE_CI_SERVICE_ACCOUNT_EMAIL: pulumi-ci@pulumi-k8s-provider.iam.gserviceaccount.com
   GOOGLE_CI_WORKLOAD_IDENTITY_POOL: pulumi-ci
   GOOGLE_CI_WORKLOAD_IDENTITY_PROVIDER: pulumi-ci
   GOOGLE_PROJECT_NUMBER: 637339343727

--- a/native-provider-ci/providers/kubernetes/repo/.github/workflows/build.yml
+++ b/native-provider-ci/providers/kubernetes/repo/.github/workflows/build.yml
@@ -249,12 +249,17 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        language:
-        - nodejs
-        - python
-        - dotnet
-        - go
-        - java
+        shard:
+        - 0
+        - 1
+        - 2
+        - 3
+        - 4
+        - 5
+        - 6
+        - 7
+        - 8
+        - 9
     name: test
     permissions:
       contents: read
@@ -316,14 +321,34 @@ jobs:
     - name: Restore Binary Permissions
       run: find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print
         -exec chmod +x {} \;
-    - name: Download SDK
+    - name: Download nodejs SDK
       uses: actions/download-artifact@v4
       with:
-        name: ${{ matrix.language }}-sdk.tar.gz
+        name: nodejs-sdk.tar.gz
+        path: ${{ github.workspace}}/sdk/
+    - name: Download go SDK
+      uses: actions/download-artifact@v4
+      with:
+        name: go-sdk.tar.gz
+        path: ${{ github.workspace}}/sdk/
+    - name: Download dotnet SDK
+      uses: actions/download-artifact@v4
+      with:
+        name: dotnet-sdk.tar.gz
+        path: ${{ github.workspace}}/sdk/
+    - name: Download python SDK
+      uses: actions/download-artifact@v4
+      with:
+        name: python-sdk.tar.gz
+        path: ${{ github.workspace}}/sdk/
+    - name: Download java SDK
+      uses: actions/download-artifact@v4
+      with:
+        name: java-sdk.tar.gz
         path: ${{ github.workspace}}/sdk/
     - name: UnTar SDK folder
-      run: tar -zxf ${{ github.workspace}}/sdk/${{ matrix.language}}.tar.gz -C ${{
-        github.workspace}}/sdk/${{ matrix.language}}
+      run: for f in *.tar.gz; do tar -zxf "$f" -C "${f%.tar.gz}"; done
+      working-directory: ${{ github.workspace}}/sdk
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Install Node dependencies
@@ -334,7 +359,7 @@ jobs:
         pip3 install virtualenv==20.0.23
         pip3 install pipenv
     - name: Install dependencies
-      run: make install_${{ matrix.language}}_sdk
+      run: make install_sdks
     - name: Make Kube Directory
       run: mkdir -p "~/.kube/"
     - name: Download Kubeconfig
@@ -384,9 +409,15 @@ jobs:
       with:
         version: v2.5.0
         token: ${{ secrets.GITHUB_TOKEN }}
+    - name: Shard tests
+      run: echo go test -v -count=1 -cover -timeout 2h -parallel 4 "$(go run
+        github.com/blampe/shard@b251cf8da6a83022628496125f285095772ebe86 --total
+        ${{ strategy.job-total }} --index ${{ strategy.job-index }})" >
+        test-command
+      working-directory: tests/sdk
     - name: Run tests
-      run: cd tests/sdk/${{ matrix.language }} && go test -v -count=1 -cover -timeout
-        2h -parallel 4 ./...
+      run: cat test-command && $(cat test-command)
+      working-directory: tests/sdk
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3

--- a/native-provider-ci/providers/kubernetes/repo/.github/workflows/prerelease.yml
+++ b/native-provider-ci/providers/kubernetes/repo/.github/workflows/prerelease.yml
@@ -240,12 +240,17 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        language:
-        - nodejs
-        - python
-        - dotnet
-        - go
-        - java
+        shard:
+        - 0
+        - 1
+        - 2
+        - 3
+        - 4
+        - 5
+        - 6
+        - 7
+        - 8
+        - 9
     name: test
     permissions:
       contents: read
@@ -307,14 +312,34 @@ jobs:
     - name: Restore Binary Permissions
       run: find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print
         -exec chmod +x {} \;
-    - name: Download SDK
+    - name: Download nodejs SDK
       uses: actions/download-artifact@v4
       with:
-        name: ${{ matrix.language }}-sdk.tar.gz
+        name: nodejs-sdk.tar.gz
+        path: ${{ github.workspace}}/sdk/
+    - name: Download go SDK
+      uses: actions/download-artifact@v4
+      with:
+        name: go-sdk.tar.gz
+        path: ${{ github.workspace}}/sdk/
+    - name: Download dotnet SDK
+      uses: actions/download-artifact@v4
+      with:
+        name: dotnet-sdk.tar.gz
+        path: ${{ github.workspace}}/sdk/
+    - name: Download python SDK
+      uses: actions/download-artifact@v4
+      with:
+        name: python-sdk.tar.gz
+        path: ${{ github.workspace}}/sdk/
+    - name: Download java SDK
+      uses: actions/download-artifact@v4
+      with:
+        name: java-sdk.tar.gz
         path: ${{ github.workspace}}/sdk/
     - name: UnTar SDK folder
-      run: tar -zxf ${{ github.workspace}}/sdk/${{ matrix.language}}.tar.gz -C ${{
-        github.workspace}}/sdk/${{ matrix.language}}
+      run: for f in *.tar.gz; do tar -zxf "$f" -C "${f%.tar.gz}"; done
+      working-directory: ${{ github.workspace}}/sdk
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Install Node dependencies
@@ -325,7 +350,7 @@ jobs:
         pip3 install virtualenv==20.0.23
         pip3 install pipenv
     - name: Install dependencies
-      run: make install_${{ matrix.language}}_sdk
+      run: make install_sdks
     - name: Make Kube Directory
       run: mkdir -p "~/.kube/"
     - name: Download Kubeconfig
@@ -375,9 +400,15 @@ jobs:
       with:
         version: v2.5.0
         token: ${{ secrets.GITHUB_TOKEN }}
+    - name: Shard tests
+      run: echo go test -v -count=1 -cover -timeout 2h -parallel 4 "$(go run
+        github.com/blampe/shard@b251cf8da6a83022628496125f285095772ebe86 --total
+        ${{ strategy.job-total }} --index ${{ strategy.job-index }})" >
+        test-command
+      working-directory: tests/sdk
     - name: Run tests
-      run: cd tests/sdk/${{ matrix.language }} && go test -v -count=1 -cover -timeout
-        2h -parallel 4 ./...
+      run: cat test-command && $(cat test-command)
+      working-directory: tests/sdk
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3

--- a/native-provider-ci/providers/kubernetes/repo/.github/workflows/release.yml
+++ b/native-provider-ci/providers/kubernetes/repo/.github/workflows/release.yml
@@ -240,12 +240,17 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        language:
-        - nodejs
-        - python
-        - dotnet
-        - go
-        - java
+        shard:
+        - 0
+        - 1
+        - 2
+        - 3
+        - 4
+        - 5
+        - 6
+        - 7
+        - 8
+        - 9
     name: test
     permissions:
       contents: read
@@ -307,14 +312,34 @@ jobs:
     - name: Restore Binary Permissions
       run: find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print
         -exec chmod +x {} \;
-    - name: Download SDK
+    - name: Download nodejs SDK
       uses: actions/download-artifact@v4
       with:
-        name: ${{ matrix.language }}-sdk.tar.gz
+        name: nodejs-sdk.tar.gz
+        path: ${{ github.workspace}}/sdk/
+    - name: Download go SDK
+      uses: actions/download-artifact@v4
+      with:
+        name: go-sdk.tar.gz
+        path: ${{ github.workspace}}/sdk/
+    - name: Download dotnet SDK
+      uses: actions/download-artifact@v4
+      with:
+        name: dotnet-sdk.tar.gz
+        path: ${{ github.workspace}}/sdk/
+    - name: Download python SDK
+      uses: actions/download-artifact@v4
+      with:
+        name: python-sdk.tar.gz
+        path: ${{ github.workspace}}/sdk/
+    - name: Download java SDK
+      uses: actions/download-artifact@v4
+      with:
+        name: java-sdk.tar.gz
         path: ${{ github.workspace}}/sdk/
     - name: UnTar SDK folder
-      run: tar -zxf ${{ github.workspace}}/sdk/${{ matrix.language}}.tar.gz -C ${{
-        github.workspace}}/sdk/${{ matrix.language}}
+      run: for f in *.tar.gz; do tar -zxf "$f" -C "${f%.tar.gz}"; done
+      working-directory: ${{ github.workspace}}/sdk
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Install Node dependencies
@@ -325,7 +350,7 @@ jobs:
         pip3 install virtualenv==20.0.23
         pip3 install pipenv
     - name: Install dependencies
-      run: make install_${{ matrix.language}}_sdk
+      run: make install_sdks
     - name: Make Kube Directory
       run: mkdir -p "~/.kube/"
     - name: Download Kubeconfig
@@ -375,9 +400,15 @@ jobs:
       with:
         version: v2.5.0
         token: ${{ secrets.GITHUB_TOKEN }}
+    - name: Shard tests
+      run: echo go test -v -count=1 -cover -timeout 2h -parallel 4 "$(go run
+        github.com/blampe/shard@b251cf8da6a83022628496125f285095772ebe86 --total
+        ${{ strategy.job-total }} --index ${{ strategy.job-index }})" >
+        test-command
+      working-directory: tests/sdk
     - name: Run tests
-      run: cd tests/sdk/${{ matrix.language }} && go test -v -count=1 -cover -timeout
-        2h -parallel 4 ./...
+      run: cat test-command && $(cat test-command)
+      working-directory: tests/sdk
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3

--- a/native-provider-ci/providers/kubernetes/repo/.github/workflows/run-acceptance-tests.yml
+++ b/native-provider-ci/providers/kubernetes/repo/.github/workflows/run-acceptance-tests.yml
@@ -267,12 +267,17 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        language:
-        - nodejs
-        - python
-        - dotnet
-        - go
-        - java
+        shard:
+        - 0
+        - 1
+        - 2
+        - 3
+        - 4
+        - 5
+        - 6
+        - 7
+        - 8
+        - 9
     name: test
     permissions:
       contents: read
@@ -335,14 +340,34 @@ jobs:
     - name: Restore Binary Permissions
       run: find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print
         -exec chmod +x {} \;
-    - name: Download SDK
+    - name: Download nodejs SDK
       uses: actions/download-artifact@v4
       with:
-        name: ${{ matrix.language }}-sdk.tar.gz
+        name: nodejs-sdk.tar.gz
+        path: ${{ github.workspace}}/sdk/
+    - name: Download go SDK
+      uses: actions/download-artifact@v4
+      with:
+        name: go-sdk.tar.gz
+        path: ${{ github.workspace}}/sdk/
+    - name: Download dotnet SDK
+      uses: actions/download-artifact@v4
+      with:
+        name: dotnet-sdk.tar.gz
+        path: ${{ github.workspace}}/sdk/
+    - name: Download python SDK
+      uses: actions/download-artifact@v4
+      with:
+        name: python-sdk.tar.gz
+        path: ${{ github.workspace}}/sdk/
+    - name: Download java SDK
+      uses: actions/download-artifact@v4
+      with:
+        name: java-sdk.tar.gz
         path: ${{ github.workspace}}/sdk/
     - name: UnTar SDK folder
-      run: tar -zxf ${{ github.workspace}}/sdk/${{ matrix.language}}.tar.gz -C ${{
-        github.workspace}}/sdk/${{ matrix.language}}
+      run: for f in *.tar.gz; do tar -zxf "$f" -C "${f%.tar.gz}"; done
+      working-directory: ${{ github.workspace}}/sdk
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Install Node dependencies
@@ -353,7 +378,7 @@ jobs:
         pip3 install virtualenv==20.0.23
         pip3 install pipenv
     - name: Install dependencies
-      run: make install_${{ matrix.language}}_sdk
+      run: make install_sdks
     - name: Configure AWS Credentials
       uses: aws-actions/configure-aws-credentials@v4
       with:
@@ -399,11 +424,17 @@ jobs:
     - name: Setup KinD cluster
       uses: helm/kind-action@v1
       with:
-        cluster_name: kind-integration-tests-${{ matrix.language }}
+        cluster_name: kind-integration-tests-${{ matrix.job-index }}
         node_image: kindest/node:v1.29.2
+    - name: Shard tests
+      run: echo go test -v -count=1 -cover -timeout 2h -parallel 4 -short "$(go run
+        github.com/blampe/shard@b251cf8da6a83022628496125f285095772ebe86 --total
+        ${{ strategy.job-total }} --index ${{ strategy.job-index }})" >
+        test-command
+      working-directory: tests/sdk
     - name: Run tests
-      run: cd tests/sdk/${{ matrix.language }} && go test -v -count=1 -cover -timeout
-        2h -parallel 4 -short ./...
+      run: cat test-command && $(cat test-command)
+      working-directory: tests/sdk
     - if: failure() && github.event_name == 'push'
       name: Notify Slack
       uses: 8398a7/action-slack@v3


### PR DESCRIPTION
This turns on test sharding for the docker-build and p-k providers.

The actual logic for how we discover tests and assign them is [here](https://github.com/blampe/shard/blob/main/internal/collect.go), along with some [test cases](https://github.com/blampe/shard/tree/main/internal/testdata) if there are correctness concerns.

In terms of onboarding, if a provider wants to use this they should:
* Ensure a `make install_sdks` target exists, because each shard now needs all the SDKs.
* Remove any build tags as part of updating the CI workflow (e.g. https://github.com/pulumi/pulumi-kubernetes/pull/3175). The test command on CI no longer uses build tags to shard, and you don't want tests excluded due to missing tags.
* (Optional) Ensure tests have globally unique names. Running `go run github.com/blampe/shard@latest --total 1 --index 0` will emit a warning for any tests with name collisions. Due to the way we're invoking `go test -run (names...) packages...`, it's possible for a test to get re-run on multiple shards if its name isn't unique, but this isn't the end of the world.

Refs https://github.com/pulumi/ci-mgmt/issues/676