### PR TITLE
Use the standard Github generated token with elevated permissions

### DIFF
--- a/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/main.yml
+++ b/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/main.yml
@@ -82,6 +82,8 @@ jobs:
 
   publish:
     name: publish
+    permissions:
+      contents: write
     needs:
       - prerequisites
       - build_provider

--- a/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/prerelease.yml
+++ b/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/prerelease.yml
@@ -41,6 +41,8 @@ jobs:
 
   publish:
     name: publish
+    permissions:
+      contents: write
     needs:
       - prerequisites
       - build_provider

--- a/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/publish.yml
+++ b/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/publish.yml
@@ -93,7 +93,7 @@ jobs:
         generate_release_notes: true
         files: dist/*
       env:
-        GITHUB_TOKEN: ${{ secrets.PULUMI_BOT_TOKEN }}
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   publish_sdk:
     name: publish_sdk

--- a/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/release.yml
+++ b/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/release.yml
@@ -49,6 +49,8 @@ jobs:
 
   publish:
     name: publish
+    permissions:
+      contents: write
     needs:
       - prerequisites
       - build_provider

--- a/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/release.yml
+++ b/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/release.yml
@@ -51,6 +51,7 @@ jobs:
     name: publish
     permissions:
       contents: write
+      pull-requests: write
     needs:
       - prerequisites
       - build_provider

--- a/provider-ci/test-providers/acme/.github/workflows/main.yml
+++ b/provider-ci/test-providers/acme/.github/workflows/main.yml
@@ -90,6 +90,8 @@ jobs:
 
   publish:
     name: publish
+    permissions:
+      contents: write
     needs:
       - prerequisites
       - build_provider

--- a/provider-ci/test-providers/acme/.github/workflows/prerelease.yml
+++ b/provider-ci/test-providers/acme/.github/workflows/prerelease.yml
@@ -53,6 +53,8 @@ jobs:
 
   publish:
     name: publish
+    permissions:
+      contents: write
     needs:
       - prerequisites
       - build_provider

--- a/provider-ci/test-providers/acme/.github/workflows/publish.yml
+++ b/provider-ci/test-providers/acme/.github/workflows/publish.yml
@@ -88,7 +88,7 @@ jobs:
         generate_release_notes: true
         files: dist/*
       env:
-        GITHUB_TOKEN: ${{ secrets.PULUMI_BOT_TOKEN }}
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   publish_sdk:
     name: publish_sdk

--- a/provider-ci/test-providers/acme/.github/workflows/release.yml
+++ b/provider-ci/test-providers/acme/.github/workflows/release.yml
@@ -58,6 +58,8 @@ jobs:
 
   publish:
     name: publish
+    permissions:
+      contents: write
     needs:
       - prerequisites
       - build_provider

--- a/provider-ci/test-providers/acme/.github/workflows/release.yml
+++ b/provider-ci/test-providers/acme/.github/workflows/release.yml
@@ -60,6 +60,7 @@ jobs:
     name: publish
     permissions:
       contents: write
+      pull-requests: write
     needs:
       - prerequisites
       - build_provider

--- a/provider-ci/test-providers/aws/.github/workflows/master.yml
+++ b/provider-ci/test-providers/aws/.github/workflows/master.yml
@@ -91,6 +91,8 @@ jobs:
 
   publish:
     name: publish
+    permissions:
+      contents: write
     needs:
       - prerequisites
       - build_provider

--- a/provider-ci/test-providers/aws/.github/workflows/prerelease.yml
+++ b/provider-ci/test-providers/aws/.github/workflows/prerelease.yml
@@ -52,6 +52,8 @@ jobs:
 
   publish:
     name: publish
+    permissions:
+      contents: write
     needs:
       - prerequisites
       - build_provider

--- a/provider-ci/test-providers/aws/.github/workflows/publish.yml
+++ b/provider-ci/test-providers/aws/.github/workflows/publish.yml
@@ -105,7 +105,7 @@ jobs:
         generate_release_notes: true
         files: dist/*
       env:
-        GITHUB_TOKEN: ${{ secrets.PULUMI_BOT_TOKEN }}
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   publish_sdk:
     name: publish_sdk

--- a/provider-ci/test-providers/aws/.github/workflows/release.yml
+++ b/provider-ci/test-providers/aws/.github/workflows/release.yml
@@ -57,6 +57,8 @@ jobs:
 
   publish:
     name: publish
+    permissions:
+      contents: write
     needs:
       - prerequisites
       - build_provider

--- a/provider-ci/test-providers/aws/.github/workflows/release.yml
+++ b/provider-ci/test-providers/aws/.github/workflows/release.yml
@@ -59,6 +59,7 @@ jobs:
     name: publish
     permissions:
       contents: write
+      pull-requests: write
     needs:
       - prerequisites
       - build_provider

--- a/provider-ci/test-providers/cloudflare/.github/workflows/master.yml
+++ b/provider-ci/test-providers/cloudflare/.github/workflows/master.yml
@@ -92,6 +92,8 @@ jobs:
 
   publish:
     name: publish
+    permissions:
+      contents: write
     needs:
       - prerequisites
       - build_provider

--- a/provider-ci/test-providers/cloudflare/.github/workflows/prerelease.yml
+++ b/provider-ci/test-providers/cloudflare/.github/workflows/prerelease.yml
@@ -55,6 +55,8 @@ jobs:
 
   publish:
     name: publish
+    permissions:
+      contents: write
     needs:
       - prerequisites
       - build_provider

--- a/provider-ci/test-providers/cloudflare/.github/workflows/publish.yml
+++ b/provider-ci/test-providers/cloudflare/.github/workflows/publish.yml
@@ -102,7 +102,7 @@ jobs:
         generate_release_notes: true
         files: dist/*
       env:
-        GITHUB_TOKEN: ${{ secrets.PULUMI_BOT_TOKEN }}
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   publish_sdk:
     name: publish_sdk

--- a/provider-ci/test-providers/cloudflare/.github/workflows/release.yml
+++ b/provider-ci/test-providers/cloudflare/.github/workflows/release.yml
@@ -60,6 +60,8 @@ jobs:
 
   publish:
     name: publish
+    permissions:
+      contents: write
     needs:
       - prerequisites
       - build_provider

--- a/provider-ci/test-providers/cloudflare/.github/workflows/release.yml
+++ b/provider-ci/test-providers/cloudflare/.github/workflows/release.yml
@@ -62,6 +62,7 @@ jobs:
     name: publish
     permissions:
       contents: write
+      pull-requests: write
     needs:
       - prerequisites
       - build_provider

--- a/provider-ci/test-providers/docker/.github/workflows/master.yml
+++ b/provider-ci/test-providers/docker/.github/workflows/master.yml
@@ -105,6 +105,8 @@ jobs:
 
   publish:
     name: publish
+    permissions:
+      contents: write
     needs:
       - prerequisites
       - build_provider

--- a/provider-ci/test-providers/docker/.github/workflows/prerelease.yml
+++ b/provider-ci/test-providers/docker/.github/workflows/prerelease.yml
@@ -68,6 +68,8 @@ jobs:
 
   publish:
     name: publish
+    permissions:
+      contents: write
     needs:
       - prerequisites
       - build_provider

--- a/provider-ci/test-providers/docker/.github/workflows/publish.yml
+++ b/provider-ci/test-providers/docker/.github/workflows/publish.yml
@@ -115,7 +115,7 @@ jobs:
         generate_release_notes: true
         files: dist/*
       env:
-        GITHUB_TOKEN: ${{ secrets.PULUMI_BOT_TOKEN }}
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   publish_sdk:
     name: publish_sdk

--- a/provider-ci/test-providers/docker/.github/workflows/release.yml
+++ b/provider-ci/test-providers/docker/.github/workflows/release.yml
@@ -73,6 +73,8 @@ jobs:
 
   publish:
     name: publish
+    permissions:
+      contents: write
     needs:
       - prerequisites
       - build_provider

--- a/provider-ci/test-providers/docker/.github/workflows/release.yml
+++ b/provider-ci/test-providers/docker/.github/workflows/release.yml
@@ -75,6 +75,7 @@ jobs:
     name: publish
     permissions:
       contents: write
+      pull-requests: write
     needs:
       - prerequisites
       - build_provider


### PR DESCRIPTION
Relates to: #1053, #1087

Moving from a central `PULUMI_BOT_TOKEN` to the Github Actions permissions block makes the workflows reusable for third party providers. The generated `GITHUB_TOKEN` secret in each workflow instance will receive elevated permissions based on the permissions configuration block. To limit the blast radius of a possible error, this PR focuses on the `main|master` and `(pre)release` workflows for now. Similar changes for other workflows will come in subsequent pull requests.

Besides making the workflows more reusable for third-party providers, it also improves on the situation for rate limits tied to the central `PULUMI_BOT_TOKEN`. The generated `GITHUB_TOKEN` has [much higher API rate limits](https://docs.github.com/en/rest/using-the-rest-api/rate-limits-for-the-rest-api?apiVersion=2022-11-28#primary-rate-limit-for-github_token-in-github-actions) on our Github Enterprise backed subscription for `pulumi` organization:

> The rate limit for `GITHUB_TOKEN` is 1,000 requests per hour per repository. For requests to resources that belong to a GitHub Enterprise Cloud account, the limit is 15,000 requests per hour per repository.

Already moving the `main|master` and `(pre)release` workflows to use the `GITHUB_TOKEN` reduces the usage of the `PULUMI_BOT_TOKEN`, so lowering the chance of bumping into a rate limit.

Github Docs: [Controlling permissions for `GITHUB_TOKEN`](https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/controlling-permissions-for-github_token)

**NOTE:** The required permissions for the `publish` workflow are set on the calling side of the nested job instead of within the nested job. I tested setting it within publish.yml but it seems it is not possible anymore to elevate permissions in a nested job: https://github.com/pulumiverse/pulumi-acme/actions/runs/11181469935

The changes of this PR are validated in the following third-party packages:

| Package | Commit with changes from this PR | Green `main` run | Green `release` |
|--------|--------|--------|--------|
| [pulumiverse/pulumi-acme](https://github.com/pulumiverse/pulumi-acme) | [33e7fa5](https://github.com/pulumiverse/pulumi-acme/commit/33e7fa53d999e8eee09fd19bdb1d2046b58021ce) | [11182399934](https://github.com/pulumiverse/pulumi-acme/actions/runs/11182399934) | [11182413642](https://github.com/pulumiverse/pulumi-acme/actions/runs/11182413642) |
| [pulumiverse/pulumi-matchbox](https://github.com/pulumiverse/pulumi-matchbox) | [f370a12](https://github.com/pulumiverse/pulumi-matchbox/commit/f370a122007a617e5449fa9f6e2f97db75af9532) | [11232745061](https://github.com/pulumiverse/pulumi-matchbox/actions/runs/11232926252) | [11182413642](https://github.com/pulumiverse/pulumi-matchbox/actions/runs/11232926252) |
