### PR TITLE
Add Epic template to bridged providers

### DIFF
--- a/provider-ci/internal/pkg/templates/provider/.github/ISSUE_TEMPLATE/epic.md
+++ b/provider-ci/internal/pkg/templates/provider/.github/ISSUE_TEMPLATE/epic.md
@@ -1,0 +1,35 @@
+---
+name: Epic
+about: Tracks a shippable unit of work
+title: '[Epic] {your-title-here}'
+labels: kind/epic
+projects: ['pulumi/32']
+assignees: ''
+
+---
+
+## Overview
+<!-- Start with a one- to three-sentence summary that should be understandable by any Pulumian or community member, even those without any context on the work. -->
+
+## Key KPIs
+<!-- What KPIs should this Epic will move; what could we measure to observe that this project was successful? -->
+
+## Key Stakeholders
+- Product and Engineering: <!-- Teams and individuals involved in the design and implementation -->
+- Documentation: <!-- Representative from the docs team -->
+- Marketing/Partnerships: <!-- Representative from the Marketing team -->
+- Customers: <!-- [Tracking Issue](add-link-and-uncomment) -->
+
+## Key Deliverables
+<!-- List any discrete chunks of work or milestones that are planned in the epic (eg. subcomponent A, dogfood release, beta, etc.) -->
+
+### References 📔
+
+<!-- Any project that is more than one iteration should have a Project Board using this [template](https://github.com/orgs/pulumi/projects/131).  -->
+- [ ] Project View <!-- [Link](add-link-and-uncomment) -->
+- [ ] PR/FAQ <!-- [Link](add-link-and-uncomment) -->
+- [ ] Design Doc <!-- [Link](add-link-and-uncomment) -->
+- [ ] UX Designs <!-- [Link](add-link-and-uncomment) -->
+- [ ] Decision Log <!-- [Link](add-link-and-uncomment) -->
+
+<!-- Work items should be added to the project board linked above  -->

--- a/provider-ci/internal/pkg/templates/provider/.github/ISSUE_TEMPLATE/epic.md
+++ b/provider-ci/internal/pkg/templates/provider/.github/ISSUE_TEMPLATE/epic.md
@@ -5,7 +5,7 @@ title: '[Epic] {your-title-here}'
 labels: kind/epic
 projects: ['pulumi/32']
 assignees: ''
-
+type: Epic
 ---
 
 ## Overview

--- a/provider-ci/test-providers/aws/.github/ISSUE_TEMPLATE/epic.md
+++ b/provider-ci/test-providers/aws/.github/ISSUE_TEMPLATE/epic.md
@@ -1,0 +1,35 @@
+---
+name: Epic
+about: Tracks a shippable unit of work
+title: '[Epic] {your-title-here}'
+labels: kind/epic
+projects: ['pulumi/32']
+assignees: ''
+type: Epic
+---
+
+## Overview
+<!-- Start with a one- to three-sentence summary that should be understandable by any Pulumian or community member, even those without any context on the work. -->
+
+## Key KPIs
+<!-- What KPIs should this Epic will move; what could we measure to observe that this project was successful? -->
+
+## Key Stakeholders
+- Product and Engineering: <!-- Teams and individuals involved in the design and implementation -->
+- Documentation: <!-- Representative from the docs team -->
+- Marketing/Partnerships: <!-- Representative from the Marketing team -->
+- Customers: <!-- [Tracking Issue](add-link-and-uncomment) -->
+
+## Key Deliverables
+<!-- List any discrete chunks of work or milestones that are planned in the epic (eg. subcomponent A, dogfood release, beta, etc.) -->
+
+### References 📔
+
+<!-- Any project that is more than one iteration should have a Project Board using this [template](https://github.com/orgs/pulumi/projects/131).  -->
+- [ ] Project View <!-- [Link](add-link-and-uncomment) -->
+- [ ] PR/FAQ <!-- [Link](add-link-and-uncomment) -->
+- [ ] Design Doc <!-- [Link](add-link-and-uncomment) -->
+- [ ] UX Designs <!-- [Link](add-link-and-uncomment) -->
+- [ ] Decision Log <!-- [Link](add-link-and-uncomment) -->
+
+<!-- Work items should be added to the project board linked above  -->

--- a/provider-ci/test-providers/cloudflare/.github/ISSUE_TEMPLATE/epic.md
+++ b/provider-ci/test-providers/cloudflare/.github/ISSUE_TEMPLATE/epic.md
@@ -1,0 +1,35 @@
+---
+name: Epic
+about: Tracks a shippable unit of work
+title: '[Epic] {your-title-here}'
+labels: kind/epic
+projects: ['pulumi/32']
+assignees: ''
+type: Epic
+---
+
+## Overview
+<!-- Start with a one- to three-sentence summary that should be understandable by any Pulumian or community member, even those without any context on the work. -->
+
+## Key KPIs
+<!-- What KPIs should this Epic will move; what could we measure to observe that this project was successful? -->
+
+## Key Stakeholders
+- Product and Engineering: <!-- Teams and individuals involved in the design and implementation -->
+- Documentation: <!-- Representative from the docs team -->
+- Marketing/Partnerships: <!-- Representative from the Marketing team -->
+- Customers: <!-- [Tracking Issue](add-link-and-uncomment) -->
+
+## Key Deliverables
+<!-- List any discrete chunks of work or milestones that are planned in the epic (eg. subcomponent A, dogfood release, beta, etc.) -->
+
+### References 📔
+
+<!-- Any project that is more than one iteration should have a Project Board using this [template](https://github.com/orgs/pulumi/projects/131).  -->
+- [ ] Project View <!-- [Link](add-link-and-uncomment) -->
+- [ ] PR/FAQ <!-- [Link](add-link-and-uncomment) -->
+- [ ] Design Doc <!-- [Link](add-link-and-uncomment) -->
+- [ ] UX Designs <!-- [Link](add-link-and-uncomment) -->
+- [ ] Decision Log <!-- [Link](add-link-and-uncomment) -->
+
+<!-- Work items should be added to the project board linked above  -->

--- a/provider-ci/test-providers/docker/.github/ISSUE_TEMPLATE/epic.md
+++ b/provider-ci/test-providers/docker/.github/ISSUE_TEMPLATE/epic.md
@@ -1,0 +1,35 @@
+---
+name: Epic
+about: Tracks a shippable unit of work
+title: '[Epic] {your-title-here}'
+labels: kind/epic
+projects: ['pulumi/32']
+assignees: ''
+type: Epic
+---
+
+## Overview
+<!-- Start with a one- to three-sentence summary that should be understandable by any Pulumian or community member, even those without any context on the work. -->
+
+## Key KPIs
+<!-- What KPIs should this Epic will move; what could we measure to observe that this project was successful? -->
+
+## Key Stakeholders
+- Product and Engineering: <!-- Teams and individuals involved in the design and implementation -->
+- Documentation: <!-- Representative from the docs team -->
+- Marketing/Partnerships: <!-- Representative from the Marketing team -->
+- Customers: <!-- [Tracking Issue](add-link-and-uncomment) -->
+
+## Key Deliverables
+<!-- List any discrete chunks of work or milestones that are planned in the epic (eg. subcomponent A, dogfood release, beta, etc.) -->
+
+### References 📔
+
+<!-- Any project that is more than one iteration should have a Project Board using this [template](https://github.com/orgs/pulumi/projects/131).  -->
+- [ ] Project View <!-- [Link](add-link-and-uncomment) -->
+- [ ] PR/FAQ <!-- [Link](add-link-and-uncomment) -->
+- [ ] Design Doc <!-- [Link](add-link-and-uncomment) -->
+- [ ] UX Designs <!-- [Link](add-link-and-uncomment) -->
+- [ ] Decision Log <!-- [Link](add-link-and-uncomment) -->
+
+<!-- Work items should be added to the project board linked above  -->


### PR DESCRIPTION
As a first step toward propagating the issue template to more of our repos, add it to our templates for bridged providers