### PR TITLE
Ability to select SDK languages

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Sometimes, you want those changes NOW rather than having to wait for a GitHub PR
 This example command will generate workflows for pulumi-datadog, and place them in the specified `--out` directory.
 Adjust for your provider and filesystem.
 
-```
+```bash
 ./bin/provider-ci generate --name pulumi/pulumi-datadog --template bridged-provider --config ./providers/datadog/config.yaml --out ../../pulumi-dtadog
 ```
 

--- a/provider-ci/internal/pkg/templates/bridged-provider.config.yaml
+++ b/provider-ci/internal/pkg/templates/bridged-provider.config.yaml
@@ -82,9 +82,17 @@ toolVersions:
   go: "1.21.x"
   java: "11"
   gradle: "7.6"
-  node: "20.x"
+  nodejs: "20.x"
   pulumi: "dev"
   python: "3.11.8"
+
+# Control which language SDKs get built and published.
+languages:
+  - nodejs
+  - python
+  - dotnet
+  - go
+  - java
 
 # env contains an assortment of properties for different purposes.
 # Additional entries are added by individual providers for different reasons.

--- a/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/build_sdk.yml
+++ b/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/build_sdk.yml
@@ -19,11 +19,7 @@ jobs:
       fail-fast: true
       matrix:
         language:
-        - nodejs
-        - python
-        - dotnet
-        - go
-        - java
+#{{ .Config.languages | toYaml | indent 8 }}#
     steps:
       #{{- if .Config.freeDiskSpaceBeforeSdkBuild }}#
       # Run as first step so we don't delete things that have just been installed
@@ -48,7 +44,7 @@ jobs:
       - name: Setup tools
         uses: ./.github/actions/setup-tools
         with:
-          tools: pulumictl, pulumicli, go, node, dotnet, python, java
+          tools: pulumictl, pulumicli, ${{ matrix.language }}
       - name: Download bin
         uses: ./.github/actions/download-bin
       - name: Install plugins

--- a/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/main.yml
+++ b/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/main.yml
@@ -143,10 +143,11 @@ jobs:
     - name: Setup tools
       uses: ./.github/actions/setup-tools
       with:
-        tools: pulumictl, pulumicli, go, node, dotnet, python, java
+        tools: pulumictl, pulumicli, ${{ matrix.language }}
     - name: Download bin
       uses: ./.github/actions/download-bin
     - run: dotnet nuget add source ${{ github.workspace }}/nuget
+      if: matrix.language == 'dotnet'
     - name: Download SDK
       uses: ./.github/actions/download-sdk
       with:
@@ -154,6 +155,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> "$GITHUB_PATH"
     - name: Install Python deps
+      if: matrix.language == 'python'
       run: |-
         pip3 install virtualenv==20.0.23
         pip3 install pipenv
@@ -225,11 +227,7 @@ jobs:
       fail-fast: false
       matrix:
         language:
-        - nodejs
-        - python
-        - dotnet
-        - go
-        - java
+#{{ .Config.languages | toYaml | indent 8 }}#
 #{{- if .Config.extraTests }}#
 #{{ .Config.extraTests | toYaml | indent 2 }}#
 #{{ end }}#

--- a/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/nightly-test.yml
+++ b/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/nightly-test.yml
@@ -56,7 +56,7 @@ jobs:
     - name: Setup tools
       uses: ./.github/actions/setup-tools
       with:
-        tools: pulumictl, pulumicli, go, node, dotnet, python, java
+        tools: pulumictl, pulumicli, ${{ matrix.language}}
     - name: Download bin
       uses: ./.github/actions/download-bin
     - run: dotnet nuget add source ${{ github.workspace }}/nuget
@@ -140,11 +140,7 @@ jobs:
       fail-fast: false
       matrix:
         language:
-        - nodejs
-        - python
-        - dotnet
-        - go
-        - java
+#{{ .Config.languages | toYaml | indent 10 }}#
 name: cron
 on:
   schedule:

--- a/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/prerelease.yml
+++ b/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/prerelease.yml
@@ -166,11 +166,7 @@ jobs:
       fail-fast: false
       matrix:
         language:
-        - nodejs
-        - python
-        - dotnet
-        - go
-        - java
+#{{ .Config.languages | toYaml | indent 8 }}#
 #{{- if .Config.extraTests }}#
 #{{ .Config.extraTests | toYaml | indent 2 }}#
 #{{ end }}#

--- a/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/prerelease.yml
+++ b/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/prerelease.yml
@@ -84,7 +84,7 @@ jobs:
     - name: Setup tools
       uses: ./.github/actions/setup-tools
       with:
-        tools: pulumictl, pulumicli, go, node, dotnet, python, java
+        tools: pulumictl, pulumicli, #{{ range $index, $element := .Config.languages }}##{{if $index}}#, #{{end}}##{{ $element }}##{{end}}#
     - name: Download bin
       uses: ./.github/actions/download-bin
     - run: dotnet nuget add source ${{ github.workspace }}/nuget

--- a/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/publish.yml
+++ b/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/publish.yml
@@ -67,7 +67,7 @@ jobs:
       shell: bash
       run: |
         # Get latest stable release. Return only first column from result (tag).
-        LAST_VERSION=$(gh release view --repo pulumi/pulumi-#{{ .Config.provider }}# --json tagName -q .tagName || echo "No stable release" )
+        LAST_VERSION=$(gh release view --repo #{{ .Config.organization }}#/pulumi-#{{ .Config.provider }}# --json tagName -q .tagName || echo "No stable release" )
         {
           echo 'summary<<EOF'
           if [[ "$LAST_VERSION" != "No stable release" ]]; then

--- a/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/publish.yml
+++ b/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/publish.yml
@@ -105,7 +105,7 @@ jobs:
     - name: Setup tools
       uses: ./.github/actions/setup-tools
       with:
-        tools: pulumictl, pulumicli, go, node, dotnet, python, java
+        tools: pulumictl, pulumicli, #{{ range $index, $element := .Config.languages }}##{{if $index}}#, #{{end}}##{{ $element }}##{{end}}#
     - name: Publish SDKs
       uses: pulumi/pulumi-package-publisher@v0.0.20
       with:

--- a/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/release.yml
+++ b/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/release.yml
@@ -92,7 +92,7 @@ jobs:
     - name: Setup tools
       uses: ./.github/actions/setup-tools
       with:
-        tools: pulumictl, pulumicli, go, node, dotnet, python, java
+        tools: pulumictl, pulumicli, ${{ matrix.language }}
     - name: Download bin
       uses: ./.github/actions/download-bin
     - run: dotnet nuget add source ${{ github.workspace }}/nuget
@@ -174,11 +174,7 @@ jobs:
       fail-fast: false
       matrix:
         language:
-        - nodejs
-        - python
-        - dotnet
-        - go
-        - java
+#{{ .Config.languages | toYaml | indent 8 }}#
 #{{- if .Config.extraTests }}#
 #{{ .Config.extraTests | toYaml | indent 2 }}#
 #{{ end }}#

--- a/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/run-acceptance-tests.yml
@@ -126,7 +126,7 @@ jobs:
     - name: Setup tools
       uses: ./.github/actions/setup-tools
       with:
-        tools: pulumictl, pulumicli, go, node, dotnet, python, java
+        tools: pulumictl, pulumicli, ${{ matrix.language }}
     - name: Download bin
       uses: ./.github/actions/download-bin
     - run: dotnet nuget add source ${{ github.workspace }}/nuget
@@ -214,11 +214,7 @@ jobs:
       fail-fast: false
       matrix:
         language:
-        - nodejs
-        - python
-        - dotnet
-        - go
-        - java
+#{{ .Config.languages | toYaml | indent 8 }}#
         #{{- if .Config.testPulumiExamples }}#
         testTarget: [local, pulumiExamples]
         #{{- else }}#

--- a/provider-ci/internal/pkg/templates/bridged-provider/Makefile
+++ b/provider-ci/internal/pkg/templates/bridged-provider/Makefile
@@ -45,7 +45,7 @@ development: install_plugins provider build_sdks install_sdks
 
 build: install_plugins provider build_sdks install_sdks
 
-build_sdks: build_nodejs build_python build_go build_dotnet build_java
+build_sdks: #{{ range .Config.languages }}#build_#{{ . }}# #{{ end }}#
 
 install_go_sdk:
 

--- a/provider-ci/internal/pkg/templates/dev-container/devbox.json
+++ b/provider-ci/internal/pkg/templates/dev-container/devbox.json
@@ -6,7 +6,7 @@
     "yarn@latest",
     "pulumictl@latest",
     "go@#{{ trimAll "x" .Config.toolVersions.go }}#",
-    "nodejs@#{{ trimAll "x" .Config.toolVersions.node }}#",
+    "nodejs@#{{ trimAll "x" .Config.toolVersions.nodejs }}#",
     "python3@#{{ trimAll "x" .Config.toolVersions.python }}#",
     "dotnet-sdk@#{{ trimAll "x" .Config.toolVersions.dotnet }}#",
     "gradle_7@#{{ trimAll "x" .Config.toolVersions.gradle }}#",

--- a/provider-ci/internal/pkg/templates/provider/.github/actions/setup-tools/action.yml
+++ b/provider-ci/internal/pkg/templates/provider/.github/actions/setup-tools/action.yml
@@ -9,7 +9,7 @@ inputs:
         pulumicli
         pulumictl
         schema-tools
-        node
+        nodejs
         python
         dotnet
         java
@@ -48,10 +48,10 @@ runs:
         repo: pulumi/schema-tools
 
     - name: Setup Node
-      if: inputs.tools == 'all' || contains(inputs.tools, 'node')
+      if: inputs.tools == 'all' || contains(inputs.tools, 'nodejs')
       uses: actions/setup-node@v4
       with:
-        node-version: #{{ .Config.toolVersions.node }}#
+        node-version: #{{ .Config.toolVersions.nodejs }}#
         registry-url: https://registry.npmjs.org
 
     - name: Setup DotNet

--- a/provider-ci/internal/pkg/templates/provider/.golangci.yml
+++ b/provider-ci/internal/pkg/templates/provider/.golangci.yml
@@ -29,5 +29,5 @@ linters-settings:
       - blank # Blank section: contains all blank imports.
       - default # Default section: contains all imports that could not be matched to another section type.
       - prefix(github.com/pulumi/) # Custom section: groups all imports with the github.com/pulumi/ prefix.
-      - prefix(github.com/pulumi/pulumi-#{{ .Config.provider }}#) # Custom section: local imports
+      - prefix(github.com/#{{ .Config.organization }}#/pulumi-#{{ .Config.provider }}#) # Custom section: local imports
     custom-order: true

--- a/provider-ci/test-providers/aws/.github/actions/setup-tools/action.yml
+++ b/provider-ci/test-providers/aws/.github/actions/setup-tools/action.yml
@@ -9,7 +9,7 @@ inputs:
         pulumicli
         pulumictl
         schema-tools
-        node
+        nodejs
         python
         dotnet
         java
@@ -48,7 +48,7 @@ runs:
         repo: pulumi/schema-tools
 
     - name: Setup Node
-      if: inputs.tools == 'all' || contains(inputs.tools, 'node')
+      if: inputs.tools == 'all' || contains(inputs.tools, 'nodejs')
       uses: actions/setup-node@v4
       with:
         node-version: 20.x

--- a/provider-ci/test-providers/aws/.github/workflows/build_sdk.yml
+++ b/provider-ci/test-providers/aws/.github/workflows/build_sdk.yml
@@ -62,7 +62,7 @@ jobs:
       - name: Setup tools
         uses: ./.github/actions/setup-tools
         with:
-          tools: pulumictl, pulumicli, go, node, dotnet, python, java
+          tools: pulumictl, pulumicli, ${{ matrix.language }}
       - name: Download bin
         uses: ./.github/actions/download-bin
       - name: Install plugins

--- a/provider-ci/test-providers/aws/.github/workflows/master.yml
+++ b/provider-ci/test-providers/aws/.github/workflows/master.yml
@@ -149,10 +149,11 @@ jobs:
     - name: Setup tools
       uses: ./.github/actions/setup-tools
       with:
-        tools: pulumictl, pulumicli, go, node, dotnet, python, java
+        tools: pulumictl, pulumicli, ${{ matrix.language }}
     - name: Download bin
       uses: ./.github/actions/download-bin
     - run: dotnet nuget add source ${{ github.workspace }}/nuget
+      if: matrix.language == 'dotnet'
     - name: Download SDK
       uses: ./.github/actions/download-sdk
       with:
@@ -160,6 +161,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> "$GITHUB_PATH"
     - name: Install Python deps
+      if: matrix.language == 'python'
       run: |-
         pip3 install virtualenv==20.0.23
         pip3 install pipenv

--- a/provider-ci/test-providers/aws/.github/workflows/nightly-test.yml
+++ b/provider-ci/test-providers/aws/.github/workflows/nightly-test.yml
@@ -69,7 +69,7 @@ jobs:
     - name: Setup tools
       uses: ./.github/actions/setup-tools
       with:
-        tools: pulumictl, pulumicli, go, node, dotnet, python, java
+        tools: pulumictl, pulumicli, ${{ matrix.language}}
     - name: Download bin
       uses: ./.github/actions/download-bin
     - run: dotnet nuget add source ${{ github.workspace }}/nuget
@@ -108,11 +108,11 @@ jobs:
       fail-fast: false
       matrix:
         language:
-        - nodejs
-        - python
-        - dotnet
-        - go
-        - java
+          - nodejs
+          - python
+          - dotnet
+          - go
+          - java
 name: cron
 on:
   schedule:

--- a/provider-ci/test-providers/aws/.github/workflows/prerelease.yml
+++ b/provider-ci/test-providers/aws/.github/workflows/prerelease.yml
@@ -92,7 +92,7 @@ jobs:
     - name: Setup tools
       uses: ./.github/actions/setup-tools
       with:
-        tools: pulumictl, pulumicli, go, node, dotnet, python, java
+        tools: pulumictl, pulumicli, nodejs, python, dotnet, go, java
     - name: Download bin
       uses: ./.github/actions/download-bin
     - run: dotnet nuget add source ${{ github.workspace }}/nuget

--- a/provider-ci/test-providers/aws/.github/workflows/publish.yml
+++ b/provider-ci/test-providers/aws/.github/workflows/publish.yml
@@ -119,7 +119,7 @@ jobs:
     - name: Setup tools
       uses: ./.github/actions/setup-tools
       with:
-        tools: pulumictl, pulumicli, go, node, dotnet, python, java
+        tools: pulumictl, pulumicli, nodejs, python, dotnet, go, java
     - name: Publish SDKs
       uses: pulumi/pulumi-package-publisher@v0.0.20
       with:

--- a/provider-ci/test-providers/aws/.github/workflows/release.yml
+++ b/provider-ci/test-providers/aws/.github/workflows/release.yml
@@ -97,7 +97,7 @@ jobs:
     - name: Setup tools
       uses: ./.github/actions/setup-tools
       with:
-        tools: pulumictl, pulumicli, go, node, dotnet, python, java
+        tools: pulumictl, pulumicli, ${{ matrix.language }}
     - name: Download bin
       uses: ./.github/actions/download-bin
     - run: dotnet nuget add source ${{ github.workspace }}/nuget

--- a/provider-ci/test-providers/aws/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/test-providers/aws/.github/workflows/run-acceptance-tests.yml
@@ -129,7 +129,7 @@ jobs:
     - name: Setup tools
       uses: ./.github/actions/setup-tools
       with:
-        tools: pulumictl, pulumicli, go, node, dotnet, python, java
+        tools: pulumictl, pulumicli, ${{ matrix.language }}
     - name: Download bin
       uses: ./.github/actions/download-bin
     - run: dotnet nuget add source ${{ github.workspace }}/nuget

--- a/provider-ci/test-providers/aws/Makefile
+++ b/provider-ci/test-providers/aws/Makefile
@@ -29,7 +29,7 @@ development: install_plugins provider build_sdks install_sdks
 
 build: install_plugins provider build_sdks install_sdks
 
-build_sdks: build_nodejs build_python build_go build_dotnet build_java
+build_sdks: build_nodejs build_python build_dotnet build_go build_java 
 
 install_go_sdk:
 

--- a/provider-ci/test-providers/cloudflare/.github/actions/setup-tools/action.yml
+++ b/provider-ci/test-providers/cloudflare/.github/actions/setup-tools/action.yml
@@ -9,7 +9,7 @@ inputs:
         pulumicli
         pulumictl
         schema-tools
-        node
+        nodejs
         python
         dotnet
         java
@@ -48,7 +48,7 @@ runs:
         repo: pulumi/schema-tools
 
     - name: Setup Node
-      if: inputs.tools == 'all' || contains(inputs.tools, 'node')
+      if: inputs.tools == 'all' || contains(inputs.tools, 'nodejs')
       uses: actions/setup-node@v4
       with:
         node-version: 20.x

--- a/provider-ci/test-providers/cloudflare/.github/workflows/build_sdk.yml
+++ b/provider-ci/test-providers/cloudflare/.github/workflows/build_sdk.yml
@@ -53,7 +53,7 @@ jobs:
       - name: Setup tools
         uses: ./.github/actions/setup-tools
         with:
-          tools: pulumictl, pulumicli, go, node, dotnet, python, java
+          tools: pulumictl, pulumicli, ${{ matrix.language }}
       - name: Download bin
         uses: ./.github/actions/download-bin
       - name: Install plugins

--- a/provider-ci/test-providers/cloudflare/.github/workflows/master.yml
+++ b/provider-ci/test-providers/cloudflare/.github/workflows/master.yml
@@ -138,10 +138,11 @@ jobs:
     - name: Setup tools
       uses: ./.github/actions/setup-tools
       with:
-        tools: pulumictl, pulumicli, go, node, dotnet, python, java
+        tools: pulumictl, pulumicli, ${{ matrix.language }}
     - name: Download bin
       uses: ./.github/actions/download-bin
     - run: dotnet nuget add source ${{ github.workspace }}/nuget
+      if: matrix.language == 'dotnet'
     - name: Download SDK
       uses: ./.github/actions/download-sdk
       with:
@@ -149,6 +150,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> "$GITHUB_PATH"
     - name: Install Python deps
+      if: matrix.language == 'python'
       run: |-
         pip3 install virtualenv==20.0.23
         pip3 install pipenv

--- a/provider-ci/test-providers/cloudflare/.github/workflows/prerelease.yml
+++ b/provider-ci/test-providers/cloudflare/.github/workflows/prerelease.yml
@@ -83,7 +83,7 @@ jobs:
     - name: Setup tools
       uses: ./.github/actions/setup-tools
       with:
-        tools: pulumictl, pulumicli, go, node, dotnet, python, java
+        tools: pulumictl, pulumicli, nodejs, python, dotnet, go, java
     - name: Download bin
       uses: ./.github/actions/download-bin
     - run: dotnet nuget add source ${{ github.workspace }}/nuget

--- a/provider-ci/test-providers/cloudflare/.github/workflows/publish.yml
+++ b/provider-ci/test-providers/cloudflare/.github/workflows/publish.yml
@@ -114,7 +114,7 @@ jobs:
     - name: Setup tools
       uses: ./.github/actions/setup-tools
       with:
-        tools: pulumictl, pulumicli, go, node, dotnet, python, java
+        tools: pulumictl, pulumicli, nodejs, python, dotnet, go, java
     - name: Publish SDKs
       uses: pulumi/pulumi-package-publisher@v0.0.20
       with:

--- a/provider-ci/test-providers/cloudflare/.github/workflows/release.yml
+++ b/provider-ci/test-providers/cloudflare/.github/workflows/release.yml
@@ -88,7 +88,7 @@ jobs:
     - name: Setup tools
       uses: ./.github/actions/setup-tools
       with:
-        tools: pulumictl, pulumicli, go, node, dotnet, python, java
+        tools: pulumictl, pulumicli, ${{ matrix.language }}
     - name: Download bin
       uses: ./.github/actions/download-bin
     - run: dotnet nuget add source ${{ github.workspace }}/nuget

--- a/provider-ci/test-providers/cloudflare/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/test-providers/cloudflare/.github/workflows/run-acceptance-tests.yml
@@ -124,7 +124,7 @@ jobs:
     - name: Setup tools
       uses: ./.github/actions/setup-tools
       with:
-        tools: pulumictl, pulumicli, go, node, dotnet, python, java
+        tools: pulumictl, pulumicli, ${{ matrix.language }}
     - name: Download bin
       uses: ./.github/actions/download-bin
     - run: dotnet nuget add source ${{ github.workspace }}/nuget

--- a/provider-ci/test-providers/cloudflare/Makefile
+++ b/provider-ci/test-providers/cloudflare/Makefile
@@ -29,7 +29,7 @@ development: install_plugins provider build_sdks install_sdks
 
 build: install_plugins provider build_sdks install_sdks
 
-build_sdks: build_nodejs build_python build_go build_dotnet build_java
+build_sdks: build_nodejs build_python build_dotnet build_go build_java 
 
 install_go_sdk:
 

--- a/provider-ci/test-providers/docker/.github/actions/setup-tools/action.yml
+++ b/provider-ci/test-providers/docker/.github/actions/setup-tools/action.yml
@@ -9,7 +9,7 @@ inputs:
         pulumicli
         pulumictl
         schema-tools
-        node
+        nodejs
         python
         dotnet
         java
@@ -48,7 +48,7 @@ runs:
         repo: pulumi/schema-tools
 
     - name: Setup Node
-      if: inputs.tools == 'all' || contains(inputs.tools, 'node')
+      if: inputs.tools == 'all' || contains(inputs.tools, 'nodejs')
       uses: actions/setup-node@v4
       with:
         node-version: 20.x

--- a/provider-ci/test-providers/docker/.github/workflows/build_sdk.yml
+++ b/provider-ci/test-providers/docker/.github/workflows/build_sdk.yml
@@ -66,7 +66,7 @@ jobs:
       - name: Setup tools
         uses: ./.github/actions/setup-tools
         with:
-          tools: pulumictl, pulumicli, go, node, dotnet, python, java
+          tools: pulumictl, pulumicli, ${{ matrix.language }}
       - name: Download bin
         uses: ./.github/actions/download-bin
       - name: Install plugins

--- a/provider-ci/test-providers/docker/.github/workflows/master.yml
+++ b/provider-ci/test-providers/docker/.github/workflows/master.yml
@@ -151,10 +151,11 @@ jobs:
     - name: Setup tools
       uses: ./.github/actions/setup-tools
       with:
-        tools: pulumictl, pulumicli, go, node, dotnet, python, java
+        tools: pulumictl, pulumicli, ${{ matrix.language }}
     - name: Download bin
       uses: ./.github/actions/download-bin
     - run: dotnet nuget add source ${{ github.workspace }}/nuget
+      if: matrix.language == 'dotnet'
     - name: Download SDK
       uses: ./.github/actions/download-sdk
       with:
@@ -162,6 +163,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> "$GITHUB_PATH"
     - name: Install Python deps
+      if: matrix.language == 'python'
       run: |-
         pip3 install virtualenv==20.0.23
         pip3 install pipenv

--- a/provider-ci/test-providers/docker/.github/workflows/prerelease.yml
+++ b/provider-ci/test-providers/docker/.github/workflows/prerelease.yml
@@ -96,7 +96,7 @@ jobs:
     - name: Setup tools
       uses: ./.github/actions/setup-tools
       with:
-        tools: pulumictl, pulumicli, go, node, dotnet, python, java
+        tools: pulumictl, pulumicli, nodejs, python, dotnet, go, java
     - name: Download bin
       uses: ./.github/actions/download-bin
     - run: dotnet nuget add source ${{ github.workspace }}/nuget

--- a/provider-ci/test-providers/docker/.github/workflows/publish.yml
+++ b/provider-ci/test-providers/docker/.github/workflows/publish.yml
@@ -127,7 +127,7 @@ jobs:
     - name: Setup tools
       uses: ./.github/actions/setup-tools
       with:
-        tools: pulumictl, pulumicli, go, node, dotnet, python, java
+        tools: pulumictl, pulumicli, nodejs, python, dotnet, go, java
     - name: Publish SDKs
       uses: pulumi/pulumi-package-publisher@v0.0.20
       with:

--- a/provider-ci/test-providers/docker/.github/workflows/release.yml
+++ b/provider-ci/test-providers/docker/.github/workflows/release.yml
@@ -101,7 +101,7 @@ jobs:
     - name: Setup tools
       uses: ./.github/actions/setup-tools
       with:
-        tools: pulumictl, pulumicli, go, node, dotnet, python, java
+        tools: pulumictl, pulumicli, ${{ matrix.language }}
     - name: Download bin
       uses: ./.github/actions/download-bin
     - run: dotnet nuget add source ${{ github.workspace }}/nuget

--- a/provider-ci/test-providers/docker/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/test-providers/docker/.github/workflows/run-acceptance-tests.yml
@@ -137,7 +137,7 @@ jobs:
     - name: Setup tools
       uses: ./.github/actions/setup-tools
       with:
-        tools: pulumictl, pulumicli, go, node, dotnet, python, java
+        tools: pulumictl, pulumicli, ${{ matrix.language }}
     - name: Download bin
       uses: ./.github/actions/download-bin
     - run: dotnet nuget add source ${{ github.workspace }}/nuget

--- a/provider-ci/test-providers/docker/Makefile
+++ b/provider-ci/test-providers/docker/Makefile
@@ -29,7 +29,7 @@ development: install_plugins provider build_sdks install_sdks
 
 build: install_plugins provider build_sdks install_sdks
 
-build_sdks: build_nodejs build_python build_go build_dotnet build_java
+build_sdks: build_nodejs build_python build_dotnet build_go build_java 
 
 install_go_sdk:
 


### PR DESCRIPTION
**Update Sep 9**: dropped the `enableAutoRelease` from this PR. Will redo this as a separate PR.

Round 2 to add support for third-party providers:

* Fix: Pass the configured `organization` to 2 more places where it is needed
* `languages` (default: all supported languages): third party providers can configure a subset of the supported languages if they don't have the publishing infrastructure ready for all the languages. Changes:
  * changes the build matrix to only the set of configured languages
  * will install only the tools needed for the given value of the language matrix. Changed this because installing the Java tools failed when no Java SDK is available.

<img width="1621" alt="Screenshot 2024-08-28 at 15 00 07" src="https://github.com/user-attachments/assets/eba0eeba-6d40-4e33-ba12-21775c0a2f4f">

The changes in this PR are focussed on the `main` workflow. Testing this on `pulumiverse/pulumi-acme` already got me this far:

https://github.com/pulumiverse/pulumi-acme/actions/runs/10596199445
