### PR TITLE
Run registry docs command from correct file location

### DIFF
--- a/provider-ci/internal/pkg/templates/bridged-provider/Makefile
+++ b/provider-ci/internal/pkg/templates/bridged-provider/Makefile
@@ -114,7 +114,7 @@ build_python: upstream
 #{{- if .Config.registryDocs }}#
 
 build_registry_docs:
-	cd provider && $(WORKING_DIR)/bin/$(TFGEN) registry-docs --out $(WORKING_DIR)/docs
+	$(WORKING_DIR)/bin/$(TFGEN) registry-docs --out $(WORKING_DIR)/docs
 #{{- end }}#
 
 clean:

--- a/provider-ci/test-providers/cloudflare/Makefile
+++ b/provider-ci/test-providers/cloudflare/Makefile
@@ -97,7 +97,7 @@ build_python: upstream
 		../venv/bin/python -m build .
 
 build_registry_docs:
-	cd provider && $(WORKING_DIR)/bin/$(TFGEN) registry-docs --out $(WORKING_DIR)/docs
+	$(WORKING_DIR)/bin/$(TFGEN) registry-docs --out $(WORKING_DIR)/docs
 
 clean:
 	rm -rf sdk/{dotnet,nodejs,go,python}

--- a/provider-ci/test-providers/docker/Makefile
+++ b/provider-ci/test-providers/docker/Makefile
@@ -97,7 +97,7 @@ build_python: upstream
 		../venv/bin/python -m build .
 
 build_registry_docs:
-	cd provider && $(WORKING_DIR)/bin/$(TFGEN) registry-docs --out $(WORKING_DIR)/docs
+	$(WORKING_DIR)/bin/$(TFGEN) registry-docs --out $(WORKING_DIR)/docs
 
 clean:
 	rm -rf sdk/{dotnet,nodejs,go,python}


### PR DESCRIPTION
Previous version was running `make` from `provider` folder. This is the correct location at repo root.


