### PR TITLE
Fix security warnings from zizmor

### DIFF
--- a/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/build_provider.yml
+++ b/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/build_provider.yml
@@ -40,10 +40,11 @@ jobs:
       #{{- end }}#
       - name: Checkout Repo
         uses: #{{ .Config.actionVersions.checkout }}#
-        #{{- if .Config.checkoutSubmodules }}#
         with:
+          #{{- if .Config.checkoutSubmodules }}#
           submodules: #{{ .Config.checkoutSubmodules }}#
-        #{{- end }}#
+          #{{- end }}#
+          persist-credentials: false
       - name: Setup tools
         uses: ./.github/actions/setup-tools
         with:

--- a/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/build_sdk.yml
+++ b/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/build_sdk.yml
@@ -32,10 +32,11 @@ jobs:
       #{{- end }}#
       - name: Checkout Repo
         uses: #{{ .Config.actionVersions.checkout }}#
-#{{- if .Config.checkoutSubmodules }}#
         with:
+          #{{- if .Config.checkoutSubmodules }}#
           submodules: #{{ .Config.checkoutSubmodules }}#
-#{{- end }}#
+          #{{- end }}#
+          persist-credentials: false
       - name: Cache examples generation
         uses: actions/cache@v4
         with:

--- a/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/main.yml
+++ b/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/main.yml
@@ -41,10 +41,11 @@ jobs:
         swap-storage: false
     - name: Checkout Repo
       uses: #{{ .Config.actionVersions.checkout }}#
-#{{- if .Config.checkoutSubmodules }}#
       with:
+        #{{- if .Config.checkoutSubmodules }}#
         submodules: #{{ .Config.checkoutSubmodules }}#
-#{{- end }}#
+        #{{- end }}#
+        persist-credentials: false
     - name: Configure AWS Credentials
       uses: #{{ .Config.actionVersions.configureAwsCredentials }}#
       with:
@@ -140,10 +141,11 @@ jobs:
 #{{- end }}#
     - name: Checkout Repo
       uses: #{{ .Config.actionVersions.checkout }}#
-#{{- if .Config.checkoutSubmodules }}#
       with:
+        #{{- if .Config.checkoutSubmodules }}#
         submodules: #{{ .Config.checkoutSubmodules }}#
-#{{- end }}#
+        #{{- end }}#
+        persist-credentials: false
     - name: Setup tools
       uses: ./.github/actions/setup-tools
       with:

--- a/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/nightly-test.yml
+++ b/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/nightly-test.yml
@@ -50,10 +50,11 @@ jobs:
 #{{- end }}#
     - name: Checkout Repo
       uses: #{{ .Config.actionVersions.checkout }}#
-#{{- if .Config.checkoutSubmodules }}#
       with:
+        #{{- if .Config.checkoutSubmodules }}#
         submodules: #{{ .Config.checkoutSubmodules }}#
-#{{- end }}#
+        #{{- end }}#
+        persist-credentials: false
     - name: Setup tools
       uses: ./.github/actions/setup-tools
       with:

--- a/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/prerelease.yml
+++ b/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/prerelease.yml
@@ -80,10 +80,11 @@ jobs:
 #{{- end }}#
     - name: Checkout Repo
       uses: #{{ .Config.actionVersions.checkout }}#
-#{{- if .Config.checkoutSubmodules }}#
       with:
+        #{{- if .Config.checkoutSubmodules }}#
         submodules: #{{ .Config.checkoutSubmodules }}#
-#{{- end }}#
+        #{{- end }}#
+        persist-credentials: false
     - name: Setup tools
       uses: ./.github/actions/setup-tools
       with:

--- a/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/prerequisites.yml
+++ b/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/prerequisites.yml
@@ -78,7 +78,7 @@ jobs:
         EOF=$(dd if=/dev/urandom bs=15 count=1 status=none | base64)
         {
           echo "SCHEMA_CHANGES<<$EOF";
-          schema-tools compare -r github://api.github.com/#{{ .Config.organization }}# -p #{{ .Config.provider }}# -o ${{ inputs.default_branch }} -n --local-path=provider/cmd/pulumi-resource-#{{ .Config.provider }}#/schema.json;
+          schema-tools compare -r github://api.github.com/#{{ .Config.organization }}# -p #{{ .Config.provider }}# -o "${{ inputs.default_branch }}" -n --local-path=provider/cmd/pulumi-resource-#{{ .Config.provider }}#/schema.json;
           echo "$EOF";
         } >> "$GITHUB_ENV"
     - if: inputs.is_pr && inputs.is_automated == false

--- a/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/prerequisites.yml
+++ b/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/prerequisites.yml
@@ -38,10 +38,11 @@ jobs:
 #{{- end }}#
     - name: Checkout Repo
       uses: #{{ .Config.actionVersions.checkout }}#
-#{{- if .Config.checkoutSubmodules }}#
       with:
+        #{{- if .Config.checkoutSubmodules }}#
         submodules: #{{ .Config.checkoutSubmodules }}#
-#{{- end }}#
+        #{{- end }}#
+        persist-credentials: false
     - uses: pulumi/provider-version-action@v1
       id: provider-version
       with:

--- a/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/publish.yml
+++ b/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/publish.yml
@@ -64,7 +64,7 @@ jobs:
         merge-multiple: true
     - name: Calculate checksums
       working-directory: dist
-      run: shasum ./*.tar.gz > pulumi-#{{ .Config.provider }}#_${{ inputs.version }}_checksums.txt
+      run: shasum ./*.tar.gz > "pulumi-#{{ .Config.provider }}#_${{ inputs.version }}_checksums.txt"
     - name: Get Schema Change Summary
       id: schema-summary
       shell: bash

--- a/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/publish.yml
+++ b/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/publish.yml
@@ -32,10 +32,11 @@ jobs:
       run: echo "Can't skip Go SDK for stable releases. This is likely a bug in the calling workflow." && exit 1
     - name: Checkout Repo
       uses: #{{ .Config.actionVersions.checkout }}#
-#{{- if .Config.checkoutSubmodules }}#
       with:
+        #{{- if .Config.checkoutSubmodules }}#
         submodules: #{{ .Config.checkoutSubmodules }}#
-#{{- end }}#
+        #{{- end }}#
+        persist-credentials: false
     - name: Setup tools
       uses: ./.github/actions/setup-tools
       with:
@@ -102,10 +103,12 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: #{{ .Config.actionVersions.checkout }}#
-#{{- if .Config.checkoutSubmodules }}#
       with:
+        #{{- if .Config.checkoutSubmodules }}#
         submodules: #{{ .Config.checkoutSubmodules }}#
-#{{- end }}#
+        #{{- end }}#
+        # Persist credentials so we can push back to the repo
+        persist-credentials: true
     - name: Setup tools
       uses: ./.github/actions/setup-tools
       with:
@@ -168,7 +171,9 @@ jobs:
     runs-on: #{{ .Config.runner.default }}#
     steps:
     - name: Checkout Repo
-      uses: actions/checkout@v4
+      uses: #{{ .Config.actionVersions.checkout }}#
+      with:
+        persist-credentials: false
     - name: Clean up release labels
       uses: pulumi/action-release-by-pr-label@main
       with:

--- a/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/release.yml
+++ b/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/release.yml
@@ -89,10 +89,11 @@ jobs:
 #{{- end }}#
     - name: Checkout Repo
       uses: #{{ .Config.actionVersions.checkout }}#
-#{{- if .Config.checkoutSubmodules }}#
       with:
+        #{{- if .Config.checkoutSubmodules }}#
         submodules: #{{ .Config.checkoutSubmodules }}#
-#{{- end }}#
+        #{{- end }}#
+        persist-credentials: false
     - name: Setup tools
       uses: ./.github/actions/setup-tools
       with:

--- a/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/resync-build.yml
+++ b/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/resync-build.yml
@@ -11,15 +11,18 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: #{{ .Config.actionVersions.checkout }}#
-      #{{- if .Config.checkoutSubmodules }}#
       with:
+        #{{- if .Config.checkoutSubmodules }}#
         submodules: #{{ .Config.checkoutSubmodules }}#
-      #{{- end }}#
+        #{{- end }}#
+        # Persist credentials so we can push a new branch.
+        persist-credentials: true
     - name: Checkout repo
       uses: #{{ .Config.actionVersions.checkout }}#
       with:
         path: ci-mgmt
         repository: pulumi/ci-mgmt
+        persist-credentials: false
     - id: run-url
       name: Create URL to the run output
       run:  echo "run-url=https://github.com/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID" >> "$GITHUB_OUTPUT"

--- a/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/run-acceptance-tests.yml
@@ -135,6 +135,7 @@ jobs:
         #{{- if .Config.checkoutSubmodules }}#
         submodules: #{{ .Config.checkoutSubmodules }}#
         #{{- end }}#
+        persist-credentials: false
     - name: Checkout p/examples
       if: matrix.testTarget == 'pulumiExamples'
       uses: #{{ .Config.actionVersions.checkout }}#

--- a/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/upgrade-bridge.yml
+++ b/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/upgrade-bridge.yml
@@ -68,10 +68,11 @@ jobs:
     #{{- end }}#
     - name: Checkout Repo
       uses: #{{ .Config.actionVersions.checkout }}#
-      #{{- if .Config.checkoutSubmodules }}#
       with:
+        #{{- if .Config.checkoutSubmodules }}#
         submodules: #{{ .Config.checkoutSubmodules }}#
-    #{{- end }}#
+        #{{- end }}#
+        persist-credentials: false
     - name: Setup tools
       uses: ./.github/actions/setup-tools
       with:

--- a/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/upgrade-provider.yml
+++ b/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/upgrade-provider.yml
@@ -34,10 +34,12 @@ jobs:
       #{{- end }}#
       - name: Checkout Repo
         uses: #{{ .Config.actionVersions.checkout }}#
-        #{{- if .Config.checkoutSubmodules }}#
         with:
+          #{{- if .Config.checkoutSubmodules }}#
           submodules: #{{ .Config.checkoutSubmodules }}#
-        #{{- end }}#
+          #{{- end }}#
+          # Persist credentials so upgrade-provider can push a new branch.
+          persist-credentials: true
       - name: Setup tools
         uses: ./.github/actions/setup-tools
         with:

--- a/provider-ci/internal/pkg/templates/provider/.github/workflows/license.yml
+++ b/provider-ci/internal/pkg/templates/provider/.github/workflows/license.yml
@@ -15,7 +15,9 @@ jobs:
     runs-on: #{{ .Config.runner.default }}#
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@v4
+        uses: #{{ .Config.actionVersions.checkout }}#
+        with:
+          persist-credentials: false
       - name: Setup tools
         uses: ./.github/actions/setup-tools
         with:

--- a/provider-ci/internal/pkg/templates/provider/.github/workflows/lint.yml
+++ b/provider-ci/internal/pkg/templates/provider/.github/workflows/lint.yml
@@ -16,10 +16,11 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: #{{ .Config.actionVersions.checkout }}#
-#{{- if .Config.checkoutSubmodules }}#
       with:
+        #{{- if .Config.checkoutSubmodules }}#
         submodules: #{{ .Config.checkoutSubmodules }}#
-#{{- end }}#
+        #{{- end }}#
+        persist-credentials: false
     - name: Install go
       uses: actions/setup-go@v5
       with:

--- a/provider-ci/internal/pkg/templates/provider/.github/workflows/pull-request.yml
+++ b/provider-ci/internal/pkg/templates/provider/.github/workflows/pull-request.yml
@@ -10,10 +10,11 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: #{{ .Config.actionVersions.checkout }}#
-#{{- if .Config.checkoutSubmodules }}#
       with:
+        #{{- if .Config.checkoutSubmodules }}#
         submodules: #{{ .Config.checkoutSubmodules }}#
-#{{- end }}#
+        #{{- end }}#
+        persist-credentials: false
     - name: Comment PR
       uses: #{{ .Config.actionVersions.prComment }}#
       with:

--- a/provider-ci/internal/pkg/templates/provider/.github/workflows/verify-release.yml
+++ b/provider-ci/internal/pkg/templates/provider/.github/workflows/verify-release.yml
@@ -64,7 +64,9 @@ jobs:
     runs-on: ${{ matrix.runner }}
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@v4
+        uses: #{{ .Config.actionVersions.checkout }}#
+        with:
+          persist-credentials: false
       - name: Setup tools
         uses: ./.github/actions/setup-tools
         with:

--- a/provider-ci/internal/pkg/templates/pulumi-provider/.github/workflows/command-dispatch.yml
+++ b/provider-ci/internal/pkg/templates/pulumi-provider/.github/workflows/command-dispatch.yml
@@ -9,10 +9,11 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: #{{ .Config.actionVersions.checkout }}#
-#{{- if .Config.checkoutSubmodules }}#
       with:
+        #{{- if .Config.checkoutSubmodules }}#
         submodules: #{{ .Config.checkoutSubmodules }}#
-#{{- end }}#
+        #{{- end }}#
+        persist-credentials: false
     - uses: peter-evans/slash-command-dispatch@v4
       with:
         commands: |

--- a/provider-ci/internal/pkg/templates/pulumi-provider/.github/workflows/community-moderation.yml
+++ b/provider-ci/internal/pkg/templates/pulumi-provider/.github/workflows/community-moderation.yml
@@ -9,10 +9,11 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: #{{ .Config.actionVersions.checkout }}#
-#{{- if .Config.checkoutSubmodules }}#
       with:
+        #{{- if .Config.checkoutSubmodules }}#
         submodules: #{{ .Config.checkoutSubmodules }}#
-#{{- end }}#
+        #{{- end }}#
+        persist-credentials: false
     - id: schema_changed
       name: Check for diff in schema
       uses: #{{ .Config.actionVersions.pathsFilter }}#

--- a/provider-ci/internal/pkg/templates/pulumi-provider/.github/workflows/release_command.yml
+++ b/provider-ci/internal/pkg/templates/pulumi-provider/.github/workflows/release_command.yml
@@ -12,6 +12,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: #{{ .Config.actionVersions.checkout }}#
+      with:
+        persist-credentials: false
     - name: Should release PR
       uses: pulumi/action-release-by-pr-label@main
       with:

--- a/provider-ci/test-providers/acme/.github/workflows/build_provider.yml
+++ b/provider-ci/test-providers/acme/.github/workflows/build_provider.yml
@@ -31,6 +31,8 @@ jobs:
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - name: Setup tools
         uses: ./.github/actions/setup-tools
         with:

--- a/provider-ci/test-providers/acme/.github/workflows/build_sdk.yml
+++ b/provider-ci/test-providers/acme/.github/workflows/build_sdk.yml
@@ -41,6 +41,8 @@ jobs:
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - name: Cache examples generation
         uses: actions/cache@v4
         with:

--- a/provider-ci/test-providers/acme/.github/workflows/license.yml
+++ b/provider-ci/test-providers/acme/.github/workflows/license.yml
@@ -31,6 +31,8 @@ jobs:
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - name: Setup tools
         uses: ./.github/actions/setup-tools
         with:

--- a/provider-ci/test-providers/acme/.github/workflows/lint.yml
+++ b/provider-ci/test-providers/acme/.github/workflows/lint.yml
@@ -31,6 +31,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v4
+      with:
+        persist-credentials: false
     - name: Install go
       uses: actions/setup-go@v5
       with:

--- a/provider-ci/test-providers/acme/.github/workflows/main.yml
+++ b/provider-ci/test-providers/acme/.github/workflows/main.yml
@@ -56,6 +56,8 @@ jobs:
         swap-storage: false
     - name: Checkout Repo
       uses: actions/checkout@v4
+      with:
+        persist-credentials: false
     - name: Configure AWS Credentials
       uses: aws-actions/configure-aws-credentials@v4
       with:
@@ -136,6 +138,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v4
+      with:
+        persist-credentials: false
     - name: Setup tools
       uses: ./.github/actions/setup-tools
       with:

--- a/provider-ci/test-providers/acme/.github/workflows/prerelease.yml
+++ b/provider-ci/test-providers/acme/.github/workflows/prerelease.yml
@@ -80,6 +80,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v4
+      with:
+        persist-credentials: false
     - name: Setup tools
       uses: ./.github/actions/setup-tools
       with:

--- a/provider-ci/test-providers/acme/.github/workflows/prerequisites.yml
+++ b/provider-ci/test-providers/acme/.github/workflows/prerequisites.yml
@@ -44,6 +44,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v4
+      with:
+        persist-credentials: false
     - uses: pulumi/provider-version-action@v1
       id: provider-version
       with:

--- a/provider-ci/test-providers/acme/.github/workflows/prerequisites.yml
+++ b/provider-ci/test-providers/acme/.github/workflows/prerequisites.yml
@@ -78,7 +78,7 @@ jobs:
         EOF=$(dd if=/dev/urandom bs=15 count=1 status=none | base64)
         {
           echo "SCHEMA_CHANGES<<$EOF";
-          schema-tools compare -r github://api.github.com/pulumiverse -p acme -o ${{ inputs.default_branch }} -n --local-path=provider/cmd/pulumi-resource-acme/schema.json;
+          schema-tools compare -r github://api.github.com/pulumiverse -p acme -o "${{ inputs.default_branch }}" -n --local-path=provider/cmd/pulumi-resource-acme/schema.json;
           echo "$EOF";
         } >> "$GITHUB_ENV"
     - if: inputs.is_pr && inputs.is_automated == false

--- a/provider-ci/test-providers/acme/.github/workflows/publish.yml
+++ b/provider-ci/test-providers/acme/.github/workflows/publish.yml
@@ -64,7 +64,7 @@ jobs:
         merge-multiple: true
     - name: Calculate checksums
       working-directory: dist
-      run: shasum ./*.tar.gz > pulumi-acme_${{ inputs.version }}_checksums.txt
+      run: shasum ./*.tar.gz > "pulumi-acme_${{ inputs.version }}_checksums.txt"
     - name: Get Schema Change Summary
       id: schema-summary
       shell: bash

--- a/provider-ci/test-providers/acme/.github/workflows/publish.yml
+++ b/provider-ci/test-providers/acme/.github/workflows/publish.yml
@@ -47,6 +47,8 @@ jobs:
       run: echo "Can't skip Go SDK for stable releases. This is likely a bug in the calling workflow." && exit 1
     - name: Checkout Repo
       uses: actions/checkout@v4
+      with:
+        persist-credentials: false
     - name: Setup tools
       uses: ./.github/actions/setup-tools
       with:
@@ -97,6 +99,9 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v4
+      with:
+        # Persist credentials so we can push back to the repo
+        persist-credentials: true
     - name: Setup tools
       uses: ./.github/actions/setup-tools
       with:
@@ -135,6 +140,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v4
+      with:
+        persist-credentials: false
     - name: Clean up release labels
       uses: pulumi/action-release-by-pr-label@main
       with:

--- a/provider-ci/test-providers/acme/.github/workflows/pull-request.yml
+++ b/provider-ci/test-providers/acme/.github/workflows/pull-request.yml
@@ -25,6 +25,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v4
+      with:
+        persist-credentials: false
     - name: Comment PR
       uses: thollander/actions-comment-pull-request@v2
       with:

--- a/provider-ci/test-providers/acme/.github/workflows/release.yml
+++ b/provider-ci/test-providers/acme/.github/workflows/release.yml
@@ -86,6 +86,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v4
+      with:
+        persist-credentials: false
     - name: Setup tools
       uses: ./.github/actions/setup-tools
       with:

--- a/provider-ci/test-providers/acme/.github/workflows/resync-build.yml
+++ b/provider-ci/test-providers/acme/.github/workflows/resync-build.yml
@@ -26,11 +26,15 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v4
+      with:
+        # Persist credentials so we can push a new branch.
+        persist-credentials: true
     - name: Checkout repo
       uses: actions/checkout@v4
       with:
         path: ci-mgmt
         repository: pulumi/ci-mgmt
+        persist-credentials: false
     - id: run-url
       name: Create URL to the run output
       run:  echo "run-url=https://github.com/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID" >> "$GITHUB_OUTPUT"

--- a/provider-ci/test-providers/acme/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/test-providers/acme/.github/workflows/run-acceptance-tests.yml
@@ -130,6 +130,7 @@ jobs:
       uses: actions/checkout@v4
       with:
         ref: ${{ env.PR_COMMIT_SHA }}
+        persist-credentials: false
     - name: Checkout p/examples
       if: matrix.testTarget == 'pulumiExamples'
       uses: actions/checkout@v4

--- a/provider-ci/test-providers/acme/.github/workflows/upgrade-bridge.yml
+++ b/provider-ci/test-providers/acme/.github/workflows/upgrade-bridge.yml
@@ -59,6 +59,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v4
+      with:
+        persist-credentials: false
     - name: Setup tools
       uses: ./.github/actions/setup-tools
       with:

--- a/provider-ci/test-providers/acme/.github/workflows/upgrade-provider.yml
+++ b/provider-ci/test-providers/acme/.github/workflows/upgrade-provider.yml
@@ -25,6 +25,9 @@ jobs:
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v4
+        with:
+          # Persist credentials so upgrade-provider can push a new branch.
+          persist-credentials: true
       - name: Setup tools
         uses: ./.github/actions/setup-tools
         with:

--- a/provider-ci/test-providers/acme/.github/workflows/verify-release.yml
+++ b/provider-ci/test-providers/acme/.github/workflows/verify-release.yml
@@ -70,6 +70,8 @@ jobs:
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - name: Setup tools
         uses: ./.github/actions/setup-tools
         with:

--- a/provider-ci/test-providers/aws/.github/workflows/build_provider.yml
+++ b/provider-ci/test-providers/aws/.github/workflows/build_provider.yml
@@ -40,6 +40,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           submodules: true
+          persist-credentials: false
       - name: Setup tools
         uses: ./.github/actions/setup-tools
         with:

--- a/provider-ci/test-providers/aws/.github/workflows/build_sdk.yml
+++ b/provider-ci/test-providers/aws/.github/workflows/build_sdk.yml
@@ -54,6 +54,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           submodules: true
+          persist-credentials: false
       - name: Cache examples generation
         uses: actions/cache@v4
         with:

--- a/provider-ci/test-providers/aws/.github/workflows/command-dispatch.yml
+++ b/provider-ci/test-providers/aws/.github/workflows/command-dispatch.yml
@@ -29,6 +29,7 @@ jobs:
       uses: actions/checkout@v4
       with:
         submodules: true
+        persist-credentials: false
     - uses: peter-evans/slash-command-dispatch@v4
       with:
         commands: |

--- a/provider-ci/test-providers/aws/.github/workflows/community-moderation.yml
+++ b/provider-ci/test-providers/aws/.github/workflows/community-moderation.yml
@@ -11,6 +11,7 @@ jobs:
       uses: actions/checkout@v4
       with:
         submodules: true
+        persist-credentials: false
     - id: schema_changed
       name: Check for diff in schema
       uses: dorny/paths-filter@v2

--- a/provider-ci/test-providers/aws/.github/workflows/license.yml
+++ b/provider-ci/test-providers/aws/.github/workflows/license.yml
@@ -34,6 +34,8 @@ jobs:
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - name: Setup tools
         uses: ./.github/actions/setup-tools
         with:

--- a/provider-ci/test-providers/aws/.github/workflows/lint.yml
+++ b/provider-ci/test-providers/aws/.github/workflows/lint.yml
@@ -36,6 +36,7 @@ jobs:
       uses: actions/checkout@v4
       with:
         submodules: true
+        persist-credentials: false
     - name: Install go
       uses: actions/setup-go@v5
       with:

--- a/provider-ci/test-providers/aws/.github/workflows/master.yml
+++ b/provider-ci/test-providers/aws/.github/workflows/master.yml
@@ -61,6 +61,7 @@ jobs:
       uses: actions/checkout@v4
       with:
         submodules: true
+        persist-credentials: false
     - name: Configure AWS Credentials
       uses: aws-actions/configure-aws-credentials@v4
       with:
@@ -150,6 +151,7 @@ jobs:
       uses: actions/checkout@v4
       with:
         submodules: true
+        persist-credentials: false
     - name: Setup tools
       uses: ./.github/actions/setup-tools
       with:

--- a/provider-ci/test-providers/aws/.github/workflows/nightly-test.yml
+++ b/provider-ci/test-providers/aws/.github/workflows/nightly-test.yml
@@ -67,6 +67,7 @@ jobs:
       uses: actions/checkout@v4
       with:
         submodules: true
+        persist-credentials: false
     - name: Setup tools
       uses: ./.github/actions/setup-tools
       with:

--- a/provider-ci/test-providers/aws/.github/workflows/prerelease.yml
+++ b/provider-ci/test-providers/aws/.github/workflows/prerelease.yml
@@ -92,6 +92,7 @@ jobs:
       uses: actions/checkout@v4
       with:
         submodules: true
+        persist-credentials: false
     - name: Setup tools
       uses: ./.github/actions/setup-tools
       with:

--- a/provider-ci/test-providers/aws/.github/workflows/prerequisites.yml
+++ b/provider-ci/test-providers/aws/.github/workflows/prerequisites.yml
@@ -56,6 +56,7 @@ jobs:
       uses: actions/checkout@v4
       with:
         submodules: true
+        persist-credentials: false
     - uses: pulumi/provider-version-action@v1
       id: provider-version
       with:

--- a/provider-ci/test-providers/aws/.github/workflows/prerequisites.yml
+++ b/provider-ci/test-providers/aws/.github/workflows/prerequisites.yml
@@ -89,7 +89,7 @@ jobs:
         EOF=$(dd if=/dev/urandom bs=15 count=1 status=none | base64)
         {
           echo "SCHEMA_CHANGES<<$EOF";
-          schema-tools compare -r github://api.github.com/pulumi -p aws -o ${{ inputs.default_branch }} -n --local-path=provider/cmd/pulumi-resource-aws/schema.json;
+          schema-tools compare -r github://api.github.com/pulumi -p aws -o "${{ inputs.default_branch }}" -n --local-path=provider/cmd/pulumi-resource-aws/schema.json;
           echo "$EOF";
         } >> "$GITHUB_ENV"
     - if: inputs.is_pr && inputs.is_automated == false

--- a/provider-ci/test-providers/aws/.github/workflows/publish.yml
+++ b/provider-ci/test-providers/aws/.github/workflows/publish.yml
@@ -78,7 +78,7 @@ jobs:
         merge-multiple: true
     - name: Calculate checksums
       working-directory: dist
-      run: shasum ./*.tar.gz > pulumi-aws_${{ inputs.version }}_checksums.txt
+      run: shasum ./*.tar.gz > "pulumi-aws_${{ inputs.version }}_checksums.txt"
     - name: Get Schema Change Summary
       id: schema-summary
       shell: bash

--- a/provider-ci/test-providers/aws/.github/workflows/publish.yml
+++ b/provider-ci/test-providers/aws/.github/workflows/publish.yml
@@ -52,6 +52,7 @@ jobs:
       uses: actions/checkout@v4
       with:
         submodules: true
+        persist-credentials: false
     - name: Setup tools
       uses: ./.github/actions/setup-tools
       with:
@@ -116,6 +117,8 @@ jobs:
       uses: actions/checkout@v4
       with:
         submodules: true
+        # Persist credentials so we can push back to the repo
+        persist-credentials: true
     - name: Setup tools
       uses: ./.github/actions/setup-tools
       with:
@@ -173,6 +176,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v4
+      with:
+        persist-credentials: false
     - name: Clean up release labels
       uses: pulumi/action-release-by-pr-label@main
       with:

--- a/provider-ci/test-providers/aws/.github/workflows/pull-request.yml
+++ b/provider-ci/test-providers/aws/.github/workflows/pull-request.yml
@@ -30,6 +30,7 @@ jobs:
       uses: actions/checkout@v4
       with:
         submodules: true
+        persist-credentials: false
     - name: Comment PR
       uses: thollander/actions-comment-pull-request@v2
       with:

--- a/provider-ci/test-providers/aws/.github/workflows/release.yml
+++ b/provider-ci/test-providers/aws/.github/workflows/release.yml
@@ -98,6 +98,7 @@ jobs:
       uses: actions/checkout@v4
       with:
         submodules: true
+        persist-credentials: false
     - name: Setup tools
       uses: ./.github/actions/setup-tools
       with:

--- a/provider-ci/test-providers/aws/.github/workflows/release_command.yml
+++ b/provider-ci/test-providers/aws/.github/workflows/release_command.yml
@@ -12,6 +12,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v4
+      with:
+        persist-credentials: false
     - name: Should release PR
       uses: pulumi/action-release-by-pr-label@main
       with:

--- a/provider-ci/test-providers/aws/.github/workflows/resync-build.yml
+++ b/provider-ci/test-providers/aws/.github/workflows/resync-build.yml
@@ -31,11 +31,14 @@ jobs:
       uses: actions/checkout@v4
       with:
         submodules: true
+        # Persist credentials so we can push a new branch.
+        persist-credentials: true
     - name: Checkout repo
       uses: actions/checkout@v4
       with:
         path: ci-mgmt
         repository: pulumi/ci-mgmt
+        persist-credentials: false
     - id: run-url
       name: Create URL to the run output
       run:  echo "run-url=https://github.com/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID" >> "$GITHUB_OUTPUT"

--- a/provider-ci/test-providers/aws/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/test-providers/aws/.github/workflows/run-acceptance-tests.yml
@@ -138,6 +138,7 @@ jobs:
       with:
         ref: ${{ env.PR_COMMIT_SHA }}
         submodules: true
+        persist-credentials: false
     - name: Checkout p/examples
       if: matrix.testTarget == 'pulumiExamples'
       uses: actions/checkout@v4

--- a/provider-ci/test-providers/aws/.github/workflows/upgrade-bridge.yml
+++ b/provider-ci/test-providers/aws/.github/workflows/upgrade-bridge.yml
@@ -68,6 +68,7 @@ jobs:
       uses: actions/checkout@v4
       with:
         submodules: true
+        persist-credentials: false
     - name: Setup tools
       uses: ./.github/actions/setup-tools
       with:

--- a/provider-ci/test-providers/aws/.github/workflows/upgrade-provider.yml
+++ b/provider-ci/test-providers/aws/.github/workflows/upgrade-provider.yml
@@ -34,6 +34,8 @@ jobs:
         uses: actions/checkout@v4
         with:
           submodules: true
+          # Persist credentials so upgrade-provider can push a new branch.
+          persist-credentials: true
       - name: Setup tools
         uses: ./.github/actions/setup-tools
         with:

--- a/provider-ci/test-providers/aws/.github/workflows/verify-release.yml
+++ b/provider-ci/test-providers/aws/.github/workflows/verify-release.yml
@@ -73,6 +73,8 @@ jobs:
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - name: Setup tools
         uses: ./.github/actions/setup-tools
         with:

--- a/provider-ci/test-providers/cloudflare/.github/workflows/build_provider.yml
+++ b/provider-ci/test-providers/cloudflare/.github/workflows/build_provider.yml
@@ -31,6 +31,8 @@ jobs:
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - name: Setup tools
         uses: ./.github/actions/setup-tools
         with:

--- a/provider-ci/test-providers/cloudflare/.github/workflows/build_sdk.yml
+++ b/provider-ci/test-providers/cloudflare/.github/workflows/build_sdk.yml
@@ -44,6 +44,8 @@ jobs:
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - name: Cache examples generation
         uses: actions/cache@v4
         with:

--- a/provider-ci/test-providers/cloudflare/.github/workflows/command-dispatch.yml
+++ b/provider-ci/test-providers/cloudflare/.github/workflows/command-dispatch.yml
@@ -26,6 +26,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v4
+      with:
+        persist-credentials: false
     - uses: peter-evans/slash-command-dispatch@v4
       with:
         commands: |

--- a/provider-ci/test-providers/cloudflare/.github/workflows/community-moderation.yml
+++ b/provider-ci/test-providers/cloudflare/.github/workflows/community-moderation.yml
@@ -9,6 +9,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v4
+      with:
+        persist-credentials: false
     - id: schema_changed
       name: Check for diff in schema
       uses: dorny/paths-filter@v2

--- a/provider-ci/test-providers/cloudflare/.github/workflows/license.yml
+++ b/provider-ci/test-providers/cloudflare/.github/workflows/license.yml
@@ -33,6 +33,8 @@ jobs:
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - name: Setup tools
         uses: ./.github/actions/setup-tools
         with:

--- a/provider-ci/test-providers/cloudflare/.github/workflows/lint.yml
+++ b/provider-ci/test-providers/cloudflare/.github/workflows/lint.yml
@@ -33,6 +33,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v4
+      with:
+        persist-credentials: false
     - name: Install go
       uses: actions/setup-go@v5
       with:

--- a/provider-ci/test-providers/cloudflare/.github/workflows/master.yml
+++ b/provider-ci/test-providers/cloudflare/.github/workflows/master.yml
@@ -58,6 +58,8 @@ jobs:
         swap-storage: false
     - name: Checkout Repo
       uses: actions/checkout@v4
+      with:
+        persist-credentials: false
     - name: Configure AWS Credentials
       uses: aws-actions/configure-aws-credentials@v4
       with:
@@ -138,6 +140,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v4
+      with:
+        persist-credentials: false
     - name: Setup tools
       uses: ./.github/actions/setup-tools
       with:

--- a/provider-ci/test-providers/cloudflare/.github/workflows/prerelease.yml
+++ b/provider-ci/test-providers/cloudflare/.github/workflows/prerelease.yml
@@ -82,6 +82,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v4
+      with:
+        persist-credentials: false
     - name: Setup tools
       uses: ./.github/actions/setup-tools
       with:

--- a/provider-ci/test-providers/cloudflare/.github/workflows/prerequisites.yml
+++ b/provider-ci/test-providers/cloudflare/.github/workflows/prerequisites.yml
@@ -80,7 +80,7 @@ jobs:
         EOF=$(dd if=/dev/urandom bs=15 count=1 status=none | base64)
         {
           echo "SCHEMA_CHANGES<<$EOF";
-          schema-tools compare -r github://api.github.com/pulumi -p cloudflare -o ${{ inputs.default_branch }} -n --local-path=provider/cmd/pulumi-resource-cloudflare/schema.json;
+          schema-tools compare -r github://api.github.com/pulumi -p cloudflare -o "${{ inputs.default_branch }}" -n --local-path=provider/cmd/pulumi-resource-cloudflare/schema.json;
           echo "$EOF";
         } >> "$GITHUB_ENV"
     - if: inputs.is_pr && inputs.is_automated == false

--- a/provider-ci/test-providers/cloudflare/.github/workflows/prerequisites.yml
+++ b/provider-ci/test-providers/cloudflare/.github/workflows/prerequisites.yml
@@ -46,6 +46,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v4
+      with:
+        persist-credentials: false
     - uses: pulumi/provider-version-action@v1
       id: provider-version
       with:

--- a/provider-ci/test-providers/cloudflare/.github/workflows/publish.yml
+++ b/provider-ci/test-providers/cloudflare/.github/workflows/publish.yml
@@ -49,6 +49,8 @@ jobs:
       run: echo "Can't skip Go SDK for stable releases. This is likely a bug in the calling workflow." && exit 1
     - name: Checkout Repo
       uses: actions/checkout@v4
+      with:
+        persist-credentials: false
     - name: Setup tools
       uses: ./.github/actions/setup-tools
       with:
@@ -111,6 +113,9 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v4
+      with:
+        # Persist credentials so we can push back to the repo
+        persist-credentials: true
     - name: Setup tools
       uses: ./.github/actions/setup-tools
       with:
@@ -168,6 +173,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v4
+      with:
+        persist-credentials: false
     - name: Clean up release labels
       uses: pulumi/action-release-by-pr-label@main
       with:

--- a/provider-ci/test-providers/cloudflare/.github/workflows/publish.yml
+++ b/provider-ci/test-providers/cloudflare/.github/workflows/publish.yml
@@ -76,7 +76,7 @@ jobs:
         merge-multiple: true
     - name: Calculate checksums
       working-directory: dist
-      run: shasum ./*.tar.gz > pulumi-cloudflare_${{ inputs.version }}_checksums.txt
+      run: shasum ./*.tar.gz > "pulumi-cloudflare_${{ inputs.version }}_checksums.txt"
     - name: Get Schema Change Summary
       id: schema-summary
       shell: bash

--- a/provider-ci/test-providers/cloudflare/.github/workflows/pull-request.yml
+++ b/provider-ci/test-providers/cloudflare/.github/workflows/pull-request.yml
@@ -27,6 +27,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v4
+      with:
+        persist-credentials: false
     - name: Comment PR
       uses: thollander/actions-comment-pull-request@v2
       with:

--- a/provider-ci/test-providers/cloudflare/.github/workflows/release.yml
+++ b/provider-ci/test-providers/cloudflare/.github/workflows/release.yml
@@ -88,6 +88,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v4
+      with:
+        persist-credentials: false
     - name: Setup tools
       uses: ./.github/actions/setup-tools
       with:

--- a/provider-ci/test-providers/cloudflare/.github/workflows/release_command.yml
+++ b/provider-ci/test-providers/cloudflare/.github/workflows/release_command.yml
@@ -12,6 +12,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v4
+      with:
+        persist-credentials: false
     - name: Should release PR
       uses: pulumi/action-release-by-pr-label@main
       with:

--- a/provider-ci/test-providers/cloudflare/.github/workflows/resync-build.yml
+++ b/provider-ci/test-providers/cloudflare/.github/workflows/resync-build.yml
@@ -28,11 +28,15 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v4
+      with:
+        # Persist credentials so we can push a new branch.
+        persist-credentials: true
     - name: Checkout repo
       uses: actions/checkout@v4
       with:
         path: ci-mgmt
         repository: pulumi/ci-mgmt
+        persist-credentials: false
     - id: run-url
       name: Create URL to the run output
       run:  echo "run-url=https://github.com/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID" >> "$GITHUB_OUTPUT"

--- a/provider-ci/test-providers/cloudflare/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/test-providers/cloudflare/.github/workflows/run-acceptance-tests.yml
@@ -132,6 +132,7 @@ jobs:
       uses: actions/checkout@v4
       with:
         ref: ${{ env.PR_COMMIT_SHA }}
+        persist-credentials: false
     - name: Checkout p/examples
       if: matrix.testTarget == 'pulumiExamples'
       uses: actions/checkout@v4

--- a/provider-ci/test-providers/cloudflare/.github/workflows/upgrade-bridge.yml
+++ b/provider-ci/test-providers/cloudflare/.github/workflows/upgrade-bridge.yml
@@ -59,6 +59,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v4
+      with:
+        persist-credentials: false
     - name: Setup tools
       uses: ./.github/actions/setup-tools
       with:

--- a/provider-ci/test-providers/cloudflare/.github/workflows/upgrade-provider.yml
+++ b/provider-ci/test-providers/cloudflare/.github/workflows/upgrade-provider.yml
@@ -25,6 +25,9 @@ jobs:
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v4
+        with:
+          # Persist credentials so upgrade-provider can push a new branch.
+          persist-credentials: true
       - name: Setup tools
         uses: ./.github/actions/setup-tools
         with:

--- a/provider-ci/test-providers/cloudflare/.github/workflows/verify-release.yml
+++ b/provider-ci/test-providers/cloudflare/.github/workflows/verify-release.yml
@@ -72,6 +72,8 @@ jobs:
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - name: Setup tools
         uses: ./.github/actions/setup-tools
         with:

--- a/provider-ci/test-providers/docker/.github/workflows/build_provider.yml
+++ b/provider-ci/test-providers/docker/.github/workflows/build_provider.yml
@@ -31,6 +31,8 @@ jobs:
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - name: Setup tools
         uses: ./.github/actions/setup-tools
         with:

--- a/provider-ci/test-providers/docker/.github/workflows/build_sdk.yml
+++ b/provider-ci/test-providers/docker/.github/workflows/build_sdk.yml
@@ -57,6 +57,8 @@ jobs:
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - name: Cache examples generation
         uses: actions/cache@v4
         with:

--- a/provider-ci/test-providers/docker/.github/workflows/command-dispatch.yml
+++ b/provider-ci/test-providers/docker/.github/workflows/command-dispatch.yml
@@ -39,6 +39,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v4
+      with:
+        persist-credentials: false
     - uses: peter-evans/slash-command-dispatch@v4
       with:
         commands: |

--- a/provider-ci/test-providers/docker/.github/workflows/community-moderation.yml
+++ b/provider-ci/test-providers/docker/.github/workflows/community-moderation.yml
@@ -9,6 +9,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v4
+      with:
+        persist-credentials: false
     - id: schema_changed
       name: Check for diff in schema
       uses: dorny/paths-filter@v2

--- a/provider-ci/test-providers/docker/.github/workflows/license.yml
+++ b/provider-ci/test-providers/docker/.github/workflows/license.yml
@@ -46,6 +46,8 @@ jobs:
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - name: Setup tools
         uses: ./.github/actions/setup-tools
         with:

--- a/provider-ci/test-providers/docker/.github/workflows/lint.yml
+++ b/provider-ci/test-providers/docker/.github/workflows/lint.yml
@@ -46,6 +46,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v4
+      with:
+        persist-credentials: false
     - name: Install go
       uses: actions/setup-go@v5
       with:

--- a/provider-ci/test-providers/docker/.github/workflows/master.yml
+++ b/provider-ci/test-providers/docker/.github/workflows/master.yml
@@ -71,6 +71,8 @@ jobs:
         swap-storage: false
     - name: Checkout Repo
       uses: actions/checkout@v4
+      with:
+        persist-credentials: false
     - name: Configure AWS Credentials
       uses: aws-actions/configure-aws-credentials@v4
       with:
@@ -151,6 +153,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v4
+      with:
+        persist-credentials: false
     - name: Setup tools
       uses: ./.github/actions/setup-tools
       with:

--- a/provider-ci/test-providers/docker/.github/workflows/prerelease.yml
+++ b/provider-ci/test-providers/docker/.github/workflows/prerelease.yml
@@ -95,6 +95,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v4
+      with:
+        persist-credentials: false
     - name: Setup tools
       uses: ./.github/actions/setup-tools
       with:

--- a/provider-ci/test-providers/docker/.github/workflows/prerequisites.yml
+++ b/provider-ci/test-providers/docker/.github/workflows/prerequisites.yml
@@ -93,7 +93,7 @@ jobs:
         EOF=$(dd if=/dev/urandom bs=15 count=1 status=none | base64)
         {
           echo "SCHEMA_CHANGES<<$EOF";
-          schema-tools compare -r github://api.github.com/pulumi -p docker -o ${{ inputs.default_branch }} -n --local-path=provider/cmd/pulumi-resource-docker/schema.json;
+          schema-tools compare -r github://api.github.com/pulumi -p docker -o "${{ inputs.default_branch }}" -n --local-path=provider/cmd/pulumi-resource-docker/schema.json;
           echo "$EOF";
         } >> "$GITHUB_ENV"
     - if: inputs.is_pr && inputs.is_automated == false

--- a/provider-ci/test-providers/docker/.github/workflows/prerequisites.yml
+++ b/provider-ci/test-providers/docker/.github/workflows/prerequisites.yml
@@ -59,6 +59,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v4
+      with:
+        persist-credentials: false
     - uses: pulumi/provider-version-action@v1
       id: provider-version
       with:

--- a/provider-ci/test-providers/docker/.github/workflows/publish.yml
+++ b/provider-ci/test-providers/docker/.github/workflows/publish.yml
@@ -62,6 +62,8 @@ jobs:
       run: echo "Can't skip Go SDK for stable releases. This is likely a bug in the calling workflow." && exit 1
     - name: Checkout Repo
       uses: actions/checkout@v4
+      with:
+        persist-credentials: false
     - name: Setup tools
       uses: ./.github/actions/setup-tools
       with:
@@ -124,6 +126,9 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v4
+      with:
+        # Persist credentials so we can push back to the repo
+        persist-credentials: true
     - name: Setup tools
       uses: ./.github/actions/setup-tools
       with:
@@ -181,6 +186,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v4
+      with:
+        persist-credentials: false
     - name: Clean up release labels
       uses: pulumi/action-release-by-pr-label@main
       with:

--- a/provider-ci/test-providers/docker/.github/workflows/publish.yml
+++ b/provider-ci/test-providers/docker/.github/workflows/publish.yml
@@ -89,7 +89,7 @@ jobs:
         merge-multiple: true
     - name: Calculate checksums
       working-directory: dist
-      run: shasum ./*.tar.gz > pulumi-docker_${{ inputs.version }}_checksums.txt
+      run: shasum ./*.tar.gz > "pulumi-docker_${{ inputs.version }}_checksums.txt"
     - name: Get Schema Change Summary
       id: schema-summary
       shell: bash

--- a/provider-ci/test-providers/docker/.github/workflows/pull-request.yml
+++ b/provider-ci/test-providers/docker/.github/workflows/pull-request.yml
@@ -40,6 +40,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v4
+      with:
+        persist-credentials: false
     - name: Comment PR
       uses: thollander/actions-comment-pull-request@v2
       with:

--- a/provider-ci/test-providers/docker/.github/workflows/release.yml
+++ b/provider-ci/test-providers/docker/.github/workflows/release.yml
@@ -101,6 +101,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v4
+      with:
+        persist-credentials: false
     - name: Setup tools
       uses: ./.github/actions/setup-tools
       with:

--- a/provider-ci/test-providers/docker/.github/workflows/release_command.yml
+++ b/provider-ci/test-providers/docker/.github/workflows/release_command.yml
@@ -12,6 +12,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v4
+      with:
+        persist-credentials: false
     - name: Should release PR
       uses: pulumi/action-release-by-pr-label@main
       with:

--- a/provider-ci/test-providers/docker/.github/workflows/resync-build.yml
+++ b/provider-ci/test-providers/docker/.github/workflows/resync-build.yml
@@ -41,11 +41,15 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v4
+      with:
+        # Persist credentials so we can push a new branch.
+        persist-credentials: true
     - name: Checkout repo
       uses: actions/checkout@v4
       with:
         path: ci-mgmt
         repository: pulumi/ci-mgmt
+        persist-credentials: false
     - id: run-url
       name: Create URL to the run output
       run:  echo "run-url=https://github.com/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID" >> "$GITHUB_OUTPUT"

--- a/provider-ci/test-providers/docker/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/test-providers/docker/.github/workflows/run-acceptance-tests.yml
@@ -145,6 +145,7 @@ jobs:
       uses: actions/checkout@v4
       with:
         ref: ${{ env.PR_COMMIT_SHA }}
+        persist-credentials: false
     - name: Checkout p/examples
       if: matrix.testTarget == 'pulumiExamples'
       uses: actions/checkout@v4

--- a/provider-ci/test-providers/docker/.github/workflows/upgrade-bridge.yml
+++ b/provider-ci/test-providers/docker/.github/workflows/upgrade-bridge.yml
@@ -59,6 +59,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v4
+      with:
+        persist-credentials: false
     - name: Setup tools
       uses: ./.github/actions/setup-tools
       with:

--- a/provider-ci/test-providers/docker/.github/workflows/upgrade-provider.yml
+++ b/provider-ci/test-providers/docker/.github/workflows/upgrade-provider.yml
@@ -25,6 +25,9 @@ jobs:
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v4
+        with:
+          # Persist credentials so upgrade-provider can push a new branch.
+          persist-credentials: true
       - name: Setup tools
         uses: ./.github/actions/setup-tools
         with:

--- a/provider-ci/test-providers/docker/.github/workflows/verify-release.yml
+++ b/provider-ci/test-providers/docker/.github/workflows/verify-release.yml
@@ -85,6 +85,8 @@ jobs:
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - name: Setup tools
         uses: ./.github/actions/setup-tools
         with:


### PR DESCRIPTION
Experimenting with the new [zizmor tool](https://github.com/woodruffw/zizmor). There's still a number of false-positives so probably not yet worth integrating into our CI run, but have audited the current feedback.

Related to:
- https://github.com/pulumi/ci-mgmt/issues/1114

## Only persist git credentials where we need to use them

- Don't leave these around when we don't need to.
- Explicitly set to true where we need them, with a comment highlighting why we're keeping them.
- Fix a few places we weren't using the centrally managed checkout version.
- Tweak the conditionals for submodules so the `with:` is always there now.

## Use of fundamentally insecure workflow trigger - `pull_request_target`

These appear ok because we're just using this to comment on community PRs. These don't run builds 

```
error[dangerous-triggers]: use of fundamentally insecure workflow trigger
  --> .github/workflows/community-moderation.yml:38:1
   |
38 | / on:
39 | |   pull_request_target:
...  |
42 | |     types:
43 | |     - opened
   | |_____________^ pull_request_target is almost always used insecurely
   |
```

```
error[dangerous-triggers]: use of fundamentally insecure workflow trigger
  --> .github/workflows/pull-request.yml:44:1
   |
44 | / on:
45 | |   pull_request_target: {}
   | |__________________________^ pull_request_target is almost always used insecurely
   |
```


## Code injection via template expansion

```
.github/workflows/master.yml
  env.COVERAGE_OUTPUT_DIR may expand into attacker-controllable code
```

This is not inputtable by a third party user. 

```
.github/workflows/prerequisites.yml
  inputs.default_branch may expand into attacker-controllable code
```

This is a workflow call (reusable workflow) and the input is always set as `github.event.repository.default_branch`.

```
.github/workflows/upgrade-provider.yml
  github.event.inputs.version may expand into attacker-controllable code
  steps.upstream_version.outputs.latest_version may expand into attacker-controllable code
  github.repository may expand into attacker-controllable code
  steps.target_version.outputs.version may expand into attacker-controllable code
```

This can only be triggered by internal users.