### PR TITLE
Disable triggering a release based on issue/pr labels

### DIFF
--- a/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/build_sdk.yml
+++ b/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/build_sdk.yml
@@ -58,7 +58,7 @@ jobs:
         with:
           allowed-changes: |
             sdk/**/pulumi-plugin.json
-            sdk/dotnet/Pulumi.*.csproj
+            sdk/dotnet/*.csproj
             sdk/go/**/pulumiUtilities.go
             sdk/nodejs/package.json
             sdk/python/pyproject.toml

--- a/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/main.yml
+++ b/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/main.yml
@@ -103,6 +103,7 @@ jobs:
     runs-on: #{{ .Config.runner.default }}#
     steps:
     - name: check if this commit needs release
+      if: ${{ env.RELEASE_BOT_ENDPOINT != '' }}
       uses: pulumi/action-release-by-pr-label@main
       with:
         command: "release-if-needed"

--- a/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/publish.yml
+++ b/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/publish.yml
@@ -73,7 +73,7 @@ jobs:
         {
           echo 'summary<<EOF'
           if [[ "$LAST_VERSION" != "No stable release" ]]; then
-            schema-tools compare --provider="#{{ .Config.provider }}#" --old-commit="$LAST_VERSION" --new-commit="--local-path=provider/cmd/pulumi-resource-#{{ .Config.provider }}#/schema.json"
+            schema-tools compare --provider="#{{ .Config.provider }}#" --old-commit="$LAST_VERSION" --repository="github://api.github.com/#{{ .Config.organization }}#" --new-commit="--local-path=provider/cmd/pulumi-resource-#{{ .Config.provider }}#/schema.json"
           fi
           echo 'EOF'
         } >> "$GITHUB_OUTPUT"

--- a/provider-ci/test-providers/acme/.github/workflows/build_sdk.yml
+++ b/provider-ci/test-providers/acme/.github/workflows/build_sdk.yml
@@ -64,7 +64,7 @@ jobs:
         with:
           allowed-changes: |
             sdk/**/pulumi-plugin.json
-            sdk/dotnet/Pulumi.*.csproj
+            sdk/dotnet/*.csproj
             sdk/go/**/pulumiUtilities.go
             sdk/nodejs/package.json
             sdk/python/pyproject.toml

--- a/provider-ci/test-providers/acme/.github/workflows/main.yml
+++ b/provider-ci/test-providers/acme/.github/workflows/main.yml
@@ -108,6 +108,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: check if this commit needs release
+      if: ${{ env.RELEASE_BOT_ENDPOINT != '' }}
       uses: pulumi/action-release-by-pr-label@main
       with:
         command: "release-if-needed"

--- a/provider-ci/test-providers/acme/.github/workflows/publish.yml
+++ b/provider-ci/test-providers/acme/.github/workflows/publish.yml
@@ -72,7 +72,7 @@ jobs:
         {
           echo 'summary<<EOF'
           if [[ "$LAST_VERSION" != "No stable release" ]]; then
-            schema-tools compare --provider="acme" --old-commit="$LAST_VERSION" --new-commit="--local-path=provider/cmd/pulumi-resource-acme/schema.json"
+            schema-tools compare --provider="acme" --old-commit="$LAST_VERSION" --repository="github://api.github.com/pulumiverse" --new-commit="--local-path=provider/cmd/pulumi-resource-acme/schema.json"
           fi
           echo 'EOF'
         } >> "$GITHUB_OUTPUT"

--- a/provider-ci/test-providers/aws/.github/workflows/build_sdk.yml
+++ b/provider-ci/test-providers/aws/.github/workflows/build_sdk.yml
@@ -76,7 +76,7 @@ jobs:
         with:
           allowed-changes: |
             sdk/**/pulumi-plugin.json
-            sdk/dotnet/Pulumi.*.csproj
+            sdk/dotnet/*.csproj
             sdk/go/**/pulumiUtilities.go
             sdk/nodejs/package.json
             sdk/python/pyproject.toml

--- a/provider-ci/test-providers/aws/.github/workflows/master.yml
+++ b/provider-ci/test-providers/aws/.github/workflows/master.yml
@@ -113,6 +113,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: check if this commit needs release
+      if: ${{ env.RELEASE_BOT_ENDPOINT != '' }}
       uses: pulumi/action-release-by-pr-label@main
       with:
         command: "release-if-needed"

--- a/provider-ci/test-providers/aws/.github/workflows/publish.yml
+++ b/provider-ci/test-providers/aws/.github/workflows/publish.yml
@@ -87,7 +87,7 @@ jobs:
         {
           echo 'summary<<EOF'
           if [[ "$LAST_VERSION" != "No stable release" ]]; then
-            schema-tools compare --provider="aws" --old-commit="$LAST_VERSION" --new-commit="--local-path=provider/cmd/pulumi-resource-aws/schema.json"
+            schema-tools compare --provider="aws" --old-commit="$LAST_VERSION" --repository="github://api.github.com/pulumi" --new-commit="--local-path=provider/cmd/pulumi-resource-aws/schema.json"
           fi
           echo 'EOF'
         } >> "$GITHUB_OUTPUT"

--- a/provider-ci/test-providers/cloudflare/.github/workflows/build_sdk.yml
+++ b/provider-ci/test-providers/cloudflare/.github/workflows/build_sdk.yml
@@ -67,7 +67,7 @@ jobs:
         with:
           allowed-changes: |
             sdk/**/pulumi-plugin.json
-            sdk/dotnet/Pulumi.*.csproj
+            sdk/dotnet/*.csproj
             sdk/go/**/pulumiUtilities.go
             sdk/nodejs/package.json
             sdk/python/pyproject.toml

--- a/provider-ci/test-providers/cloudflare/.github/workflows/master.yml
+++ b/provider-ci/test-providers/cloudflare/.github/workflows/master.yml
@@ -110,6 +110,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: check if this commit needs release
+      if: ${{ env.RELEASE_BOT_ENDPOINT != '' }}
       uses: pulumi/action-release-by-pr-label@main
       with:
         command: "release-if-needed"

--- a/provider-ci/test-providers/cloudflare/.github/workflows/publish.yml
+++ b/provider-ci/test-providers/cloudflare/.github/workflows/publish.yml
@@ -84,7 +84,7 @@ jobs:
         {
           echo 'summary<<EOF'
           if [[ "$LAST_VERSION" != "No stable release" ]]; then
-            schema-tools compare --provider="cloudflare" --old-commit="$LAST_VERSION" --new-commit="--local-path=provider/cmd/pulumi-resource-cloudflare/schema.json"
+            schema-tools compare --provider="cloudflare" --old-commit="$LAST_VERSION" --repository="github://api.github.com/pulumi" --new-commit="--local-path=provider/cmd/pulumi-resource-cloudflare/schema.json"
           fi
           echo 'EOF'
         } >> "$GITHUB_OUTPUT"

--- a/provider-ci/test-providers/docker/.github/workflows/build_sdk.yml
+++ b/provider-ci/test-providers/docker/.github/workflows/build_sdk.yml
@@ -80,7 +80,7 @@ jobs:
         with:
           allowed-changes: |
             sdk/**/pulumi-plugin.json
-            sdk/dotnet/Pulumi.*.csproj
+            sdk/dotnet/*.csproj
             sdk/go/**/pulumiUtilities.go
             sdk/nodejs/package.json
             sdk/python/pyproject.toml

--- a/provider-ci/test-providers/docker/.github/workflows/master.yml
+++ b/provider-ci/test-providers/docker/.github/workflows/master.yml
@@ -123,6 +123,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: check if this commit needs release
+      if: ${{ env.RELEASE_BOT_ENDPOINT != '' }}
       uses: pulumi/action-release-by-pr-label@main
       with:
         command: "release-if-needed"

--- a/provider-ci/test-providers/docker/.github/workflows/publish.yml
+++ b/provider-ci/test-providers/docker/.github/workflows/publish.yml
@@ -97,7 +97,7 @@ jobs:
         {
           echo 'summary<<EOF'
           if [[ "$LAST_VERSION" != "No stable release" ]]; then
-            schema-tools compare --provider="docker" --old-commit="$LAST_VERSION" --new-commit="--local-path=provider/cmd/pulumi-resource-docker/schema.json"
+            schema-tools compare --provider="docker" --old-commit="$LAST_VERSION" --repository="github://api.github.com/pulumi" --new-commit="--local-path=provider/cmd/pulumi-resource-docker/schema.json"
           fi
           echo 'EOF'
         } >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
Summary of changes:

* Thirdparty providers do not have the Pulumi Bot active. Any workflow step making use of it should be skipped if no such endpoint has been defined.
* Providers need the `--repository` option set for `schema-tools` to fetch the schema in the correct Github organization