### PR TITLE
Migrate the default template name to the defaults config file

### DIFF
--- a/provider-ci/internal/cmd/generate.go
+++ b/provider-ci/internal/cmd/generate.go
@@ -31,14 +31,11 @@ var generateCmd = &cobra.Command{
 			return err
 		}
 
-		// Template name priority: CLI flag > config file > "bridged-provider"
+		// Template name priority: CLI flag > config file
 		if generateArgs.TemplateName == "" {
 			if templateName, ok := mergedConfig["template"].(string); ok {
 				generateArgs.TemplateName = templateName
 			}
-		}
-		if generateArgs.TemplateName == "" {
-			generateArgs.TemplateName = "bridged-provider"
 		}
 
 		// Name priority: CLI flag > config file ("repository", then "name" field)

--- a/provider-ci/internal/pkg/templates/bridged-provider/Makefile
+++ b/provider-ci/internal/pkg/templates/bridged-provider/Makefile
@@ -217,7 +217,7 @@ ci-mgmt: .ci-mgmt.yaml
 	go run github.com/pulumi/ci-mgmt/provider-ci@master generate \
 		--name $(ORG)/pulumi-$(PACK) \
 		--out . \
-		--template bridged-provider \
+		--template #{{ .Config.template }}# \
 		--config $<
 
 # Because some codegen depends on the version of the CLI used, we install a local CLI

--- a/provider-ci/internal/pkg/templates/defaults.config.yaml
+++ b/provider-ci/internal/pkg/templates/defaults.config.yaml
@@ -1,3 +1,7 @@
+# The default template name to apply
+# Possible template names can be found in the getTemplateDirs function in provider-ci/internal/pkg/generate.go file
+template: bridged-provider
+
 # provider is the name of the provider without the pulumi-prefix e.g. "aws"
 # This MUST be set in every provider
 #provider: xyz

--- a/provider-ci/test-providers/acme/Makefile
+++ b/provider-ci/test-providers/acme/Makefile
@@ -178,7 +178,7 @@ ci-mgmt: .ci-mgmt.yaml
 	go run github.com/pulumi/ci-mgmt/provider-ci@master generate \
 		--name $(ORG)/pulumi-$(PACK) \
 		--out . \
-		--template bridged-provider \
+		--template external-bridged-provider \
 		--config $<
 
 # Because some codegen depends on the version of the CLI used, we install a local CLI


### PR DESCRIPTION
Continuing on #1084, the name of the template must be populated correctly into the `Makefile` of external bridged providers. 

I moved `bridged-provider` as the default value into `defaults.config.json` and updated the code generation accordingly.