### PR TITLE
Set elevated token permissions

### DIFF
--- a/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/run-acceptance-tests.yml
@@ -23,6 +23,8 @@ jobs:
   prerequisites:
     if: github.event_name == 'repository_dispatch' ||
       github.event.pull_request.head.repo.full_name == github.repository
+    permissions:
+      pull-requests: write
     uses: ./.github/workflows/prerequisites.yml
     secrets: inherit
     with:
@@ -77,6 +79,8 @@ jobs:
     name: sentinel
     if: github.event_name == 'repository_dispatch' ||
       github.event.pull_request.head.repo.full_name == github.repository
+    permissions:
+      statuses: write
     needs:
     - test
     - build_provider

--- a/provider-ci/test-providers/acme/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/test-providers/acme/.github/workflows/run-acceptance-tests.yml
@@ -38,6 +38,8 @@ jobs:
   prerequisites:
     if: github.event_name == 'repository_dispatch' ||
       github.event.pull_request.head.repo.full_name == github.repository
+    permissions:
+      pull-requests: write
     uses: ./.github/workflows/prerequisites.yml
     secrets: inherit
     with:
@@ -89,6 +91,8 @@ jobs:
     name: sentinel
     if: github.event_name == 'repository_dispatch' ||
       github.event.pull_request.head.repo.full_name == github.repository
+    permissions:
+      statuses: write
     needs:
     - test
     - build_provider

--- a/provider-ci/test-providers/aws/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/test-providers/aws/.github/workflows/run-acceptance-tests.yml
@@ -41,6 +41,8 @@ jobs:
   prerequisites:
     if: github.event_name == 'repository_dispatch' ||
       github.event.pull_request.head.repo.full_name == github.repository
+    permissions:
+      pull-requests: write
     uses: ./.github/workflows/prerequisites.yml
     secrets: inherit
     with:
@@ -86,6 +88,8 @@ jobs:
     name: sentinel
     if: github.event_name == 'repository_dispatch' ||
       github.event.pull_request.head.repo.full_name == github.repository
+    permissions:
+      statuses: write
     needs:
     - test
     - build_provider

--- a/provider-ci/test-providers/cloudflare/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/test-providers/cloudflare/.github/workflows/run-acceptance-tests.yml
@@ -40,6 +40,8 @@ jobs:
   prerequisites:
     if: github.event_name == 'repository_dispatch' ||
       github.event.pull_request.head.repo.full_name == github.repository
+    permissions:
+      pull-requests: write
     uses: ./.github/workflows/prerequisites.yml
     secrets: inherit
     with:
@@ -91,6 +93,8 @@ jobs:
     name: sentinel
     if: github.event_name == 'repository_dispatch' ||
       github.event.pull_request.head.repo.full_name == github.repository
+    permissions:
+      statuses: write
     needs:
     - test
     - build_provider

--- a/provider-ci/test-providers/docker/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/test-providers/docker/.github/workflows/run-acceptance-tests.yml
@@ -53,6 +53,8 @@ jobs:
   prerequisites:
     if: github.event_name == 'repository_dispatch' ||
       github.event.pull_request.head.repo.full_name == github.repository
+    permissions:
+      pull-requests: write
     uses: ./.github/workflows/prerequisites.yml
     secrets: inherit
     with:
@@ -104,6 +106,8 @@ jobs:
     name: sentinel
     if: github.event_name == 'repository_dispatch' ||
       github.event.pull_request.head.repo.full_name == github.repository
+    permissions:
+      statuses: write
     needs:
     - test
     - build_provider


### PR DESCRIPTION
Set permissions to allow automated comments and write commit status to the PR.

Manually tested on `pulumiverse/pulumi-scaleway`:

* commenting on the PR
  * [commit](https://github.com/pulumiverse/pulumi-scaleway/commit/9bd922133c17190889080a41cad7ca52305c3b2c)
  * workflow [before](https://github.com/pulumiverse/pulumi-scaleway/actions/runs/11554373185) / [after](https://github.com/pulumiverse/pulumi-scaleway/actions/runs/11554533807)
* writing back the sentinel commit status
  * [commit](https://github.com/pulumiverse/pulumi-scaleway/commit/f4c7cf66bea2f53a61cd0b50323b0ea85c1ea968)
  * workflow [before](https://github.com/pulumiverse/pulumi-scaleway/actions/runs/11554533807) / [after](https://github.com/pulumiverse/pulumi-scaleway/actions/runs/11554834824)
