### PR TITLE
Remove defaultable provider-ci arguments

### DIFF
--- a/.github/workflows/update-workflows.yml
+++ b/.github/workflows/update-workflows.yml
@@ -78,8 +78,6 @@ jobs:
         if: inputs.bridged
         run: |
           cd ci-mgmt/provider-ci && go run ./... generate \
-          	--name pulumi/pulumi-${{ inputs.provider_name }} \
-                --template bridged-provider \
                 --config ../../pulumi-${{ inputs.provider_name }}/.ci-mgmt.yaml \
                 --out ../../pulumi-${{ inputs.provider_name }}
       - name: Copy files from ci-mgmt to pulumi-${{ inputs.provider_name }}

--- a/provider-ci/internal/pkg/templates/bridged-provider/Makefile
+++ b/provider-ci/internal/pkg/templates/bridged-provider/Makefile
@@ -214,11 +214,7 @@ bin/pulumi-java-gen: .pulumi-java-gen.version
 # - Run make ci-mgmt to apply the change locally.
 #
 ci-mgmt: .ci-mgmt.yaml
-	go run github.com/pulumi/ci-mgmt/provider-ci@master generate \
-		--name $(ORG)/pulumi-$(PACK) \
-		--out . \
-		--template #{{ .Config.template }}# \
-		--config $<
+	go run github.com/pulumi/ci-mgmt/provider-ci@master generate
 
 # Because some codegen depends on the version of the CLI used, we install a local CLI
 # version pinned to the same version as `provider/go.mod`.

--- a/provider-ci/test-providers/acme/Makefile
+++ b/provider-ci/test-providers/acme/Makefile
@@ -174,11 +174,7 @@ bin/pulumi-java-gen: .pulumi-java-gen.version
 # - Run make ci-mgmt to apply the change locally.
 #
 ci-mgmt: .ci-mgmt.yaml
-	go run github.com/pulumi/ci-mgmt/provider-ci@master generate \
-		--name $(ORG)/pulumi-$(PACK) \
-		--out . \
-		--template external-bridged-provider \
-		--config $<
+	go run github.com/pulumi/ci-mgmt/provider-ci@master generate
 
 # Because some codegen depends on the version of the CLI used, we install a local CLI
 # version pinned to the same version as `provider/go.mod`.

--- a/provider-ci/test-providers/aws/Makefile
+++ b/provider-ci/test-providers/aws/Makefile
@@ -189,11 +189,7 @@ bin/pulumi-java-gen: .pulumi-java-gen.version
 # - Run make ci-mgmt to apply the change locally.
 #
 ci-mgmt: .ci-mgmt.yaml
-	go run github.com/pulumi/ci-mgmt/provider-ci@master generate \
-		--name $(ORG)/pulumi-$(PACK) \
-		--out . \
-		--template bridged-provider \
-		--config $<
+	go run github.com/pulumi/ci-mgmt/provider-ci@master generate
 
 # Because some codegen depends on the version of the CLI used, we install a local CLI
 # version pinned to the same version as `provider/go.mod`.

--- a/provider-ci/test-providers/cloudflare/Makefile
+++ b/provider-ci/test-providers/cloudflare/Makefile
@@ -182,11 +182,7 @@ bin/pulumi-java-gen: .pulumi-java-gen.version
 # - Run make ci-mgmt to apply the change locally.
 #
 ci-mgmt: .ci-mgmt.yaml
-	go run github.com/pulumi/ci-mgmt/provider-ci@master generate \
-		--name $(ORG)/pulumi-$(PACK) \
-		--out . \
-		--template bridged-provider \
-		--config $<
+	go run github.com/pulumi/ci-mgmt/provider-ci@master generate
 
 # Because some codegen depends on the version of the CLI used, we install a local CLI
 # version pinned to the same version as `provider/go.mod`.

--- a/provider-ci/test-providers/docker/Makefile
+++ b/provider-ci/test-providers/docker/Makefile
@@ -183,11 +183,7 @@ bin/pulumi-java-gen: .pulumi-java-gen.version
 # - Run make ci-mgmt to apply the change locally.
 #
 ci-mgmt: .ci-mgmt.yaml
-	go run github.com/pulumi/ci-mgmt/provider-ci@master generate \
-		--name $(ORG)/pulumi-$(PACK) \
-		--out . \
-		--template bridged-provider \
-		--config $<
+	go run github.com/pulumi/ci-mgmt/provider-ci@master generate
 
 # Because some codegen depends on the version of the CLI used, we install a local CLI
 # version pinned to the same version as `provider/go.mod`.


### PR DESCRIPTION
I noticed while testing https://github.com/pulumi/ci-mgmt/pull/1143 that [the generated PR](https://github.com/pulumi/pulumi-tf-provider-boilerplate/pull/138/files) ignored the repo's configured template and changed it.

- Use values from the config instead of hard coding them
- `--name` defaults to `{config.repository}` or `{config.organization}/pulumi-{config.provider}`
- `--template` defaults to `{config.template}` or otherwise "bridged-provider"
- `--config` defaults to `.ci-mgmt.yaml` so only specify in the update-workflows job where it's checked out into a different directory
- `--out` defaults to `.` so only specify in the update-workflows job where it's checked out into a different directory