### PR TITLE
Add Palo Alto Cloudngfwaws provider to providers.json

### DIFF
--- a/provider-ci/providers.json
+++ b/provider-ci/providers.json
@@ -13,6 +13,7 @@
     "cloudamqp",
     "cloudflare",
     "cloudinit",
+    "cloudngfwaws",
     "confluentcloud",
     "consul",
     "databricks",


### PR DESCRIPTION
A new bridged provider for the fleet. 