### PR TITLE
Update actions/github-script to v7

### DIFF
--- a/.github/workflows/update-workflows.yml
+++ b/.github/workflows/update-workflows.yml
@@ -99,7 +99,7 @@ jobs:
           npm ci
           npx ts-node index.ts "$DIR"
       - name: Close obsolete PRs started by this workflow
-        uses: actions/github-script@v6
+        uses: actions/github-script@v7
         if: ${{ !inputs.skip_closing_prs }}
         with:
           github-token: ${{ secrets.PULUMI_BOT_TOKEN }}

--- a/native-provider-ci/src/action-versions.ts
+++ b/native-provider-ci/src/action-versions.ts
@@ -38,7 +38,7 @@ export const pullRequest = "repo-sync/pull-request@v2.6.2";
 export const prComment = "thollander/actions-comment-pull-request@v2";
 export const slashCommand = "peter-evans/slash-command-dispatch@v2";
 export const uploadArtifact = "actions/upload-artifact@v4";
-export const githubScript = "actions/github-script@v6";
+export const githubScript = "actions/github-script@v7";
 export const upgradeProviderAction =
   "pulumi/pulumi-upgrade-provider-action@v0.0.5";
 export const slackNotification = "rtCamp/action-slack-notify@v2";


### PR DESCRIPTION
Moves Node.js dependency to v20

Fixes:

    .github/workflows/update-workflows.yml:102:15: the runner of "actions/github-script@v6" action is too old to run on GitHub Actions. update the action's version to fix this issue [action]