### PR TITLE
Use the configured Github organization for schema-tools

### DIFF
--- a/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/prerequisites.yml
+++ b/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/prerequisites.yml
@@ -77,7 +77,7 @@ jobs:
         EOF=$(dd if=/dev/urandom bs=15 count=1 status=none | base64)
         {
           echo "SCHEMA_CHANGES<<$EOF";
-          schema-tools compare -p #{{ .Config.provider }}# -o ${{ inputs.default_branch }} -n --local-path=provider/cmd/pulumi-resource-#{{ .Config.provider }}#/schema.json;
+          schema-tools compare -r github://api.github.com/#{{ .Config.organization }}# -p #{{ .Config.provider }}# -o ${{ inputs.default_branch }} -n --local-path=provider/cmd/pulumi-resource-#{{ .Config.provider }}#/schema.json;
           echo "$EOF";
         } >> "$GITHUB_ENV"
     - if: inputs.is_pr && inputs.is_automated == false

--- a/provider-ci/test-providers/acme/.github/workflows/prerequisites.yml
+++ b/provider-ci/test-providers/acme/.github/workflows/prerequisites.yml
@@ -76,7 +76,7 @@ jobs:
         EOF=$(dd if=/dev/urandom bs=15 count=1 status=none | base64)
         {
           echo "SCHEMA_CHANGES<<$EOF";
-          schema-tools compare -p acme -o ${{ inputs.default_branch }} -n --local-path=provider/cmd/pulumi-resource-acme/schema.json;
+          schema-tools compare -r github://api.github.com/pulumiverse -p acme -o ${{ inputs.default_branch }} -n --local-path=provider/cmd/pulumi-resource-acme/schema.json;
           echo "$EOF";
         } >> "$GITHUB_ENV"
     - if: inputs.is_pr && inputs.is_automated == false

--- a/provider-ci/test-providers/aws/.github/workflows/prerequisites.yml
+++ b/provider-ci/test-providers/aws/.github/workflows/prerequisites.yml
@@ -88,7 +88,7 @@ jobs:
         EOF=$(dd if=/dev/urandom bs=15 count=1 status=none | base64)
         {
           echo "SCHEMA_CHANGES<<$EOF";
-          schema-tools compare -p aws -o ${{ inputs.default_branch }} -n --local-path=provider/cmd/pulumi-resource-aws/schema.json;
+          schema-tools compare -r github://api.github.com/pulumi -p aws -o ${{ inputs.default_branch }} -n --local-path=provider/cmd/pulumi-resource-aws/schema.json;
           echo "$EOF";
         } >> "$GITHUB_ENV"
     - if: inputs.is_pr && inputs.is_automated == false

--- a/provider-ci/test-providers/cloudflare/.github/workflows/prerequisites.yml
+++ b/provider-ci/test-providers/cloudflare/.github/workflows/prerequisites.yml
@@ -78,7 +78,7 @@ jobs:
         EOF=$(dd if=/dev/urandom bs=15 count=1 status=none | base64)
         {
           echo "SCHEMA_CHANGES<<$EOF";
-          schema-tools compare -p cloudflare -o ${{ inputs.default_branch }} -n --local-path=provider/cmd/pulumi-resource-cloudflare/schema.json;
+          schema-tools compare -r github://api.github.com/pulumi -p cloudflare -o ${{ inputs.default_branch }} -n --local-path=provider/cmd/pulumi-resource-cloudflare/schema.json;
           echo "$EOF";
         } >> "$GITHUB_ENV"
     - if: inputs.is_pr && inputs.is_automated == false

--- a/provider-ci/test-providers/docker/.github/workflows/prerequisites.yml
+++ b/provider-ci/test-providers/docker/.github/workflows/prerequisites.yml
@@ -91,7 +91,7 @@ jobs:
         EOF=$(dd if=/dev/urandom bs=15 count=1 status=none | base64)
         {
           echo "SCHEMA_CHANGES<<$EOF";
-          schema-tools compare -p docker -o ${{ inputs.default_branch }} -n --local-path=provider/cmd/pulumi-resource-docker/schema.json;
+          schema-tools compare -r github://api.github.com/pulumi -p docker -o ${{ inputs.default_branch }} -n --local-path=provider/cmd/pulumi-resource-docker/schema.json;
           echo "$EOF";
         } >> "$GITHUB_ENV"
     - if: inputs.is_pr && inputs.is_automated == false


### PR DESCRIPTION
Use the configured Github organization to fetch the schema from the correct location and pass it as an argument to the `schema-tools` check.