### PR TITLE
Allow specifying upgrade-provider version

### DIFF
--- a/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/upgrade-provider.yml
+++ b/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/upgrade-provider.yml
@@ -15,6 +15,8 @@ on:
       upgradeProviderVersion:
         description: |
           Version of upgrade-provider to use. This must be a valid git reference in the pulumi/upgrade-provider repo. Defaults to "main"
+
+          See https://go.dev/ref/mod#versions for valid versions. E.g. "v0.1.0", "main", "da25dec".
         default: main
         type: string
   schedule:

--- a/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/upgrade-provider.yml
+++ b/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/upgrade-provider.yml
@@ -12,6 +12,11 @@ on:
           If no version is specified, it will be inferred from the upstream provider's release tags.
         required: false
         type: string
+      upgradeProviderVersion:
+        description: |
+          Version of upgrade-provider to use. This must be a valid git reference in the pulumi/upgrade-provider repo. Defaults to "main"
+        default: main
+        type: string
   schedule:
     # 3 AM UTC ~ 8 PM PDT / 7 PM PST daily. Time chosen to run during off hours.
     - cron: 0 3 * * *
@@ -46,7 +51,7 @@ jobs:
         with:
           tools: pulumictl, pulumicli, #{{ range $index, $element := .Config.languages }}##{{if $index}}#, #{{end}}##{{ $element }}##{{end}}#
       - name: Install upgrade-provider
-        run: go install github.com/pulumi/upgrade-provider@main
+        run: go install github.com/pulumi/upgrade-provider@${{ inputs.upgradeProviderVersion || 'main' }}
         shell: bash
       - name: "Set up git identity"
         run: |
@@ -81,4 +86,5 @@ jobs:
         run: |
           issue_number=$(gh issue list --search "pulumiupgradeproviderissue" --repo "${{ github.repository }}" --json=number --jq=".[0].number")
           gh issue comment "${issue_number}" --repo "${{ github.repository }}" --body "Failed to create automatic PR: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}/"
+
 #{{ end -}}#

--- a/provider-ci/test-providers/acme/.github/workflows/upgrade-provider.yml
+++ b/provider-ci/test-providers/acme/.github/workflows/upgrade-provider.yml
@@ -14,6 +14,8 @@ on:
       upgradeProviderVersion:
         description: |
           Version of upgrade-provider to use. This must be a valid git reference in the pulumi/upgrade-provider repo. Defaults to "main"
+
+          See https://go.dev/ref/mod#versions for valid versions. E.g. "v0.1.0", "main", "da25dec".
         default: main
         type: string
   schedule:

--- a/provider-ci/test-providers/acme/.github/workflows/upgrade-provider.yml
+++ b/provider-ci/test-providers/acme/.github/workflows/upgrade-provider.yml
@@ -11,6 +11,11 @@ on:
           If no version is specified, it will be inferred from the upstream provider's release tags.
         required: false
         type: string
+      upgradeProviderVersion:
+        description: |
+          Version of upgrade-provider to use. This must be a valid git reference in the pulumi/upgrade-provider repo. Defaults to "main"
+        default: main
+        type: string
   schedule:
     # 3 AM UTC ~ 8 PM PDT / 7 PM PST daily. Time chosen to run during off hours.
     - cron: 0 3 * * *
@@ -33,7 +38,7 @@ jobs:
         with:
           tools: pulumictl, pulumicli, dotnet, go, nodejs, python
       - name: Install upgrade-provider
-        run: go install github.com/pulumi/upgrade-provider@main
+        run: go install github.com/pulumi/upgrade-provider@${{ inputs.upgradeProviderVersion || 'main' }}
         shell: bash
       - name: "Set up git identity"
         run: |
@@ -68,3 +73,4 @@ jobs:
         run: |
           issue_number=$(gh issue list --search "pulumiupgradeproviderissue" --repo "${{ github.repository }}" --json=number --jq=".[0].number")
           gh issue comment "${issue_number}" --repo "${{ github.repository }}" --body "Failed to create automatic PR: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}/"
+

--- a/provider-ci/test-providers/aws/.github/workflows/upgrade-provider.yml
+++ b/provider-ci/test-providers/aws/.github/workflows/upgrade-provider.yml
@@ -14,6 +14,8 @@ on:
       upgradeProviderVersion:
         description: |
           Version of upgrade-provider to use. This must be a valid git reference in the pulumi/upgrade-provider repo. Defaults to "main"
+
+          See https://go.dev/ref/mod#versions for valid versions. E.g. "v0.1.0", "main", "da25dec".
         default: main
         type: string
   schedule:

--- a/provider-ci/test-providers/aws/.github/workflows/upgrade-provider.yml
+++ b/provider-ci/test-providers/aws/.github/workflows/upgrade-provider.yml
@@ -11,6 +11,11 @@ on:
           If no version is specified, it will be inferred from the upstream provider's release tags.
         required: false
         type: string
+      upgradeProviderVersion:
+        description: |
+          Version of upgrade-provider to use. This must be a valid git reference in the pulumi/upgrade-provider repo. Defaults to "main"
+        default: main
+        type: string
   schedule:
     # 3 AM UTC ~ 8 PM PDT / 7 PM PST daily. Time chosen to run during off hours.
     - cron: 0 3 * * *
@@ -41,7 +46,7 @@ jobs:
         with:
           tools: pulumictl, pulumicli, nodejs, python, dotnet, go, java
       - name: Install upgrade-provider
-        run: go install github.com/pulumi/upgrade-provider@main
+        run: go install github.com/pulumi/upgrade-provider@${{ inputs.upgradeProviderVersion || 'main' }}
         shell: bash
       - name: "Set up git identity"
         run: |
@@ -76,3 +81,4 @@ jobs:
         run: |
           issue_number=$(gh issue list --search "pulumiupgradeproviderissue" --repo "${{ github.repository }}" --json=number --jq=".[0].number")
           gh issue comment "${issue_number}" --repo "${{ github.repository }}" --body "Failed to create automatic PR: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}/"
+

--- a/provider-ci/test-providers/docker/.github/workflows/upgrade-provider.yml
+++ b/provider-ci/test-providers/docker/.github/workflows/upgrade-provider.yml
@@ -14,6 +14,8 @@ on:
       upgradeProviderVersion:
         description: |
           Version of upgrade-provider to use. This must be a valid git reference in the pulumi/upgrade-provider repo. Defaults to "main"
+
+          See https://go.dev/ref/mod#versions for valid versions. E.g. "v0.1.0", "main", "da25dec".
         default: main
         type: string
   schedule:

--- a/provider-ci/test-providers/docker/.github/workflows/upgrade-provider.yml
+++ b/provider-ci/test-providers/docker/.github/workflows/upgrade-provider.yml
@@ -11,6 +11,11 @@ on:
           If no version is specified, it will be inferred from the upstream provider's release tags.
         required: false
         type: string
+      upgradeProviderVersion:
+        description: |
+          Version of upgrade-provider to use. This must be a valid git reference in the pulumi/upgrade-provider repo. Defaults to "main"
+        default: main
+        type: string
   schedule:
     # 3 AM UTC ~ 8 PM PDT / 7 PM PST daily. Time chosen to run during off hours.
     - cron: 0 3 * * *
@@ -33,7 +38,7 @@ jobs:
         with:
           tools: pulumictl, pulumicli, nodejs, python, dotnet, go, java
       - name: Install upgrade-provider
-        run: go install github.com/pulumi/upgrade-provider@main
+        run: go install github.com/pulumi/upgrade-provider@${{ inputs.upgradeProviderVersion || 'main' }}
         shell: bash
       - name: "Set up git identity"
         run: |
@@ -68,3 +73,4 @@ jobs:
         run: |
           issue_number=$(gh issue list --search "pulumiupgradeproviderissue" --repo "${{ github.repository }}" --json=number --jq=".[0].number")
           gh issue comment "${issue_number}" --repo "${{ github.repository }}" --body "Failed to create automatic PR: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}/"
+


### PR DESCRIPTION
Give us a little more control so we can test pre-release versions before rolling out to all providers.

This hasn't deployed to the xyz provider because the xyz provider currently excludes the upgrade-provider workflow. I've set up a manual test instead in the xyz provider:
- https://github.com/pulumi/pulumi-xyz/pull/510