### PR TITLE
Add linker flags for stripping debug symbols from provider binary

### DIFF
--- a/provider-ci/internal/pkg/templates/bridged-provider/Makefile
+++ b/provider-ci/internal/pkg/templates/bridged-provider/Makefile
@@ -32,6 +32,8 @@ PROVIDER_VERSION ?= #{{ index .Config "major-version" }}#.0.0-alpha.0+dev
 # Use this normalised version everywhere rather than the raw input to ensure consistency.
 VERSION_GENERIC = $(shell pulumictl convert-version --language generic --version "$(PROVIDER_VERSION)")
 
+# Strips debug information from the provider binary to reduce its size and speed up builds
+LDFLAGS_STRIP_SYMBOLS=-s -w
 LDFLAGS_PROJ_VERSION=-X $(PROJECT)/$(VERSION_PATH)=$(VERSION_GENERIC)#{{if .Config.providerVersion}}# -X #{{ .Config.providerVersion }}#=$(VERSION_GENERIC)#{{end}}#
 #{{- if .Config.providerVersion }}#
 LDFLAGS_UPSTREAM_VERSION=-X #{{ .Config.providerVersion }}#=v$(VERSION_GENERIC)
@@ -39,7 +41,7 @@ LDFLAGS_UPSTREAM_VERSION=-X #{{ .Config.providerVersion }}#=v$(VERSION_GENERIC)
 LDFLAGS_UPSTREAM_VERSION=
 #{{- end }}#
 LDFLAGS_EXTRAS=#{{- range (index .Config "extra-ld-flags") }}# #{{ . }}# #{{- end }}#
-LDFLAGS=$(LDFLAGS_PROJ_VERSION) $(LDFLAGS_UPSTREAM_VERSION) $(LDFLAGS_EXTRAS)
+LDFLAGS=$(LDFLAGS_PROJ_VERSION) $(LDFLAGS_UPSTREAM_VERSION) $(LDFLAGS_EXTRAS) $(LDFLAGS_STRIP_SYMBOLS)
 
 development: install_plugins provider build_sdks install_sdks
 

--- a/provider-ci/test-providers/acme/Makefile
+++ b/provider-ci/test-providers/acme/Makefile
@@ -20,10 +20,12 @@ PROVIDER_VERSION ?= 0.0.0-alpha.0+dev
 # Use this normalised version everywhere rather than the raw input to ensure consistency.
 VERSION_GENERIC = $(shell pulumictl convert-version --language generic --version "$(PROVIDER_VERSION)")
 
+# Strips debug information from the provider binary to reduce its size and speed up builds
+LDFLAGS_STRIP_SYMBOLS=-s -w
 LDFLAGS_PROJ_VERSION=-X $(PROJECT)/$(VERSION_PATH)=$(VERSION_GENERIC)
 LDFLAGS_UPSTREAM_VERSION=
 LDFLAGS_EXTRAS=
-LDFLAGS=$(LDFLAGS_PROJ_VERSION) $(LDFLAGS_UPSTREAM_VERSION) $(LDFLAGS_EXTRAS)
+LDFLAGS=$(LDFLAGS_PROJ_VERSION) $(LDFLAGS_UPSTREAM_VERSION) $(LDFLAGS_EXTRAS) $(LDFLAGS_STRIP_SYMBOLS)
 
 development: install_plugins provider build_sdks install_sdks
 

--- a/provider-ci/test-providers/aws/Makefile
+++ b/provider-ci/test-providers/aws/Makefile
@@ -20,10 +20,12 @@ PROVIDER_VERSION ?= 6.0.0-alpha.0+dev
 # Use this normalised version everywhere rather than the raw input to ensure consistency.
 VERSION_GENERIC = $(shell pulumictl convert-version --language generic --version "$(PROVIDER_VERSION)")
 
+# Strips debug information from the provider binary to reduce its size and speed up builds
+LDFLAGS_STRIP_SYMBOLS=-s -w
 LDFLAGS_PROJ_VERSION=-X $(PROJECT)/$(VERSION_PATH)=$(VERSION_GENERIC) -X github.com/hashicorp/terraform-provider-aws/version.ProviderVersion=$(VERSION_GENERIC)
 LDFLAGS_UPSTREAM_VERSION=-X github.com/hashicorp/terraform-provider-aws/version.ProviderVersion=v$(VERSION_GENERIC)
 LDFLAGS_EXTRAS=
-LDFLAGS=$(LDFLAGS_PROJ_VERSION) $(LDFLAGS_UPSTREAM_VERSION) $(LDFLAGS_EXTRAS)
+LDFLAGS=$(LDFLAGS_PROJ_VERSION) $(LDFLAGS_UPSTREAM_VERSION) $(LDFLAGS_EXTRAS) $(LDFLAGS_STRIP_SYMBOLS)
 
 development: install_plugins provider build_sdks install_sdks
 

--- a/provider-ci/test-providers/cloudflare/Makefile
+++ b/provider-ci/test-providers/cloudflare/Makefile
@@ -20,10 +20,12 @@ PROVIDER_VERSION ?= 5.0.0-alpha.0+dev
 # Use this normalised version everywhere rather than the raw input to ensure consistency.
 VERSION_GENERIC = $(shell pulumictl convert-version --language generic --version "$(PROVIDER_VERSION)")
 
+# Strips debug information from the provider binary to reduce its size and speed up builds
+LDFLAGS_STRIP_SYMBOLS=-s -w
 LDFLAGS_PROJ_VERSION=-X $(PROJECT)/$(VERSION_PATH)=$(VERSION_GENERIC)
 LDFLAGS_UPSTREAM_VERSION=
 LDFLAGS_EXTRAS=
-LDFLAGS=$(LDFLAGS_PROJ_VERSION) $(LDFLAGS_UPSTREAM_VERSION) $(LDFLAGS_EXTRAS)
+LDFLAGS=$(LDFLAGS_PROJ_VERSION) $(LDFLAGS_UPSTREAM_VERSION) $(LDFLAGS_EXTRAS) $(LDFLAGS_STRIP_SYMBOLS)
 
 development: install_plugins provider build_sdks install_sdks
 

--- a/provider-ci/test-providers/docker/Makefile
+++ b/provider-ci/test-providers/docker/Makefile
@@ -20,10 +20,12 @@ PROVIDER_VERSION ?= 4.0.0-alpha.0+dev
 # Use this normalised version everywhere rather than the raw input to ensure consistency.
 VERSION_GENERIC = $(shell pulumictl convert-version --language generic --version "$(PROVIDER_VERSION)")
 
+# Strips debug information from the provider binary to reduce its size and speed up builds
+LDFLAGS_STRIP_SYMBOLS=-s -w
 LDFLAGS_PROJ_VERSION=-X $(PROJECT)/$(VERSION_PATH)=$(VERSION_GENERIC)
 LDFLAGS_UPSTREAM_VERSION=
 LDFLAGS_EXTRAS=
-LDFLAGS=$(LDFLAGS_PROJ_VERSION) $(LDFLAGS_UPSTREAM_VERSION) $(LDFLAGS_EXTRAS)
+LDFLAGS=$(LDFLAGS_PROJ_VERSION) $(LDFLAGS_UPSTREAM_VERSION) $(LDFLAGS_EXTRAS) $(LDFLAGS_STRIP_SYMBOLS)
 
 development: install_plugins provider build_sdks install_sdks
 


### PR DESCRIPTION
Some of the providers binary, like aws, reached critical sizes. `pulumi-resource-aws` is now ~930MB big ([see](https://github.com/pulumi/pulumi-aws/issues/4383#issuecomment-2479294836)).

By stripping debug symbols we save ~300MB for AWS. Panics and stack traces still contain all the necessary information.

In detail this adds the `-s` and `-w` linker flags which strip the symbol table, debug information and DWARF symbol table.

Relates to https://github.com/pulumi/pulumi-aws/issues/4383