### PR TITLE
Allow skipping the Go SDK verification when invoking directly

### DIFF
--- a/provider-ci/internal/pkg/templates/provider/.github/workflows/verify-release.yml
+++ b/provider-ci/internal/pkg/templates/provider/.github/workflows/verify-release.yml
@@ -11,6 +11,11 @@ on:
         description: "Enable the MacOS runner in addition to Linux and Windows. Defaults to 'false'."
         required: false
         type: boolean
+      skipGoSdk:
+        description: "Skip the Go SDK verification. Defaults to 'false'. This is used when we're not publishing a Go SDK on the default branch build."
+        required: false
+        type: boolean
+        default: false
   workflow_call:
     inputs:
       providerVersion:

--- a/provider-ci/test-providers/aws/.github/workflows/verify-release.yml
+++ b/provider-ci/test-providers/aws/.github/workflows/verify-release.yml
@@ -11,6 +11,11 @@ on:
         description: "Enable the MacOS runner in addition to Linux and Windows. Defaults to 'false'."
         required: false
         type: boolean
+      skipGoSdk:
+        description: "Skip the Go SDK verification. Defaults to 'false'. This is used when we're not publishing a Go SDK on the default branch build."
+        required: false
+        type: boolean
+        default: false
   workflow_call:
     inputs:
       providerVersion:

--- a/provider-ci/test-providers/cloudflare/.github/workflows/verify-release.yml
+++ b/provider-ci/test-providers/cloudflare/.github/workflows/verify-release.yml
@@ -11,6 +11,11 @@ on:
         description: "Enable the MacOS runner in addition to Linux and Windows. Defaults to 'false'."
         required: false
         type: boolean
+      skipGoSdk:
+        description: "Skip the Go SDK verification. Defaults to 'false'. This is used when we're not publishing a Go SDK on the default branch build."
+        required: false
+        type: boolean
+        default: false
   workflow_call:
     inputs:
       providerVersion:

--- a/provider-ci/test-providers/docker/.github/workflows/verify-release.yml
+++ b/provider-ci/test-providers/docker/.github/workflows/verify-release.yml
@@ -11,6 +11,11 @@ on:
         description: "Enable the MacOS runner in addition to Linux and Windows. Defaults to 'false'."
         required: false
         type: boolean
+      skipGoSdk:
+        description: "Skip the Go SDK verification. Defaults to 'false'. This is used when we're not publishing a Go SDK on the default branch build."
+        required: false
+        type: boolean
+        default: false
   workflow_call:
     inputs:
       providerVersion:


### PR DESCRIPTION
We can't test Go SDKs for pre-releases because we don't publish the Go SDKs for them. This is already implemented when invoked via a workflow_call, but the option wasn't available when using a workflow_dispatch (manual run).