### PR TITLE
Fix golangci-lint warnings

### DIFF
--- a/provider-ci/internal/pkg/templates/provider/.golangci.yml
+++ b/provider-ci/internal/pkg/templates/provider/.golangci.yml
@@ -10,17 +10,19 @@ linters:
   - govet
   - ineffassign
   - lll
-  - megacheck
+  - gosimple
+  - staticcheck
   - misspell
   - nakedret
   - revive
   - unconvert
   - unused
   enable-all: false
-run:
-  skip-files:
+issues:
+  exclude-files:
   - schema.go
   - pulumiManifest.go
+run:
   timeout: 20m
 linters-settings:
   gci:

--- a/provider-ci/test-providers/aws/.golangci.yml
+++ b/provider-ci/test-providers/aws/.golangci.yml
@@ -10,17 +10,19 @@ linters:
   - govet
   - ineffassign
   - lll
-  - megacheck
+  - gosimple
+  - staticcheck
   - misspell
   - nakedret
   - revive
   - unconvert
   - unused
   enable-all: false
-run:
-  skip-files:
+issues:
+  exclude-files:
   - schema.go
   - pulumiManifest.go
+run:
   timeout: 20m
 linters-settings:
   gci:

--- a/provider-ci/test-providers/cloudflare/.golangci.yml
+++ b/provider-ci/test-providers/cloudflare/.golangci.yml
@@ -10,17 +10,19 @@ linters:
   - govet
   - ineffassign
   - lll
-  - megacheck
+  - gosimple
+  - staticcheck
   - misspell
   - nakedret
   - revive
   - unconvert
   - unused
   enable-all: false
-run:
-  skip-files:
+issues:
+  exclude-files:
   - schema.go
   - pulumiManifest.go
+run:
   timeout: 20m
 linters-settings:
   gci:

--- a/provider-ci/test-providers/docker/.golangci.yml
+++ b/provider-ci/test-providers/docker/.golangci.yml
@@ -10,17 +10,19 @@ linters:
   - govet
   - ineffassign
   - lll
-  - megacheck
+  - gosimple
+  - staticcheck
   - misspell
   - nakedret
   - revive
   - unconvert
   - unused
   enable-all: false
-run:
-  skip-files:
+issues:
+  exclude-files:
   - schema.go
   - pulumiManifest.go
+run:
   timeout: 20m
 linters-settings:
   gci:


### PR DESCRIPTION
- Upgrade golangci-lint to v1.60 (#1062) surfaced new warnings about deprecations.
- The configuration option `run.skip-files` is deprecated, please use `issues.exclude-files`.
- The linter named "megacheck" is deprecated. It has been split into: gosimple, staticcheck, unused.