### PR TITLE
Fix upgrade-provider tools & disk cleanup

### DIFF
--- a/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/build_provider.yml
+++ b/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/build_provider.yml
@@ -36,6 +36,7 @@ jobs:
         with:
           tool-cache: false
           swap-storage: false
+          dotnet: false
       #{{- end }}#
       - name: Checkout Repo
         uses: #{{ .Config.actionVersions.checkout }}#

--- a/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/build_sdk.yml
+++ b/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/build_sdk.yml
@@ -28,6 +28,7 @@ jobs:
         with:
           tool-cache: false
           swap-storage: false
+          dotnet: false
       #{{- end }}#
       - name: Checkout Repo
         uses: #{{ .Config.actionVersions.checkout }}#

--- a/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/main.yml
+++ b/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/main.yml
@@ -134,6 +134,7 @@ jobs:
       with:
         tool-cache: false
         swap-storage: false
+        dotnet: false
 #{{- end }}#
     - name: Checkout Repo
       uses: #{{ .Config.actionVersions.checkout }}#

--- a/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/nightly-test.yml
+++ b/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/nightly-test.yml
@@ -46,6 +46,7 @@ jobs:
       with:
         tool-cache: false
         swap-storage: false
+        dotnet: false
 #{{- end }}#
     - name: Checkout Repo
       uses: #{{ .Config.actionVersions.checkout }}#

--- a/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/prerelease.yml
+++ b/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/prerelease.yml
@@ -74,6 +74,7 @@ jobs:
       with:
         tool-cache: false
         swap-storage: false
+        dotnet: false
 #{{- end }}#
     - name: Checkout Repo
       uses: #{{ .Config.actionVersions.checkout }}#

--- a/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/prerequisites.yml
+++ b/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/prerequisites.yml
@@ -34,6 +34,7 @@ jobs:
       with:
         tool-cache: false
         swap-storage: false
+        dotnet: false
 #{{- end }}#
     - name: Checkout Repo
       uses: #{{ .Config.actionVersions.checkout }}#

--- a/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/release.yml
+++ b/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/release.yml
@@ -82,6 +82,7 @@ jobs:
       with:
         tool-cache: false
         swap-storage: false
+        dotnet: false
 #{{- end }}#
     - name: Checkout Repo
       uses: #{{ .Config.actionVersions.checkout }}#

--- a/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/upgrade-bridge.yml
+++ b/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/upgrade-bridge.yml
@@ -64,6 +64,7 @@ jobs:
       with:
         tool-cache: false
         swap-storage: false
+        dotnet: false
     #{{- end }}#
     - name: Checkout Repo
       uses: #{{ .Config.actionVersions.checkout }}#

--- a/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/upgrade-provider.yml
+++ b/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/upgrade-provider.yml
@@ -9,26 +9,30 @@ jobs:
     name: upgrade-provider
     runs-on: #{{ .Config.runner.default }}#
     steps:
-    #{{- if .Config.freeDiskSpaceBeforeBuild }}#
-    # Run as first step so we don't delete things that have just been installed
-    - name: Free Disk Space (Ubuntu)
-      uses: #{{ .Config.actionVersions.freeDiskSpace }}#
-      with:
-        tool-cache: false
-        swap-storage: false
-    #{{- end }}#
-    - name: Call upgrade provider action
-      uses: #{{ .Config.actionVersions.upgradeProviderAction }}#
-      with:
-        kind: all
-        #{{- if .Config.javaGenVersion }}#
-        target-java-version: #{{ .Config.javaGenVersion }}#
-        #{{- end }}#
-        email: bot@pulumi.com
-        username: pulumi-bot
+      #{{- if .Config.freeDiskSpaceBeforeBuild }}#
+      # Run as first step so we don't delete things that have just been installed
+      - name: Free Disk Space (Ubuntu)
+        uses: #{{ .Config.actionVersions.freeDiskSpace }}#
+        with:
+          tool-cache: false
+          swap-storage: false
+      #{{- end }}#
+      - name: Setup tools
+        uses: ./.github/actions/setup-tools
+        with:
+          tools: pulumictl, pulumicli, go, nodejs, dotnet, python, java
+      - name: Call upgrade provider action
+        uses: #{{ .Config.actionVersions.upgradeProviderAction }}#
+        with:
+          kind: all
+          #{{- if .Config.javaGenVersion }}#
+          target-java-version: #{{ .Config.javaGenVersion }}#
+          #{{- end }}#
+          email: bot@pulumi.com
+          username: pulumi-bot
 name: Upgrade provider
 on:
   issues:
     types:
-    - opened
+      - opened
   workflow_dispatch: {}

--- a/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/upgrade-provider.yml
+++ b/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/upgrade-provider.yml
@@ -16,6 +16,7 @@ jobs:
         with:
           tool-cache: false
           swap-storage: false
+          dotnet: false
       #{{- end }}#
       - name: Setup tools
         uses: ./.github/actions/setup-tools

--- a/provider-ci/internal/pkg/templates/pulumi-provider/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/internal/pkg/templates/pulumi-provider/.github/workflows/run-acceptance-tests.yml
@@ -109,6 +109,7 @@ jobs:
       with:
         tool-cache: false
         swap-storage: false
+        dotnet: false
 #{{- end }}#
     - name: Checkout Repo
       uses: #{{ .Config.actionVersions.checkout }}#

--- a/provider-ci/test-providers/acme/.github/workflows/upgrade-provider.yml
+++ b/provider-ci/test-providers/acme/.github/workflows/upgrade-provider.yml
@@ -9,15 +9,19 @@ jobs:
     name: upgrade-provider
     runs-on: ubuntu-latest
     steps:
-    - name: Call upgrade provider action
-      uses: pulumi/pulumi-upgrade-provider-action@v0.0.12
-      with:
-        kind: all
-        email: bot@pulumi.com
-        username: pulumi-bot
+      - name: Setup tools
+        uses: ./.github/actions/setup-tools
+        with:
+          tools: pulumictl, pulumicli, go, nodejs, dotnet, python, java
+      - name: Call upgrade provider action
+        uses: pulumi/pulumi-upgrade-provider-action@v0.0.12
+        with:
+          kind: all
+          email: bot@pulumi.com
+          username: pulumi-bot
 name: Upgrade provider
 on:
   issues:
     types:
-    - opened
+      - opened
   workflow_dispatch: {}

--- a/provider-ci/test-providers/aws/.github/workflows/build_provider.yml
+++ b/provider-ci/test-providers/aws/.github/workflows/build_provider.yml
@@ -35,6 +35,7 @@ jobs:
         with:
           tool-cache: false
           swap-storage: false
+          dotnet: false
       - name: Checkout Repo
         uses: actions/checkout@v4
         with:

--- a/provider-ci/test-providers/aws/.github/workflows/build_sdk.yml
+++ b/provider-ci/test-providers/aws/.github/workflows/build_sdk.yml
@@ -49,6 +49,7 @@ jobs:
         with:
           tool-cache: false
           swap-storage: false
+          dotnet: false
       - name: Checkout Repo
         uses: actions/checkout@v4
         with:

--- a/provider-ci/test-providers/aws/.github/workflows/master.yml
+++ b/provider-ci/test-providers/aws/.github/workflows/master.yml
@@ -143,6 +143,7 @@ jobs:
       with:
         tool-cache: false
         swap-storage: false
+        dotnet: false
     - name: Checkout Repo
       uses: actions/checkout@v4
       with:

--- a/provider-ci/test-providers/aws/.github/workflows/nightly-test.yml
+++ b/provider-ci/test-providers/aws/.github/workflows/nightly-test.yml
@@ -62,6 +62,7 @@ jobs:
       with:
         tool-cache: false
         swap-storage: false
+        dotnet: false
     - name: Checkout Repo
       uses: actions/checkout@v4
       with:

--- a/provider-ci/test-providers/aws/.github/workflows/prerelease.yml
+++ b/provider-ci/test-providers/aws/.github/workflows/prerelease.yml
@@ -85,6 +85,7 @@ jobs:
       with:
         tool-cache: false
         swap-storage: false
+        dotnet: false
     - name: Checkout Repo
       uses: actions/checkout@v4
       with:

--- a/provider-ci/test-providers/aws/.github/workflows/prerequisites.yml
+++ b/provider-ci/test-providers/aws/.github/workflows/prerequisites.yml
@@ -51,6 +51,7 @@ jobs:
       with:
         tool-cache: false
         swap-storage: false
+        dotnet: false
     - name: Checkout Repo
       uses: actions/checkout@v4
       with:

--- a/provider-ci/test-providers/aws/.github/workflows/release.yml
+++ b/provider-ci/test-providers/aws/.github/workflows/release.yml
@@ -90,6 +90,7 @@ jobs:
       with:
         tool-cache: false
         swap-storage: false
+        dotnet: false
     - name: Checkout Repo
       uses: actions/checkout@v4
       with:

--- a/provider-ci/test-providers/aws/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/test-providers/aws/.github/workflows/run-acceptance-tests.yml
@@ -115,6 +115,7 @@ jobs:
       with:
         tool-cache: false
         swap-storage: false
+        dotnet: false
     - name: Checkout Repo
       uses: actions/checkout@v4
       with:

--- a/provider-ci/test-providers/aws/.github/workflows/upgrade-bridge.yml
+++ b/provider-ci/test-providers/aws/.github/workflows/upgrade-bridge.yml
@@ -63,6 +63,7 @@ jobs:
       with:
         tool-cache: false
         swap-storage: false
+        dotnet: false
     - name: Checkout Repo
       uses: actions/checkout@v4
       with:

--- a/provider-ci/test-providers/aws/.github/workflows/upgrade-provider.yml
+++ b/provider-ci/test-providers/aws/.github/workflows/upgrade-provider.yml
@@ -9,21 +9,25 @@ jobs:
     name: upgrade-provider
     runs-on: ubuntu-latest
     steps:
-    # Run as first step so we don't delete things that have just been installed
-    - name: Free Disk Space (Ubuntu)
-      uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be
-      with:
-        tool-cache: false
-        swap-storage: false
-    - name: Call upgrade provider action
-      uses: pulumi/pulumi-upgrade-provider-action@v0.0.12
-      with:
-        kind: all
-        email: bot@pulumi.com
-        username: pulumi-bot
+      # Run as first step so we don't delete things that have just been installed
+      - name: Free Disk Space (Ubuntu)
+        uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be
+        with:
+          tool-cache: false
+          swap-storage: false
+      - name: Setup tools
+        uses: ./.github/actions/setup-tools
+        with:
+          tools: pulumictl, pulumicli, go, nodejs, dotnet, python, java
+      - name: Call upgrade provider action
+        uses: pulumi/pulumi-upgrade-provider-action@v0.0.12
+        with:
+          kind: all
+          email: bot@pulumi.com
+          username: pulumi-bot
 name: Upgrade provider
 on:
   issues:
     types:
-    - opened
+      - opened
   workflow_dispatch: {}

--- a/provider-ci/test-providers/aws/.github/workflows/upgrade-provider.yml
+++ b/provider-ci/test-providers/aws/.github/workflows/upgrade-provider.yml
@@ -15,6 +15,7 @@ jobs:
         with:
           tool-cache: false
           swap-storage: false
+          dotnet: false
       - name: Setup tools
         uses: ./.github/actions/setup-tools
         with:

--- a/provider-ci/test-providers/cloudflare/.github/workflows/upgrade-provider.yml
+++ b/provider-ci/test-providers/cloudflare/.github/workflows/upgrade-provider.yml
@@ -9,15 +9,19 @@ jobs:
     name: upgrade-provider
     runs-on: ubuntu-latest
     steps:
-    - name: Call upgrade provider action
-      uses: pulumi/pulumi-upgrade-provider-action@v0.0.12
-      with:
-        kind: all
-        email: bot@pulumi.com
-        username: pulumi-bot
+      - name: Setup tools
+        uses: ./.github/actions/setup-tools
+        with:
+          tools: pulumictl, pulumicli, go, nodejs, dotnet, python, java
+      - name: Call upgrade provider action
+        uses: pulumi/pulumi-upgrade-provider-action@v0.0.12
+        with:
+          kind: all
+          email: bot@pulumi.com
+          username: pulumi-bot
 name: Upgrade provider
 on:
   issues:
     types:
-    - opened
+      - opened
   workflow_dispatch: {}

--- a/provider-ci/test-providers/docker/.github/workflows/upgrade-provider.yml
+++ b/provider-ci/test-providers/docker/.github/workflows/upgrade-provider.yml
@@ -9,15 +9,19 @@ jobs:
     name: upgrade-provider
     runs-on: ubuntu-latest
     steps:
-    - name: Call upgrade provider action
-      uses: pulumi/pulumi-upgrade-provider-action@v0.0.12
-      with:
-        kind: all
-        email: bot@pulumi.com
-        username: pulumi-bot
+      - name: Setup tools
+        uses: ./.github/actions/setup-tools
+        with:
+          tools: pulumictl, pulumicli, go, nodejs, dotnet, python, java
+      - name: Call upgrade provider action
+        uses: pulumi/pulumi-upgrade-provider-action@v0.0.12
+        with:
+          kind: all
+          email: bot@pulumi.com
+          username: pulumi-bot
 name: Upgrade provider
 on:
   issues:
     types:
-    - opened
+      - opened
   workflow_dispatch: {}


### PR DESCRIPTION
Call setup-tools in upgrade-provider 

- Ensure we're using our consistent set of tool versions when performing an upgrade.
- Fixes #1095 where we deleted dotnet during disk cleaning.

Never delete the dotnet runtime 
- We actually use this and it should speed up the subsequent tool setup step.