### PR TITLE
Upgrade golangci-lint to v1.60

### DIFF
--- a/provider-ci/internal/pkg/templates/provider/.github/workflows/lint.yml
+++ b/provider-ci/internal/pkg/templates/provider/.github/workflows/lint.yml
@@ -24,7 +24,7 @@ jobs:
       uses: actions/setup-go@v5
       with:
         # The versions of golangci-lint and setup-go here cross-depend and need to update together.
-        go-version: 1.22
+        go-version: 1.23
         # Either this action or golangci-lint needs to disable the cache
         cache: false
     - name: disarm go:embed directives to enable lint
@@ -37,5 +37,5 @@ jobs:
     - name: golangci-lint
       uses: golangci/golangci-lint-action@v6
       with:
-        version: v1.58.0
+        version: v1.60
         working-directory: provider

--- a/provider-ci/test-providers/aws/.github/workflows/lint.yml
+++ b/provider-ci/test-providers/aws/.github/workflows/lint.yml
@@ -40,7 +40,7 @@ jobs:
       uses: actions/setup-go@v5
       with:
         # The versions of golangci-lint and setup-go here cross-depend and need to update together.
-        go-version: 1.22
+        go-version: 1.23
         # Either this action or golangci-lint needs to disable the cache
         cache: false
     - name: disarm go:embed directives to enable lint
@@ -53,5 +53,5 @@ jobs:
     - name: golangci-lint
       uses: golangci/golangci-lint-action@v6
       with:
-        version: v1.58.0
+        version: v1.60
         working-directory: provider

--- a/provider-ci/test-providers/cloudflare/.github/workflows/lint.yml
+++ b/provider-ci/test-providers/cloudflare/.github/workflows/lint.yml
@@ -37,7 +37,7 @@ jobs:
       uses: actions/setup-go@v5
       with:
         # The versions of golangci-lint and setup-go here cross-depend and need to update together.
-        go-version: 1.22
+        go-version: 1.23
         # Either this action or golangci-lint needs to disable the cache
         cache: false
     - name: disarm go:embed directives to enable lint
@@ -50,5 +50,5 @@ jobs:
     - name: golangci-lint
       uses: golangci/golangci-lint-action@v6
       with:
-        version: v1.58.0
+        version: v1.60
         working-directory: provider

--- a/provider-ci/test-providers/docker/.github/workflows/lint.yml
+++ b/provider-ci/test-providers/docker/.github/workflows/lint.yml
@@ -50,7 +50,7 @@ jobs:
       uses: actions/setup-go@v5
       with:
         # The versions of golangci-lint and setup-go here cross-depend and need to update together.
-        go-version: 1.22
+        go-version: 1.23
         # Either this action or golangci-lint needs to disable the cache
         cache: false
     - name: disarm go:embed directives to enable lint
@@ -63,5 +63,5 @@ jobs:
     - name: golangci-lint
       uses: golangci/golangci-lint-action@v6
       with:
-        version: v1.58.0
+        version: v1.60
         working-directory: provider


### PR DESCRIPTION
This is necessary to accommodate providers who require go1.23, since previous versions of golangci-lint do not support go1.23.