### PR TITLE
Use configured `languages` for tool installation

### DIFF
--- a/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/resync-build.yml
+++ b/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/resync-build.yml
@@ -26,7 +26,7 @@ jobs:
     - name: Setup tools
       uses: ./.github/actions/setup-tools
       with:
-        tools: pulumictl, pulumicli, go, node, dotnet, python
+        tools: pulumictl, pulumicli, go, nodejs, dotnet, python
     - name: Sync with ci-mgmt
       run: cp -r "ci-mgmt/provider-ci/providers/$PROVIDER/repo/." .
     - name: Remove ci-mgmt directory

--- a/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/upgrade-bridge.yml
+++ b/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/upgrade-bridge.yml
@@ -74,7 +74,7 @@ jobs:
     - name: Setup tools
       uses: ./.github/actions/setup-tools
       with:
-        tools: pulumictl, pulumicli, go, node, dotnet, python, java
+        tools: pulumictl, pulumicli, #{{ range $index, $element := .Config.languages }}##{{if $index}}#, #{{end}}##{{ $element }}##{{end}}#
     - name: Call upgrade provider action
       if: github.event_name == 'workflow_dispatch'
       uses: #{{ .Config.actionVersions.upgradeProviderAction }}#

--- a/provider-ci/internal/pkg/templates/provider/.github/workflows/verify-release.yml
+++ b/provider-ci/internal/pkg/templates/provider/.github/workflows/verify-release.yml
@@ -63,7 +63,7 @@ jobs:
       - name: Setup tools
         uses: ./.github/actions/setup-tools
         with:
-          tools: pulumicli, go, node, dotnet, python, java
+          tools: pulumicli, #{{ range $index, $element := .Config.languages }}##{{if $index}}#, #{{end}}##{{ $element }}##{{end}}#
 #{{- if .Config.releaseVerification.nodejs }}#
       - name: Verify nodejs release
         uses: pulumi/verify-provider-release@v1

--- a/provider-ci/test-providers/aws/.github/workflows/resync-build.yml
+++ b/provider-ci/test-providers/aws/.github/workflows/resync-build.yml
@@ -42,7 +42,7 @@ jobs:
     - name: Setup tools
       uses: ./.github/actions/setup-tools
       with:
-        tools: pulumictl, pulumicli, go, node, dotnet, python
+        tools: pulumictl, pulumicli, go, nodejs, dotnet, python
     - name: Sync with ci-mgmt
       run: cp -r "ci-mgmt/provider-ci/providers/$PROVIDER/repo/." .
     - name: Remove ci-mgmt directory

--- a/provider-ci/test-providers/aws/.github/workflows/upgrade-bridge.yml
+++ b/provider-ci/test-providers/aws/.github/workflows/upgrade-bridge.yml
@@ -70,7 +70,7 @@ jobs:
     - name: Setup tools
       uses: ./.github/actions/setup-tools
       with:
-        tools: pulumictl, pulumicli, go, node, dotnet, python, java
+        tools: pulumictl, pulumicli, nodejs, python, dotnet, go, java
     - name: Call upgrade provider action
       if: github.event_name == 'workflow_dispatch'
       uses: pulumi/pulumi-upgrade-provider-action@v0.0.12

--- a/provider-ci/test-providers/aws/.github/workflows/verify-release.yml
+++ b/provider-ci/test-providers/aws/.github/workflows/verify-release.yml
@@ -71,4 +71,4 @@ jobs:
       - name: Setup tools
         uses: ./.github/actions/setup-tools
         with:
-          tools: pulumicli, go, node, dotnet, python, java
+          tools: pulumicli, nodejs, python, dotnet, go, java

--- a/provider-ci/test-providers/cloudflare/.github/workflows/resync-build.yml
+++ b/provider-ci/test-providers/cloudflare/.github/workflows/resync-build.yml
@@ -39,7 +39,7 @@ jobs:
     - name: Setup tools
       uses: ./.github/actions/setup-tools
       with:
-        tools: pulumictl, pulumicli, go, node, dotnet, python
+        tools: pulumictl, pulumicli, go, nodejs, dotnet, python
     - name: Sync with ci-mgmt
       run: cp -r "ci-mgmt/provider-ci/providers/$PROVIDER/repo/." .
     - name: Remove ci-mgmt directory

--- a/provider-ci/test-providers/cloudflare/.github/workflows/upgrade-bridge.yml
+++ b/provider-ci/test-providers/cloudflare/.github/workflows/upgrade-bridge.yml
@@ -62,7 +62,7 @@ jobs:
     - name: Setup tools
       uses: ./.github/actions/setup-tools
       with:
-        tools: pulumictl, pulumicli, go, node, dotnet, python, java
+        tools: pulumictl, pulumicli, nodejs, python, dotnet, go, java
     - name: Call upgrade provider action
       if: github.event_name == 'workflow_dispatch'
       uses: pulumi/pulumi-upgrade-provider-action@v0.0.12

--- a/provider-ci/test-providers/cloudflare/.github/workflows/verify-release.yml
+++ b/provider-ci/test-providers/cloudflare/.github/workflows/verify-release.yml
@@ -70,4 +70,4 @@ jobs:
       - name: Setup tools
         uses: ./.github/actions/setup-tools
         with:
-          tools: pulumicli, go, node, dotnet, python, java
+          tools: pulumicli, nodejs, python, dotnet, go, java

--- a/provider-ci/test-providers/docker/.github/workflows/resync-build.yml
+++ b/provider-ci/test-providers/docker/.github/workflows/resync-build.yml
@@ -52,7 +52,7 @@ jobs:
     - name: Setup tools
       uses: ./.github/actions/setup-tools
       with:
-        tools: pulumictl, pulumicli, go, node, dotnet, python
+        tools: pulumictl, pulumicli, go, nodejs, dotnet, python
     - name: Sync with ci-mgmt
       run: cp -r "ci-mgmt/provider-ci/providers/$PROVIDER/repo/." .
     - name: Remove ci-mgmt directory

--- a/provider-ci/test-providers/docker/.github/workflows/upgrade-bridge.yml
+++ b/provider-ci/test-providers/docker/.github/workflows/upgrade-bridge.yml
@@ -62,7 +62,7 @@ jobs:
     - name: Setup tools
       uses: ./.github/actions/setup-tools
       with:
-        tools: pulumictl, pulumicli, go, node, dotnet, python, java
+        tools: pulumictl, pulumicli, nodejs, python, dotnet, go, java
     - name: Call upgrade provider action
       if: github.event_name == 'workflow_dispatch'
       uses: pulumi/pulumi-upgrade-provider-action@v0.0.12

--- a/provider-ci/test-providers/docker/.github/workflows/verify-release.yml
+++ b/provider-ci/test-providers/docker/.github/workflows/verify-release.yml
@@ -83,4 +83,4 @@ jobs:
       - name: Setup tools
         uses: ./.github/actions/setup-tools
         with:
-          tools: pulumicli, go, node, dotnet, python, java
+          tools: pulumicli, nodejs, python, dotnet, go, java


### PR DESCRIPTION
In `setup-tools`, the language `node` was renamed to `nodejs` for consistency. We missed it in 3 spots.

It should fix the failing `verify-release` in downstream `pulumi-xyz` provider:
* https://github.com/pulumi/pulumi-xyz/actions/runs/10789722716/job/29924862046
* https://github.com/pulumi/pulumi-xyz/actions/runs/10789596609/job/29923455243