### PR TITLE
Inline upgrade provider action

### DIFF
--- a/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/upgrade-provider.yml
+++ b/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/upgrade-provider.yml
@@ -18,19 +18,28 @@ jobs:
           swap-storage: false
           dotnet: false
       #{{- end }}#
+      - name: Checkout Repo
+        uses: #{{ .Config.actionVersions.checkout }}#
+        with:
+          depth: 0 # Fetch full history for checking previous tags
+          #{{- if .Config.checkoutSubmodules }}#
+          submodules: #{{ .Config.checkoutSubmodules }}#
+          #{{- end }}#
       - name: Setup tools
         uses: ./.github/actions/setup-tools
         with:
           tools: pulumictl, pulumicli, go, nodejs, dotnet, python, java
-      - name: Call upgrade provider action
-        uses: #{{ .Config.actionVersions.upgradeProviderAction }}#
-        with:
-          kind: all
-          #{{- if .Config.javaGenVersion }}#
-          target-java-version: #{{ .Config.javaGenVersion }}#
-          #{{- end }}#
-          email: bot@pulumi.com
-          username: pulumi-bot
+      - name: Install upgrade-provider
+        run: go install github.com/pulumi/upgrade-provider@main
+        shell: bash
+      - name: "Set up git identity: name"
+        run: |
+          git config --global user.name 'bot@pulumi.com'
+          git config --global user.email 'bot@pulumi.com'
+        shell: bash
+      - name: Run upgrade-provider
+        run: upgrade-provider "${{ github.repository }}" --kind="all" #{{ if .Config.javaGenVersion }}#--java-version="#{{ .Config.javaGenVersion }}#"#{{ end }}#
+        shell: bash
 name: Upgrade provider
 on:
   issues:

--- a/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/upgrade-provider.yml
+++ b/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/upgrade-provider.yml
@@ -20,11 +20,10 @@ jobs:
       #{{- end }}#
       - name: Checkout Repo
         uses: #{{ .Config.actionVersions.checkout }}#
+        #{{- if .Config.checkoutSubmodules }}#
         with:
-          depth: 0 # Fetch full history for checking previous tags
-          #{{- if .Config.checkoutSubmodules }}#
           submodules: #{{ .Config.checkoutSubmodules }}#
-          #{{- end }}#
+        #{{- end }}#
       - name: Setup tools
         uses: ./.github/actions/setup-tools
         with:

--- a/provider-ci/test-providers/acme/.github/workflows/upgrade-provider.yml
+++ b/provider-ci/test-providers/acme/.github/workflows/upgrade-provider.yml
@@ -11,8 +11,6 @@ jobs:
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v4
-        with:
-          depth: 0 # Fetch full history for checking previous tags
       - name: Setup tools
         uses: ./.github/actions/setup-tools
         with:

--- a/provider-ci/test-providers/acme/.github/workflows/upgrade-provider.yml
+++ b/provider-ci/test-providers/acme/.github/workflows/upgrade-provider.yml
@@ -9,16 +9,25 @@ jobs:
     name: upgrade-provider
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout Repo
+        uses: actions/checkout@v4
+        with:
+          depth: 0 # Fetch full history for checking previous tags
       - name: Setup tools
         uses: ./.github/actions/setup-tools
         with:
           tools: pulumictl, pulumicli, go, nodejs, dotnet, python, java
-      - name: Call upgrade provider action
-        uses: pulumi/pulumi-upgrade-provider-action@v0.0.12
-        with:
-          kind: all
-          email: bot@pulumi.com
-          username: pulumi-bot
+      - name: Install upgrade-provider
+        run: go install github.com/pulumi/upgrade-provider@main
+        shell: bash
+      - name: "Set up git identity: name"
+        run: |
+          git config --global user.name 'bot@pulumi.com'
+          git config --global user.email 'bot@pulumi.com'
+        shell: bash
+      - name: Run upgrade-provider
+        run: upgrade-provider "${{ github.repository }}" --kind="all" 
+        shell: bash
 name: Upgrade provider
 on:
   issues:

--- a/provider-ci/test-providers/aws/.github/workflows/upgrade-provider.yml
+++ b/provider-ci/test-providers/aws/.github/workflows/upgrade-provider.yml
@@ -19,7 +19,6 @@ jobs:
       - name: Checkout Repo
         uses: actions/checkout@v4
         with:
-          depth: 0 # Fetch full history for checking previous tags
           submodules: true
       - name: Setup tools
         uses: ./.github/actions/setup-tools

--- a/provider-ci/test-providers/aws/.github/workflows/upgrade-provider.yml
+++ b/provider-ci/test-providers/aws/.github/workflows/upgrade-provider.yml
@@ -16,16 +16,26 @@ jobs:
           tool-cache: false
           swap-storage: false
           dotnet: false
+      - name: Checkout Repo
+        uses: actions/checkout@v4
+        with:
+          depth: 0 # Fetch full history for checking previous tags
+          submodules: true
       - name: Setup tools
         uses: ./.github/actions/setup-tools
         with:
           tools: pulumictl, pulumicli, go, nodejs, dotnet, python, java
-      - name: Call upgrade provider action
-        uses: pulumi/pulumi-upgrade-provider-action@v0.0.12
-        with:
-          kind: all
-          email: bot@pulumi.com
-          username: pulumi-bot
+      - name: Install upgrade-provider
+        run: go install github.com/pulumi/upgrade-provider@main
+        shell: bash
+      - name: "Set up git identity: name"
+        run: |
+          git config --global user.name 'bot@pulumi.com'
+          git config --global user.email 'bot@pulumi.com'
+        shell: bash
+      - name: Run upgrade-provider
+        run: upgrade-provider "${{ github.repository }}" --kind="all" 
+        shell: bash
 name: Upgrade provider
 on:
   issues:

--- a/provider-ci/test-providers/cloudflare/.github/workflows/upgrade-provider.yml
+++ b/provider-ci/test-providers/cloudflare/.github/workflows/upgrade-provider.yml
@@ -11,8 +11,6 @@ jobs:
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v4
-        with:
-          depth: 0 # Fetch full history for checking previous tags
       - name: Setup tools
         uses: ./.github/actions/setup-tools
         with:

--- a/provider-ci/test-providers/cloudflare/.github/workflows/upgrade-provider.yml
+++ b/provider-ci/test-providers/cloudflare/.github/workflows/upgrade-provider.yml
@@ -9,16 +9,25 @@ jobs:
     name: upgrade-provider
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout Repo
+        uses: actions/checkout@v4
+        with:
+          depth: 0 # Fetch full history for checking previous tags
       - name: Setup tools
         uses: ./.github/actions/setup-tools
         with:
           tools: pulumictl, pulumicli, go, nodejs, dotnet, python, java
-      - name: Call upgrade provider action
-        uses: pulumi/pulumi-upgrade-provider-action@v0.0.12
-        with:
-          kind: all
-          email: bot@pulumi.com
-          username: pulumi-bot
+      - name: Install upgrade-provider
+        run: go install github.com/pulumi/upgrade-provider@main
+        shell: bash
+      - name: "Set up git identity: name"
+        run: |
+          git config --global user.name 'bot@pulumi.com'
+          git config --global user.email 'bot@pulumi.com'
+        shell: bash
+      - name: Run upgrade-provider
+        run: upgrade-provider "${{ github.repository }}" --kind="all" 
+        shell: bash
 name: Upgrade provider
 on:
   issues:

--- a/provider-ci/test-providers/docker/.github/workflows/upgrade-provider.yml
+++ b/provider-ci/test-providers/docker/.github/workflows/upgrade-provider.yml
@@ -11,8 +11,6 @@ jobs:
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v4
-        with:
-          depth: 0 # Fetch full history for checking previous tags
       - name: Setup tools
         uses: ./.github/actions/setup-tools
         with:

--- a/provider-ci/test-providers/docker/.github/workflows/upgrade-provider.yml
+++ b/provider-ci/test-providers/docker/.github/workflows/upgrade-provider.yml
@@ -9,16 +9,25 @@ jobs:
     name: upgrade-provider
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout Repo
+        uses: actions/checkout@v4
+        with:
+          depth: 0 # Fetch full history for checking previous tags
       - name: Setup tools
         uses: ./.github/actions/setup-tools
         with:
           tools: pulumictl, pulumicli, go, nodejs, dotnet, python, java
-      - name: Call upgrade provider action
-        uses: pulumi/pulumi-upgrade-provider-action@v0.0.12
-        with:
-          kind: all
-          email: bot@pulumi.com
-          username: pulumi-bot
+      - name: Install upgrade-provider
+        run: go install github.com/pulumi/upgrade-provider@main
+        shell: bash
+      - name: "Set up git identity: name"
+        run: |
+          git config --global user.name 'bot@pulumi.com'
+          git config --global user.email 'bot@pulumi.com'
+        shell: bash
+      - name: Run upgrade-provider
+        run: upgrade-provider "${{ github.repository }}" --kind="all" 
+        shell: bash
 name: Upgrade provider
 on:
   issues:


### PR DESCRIPTION
This action was originally failing due to missing dotnet if we run the disk clean-up action first. Then when trying to install dotnet using the setup-tools action, it was failing because the repo wasn't yet checked out, however, the `pulumi-upgrade-provider-action` does it's own checkout action, so it would have required removing the checkout from that action, creating a new version, then upgrading the version via ci-mgmt. At this point the `pulumi-upgrade-provider-action` would only contain the install and execution of the upgrade-provider CLI tool.

## Change summary

- Go direct to the `upgrade-provider` program instead of via the `pulumi-upgrade-provider-action` wrapper action.
- Enables us to use the shared setup-tools action for tool consistency.

## References

- Existing wrapper action: https://github.com/pulumi/pulumi-upgrade-provider-action/blob/main/action.yml
- Sample run: https://github.com/pulumi/pulumi-azure/actions/runs/11219063931/job/31184185595