### PR TITLE
Disarm any go:embed directives before running golangci-lint for native providers

### DIFF
--- a/native-provider-ci/providers/command/repo/.github/workflows/build.yml
+++ b/native-provider-ci/providers/command/repo/.github/workflows/build.yml
@@ -474,6 +474,9 @@ jobs:
       with:
         go-version: ${{ env.GOVERSION }}
         cache-dependency-path: "**/*.sum"
+    - name: Disarm go:embed directives to enable linters that compile source code
+      run: git grep -l 'go:embed' -- provider | xargs --no-run-if-empty sed -i
+        's/go:embed/ goembed/g'
     - name: golangci-lint provider pkg
       uses: golangci/golangci-lint-action@d6238b002a20823d52840fda27e2d4891c5952dc # v4.0.1
       with:

--- a/native-provider-ci/providers/command/repo/.github/workflows/run-acceptance-tests.yml
+++ b/native-provider-ci/providers/command/repo/.github/workflows/run-acceptance-tests.yml
@@ -371,6 +371,9 @@ jobs:
       with:
         go-version: ${{ env.GOVERSION }}
         cache-dependency-path: "**/*.sum"
+    - name: Disarm go:embed directives to enable linters that compile source code
+      run: git grep -l 'go:embed' -- provider | xargs --no-run-if-empty sed -i
+        's/go:embed/ goembed/g'
     - name: golangci-lint provider pkg
       uses: golangci/golangci-lint-action@d6238b002a20823d52840fda27e2d4891c5952dc # v4.0.1
       with:

--- a/native-provider-ci/providers/docker-build/repo/.github/workflows/build.yml
+++ b/native-provider-ci/providers/docker-build/repo/.github/workflows/build.yml
@@ -528,6 +528,9 @@ jobs:
       with:
         go-version: ${{ env.GOVERSION }}
         cache-dependency-path: "**/*.sum"
+    - name: Disarm go:embed directives to enable linters that compile source code
+      run: git grep -l 'go:embed' -- provider | xargs --no-run-if-empty sed -i
+        's/go:embed/ goembed/g'
     - name: golangci-lint provider pkg
       uses: golangci/golangci-lint-action@d6238b002a20823d52840fda27e2d4891c5952dc # v4.0.1
       with:

--- a/native-provider-ci/providers/docker-build/repo/.github/workflows/run-acceptance-tests.yml
+++ b/native-provider-ci/providers/docker-build/repo/.github/workflows/run-acceptance-tests.yml
@@ -427,6 +427,9 @@ jobs:
       with:
         go-version: ${{ env.GOVERSION }}
         cache-dependency-path: "**/*.sum"
+    - name: Disarm go:embed directives to enable linters that compile source code
+      run: git grep -l 'go:embed' -- provider | xargs --no-run-if-empty sed -i
+        's/go:embed/ goembed/g'
     - name: golangci-lint provider pkg
       uses: golangci/golangci-lint-action@d6238b002a20823d52840fda27e2d4891c5952dc # v4.0.1
       with:

--- a/native-provider-ci/providers/kubernetes-cert-manager/repo/.github/workflows/build.yml
+++ b/native-provider-ci/providers/kubernetes-cert-manager/repo/.github/workflows/build.yml
@@ -506,6 +506,9 @@ jobs:
       with:
         go-version: ${{ env.GOVERSION }}
         cache-dependency-path: "**/*.sum"
+    - name: Disarm go:embed directives to enable linters that compile source code
+      run: git grep -l 'go:embed' -- provider | xargs --no-run-if-empty sed -i
+        's/go:embed/ goembed/g'
     - name: golangci-lint provider pkg
       uses: golangci/golangci-lint-action@d6238b002a20823d52840fda27e2d4891c5952dc # v4.0.1
       with:

--- a/native-provider-ci/providers/kubernetes-cert-manager/repo/.github/workflows/run-acceptance-tests.yml
+++ b/native-provider-ci/providers/kubernetes-cert-manager/repo/.github/workflows/run-acceptance-tests.yml
@@ -403,6 +403,9 @@ jobs:
       with:
         go-version: ${{ env.GOVERSION }}
         cache-dependency-path: "**/*.sum"
+    - name: Disarm go:embed directives to enable linters that compile source code
+      run: git grep -l 'go:embed' -- provider | xargs --no-run-if-empty sed -i
+        's/go:embed/ goembed/g'
     - name: golangci-lint provider pkg
       uses: golangci/golangci-lint-action@d6238b002a20823d52840fda27e2d4891c5952dc # v4.0.1
       with:

--- a/native-provider-ci/providers/kubernetes/repo/.github/workflows/build.yml
+++ b/native-provider-ci/providers/kubernetes/repo/.github/workflows/build.yml
@@ -549,6 +549,9 @@ jobs:
       with:
         go-version: ${{ env.GOVERSION }}
         cache-dependency-path: "**/*.sum"
+    - name: Disarm go:embed directives to enable linters that compile source code
+      run: git grep -l 'go:embed' -- provider | xargs --no-run-if-empty sed -i
+        's/go:embed/ goembed/g'
     - name: golangci-lint provider pkg
       uses: golangci/golangci-lint-action@d6238b002a20823d52840fda27e2d4891c5952dc # v4.0.1
       with:

--- a/native-provider-ci/providers/kubernetes/repo/.github/workflows/run-acceptance-tests.yml
+++ b/native-provider-ci/providers/kubernetes/repo/.github/workflows/run-acceptance-tests.yml
@@ -443,6 +443,9 @@ jobs:
       with:
         go-version: ${{ env.GOVERSION }}
         cache-dependency-path: "**/*.sum"
+    - name: Disarm go:embed directives to enable linters that compile source code
+      run: git grep -l 'go:embed' -- provider | xargs --no-run-if-empty sed -i
+        's/go:embed/ goembed/g'
     - name: golangci-lint provider pkg
       uses: golangci/golangci-lint-action@d6238b002a20823d52840fda27e2d4891c5952dc # v4.0.1
       with:

--- a/native-provider-ci/src/steps.ts
+++ b/native-provider-ci/src/steps.ts
@@ -912,8 +912,13 @@ export function InstallandConfigureHelm(provider: string): Step {
   return {};
 }
 
-export function GolangciLint(): Step {
-  return {
+export function GolangciLint(): Step[] {
+  const disarmGoEmbed = {
+    name: "Disarm go:embed directives to enable linters that compile source code",
+    run: "git grep -l 'go:embed' -- provider | xargs --no-run-if-empty sed -i 's/go:embed/ goembed/g'",
+  };
+
+  const lintStep = {
     name: "golangci-lint provider pkg",
     uses: action.goLint,
     with: {
@@ -922,6 +927,8 @@ export function GolangciLint(): Step {
       "working-directory": "provider",
     },
   };
+
+  return [disarmGoEmbed, lintStep];
 }
 
 export function CodegenDuringSDKBuild(provider: string) {

--- a/native-provider-ci/src/workflows.ts
+++ b/native-provider-ci/src/workflows.ts
@@ -711,13 +711,17 @@ export class TeardownTestClusterJob implements NormalJob {
 
 export class LintJob implements NormalJob {
   "runs-on" = "ubuntu-latest";
-  steps = [steps.CheckoutRepoStep(), steps.InstallGo(), steps.GolangciLint()];
+  steps = [
+    steps.CheckoutRepoStep(),
+    steps.InstallGo(),
+    ...steps.GolangciLint(),
+  ];
   name: string;
   if: NormalJob["if"];
 
   constructor(name: string) {
     this.name = name;
-    Object.assign(this, { name });
+    Object.assign(this, { name, steps: this.steps });
   }
 
   addDispatchConditional(isWorkflowDispatch: boolean) {


### PR DESCRIPTION
The pulumi-kubernetes provider embeds a minified version of a Pulumi JSON schema in the built binary. This file is not checked into source, only the non minified version is. `golangci-lint` is unable to compile the provider for linting if the file does not exist. This PR ensures that we disable any go:embed directives by doing a simple find/replace.

This is necessary as `golangci-lint` is unable to skip processing files/directories. Instead, the `exclude-dirs/files` directives will still parse those files/directories, but just suppress warnings/errors. If it is not compilable, in this case due to missing embed files, the linter will also fail. See https://golangci-lint.run/welcome/faq/#why-do-you-have-typecheck-errors

Seehttps://github.com/pulumi/pulumi-kubernetes/pull/3355 for example passing run that modifies the workflow file directly.