### PR TITLE
Set `--path-prefix` in `lint_provider`

### DIFF
--- a/provider-ci/internal/pkg/templates/bridged-provider/Makefile
+++ b/provider-ci/internal/pkg/templates/bridged-provider/Makefile
@@ -145,12 +145,12 @@ install_plugins: .pulumi/bin/pulumi
 	#{{- end }}#
 
 lint_provider: provider
-	cd provider && golangci-lint run -c ../.golangci.yml
+	cd provider && golangci-lint run --path-prefix provider -c ../.golangci.yml
 
 # `lint_provider.fix` is a utility target meant to be run manually
 # that will run the linter and fix errors when possible.
 lint_provider.fix:
-	cd provider && golangci-lint run -c ../.golangci.yml --fix
+	cd provider && golangci-lint run --path-prefix provider -c ../.golangci.yml --fix
 
 # `make provider_no_deps` builds the provider binary directly, without ensuring that
 # `cmd/pulumi-resource-#{{ .Config.provider }}#/schema.json` is valid and up to date.

--- a/provider-ci/test-providers/aws/Makefile
+++ b/provider-ci/test-providers/aws/Makefile
@@ -130,12 +130,12 @@ install_plugins: .pulumi/bin/pulumi
 	.pulumi/bin/pulumi plugin install converter terraform 1.0.17
 
 lint_provider: provider
-	cd provider && golangci-lint run -c ../.golangci.yml
+	cd provider && golangci-lint run --path-prefix provider -c ../.golangci.yml
 
 # `lint_provider.fix` is a utility target meant to be run manually
 # that will run the linter and fix errors when possible.
 lint_provider.fix:
-	cd provider && golangci-lint run -c ../.golangci.yml --fix
+	cd provider && golangci-lint run --path-prefix provider -c ../.golangci.yml --fix
 
 # `make provider_no_deps` builds the provider binary directly, without ensuring that
 # `cmd/pulumi-resource-aws/schema.json` is valid and up to date.

--- a/provider-ci/test-providers/cloudflare/Makefile
+++ b/provider-ci/test-providers/cloudflare/Makefile
@@ -124,12 +124,12 @@ install_plugins: .pulumi/bin/pulumi
 	.pulumi/bin/pulumi plugin install resource tls 4.0.0
 
 lint_provider: provider
-	cd provider && golangci-lint run -c ../.golangci.yml
+	cd provider && golangci-lint run --path-prefix provider -c ../.golangci.yml
 
 # `lint_provider.fix` is a utility target meant to be run manually
 # that will run the linter and fix errors when possible.
 lint_provider.fix:
-	cd provider && golangci-lint run -c ../.golangci.yml --fix
+	cd provider && golangci-lint run --path-prefix provider -c ../.golangci.yml --fix
 
 # `make provider_no_deps` builds the provider binary directly, without ensuring that
 # `cmd/pulumi-resource-cloudflare/schema.json` is valid and up to date.

--- a/provider-ci/test-providers/docker/Makefile
+++ b/provider-ci/test-providers/docker/Makefile
@@ -125,12 +125,12 @@ install_plugins: .pulumi/bin/pulumi
 	.pulumi/bin/pulumi plugin install resource aws 6.8.0
 
 lint_provider: provider
-	cd provider && golangci-lint run -c ../.golangci.yml
+	cd provider && golangci-lint run --path-prefix provider -c ../.golangci.yml
 
 # `lint_provider.fix` is a utility target meant to be run manually
 # that will run the linter and fix errors when possible.
 lint_provider.fix:
-	cd provider && golangci-lint run -c ../.golangci.yml --fix
+	cd provider && golangci-lint run --path-prefix provider -c ../.golangci.yml --fix
 
 # `make provider_no_deps` builds the provider binary directly, without ensuring that
 # `cmd/pulumi-resource-docker/schema.json` is valid and up to date.


### PR DESCRIPTION
This generates lint errors that look like this:

```
provider/resources.go:144:25: printf: non-constant format string in call to fmt.Errorf (govet)
		return "", fmt.Errorf("Expected base64 property to be a string" + c)
		                      ^
```

Instead of like this:

```
resources.go:144:25: printf: non-constant format string in call to fmt.Errorf (govet)
		return "", fmt.Errorf("Expected base64 property to be a string" + c)
		                      ^
```

Having the prefixed `provider` allows IDEs to understand where `resources.go` is located.