### PR TITLE
Migration to remove explicit SDK dependencies for python and JS

### DIFF
--- a/tools/sourcemigrator/index.ts
+++ b/tools/sourcemigrator/index.ts
@@ -99,6 +99,33 @@ function run(command: string): shell.ShellString {
 //   };
 // }
 
+function removeExplicitSDKDependency(): SourceMigration {
+  return {
+    name: "Respect Schema Version",
+    async execute(context) {
+      const patchPath = fs.realpathSync("removeExplicitSDKdependency.patch");
+      shell.pushd(context.dir);
+      try {
+        // Apply patch
+        run(
+          `go run github.com/uber-go/gopatch@latest -p "${patchPath}" ./provider/resources.go`
+        );
+        // Format the code - twice to ensure that the code is formatted correctly
+        run(`go install mvdan.cc/gofumpt@latest`);
+        run(`gofumpt -w ./provider/resources.go`);
+        run(`gofumpt -w ./provider/resources.go`);
+        // Check if we've made changes
+        const gitStatus = run(`git status --porcelain`).stdout;
+        if (gitStatus.includes("provider/resources.go")) {
+          run(`make tfgen build_sdks`);
+        }
+      } finally {
+        shell.popd();
+      }
+    },
+  };
+}
+
 async function runMigrations(
   context: MigrateContext,
   migrations: SourceMigration[]
@@ -110,7 +137,7 @@ async function runMigrations(
 }
 
 function allMigrations(): SourceMigration[] {
-  return [];
+  return [removeExplicitSDKDependency()];
 }
 
 async function main() {

--- a/tools/sourcemigrator/index.ts
+++ b/tools/sourcemigrator/index.ts
@@ -108,7 +108,7 @@ function removeExplicitSDKDependency(): SourceMigration {
       try {
         // Apply patch
         run(
-          `go run github.com/uber-go/gopatch@latest -p "${patchPath}" ./provider/resources.go`
+          `go run github.com/uber-go/gopatch@v0.4.0 -p "${patchPath}" ./provider/resources.go`
         );
         // Format the code - twice to ensure that the code is formatted correctly
         run(`go install mvdan.cc/gofumpt@latest`);

--- a/tools/sourcemigrator/removeExplicitSDKdependency.patch
+++ b/tools/sourcemigrator/removeExplicitSDKdependency.patch
@@ -1,0 +1,55 @@
+@@
+// JS: Remove explicit SDK dependency
+var tfbridge identifier
+@@
+ import tfbridge "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfbridge"
+
+ tfbridge.JavaScriptInfo{
+     ...,
+    Dependencies: map[string]string{
+        ...,
+-         "@pulumi/pulumi": "^3.0.0",
+        ...,
+    },
+     ...,
+ }
+
+@@
+// JS: Remove empty Dependencies
+var tfbridge identifier
+@@
+ import tfbridge "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfbridge"
+
+ tfbridge.JavaScriptInfo{
+     ...,
+-    Dependencies: map[string]string{},
+    ...,
+ }
+
+@@
+// Py: Remove explicit SDK dependency
+var tfbridge identifier
+@@
+ import tfbridge "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfbridge"
+
+ tfbridge.PythonInfo{
+     ...,
+    Requires: map[string]string{
+        ...,
+-         "pulumi": ">=3.0.0,<4.0.0",
+        ...,
+    },
+     ...,
+ }
+
+@@
+// Py: Remove empty Requires
+var tfbridge identifier
+@@
+ import tfbridge "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfbridge"
+
+ tfbridge.PythonInfo{
+     ...,
+-    Requires: map[string]string{},
+     ...,
+ }


### PR DESCRIPTION
This adds a migration for providers to remove the explicit SDK dependencies for python and javascript.

this should solve https://github.com/pulumi/ci-mgmt/issues/1091 for tier 2+ providers

I've tested this on pulumi-cloudflare and pulumi-random. I've also tested it doesn't do anything the second time around.