### PR TITLE
Do not delete provider custom workflows in make ci-mgmt

### DIFF
--- a/provider-ci/internal/pkg/templates/bridged-provider/Makefile
+++ b/provider-ci/internal/pkg/templates/bridged-provider/Makefile
@@ -208,7 +208,9 @@ bin/pulumi-java-gen: .pulumi-java-gen.version
 # - Run make ci-mgmt to apply the change locally.
 #
 ci-mgmt: .ci-mgmt.yaml
-	rm -f .github/workflows/*.yml # Copied from update-workflows.yml
+	# Copied from update-workflows.yml
+        find pulumi-#{{ .Config.provider }}/.github/workflows/*.yml -type f ! -name '#{{ .Config.provider }}*.yml' -delete
+
 	go run github.com/pulumi/ci-mgmt/provider-ci@master generate \
 		--name $(ORG)/pulumi-$(PACK) \
 		--out . \

--- a/provider-ci/internal/pkg/templates/bridged-provider/Makefile
+++ b/provider-ci/internal/pkg/templates/bridged-provider/Makefile
@@ -208,7 +208,7 @@ bin/pulumi-java-gen: .pulumi-java-gen.version
 # - Run make ci-mgmt to apply the change locally.
 #
 ci-mgmt: .ci-mgmt.yaml
-	find pulumi-$(PACK)/.github/workflows/*.yml -type f ! -name "$(PACK)*.yml" -delete
+	find .github/workflows/*.yml -type f ! -name "$(PACK)*.yml" -delete
 	go run github.com/pulumi/ci-mgmt/provider-ci@master generate \
 		--name $(ORG)/pulumi-$(PACK) \
 		--out . \

--- a/provider-ci/internal/pkg/templates/bridged-provider/Makefile
+++ b/provider-ci/internal/pkg/templates/bridged-provider/Makefile
@@ -208,9 +208,7 @@ bin/pulumi-java-gen: .pulumi-java-gen.version
 # - Run make ci-mgmt to apply the change locally.
 #
 ci-mgmt: .ci-mgmt.yaml
-	# Copied from update-workflows.yml
-        find pulumi-#{{ .Config.provider }}/.github/workflows/*.yml -type f ! -name '#{{ .Config.provider }}*.yml' -delete
-
+	find pulumi-$(PACK)/.github/workflows/*.yml -type f ! -name "$(PACK)*.yml" -delete
 	go run github.com/pulumi/ci-mgmt/provider-ci@master generate \
 		--name $(ORG)/pulumi-$(PACK) \
 		--out . \

--- a/provider-ci/test-providers/acme/Makefile
+++ b/provider-ci/test-providers/acme/Makefile
@@ -174,7 +174,7 @@ bin/pulumi-java-gen: .pulumi-java-gen.version
 # - Run make ci-mgmt to apply the change locally.
 #
 ci-mgmt: .ci-mgmt.yaml
-	rm -f .github/workflows/*.yml # Copied from update-workflows.yml
+	find .github/workflows/*.yml -type f ! -name "$(PACK)*.yml" -delete
 	go run github.com/pulumi/ci-mgmt/provider-ci@master generate \
 		--name $(ORG)/pulumi-$(PACK) \
 		--out . \

--- a/provider-ci/test-providers/aws/Makefile
+++ b/provider-ci/test-providers/aws/Makefile
@@ -189,7 +189,7 @@ bin/pulumi-java-gen: .pulumi-java-gen.version
 # - Run make ci-mgmt to apply the change locally.
 #
 ci-mgmt: .ci-mgmt.yaml
-	rm -f .github/workflows/*.yml # Copied from update-workflows.yml
+	find pulumi-$(PACK)/.github/workflows/*.yml -type f ! -name "$(PACK)*.yml" -delete
 	go run github.com/pulumi/ci-mgmt/provider-ci@master generate \
 		--name $(ORG)/pulumi-$(PACK) \
 		--out . \

--- a/provider-ci/test-providers/aws/Makefile
+++ b/provider-ci/test-providers/aws/Makefile
@@ -189,7 +189,7 @@ bin/pulumi-java-gen: .pulumi-java-gen.version
 # - Run make ci-mgmt to apply the change locally.
 #
 ci-mgmt: .ci-mgmt.yaml
-	find pulumi-$(PACK)/.github/workflows/*.yml -type f ! -name "$(PACK)*.yml" -delete
+	find .github/workflows/*.yml -type f ! -name "$(PACK)*.yml" -delete
 	go run github.com/pulumi/ci-mgmt/provider-ci@master generate \
 		--name $(ORG)/pulumi-$(PACK) \
 		--out . \

--- a/provider-ci/test-providers/cloudflare/Makefile
+++ b/provider-ci/test-providers/cloudflare/Makefile
@@ -178,7 +178,7 @@ bin/pulumi-java-gen: .pulumi-java-gen.version
 # - Run make ci-mgmt to apply the change locally.
 #
 ci-mgmt: .ci-mgmt.yaml
-	rm -f .github/workflows/*.yml # Copied from update-workflows.yml
+	find pulumi-$(PACK)/.github/workflows/*.yml -type f ! -name "$(PACK)*.yml" -delete
 	go run github.com/pulumi/ci-mgmt/provider-ci@master generate \
 		--name $(ORG)/pulumi-$(PACK) \
 		--out . \

--- a/provider-ci/test-providers/cloudflare/Makefile
+++ b/provider-ci/test-providers/cloudflare/Makefile
@@ -178,7 +178,7 @@ bin/pulumi-java-gen: .pulumi-java-gen.version
 # - Run make ci-mgmt to apply the change locally.
 #
 ci-mgmt: .ci-mgmt.yaml
-	find pulumi-$(PACK)/.github/workflows/*.yml -type f ! -name "$(PACK)*.yml" -delete
+	find .github/workflows/*.yml -type f ! -name "$(PACK)*.yml" -delete
 	go run github.com/pulumi/ci-mgmt/provider-ci@master generate \
 		--name $(ORG)/pulumi-$(PACK) \
 		--out . \

--- a/provider-ci/test-providers/docker/Makefile
+++ b/provider-ci/test-providers/docker/Makefile
@@ -179,7 +179,7 @@ bin/pulumi-java-gen: .pulumi-java-gen.version
 # - Run make ci-mgmt to apply the change locally.
 #
 ci-mgmt: .ci-mgmt.yaml
-	find pulumi-$(PACK)/.github/workflows/*.yml -type f ! -name "$(PACK)*.yml" -delete
+	find .github/workflows/*.yml -type f ! -name "$(PACK)*.yml" -delete
 	go run github.com/pulumi/ci-mgmt/provider-ci@master generate \
 		--name $(ORG)/pulumi-$(PACK) \
 		--out . \

--- a/provider-ci/test-providers/docker/Makefile
+++ b/provider-ci/test-providers/docker/Makefile
@@ -179,7 +179,7 @@ bin/pulumi-java-gen: .pulumi-java-gen.version
 # - Run make ci-mgmt to apply the change locally.
 #
 ci-mgmt: .ci-mgmt.yaml
-	rm -f .github/workflows/*.yml # Copied from update-workflows.yml
+	find pulumi-$(PACK)/.github/workflows/*.yml -type f ! -name "$(PACK)*.yml" -delete
 	go run github.com/pulumi/ci-mgmt/provider-ci@master generate \
 		--name $(ORG)/pulumi-$(PACK) \
 		--out . \


### PR DESCRIPTION
We introduced a notion of provider-custom workflow files, such as:

    aws-upstream-tests.yml

Currently CI knows to not delete them, but `make ci-mgmt` target still does. This PR fixes this so that `make ci-mgmt`
target matches the behavior of CI workflows.