### PR TITLE
Makefile performance improvements

### DIFF
--- a/provider-ci/internal/pkg/migrations/ignoreMakeDir.go
+++ b/provider-ci/internal/pkg/migrations/ignoreMakeDir.go
@@ -1,0 +1,38 @@
+package migrations
+
+import (
+	_ "embed"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+type ignoreMakeDir struct{}
+
+func (ignoreMakeDir) Name() string {
+	return "Fixup Bridge Imports"
+}
+func (ignoreMakeDir) ShouldRun(templateName string) bool {
+	return templateName == "bridged-provider"
+}
+func (ignoreMakeDir) Migrate(templateName, outDir string) error {
+	gitignorePath := filepath.Join(outDir, ".gitignore")
+	gitignore, err := os.ReadFile(gitignorePath)
+	if err != nil {
+		if !os.IsNotExist(err) {
+			return fmt.Errorf("error reading .gitignore: %w", err)
+		}
+		gitignore = []byte{}
+	}
+	gitignoreString := string(gitignore)
+	if !strings.Contains(gitignoreString, ".make") {
+		gitignoreString += "\n\n# Ignore local build tracking directory\n.make\n"
+		err := os.WriteFile(gitignorePath, []byte(gitignoreString), 0644)
+		if err != nil {
+			return fmt.Errorf("error writing to .gitignore: %w", err)
+		}
+		return err
+	}
+	return nil
+}

--- a/provider-ci/internal/pkg/migrations/ignoreMakeDir.go
+++ b/provider-ci/internal/pkg/migrations/ignoreMakeDir.go
@@ -11,7 +11,7 @@ import (
 type ignoreMakeDir struct{}
 
 func (ignoreMakeDir) Name() string {
-	return "Fixup Bridge Imports"
+	return "Add .make directory to .gitignore"
 }
 func (ignoreMakeDir) ShouldRun(templateName string) bool {
 	return templateName == "bridged-provider"

--- a/provider-ci/internal/pkg/migrations/migrations.go
+++ b/provider-ci/internal/pkg/migrations/migrations.go
@@ -16,6 +16,7 @@ func Migrate(templateName, outDir string) error {
 	migrations := []Migration{
 		fixupBridgeImports{},
 		removeExplicitSDKDependency{},
+		ignoreMakeDir{},
 	}
 	for i, migration := range migrations {
 		if !migration.ShouldRun(templateName) {

--- a/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/build_provider.yml
+++ b/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/build_provider.yml
@@ -49,6 +49,8 @@ jobs:
         uses: ./.github/actions/setup-tools
         with:
           tools: pulumictl, go
+      - name: Prepare local workspace before restoring previously built
+        run: make prepare_local_workspace
       - name: Download schema-embed.json
         uses: #{{ .Config.ActionVersions.DownloadArtifact }}#
         with:
@@ -57,9 +59,11 @@ jobs:
           # Avoid creating directories for each artifact
           merge-multiple: true
           path: provider/cmd/pulumi-resource-#{{ .Config.Provider }}#/schema-embed.json
-      - name: Prepare for build
-        # This installs plugins and prepares upstream
-        run: make upstream
+      - name: Restore makefile progress
+        uses: #{{ .Config.ActionVersions.DownloadArtifact }}#
+        with:
+          name: prerequisites.make
+          path: .make
       - name: Build & package provider
         run: make provider_dist-${{ matrix.platform.os }}-${{ matrix.platform.arch }}
       - name: Upload artifacts

--- a/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/build_sdk.yml
+++ b/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/build_sdk.yml
@@ -47,12 +47,17 @@ jobs:
         uses: ./.github/actions/setup-tools
         with:
           tools: pulumictl, pulumicli, ${{ matrix.language }}
+      - name: Prepare local workspace
+        run: make prepare_local_workspace
       - name: Download bin
         uses: ./.github/actions/download-bin
-      - name: Install plugins
-        run: make install_plugins
       - name: Update path
         run: echo "${{ github.workspace }}/bin" >> "$GITHUB_PATH"
+      - name: Restore makefile progress
+        uses: #{{ .Config.ActionVersions.DownloadArtifact }}#
+        with:
+          name: prerequisites.make
+          path: .make
       - name: Build SDK
         run: make build_${{ matrix.language }}
       - name: Check worktree clean
@@ -68,3 +73,9 @@ jobs:
         uses: ./.github/actions/upload-sdk
         with:
           language: ${{ matrix.language }}
+      - name: Save makefile progress
+        uses: #{{ .Config.ActionVersions.UploadArtifact }}#
+        with:
+          name: build_${{ matrix.language }}.make
+          path: .make
+          include-hidden-files: true

--- a/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/main.yml
+++ b/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/main.yml
@@ -152,9 +152,6 @@ jobs:
         tools: pulumictl, pulumicli, ${{ matrix.language }}
     - name: Download bin
       uses: ./.github/actions/download-bin
-    - name: Add NuGet source
-      if: matrix.language == 'dotnet'
-      run: dotnet nuget add source ${{ github.workspace }}/nuget
     - name: Download SDK
       uses: ./.github/actions/download-sdk
       with:

--- a/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/main.yml
+++ b/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/main.yml
@@ -150,14 +150,19 @@ jobs:
       uses: ./.github/actions/setup-tools
       with:
         tools: pulumictl, pulumicli, ${{ matrix.language }}
+    - name: Prepare local workspace
+      run: make prepare_local_workspace
     - name: Download bin
       uses: ./.github/actions/download-bin
     - name: Download SDK
       uses: ./.github/actions/download-sdk
       with:
         language: ${{ matrix.language }}
-    - name: Mark SDK up to date
-      run: make --touch build_${{ matrix.language }}
+    - name: Restore makefile progress
+      uses: #{{ .Config.ActionVersions.DownloadArtifact }}#
+      with:
+        name: build_${{ matrix.language }}.make
+        path: .make
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> "$GITHUB_PATH"
     - name: Install Python deps
@@ -203,10 +208,6 @@ jobs:
       uses: webfactory/ssh-agent@v0.7.0
       with:
         ssh-private-key: #{{ .Config.SSHPrivateKey }}#
-    #{{- end }}#
-    #{{- if .Config.IntegrationTestProvider }}#
-    - name: Prepare upstream code
-      run: make upstream
     #{{- end }}#
     #{{- if index .Config.SetupScript }}#
     - name: Run setup script

--- a/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/main.yml
+++ b/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/main.yml
@@ -159,6 +159,8 @@ jobs:
       uses: ./.github/actions/download-sdk
       with:
         language: ${{ matrix.language }}
+    - name: Mark SDK up to date
+      run: make --touch build_${{ matrix.language }}
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> "$GITHUB_PATH"
     - name: Install Python deps

--- a/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/nightly-test.yml
+++ b/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/nightly-test.yml
@@ -59,14 +59,19 @@ jobs:
       uses: ./.github/actions/setup-tools
       with:
         tools: pulumictl, pulumicli, ${{ matrix.language}}
+    - name: Prepare local workspace
+      run: make prepare_local_workspace
     - name: Download bin
       uses: ./.github/actions/download-bin
     - name: Download SDK
       uses: ./.github/actions/download-sdk
       with:
         language: ${{ matrix.language }}
-    - name: Mark SDK up to date
-      run: make --touch build_${{ matrix.language }}
+    - name: Restore makefile progress
+      uses: #{{ .Config.ActionVersions.DownloadArtifact }}#
+      with:
+        name: build_${{ matrix.language }}.make
+        path: .make
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> "$GITHUB_PATH"
     - name: Install Python deps
@@ -112,10 +117,6 @@ jobs:
       uses: webfactory/ssh-agent@v0.7.0
       with:
         ssh-private-key: #{{ .Config.SSHPrivateKey }}#
-    #{{- end }}#
-    #{{- if .Config.IntegrationTestProvider }}#
-    - name: Prepare upstream code
-      run: make upstream
     #{{- end }}#
     #{{- if index .Config.SetupScript }}#
     - name: Run setup script

--- a/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/nightly-test.yml
+++ b/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/nightly-test.yml
@@ -68,6 +68,8 @@ jobs:
       uses: ./.github/actions/download-sdk
       with:
         language: ${{ matrix.language }}
+    - name: Mark SDK up to date
+      run: make --touch build_${{ matrix.language }}
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> "$GITHUB_PATH"
     - name: Install Python deps

--- a/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/nightly-test.yml
+++ b/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/nightly-test.yml
@@ -61,9 +61,6 @@ jobs:
         tools: pulumictl, pulumicli, ${{ matrix.language}}
     - name: Download bin
       uses: ./.github/actions/download-bin
-    - name: Add NuGet source
-      if: matrix.language == 'dotnet'
-      run: dotnet nuget add source ${{ github.workspace }}/nuget
     - name: Download SDK
       uses: ./.github/actions/download-sdk
       with:

--- a/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/prerelease.yml
+++ b/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/prerelease.yml
@@ -91,9 +91,6 @@ jobs:
         tools: pulumictl, pulumicli, #{{ range $index, $element := .Config.Languages }}##{{if $index}}#, #{{end}}##{{ $element }}##{{end}}#
     - name: Download bin
       uses: ./.github/actions/download-bin
-    - name: Add NuGet source
-      if: matrix.language == 'dotnet'
-      run: dotnet nuget add source ${{ github.workspace }}/nuget
     - name: Download SDK
       uses: ./.github/actions/download-sdk
       with:

--- a/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/prerelease.yml
+++ b/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/prerelease.yml
@@ -89,14 +89,19 @@ jobs:
       uses: ./.github/actions/setup-tools
       with:
         tools: pulumictl, pulumicli, #{{ range $index, $element := .Config.Languages }}##{{if $index}}#, #{{end}}##{{ $element }}##{{end}}#
+    - name: Prepare local workspace
+      run: make prepare_local_workspace
     - name: Download bin
       uses: ./.github/actions/download-bin
     - name: Download SDK
       uses: ./.github/actions/download-sdk
       with:
         language: ${{ matrix.language }}
-    - name: Mark SDK up to date
-      run: make --touch build_${{ matrix.language }}
+    - name: Restore makefile progress
+      uses: #{{ .Config.ActionVersions.DownloadArtifact }}#
+      with:
+        name: build_${{ matrix.language }}.make
+        path: .make
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> "$GITHUB_PATH"
     - name: Install Python deps
@@ -142,10 +147,6 @@ jobs:
       uses: webfactory/ssh-agent@v0.7.0
       with:
         ssh-private-key: #{{ .Config.SSHPrivateKey }}#
-    #{{- end }}#
-    #{{- if .Config.IntegrationTestProvider }}#
-    - name: Prepare upstream code
-      run: make upstream
     #{{- end }}#
     #{{- if index .Config.SetupScript }}#
     - name: Run setup script

--- a/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/prerelease.yml
+++ b/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/prerelease.yml
@@ -98,6 +98,8 @@ jobs:
       uses: ./.github/actions/download-sdk
       with:
         language: ${{ matrix.language }}
+    - name: Mark SDK up to date
+      run: make --touch build_${{ matrix.language }}
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> "$GITHUB_PATH"
     - name: Install Python deps

--- a/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/prerequisites.yml
+++ b/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/prerequisites.yml
@@ -53,23 +53,19 @@ jobs:
         path: |
           .pulumi/examples-cache
         key: ${{ runner.os }}-${{ hashFiles('provider/go.sum') }}
-    - name: Prepare upstream code
-      run: make upstream
     - name: Setup tools
       uses: ./.github/actions/setup-tools
       with:
         tools: go, pulumictl, pulumicli, schema-tools
+    - name: Prepare local workspace before restoring previously built files
+      run: make prepare_local_workspace
 #{{- if .Config.Actions.PreBuild }}#
 #{{ .Config.Actions.PreBuild | toYaml | indent 4 }}#
 #{{- end }}#
-    - name: Build schema generator binary
-      run: make tfgen_build_only
-    - name: Install plugins
-      run: make install_plugins
     - name: Generate schema
-      run: make tfgen_no_deps
+      run: make schema
     - name: Build provider binary
-      run: make provider_no_deps
+      run: make provider
     - name: Unit-test provider code
       run: make test_provider
     - if: inputs.is_pr
@@ -81,6 +77,12 @@ jobs:
           schema-tools compare -r github://api.github.com/#{{ .Config.Organization }}# -p #{{ .Config.Provider }}# -o "${{ inputs.default_branch }}" -n --local-path=provider/cmd/pulumi-resource-#{{ .Config.Provider }}#/schema.json;
           echo "$EOF";
         } >> "$GITHUB_ENV"
+    - name: Save makefile progress
+      uses: #{{ .Config.ActionVersions.UploadArtifact }}#
+      with:
+        name: prerequisites.make
+        path: .make
+        include-hidden-files: true
     - if: inputs.is_pr && inputs.is_automated == false
       name: Comment on PR with Details of Schema Check
       uses: #{{ .Config.ActionVersions.PrComment }}#

--- a/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/release.yml
+++ b/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/release.yml
@@ -98,14 +98,19 @@ jobs:
       uses: ./.github/actions/setup-tools
       with:
         tools: pulumictl, pulumicli, ${{ matrix.language }}
+    - name: Prepare local workspace
+      run: make prepare_local_workspace
     - name: Download bin
       uses: ./.github/actions/download-bin
     - name: Download SDK
       uses: ./.github/actions/download-sdk
       with:
         language: ${{ matrix.language }}
-    - name: Mark SDK up to date
-      run: make --touch build_${{ matrix.language }}
+    - name: Restore makefile progress
+      uses: #{{ .Config.ActionVersions.DownloadArtifact }}#
+      with:
+        name: build_${{ matrix.language }}.make
+        path: .make
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> "$GITHUB_PATH"
     - name: Install Python deps
@@ -151,10 +156,6 @@ jobs:
       uses: webfactory/ssh-agent@v0.7.0
       with:
         ssh-private-key: #{{ .Config.SSHPrivateKey }}#
-    #{{- end }}#
-    #{{- if .Config.IntegrationTestProvider }}#
-    - name: Prepare upstream code
-      run: make upstream
     #{{- end }}#
     #{{- if index .Config.SetupScript }}#
     - name: Run setup script

--- a/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/release.yml
+++ b/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/release.yml
@@ -100,9 +100,6 @@ jobs:
         tools: pulumictl, pulumicli, ${{ matrix.language }}
     - name: Download bin
       uses: ./.github/actions/download-bin
-    - name: Add NuGet source
-      if: matrix.language == 'dotnet'
-      run: dotnet nuget add source ${{ github.workspace }}/nuget
     - name: Download SDK
       uses: ./.github/actions/download-sdk
       with:

--- a/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/release.yml
+++ b/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/release.yml
@@ -107,6 +107,8 @@ jobs:
       uses: ./.github/actions/download-sdk
       with:
         language: ${{ matrix.language }}
+    - name: Mark SDK up to date
+      run: make --touch build_${{ matrix.language }}
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> "$GITHUB_PATH"
     - name: Install Python deps

--- a/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/run-acceptance-tests.yml
@@ -148,9 +148,6 @@ jobs:
         tools: pulumictl, pulumicli, ${{ matrix.language }}
     - name: Download bin
       uses: ./.github/actions/download-bin
-    - name: Add NuGet source
-      if: matrix.language == 'dotnet'
-      run: dotnet nuget add source ${{ github.workspace }}/nuget
     - name: Download SDK
       uses: ./.github/actions/download-sdk
       with:

--- a/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/run-acceptance-tests.yml
@@ -146,14 +146,19 @@ jobs:
       uses: ./.github/actions/setup-tools
       with:
         tools: pulumictl, pulumicli, ${{ matrix.language }}
+    - name: Prepare local workspace
+      run: make prepare_local_workspace
     - name: Download bin
       uses: ./.github/actions/download-bin
     - name: Download SDK
       uses: ./.github/actions/download-sdk
       with:
         language: ${{ matrix.language }}
-    - name: Mark SDK up to date
-      run: make --touch build_${{ matrix.language }}
+    - name: Restore makefile progress
+      uses: #{{ .Config.ActionVersions.DownloadArtifact }}#
+      with:
+        name: build_${{ matrix.language }}.make
+        path: .make
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> "$GITHUB_PATH"
     - name: Install Python deps
@@ -199,10 +204,6 @@ jobs:
       uses: webfactory/ssh-agent@v0.7.0
       with:
         ssh-private-key: #{{ .Config.SSHPrivateKey }}#
-    #{{- end }}#
-    #{{- if .Config.IntegrationTestProvider }}#
-    - name: Prepare upstream code
-      run: make upstream
     #{{- end }}#
     #{{- if index .Config.SetupScript }}#
     - name: Run setup script

--- a/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/run-acceptance-tests.yml
@@ -155,6 +155,8 @@ jobs:
       uses: ./.github/actions/download-sdk
       with:
         language: ${{ matrix.language }}
+    - name: Mark SDK up to date
+      run: make --touch build_${{ matrix.language }}
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> "$GITHUB_PATH"
     - name: Install Python deps

--- a/provider-ci/internal/pkg/templates/bridged-provider/Makefile
+++ b/provider-ci/internal/pkg/templates/bridged-provider/Makefile
@@ -43,6 +43,13 @@ LDFLAGS_UPSTREAM_VERSION=
 LDFLAGS_EXTRAS=#{{- range .Config.ExtraLDFlags }}# #{{ . }}# #{{- end }}#
 LDFLAGS=$(LDFLAGS_PROJ_VERSION) $(LDFLAGS_UPSTREAM_VERSION) $(LDFLAGS_EXTRAS) $(LDFLAGS_STRIP_SYMBOLS)
 
+# Create a `.make` directory for tracking targets which don't generate a single file output. This should be ignored by git.
+# For targets which either don't generate a single file output, or the output file is committed, we use a "sentinel"
+# file within `.make/` to track the staleness of the target and only rebuild when needed. 
+# For each phony target, we create an internal target with the same name, but prefixed with `.make/` where the work is performed.
+# At the end of each internal target we run `@touch $@` to update the file which is the name of the target.
+_ := $(shell mkdir -p .make)
+
 development: install_plugins provider build_sdks install_sdks
 
 build: install_plugins provider build_sdks install_sdks

--- a/provider-ci/internal/pkg/templates/bridged-provider/Makefile
+++ b/provider-ci/internal/pkg/templates/bridged-provider/Makefile
@@ -67,6 +67,43 @@ build_sdks:#{{ range .Config.Languages }}# build_#{{ . }}##{{ end }}#
 install_sdks:#{{ range .Config.Languages }}# install_#{{ . }}#_sdk#{{ end }}#
 .PHONY: development only_build build generate generate_sdks build_sdks install_sdks
 
+help:
+	@echo "Usage: make [target]"
+	@echo ""
+	@echo "Main Targets"
+	@echo "  build (default)     Build the provider and all SDKs and install for testing"
+	@echo "  generate            Generate all SDKs, documentation and schema"
+	@echo "  provider            Build the local provider binary"
+	@echo "  lint_provider<.fix> Run the linter on the provider (& optionally fix)"
+	@echo "  test_provider       Run the provider tests"
+	@echo "  test                Run the example tests (must run 'build' first)"
+	@echo "  clean               Clean up generated files"
+	@echo ""
+	@echo "More Precise Targets"
+	@echo "  schema        Generate the schema"
+	@echo "  generate_sdks Generate all SDKs"
+	@echo "  build_sdks    Build all SDKs"
+	@echo "  install_sdks  Install all SDKs"
+	@echo "  provider_dist Build and package the provider for all platforms"
+	@echo ""
+	@echo "Tool Targets"
+	@echo "  ci-mgmt     Re-generate CI configuration from .ci-mgmt.yaml"
+	@echo "  debug_tfgen Start a debug server for tfgen"
+	@echo ""
+	@echo "Internal Targets (automatically run as dependencies of other targets)"
+	@echo "  prepare_local_workspace  Prepare for building"
+	@echo "  install_plugins          Install plugin dependencies"
+	@echo "  upstream                 Initialize the upstream submodule, if present"
+	@echo ""
+	@echo "Language-Specific Targets"
+	@echo "  generate_[language]    Generate the SDK files ready for committing"
+	@echo "  build_[language]       Build the SDK to check correctness"
+	@echo "  install_[language]_sdk Install the SDK ready for testing"
+	@echo ""
+	@echo "  [language] =#{{ range .Config.Languages }}# #{{ . }}##{{ end }}#"
+	@echo ""
+.PHONY: help
+
 GEN_PULUMI_HOME := $(WORKING_DIR)/.pulumi
 GEN_PULUMI_CONVERT_EXAMPLES_CACHE_DIR := $(GEN_PULUMI_HOME)/examples-cache
 GEN_ENVS := PULUMI_HOME=$(GEN_PULUMI_HOME) PULUMI_CONVERT_EXAMPLES_CACHE_DIR=$(GEN_PULUMI_CONVERT_EXAMPLES_CACHE_DIR) PULUMI_CONVERT=$(PULUMI_CONVERT) PULUMI_DISABLE_AUTOMATIC_PLUGIN_ACQUISITION=$(PULUMI_CONVERT)

--- a/provider-ci/internal/pkg/templates/bridged-provider/Makefile
+++ b/provider-ci/internal/pkg/templates/bridged-provider/Makefile
@@ -136,9 +136,11 @@ clean:
 	rm -rf .make/*
 
 #{{- if .Config.DocsCmd }}#
-
-docs:
+.PHONY: docs
+docs: .make/docs
+.make/docs:
 	#{{ .Config.DocsCmd }}#
+	@touch $@
 #{{- end }}#
 
 help:
@@ -191,7 +193,7 @@ test_provider:
 
 .PHONY: tfgen schema tfgen_no_deps tfgen_build_only
 tfgen: schema
-schema: .make/schema #{{ if .Config.DocsCmd }}# docs#{{ end }}#
+schema: .make/schema #{{ if .Config.DocsCmd }}# .make/docs#{{ end }}#
 # This does actually have dependencies, but we're keeping it around for backwards compatibility for now
 tfgen_no_deps: .make/schema
 
@@ -260,7 +262,7 @@ ci-mgmt: .ci-mgmt.yaml
 debug_tfgen:
 	dlv  --listen=:2345 --headless=true --api-version=2  exec $(WORKING_DIR)/bin/$(TFGEN) -- schema --out provider/cmd/$(PROVIDER)
 
-.PHONY: development build build_sdks install_go_sdk install_java_sdk install_python_sdk install_sdks only_build build_dotnet build_go build_java build_nodejs build_python#{{ if .Config.DocsCmd }}# docs#{{end}}# help install_dotnet_sdk install_nodejs_sdk lint_provider provider provider_no_deps test ci-mgmt test_provider debug_tfgen
+.PHONY: development build build_sdks install_go_sdk install_java_sdk install_python_sdk install_sdks only_build build_dotnet build_go build_java build_nodejs build_python help install_dotnet_sdk install_nodejs_sdk lint_provider provider provider_no_deps test ci-mgmt test_provider debug_tfgen
 
 # Provider cross-platform build & packaging
 

--- a/provider-ci/internal/pkg/templates/bridged-provider/Makefile
+++ b/provider-ci/internal/pkg/templates/bridged-provider/Makefile
@@ -69,7 +69,7 @@ only_build: build
 build_dotnet: export PULUMI_HOME := $(WORKING_DIR)/.pulumi
 build_dotnet: export PATH := $(WORKING_DIR)/.pulumi/bin:$(PATH)
 build_dotnet: export PULUMI_CONVERT_EXAMPLES_CACHE_DIR := $(WORKING_DIR)/.pulumi/examples-cache
-build_dotnet: upstream
+build_dotnet: .make/upstream
 	PULUMI_CONVERT=$(PULUMI_CONVERT) PULUMI_DISABLE_AUTOMATIC_PLUGIN_ACQUISITION=$(PULUMI_CONVERT) $(WORKING_DIR)/bin/$(TFGEN) dotnet --out sdk/dotnet/
 	cd sdk/dotnet/ && \
 		printf "module fake_dotnet_module // Exclude this directory from Go tools\n\ngo 1.17\n" > go.mod && \
@@ -79,7 +79,7 @@ build_dotnet: upstream
 build_go: export PULUMI_HOME := $(WORKING_DIR)/.pulumi
 build_go: export PATH := $(WORKING_DIR)/.pulumi/bin:$(PATH)
 build_go: export PULUMI_CONVERT_EXAMPLES_CACHE_DIR := $(WORKING_DIR)/.pulumi/examples-cache
-build_go: upstream
+build_go: .make/upstream
 	PULUMI_CONVERT=$(PULUMI_CONVERT) PULUMI_DISABLE_AUTOMATIC_PLUGIN_ACQUISITION=$(PULUMI_CONVERT) $(WORKING_DIR)/bin/$(TFGEN) go --out sdk/go/
 	cd sdk && go list "$$(grep -e "^module" go.mod | cut -d ' ' -f 2)/go/..." | xargs -I {} bash -c 'go build {} && go clean -i {}'
 
@@ -87,7 +87,7 @@ build_java: PACKAGE_VERSION := $(VERSION_GENERIC)
 build_java: export PULUMI_HOME := $(WORKING_DIR)/.pulumi
 build_java: export PATH := $(WORKING_DIR)/.pulumi/bin:$(PATH)
 build_java: export PULUMI_CONVERT_EXAMPLES_CACHE_DIR := $(WORKING_DIR)/.pulumi/examples-cache
-build_java: bin/pulumi-java-gen upstream
+build_java: bin/pulumi-java-gen .make/upstream
 	$(WORKING_DIR)/bin/$(JAVA_GEN) generate --schema provider/cmd/$(PROVIDER)/schema.json --out sdk/java  --build gradle-nexus
 	cd sdk/java/ && \
 		printf "module fake_java_module // Exclude this directory from Go tools\n\ngo 1.17\n" > go.mod && \
@@ -97,7 +97,7 @@ build_java: bin/pulumi-java-gen upstream
 build_nodejs: export PULUMI_HOME := $(WORKING_DIR)/.pulumi
 build_nodejs: export PATH := $(WORKING_DIR)/.pulumi/bin:$(PATH)
 build_nodejs: export PULUMI_CONVERT_EXAMPLES_CACHE_DIR := $(WORKING_DIR)/.pulumi/examples-cache
-build_nodejs: upstream
+build_nodejs: .make/upstream
 	PULUMI_CONVERT=$(PULUMI_CONVERT) PULUMI_DISABLE_AUTOMATIC_PLUGIN_ACQUISITION=$(PULUMI_CONVERT) $(WORKING_DIR)/bin/$(TFGEN) nodejs --out sdk/nodejs/
 	cd sdk/nodejs/ && \
 		printf "module fake_nodejs_module // Exclude this directory from Go tools\n\ngo 1.17\n" > go.mod && \
@@ -108,7 +108,7 @@ build_nodejs: upstream
 build_python: export PULUMI_HOME := $(WORKING_DIR)/.pulumi
 build_python: export PATH := $(WORKING_DIR)/.pulumi/bin:$(PATH)
 build_python: export PULUMI_CONVERT_EXAMPLES_CACHE_DIR := $(WORKING_DIR)/.pulumi/examples-cache
-build_python: upstream
+build_python: .make/upstream
 	rm -rf sdk/python/
 	PULUMI_CONVERT=$(PULUMI_CONVERT) PULUMI_DISABLE_AUTOMATIC_PLUGIN_ACQUISITION=$(PULUMI_CONVERT) $(WORKING_DIR)/bin/$(TFGEN) python --out sdk/python/
 	cd sdk/python/ && \
@@ -203,19 +203,20 @@ tfgen_build_only: bin/$(TFGEN)
 bin/$(TFGEN):
 	(cd provider && go build $(PULUMI_PROVIDER_BUILD_PARALLELISM) -o $(WORKING_DIR)/bin/$(TFGEN) -ldflags "$(LDFLAGS_PROJ_VERSION) $(LDFLAGS_EXTRAS)" $(PROJECT)/$(PROVIDER_PATH)/cmd/$(TFGEN))
 
-upstream:
+.PHONY: upstream
+upstream: .make/upstream
+# Re-run if the upstream commit or the patches change
+.make/upstream: $(wildcard patches/*) $(wildcard .git/modules/upstream/HEAD)
 ifneq ("$(wildcard upstream)","")
 	./upstream.sh init
 endif
-
 #{{- if .Config.XrunUpstreamTools }}#
-
 	# Ensure tool is installed
 	cd upstream-tools && yarn install --frozen-lockfile
 	# Apply all automated changes
 	cd upstream-tools && yarn --silent run apply
-
 #{{- end }}#
+	@touch $@
 
 bin/pulumi-java-gen: .pulumi-java-gen.version
 	pulumictl download-binary -n pulumi-language-java -v v$(shell cat .pulumi-java-gen.version) -r pulumi/pulumi-java
@@ -251,7 +252,7 @@ ci-mgmt: .ci-mgmt.yaml
 debug_tfgen:
 	dlv  --listen=:2345 --headless=true --api-version=2  exec $(WORKING_DIR)/bin/$(TFGEN) -- schema --out provider/cmd/$(PROVIDER)
 
-.PHONY: development build build_sdks install_go_sdk install_java_sdk install_python_sdk install_sdks only_build build_dotnet build_go build_java build_nodejs build_python clean cleanup#{{ if .Config.DocsCmd }}# docs#{{end}}# help install_dotnet_sdk install_nodejs_sdk install_plugins lint_provider provider provider_no_deps test upstream ci-mgmt test_provider debug_tfgen
+.PHONY: development build build_sdks install_go_sdk install_java_sdk install_python_sdk install_sdks only_build build_dotnet build_go build_java build_nodejs build_python clean cleanup#{{ if .Config.DocsCmd }}# docs#{{end}}# help install_dotnet_sdk install_nodejs_sdk install_plugins lint_provider provider provider_no_deps test ci-mgmt test_provider debug_tfgen
 
 # Provider cross-platform build & packaging
 

--- a/provider-ci/internal/pkg/templates/bridged-provider/Makefile
+++ b/provider-ci/internal/pkg/templates/bridged-provider/Makefile
@@ -52,7 +52,6 @@ LDFLAGS=$(LDFLAGS_PROJ_VERSION) $(LDFLAGS_UPSTREAM_VERSION) $(LDFLAGS_EXTRAS) $(
 # Ensure all directories exist before evaluating targets to avoid issues with `touch` creating directories.
 _ := $(shell mkdir -p .make bin .pulumi/bin)
 
-.PHONY: development only_build build generate_sdks build_sdks install_sdks
 # Keep aliases for old targets to ensure backwards compatibility
 development: build
 only_build: build
@@ -60,12 +59,12 @@ build: install_plugins provider build_sdks install_sdks
 generate_sdks:#{{ range .Config.Languages }}# generate_#{{ . }}##{{ end }}#
 build_sdks:#{{ range .Config.Languages }}# build_#{{ . }}##{{ end }}##{{- if .Config.RegistryDocs }}#.make/build_registry_docs#{{- end }}#
 install_sdks:#{{ range .Config.Languages }}# install_#{{ . }}#_sdk#{{ end }}#
+.PHONY: development only_build build generate_sdks build_sdks install_sdks
 
 GEN_PULUMI_HOME := $(WORKING_DIR)/.pulumi
 GEN_PULUMI_CONVERT_EXAMPLES_CACHE_DIR := $(GEN_PULUMI_HOME)/examples-cache
 GEN_ENVS := PULUMI_HOME=$(GEN_PULUMI_HOME) PULUMI_CONVERT_EXAMPLES_CACHE_DIR=$(GEN_PULUMI_CONVERT_EXAMPLES_CACHE_DIR) PULUMI_CONVERT=$(PULUMI_CONVERT) PULUMI_DISABLE_AUTOMATIC_PLUGIN_ACQUISITION=$(PULUMI_CONVERT)
 
-.PHONY: generate_dotnet build_dotnet
 generate_dotnet: .make/generate_dotnet
 build_dotnet: .make/build_dotnet
 .make/generate_dotnet: export PATH := $(WORKING_DIR)/.pulumi/bin:$(PATH)
@@ -78,8 +77,8 @@ build_dotnet: .make/build_dotnet
 .make/build_dotnet: .make/generate_dotnet
 	cd sdk/dotnet/ && dotnet build
 	@touch $@
+.PHONY: generate_dotnet build_dotnet
 
-.PHONY: generate_go build_go
 generate_go: .make/generate_go
 build_go: .make/build_go
 .make/generate_go: export PATH := $(WORKING_DIR)/.pulumi/bin:$(PATH)
@@ -89,8 +88,8 @@ build_go: .make/build_go
 .make/build_go: .make/generate_go
 	cd sdk && go list "$$(grep -e "^module" go.mod | cut -d ' ' -f 2)/go/..." | xargs -I {} bash -c 'go build {} && go clean -i {}'
 	@touch $@
+.PHONY: generate_go build_go
 
-.PHONY: generate_java build_java
 generate_java: .make/generate_java
 build_java: .make/build_java
 .make/generate_java: export PATH := $(WORKING_DIR)/.pulumi/bin:$(PATH)
@@ -105,8 +104,8 @@ build_java: .make/build_java
 		gradle --console=plain build && \
 		gradle --console=plain javadoc
 	@touch $@
+.PHONY: generate_java build_java
 
-.PHONY: generate_nodejs build_nodejs
 generate_nodejs: .make/generate_nodejs
 build_nodejs: .make/build_nodejs
 .make/generate_nodejs: export PATH := $(WORKING_DIR)/.pulumi/bin:$(PATH)
@@ -120,8 +119,8 @@ build_nodejs: .make/build_nodejs
 		yarn run tsc && \
 		cp ../../README.md ../../LICENSE* package.json yarn.lock ./bin/
 	@touch $@
+.PHONY: generate_nodejs build_nodejs
 
-.PHONY: generate_python build_python
 generate_python: .make/generate_python
 build_python: .make/build_python
 .make/generate_python: export PATH := $(WORKING_DIR)/.pulumi/bin:$(PATH)
@@ -139,31 +138,31 @@ build_python: .make/build_python
 		cd ./bin && \
 		../venv/bin/python -m build .
 	@touch $@
+.PHONY: generate_python build_python
 
 #{{- if .Config.RegistryDocs }}#
 # Run the bridge's registry-docs command to generated the content of the installation docs/ folder at provider repo root
-.PHONY: build_registry_docs
 build_registry_docs: .make/build_registry_docs
 .make/build_registry_docs: bin/$(TFGEN)
 	bin/$(TFGEN) registry-docs --out $(WORKING_DIR)/docs
 	@touch $@
+.PHONY: build_registry_docs
 #{{- end }}#
 
-.PHONY: clean
 clean:
 	rm -rf sdk/{dotnet,nodejs,go,python}
 	rm -rf bin/*
 	rm -rf .make/*
+.PHONY: clean
 
 #{{- if .Config.DocsCmd }}#
-.PHONY: docs
 docs: .make/docs
 .make/docs:
 	#{{ .Config.DocsCmd }}#
 	@touch $@
+.PHONY: docs
 #{{- end }}#
 
-.PHONY: install_dotnet_sdk install_go_sdk install_java_sdk install_nodejs_sdk install_python_sdk
 install_dotnet_sdk: .make/install_dotnet_sdk
 .make/install_dotnet_sdk: .make/build_dotnet
 	mkdir -p $(WORKING_DIR)/nuget
@@ -176,8 +175,8 @@ install_nodejs_sdk: .make/install_nodejs_sdk
 	yarn link --cwd $(WORKING_DIR)/sdk/nodejs/bin
 	@touch $@
 install_python_sdk:
+.PHONY: install_dotnet_sdk install_go_sdk install_java_sdk install_nodejs_sdk install_python_sdk
 
-.PHONY: install_plugins
 install_plugins: .make/install_plugins
 .make/install_plugins: export PULUMI_HOME := $(WORKING_DIR)/.pulumi
 .make/install_plugins: export PATH := $(WORKING_DIR)/.pulumi/bin:$(PATH)
@@ -186,6 +185,7 @@ install_plugins: .make/install_plugins
 	.pulumi/bin/pulumi plugin install #{{ or .Kind "resource" }}# #{{ .Name }}# #{{ .Version }}#
 	#{{- end }}#
 	@touch $@
+.PHONY: install_plugins
 
 lint_provider: provider
 	cd provider && golangci-lint run --path-prefix provider -c ../.golangci.yml
@@ -198,13 +198,13 @@ lint_provider.fix:
 # `make provider_no_deps` builds the provider binary directly, without ensuring that
 # `cmd/pulumi-resource-#{{ .Config.Provider }}#/schema.json` is valid and up to date.
 # To create a release ready binary, you should use `make provider`.
-.PHONY: provider provider_no_deps
 build_provider_cmd = cd provider && go build $(PULUMI_PROVIDER_BUILD_PARALLELISM) -o $(WORKING_DIR)/bin/$(PROVIDER) -ldflags "$(LDFLAGS)" $(PROJECT)/$(PROVIDER_PATH)/cmd/$(PROVIDER)
 provider: bin/$(PROVIDER)
 provider_no_deps:
 	$(call build_provider_cmd)
 bin/$(PROVIDER): .make/schema
 	$(call build_provider_cmd)
+.PHONY: provider provider_no_deps
 
 test: export PATH := $(WORKING_DIR)/bin:$(PATH)
 test:
@@ -215,12 +215,10 @@ test_provider:
 	cd provider && go test -v -short ./... -parallel $(TESTPARALLELISM)
 .PHONY: test_provider
 
-.PHONY: tfgen schema tfgen_no_deps tfgen_build_only
 tfgen: schema
 schema: .make/schema #{{ if .Config.DocsCmd }}# .make/docs#{{ end }}#
 # This does actually have dependencies, but we're keeping it around for backwards compatibility for now
 tfgen_no_deps: .make/schema
-
 .make/schema: export PULUMI_HOME := $(WORKING_DIR)/.pulumi
 .make/schema: export PATH := $(WORKING_DIR)/.pulumi/bin:$(PATH)
 .make/schema: export PULUMI_CONVERT := $(PULUMI_CONVERT)
@@ -231,13 +229,11 @@ tfgen_no_deps: .make/schema
 	$(WORKING_DIR)/bin/$(TFGEN) schema --out provider/cmd/$(PROVIDER)
 	(cd provider && VERSION=$(VERSION_GENERIC) go generate cmd/$(PROVIDER)/main.go)
 	@touch $@
-
 tfgen_build_only: bin/$(TFGEN)
-
 bin/$(TFGEN):
 	(cd provider && go build $(PULUMI_PROVIDER_BUILD_PARALLELISM) -o $(WORKING_DIR)/bin/$(TFGEN) -ldflags "$(LDFLAGS_PROJ_VERSION) $(LDFLAGS_EXTRAS)" $(PROJECT)/$(PROVIDER_PATH)/cmd/$(TFGEN))
+.PHONY: tfgen schema tfgen_no_deps tfgen_build_only
 
-.PHONY: upstream
 upstream: .make/upstream
 # Re-run if the upstream commit or the patches change
 .make/upstream: $(wildcard patches/*) $(wildcard .git/modules/upstream/HEAD)
@@ -251,6 +247,7 @@ endif
 	cd upstream-tools && yarn --silent run apply
 #{{- end }}#
 	@touch $@
+.PHONY: upstream
 
 bin/pulumi-java-gen: .pulumi-java-gen.version
 	pulumictl download-binary -n pulumi-language-java -v v$(shell cat .pulumi-java-gen.version) -r pulumi/pulumi-java

--- a/provider-ci/internal/pkg/templates/bridged-provider/Makefile
+++ b/provider-ci/internal/pkg/templates/bridged-provider/Makefile
@@ -68,15 +68,23 @@ install_sdks: install_dotnet_sdk install_python_sdk install_nodejs_sdk install_j
 
 only_build: build
 
-build_dotnet: export PULUMI_HOME := $(WORKING_DIR)/.pulumi
-build_dotnet: export PATH := $(WORKING_DIR)/.pulumi/bin:$(PATH)
-build_dotnet: export PULUMI_CONVERT_EXAMPLES_CACHE_DIR := $(WORKING_DIR)/.pulumi/examples-cache
-build_dotnet: .make/upstream
-	PULUMI_CONVERT=$(PULUMI_CONVERT) PULUMI_DISABLE_AUTOMATIC_PLUGIN_ACQUISITION=$(PULUMI_CONVERT) $(WORKING_DIR)/bin/$(TFGEN) dotnet --out sdk/dotnet/
+GEN_PULUMI_HOME := $(WORKING_DIR)/.pulumi
+GEN_PULUMI_CONVERT_EXAMPLES_CACHE_DIR := $(GEN_PULUMI_HOME)/examples-cache
+GEN_ENVS := PULUMI_HOME=$(GEN_PULUMI_HOME) PULUMI_CONVERT_EXAMPLES_CACHE_DIR=$(GEN_PULUMI_CONVERT_EXAMPLES_CACHE_DIR) PULUMI_CONVERT=$(PULUMI_CONVERT) PULUMI_DISABLE_AUTOMATIC_PLUGIN_ACQUISITION=$(PULUMI_CONVERT)
+
+.PHONY: generate_dotnet build_dotnet
+generate_dotnet: .make/generate_dotnet
+build_dotnet: .make/build_dotnet
+.make/generate_dotnet: export PATH := $(WORKING_DIR)/.pulumi/bin:$(PATH)
+.make/generate_dotnet: bin/$(TFGEN)
+	$(GEN_ENVS) $(WORKING_DIR)/bin/$(TFGEN) dotnet --out sdk/dotnet/
 	cd sdk/dotnet/ && \
 		printf "module fake_dotnet_module // Exclude this directory from Go tools\n\ngo 1.17\n" > go.mod && \
-		echo "$(VERSION_GENERIC)" >version.txt && \
-		dotnet build
+		echo "$(VERSION_GENERIC)" >version.txt
+	@touch $@
+.make/build_dotnet: .make/generate_dotnet
+	cd sdk/dotnet/ && dotnet build
+	@touch $@
 
 build_go: export PULUMI_HOME := $(WORKING_DIR)/.pulumi
 build_go: export PATH := $(WORKING_DIR)/.pulumi/bin:$(PATH)
@@ -263,7 +271,7 @@ ci-mgmt: .ci-mgmt.yaml
 debug_tfgen:
 	dlv  --listen=:2345 --headless=true --api-version=2  exec $(WORKING_DIR)/bin/$(TFGEN) -- schema --out provider/cmd/$(PROVIDER)
 
-.PHONY: development build build_sdks install_go_sdk install_java_sdk install_python_sdk install_sdks only_build build_dotnet build_go build_java build_nodejs build_python install_dotnet_sdk install_nodejs_sdk lint_provider provider provider_no_deps test ci-mgmt test_provider debug_tfgen
+.PHONY: development build build_sdks install_go_sdk install_java_sdk install_python_sdk install_sdks only_build build_go build_java build_nodejs build_python install_dotnet_sdk install_nodejs_sdk lint_provider provider provider_no_deps test ci-mgmt test_provider debug_tfgen
 
 # Provider cross-platform build & packaging
 

--- a/provider-ci/internal/pkg/templates/bridged-provider/Makefile
+++ b/provider-ci/internal/pkg/templates/bridged-provider/Makefile
@@ -56,11 +56,11 @@ _ := $(shell mkdir -p .make bin .pulumi/bin)
 development: build
 only_build: build
 # Build the provider and all SDKs and install ready for testing
-build: install_plugins provider build_sdks install_sdks
+build: install_plugins provider build_sdks install_sdks#{{- if .Config.RegistryDocs }}# build_registry_docs#{{- end }}#
 # Creates all generated files which need to be committed
 generate: generate_sdks schema#{{- if .Config.RegistryDocs }}# build_registry_docs#{{- end }}#
 generate_sdks:#{{ range .Config.Languages }}# generate_#{{ . }}##{{ end }}#
-build_sdks:#{{ range .Config.Languages }}# build_#{{ . }}##{{ end }}##{{- if .Config.RegistryDocs }}#build_registry_docs#{{- end }}#
+build_sdks:#{{ range .Config.Languages }}# build_#{{ . }}##{{ end }}#
 install_sdks:#{{ range .Config.Languages }}# install_#{{ . }}#_sdk#{{ end }}#
 .PHONY: development only_build build generate generate_sdks build_sdks install_sdks
 

--- a/provider-ci/internal/pkg/templates/bridged-provider/Makefile
+++ b/provider-ci/internal/pkg/templates/bridged-provider/Makefile
@@ -55,11 +55,14 @@ _ := $(shell mkdir -p .make bin .pulumi/bin)
 # Keep aliases for old targets to ensure backwards compatibility
 development: build
 only_build: build
+# Build the provider and all SDKs and install ready for testing
 build: install_plugins provider build_sdks install_sdks
+# Creates all generated files which need to be committed
+generate: generate_sdks schema#{{- if .Config.RegistryDocs }}# build_registry_docs#{{- end }}#
 generate_sdks:#{{ range .Config.Languages }}# generate_#{{ . }}##{{ end }}#
-build_sdks:#{{ range .Config.Languages }}# build_#{{ . }}##{{ end }}##{{- if .Config.RegistryDocs }}#.make/build_registry_docs#{{- end }}#
+build_sdks:#{{ range .Config.Languages }}# build_#{{ . }}##{{ end }}##{{- if .Config.RegistryDocs }}#build_registry_docs#{{- end }}#
 install_sdks:#{{ range .Config.Languages }}# install_#{{ . }}#_sdk#{{ end }}#
-.PHONY: development only_build build generate_sdks build_sdks install_sdks
+.PHONY: development only_build build generate generate_sdks build_sdks install_sdks
 
 GEN_PULUMI_HOME := $(WORKING_DIR)/.pulumi
 GEN_PULUMI_CONVERT_EXAMPLES_CACHE_DIR := $(GEN_PULUMI_HOME)/examples-cache

--- a/provider-ci/internal/pkg/templates/bridged-provider/Makefile
+++ b/provider-ci/internal/pkg/templates/bridged-provider/Makefile
@@ -185,6 +185,7 @@ test_provider:
 	@echo ""
 	cd provider && go test -v -short ./... -parallel $(TESTPARALLELISM)
 
+.PHONY: tfgen tfgen_no_deps tfgen_build_only
 tfgen: install_plugins upstream#{{ if .Config.DocsCmd }}# docs#{{ end }}# tfgen_no_deps
 
 tfgen_no_deps: export PULUMI_HOME := $(WORKING_DIR)/.pulumi
@@ -193,11 +194,13 @@ tfgen_no_deps: export PULUMI_CONVERT := $(PULUMI_CONVERT)
 tfgen_no_deps: export PULUMI_CONVERT_EXAMPLES_CACHE_DIR := $(WORKING_DIR)/.pulumi/examples-cache
 tfgen_no_deps: export PULUMI_DISABLE_AUTOMATIC_PLUGIN_ACQUISITION := $(PULUMI_CONVERT)
 tfgen_no_deps: export PULUMI_MISSING_DOCS_ERROR := $(PULUMI_MISSING_DOCS_ERROR)
-tfgen_no_deps: tfgen_build_only
+tfgen_no_deps: bin/$(TFGEN)
 	$(WORKING_DIR)/bin/$(TFGEN) schema --out provider/cmd/$(PROVIDER)
 	(cd provider && VERSION=$(VERSION_GENERIC) go generate cmd/$(PROVIDER)/main.go)
 
-tfgen_build_only:
+tfgen_build_only: bin/$(TFGEN)
+
+bin/$(TFGEN):
 	(cd provider && go build $(PULUMI_PROVIDER_BUILD_PARALLELISM) -o $(WORKING_DIR)/bin/$(TFGEN) -ldflags "$(LDFLAGS_PROJ_VERSION) $(LDFLAGS_EXTRAS)" $(PROJECT)/$(PROVIDER_PATH)/cmd/$(TFGEN))
 
 upstream:
@@ -248,7 +251,7 @@ ci-mgmt: .ci-mgmt.yaml
 debug_tfgen:
 	dlv  --listen=:2345 --headless=true --api-version=2  exec $(WORKING_DIR)/bin/$(TFGEN) -- schema --out provider/cmd/$(PROVIDER)
 
-.PHONY: development build build_sdks install_go_sdk install_java_sdk install_python_sdk install_sdks only_build build_dotnet build_go build_java build_nodejs build_python clean cleanup#{{ if .Config.DocsCmd }}# docs#{{end}}# help install_dotnet_sdk install_nodejs_sdk install_plugins lint_provider provider provider_no_deps test tfgen upstream ci-mgmt test_provider debug_tfgen tfgen_build_only
+.PHONY: development build build_sdks install_go_sdk install_java_sdk install_python_sdk install_sdks only_build build_dotnet build_go build_java build_nodejs build_python clean cleanup#{{ if .Config.DocsCmd }}# docs#{{end}}# help install_dotnet_sdk install_nodejs_sdk install_plugins lint_provider provider provider_no_deps test upstream ci-mgmt test_provider debug_tfgen
 
 # Provider cross-platform build & packaging
 

--- a/provider-ci/internal/pkg/templates/bridged-provider/Makefile
+++ b/provider-ci/internal/pkg/templates/bridged-provider/Makefile
@@ -97,16 +97,21 @@ build_go: .make/build_go
 	cd sdk && go list "$$(grep -e "^module" go.mod | cut -d ' ' -f 2)/go/..." | xargs -I {} bash -c 'go build {} && go clean -i {}'
 	@touch $@
 
-build_java: PACKAGE_VERSION := $(VERSION_GENERIC)
-build_java: export PULUMI_HOME := $(WORKING_DIR)/.pulumi
-build_java: export PATH := $(WORKING_DIR)/.pulumi/bin:$(PATH)
-build_java: export PULUMI_CONVERT_EXAMPLES_CACHE_DIR := $(WORKING_DIR)/.pulumi/examples-cache
-build_java: bin/pulumi-java-gen .make/upstream
-	$(WORKING_DIR)/bin/$(JAVA_GEN) generate --schema provider/cmd/$(PROVIDER)/schema.json --out sdk/java  --build gradle-nexus
+.PHONY: generate_java build_java
+generate_java: .make/generate_java
+build_java: .make/build_java
+.make/generate_java: export PATH := $(WORKING_DIR)/.pulumi/bin:$(PATH)
+.make/generate_java: PACKAGE_VERSION := $(VERSION_GENERIC)
+.make/generate_java: bin/pulumi-java-gen .make/schema
+	PULUMI_HOME=$(GEN_PULUMI_HOME) PULUMI_CONVERT_EXAMPLES_CACHE_DIR=$(GEN_PULUMI_CONVERT_EXAMPLES_CACHE_DIR) bin/$(JAVA_GEN) generate --schema provider/cmd/$(PROVIDER)/schema.json --out sdk/java  --build gradle-nexus
+	printf "module fake_java_module // Exclude this directory from Go tools\n\ngo 1.17\n" > sdk/java/go.mod
+	@touch $@
+.make/build_java: PACKAGE_VERSION := $(VERSION_GENERIC)
+.make/build_java: .make/generate_java
 	cd sdk/java/ && \
-		printf "module fake_java_module // Exclude this directory from Go tools\n\ngo 1.17\n" > go.mod && \
 		gradle --console=plain build && \
 		gradle --console=plain javadoc
+	@touch $@
 
 .PHONY: generate_nodejs build_nodejs
 generate_nodejs: .make/generate_nodejs
@@ -282,7 +287,7 @@ ci-mgmt: .ci-mgmt.yaml
 debug_tfgen:
 	dlv  --listen=:2345 --headless=true --api-version=2  exec $(WORKING_DIR)/bin/$(TFGEN) -- schema --out provider/cmd/$(PROVIDER)
 
-.PHONY: development build build_sdks install_go_sdk install_java_sdk install_python_sdk install_sdks only_build build_java install_dotnet_sdk install_nodejs_sdk lint_provider provider provider_no_deps test ci-mgmt test_provider debug_tfgen
+.PHONY: development build build_sdks install_go_sdk install_java_sdk install_python_sdk install_sdks only_build install_dotnet_sdk install_nodejs_sdk lint_provider provider provider_no_deps test ci-mgmt test_provider debug_tfgen
 
 # Provider cross-platform build & packaging
 

--- a/provider-ci/internal/pkg/templates/bridged-provider/Makefile
+++ b/provider-ci/internal/pkg/templates/bridged-provider/Makefile
@@ -108,16 +108,20 @@ build_java: bin/pulumi-java-gen .make/upstream
 		gradle --console=plain build && \
 		gradle --console=plain javadoc
 
-build_nodejs: export PULUMI_HOME := $(WORKING_DIR)/.pulumi
-build_nodejs: export PATH := $(WORKING_DIR)/.pulumi/bin:$(PATH)
-build_nodejs: export PULUMI_CONVERT_EXAMPLES_CACHE_DIR := $(WORKING_DIR)/.pulumi/examples-cache
-build_nodejs: .make/upstream
-	PULUMI_CONVERT=$(PULUMI_CONVERT) PULUMI_DISABLE_AUTOMATIC_PLUGIN_ACQUISITION=$(PULUMI_CONVERT) $(WORKING_DIR)/bin/$(TFGEN) nodejs --out sdk/nodejs/
+.PHONY: generate_nodejs build_nodejs
+generate_nodejs: .make/generate_nodejs
+build_nodejs: .make/build_nodejs
+.make/generate_nodejs: export PATH := $(WORKING_DIR)/.pulumi/bin:$(PATH)
+.make/generate_nodejs: bin/$(TFGEN)
+	$(GEN_ENVS) $(WORKING_DIR)/bin/$(TFGEN) nodejs --out sdk/nodejs/
+	printf "module fake_nodejs_module // Exclude this directory from Go tools\n\ngo 1.17\n" > sdk/nodejs/go.mod
+	@touch $@
+.make/build_nodejs: .make/generate_nodejs
 	cd sdk/nodejs/ && \
-		printf "module fake_nodejs_module // Exclude this directory from Go tools\n\ngo 1.17\n" > go.mod && \
 		yarn install && \
 		yarn run tsc && \
 		cp ../../README.md ../../LICENSE* package.json yarn.lock ./bin/
+	@touch $@
 
 build_python: export PULUMI_HOME := $(WORKING_DIR)/.pulumi
 build_python: export PATH := $(WORKING_DIR)/.pulumi/bin:$(PATH)
@@ -275,7 +279,7 @@ ci-mgmt: .ci-mgmt.yaml
 debug_tfgen:
 	dlv  --listen=:2345 --headless=true --api-version=2  exec $(WORKING_DIR)/bin/$(TFGEN) -- schema --out provider/cmd/$(PROVIDER)
 
-.PHONY: development build build_sdks install_go_sdk install_java_sdk install_python_sdk install_sdks only_build build_java build_nodejs build_python install_dotnet_sdk install_nodejs_sdk lint_provider provider provider_no_deps test ci-mgmt test_provider debug_tfgen
+.PHONY: development build build_sdks install_go_sdk install_java_sdk install_python_sdk install_sdks only_build build_java build_python install_dotnet_sdk install_nodejs_sdk lint_provider provider provider_no_deps test ci-mgmt test_provider debug_tfgen
 
 # Provider cross-platform build & packaging
 

--- a/provider-ci/internal/pkg/templates/bridged-provider/Makefile
+++ b/provider-ci/internal/pkg/templates/bridged-provider/Makefile
@@ -156,6 +156,9 @@ clean:
 	rm -rf sdk/{dotnet,nodejs,go,python}
 	rm -rf bin/*
 	rm -rf .make/*
+	if dotnet nuget list source | grep "$(WORKING_DIR)/nuget"; then \
+		dotnet nuget remove source "$(WORKING_DIR)/nuget" \
+	; fi
 .PHONY: clean
 
 #{{- if .Config.DocsCmd }}#
@@ -168,8 +171,11 @@ docs: .make/docs
 
 install_dotnet_sdk: .make/install_dotnet_sdk
 .make/install_dotnet_sdk: .make/build_dotnet
-	mkdir -p $(WORKING_DIR)/nuget
-	find . -name '*.nupkg' -print -exec cp -p {} $(WORKING_DIR)/nuget \;
+	mkdir -p nuget
+	find sdk/dotnet/bin -name '*.nupkg' -print -exec cp -p "{}" ${WORKING_DIR}/nuget \;
+	if ! dotnet nuget list source | grep "${WORKING_DIR}/nuget"; then \
+		dotnet nuget add source "${WORKING_DIR}/nuget" --name "${WORKING_DIR}/nuget" \
+	; fi
 	@touch $@
 install_go_sdk:
 install_java_sdk:

--- a/provider-ci/internal/pkg/templates/bridged-provider/Makefile
+++ b/provider-ci/internal/pkg/templates/bridged-provider/Makefile
@@ -52,21 +52,20 @@ LDFLAGS=$(LDFLAGS_PROJ_VERSION) $(LDFLAGS_UPSTREAM_VERSION) $(LDFLAGS_EXTRAS) $(
 # Ensure all directories exist before evaluating targets to avoid issues with `touch` creating directories.
 _ := $(shell mkdir -p .make bin .pulumi/bin)
 
-development: .make/install_plugins provider build_sdks install_sdks
-
-build: .make/install_plugins provider build_sdks install_sdks
-
-build_sdks: #{{ range .Config.Languages }}#build_#{{ . }}# #{{ end }}##{{- if .Config.RegistryDocs }}#.make/build_registry_docs#{{- end }}#
+.PHONY: development only_build build generate_sdks build_sdks install_sdks
+# Keep aliases for old targets to ensure backwards compatibility
+development: build
+only_build: build
+build: install_plugins provider build_sdks install_sdks
+generate_sdks:#{{ range .Config.Languages }}# generate_#{{ . }}##{{ end }}#
+build_sdks:#{{ range .Config.Languages }}# build_#{{ . }}##{{ end }}##{{- if .Config.RegistryDocs }}#.make/build_registry_docs#{{- end }}#
+install_sdks:#{{ range .Config.Languages }}# install_#{{ . }}#_sdk#{{ end }}#
 
 install_go_sdk:
 
 install_java_sdk:
 
 install_python_sdk:
-
-install_sdks: install_dotnet_sdk install_python_sdk install_nodejs_sdk install_java_sdk
-
-only_build: build
 
 GEN_PULUMI_HOME := $(WORKING_DIR)/.pulumi
 GEN_PULUMI_CONVERT_EXAMPLES_CACHE_DIR := $(GEN_PULUMI_HOME)/examples-cache
@@ -287,7 +286,7 @@ ci-mgmt: .ci-mgmt.yaml
 debug_tfgen:
 	dlv  --listen=:2345 --headless=true --api-version=2  exec $(WORKING_DIR)/bin/$(TFGEN) -- schema --out provider/cmd/$(PROVIDER)
 
-.PHONY: development build build_sdks install_go_sdk install_java_sdk install_python_sdk install_sdks only_build install_dotnet_sdk install_nodejs_sdk lint_provider provider provider_no_deps test ci-mgmt test_provider debug_tfgen
+.PHONY: install_go_sdk install_java_sdk install_python_sdk install_sdks install_dotnet_sdk install_nodejs_sdk lint_provider test ci-mgmt test_provider debug_tfgen
 
 # Provider cross-platform build & packaging
 

--- a/provider-ci/internal/pkg/templates/bridged-provider/Makefile
+++ b/provider-ci/internal/pkg/templates/bridged-provider/Makefile
@@ -129,12 +129,11 @@ build_registry_docs:
 	$(WORKING_DIR)/bin/$(TFGEN) registry-docs --out $(WORKING_DIR)/docs
 #{{- end }}#
 
+.PHONY: clean
 clean:
 	rm -rf sdk/{dotnet,nodejs,go,python}
-
-cleanup:
-	rm -r $(WORKING_DIR)/bin
-	rm -f provider/cmd/$(PROVIDER)/schema.go
+	rm -rf bin/*
+	rm -rf .make/*
 
 #{{- if .Config.DocsCmd }}#
 
@@ -261,7 +260,7 @@ ci-mgmt: .ci-mgmt.yaml
 debug_tfgen:
 	dlv  --listen=:2345 --headless=true --api-version=2  exec $(WORKING_DIR)/bin/$(TFGEN) -- schema --out provider/cmd/$(PROVIDER)
 
-.PHONY: development build build_sdks install_go_sdk install_java_sdk install_python_sdk install_sdks only_build build_dotnet build_go build_java build_nodejs build_python clean cleanup#{{ if .Config.DocsCmd }}# docs#{{end}}# help install_dotnet_sdk install_nodejs_sdk lint_provider provider provider_no_deps test ci-mgmt test_provider debug_tfgen
+.PHONY: development build build_sdks install_go_sdk install_java_sdk install_python_sdk install_sdks only_build build_dotnet build_go build_java build_nodejs build_python#{{ if .Config.DocsCmd }}# docs#{{end}}# help install_dotnet_sdk install_nodejs_sdk lint_provider provider provider_no_deps test ci-mgmt test_provider debug_tfgen
 
 # Provider cross-platform build & packaging
 

--- a/provider-ci/internal/pkg/templates/bridged-provider/Makefile
+++ b/provider-ci/internal/pkg/templates/bridged-provider/Makefile
@@ -50,9 +50,9 @@ LDFLAGS=$(LDFLAGS_PROJ_VERSION) $(LDFLAGS_UPSTREAM_VERSION) $(LDFLAGS_EXTRAS) $(
 # At the end of each internal target we run `@touch $@` to update the file which is the name of the target.
 _ := $(shell mkdir -p .make)
 
-development: install_plugins provider build_sdks install_sdks
+development: .make/install_plugins provider build_sdks install_sdks
 
-build: install_plugins provider build_sdks install_sdks
+build: .make/install_plugins provider build_sdks install_sdks
 
 build_sdks: #{{ range .Config.Languages }}#build_#{{ . }}# #{{ end }}##{{- if .Config.RegistryDocs }}#build_registry_docs#{{- end }}#
 
@@ -152,12 +152,15 @@ install_dotnet_sdk:
 install_nodejs_sdk:
 	yarn link --cwd $(WORKING_DIR)/sdk/nodejs/bin
 
-install_plugins: export PULUMI_HOME := $(WORKING_DIR)/.pulumi
-install_plugins: export PATH := $(WORKING_DIR)/.pulumi/bin:$(PATH)
-install_plugins: .pulumi/bin/pulumi
+.PHONY: install_plugins
+install_plugins: .make/install_plugins
+.make/install_plugins: export PULUMI_HOME := $(WORKING_DIR)/.pulumi
+.make/install_plugins: export PATH := $(WORKING_DIR)/.pulumi/bin:$(PATH)
+.make/install_plugins: .pulumi/bin/pulumi
 	#{{- range .Config.Plugins }}#
 	.pulumi/bin/pulumi plugin install #{{ or .Kind "resource" }}# #{{ .Name }}# #{{ .Version }}#
 	#{{- end }}#
+	@touch $@
 
 lint_provider: provider
 	cd provider && golangci-lint run --path-prefix provider -c ../.golangci.yml
@@ -252,7 +255,7 @@ ci-mgmt: .ci-mgmt.yaml
 debug_tfgen:
 	dlv  --listen=:2345 --headless=true --api-version=2  exec $(WORKING_DIR)/bin/$(TFGEN) -- schema --out provider/cmd/$(PROVIDER)
 
-.PHONY: development build build_sdks install_go_sdk install_java_sdk install_python_sdk install_sdks only_build build_dotnet build_go build_java build_nodejs build_python clean cleanup#{{ if .Config.DocsCmd }}# docs#{{end}}# help install_dotnet_sdk install_nodejs_sdk install_plugins lint_provider provider provider_no_deps test ci-mgmt test_provider debug_tfgen
+.PHONY: development build build_sdks install_go_sdk install_java_sdk install_python_sdk install_sdks only_build build_dotnet build_go build_java build_nodejs build_python clean cleanup#{{ if .Config.DocsCmd }}# docs#{{end}}# help install_dotnet_sdk install_nodejs_sdk lint_provider provider provider_no_deps test ci-mgmt test_provider debug_tfgen
 
 # Provider cross-platform build & packaging
 

--- a/provider-ci/internal/pkg/templates/bridged-provider/Makefile
+++ b/provider-ci/internal/pkg/templates/bridged-provider/Makefile
@@ -143,11 +143,6 @@ docs: .make/docs
 	@touch $@
 #{{- end }}#
 
-help:
-	@grep '^[^.#]\+:\s\+.*#' Makefile | \
-	sed "s/\(.\+\):\s*\(.*\) #\s*\(.*\)/`printf "\033[93m"`\1`printf "\033[0m"`	\3 [\2]/" | \
-	expand -t20
-
 install_dotnet_sdk:
 	mkdir -p $(WORKING_DIR)/nuget
 	find . -name '*.nupkg' -print -exec cp -p {} $(WORKING_DIR)/nuget \;
@@ -262,7 +257,7 @@ ci-mgmt: .ci-mgmt.yaml
 debug_tfgen:
 	dlv  --listen=:2345 --headless=true --api-version=2  exec $(WORKING_DIR)/bin/$(TFGEN) -- schema --out provider/cmd/$(PROVIDER)
 
-.PHONY: development build build_sdks install_go_sdk install_java_sdk install_python_sdk install_sdks only_build build_dotnet build_go build_java build_nodejs build_python help install_dotnet_sdk install_nodejs_sdk lint_provider provider provider_no_deps test ci-mgmt test_provider debug_tfgen
+.PHONY: development build build_sdks install_go_sdk install_java_sdk install_python_sdk install_sdks only_build build_dotnet build_go build_java build_nodejs build_python install_dotnet_sdk install_nodejs_sdk lint_provider provider provider_no_deps test ci-mgmt test_provider debug_tfgen
 
 # Provider cross-platform build & packaging
 

--- a/provider-ci/internal/pkg/templates/bridged-provider/Makefile
+++ b/provider-ci/internal/pkg/templates/bridged-provider/Makefile
@@ -123,21 +123,24 @@ build_nodejs: .make/build_nodejs
 		cp ../../README.md ../../LICENSE* package.json yarn.lock ./bin/
 	@touch $@
 
-build_python: export PULUMI_HOME := $(WORKING_DIR)/.pulumi
-build_python: export PATH := $(WORKING_DIR)/.pulumi/bin:$(PATH)
-build_python: export PULUMI_CONVERT_EXAMPLES_CACHE_DIR := $(WORKING_DIR)/.pulumi/examples-cache
-build_python: .make/upstream
-	rm -rf sdk/python/
-	PULUMI_CONVERT=$(PULUMI_CONVERT) PULUMI_DISABLE_AUTOMATIC_PLUGIN_ACQUISITION=$(PULUMI_CONVERT) $(WORKING_DIR)/bin/$(TFGEN) python --out sdk/python/
+.PHONY: generate_python build_python
+generate_python: .make/generate_python
+build_python: .make/build_python
+.make/generate_python: export PATH := $(WORKING_DIR)/.pulumi/bin:$(PATH)
+.make/generate_python: bin/$(TFGEN)
+	$(GEN_ENVS) $(WORKING_DIR)/bin/$(TFGEN) python --out sdk/python/
+	printf "module fake_python_module // Exclude this directory from Go tools\n\ngo 1.17\n" > sdk/python/go.mod
+	cp README.md sdk/python/
+	@touch $@
+.make/build_python: .make/generate_python
 	cd sdk/python/ && \
-		printf "module fake_python_module // Exclude this directory from Go tools\n\ngo 1.17\n" > go.mod && \
-		cp ../../README.md . && \
 		rm -rf ./bin/ ../python.bin/ && cp -R . ../python.bin && mv ../python.bin ./bin && \
 		rm ./bin/go.mod && \
 		python3 -m venv venv && \
 		./venv/bin/python -m pip install build==1.2.1 && \
 		cd ./bin && \
 		../venv/bin/python -m build .
+	@touch $@
 
 #{{- if .Config.RegistryDocs }}#
 # Run the bridge's registry-docs command to generated the content of the installation docs/ folder at provider repo root
@@ -279,7 +282,7 @@ ci-mgmt: .ci-mgmt.yaml
 debug_tfgen:
 	dlv  --listen=:2345 --headless=true --api-version=2  exec $(WORKING_DIR)/bin/$(TFGEN) -- schema --out provider/cmd/$(PROVIDER)
 
-.PHONY: development build build_sdks install_go_sdk install_java_sdk install_python_sdk install_sdks only_build build_java build_python install_dotnet_sdk install_nodejs_sdk lint_provider provider provider_no_deps test ci-mgmt test_provider debug_tfgen
+.PHONY: development build build_sdks install_go_sdk install_java_sdk install_python_sdk install_sdks only_build build_java install_dotnet_sdk install_nodejs_sdk lint_provider provider provider_no_deps test ci-mgmt test_provider debug_tfgen
 
 # Provider cross-platform build & packaging
 

--- a/provider-ci/internal/pkg/templates/bridged-provider/Makefile
+++ b/provider-ci/internal/pkg/templates/bridged-provider/Makefile
@@ -56,7 +56,7 @@ development: .make/install_plugins provider build_sdks install_sdks
 
 build: .make/install_plugins provider build_sdks install_sdks
 
-build_sdks: #{{ range .Config.Languages }}#build_#{{ . }}# #{{ end }}##{{- if .Config.RegistryDocs }}#build_registry_docs#{{- end }}#
+build_sdks: #{{ range .Config.Languages }}#build_#{{ . }}# #{{ end }}##{{- if .Config.RegistryDocs }}#.make/build_registry_docs#{{- end }}#
 
 install_go_sdk:
 
@@ -122,11 +122,14 @@ build_python: .make/upstream
 		./venv/bin/python -m pip install build==1.2.1 && \
 		cd ./bin && \
 		../venv/bin/python -m build .
-#{{- if .Config.RegistryDocs }}#
 
+#{{- if .Config.RegistryDocs }}#
 # Run the bridge's registry-docs command to generated the content of the installation docs/ folder at provider repo root
-build_registry_docs:
-	$(WORKING_DIR)/bin/$(TFGEN) registry-docs --out $(WORKING_DIR)/docs
+.PHONY: build_registry_docs
+build_registry_docs: .make/build_registry_docs
+.make/build_registry_docs: bin/$(TFGEN)
+	bin/$(TFGEN) registry-docs --out $(WORKING_DIR)/docs
+	@touch $@
 #{{- end }}#
 
 .PHONY: clean

--- a/provider-ci/internal/pkg/templates/bridged-provider/Makefile
+++ b/provider-ci/internal/pkg/templates/bridged-provider/Makefile
@@ -52,11 +52,14 @@ LDFLAGS=$(LDFLAGS_PROJ_VERSION) $(LDFLAGS_UPSTREAM_VERSION) $(LDFLAGS_EXTRAS) $(
 # Ensure all directories exist before evaluating targets to avoid issues with `touch` creating directories.
 _ := $(shell mkdir -p .make bin .pulumi/bin)
 
+# Build the provider and all SDKs and install ready for testing
+build: install_plugins provider build_sdks install_sdks#{{- if .Config.RegistryDocs }}# build_registry_docs#{{- end }}#
 # Keep aliases for old targets to ensure backwards compatibility
 development: build
 only_build: build
-# Build the provider and all SDKs and install ready for testing
-build: install_plugins provider build_sdks install_sdks#{{- if .Config.RegistryDocs }}# build_registry_docs#{{- end }}#
+# Prepare the workspace for building the provider and SDKs
+# Importantly this is run by CI ahead of restoring the bin directory and resuming SDK builds
+prepare_local_workspace: install_plugins upstream
 # Creates all generated files which need to be committed
 generate: generate_sdks schema#{{- if .Config.RegistryDocs }}# build_registry_docs#{{- end }}#
 generate_sdks:#{{ range .Config.Languages }}# generate_#{{ . }}##{{ end }}#
@@ -186,6 +189,7 @@ install_nodejs_sdk: .make/install_nodejs_sdk
 install_python_sdk:
 .PHONY: install_dotnet_sdk install_go_sdk install_java_sdk install_nodejs_sdk install_python_sdk
 
+# Install Pulumi plugins required for TFGen to resolve references
 install_plugins: .make/install_plugins
 .make/install_plugins: export PULUMI_HOME := $(WORKING_DIR)/.pulumi
 .make/install_plugins: export PATH := $(WORKING_DIR)/.pulumi/bin:$(PATH)
@@ -243,6 +247,7 @@ bin/$(TFGEN):
 	(cd provider && go build $(PULUMI_PROVIDER_BUILD_PARALLELISM) -o $(WORKING_DIR)/bin/$(TFGEN) -ldflags "$(LDFLAGS_PROJ_VERSION) $(LDFLAGS_EXTRAS)" $(PROJECT)/$(PROVIDER_PATH)/cmd/$(TFGEN))
 .PHONY: tfgen schema tfgen_no_deps tfgen_build_only
 
+# Apply patches to the upstream submodule, if it exists
 upstream: .make/upstream
 # Re-run if the upstream commit or the patches change
 .make/upstream: $(wildcard patches/*) $(wildcard .git/modules/upstream/HEAD)

--- a/provider-ci/internal/pkg/templates/bridged-provider/Makefile
+++ b/provider-ci/internal/pkg/templates/bridged-provider/Makefile
@@ -174,10 +174,13 @@ lint_provider.fix:
 # `make provider_no_deps` builds the provider binary directly, without ensuring that
 # `cmd/pulumi-resource-#{{ .Config.Provider }}#/schema.json` is valid and up to date.
 # To create a release ready binary, you should use `make provider`.
+.PHONY: provider provider_no_deps
+build_provider_cmd = cd provider && go build $(PULUMI_PROVIDER_BUILD_PARALLELISM) -o $(WORKING_DIR)/bin/$(PROVIDER) -ldflags "$(LDFLAGS)" $(PROJECT)/$(PROVIDER_PATH)/cmd/$(PROVIDER)
+provider: bin/$(PROVIDER)
 provider_no_deps:
-	(cd provider && go build $(PULUMI_PROVIDER_BUILD_PARALLELISM) -o $(WORKING_DIR)/bin/$(PROVIDER) -ldflags "$(LDFLAGS)" $(PROJECT)/$(PROVIDER_PATH)/cmd/$(PROVIDER))
-
-provider: tfgen provider_no_deps
+	$(call build_provider_cmd)
+bin/$(PROVIDER): .make/schema
+	$(call build_provider_cmd)
 
 test: export PATH := $(WORKING_DIR)/bin:$(PATH)
 test:

--- a/provider-ci/internal/pkg/templates/bridged-provider/Makefile
+++ b/provider-ci/internal/pkg/templates/bridged-provider/Makefile
@@ -188,18 +188,22 @@ test_provider:
 	@echo ""
 	cd provider && go test -v -short ./... -parallel $(TESTPARALLELISM)
 
-.PHONY: tfgen tfgen_no_deps tfgen_build_only
-tfgen: install_plugins upstream#{{ if .Config.DocsCmd }}# docs#{{ end }}# tfgen_no_deps
+.PHONY: tfgen schema tfgen_no_deps tfgen_build_only
+tfgen: schema
+schema: .make/schema #{{ if .Config.DocsCmd }}# docs#{{ end }}#
+# This does actually have dependencies, but we're keeping it around for backwards compatibility for now
+tfgen_no_deps: .make/schema
 
-tfgen_no_deps: export PULUMI_HOME := $(WORKING_DIR)/.pulumi
-tfgen_no_deps: export PATH := $(WORKING_DIR)/.pulumi/bin:$(PATH)
-tfgen_no_deps: export PULUMI_CONVERT := $(PULUMI_CONVERT)
-tfgen_no_deps: export PULUMI_CONVERT_EXAMPLES_CACHE_DIR := $(WORKING_DIR)/.pulumi/examples-cache
-tfgen_no_deps: export PULUMI_DISABLE_AUTOMATIC_PLUGIN_ACQUISITION := $(PULUMI_CONVERT)
-tfgen_no_deps: export PULUMI_MISSING_DOCS_ERROR := $(PULUMI_MISSING_DOCS_ERROR)
-tfgen_no_deps: bin/$(TFGEN)
+.make/schema: export PULUMI_HOME := $(WORKING_DIR)/.pulumi
+.make/schema: export PATH := $(WORKING_DIR)/.pulumi/bin:$(PATH)
+.make/schema: export PULUMI_CONVERT := $(PULUMI_CONVERT)
+.make/schema: export PULUMI_CONVERT_EXAMPLES_CACHE_DIR := $(WORKING_DIR)/.pulumi/examples-cache
+.make/schema: export PULUMI_DISABLE_AUTOMATIC_PLUGIN_ACQUISITION := $(PULUMI_CONVERT)
+.make/schema: export PULUMI_MISSING_DOCS_ERROR := $(PULUMI_MISSING_DOCS_ERROR)
+.make/schema: bin/$(TFGEN) provider/resources.go provider/go.mod .make/install_plugins .make/upstream
 	$(WORKING_DIR)/bin/$(TFGEN) schema --out provider/cmd/$(PROVIDER)
 	(cd provider && VERSION=$(VERSION_GENERIC) go generate cmd/$(PROVIDER)/main.go)
+	@touch $@
 
 tfgen_build_only: bin/$(TFGEN)
 

--- a/provider-ci/internal/pkg/templates/bridged-provider/Makefile
+++ b/provider-ci/internal/pkg/templates/bridged-provider/Makefile
@@ -189,11 +189,11 @@ install_plugins: .make/install_plugins
 
 lint_provider: provider
 	cd provider && golangci-lint run --path-prefix provider -c ../.golangci.yml
-
 # `lint_provider.fix` is a utility target meant to be run manually
 # that will run the linter and fix errors when possible.
 lint_provider.fix:
 	cd provider && golangci-lint run --path-prefix provider -c ../.golangci.yml --fix
+.PHONY: lint_provider lint_provider.fix
 
 # `make provider_no_deps` builds the provider binary directly, without ensuring that
 # `cmd/pulumi-resource-#{{ .Config.Provider }}#/schema.json` is valid and up to date.
@@ -209,12 +209,11 @@ bin/$(PROVIDER): .make/schema
 test: export PATH := $(WORKING_DIR)/bin:$(PATH)
 test:
 	cd examples && go test -v -tags=all -parallel $(TESTPARALLELISM) -timeout 2h
+.PHONY: test
 
 test_provider:
-	@echo ""
-	@echo "== test_provider ==================================================================="
-	@echo ""
 	cd provider && go test -v -short ./... -parallel $(TESTPARALLELISM)
+.PHONY: test_provider
 
 .PHONY: tfgen schema tfgen_no_deps tfgen_build_only
 tfgen: schema
@@ -263,6 +262,7 @@ bin/pulumi-java-gen: .pulumi-java-gen.version
 #
 ci-mgmt: .ci-mgmt.yaml
 	go run github.com/pulumi/ci-mgmt/provider-ci@master generate
+.PHONY: ci-mgmt
 
 # Because some codegen depends on the version of the CLI used, we install a local CLI
 # version pinned to the same version as `provider/go.mod`.
@@ -286,8 +286,7 @@ ci-mgmt: .ci-mgmt.yaml
 # Start debug server for tfgen
 debug_tfgen:
 	dlv  --listen=:2345 --headless=true --api-version=2  exec $(WORKING_DIR)/bin/$(TFGEN) -- schema --out provider/cmd/$(PROVIDER)
-
-.PHONY: lint_provider test ci-mgmt test_provider debug_tfgen
+.PHONY: debug_tfgen
 
 # Provider cross-platform build & packaging
 

--- a/provider-ci/internal/pkg/templates/bridged-provider/Makefile
+++ b/provider-ci/internal/pkg/templates/bridged-provider/Makefile
@@ -61,12 +61,6 @@ generate_sdks:#{{ range .Config.Languages }}# generate_#{{ . }}##{{ end }}#
 build_sdks:#{{ range .Config.Languages }}# build_#{{ . }}##{{ end }}##{{- if .Config.RegistryDocs }}#.make/build_registry_docs#{{- end }}#
 install_sdks:#{{ range .Config.Languages }}# install_#{{ . }}#_sdk#{{ end }}#
 
-install_go_sdk:
-
-install_java_sdk:
-
-install_python_sdk:
-
 GEN_PULUMI_HOME := $(WORKING_DIR)/.pulumi
 GEN_PULUMI_CONVERT_EXAMPLES_CACHE_DIR := $(GEN_PULUMI_HOME)/examples-cache
 GEN_ENVS := PULUMI_HOME=$(GEN_PULUMI_HOME) PULUMI_CONVERT_EXAMPLES_CACHE_DIR=$(GEN_PULUMI_CONVERT_EXAMPLES_CACHE_DIR) PULUMI_CONVERT=$(PULUMI_CONVERT) PULUMI_DISABLE_AUTOMATIC_PLUGIN_ACQUISITION=$(PULUMI_CONVERT)
@@ -169,12 +163,19 @@ docs: .make/docs
 	@touch $@
 #{{- end }}#
 
-install_dotnet_sdk:
+.PHONY: install_dotnet_sdk install_go_sdk install_java_sdk install_nodejs_sdk install_python_sdk
+install_dotnet_sdk: .make/install_dotnet_sdk
+.make/install_dotnet_sdk: .make/build_dotnet
 	mkdir -p $(WORKING_DIR)/nuget
 	find . -name '*.nupkg' -print -exec cp -p {} $(WORKING_DIR)/nuget \;
-
-install_nodejs_sdk:
+	@touch $@
+install_go_sdk:
+install_java_sdk:
+install_nodejs_sdk: .make/install_nodejs_sdk
+.make/install_nodejs_sdk: .make/build_nodejs
 	yarn link --cwd $(WORKING_DIR)/sdk/nodejs/bin
+	@touch $@
+install_python_sdk:
 
 .PHONY: install_plugins
 install_plugins: .make/install_plugins
@@ -286,7 +287,7 @@ ci-mgmt: .ci-mgmt.yaml
 debug_tfgen:
 	dlv  --listen=:2345 --headless=true --api-version=2  exec $(WORKING_DIR)/bin/$(TFGEN) -- schema --out provider/cmd/$(PROVIDER)
 
-.PHONY: install_go_sdk install_java_sdk install_python_sdk install_sdks install_dotnet_sdk install_nodejs_sdk lint_provider test ci-mgmt test_provider debug_tfgen
+.PHONY: lint_provider test ci-mgmt test_provider debug_tfgen
 
 # Provider cross-platform build & packaging
 

--- a/provider-ci/internal/pkg/templates/bridged-provider/Makefile
+++ b/provider-ci/internal/pkg/templates/bridged-provider/Makefile
@@ -245,6 +245,7 @@ ci-mgmt: .ci-mgmt.yaml
 .pulumi/bin/pulumi: .pulumi/version
 	@if [ -x .pulumi/bin/pulumi ] && [ "v$$(cat .pulumi/version)" = "$$(.pulumi/bin/pulumi version)" ]; then \
 		echo "pulumi/bin/pulumi version: v$$(cat .pulumi/version)"; \
+		touch $@; \
 	else \
 		curl -fsSL https://get.pulumi.com | \
 			HOME=$(WORKING_DIR) sh -s -- --version "$$(cat .pulumi/version)"; \

--- a/provider-ci/internal/pkg/templates/bridged-provider/Makefile
+++ b/provider-ci/internal/pkg/templates/bridged-provider/Makefile
@@ -86,12 +86,16 @@ build_dotnet: .make/build_dotnet
 	cd sdk/dotnet/ && dotnet build
 	@touch $@
 
-build_go: export PULUMI_HOME := $(WORKING_DIR)/.pulumi
-build_go: export PATH := $(WORKING_DIR)/.pulumi/bin:$(PATH)
-build_go: export PULUMI_CONVERT_EXAMPLES_CACHE_DIR := $(WORKING_DIR)/.pulumi/examples-cache
-build_go: .make/upstream
-	PULUMI_CONVERT=$(PULUMI_CONVERT) PULUMI_DISABLE_AUTOMATIC_PLUGIN_ACQUISITION=$(PULUMI_CONVERT) $(WORKING_DIR)/bin/$(TFGEN) go --out sdk/go/
+.PHONY: generate_go build_go
+generate_go: .make/generate_go
+build_go: .make/build_go
+.make/generate_go: export PATH := $(WORKING_DIR)/.pulumi/bin:$(PATH)
+.make/generate_go: bin/$(TFGEN)
+	$(GEN_ENVS) $(WORKING_DIR)/bin/$(TFGEN) go --out sdk/go/
+	@touch $@
+.make/build_go: .make/generate_go
 	cd sdk && go list "$$(grep -e "^module" go.mod | cut -d ' ' -f 2)/go/..." | xargs -I {} bash -c 'go build {} && go clean -i {}'
+	@touch $@
 
 build_java: PACKAGE_VERSION := $(VERSION_GENERIC)
 build_java: export PULUMI_HOME := $(WORKING_DIR)/.pulumi
@@ -271,7 +275,7 @@ ci-mgmt: .ci-mgmt.yaml
 debug_tfgen:
 	dlv  --listen=:2345 --headless=true --api-version=2  exec $(WORKING_DIR)/bin/$(TFGEN) -- schema --out provider/cmd/$(PROVIDER)
 
-.PHONY: development build build_sdks install_go_sdk install_java_sdk install_python_sdk install_sdks only_build build_go build_java build_nodejs build_python install_dotnet_sdk install_nodejs_sdk lint_provider provider provider_no_deps test ci-mgmt test_provider debug_tfgen
+.PHONY: development build build_sdks install_go_sdk install_java_sdk install_python_sdk install_sdks only_build build_java build_nodejs build_python install_dotnet_sdk install_nodejs_sdk lint_provider provider provider_no_deps test ci-mgmt test_provider debug_tfgen
 
 # Provider cross-platform build & packaging
 

--- a/provider-ci/internal/pkg/templates/bridged-provider/Makefile
+++ b/provider-ci/internal/pkg/templates/bridged-provider/Makefile
@@ -48,7 +48,9 @@ LDFLAGS=$(LDFLAGS_PROJ_VERSION) $(LDFLAGS_UPSTREAM_VERSION) $(LDFLAGS_EXTRAS) $(
 # file within `.make/` to track the staleness of the target and only rebuild when needed. 
 # For each phony target, we create an internal target with the same name, but prefixed with `.make/` where the work is performed.
 # At the end of each internal target we run `@touch $@` to update the file which is the name of the target.
-_ := $(shell mkdir -p .make)
+
+# Ensure all directories exist before evaluating targets to avoid issues with `touch` creating directories.
+_ := $(shell mkdir -p .make bin .pulumi/bin)
 
 development: .make/install_plugins provider build_sdks install_sdks
 
@@ -253,8 +255,7 @@ ci-mgmt: .ci-mgmt.yaml
 
 # Compute the version of Pulumi to use by inspecting the Go dependencies of the provider.
 .pulumi/version: provider/go.mod
-	@mkdir -p .pulumi
-	@cd provider && go list -f "{{slice .Version 1}}" -m github.com/pulumi/pulumi/pkg/v3 | tee ../$@
+	cd provider && go list -f "{{slice .Version 1}}" -m github.com/pulumi/pulumi/pkg/v3 | tee ../$@
 
 # Start debug server for tfgen
 debug_tfgen:

--- a/provider-ci/test-providers/acme/.github/workflows/build_provider.yml
+++ b/provider-ci/test-providers/acme/.github/workflows/build_provider.yml
@@ -37,6 +37,8 @@ jobs:
         uses: ./.github/actions/setup-tools
         with:
           tools: pulumictl, go
+      - name: Prepare local workspace before restoring previously built
+        run: make prepare_local_workspace
       - name: Download schema-embed.json
         uses: actions/download-artifact@v4
         with:
@@ -45,9 +47,11 @@ jobs:
           # Avoid creating directories for each artifact
           merge-multiple: true
           path: provider/cmd/pulumi-resource-acme/schema-embed.json
-      - name: Prepare for build
-        # This installs plugins and prepares upstream
-        run: make upstream
+      - name: Restore makefile progress
+        uses: actions/download-artifact@v4
+        with:
+          name: prerequisites.make
+          path: .make
       - name: Build & package provider
         run: make provider_dist-${{ matrix.platform.os }}-${{ matrix.platform.arch }}
       - name: Upload artifacts

--- a/provider-ci/test-providers/acme/.github/workflows/build_sdk.yml
+++ b/provider-ci/test-providers/acme/.github/workflows/build_sdk.yml
@@ -53,12 +53,17 @@ jobs:
         uses: ./.github/actions/setup-tools
         with:
           tools: pulumictl, pulumicli, ${{ matrix.language }}
+      - name: Prepare local workspace
+        run: make prepare_local_workspace
       - name: Download bin
         uses: ./.github/actions/download-bin
-      - name: Install plugins
-        run: make install_plugins
       - name: Update path
         run: echo "${{ github.workspace }}/bin" >> "$GITHUB_PATH"
+      - name: Restore makefile progress
+        uses: actions/download-artifact@v4
+        with:
+          name: prerequisites.make
+          path: .make
       - name: Build SDK
         run: make build_${{ matrix.language }}
       - name: Check worktree clean
@@ -74,3 +79,9 @@ jobs:
         uses: ./.github/actions/upload-sdk
         with:
           language: ${{ matrix.language }}
+      - name: Save makefile progress
+        uses: actions/upload-artifact@v4
+        with:
+          name: build_${{ matrix.language }}.make
+          path: .make
+          include-hidden-files: true

--- a/provider-ci/test-providers/acme/.github/workflows/main.yml
+++ b/provider-ci/test-providers/acme/.github/workflows/main.yml
@@ -146,9 +146,6 @@ jobs:
         tools: pulumictl, pulumicli, ${{ matrix.language }}
     - name: Download bin
       uses: ./.github/actions/download-bin
-    - name: Add NuGet source
-      if: matrix.language == 'dotnet'
-      run: dotnet nuget add source ${{ github.workspace }}/nuget
     - name: Download SDK
       uses: ./.github/actions/download-sdk
       with:

--- a/provider-ci/test-providers/acme/.github/workflows/main.yml
+++ b/provider-ci/test-providers/acme/.github/workflows/main.yml
@@ -144,14 +144,19 @@ jobs:
       uses: ./.github/actions/setup-tools
       with:
         tools: pulumictl, pulumicli, ${{ matrix.language }}
+    - name: Prepare local workspace
+      run: make prepare_local_workspace
     - name: Download bin
       uses: ./.github/actions/download-bin
     - name: Download SDK
       uses: ./.github/actions/download-sdk
       with:
         language: ${{ matrix.language }}
-    - name: Mark SDK up to date
-      run: make --touch build_${{ matrix.language }}
+    - name: Restore makefile progress
+      uses: actions/download-artifact@v4
+      with:
+        name: build_${{ matrix.language }}.make
+        path: .make
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> "$GITHUB_PATH"
     - name: Install Python deps

--- a/provider-ci/test-providers/acme/.github/workflows/main.yml
+++ b/provider-ci/test-providers/acme/.github/workflows/main.yml
@@ -153,6 +153,8 @@ jobs:
       uses: ./.github/actions/download-sdk
       with:
         language: ${{ matrix.language }}
+    - name: Mark SDK up to date
+      run: make --touch build_${{ matrix.language }}
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> "$GITHUB_PATH"
     - name: Install Python deps

--- a/provider-ci/test-providers/acme/.github/workflows/prerelease.yml
+++ b/provider-ci/test-providers/acme/.github/workflows/prerelease.yml
@@ -88,9 +88,6 @@ jobs:
         tools: pulumictl, pulumicli, dotnet, go, nodejs, python
     - name: Download bin
       uses: ./.github/actions/download-bin
-    - name: Add NuGet source
-      if: matrix.language == 'dotnet'
-      run: dotnet nuget add source ${{ github.workspace }}/nuget
     - name: Download SDK
       uses: ./.github/actions/download-sdk
       with:

--- a/provider-ci/test-providers/acme/.github/workflows/prerelease.yml
+++ b/provider-ci/test-providers/acme/.github/workflows/prerelease.yml
@@ -95,6 +95,8 @@ jobs:
       uses: ./.github/actions/download-sdk
       with:
         language: ${{ matrix.language }}
+    - name: Mark SDK up to date
+      run: make --touch build_${{ matrix.language }}
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> "$GITHUB_PATH"
     - name: Install Python deps

--- a/provider-ci/test-providers/acme/.github/workflows/prerelease.yml
+++ b/provider-ci/test-providers/acme/.github/workflows/prerelease.yml
@@ -86,14 +86,19 @@ jobs:
       uses: ./.github/actions/setup-tools
       with:
         tools: pulumictl, pulumicli, dotnet, go, nodejs, python
+    - name: Prepare local workspace
+      run: make prepare_local_workspace
     - name: Download bin
       uses: ./.github/actions/download-bin
     - name: Download SDK
       uses: ./.github/actions/download-sdk
       with:
         language: ${{ matrix.language }}
-    - name: Mark SDK up to date
-      run: make --touch build_${{ matrix.language }}
+    - name: Restore makefile progress
+      uses: actions/download-artifact@v4
+      with:
+        name: build_${{ matrix.language }}.make
+        path: .make
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> "$GITHUB_PATH"
     - name: Install Python deps

--- a/provider-ci/test-providers/acme/.github/workflows/prerequisites.yml
+++ b/provider-ci/test-providers/acme/.github/workflows/prerequisites.yml
@@ -56,20 +56,16 @@ jobs:
         path: |
           .pulumi/examples-cache
         key: ${{ runner.os }}-${{ hashFiles('provider/go.sum') }}
-    - name: Prepare upstream code
-      run: make upstream
     - name: Setup tools
       uses: ./.github/actions/setup-tools
       with:
         tools: go, pulumictl, pulumicli, schema-tools
-    - name: Build schema generator binary
-      run: make tfgen_build_only
-    - name: Install plugins
-      run: make install_plugins
+    - name: Prepare local workspace before restoring previously built files
+      run: make prepare_local_workspace
     - name: Generate schema
-      run: make tfgen_no_deps
+      run: make schema
     - name: Build provider binary
-      run: make provider_no_deps
+      run: make provider
     - name: Unit-test provider code
       run: make test_provider
     - if: inputs.is_pr
@@ -81,6 +77,12 @@ jobs:
           schema-tools compare -r github://api.github.com/pulumiverse -p acme -o "${{ inputs.default_branch }}" -n --local-path=provider/cmd/pulumi-resource-acme/schema.json;
           echo "$EOF";
         } >> "$GITHUB_ENV"
+    - name: Save makefile progress
+      uses: actions/upload-artifact@v4
+      with:
+        name: prerequisites.make
+        path: .make
+        include-hidden-files: true
     - if: inputs.is_pr && inputs.is_automated == false
       name: Comment on PR with Details of Schema Check
       uses: thollander/actions-comment-pull-request@v2

--- a/provider-ci/test-providers/acme/.github/workflows/release.yml
+++ b/provider-ci/test-providers/acme/.github/workflows/release.yml
@@ -101,6 +101,8 @@ jobs:
       uses: ./.github/actions/download-sdk
       with:
         language: ${{ matrix.language }}
+    - name: Mark SDK up to date
+      run: make --touch build_${{ matrix.language }}
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> "$GITHUB_PATH"
     - name: Install Python deps

--- a/provider-ci/test-providers/acme/.github/workflows/release.yml
+++ b/provider-ci/test-providers/acme/.github/workflows/release.yml
@@ -94,9 +94,6 @@ jobs:
         tools: pulumictl, pulumicli, ${{ matrix.language }}
     - name: Download bin
       uses: ./.github/actions/download-bin
-    - name: Add NuGet source
-      if: matrix.language == 'dotnet'
-      run: dotnet nuget add source ${{ github.workspace }}/nuget
     - name: Download SDK
       uses: ./.github/actions/download-sdk
       with:

--- a/provider-ci/test-providers/acme/.github/workflows/release.yml
+++ b/provider-ci/test-providers/acme/.github/workflows/release.yml
@@ -92,14 +92,19 @@ jobs:
       uses: ./.github/actions/setup-tools
       with:
         tools: pulumictl, pulumicli, ${{ matrix.language }}
+    - name: Prepare local workspace
+      run: make prepare_local_workspace
     - name: Download bin
       uses: ./.github/actions/download-bin
     - name: Download SDK
       uses: ./.github/actions/download-sdk
       with:
         language: ${{ matrix.language }}
-    - name: Mark SDK up to date
-      run: make --touch build_${{ matrix.language }}
+    - name: Restore makefile progress
+      uses: actions/download-artifact@v4
+      with:
+        name: build_${{ matrix.language }}.make
+        path: .make
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> "$GITHUB_PATH"
     - name: Install Python deps

--- a/provider-ci/test-providers/acme/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/test-providers/acme/.github/workflows/run-acceptance-tests.yml
@@ -150,6 +150,8 @@ jobs:
       uses: ./.github/actions/download-sdk
       with:
         language: ${{ matrix.language }}
+    - name: Mark SDK up to date
+      run: make --touch build_${{ matrix.language }}
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> "$GITHUB_PATH"
     - name: Install Python deps

--- a/provider-ci/test-providers/acme/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/test-providers/acme/.github/workflows/run-acceptance-tests.yml
@@ -143,9 +143,6 @@ jobs:
         tools: pulumictl, pulumicli, ${{ matrix.language }}
     - name: Download bin
       uses: ./.github/actions/download-bin
-    - name: Add NuGet source
-      if: matrix.language == 'dotnet'
-      run: dotnet nuget add source ${{ github.workspace }}/nuget
     - name: Download SDK
       uses: ./.github/actions/download-sdk
       with:

--- a/provider-ci/test-providers/acme/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/test-providers/acme/.github/workflows/run-acceptance-tests.yml
@@ -141,14 +141,19 @@ jobs:
       uses: ./.github/actions/setup-tools
       with:
         tools: pulumictl, pulumicli, ${{ matrix.language }}
+    - name: Prepare local workspace
+      run: make prepare_local_workspace
     - name: Download bin
       uses: ./.github/actions/download-bin
     - name: Download SDK
       uses: ./.github/actions/download-sdk
       with:
         language: ${{ matrix.language }}
-    - name: Mark SDK up to date
-      run: make --touch build_${{ matrix.language }}
+    - name: Restore makefile progress
+      uses: actions/download-artifact@v4
+      with:
+        name: build_${{ matrix.language }}.make
+        path: .make
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> "$GITHUB_PATH"
     - name: Install Python deps

--- a/provider-ci/test-providers/acme/Makefile
+++ b/provider-ci/test-providers/acme/Makefile
@@ -131,12 +131,18 @@ clean:
 	rm -rf sdk/{dotnet,nodejs,go,python}
 	rm -rf bin/*
 	rm -rf .make/*
+	if dotnet nuget list source | grep "$(WORKING_DIR)/nuget"; then \
+		dotnet nuget remove source "$(WORKING_DIR)/nuget" \
+	; fi
 .PHONY: clean
 
 install_dotnet_sdk: .make/install_dotnet_sdk
 .make/install_dotnet_sdk: .make/build_dotnet
-	mkdir -p $(WORKING_DIR)/nuget
-	find . -name '*.nupkg' -print -exec cp -p {} $(WORKING_DIR)/nuget \;
+	mkdir -p nuget
+	find sdk/dotnet/bin -name '*.nupkg' -print -exec cp -p "{}" ${WORKING_DIR}/nuget \;
+	if ! dotnet nuget list source | grep "${WORKING_DIR}/nuget"; then \
+		dotnet nuget add source "${WORKING_DIR}/nuget" --name "${WORKING_DIR}/nuget" \
+	; fi
 	@touch $@
 install_go_sdk:
 install_java_sdk:

--- a/provider-ci/test-providers/acme/Makefile
+++ b/provider-ci/test-providers/acme/Makefile
@@ -154,6 +154,7 @@ test_provider:
 	@echo ""
 	cd provider && go test -v -short ./... -parallel $(TESTPARALLELISM)
 
+.PHONY: tfgen tfgen_no_deps tfgen_build_only
 tfgen: install_plugins upstream tfgen_no_deps
 
 tfgen_no_deps: export PULUMI_HOME := $(WORKING_DIR)/.pulumi
@@ -162,11 +163,13 @@ tfgen_no_deps: export PULUMI_CONVERT := $(PULUMI_CONVERT)
 tfgen_no_deps: export PULUMI_CONVERT_EXAMPLES_CACHE_DIR := $(WORKING_DIR)/.pulumi/examples-cache
 tfgen_no_deps: export PULUMI_DISABLE_AUTOMATIC_PLUGIN_ACQUISITION := $(PULUMI_CONVERT)
 tfgen_no_deps: export PULUMI_MISSING_DOCS_ERROR := $(PULUMI_MISSING_DOCS_ERROR)
-tfgen_no_deps: tfgen_build_only
+tfgen_no_deps: bin/$(TFGEN)
 	$(WORKING_DIR)/bin/$(TFGEN) schema --out provider/cmd/$(PROVIDER)
 	(cd provider && VERSION=$(VERSION_GENERIC) go generate cmd/$(PROVIDER)/main.go)
 
-tfgen_build_only:
+tfgen_build_only: bin/$(TFGEN)
+
+bin/$(TFGEN):
 	(cd provider && go build $(PULUMI_PROVIDER_BUILD_PARALLELISM) -o $(WORKING_DIR)/bin/$(TFGEN) -ldflags "$(LDFLAGS_PROJ_VERSION) $(LDFLAGS_EXTRAS)" $(PROJECT)/$(PROVIDER_PATH)/cmd/$(TFGEN))
 
 upstream:
@@ -208,7 +211,7 @@ ci-mgmt: .ci-mgmt.yaml
 debug_tfgen:
 	dlv  --listen=:2345 --headless=true --api-version=2  exec $(WORKING_DIR)/bin/$(TFGEN) -- schema --out provider/cmd/$(PROVIDER)
 
-.PHONY: development build build_sdks install_go_sdk install_java_sdk install_python_sdk install_sdks only_build build_dotnet build_go build_java build_nodejs build_python clean cleanup help install_dotnet_sdk install_nodejs_sdk install_plugins lint_provider provider provider_no_deps test tfgen upstream ci-mgmt test_provider debug_tfgen tfgen_build_only
+.PHONY: development build build_sdks install_go_sdk install_java_sdk install_python_sdk install_sdks only_build build_dotnet build_go build_java build_nodejs build_python clean cleanup help install_dotnet_sdk install_nodejs_sdk install_plugins lint_provider provider provider_no_deps test upstream ci-mgmt test_provider debug_tfgen
 
 # Provider cross-platform build & packaging
 

--- a/provider-ci/test-providers/acme/Makefile
+++ b/provider-ci/test-providers/acme/Makefile
@@ -27,6 +27,13 @@ LDFLAGS_UPSTREAM_VERSION=
 LDFLAGS_EXTRAS=
 LDFLAGS=$(LDFLAGS_PROJ_VERSION) $(LDFLAGS_UPSTREAM_VERSION) $(LDFLAGS_EXTRAS) $(LDFLAGS_STRIP_SYMBOLS)
 
+# Create a `.make` directory for tracking targets which don't generate a single file output. This should be ignored by git.
+# For targets which either don't generate a single file output, or the output file is committed, we use a "sentinel"
+# file within `.make/` to track the staleness of the target and only rebuild when needed. 
+# For each phony target, we create an internal target with the same name, but prefixed with `.make/` where the work is performed.
+# At the end of each internal target we run `@touch $@` to update the file which is the name of the target.
+_ := $(shell mkdir -p .make)
+
 development: install_plugins provider build_sdks install_sdks
 
 build: install_plugins provider build_sdks install_sdks

--- a/provider-ci/test-providers/acme/Makefile
+++ b/provider-ci/test-providers/acme/Makefile
@@ -208,6 +208,7 @@ ci-mgmt: .ci-mgmt.yaml
 .pulumi/bin/pulumi: .pulumi/version
 	@if [ -x .pulumi/bin/pulumi ] && [ "v$$(cat .pulumi/version)" = "$$(.pulumi/bin/pulumi version)" ]; then \
 		echo "pulumi/bin/pulumi version: v$$(cat .pulumi/version)"; \
+		touch $@; \
 	else \
 		curl -fsSL https://get.pulumi.com | \
 			HOME=$(WORKING_DIR) sh -s -- --version "$$(cat .pulumi/version)"; \

--- a/provider-ci/test-providers/acme/Makefile
+++ b/provider-ci/test-providers/acme/Makefile
@@ -51,6 +51,43 @@ build_sdks: build_dotnet build_go build_nodejs build_python
 install_sdks: install_dotnet_sdk install_go_sdk install_nodejs_sdk install_python_sdk
 .PHONY: development only_build build generate generate_sdks build_sdks install_sdks
 
+help:
+	@echo "Usage: make [target]"
+	@echo ""
+	@echo "Main Targets"
+	@echo "  build (default)     Build the provider and all SDKs and install for testing"
+	@echo "  generate            Generate all SDKs, documentation and schema"
+	@echo "  provider            Build the local provider binary"
+	@echo "  lint_provider<.fix> Run the linter on the provider (& optionally fix)"
+	@echo "  test_provider       Run the provider tests"
+	@echo "  test                Run the example tests (must run 'build' first)"
+	@echo "  clean               Clean up generated files"
+	@echo ""
+	@echo "More Precise Targets"
+	@echo "  schema        Generate the schema"
+	@echo "  generate_sdks Generate all SDKs"
+	@echo "  build_sdks    Build all SDKs"
+	@echo "  install_sdks  Install all SDKs"
+	@echo "  provider_dist Build and package the provider for all platforms"
+	@echo ""
+	@echo "Tool Targets"
+	@echo "  ci-mgmt     Re-generate CI configuration from .ci-mgmt.yaml"
+	@echo "  debug_tfgen Start a debug server for tfgen"
+	@echo ""
+	@echo "Internal Targets (automatically run as dependencies of other targets)"
+	@echo "  prepare_local_workspace  Prepare for building"
+	@echo "  install_plugins          Install plugin dependencies"
+	@echo "  upstream                 Initialize the upstream submodule, if present"
+	@echo ""
+	@echo "Language-Specific Targets"
+	@echo "  generate_[language]    Generate the SDK files ready for committing"
+	@echo "  build_[language]       Build the SDK to check correctness"
+	@echo "  install_[language]_sdk Install the SDK ready for testing"
+	@echo ""
+	@echo "  [language] = dotnet go nodejs python"
+	@echo ""
+.PHONY: help
+
 GEN_PULUMI_HOME := $(WORKING_DIR)/.pulumi
 GEN_PULUMI_CONVERT_EXAMPLES_CACHE_DIR := $(GEN_PULUMI_HOME)/examples-cache
 GEN_ENVS := PULUMI_HOME=$(GEN_PULUMI_HOME) PULUMI_CONVERT_EXAMPLES_CACHE_DIR=$(GEN_PULUMI_CONVERT_EXAMPLES_CACHE_DIR) PULUMI_CONVERT=$(PULUMI_CONVERT) PULUMI_DISABLE_AUTOMATIC_PLUGIN_ACQUISITION=$(PULUMI_CONVERT)

--- a/provider-ci/test-providers/acme/Makefile
+++ b/provider-ci/test-providers/acme/Makefile
@@ -45,12 +45,6 @@ generate_sdks: generate_dotnet generate_go generate_nodejs generate_python
 build_sdks: build_dotnet build_go build_nodejs build_python
 install_sdks: install_dotnet_sdk install_go_sdk install_nodejs_sdk install_python_sdk
 
-install_go_sdk:
-
-install_java_sdk:
-
-install_python_sdk:
-
 GEN_PULUMI_HOME := $(WORKING_DIR)/.pulumi
 GEN_PULUMI_CONVERT_EXAMPLES_CACHE_DIR := $(GEN_PULUMI_HOME)/examples-cache
 GEN_ENVS := PULUMI_HOME=$(GEN_PULUMI_HOME) PULUMI_CONVERT_EXAMPLES_CACHE_DIR=$(GEN_PULUMI_CONVERT_EXAMPLES_CACHE_DIR) PULUMI_CONVERT=$(PULUMI_CONVERT) PULUMI_DISABLE_AUTOMATIC_PLUGIN_ACQUISITION=$(PULUMI_CONVERT)
@@ -136,12 +130,19 @@ clean:
 	rm -rf bin/*
 	rm -rf .make/*
 
-install_dotnet_sdk:
+.PHONY: install_dotnet_sdk install_go_sdk install_java_sdk install_nodejs_sdk install_python_sdk
+install_dotnet_sdk: .make/install_dotnet_sdk
+.make/install_dotnet_sdk: .make/build_dotnet
 	mkdir -p $(WORKING_DIR)/nuget
 	find . -name '*.nupkg' -print -exec cp -p {} $(WORKING_DIR)/nuget \;
-
-install_nodejs_sdk:
+	@touch $@
+install_go_sdk:
+install_java_sdk:
+install_nodejs_sdk: .make/install_nodejs_sdk
+.make/install_nodejs_sdk: .make/build_nodejs
 	yarn link --cwd $(WORKING_DIR)/sdk/nodejs/bin
+	@touch $@
+install_python_sdk:
 
 .PHONY: install_plugins
 install_plugins: .make/install_plugins
@@ -244,7 +245,7 @@ ci-mgmt: .ci-mgmt.yaml
 debug_tfgen:
 	dlv  --listen=:2345 --headless=true --api-version=2  exec $(WORKING_DIR)/bin/$(TFGEN) -- schema --out provider/cmd/$(PROVIDER)
 
-.PHONY: install_go_sdk install_java_sdk install_python_sdk install_sdks install_dotnet_sdk install_nodejs_sdk lint_provider test ci-mgmt test_provider debug_tfgen
+.PHONY: lint_provider test ci-mgmt test_provider debug_tfgen
 
 # Provider cross-platform build & packaging
 

--- a/provider-ci/test-providers/acme/Makefile
+++ b/provider-ci/test-providers/acme/Makefile
@@ -81,16 +81,21 @@ build_go: .make/build_go
 	cd sdk && go list "$$(grep -e "^module" go.mod | cut -d ' ' -f 2)/go/..." | xargs -I {} bash -c 'go build {} && go clean -i {}'
 	@touch $@
 
-build_java: PACKAGE_VERSION := $(VERSION_GENERIC)
-build_java: export PULUMI_HOME := $(WORKING_DIR)/.pulumi
-build_java: export PATH := $(WORKING_DIR)/.pulumi/bin:$(PATH)
-build_java: export PULUMI_CONVERT_EXAMPLES_CACHE_DIR := $(WORKING_DIR)/.pulumi/examples-cache
-build_java: bin/pulumi-java-gen .make/upstream
-	$(WORKING_DIR)/bin/$(JAVA_GEN) generate --schema provider/cmd/$(PROVIDER)/schema.json --out sdk/java  --build gradle-nexus
+.PHONY: generate_java build_java
+generate_java: .make/generate_java
+build_java: .make/build_java
+.make/generate_java: export PATH := $(WORKING_DIR)/.pulumi/bin:$(PATH)
+.make/generate_java: PACKAGE_VERSION := $(VERSION_GENERIC)
+.make/generate_java: bin/pulumi-java-gen .make/schema
+	PULUMI_HOME=$(GEN_PULUMI_HOME) PULUMI_CONVERT_EXAMPLES_CACHE_DIR=$(GEN_PULUMI_CONVERT_EXAMPLES_CACHE_DIR) bin/$(JAVA_GEN) generate --schema provider/cmd/$(PROVIDER)/schema.json --out sdk/java  --build gradle-nexus
+	printf "module fake_java_module // Exclude this directory from Go tools\n\ngo 1.17\n" > sdk/java/go.mod
+	@touch $@
+.make/build_java: PACKAGE_VERSION := $(VERSION_GENERIC)
+.make/build_java: .make/generate_java
 	cd sdk/java/ && \
-		printf "module fake_java_module // Exclude this directory from Go tools\n\ngo 1.17\n" > go.mod && \
 		gradle --console=plain build && \
 		gradle --console=plain javadoc
+	@touch $@
 
 .PHONY: generate_nodejs build_nodejs
 generate_nodejs: .make/generate_nodejs
@@ -240,7 +245,7 @@ ci-mgmt: .ci-mgmt.yaml
 debug_tfgen:
 	dlv  --listen=:2345 --headless=true --api-version=2  exec $(WORKING_DIR)/bin/$(TFGEN) -- schema --out provider/cmd/$(PROVIDER)
 
-.PHONY: development build build_sdks install_go_sdk install_java_sdk install_python_sdk install_sdks only_build build_java install_dotnet_sdk install_nodejs_sdk lint_provider provider provider_no_deps test ci-mgmt test_provider debug_tfgen
+.PHONY: development build build_sdks install_go_sdk install_java_sdk install_python_sdk install_sdks only_build install_dotnet_sdk install_nodejs_sdk lint_provider provider provider_no_deps test ci-mgmt test_provider debug_tfgen
 
 # Provider cross-platform build & packaging
 

--- a/provider-ci/test-providers/acme/Makefile
+++ b/provider-ci/test-providers/acme/Makefile
@@ -32,7 +32,9 @@ LDFLAGS=$(LDFLAGS_PROJ_VERSION) $(LDFLAGS_UPSTREAM_VERSION) $(LDFLAGS_EXTRAS) $(
 # file within `.make/` to track the staleness of the target and only rebuild when needed. 
 # For each phony target, we create an internal target with the same name, but prefixed with `.make/` where the work is performed.
 # At the end of each internal target we run `@touch $@` to update the file which is the name of the target.
-_ := $(shell mkdir -p .make)
+
+# Ensure all directories exist before evaluating targets to avoid issues with `touch` creating directories.
+_ := $(shell mkdir -p .make bin .pulumi/bin)
 
 development: .make/install_plugins provider build_sdks install_sdks
 
@@ -216,8 +218,7 @@ ci-mgmt: .ci-mgmt.yaml
 
 # Compute the version of Pulumi to use by inspecting the Go dependencies of the provider.
 .pulumi/version: provider/go.mod
-	@mkdir -p .pulumi
-	@cd provider && go list -f "{{slice .Version 1}}" -m github.com/pulumi/pulumi/pkg/v3 | tee ../$@
+	cd provider && go list -f "{{slice .Version 1}}" -m github.com/pulumi/pulumi/pkg/v3 | tee ../$@
 
 # Start debug server for tfgen
 debug_tfgen:

--- a/provider-ci/test-providers/acme/Makefile
+++ b/provider-ci/test-providers/acme/Makefile
@@ -36,21 +36,20 @@ LDFLAGS=$(LDFLAGS_PROJ_VERSION) $(LDFLAGS_UPSTREAM_VERSION) $(LDFLAGS_EXTRAS) $(
 # Ensure all directories exist before evaluating targets to avoid issues with `touch` creating directories.
 _ := $(shell mkdir -p .make bin .pulumi/bin)
 
-development: .make/install_plugins provider build_sdks install_sdks
-
-build: .make/install_plugins provider build_sdks install_sdks
-
-build_sdks: build_dotnet build_go build_nodejs build_python 
+.PHONY: development only_build build generate_sdks build_sdks install_sdks
+# Keep aliases for old targets to ensure backwards compatibility
+development: build
+only_build: build
+build: install_plugins provider build_sdks install_sdks
+generate_sdks: generate_dotnet generate_go generate_nodejs generate_python
+build_sdks: build_dotnet build_go build_nodejs build_python
+install_sdks: install_dotnet_sdk install_go_sdk install_nodejs_sdk install_python_sdk
 
 install_go_sdk:
 
 install_java_sdk:
 
 install_python_sdk:
-
-install_sdks: install_dotnet_sdk install_python_sdk install_nodejs_sdk install_java_sdk
-
-only_build: build
 
 GEN_PULUMI_HOME := $(WORKING_DIR)/.pulumi
 GEN_PULUMI_CONVERT_EXAMPLES_CACHE_DIR := $(GEN_PULUMI_HOME)/examples-cache
@@ -245,7 +244,7 @@ ci-mgmt: .ci-mgmt.yaml
 debug_tfgen:
 	dlv  --listen=:2345 --headless=true --api-version=2  exec $(WORKING_DIR)/bin/$(TFGEN) -- schema --out provider/cmd/$(PROVIDER)
 
-.PHONY: development build build_sdks install_go_sdk install_java_sdk install_python_sdk install_sdks only_build install_dotnet_sdk install_nodejs_sdk lint_provider provider provider_no_deps test ci-mgmt test_provider debug_tfgen
+.PHONY: install_go_sdk install_java_sdk install_python_sdk install_sdks install_dotnet_sdk install_nodejs_sdk lint_provider test ci-mgmt test_provider debug_tfgen
 
 # Provider cross-platform build & packaging
 

--- a/provider-ci/test-providers/acme/Makefile
+++ b/provider-ci/test-providers/acme/Makefile
@@ -52,15 +52,23 @@ install_sdks: install_dotnet_sdk install_python_sdk install_nodejs_sdk install_j
 
 only_build: build
 
-build_dotnet: export PULUMI_HOME := $(WORKING_DIR)/.pulumi
-build_dotnet: export PATH := $(WORKING_DIR)/.pulumi/bin:$(PATH)
-build_dotnet: export PULUMI_CONVERT_EXAMPLES_CACHE_DIR := $(WORKING_DIR)/.pulumi/examples-cache
-build_dotnet: .make/upstream
-	PULUMI_CONVERT=$(PULUMI_CONVERT) PULUMI_DISABLE_AUTOMATIC_PLUGIN_ACQUISITION=$(PULUMI_CONVERT) $(WORKING_DIR)/bin/$(TFGEN) dotnet --out sdk/dotnet/
+GEN_PULUMI_HOME := $(WORKING_DIR)/.pulumi
+GEN_PULUMI_CONVERT_EXAMPLES_CACHE_DIR := $(GEN_PULUMI_HOME)/examples-cache
+GEN_ENVS := PULUMI_HOME=$(GEN_PULUMI_HOME) PULUMI_CONVERT_EXAMPLES_CACHE_DIR=$(GEN_PULUMI_CONVERT_EXAMPLES_CACHE_DIR) PULUMI_CONVERT=$(PULUMI_CONVERT) PULUMI_DISABLE_AUTOMATIC_PLUGIN_ACQUISITION=$(PULUMI_CONVERT)
+
+.PHONY: generate_dotnet build_dotnet
+generate_dotnet: .make/generate_dotnet
+build_dotnet: .make/build_dotnet
+.make/generate_dotnet: export PATH := $(WORKING_DIR)/.pulumi/bin:$(PATH)
+.make/generate_dotnet: bin/$(TFGEN)
+	$(GEN_ENVS) $(WORKING_DIR)/bin/$(TFGEN) dotnet --out sdk/dotnet/
 	cd sdk/dotnet/ && \
 		printf "module fake_dotnet_module // Exclude this directory from Go tools\n\ngo 1.17\n" > go.mod && \
-		echo "$(VERSION_GENERIC)" >version.txt && \
-		dotnet build
+		echo "$(VERSION_GENERIC)" >version.txt
+	@touch $@
+.make/build_dotnet: .make/generate_dotnet
+	cd sdk/dotnet/ && dotnet build
+	@touch $@
 
 build_go: export PULUMI_HOME := $(WORKING_DIR)/.pulumi
 build_go: export PATH := $(WORKING_DIR)/.pulumi/bin:$(PATH)
@@ -221,7 +229,7 @@ ci-mgmt: .ci-mgmt.yaml
 debug_tfgen:
 	dlv  --listen=:2345 --headless=true --api-version=2  exec $(WORKING_DIR)/bin/$(TFGEN) -- schema --out provider/cmd/$(PROVIDER)
 
-.PHONY: development build build_sdks install_go_sdk install_java_sdk install_python_sdk install_sdks only_build build_dotnet build_go build_java build_nodejs build_python install_dotnet_sdk install_nodejs_sdk lint_provider provider provider_no_deps test ci-mgmt test_provider debug_tfgen
+.PHONY: development build build_sdks install_go_sdk install_java_sdk install_python_sdk install_sdks only_build build_go build_java build_nodejs build_python install_dotnet_sdk install_nodejs_sdk lint_provider provider provider_no_deps test ci-mgmt test_provider debug_tfgen
 
 # Provider cross-platform build & packaging
 

--- a/provider-ci/test-providers/acme/Makefile
+++ b/provider-ci/test-providers/acme/Makefile
@@ -34,9 +34,9 @@ LDFLAGS=$(LDFLAGS_PROJ_VERSION) $(LDFLAGS_UPSTREAM_VERSION) $(LDFLAGS_EXTRAS) $(
 # At the end of each internal target we run `@touch $@` to update the file which is the name of the target.
 _ := $(shell mkdir -p .make)
 
-development: install_plugins provider build_sdks install_sdks
+development: .make/install_plugins provider build_sdks install_sdks
 
-build: install_plugins provider build_sdks install_sdks
+build: .make/install_plugins provider build_sdks install_sdks
 
 build_sdks: build_dotnet build_go build_nodejs build_python 
 
@@ -124,9 +124,12 @@ install_dotnet_sdk:
 install_nodejs_sdk:
 	yarn link --cwd $(WORKING_DIR)/sdk/nodejs/bin
 
-install_plugins: export PULUMI_HOME := $(WORKING_DIR)/.pulumi
-install_plugins: export PATH := $(WORKING_DIR)/.pulumi/bin:$(PATH)
-install_plugins: .pulumi/bin/pulumi
+.PHONY: install_plugins
+install_plugins: .make/install_plugins
+.make/install_plugins: export PULUMI_HOME := $(WORKING_DIR)/.pulumi
+.make/install_plugins: export PATH := $(WORKING_DIR)/.pulumi/bin:$(PATH)
+.make/install_plugins: .pulumi/bin/pulumi
+	@touch $@
 
 lint_provider: provider
 	cd provider && golangci-lint run --path-prefix provider -c ../.golangci.yml
@@ -215,7 +218,7 @@ ci-mgmt: .ci-mgmt.yaml
 debug_tfgen:
 	dlv  --listen=:2345 --headless=true --api-version=2  exec $(WORKING_DIR)/bin/$(TFGEN) -- schema --out provider/cmd/$(PROVIDER)
 
-.PHONY: development build build_sdks install_go_sdk install_java_sdk install_python_sdk install_sdks only_build build_dotnet build_go build_java build_nodejs build_python clean cleanup help install_dotnet_sdk install_nodejs_sdk install_plugins lint_provider provider provider_no_deps test ci-mgmt test_provider debug_tfgen
+.PHONY: development build build_sdks install_go_sdk install_java_sdk install_python_sdk install_sdks only_build build_dotnet build_go build_java build_nodejs build_python clean cleanup help install_dotnet_sdk install_nodejs_sdk lint_provider provider provider_no_deps test ci-mgmt test_provider debug_tfgen
 
 # Provider cross-platform build & packaging
 

--- a/provider-ci/test-providers/acme/Makefile
+++ b/provider-ci/test-providers/acme/Makefile
@@ -36,7 +36,6 @@ LDFLAGS=$(LDFLAGS_PROJ_VERSION) $(LDFLAGS_UPSTREAM_VERSION) $(LDFLAGS_EXTRAS) $(
 # Ensure all directories exist before evaluating targets to avoid issues with `touch` creating directories.
 _ := $(shell mkdir -p .make bin .pulumi/bin)
 
-.PHONY: development only_build build generate_sdks build_sdks install_sdks
 # Keep aliases for old targets to ensure backwards compatibility
 development: build
 only_build: build
@@ -44,12 +43,12 @@ build: install_plugins provider build_sdks install_sdks
 generate_sdks: generate_dotnet generate_go generate_nodejs generate_python
 build_sdks: build_dotnet build_go build_nodejs build_python
 install_sdks: install_dotnet_sdk install_go_sdk install_nodejs_sdk install_python_sdk
+.PHONY: development only_build build generate_sdks build_sdks install_sdks
 
 GEN_PULUMI_HOME := $(WORKING_DIR)/.pulumi
 GEN_PULUMI_CONVERT_EXAMPLES_CACHE_DIR := $(GEN_PULUMI_HOME)/examples-cache
 GEN_ENVS := PULUMI_HOME=$(GEN_PULUMI_HOME) PULUMI_CONVERT_EXAMPLES_CACHE_DIR=$(GEN_PULUMI_CONVERT_EXAMPLES_CACHE_DIR) PULUMI_CONVERT=$(PULUMI_CONVERT) PULUMI_DISABLE_AUTOMATIC_PLUGIN_ACQUISITION=$(PULUMI_CONVERT)
 
-.PHONY: generate_dotnet build_dotnet
 generate_dotnet: .make/generate_dotnet
 build_dotnet: .make/build_dotnet
 .make/generate_dotnet: export PATH := $(WORKING_DIR)/.pulumi/bin:$(PATH)
@@ -62,8 +61,8 @@ build_dotnet: .make/build_dotnet
 .make/build_dotnet: .make/generate_dotnet
 	cd sdk/dotnet/ && dotnet build
 	@touch $@
+.PHONY: generate_dotnet build_dotnet
 
-.PHONY: generate_go build_go
 generate_go: .make/generate_go
 build_go: .make/build_go
 .make/generate_go: export PATH := $(WORKING_DIR)/.pulumi/bin:$(PATH)
@@ -73,8 +72,8 @@ build_go: .make/build_go
 .make/build_go: .make/generate_go
 	cd sdk && go list "$$(grep -e "^module" go.mod | cut -d ' ' -f 2)/go/..." | xargs -I {} bash -c 'go build {} && go clean -i {}'
 	@touch $@
+.PHONY: generate_go build_go
 
-.PHONY: generate_java build_java
 generate_java: .make/generate_java
 build_java: .make/build_java
 .make/generate_java: export PATH := $(WORKING_DIR)/.pulumi/bin:$(PATH)
@@ -89,8 +88,8 @@ build_java: .make/build_java
 		gradle --console=plain build && \
 		gradle --console=plain javadoc
 	@touch $@
+.PHONY: generate_java build_java
 
-.PHONY: generate_nodejs build_nodejs
 generate_nodejs: .make/generate_nodejs
 build_nodejs: .make/build_nodejs
 .make/generate_nodejs: export PATH := $(WORKING_DIR)/.pulumi/bin:$(PATH)
@@ -104,8 +103,8 @@ build_nodejs: .make/build_nodejs
 		yarn run tsc && \
 		cp ../../README.md ../../LICENSE* package.json yarn.lock ./bin/
 	@touch $@
+.PHONY: generate_nodejs build_nodejs
 
-.PHONY: generate_python build_python
 generate_python: .make/generate_python
 build_python: .make/build_python
 .make/generate_python: export PATH := $(WORKING_DIR)/.pulumi/bin:$(PATH)
@@ -123,14 +122,14 @@ build_python: .make/build_python
 		cd ./bin && \
 		../venv/bin/python -m build .
 	@touch $@
+.PHONY: generate_python build_python
 
-.PHONY: clean
 clean:
 	rm -rf sdk/{dotnet,nodejs,go,python}
 	rm -rf bin/*
 	rm -rf .make/*
+.PHONY: clean
 
-.PHONY: install_dotnet_sdk install_go_sdk install_java_sdk install_nodejs_sdk install_python_sdk
 install_dotnet_sdk: .make/install_dotnet_sdk
 .make/install_dotnet_sdk: .make/build_dotnet
 	mkdir -p $(WORKING_DIR)/nuget
@@ -143,49 +142,47 @@ install_nodejs_sdk: .make/install_nodejs_sdk
 	yarn link --cwd $(WORKING_DIR)/sdk/nodejs/bin
 	@touch $@
 install_python_sdk:
+.PHONY: install_dotnet_sdk install_go_sdk install_java_sdk install_nodejs_sdk install_python_sdk
 
-.PHONY: install_plugins
 install_plugins: .make/install_plugins
 .make/install_plugins: export PULUMI_HOME := $(WORKING_DIR)/.pulumi
 .make/install_plugins: export PATH := $(WORKING_DIR)/.pulumi/bin:$(PATH)
 .make/install_plugins: .pulumi/bin/pulumi
 	@touch $@
+.PHONY: install_plugins
 
 lint_provider: provider
 	cd provider && golangci-lint run --path-prefix provider -c ../.golangci.yml
-
 # `lint_provider.fix` is a utility target meant to be run manually
 # that will run the linter and fix errors when possible.
 lint_provider.fix:
 	cd provider && golangci-lint run --path-prefix provider -c ../.golangci.yml --fix
+.PHONY: lint_provider lint_provider.fix
 
 # `make provider_no_deps` builds the provider binary directly, without ensuring that
 # `cmd/pulumi-resource-acme/schema.json` is valid and up to date.
 # To create a release ready binary, you should use `make provider`.
-.PHONY: provider provider_no_deps
 build_provider_cmd = cd provider && go build $(PULUMI_PROVIDER_BUILD_PARALLELISM) -o $(WORKING_DIR)/bin/$(PROVIDER) -ldflags "$(LDFLAGS)" $(PROJECT)/$(PROVIDER_PATH)/cmd/$(PROVIDER)
 provider: bin/$(PROVIDER)
 provider_no_deps:
 	$(call build_provider_cmd)
 bin/$(PROVIDER): .make/schema
 	$(call build_provider_cmd)
+.PHONY: provider provider_no_deps
 
 test: export PATH := $(WORKING_DIR)/bin:$(PATH)
 test:
 	cd examples && go test -v -tags=all -parallel $(TESTPARALLELISM) -timeout 2h
+.PHONY: test
 
 test_provider:
-	@echo ""
-	@echo "== test_provider ==================================================================="
-	@echo ""
 	cd provider && go test -v -short ./... -parallel $(TESTPARALLELISM)
+.PHONY: test_provider
 
-.PHONY: tfgen schema tfgen_no_deps tfgen_build_only
 tfgen: schema
 schema: .make/schema 
 # This does actually have dependencies, but we're keeping it around for backwards compatibility for now
 tfgen_no_deps: .make/schema
-
 .make/schema: export PULUMI_HOME := $(WORKING_DIR)/.pulumi
 .make/schema: export PATH := $(WORKING_DIR)/.pulumi/bin:$(PATH)
 .make/schema: export PULUMI_CONVERT := $(PULUMI_CONVERT)
@@ -196,13 +193,11 @@ tfgen_no_deps: .make/schema
 	$(WORKING_DIR)/bin/$(TFGEN) schema --out provider/cmd/$(PROVIDER)
 	(cd provider && VERSION=$(VERSION_GENERIC) go generate cmd/$(PROVIDER)/main.go)
 	@touch $@
-
 tfgen_build_only: bin/$(TFGEN)
-
 bin/$(TFGEN):
 	(cd provider && go build $(PULUMI_PROVIDER_BUILD_PARALLELISM) -o $(WORKING_DIR)/bin/$(TFGEN) -ldflags "$(LDFLAGS_PROJ_VERSION) $(LDFLAGS_EXTRAS)" $(PROJECT)/$(PROVIDER_PATH)/cmd/$(TFGEN))
+.PHONY: tfgen schema tfgen_no_deps tfgen_build_only
 
-.PHONY: upstream
 upstream: .make/upstream
 # Re-run if the upstream commit or the patches change
 .make/upstream: $(wildcard patches/*) $(wildcard .git/modules/upstream/HEAD)
@@ -210,6 +205,7 @@ ifneq ("$(wildcard upstream)","")
 	./upstream.sh init
 endif
 	@touch $@
+.PHONY: upstream
 
 bin/pulumi-java-gen: .pulumi-java-gen.version
 	pulumictl download-binary -n pulumi-language-java -v v$(shell cat .pulumi-java-gen.version) -r pulumi/pulumi-java
@@ -221,6 +217,7 @@ bin/pulumi-java-gen: .pulumi-java-gen.version
 #
 ci-mgmt: .ci-mgmt.yaml
 	go run github.com/pulumi/ci-mgmt/provider-ci@master generate
+.PHONY: ci-mgmt
 
 # Because some codegen depends on the version of the CLI used, we install a local CLI
 # version pinned to the same version as `provider/go.mod`.
@@ -244,8 +241,7 @@ ci-mgmt: .ci-mgmt.yaml
 # Start debug server for tfgen
 debug_tfgen:
 	dlv  --listen=:2345 --headless=true --api-version=2  exec $(WORKING_DIR)/bin/$(TFGEN) -- schema --out provider/cmd/$(PROVIDER)
-
-.PHONY: lint_provider test ci-mgmt test_provider debug_tfgen
+.PHONY: debug_tfgen
 
 # Provider cross-platform build & packaging
 

--- a/provider-ci/test-providers/acme/Makefile
+++ b/provider-ci/test-providers/acme/Makefile
@@ -157,18 +157,22 @@ test_provider:
 	@echo ""
 	cd provider && go test -v -short ./... -parallel $(TESTPARALLELISM)
 
-.PHONY: tfgen tfgen_no_deps tfgen_build_only
-tfgen: install_plugins upstream tfgen_no_deps
+.PHONY: tfgen schema tfgen_no_deps tfgen_build_only
+tfgen: schema
+schema: .make/schema 
+# This does actually have dependencies, but we're keeping it around for backwards compatibility for now
+tfgen_no_deps: .make/schema
 
-tfgen_no_deps: export PULUMI_HOME := $(WORKING_DIR)/.pulumi
-tfgen_no_deps: export PATH := $(WORKING_DIR)/.pulumi/bin:$(PATH)
-tfgen_no_deps: export PULUMI_CONVERT := $(PULUMI_CONVERT)
-tfgen_no_deps: export PULUMI_CONVERT_EXAMPLES_CACHE_DIR := $(WORKING_DIR)/.pulumi/examples-cache
-tfgen_no_deps: export PULUMI_DISABLE_AUTOMATIC_PLUGIN_ACQUISITION := $(PULUMI_CONVERT)
-tfgen_no_deps: export PULUMI_MISSING_DOCS_ERROR := $(PULUMI_MISSING_DOCS_ERROR)
-tfgen_no_deps: bin/$(TFGEN)
+.make/schema: export PULUMI_HOME := $(WORKING_DIR)/.pulumi
+.make/schema: export PATH := $(WORKING_DIR)/.pulumi/bin:$(PATH)
+.make/schema: export PULUMI_CONVERT := $(PULUMI_CONVERT)
+.make/schema: export PULUMI_CONVERT_EXAMPLES_CACHE_DIR := $(WORKING_DIR)/.pulumi/examples-cache
+.make/schema: export PULUMI_DISABLE_AUTOMATIC_PLUGIN_ACQUISITION := $(PULUMI_CONVERT)
+.make/schema: export PULUMI_MISSING_DOCS_ERROR := $(PULUMI_MISSING_DOCS_ERROR)
+.make/schema: bin/$(TFGEN) provider/resources.go provider/go.mod .make/install_plugins .make/upstream
 	$(WORKING_DIR)/bin/$(TFGEN) schema --out provider/cmd/$(PROVIDER)
 	(cd provider && VERSION=$(VERSION_GENERIC) go generate cmd/$(PROVIDER)/main.go)
+	@touch $@
 
 tfgen_build_only: bin/$(TFGEN)
 

--- a/provider-ci/test-providers/acme/Makefile
+++ b/provider-ci/test-providers/acme/Makefile
@@ -53,7 +53,7 @@ only_build: build
 build_dotnet: export PULUMI_HOME := $(WORKING_DIR)/.pulumi
 build_dotnet: export PATH := $(WORKING_DIR)/.pulumi/bin:$(PATH)
 build_dotnet: export PULUMI_CONVERT_EXAMPLES_CACHE_DIR := $(WORKING_DIR)/.pulumi/examples-cache
-build_dotnet: upstream
+build_dotnet: .make/upstream
 	PULUMI_CONVERT=$(PULUMI_CONVERT) PULUMI_DISABLE_AUTOMATIC_PLUGIN_ACQUISITION=$(PULUMI_CONVERT) $(WORKING_DIR)/bin/$(TFGEN) dotnet --out sdk/dotnet/
 	cd sdk/dotnet/ && \
 		printf "module fake_dotnet_module // Exclude this directory from Go tools\n\ngo 1.17\n" > go.mod && \
@@ -63,7 +63,7 @@ build_dotnet: upstream
 build_go: export PULUMI_HOME := $(WORKING_DIR)/.pulumi
 build_go: export PATH := $(WORKING_DIR)/.pulumi/bin:$(PATH)
 build_go: export PULUMI_CONVERT_EXAMPLES_CACHE_DIR := $(WORKING_DIR)/.pulumi/examples-cache
-build_go: upstream
+build_go: .make/upstream
 	PULUMI_CONVERT=$(PULUMI_CONVERT) PULUMI_DISABLE_AUTOMATIC_PLUGIN_ACQUISITION=$(PULUMI_CONVERT) $(WORKING_DIR)/bin/$(TFGEN) go --out sdk/go/
 	cd sdk && go list "$$(grep -e "^module" go.mod | cut -d ' ' -f 2)/go/..." | xargs -I {} bash -c 'go build {} && go clean -i {}'
 
@@ -71,7 +71,7 @@ build_java: PACKAGE_VERSION := $(VERSION_GENERIC)
 build_java: export PULUMI_HOME := $(WORKING_DIR)/.pulumi
 build_java: export PATH := $(WORKING_DIR)/.pulumi/bin:$(PATH)
 build_java: export PULUMI_CONVERT_EXAMPLES_CACHE_DIR := $(WORKING_DIR)/.pulumi/examples-cache
-build_java: bin/pulumi-java-gen upstream
+build_java: bin/pulumi-java-gen .make/upstream
 	$(WORKING_DIR)/bin/$(JAVA_GEN) generate --schema provider/cmd/$(PROVIDER)/schema.json --out sdk/java  --build gradle-nexus
 	cd sdk/java/ && \
 		printf "module fake_java_module // Exclude this directory from Go tools\n\ngo 1.17\n" > go.mod && \
@@ -81,7 +81,7 @@ build_java: bin/pulumi-java-gen upstream
 build_nodejs: export PULUMI_HOME := $(WORKING_DIR)/.pulumi
 build_nodejs: export PATH := $(WORKING_DIR)/.pulumi/bin:$(PATH)
 build_nodejs: export PULUMI_CONVERT_EXAMPLES_CACHE_DIR := $(WORKING_DIR)/.pulumi/examples-cache
-build_nodejs: upstream
+build_nodejs: .make/upstream
 	PULUMI_CONVERT=$(PULUMI_CONVERT) PULUMI_DISABLE_AUTOMATIC_PLUGIN_ACQUISITION=$(PULUMI_CONVERT) $(WORKING_DIR)/bin/$(TFGEN) nodejs --out sdk/nodejs/
 	cd sdk/nodejs/ && \
 		printf "module fake_nodejs_module // Exclude this directory from Go tools\n\ngo 1.17\n" > go.mod && \
@@ -92,7 +92,7 @@ build_nodejs: upstream
 build_python: export PULUMI_HOME := $(WORKING_DIR)/.pulumi
 build_python: export PATH := $(WORKING_DIR)/.pulumi/bin:$(PATH)
 build_python: export PULUMI_CONVERT_EXAMPLES_CACHE_DIR := $(WORKING_DIR)/.pulumi/examples-cache
-build_python: upstream
+build_python: .make/upstream
 	rm -rf sdk/python/
 	PULUMI_CONVERT=$(PULUMI_CONVERT) PULUMI_DISABLE_AUTOMATIC_PLUGIN_ACQUISITION=$(PULUMI_CONVERT) $(WORKING_DIR)/bin/$(TFGEN) python --out sdk/python/
 	cd sdk/python/ && \
@@ -172,10 +172,14 @@ tfgen_build_only: bin/$(TFGEN)
 bin/$(TFGEN):
 	(cd provider && go build $(PULUMI_PROVIDER_BUILD_PARALLELISM) -o $(WORKING_DIR)/bin/$(TFGEN) -ldflags "$(LDFLAGS_PROJ_VERSION) $(LDFLAGS_EXTRAS)" $(PROJECT)/$(PROVIDER_PATH)/cmd/$(TFGEN))
 
-upstream:
+.PHONY: upstream
+upstream: .make/upstream
+# Re-run if the upstream commit or the patches change
+.make/upstream: $(wildcard patches/*) $(wildcard .git/modules/upstream/HEAD)
 ifneq ("$(wildcard upstream)","")
 	./upstream.sh init
 endif
+	@touch $@
 
 bin/pulumi-java-gen: .pulumi-java-gen.version
 	pulumictl download-binary -n pulumi-language-java -v v$(shell cat .pulumi-java-gen.version) -r pulumi/pulumi-java
@@ -211,7 +215,7 @@ ci-mgmt: .ci-mgmt.yaml
 debug_tfgen:
 	dlv  --listen=:2345 --headless=true --api-version=2  exec $(WORKING_DIR)/bin/$(TFGEN) -- schema --out provider/cmd/$(PROVIDER)
 
-.PHONY: development build build_sdks install_go_sdk install_java_sdk install_python_sdk install_sdks only_build build_dotnet build_go build_java build_nodejs build_python clean cleanup help install_dotnet_sdk install_nodejs_sdk install_plugins lint_provider provider provider_no_deps test upstream ci-mgmt test_provider debug_tfgen
+.PHONY: development build build_sdks install_go_sdk install_java_sdk install_python_sdk install_sdks only_build build_dotnet build_go build_java build_nodejs build_python clean cleanup help install_dotnet_sdk install_nodejs_sdk install_plugins lint_provider provider provider_no_deps test ci-mgmt test_provider debug_tfgen
 
 # Provider cross-platform build & packaging
 

--- a/provider-ci/test-providers/acme/Makefile
+++ b/provider-ci/test-providers/acme/Makefile
@@ -39,11 +39,14 @@ _ := $(shell mkdir -p .make bin .pulumi/bin)
 # Keep aliases for old targets to ensure backwards compatibility
 development: build
 only_build: build
+# Build the provider and all SDKs and install ready for testing
 build: install_plugins provider build_sdks install_sdks
+# Creates all generated files which need to be committed
+generate: generate_sdks schema
 generate_sdks: generate_dotnet generate_go generate_nodejs generate_python
 build_sdks: build_dotnet build_go build_nodejs build_python
 install_sdks: install_dotnet_sdk install_go_sdk install_nodejs_sdk install_python_sdk
-.PHONY: development only_build build generate_sdks build_sdks install_sdks
+.PHONY: development only_build build generate generate_sdks build_sdks install_sdks
 
 GEN_PULUMI_HOME := $(WORKING_DIR)/.pulumi
 GEN_PULUMI_CONVERT_EXAMPLES_CACHE_DIR := $(GEN_PULUMI_HOME)/examples-cache

--- a/provider-ci/test-providers/acme/Makefile
+++ b/provider-ci/test-providers/acme/Makefile
@@ -107,21 +107,24 @@ build_nodejs: .make/build_nodejs
 		cp ../../README.md ../../LICENSE* package.json yarn.lock ./bin/
 	@touch $@
 
-build_python: export PULUMI_HOME := $(WORKING_DIR)/.pulumi
-build_python: export PATH := $(WORKING_DIR)/.pulumi/bin:$(PATH)
-build_python: export PULUMI_CONVERT_EXAMPLES_CACHE_DIR := $(WORKING_DIR)/.pulumi/examples-cache
-build_python: .make/upstream
-	rm -rf sdk/python/
-	PULUMI_CONVERT=$(PULUMI_CONVERT) PULUMI_DISABLE_AUTOMATIC_PLUGIN_ACQUISITION=$(PULUMI_CONVERT) $(WORKING_DIR)/bin/$(TFGEN) python --out sdk/python/
+.PHONY: generate_python build_python
+generate_python: .make/generate_python
+build_python: .make/build_python
+.make/generate_python: export PATH := $(WORKING_DIR)/.pulumi/bin:$(PATH)
+.make/generate_python: bin/$(TFGEN)
+	$(GEN_ENVS) $(WORKING_DIR)/bin/$(TFGEN) python --out sdk/python/
+	printf "module fake_python_module // Exclude this directory from Go tools\n\ngo 1.17\n" > sdk/python/go.mod
+	cp README.md sdk/python/
+	@touch $@
+.make/build_python: .make/generate_python
 	cd sdk/python/ && \
-		printf "module fake_python_module // Exclude this directory from Go tools\n\ngo 1.17\n" > go.mod && \
-		cp ../../README.md . && \
 		rm -rf ./bin/ ../python.bin/ && cp -R . ../python.bin && mv ../python.bin ./bin && \
 		rm ./bin/go.mod && \
 		python3 -m venv venv && \
 		./venv/bin/python -m pip install build==1.2.1 && \
 		cd ./bin && \
 		../venv/bin/python -m build .
+	@touch $@
 
 .PHONY: clean
 clean:
@@ -237,7 +240,7 @@ ci-mgmt: .ci-mgmt.yaml
 debug_tfgen:
 	dlv  --listen=:2345 --headless=true --api-version=2  exec $(WORKING_DIR)/bin/$(TFGEN) -- schema --out provider/cmd/$(PROVIDER)
 
-.PHONY: development build build_sdks install_go_sdk install_java_sdk install_python_sdk install_sdks only_build build_java build_python install_dotnet_sdk install_nodejs_sdk lint_provider provider provider_no_deps test ci-mgmt test_provider debug_tfgen
+.PHONY: development build build_sdks install_go_sdk install_java_sdk install_python_sdk install_sdks only_build build_java install_dotnet_sdk install_nodejs_sdk lint_provider provider provider_no_deps test ci-mgmt test_provider debug_tfgen
 
 # Provider cross-platform build & packaging
 

--- a/provider-ci/test-providers/acme/Makefile
+++ b/provider-ci/test-providers/acme/Makefile
@@ -92,16 +92,20 @@ build_java: bin/pulumi-java-gen .make/upstream
 		gradle --console=plain build && \
 		gradle --console=plain javadoc
 
-build_nodejs: export PULUMI_HOME := $(WORKING_DIR)/.pulumi
-build_nodejs: export PATH := $(WORKING_DIR)/.pulumi/bin:$(PATH)
-build_nodejs: export PULUMI_CONVERT_EXAMPLES_CACHE_DIR := $(WORKING_DIR)/.pulumi/examples-cache
-build_nodejs: .make/upstream
-	PULUMI_CONVERT=$(PULUMI_CONVERT) PULUMI_DISABLE_AUTOMATIC_PLUGIN_ACQUISITION=$(PULUMI_CONVERT) $(WORKING_DIR)/bin/$(TFGEN) nodejs --out sdk/nodejs/
+.PHONY: generate_nodejs build_nodejs
+generate_nodejs: .make/generate_nodejs
+build_nodejs: .make/build_nodejs
+.make/generate_nodejs: export PATH := $(WORKING_DIR)/.pulumi/bin:$(PATH)
+.make/generate_nodejs: bin/$(TFGEN)
+	$(GEN_ENVS) $(WORKING_DIR)/bin/$(TFGEN) nodejs --out sdk/nodejs/
+	printf "module fake_nodejs_module // Exclude this directory from Go tools\n\ngo 1.17\n" > sdk/nodejs/go.mod
+	@touch $@
+.make/build_nodejs: .make/generate_nodejs
 	cd sdk/nodejs/ && \
-		printf "module fake_nodejs_module // Exclude this directory from Go tools\n\ngo 1.17\n" > go.mod && \
 		yarn install && \
 		yarn run tsc && \
 		cp ../../README.md ../../LICENSE* package.json yarn.lock ./bin/
+	@touch $@
 
 build_python: export PULUMI_HOME := $(WORKING_DIR)/.pulumi
 build_python: export PATH := $(WORKING_DIR)/.pulumi/bin:$(PATH)
@@ -233,7 +237,7 @@ ci-mgmt: .ci-mgmt.yaml
 debug_tfgen:
 	dlv  --listen=:2345 --headless=true --api-version=2  exec $(WORKING_DIR)/bin/$(TFGEN) -- schema --out provider/cmd/$(PROVIDER)
 
-.PHONY: development build build_sdks install_go_sdk install_java_sdk install_python_sdk install_sdks only_build build_java build_nodejs build_python install_dotnet_sdk install_nodejs_sdk lint_provider provider provider_no_deps test ci-mgmt test_provider debug_tfgen
+.PHONY: development build build_sdks install_go_sdk install_java_sdk install_python_sdk install_sdks only_build build_java build_python install_dotnet_sdk install_nodejs_sdk lint_provider provider provider_no_deps test ci-mgmt test_provider debug_tfgen
 
 # Provider cross-platform build & packaging
 

--- a/provider-ci/test-providers/acme/Makefile
+++ b/provider-ci/test-providers/acme/Makefile
@@ -107,12 +107,11 @@ build_python: .make/upstream
 		cd ./bin && \
 		../venv/bin/python -m build .
 
+.PHONY: clean
 clean:
 	rm -rf sdk/{dotnet,nodejs,go,python}
-
-cleanup:
-	rm -r $(WORKING_DIR)/bin
-	rm -f provider/cmd/$(PROVIDER)/schema.go
+	rm -rf bin/*
+	rm -rf .make/*
 
 help:
 	@grep '^[^.#]\+:\s\+.*#' Makefile | \
@@ -224,7 +223,7 @@ ci-mgmt: .ci-mgmt.yaml
 debug_tfgen:
 	dlv  --listen=:2345 --headless=true --api-version=2  exec $(WORKING_DIR)/bin/$(TFGEN) -- schema --out provider/cmd/$(PROVIDER)
 
-.PHONY: development build build_sdks install_go_sdk install_java_sdk install_python_sdk install_sdks only_build build_dotnet build_go build_java build_nodejs build_python clean cleanup help install_dotnet_sdk install_nodejs_sdk lint_provider provider provider_no_deps test ci-mgmt test_provider debug_tfgen
+.PHONY: development build build_sdks install_go_sdk install_java_sdk install_python_sdk install_sdks only_build build_dotnet build_go build_java build_nodejs build_python help install_dotnet_sdk install_nodejs_sdk lint_provider provider provider_no_deps test ci-mgmt test_provider debug_tfgen
 
 # Provider cross-platform build & packaging
 

--- a/provider-ci/test-providers/acme/Makefile
+++ b/provider-ci/test-providers/acme/Makefile
@@ -70,12 +70,16 @@ build_dotnet: .make/build_dotnet
 	cd sdk/dotnet/ && dotnet build
 	@touch $@
 
-build_go: export PULUMI_HOME := $(WORKING_DIR)/.pulumi
-build_go: export PATH := $(WORKING_DIR)/.pulumi/bin:$(PATH)
-build_go: export PULUMI_CONVERT_EXAMPLES_CACHE_DIR := $(WORKING_DIR)/.pulumi/examples-cache
-build_go: .make/upstream
-	PULUMI_CONVERT=$(PULUMI_CONVERT) PULUMI_DISABLE_AUTOMATIC_PLUGIN_ACQUISITION=$(PULUMI_CONVERT) $(WORKING_DIR)/bin/$(TFGEN) go --out sdk/go/
+.PHONY: generate_go build_go
+generate_go: .make/generate_go
+build_go: .make/build_go
+.make/generate_go: export PATH := $(WORKING_DIR)/.pulumi/bin:$(PATH)
+.make/generate_go: bin/$(TFGEN)
+	$(GEN_ENVS) $(WORKING_DIR)/bin/$(TFGEN) go --out sdk/go/
+	@touch $@
+.make/build_go: .make/generate_go
 	cd sdk && go list "$$(grep -e "^module" go.mod | cut -d ' ' -f 2)/go/..." | xargs -I {} bash -c 'go build {} && go clean -i {}'
+	@touch $@
 
 build_java: PACKAGE_VERSION := $(VERSION_GENERIC)
 build_java: export PULUMI_HOME := $(WORKING_DIR)/.pulumi
@@ -229,7 +233,7 @@ ci-mgmt: .ci-mgmt.yaml
 debug_tfgen:
 	dlv  --listen=:2345 --headless=true --api-version=2  exec $(WORKING_DIR)/bin/$(TFGEN) -- schema --out provider/cmd/$(PROVIDER)
 
-.PHONY: development build build_sdks install_go_sdk install_java_sdk install_python_sdk install_sdks only_build build_go build_java build_nodejs build_python install_dotnet_sdk install_nodejs_sdk lint_provider provider provider_no_deps test ci-mgmt test_provider debug_tfgen
+.PHONY: development build build_sdks install_go_sdk install_java_sdk install_python_sdk install_sdks only_build build_java build_nodejs build_python install_dotnet_sdk install_nodejs_sdk lint_provider provider provider_no_deps test ci-mgmt test_provider debug_tfgen
 
 # Provider cross-platform build & packaging
 

--- a/provider-ci/test-providers/acme/Makefile
+++ b/provider-ci/test-providers/acme/Makefile
@@ -113,11 +113,6 @@ clean:
 	rm -rf bin/*
 	rm -rf .make/*
 
-help:
-	@grep '^[^.#]\+:\s\+.*#' Makefile | \
-	sed "s/\(.\+\):\s*\(.*\) #\s*\(.*\)/`printf "\033[93m"`\1`printf "\033[0m"`	\3 [\2]/" | \
-	expand -t20
-
 install_dotnet_sdk:
 	mkdir -p $(WORKING_DIR)/nuget
 	find . -name '*.nupkg' -print -exec cp -p {} $(WORKING_DIR)/nuget \;
@@ -223,7 +218,7 @@ ci-mgmt: .ci-mgmt.yaml
 debug_tfgen:
 	dlv  --listen=:2345 --headless=true --api-version=2  exec $(WORKING_DIR)/bin/$(TFGEN) -- schema --out provider/cmd/$(PROVIDER)
 
-.PHONY: development build build_sdks install_go_sdk install_java_sdk install_python_sdk install_sdks only_build build_dotnet build_go build_java build_nodejs build_python help install_dotnet_sdk install_nodejs_sdk lint_provider provider provider_no_deps test ci-mgmt test_provider debug_tfgen
+.PHONY: development build build_sdks install_go_sdk install_java_sdk install_python_sdk install_sdks only_build build_dotnet build_go build_java build_nodejs build_python install_dotnet_sdk install_nodejs_sdk lint_provider provider provider_no_deps test ci-mgmt test_provider debug_tfgen
 
 # Provider cross-platform build & packaging
 

--- a/provider-ci/test-providers/acme/Makefile
+++ b/provider-ci/test-providers/acme/Makefile
@@ -36,11 +36,14 @@ LDFLAGS=$(LDFLAGS_PROJ_VERSION) $(LDFLAGS_UPSTREAM_VERSION) $(LDFLAGS_EXTRAS) $(
 # Ensure all directories exist before evaluating targets to avoid issues with `touch` creating directories.
 _ := $(shell mkdir -p .make bin .pulumi/bin)
 
+# Build the provider and all SDKs and install ready for testing
+build: install_plugins provider build_sdks install_sdks
 # Keep aliases for old targets to ensure backwards compatibility
 development: build
 only_build: build
-# Build the provider and all SDKs and install ready for testing
-build: install_plugins provider build_sdks install_sdks
+# Prepare the workspace for building the provider and SDKs
+# Importantly this is run by CI ahead of restoring the bin directory and resuming SDK builds
+prepare_local_workspace: install_plugins upstream
 # Creates all generated files which need to be committed
 generate: generate_sdks schema
 generate_sdks: generate_dotnet generate_go generate_nodejs generate_python
@@ -153,6 +156,7 @@ install_nodejs_sdk: .make/install_nodejs_sdk
 install_python_sdk:
 .PHONY: install_dotnet_sdk install_go_sdk install_java_sdk install_nodejs_sdk install_python_sdk
 
+# Install Pulumi plugins required for TFGen to resolve references
 install_plugins: .make/install_plugins
 .make/install_plugins: export PULUMI_HOME := $(WORKING_DIR)/.pulumi
 .make/install_plugins: export PATH := $(WORKING_DIR)/.pulumi/bin:$(PATH)
@@ -207,6 +211,7 @@ bin/$(TFGEN):
 	(cd provider && go build $(PULUMI_PROVIDER_BUILD_PARALLELISM) -o $(WORKING_DIR)/bin/$(TFGEN) -ldflags "$(LDFLAGS_PROJ_VERSION) $(LDFLAGS_EXTRAS)" $(PROJECT)/$(PROVIDER_PATH)/cmd/$(TFGEN))
 .PHONY: tfgen schema tfgen_no_deps tfgen_build_only
 
+# Apply patches to the upstream submodule, if it exists
 upstream: .make/upstream
 # Re-run if the upstream commit or the patches change
 .make/upstream: $(wildcard patches/*) $(wildcard .git/modules/upstream/HEAD)

--- a/provider-ci/test-providers/acme/Makefile
+++ b/provider-ci/test-providers/acme/Makefile
@@ -138,10 +138,13 @@ lint_provider.fix:
 # `make provider_no_deps` builds the provider binary directly, without ensuring that
 # `cmd/pulumi-resource-acme/schema.json` is valid and up to date.
 # To create a release ready binary, you should use `make provider`.
+.PHONY: provider provider_no_deps
+build_provider_cmd = cd provider && go build $(PULUMI_PROVIDER_BUILD_PARALLELISM) -o $(WORKING_DIR)/bin/$(PROVIDER) -ldflags "$(LDFLAGS)" $(PROJECT)/$(PROVIDER_PATH)/cmd/$(PROVIDER)
+provider: bin/$(PROVIDER)
 provider_no_deps:
-	(cd provider && go build $(PULUMI_PROVIDER_BUILD_PARALLELISM) -o $(WORKING_DIR)/bin/$(PROVIDER) -ldflags "$(LDFLAGS)" $(PROJECT)/$(PROVIDER_PATH)/cmd/$(PROVIDER))
-
-provider: tfgen provider_no_deps
+	$(call build_provider_cmd)
+bin/$(PROVIDER): .make/schema
+	$(call build_provider_cmd)
 
 test: export PATH := $(WORKING_DIR)/bin:$(PATH)
 test:

--- a/provider-ci/test-providers/aws/.github/workflows/build_provider.yml
+++ b/provider-ci/test-providers/aws/.github/workflows/build_provider.yml
@@ -45,6 +45,8 @@ jobs:
         uses: ./.github/actions/setup-tools
         with:
           tools: pulumictl, go
+      - name: Prepare local workspace before restoring previously built
+        run: make prepare_local_workspace
       - name: Download schema-embed.json
         uses: actions/download-artifact@v4
         with:
@@ -53,9 +55,11 @@ jobs:
           # Avoid creating directories for each artifact
           merge-multiple: true
           path: provider/cmd/pulumi-resource-aws/schema-embed.json
-      - name: Prepare for build
-        # This installs plugins and prepares upstream
-        run: make upstream
+      - name: Restore makefile progress
+        uses: actions/download-artifact@v4
+        with:
+          name: prerequisites.make
+          path: .make
       - name: Build & package provider
         run: make provider_dist-${{ matrix.platform.os }}-${{ matrix.platform.arch }}
       - name: Upload artifacts

--- a/provider-ci/test-providers/aws/.github/workflows/build_sdk.yml
+++ b/provider-ci/test-providers/aws/.github/workflows/build_sdk.yml
@@ -65,12 +65,17 @@ jobs:
         uses: ./.github/actions/setup-tools
         with:
           tools: pulumictl, pulumicli, ${{ matrix.language }}
+      - name: Prepare local workspace
+        run: make prepare_local_workspace
       - name: Download bin
         uses: ./.github/actions/download-bin
-      - name: Install plugins
-        run: make install_plugins
       - name: Update path
         run: echo "${{ github.workspace }}/bin" >> "$GITHUB_PATH"
+      - name: Restore makefile progress
+        uses: actions/download-artifact@v4
+        with:
+          name: prerequisites.make
+          path: .make
       - name: Build SDK
         run: make build_${{ matrix.language }}
       - name: Check worktree clean
@@ -86,3 +91,9 @@ jobs:
         uses: ./.github/actions/upload-sdk
         with:
           language: ${{ matrix.language }}
+      - name: Save makefile progress
+        uses: actions/upload-artifact@v4
+        with:
+          name: build_${{ matrix.language }}.make
+          path: .make
+          include-hidden-files: true

--- a/provider-ci/test-providers/aws/.github/workflows/master.yml
+++ b/provider-ci/test-providers/aws/.github/workflows/master.yml
@@ -158,9 +158,6 @@ jobs:
         tools: pulumictl, pulumicli, ${{ matrix.language }}
     - name: Download bin
       uses: ./.github/actions/download-bin
-    - name: Add NuGet source
-      if: matrix.language == 'dotnet'
-      run: dotnet nuget add source ${{ github.workspace }}/nuget
     - name: Download SDK
       uses: ./.github/actions/download-sdk
       with:

--- a/provider-ci/test-providers/aws/.github/workflows/master.yml
+++ b/provider-ci/test-providers/aws/.github/workflows/master.yml
@@ -165,6 +165,8 @@ jobs:
       uses: ./.github/actions/download-sdk
       with:
         language: ${{ matrix.language }}
+    - name: Mark SDK up to date
+      run: make --touch build_${{ matrix.language }}
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> "$GITHUB_PATH"
     - name: Install Python deps

--- a/provider-ci/test-providers/aws/.github/workflows/master.yml
+++ b/provider-ci/test-providers/aws/.github/workflows/master.yml
@@ -156,14 +156,19 @@ jobs:
       uses: ./.github/actions/setup-tools
       with:
         tools: pulumictl, pulumicli, ${{ matrix.language }}
+    - name: Prepare local workspace
+      run: make prepare_local_workspace
     - name: Download bin
       uses: ./.github/actions/download-bin
     - name: Download SDK
       uses: ./.github/actions/download-sdk
       with:
         language: ${{ matrix.language }}
-    - name: Mark SDK up to date
-      run: make --touch build_${{ matrix.language }}
+    - name: Restore makefile progress
+      uses: actions/download-artifact@v4
+      with:
+        name: build_${{ matrix.language }}.make
+        path: .make
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> "$GITHUB_PATH"
     - name: Install Python deps

--- a/provider-ci/test-providers/aws/.github/workflows/nightly-test.yml
+++ b/provider-ci/test-providers/aws/.github/workflows/nightly-test.yml
@@ -74,9 +74,6 @@ jobs:
         tools: pulumictl, pulumicli, ${{ matrix.language}}
     - name: Download bin
       uses: ./.github/actions/download-bin
-    - name: Add NuGet source
-      if: matrix.language == 'dotnet'
-      run: dotnet nuget add source ${{ github.workspace }}/nuget
     - name: Download SDK
       uses: ./.github/actions/download-sdk
       with:

--- a/provider-ci/test-providers/aws/.github/workflows/nightly-test.yml
+++ b/provider-ci/test-providers/aws/.github/workflows/nightly-test.yml
@@ -72,14 +72,19 @@ jobs:
       uses: ./.github/actions/setup-tools
       with:
         tools: pulumictl, pulumicli, ${{ matrix.language}}
+    - name: Prepare local workspace
+      run: make prepare_local_workspace
     - name: Download bin
       uses: ./.github/actions/download-bin
     - name: Download SDK
       uses: ./.github/actions/download-sdk
       with:
         language: ${{ matrix.language }}
-    - name: Mark SDK up to date
-      run: make --touch build_${{ matrix.language }}
+    - name: Restore makefile progress
+      uses: actions/download-artifact@v4
+      with:
+        name: build_${{ matrix.language }}.make
+        path: .make
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> "$GITHUB_PATH"
     - name: Install Python deps

--- a/provider-ci/test-providers/aws/.github/workflows/nightly-test.yml
+++ b/provider-ci/test-providers/aws/.github/workflows/nightly-test.yml
@@ -81,6 +81,8 @@ jobs:
       uses: ./.github/actions/download-sdk
       with:
         language: ${{ matrix.language }}
+    - name: Mark SDK up to date
+      run: make --touch build_${{ matrix.language }}
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> "$GITHUB_PATH"
     - name: Install Python deps

--- a/provider-ci/test-providers/aws/.github/workflows/prerelease.yml
+++ b/provider-ci/test-providers/aws/.github/workflows/prerelease.yml
@@ -99,9 +99,6 @@ jobs:
         tools: pulumictl, pulumicli, nodejs, python, dotnet, go, java
     - name: Download bin
       uses: ./.github/actions/download-bin
-    - name: Add NuGet source
-      if: matrix.language == 'dotnet'
-      run: dotnet nuget add source ${{ github.workspace }}/nuget
     - name: Download SDK
       uses: ./.github/actions/download-sdk
       with:

--- a/provider-ci/test-providers/aws/.github/workflows/prerelease.yml
+++ b/provider-ci/test-providers/aws/.github/workflows/prerelease.yml
@@ -106,6 +106,8 @@ jobs:
       uses: ./.github/actions/download-sdk
       with:
         language: ${{ matrix.language }}
+    - name: Mark SDK up to date
+      run: make --touch build_${{ matrix.language }}
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> "$GITHUB_PATH"
     - name: Install Python deps

--- a/provider-ci/test-providers/aws/.github/workflows/prerelease.yml
+++ b/provider-ci/test-providers/aws/.github/workflows/prerelease.yml
@@ -97,14 +97,19 @@ jobs:
       uses: ./.github/actions/setup-tools
       with:
         tools: pulumictl, pulumicli, nodejs, python, dotnet, go, java
+    - name: Prepare local workspace
+      run: make prepare_local_workspace
     - name: Download bin
       uses: ./.github/actions/download-bin
     - name: Download SDK
       uses: ./.github/actions/download-sdk
       with:
         language: ${{ matrix.language }}
-    - name: Mark SDK up to date
-      run: make --touch build_${{ matrix.language }}
+    - name: Restore makefile progress
+      uses: actions/download-artifact@v4
+      with:
+        name: build_${{ matrix.language }}.make
+        path: .make
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> "$GITHUB_PATH"
     - name: Install Python deps

--- a/provider-ci/test-providers/aws/.github/workflows/prerequisites.yml
+++ b/provider-ci/test-providers/aws/.github/workflows/prerequisites.yml
@@ -67,20 +67,16 @@ jobs:
         path: |
           .pulumi/examples-cache
         key: ${{ runner.os }}-${{ hashFiles('provider/go.sum') }}
-    - name: Prepare upstream code
-      run: make upstream
     - name: Setup tools
       uses: ./.github/actions/setup-tools
       with:
         tools: go, pulumictl, pulumicli, schema-tools
-    - name: Build schema generator binary
-      run: make tfgen_build_only
-    - name: Install plugins
-      run: make install_plugins
+    - name: Prepare local workspace before restoring previously built files
+      run: make prepare_local_workspace
     - name: Generate schema
-      run: make tfgen_no_deps
+      run: make schema
     - name: Build provider binary
-      run: make provider_no_deps
+      run: make provider
     - name: Unit-test provider code
       run: make test_provider
     - if: inputs.is_pr
@@ -92,6 +88,12 @@ jobs:
           schema-tools compare -r github://api.github.com/pulumi -p aws -o "${{ inputs.default_branch }}" -n --local-path=provider/cmd/pulumi-resource-aws/schema.json;
           echo "$EOF";
         } >> "$GITHUB_ENV"
+    - name: Save makefile progress
+      uses: actions/upload-artifact@v4
+      with:
+        name: prerequisites.make
+        path: .make
+        include-hidden-files: true
     - if: inputs.is_pr && inputs.is_automated == false
       name: Comment on PR with Details of Schema Check
       uses: thollander/actions-comment-pull-request@v2

--- a/provider-ci/test-providers/aws/.github/workflows/release.yml
+++ b/provider-ci/test-providers/aws/.github/workflows/release.yml
@@ -103,14 +103,19 @@ jobs:
       uses: ./.github/actions/setup-tools
       with:
         tools: pulumictl, pulumicli, ${{ matrix.language }}
+    - name: Prepare local workspace
+      run: make prepare_local_workspace
     - name: Download bin
       uses: ./.github/actions/download-bin
     - name: Download SDK
       uses: ./.github/actions/download-sdk
       with:
         language: ${{ matrix.language }}
-    - name: Mark SDK up to date
-      run: make --touch build_${{ matrix.language }}
+    - name: Restore makefile progress
+      uses: actions/download-artifact@v4
+      with:
+        name: build_${{ matrix.language }}.make
+        path: .make
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> "$GITHUB_PATH"
     - name: Install Python deps

--- a/provider-ci/test-providers/aws/.github/workflows/release.yml
+++ b/provider-ci/test-providers/aws/.github/workflows/release.yml
@@ -112,6 +112,8 @@ jobs:
       uses: ./.github/actions/download-sdk
       with:
         language: ${{ matrix.language }}
+    - name: Mark SDK up to date
+      run: make --touch build_${{ matrix.language }}
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> "$GITHUB_PATH"
     - name: Install Python deps

--- a/provider-ci/test-providers/aws/.github/workflows/release.yml
+++ b/provider-ci/test-providers/aws/.github/workflows/release.yml
@@ -105,9 +105,6 @@ jobs:
         tools: pulumictl, pulumicli, ${{ matrix.language }}
     - name: Download bin
       uses: ./.github/actions/download-bin
-    - name: Add NuGet source
-      if: matrix.language == 'dotnet'
-      run: dotnet nuget add source ${{ github.workspace }}/nuget
     - name: Download SDK
       uses: ./.github/actions/download-sdk
       with:

--- a/provider-ci/test-providers/aws/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/test-providers/aws/.github/workflows/run-acceptance-tests.yml
@@ -158,6 +158,8 @@ jobs:
       uses: ./.github/actions/download-sdk
       with:
         language: ${{ matrix.language }}
+    - name: Mark SDK up to date
+      run: make --touch build_${{ matrix.language }}
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> "$GITHUB_PATH"
     - name: Install Python deps

--- a/provider-ci/test-providers/aws/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/test-providers/aws/.github/workflows/run-acceptance-tests.yml
@@ -149,14 +149,19 @@ jobs:
       uses: ./.github/actions/setup-tools
       with:
         tools: pulumictl, pulumicli, ${{ matrix.language }}
+    - name: Prepare local workspace
+      run: make prepare_local_workspace
     - name: Download bin
       uses: ./.github/actions/download-bin
     - name: Download SDK
       uses: ./.github/actions/download-sdk
       with:
         language: ${{ matrix.language }}
-    - name: Mark SDK up to date
-      run: make --touch build_${{ matrix.language }}
+    - name: Restore makefile progress
+      uses: actions/download-artifact@v4
+      with:
+        name: build_${{ matrix.language }}.make
+        path: .make
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> "$GITHUB_PATH"
     - name: Install Python deps

--- a/provider-ci/test-providers/aws/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/test-providers/aws/.github/workflows/run-acceptance-tests.yml
@@ -151,9 +151,6 @@ jobs:
         tools: pulumictl, pulumicli, ${{ matrix.language }}
     - name: Download bin
       uses: ./.github/actions/download-bin
-    - name: Add NuGet source
-      if: matrix.language == 'dotnet'
-      run: dotnet nuget add source ${{ github.workspace }}/nuget
     - name: Download SDK
       uses: ./.github/actions/download-sdk
       with:

--- a/provider-ci/test-providers/aws/Makefile
+++ b/provider-ci/test-providers/aws/Makefile
@@ -113,11 +113,6 @@ clean:
 	rm -rf bin/*
 	rm -rf .make/*
 
-help:
-	@grep '^[^.#]\+:\s\+.*#' Makefile | \
-	sed "s/\(.\+\):\s*\(.*\) #\s*\(.*\)/`printf "\033[93m"`\1`printf "\033[0m"`	\3 [\2]/" | \
-	expand -t20
-
 install_dotnet_sdk:
 	mkdir -p $(WORKING_DIR)/nuget
 	find . -name '*.nupkg' -print -exec cp -p {} $(WORKING_DIR)/nuget \;
@@ -237,7 +232,7 @@ ci-mgmt: .ci-mgmt.yaml
 debug_tfgen:
 	dlv  --listen=:2345 --headless=true --api-version=2  exec $(WORKING_DIR)/bin/$(TFGEN) -- schema --out provider/cmd/$(PROVIDER)
 
-.PHONY: development build build_sdks install_go_sdk install_java_sdk install_python_sdk install_sdks only_build build_dotnet build_go build_java build_nodejs build_python help install_dotnet_sdk install_nodejs_sdk lint_provider provider provider_no_deps test ci-mgmt test_provider debug_tfgen
+.PHONY: development build build_sdks install_go_sdk install_java_sdk install_python_sdk install_sdks only_build build_dotnet build_go build_java build_nodejs build_python install_dotnet_sdk install_nodejs_sdk lint_provider provider provider_no_deps test ci-mgmt test_provider debug_tfgen
 
 # Provider cross-platform build & packaging
 

--- a/provider-ci/test-providers/aws/Makefile
+++ b/provider-ci/test-providers/aws/Makefile
@@ -45,12 +45,6 @@ generate_sdks: generate_nodejs generate_python generate_dotnet generate_go gener
 build_sdks: build_nodejs build_python build_dotnet build_go build_java
 install_sdks: install_nodejs_sdk install_python_sdk install_dotnet_sdk install_go_sdk install_java_sdk
 
-install_go_sdk:
-
-install_java_sdk:
-
-install_python_sdk:
-
 GEN_PULUMI_HOME := $(WORKING_DIR)/.pulumi
 GEN_PULUMI_CONVERT_EXAMPLES_CACHE_DIR := $(GEN_PULUMI_HOME)/examples-cache
 GEN_ENVS := PULUMI_HOME=$(GEN_PULUMI_HOME) PULUMI_CONVERT_EXAMPLES_CACHE_DIR=$(GEN_PULUMI_CONVERT_EXAMPLES_CACHE_DIR) PULUMI_CONVERT=$(PULUMI_CONVERT) PULUMI_DISABLE_AUTOMATIC_PLUGIN_ACQUISITION=$(PULUMI_CONVERT)
@@ -136,12 +130,19 @@ clean:
 	rm -rf bin/*
 	rm -rf .make/*
 
-install_dotnet_sdk:
+.PHONY: install_dotnet_sdk install_go_sdk install_java_sdk install_nodejs_sdk install_python_sdk
+install_dotnet_sdk: .make/install_dotnet_sdk
+.make/install_dotnet_sdk: .make/build_dotnet
 	mkdir -p $(WORKING_DIR)/nuget
 	find . -name '*.nupkg' -print -exec cp -p {} $(WORKING_DIR)/nuget \;
-
-install_nodejs_sdk:
+	@touch $@
+install_go_sdk:
+install_java_sdk:
+install_nodejs_sdk: .make/install_nodejs_sdk
+.make/install_nodejs_sdk: .make/build_nodejs
 	yarn link --cwd $(WORKING_DIR)/sdk/nodejs/bin
+	@touch $@
+install_python_sdk:
 
 .PHONY: install_plugins
 install_plugins: .make/install_plugins
@@ -258,7 +259,7 @@ ci-mgmt: .ci-mgmt.yaml
 debug_tfgen:
 	dlv  --listen=:2345 --headless=true --api-version=2  exec $(WORKING_DIR)/bin/$(TFGEN) -- schema --out provider/cmd/$(PROVIDER)
 
-.PHONY: install_go_sdk install_java_sdk install_python_sdk install_sdks install_dotnet_sdk install_nodejs_sdk lint_provider test ci-mgmt test_provider debug_tfgen
+.PHONY: lint_provider test ci-mgmt test_provider debug_tfgen
 
 # Provider cross-platform build & packaging
 

--- a/provider-ci/test-providers/aws/Makefile
+++ b/provider-ci/test-providers/aws/Makefile
@@ -27,6 +27,13 @@ LDFLAGS_UPSTREAM_VERSION=-X github.com/hashicorp/terraform-provider-aws/version.
 LDFLAGS_EXTRAS=
 LDFLAGS=$(LDFLAGS_PROJ_VERSION) $(LDFLAGS_UPSTREAM_VERSION) $(LDFLAGS_EXTRAS) $(LDFLAGS_STRIP_SYMBOLS)
 
+# Create a `.make` directory for tracking targets which don't generate a single file output. This should be ignored by git.
+# For targets which either don't generate a single file output, or the output file is committed, we use a "sentinel"
+# file within `.make/` to track the staleness of the target and only rebuild when needed. 
+# For each phony target, we create an internal target with the same name, but prefixed with `.make/` where the work is performed.
+# At the end of each internal target we run `@touch $@` to update the file which is the name of the target.
+_ := $(shell mkdir -p .make)
+
 development: install_plugins provider build_sdks install_sdks
 
 build: install_plugins provider build_sdks install_sdks

--- a/provider-ci/test-providers/aws/Makefile
+++ b/provider-ci/test-providers/aws/Makefile
@@ -81,16 +81,21 @@ build_go: .make/build_go
 	cd sdk && go list "$$(grep -e "^module" go.mod | cut -d ' ' -f 2)/go/..." | xargs -I {} bash -c 'go build {} && go clean -i {}'
 	@touch $@
 
-build_java: PACKAGE_VERSION := $(VERSION_GENERIC)
-build_java: export PULUMI_HOME := $(WORKING_DIR)/.pulumi
-build_java: export PATH := $(WORKING_DIR)/.pulumi/bin:$(PATH)
-build_java: export PULUMI_CONVERT_EXAMPLES_CACHE_DIR := $(WORKING_DIR)/.pulumi/examples-cache
-build_java: bin/pulumi-java-gen .make/upstream
-	$(WORKING_DIR)/bin/$(JAVA_GEN) generate --schema provider/cmd/$(PROVIDER)/schema.json --out sdk/java  --build gradle-nexus
+.PHONY: generate_java build_java
+generate_java: .make/generate_java
+build_java: .make/build_java
+.make/generate_java: export PATH := $(WORKING_DIR)/.pulumi/bin:$(PATH)
+.make/generate_java: PACKAGE_VERSION := $(VERSION_GENERIC)
+.make/generate_java: bin/pulumi-java-gen .make/schema
+	PULUMI_HOME=$(GEN_PULUMI_HOME) PULUMI_CONVERT_EXAMPLES_CACHE_DIR=$(GEN_PULUMI_CONVERT_EXAMPLES_CACHE_DIR) bin/$(JAVA_GEN) generate --schema provider/cmd/$(PROVIDER)/schema.json --out sdk/java  --build gradle-nexus
+	printf "module fake_java_module // Exclude this directory from Go tools\n\ngo 1.17\n" > sdk/java/go.mod
+	@touch $@
+.make/build_java: PACKAGE_VERSION := $(VERSION_GENERIC)
+.make/build_java: .make/generate_java
 	cd sdk/java/ && \
-		printf "module fake_java_module // Exclude this directory from Go tools\n\ngo 1.17\n" > go.mod && \
 		gradle --console=plain build && \
 		gradle --console=plain javadoc
+	@touch $@
 
 .PHONY: generate_nodejs build_nodejs
 generate_nodejs: .make/generate_nodejs
@@ -254,7 +259,7 @@ ci-mgmt: .ci-mgmt.yaml
 debug_tfgen:
 	dlv  --listen=:2345 --headless=true --api-version=2  exec $(WORKING_DIR)/bin/$(TFGEN) -- schema --out provider/cmd/$(PROVIDER)
 
-.PHONY: development build build_sdks install_go_sdk install_java_sdk install_python_sdk install_sdks only_build build_java install_dotnet_sdk install_nodejs_sdk lint_provider provider provider_no_deps test ci-mgmt test_provider debug_tfgen
+.PHONY: development build build_sdks install_go_sdk install_java_sdk install_python_sdk install_sdks only_build install_dotnet_sdk install_nodejs_sdk lint_provider provider provider_no_deps test ci-mgmt test_provider debug_tfgen
 
 # Provider cross-platform build & packaging
 

--- a/provider-ci/test-providers/aws/Makefile
+++ b/provider-ci/test-providers/aws/Makefile
@@ -32,7 +32,9 @@ LDFLAGS=$(LDFLAGS_PROJ_VERSION) $(LDFLAGS_UPSTREAM_VERSION) $(LDFLAGS_EXTRAS) $(
 # file within `.make/` to track the staleness of the target and only rebuild when needed. 
 # For each phony target, we create an internal target with the same name, but prefixed with `.make/` where the work is performed.
 # At the end of each internal target we run `@touch $@` to update the file which is the name of the target.
-_ := $(shell mkdir -p .make)
+
+# Ensure all directories exist before evaluating targets to avoid issues with `touch` creating directories.
+_ := $(shell mkdir -p .make bin .pulumi/bin)
 
 development: .make/install_plugins provider build_sdks install_sdks
 
@@ -230,8 +232,7 @@ ci-mgmt: .ci-mgmt.yaml
 
 # Compute the version of Pulumi to use by inspecting the Go dependencies of the provider.
 .pulumi/version: provider/go.mod
-	@mkdir -p .pulumi
-	@cd provider && go list -f "{{slice .Version 1}}" -m github.com/pulumi/pulumi/pkg/v3 | tee ../$@
+	cd provider && go list -f "{{slice .Version 1}}" -m github.com/pulumi/pulumi/pkg/v3 | tee ../$@
 
 # Start debug server for tfgen
 debug_tfgen:

--- a/provider-ci/test-providers/aws/Makefile
+++ b/provider-ci/test-providers/aws/Makefile
@@ -222,6 +222,7 @@ ci-mgmt: .ci-mgmt.yaml
 .pulumi/bin/pulumi: .pulumi/version
 	@if [ -x .pulumi/bin/pulumi ] && [ "v$$(cat .pulumi/version)" = "$$(.pulumi/bin/pulumi version)" ]; then \
 		echo "pulumi/bin/pulumi version: v$$(cat .pulumi/version)"; \
+		touch $@; \
 	else \
 		curl -fsSL https://get.pulumi.com | \
 			HOME=$(WORKING_DIR) sh -s -- --version "$$(cat .pulumi/version)"; \

--- a/provider-ci/test-providers/aws/Makefile
+++ b/provider-ci/test-providers/aws/Makefile
@@ -167,18 +167,22 @@ test_provider:
 	@echo ""
 	cd provider && go test -v -short ./... -parallel $(TESTPARALLELISM)
 
-.PHONY: tfgen tfgen_no_deps tfgen_build_only
-tfgen: install_plugins upstream tfgen_no_deps
+.PHONY: tfgen schema tfgen_no_deps tfgen_build_only
+tfgen: schema
+schema: .make/schema 
+# This does actually have dependencies, but we're keeping it around for backwards compatibility for now
+tfgen_no_deps: .make/schema
 
-tfgen_no_deps: export PULUMI_HOME := $(WORKING_DIR)/.pulumi
-tfgen_no_deps: export PATH := $(WORKING_DIR)/.pulumi/bin:$(PATH)
-tfgen_no_deps: export PULUMI_CONVERT := $(PULUMI_CONVERT)
-tfgen_no_deps: export PULUMI_CONVERT_EXAMPLES_CACHE_DIR := $(WORKING_DIR)/.pulumi/examples-cache
-tfgen_no_deps: export PULUMI_DISABLE_AUTOMATIC_PLUGIN_ACQUISITION := $(PULUMI_CONVERT)
-tfgen_no_deps: export PULUMI_MISSING_DOCS_ERROR := $(PULUMI_MISSING_DOCS_ERROR)
-tfgen_no_deps: bin/$(TFGEN)
+.make/schema: export PULUMI_HOME := $(WORKING_DIR)/.pulumi
+.make/schema: export PATH := $(WORKING_DIR)/.pulumi/bin:$(PATH)
+.make/schema: export PULUMI_CONVERT := $(PULUMI_CONVERT)
+.make/schema: export PULUMI_CONVERT_EXAMPLES_CACHE_DIR := $(WORKING_DIR)/.pulumi/examples-cache
+.make/schema: export PULUMI_DISABLE_AUTOMATIC_PLUGIN_ACQUISITION := $(PULUMI_CONVERT)
+.make/schema: export PULUMI_MISSING_DOCS_ERROR := $(PULUMI_MISSING_DOCS_ERROR)
+.make/schema: bin/$(TFGEN) provider/resources.go provider/go.mod .make/install_plugins .make/upstream
 	$(WORKING_DIR)/bin/$(TFGEN) schema --out provider/cmd/$(PROVIDER)
 	(cd provider && VERSION=$(VERSION_GENERIC) go generate cmd/$(PROVIDER)/main.go)
+	@touch $@
 
 tfgen_build_only: bin/$(TFGEN)
 

--- a/provider-ci/test-providers/aws/Makefile
+++ b/provider-ci/test-providers/aws/Makefile
@@ -131,12 +131,18 @@ clean:
 	rm -rf sdk/{dotnet,nodejs,go,python}
 	rm -rf bin/*
 	rm -rf .make/*
+	if dotnet nuget list source | grep "$(WORKING_DIR)/nuget"; then \
+		dotnet nuget remove source "$(WORKING_DIR)/nuget" \
+	; fi
 .PHONY: clean
 
 install_dotnet_sdk: .make/install_dotnet_sdk
 .make/install_dotnet_sdk: .make/build_dotnet
-	mkdir -p $(WORKING_DIR)/nuget
-	find . -name '*.nupkg' -print -exec cp -p {} $(WORKING_DIR)/nuget \;
+	mkdir -p nuget
+	find sdk/dotnet/bin -name '*.nupkg' -print -exec cp -p "{}" ${WORKING_DIR}/nuget \;
+	if ! dotnet nuget list source | grep "${WORKING_DIR}/nuget"; then \
+		dotnet nuget add source "${WORKING_DIR}/nuget" --name "${WORKING_DIR}/nuget" \
+	; fi
 	@touch $@
 install_go_sdk:
 install_java_sdk:

--- a/provider-ci/test-providers/aws/Makefile
+++ b/provider-ci/test-providers/aws/Makefile
@@ -92,16 +92,20 @@ build_java: bin/pulumi-java-gen .make/upstream
 		gradle --console=plain build && \
 		gradle --console=plain javadoc
 
-build_nodejs: export PULUMI_HOME := $(WORKING_DIR)/.pulumi
-build_nodejs: export PATH := $(WORKING_DIR)/.pulumi/bin:$(PATH)
-build_nodejs: export PULUMI_CONVERT_EXAMPLES_CACHE_DIR := $(WORKING_DIR)/.pulumi/examples-cache
-build_nodejs: .make/upstream
-	PULUMI_CONVERT=$(PULUMI_CONVERT) PULUMI_DISABLE_AUTOMATIC_PLUGIN_ACQUISITION=$(PULUMI_CONVERT) $(WORKING_DIR)/bin/$(TFGEN) nodejs --out sdk/nodejs/
+.PHONY: generate_nodejs build_nodejs
+generate_nodejs: .make/generate_nodejs
+build_nodejs: .make/build_nodejs
+.make/generate_nodejs: export PATH := $(WORKING_DIR)/.pulumi/bin:$(PATH)
+.make/generate_nodejs: bin/$(TFGEN)
+	$(GEN_ENVS) $(WORKING_DIR)/bin/$(TFGEN) nodejs --out sdk/nodejs/
+	printf "module fake_nodejs_module // Exclude this directory from Go tools\n\ngo 1.17\n" > sdk/nodejs/go.mod
+	@touch $@
+.make/build_nodejs: .make/generate_nodejs
 	cd sdk/nodejs/ && \
-		printf "module fake_nodejs_module // Exclude this directory from Go tools\n\ngo 1.17\n" > go.mod && \
 		yarn install && \
 		yarn run tsc && \
 		cp ../../README.md ../../LICENSE* package.json yarn.lock ./bin/
+	@touch $@
 
 build_python: export PULUMI_HOME := $(WORKING_DIR)/.pulumi
 build_python: export PATH := $(WORKING_DIR)/.pulumi/bin:$(PATH)
@@ -247,7 +251,7 @@ ci-mgmt: .ci-mgmt.yaml
 debug_tfgen:
 	dlv  --listen=:2345 --headless=true --api-version=2  exec $(WORKING_DIR)/bin/$(TFGEN) -- schema --out provider/cmd/$(PROVIDER)
 
-.PHONY: development build build_sdks install_go_sdk install_java_sdk install_python_sdk install_sdks only_build build_java build_nodejs build_python install_dotnet_sdk install_nodejs_sdk lint_provider provider provider_no_deps test ci-mgmt test_provider debug_tfgen
+.PHONY: development build build_sdks install_go_sdk install_java_sdk install_python_sdk install_sdks only_build build_java build_python install_dotnet_sdk install_nodejs_sdk lint_provider provider provider_no_deps test ci-mgmt test_provider debug_tfgen
 
 # Provider cross-platform build & packaging
 

--- a/provider-ci/test-providers/aws/Makefile
+++ b/provider-ci/test-providers/aws/Makefile
@@ -107,12 +107,11 @@ build_python: .make/upstream
 		cd ./bin && \
 		../venv/bin/python -m build .
 
+.PHONY: clean
 clean:
 	rm -rf sdk/{dotnet,nodejs,go,python}
-
-cleanup:
-	rm -r $(WORKING_DIR)/bin
-	rm -f provider/cmd/$(PROVIDER)/schema.go
+	rm -rf bin/*
+	rm -rf .make/*
 
 help:
 	@grep '^[^.#]\+:\s\+.*#' Makefile | \
@@ -238,7 +237,7 @@ ci-mgmt: .ci-mgmt.yaml
 debug_tfgen:
 	dlv  --listen=:2345 --headless=true --api-version=2  exec $(WORKING_DIR)/bin/$(TFGEN) -- schema --out provider/cmd/$(PROVIDER)
 
-.PHONY: development build build_sdks install_go_sdk install_java_sdk install_python_sdk install_sdks only_build build_dotnet build_go build_java build_nodejs build_python clean cleanup help install_dotnet_sdk install_nodejs_sdk lint_provider provider provider_no_deps test ci-mgmt test_provider debug_tfgen
+.PHONY: development build build_sdks install_go_sdk install_java_sdk install_python_sdk install_sdks only_build build_dotnet build_go build_java build_nodejs build_python help install_dotnet_sdk install_nodejs_sdk lint_provider provider provider_no_deps test ci-mgmt test_provider debug_tfgen
 
 # Provider cross-platform build & packaging
 

--- a/provider-ci/test-providers/aws/Makefile
+++ b/provider-ci/test-providers/aws/Makefile
@@ -53,7 +53,7 @@ only_build: build
 build_dotnet: export PULUMI_HOME := $(WORKING_DIR)/.pulumi
 build_dotnet: export PATH := $(WORKING_DIR)/.pulumi/bin:$(PATH)
 build_dotnet: export PULUMI_CONVERT_EXAMPLES_CACHE_DIR := $(WORKING_DIR)/.pulumi/examples-cache
-build_dotnet: upstream
+build_dotnet: .make/upstream
 	PULUMI_CONVERT=$(PULUMI_CONVERT) PULUMI_DISABLE_AUTOMATIC_PLUGIN_ACQUISITION=$(PULUMI_CONVERT) $(WORKING_DIR)/bin/$(TFGEN) dotnet --out sdk/dotnet/
 	cd sdk/dotnet/ && \
 		printf "module fake_dotnet_module // Exclude this directory from Go tools\n\ngo 1.17\n" > go.mod && \
@@ -63,7 +63,7 @@ build_dotnet: upstream
 build_go: export PULUMI_HOME := $(WORKING_DIR)/.pulumi
 build_go: export PATH := $(WORKING_DIR)/.pulumi/bin:$(PATH)
 build_go: export PULUMI_CONVERT_EXAMPLES_CACHE_DIR := $(WORKING_DIR)/.pulumi/examples-cache
-build_go: upstream
+build_go: .make/upstream
 	PULUMI_CONVERT=$(PULUMI_CONVERT) PULUMI_DISABLE_AUTOMATIC_PLUGIN_ACQUISITION=$(PULUMI_CONVERT) $(WORKING_DIR)/bin/$(TFGEN) go --out sdk/go/
 	cd sdk && go list "$$(grep -e "^module" go.mod | cut -d ' ' -f 2)/go/..." | xargs -I {} bash -c 'go build {} && go clean -i {}'
 
@@ -71,7 +71,7 @@ build_java: PACKAGE_VERSION := $(VERSION_GENERIC)
 build_java: export PULUMI_HOME := $(WORKING_DIR)/.pulumi
 build_java: export PATH := $(WORKING_DIR)/.pulumi/bin:$(PATH)
 build_java: export PULUMI_CONVERT_EXAMPLES_CACHE_DIR := $(WORKING_DIR)/.pulumi/examples-cache
-build_java: bin/pulumi-java-gen upstream
+build_java: bin/pulumi-java-gen .make/upstream
 	$(WORKING_DIR)/bin/$(JAVA_GEN) generate --schema provider/cmd/$(PROVIDER)/schema.json --out sdk/java  --build gradle-nexus
 	cd sdk/java/ && \
 		printf "module fake_java_module // Exclude this directory from Go tools\n\ngo 1.17\n" > go.mod && \
@@ -81,7 +81,7 @@ build_java: bin/pulumi-java-gen upstream
 build_nodejs: export PULUMI_HOME := $(WORKING_DIR)/.pulumi
 build_nodejs: export PATH := $(WORKING_DIR)/.pulumi/bin:$(PATH)
 build_nodejs: export PULUMI_CONVERT_EXAMPLES_CACHE_DIR := $(WORKING_DIR)/.pulumi/examples-cache
-build_nodejs: upstream
+build_nodejs: .make/upstream
 	PULUMI_CONVERT=$(PULUMI_CONVERT) PULUMI_DISABLE_AUTOMATIC_PLUGIN_ACQUISITION=$(PULUMI_CONVERT) $(WORKING_DIR)/bin/$(TFGEN) nodejs --out sdk/nodejs/
 	cd sdk/nodejs/ && \
 		printf "module fake_nodejs_module // Exclude this directory from Go tools\n\ngo 1.17\n" > go.mod && \
@@ -92,7 +92,7 @@ build_nodejs: upstream
 build_python: export PULUMI_HOME := $(WORKING_DIR)/.pulumi
 build_python: export PATH := $(WORKING_DIR)/.pulumi/bin:$(PATH)
 build_python: export PULUMI_CONVERT_EXAMPLES_CACHE_DIR := $(WORKING_DIR)/.pulumi/examples-cache
-build_python: upstream
+build_python: .make/upstream
 	rm -rf sdk/python/
 	PULUMI_CONVERT=$(PULUMI_CONVERT) PULUMI_DISABLE_AUTOMATIC_PLUGIN_ACQUISITION=$(PULUMI_CONVERT) $(WORKING_DIR)/bin/$(TFGEN) python --out sdk/python/
 	cd sdk/python/ && \
@@ -182,15 +182,18 @@ tfgen_build_only: bin/$(TFGEN)
 bin/$(TFGEN):
 	(cd provider && go build $(PULUMI_PROVIDER_BUILD_PARALLELISM) -o $(WORKING_DIR)/bin/$(TFGEN) -ldflags "$(LDFLAGS_PROJ_VERSION) $(LDFLAGS_EXTRAS)" $(PROJECT)/$(PROVIDER_PATH)/cmd/$(TFGEN))
 
-upstream:
+.PHONY: upstream
+upstream: .make/upstream
+# Re-run if the upstream commit or the patches change
+.make/upstream: $(wildcard patches/*) $(wildcard .git/modules/upstream/HEAD)
 ifneq ("$(wildcard upstream)","")
 	./upstream.sh init
 endif
-
 	# Ensure tool is installed
 	cd upstream-tools && yarn install --frozen-lockfile
 	# Apply all automated changes
 	cd upstream-tools && yarn --silent run apply
+	@touch $@
 
 bin/pulumi-java-gen: .pulumi-java-gen.version
 	pulumictl download-binary -n pulumi-language-java -v v$(shell cat .pulumi-java-gen.version) -r pulumi/pulumi-java
@@ -226,7 +229,7 @@ ci-mgmt: .ci-mgmt.yaml
 debug_tfgen:
 	dlv  --listen=:2345 --headless=true --api-version=2  exec $(WORKING_DIR)/bin/$(TFGEN) -- schema --out provider/cmd/$(PROVIDER)
 
-.PHONY: development build build_sdks install_go_sdk install_java_sdk install_python_sdk install_sdks only_build build_dotnet build_go build_java build_nodejs build_python clean cleanup help install_dotnet_sdk install_nodejs_sdk install_plugins lint_provider provider provider_no_deps test upstream ci-mgmt test_provider debug_tfgen
+.PHONY: development build build_sdks install_go_sdk install_java_sdk install_python_sdk install_sdks only_build build_dotnet build_go build_java build_nodejs build_python clean cleanup help install_dotnet_sdk install_nodejs_sdk install_plugins lint_provider provider provider_no_deps test ci-mgmt test_provider debug_tfgen
 
 # Provider cross-platform build & packaging
 

--- a/provider-ci/test-providers/aws/Makefile
+++ b/provider-ci/test-providers/aws/Makefile
@@ -52,15 +52,23 @@ install_sdks: install_dotnet_sdk install_python_sdk install_nodejs_sdk install_j
 
 only_build: build
 
-build_dotnet: export PULUMI_HOME := $(WORKING_DIR)/.pulumi
-build_dotnet: export PATH := $(WORKING_DIR)/.pulumi/bin:$(PATH)
-build_dotnet: export PULUMI_CONVERT_EXAMPLES_CACHE_DIR := $(WORKING_DIR)/.pulumi/examples-cache
-build_dotnet: .make/upstream
-	PULUMI_CONVERT=$(PULUMI_CONVERT) PULUMI_DISABLE_AUTOMATIC_PLUGIN_ACQUISITION=$(PULUMI_CONVERT) $(WORKING_DIR)/bin/$(TFGEN) dotnet --out sdk/dotnet/
+GEN_PULUMI_HOME := $(WORKING_DIR)/.pulumi
+GEN_PULUMI_CONVERT_EXAMPLES_CACHE_DIR := $(GEN_PULUMI_HOME)/examples-cache
+GEN_ENVS := PULUMI_HOME=$(GEN_PULUMI_HOME) PULUMI_CONVERT_EXAMPLES_CACHE_DIR=$(GEN_PULUMI_CONVERT_EXAMPLES_CACHE_DIR) PULUMI_CONVERT=$(PULUMI_CONVERT) PULUMI_DISABLE_AUTOMATIC_PLUGIN_ACQUISITION=$(PULUMI_CONVERT)
+
+.PHONY: generate_dotnet build_dotnet
+generate_dotnet: .make/generate_dotnet
+build_dotnet: .make/build_dotnet
+.make/generate_dotnet: export PATH := $(WORKING_DIR)/.pulumi/bin:$(PATH)
+.make/generate_dotnet: bin/$(TFGEN)
+	$(GEN_ENVS) $(WORKING_DIR)/bin/$(TFGEN) dotnet --out sdk/dotnet/
 	cd sdk/dotnet/ && \
 		printf "module fake_dotnet_module // Exclude this directory from Go tools\n\ngo 1.17\n" > go.mod && \
-		echo "$(VERSION_GENERIC)" >version.txt && \
-		dotnet build
+		echo "$(VERSION_GENERIC)" >version.txt
+	@touch $@
+.make/build_dotnet: .make/generate_dotnet
+	cd sdk/dotnet/ && dotnet build
+	@touch $@
 
 build_go: export PULUMI_HOME := $(WORKING_DIR)/.pulumi
 build_go: export PATH := $(WORKING_DIR)/.pulumi/bin:$(PATH)
@@ -235,7 +243,7 @@ ci-mgmt: .ci-mgmt.yaml
 debug_tfgen:
 	dlv  --listen=:2345 --headless=true --api-version=2  exec $(WORKING_DIR)/bin/$(TFGEN) -- schema --out provider/cmd/$(PROVIDER)
 
-.PHONY: development build build_sdks install_go_sdk install_java_sdk install_python_sdk install_sdks only_build build_dotnet build_go build_java build_nodejs build_python install_dotnet_sdk install_nodejs_sdk lint_provider provider provider_no_deps test ci-mgmt test_provider debug_tfgen
+.PHONY: development build build_sdks install_go_sdk install_java_sdk install_python_sdk install_sdks only_build build_go build_java build_nodejs build_python install_dotnet_sdk install_nodejs_sdk lint_provider provider provider_no_deps test ci-mgmt test_provider debug_tfgen
 
 # Provider cross-platform build & packaging
 

--- a/provider-ci/test-providers/aws/Makefile
+++ b/provider-ci/test-providers/aws/Makefile
@@ -164,6 +164,7 @@ test_provider:
 	@echo ""
 	cd provider && go test -v -short ./... -parallel $(TESTPARALLELISM)
 
+.PHONY: tfgen tfgen_no_deps tfgen_build_only
 tfgen: install_plugins upstream tfgen_no_deps
 
 tfgen_no_deps: export PULUMI_HOME := $(WORKING_DIR)/.pulumi
@@ -172,11 +173,13 @@ tfgen_no_deps: export PULUMI_CONVERT := $(PULUMI_CONVERT)
 tfgen_no_deps: export PULUMI_CONVERT_EXAMPLES_CACHE_DIR := $(WORKING_DIR)/.pulumi/examples-cache
 tfgen_no_deps: export PULUMI_DISABLE_AUTOMATIC_PLUGIN_ACQUISITION := $(PULUMI_CONVERT)
 tfgen_no_deps: export PULUMI_MISSING_DOCS_ERROR := $(PULUMI_MISSING_DOCS_ERROR)
-tfgen_no_deps: tfgen_build_only
+tfgen_no_deps: bin/$(TFGEN)
 	$(WORKING_DIR)/bin/$(TFGEN) schema --out provider/cmd/$(PROVIDER)
 	(cd provider && VERSION=$(VERSION_GENERIC) go generate cmd/$(PROVIDER)/main.go)
 
-tfgen_build_only:
+tfgen_build_only: bin/$(TFGEN)
+
+bin/$(TFGEN):
 	(cd provider && go build $(PULUMI_PROVIDER_BUILD_PARALLELISM) -o $(WORKING_DIR)/bin/$(TFGEN) -ldflags "$(LDFLAGS_PROJ_VERSION) $(LDFLAGS_EXTRAS)" $(PROJECT)/$(PROVIDER_PATH)/cmd/$(TFGEN))
 
 upstream:
@@ -223,7 +226,7 @@ ci-mgmt: .ci-mgmt.yaml
 debug_tfgen:
 	dlv  --listen=:2345 --headless=true --api-version=2  exec $(WORKING_DIR)/bin/$(TFGEN) -- schema --out provider/cmd/$(PROVIDER)
 
-.PHONY: development build build_sdks install_go_sdk install_java_sdk install_python_sdk install_sdks only_build build_dotnet build_go build_java build_nodejs build_python clean cleanup help install_dotnet_sdk install_nodejs_sdk install_plugins lint_provider provider provider_no_deps test tfgen upstream ci-mgmt test_provider debug_tfgen tfgen_build_only
+.PHONY: development build build_sdks install_go_sdk install_java_sdk install_python_sdk install_sdks only_build build_dotnet build_go build_java build_nodejs build_python clean cleanup help install_dotnet_sdk install_nodejs_sdk install_plugins lint_provider provider provider_no_deps test upstream ci-mgmt test_provider debug_tfgen
 
 # Provider cross-platform build & packaging
 

--- a/provider-ci/test-providers/aws/Makefile
+++ b/provider-ci/test-providers/aws/Makefile
@@ -148,10 +148,13 @@ lint_provider.fix:
 # `make provider_no_deps` builds the provider binary directly, without ensuring that
 # `cmd/pulumi-resource-aws/schema.json` is valid and up to date.
 # To create a release ready binary, you should use `make provider`.
+.PHONY: provider provider_no_deps
+build_provider_cmd = cd provider && go build $(PULUMI_PROVIDER_BUILD_PARALLELISM) -o $(WORKING_DIR)/bin/$(PROVIDER) -ldflags "$(LDFLAGS)" $(PROJECT)/$(PROVIDER_PATH)/cmd/$(PROVIDER)
+provider: bin/$(PROVIDER)
 provider_no_deps:
-	(cd provider && go build $(PULUMI_PROVIDER_BUILD_PARALLELISM) -o $(WORKING_DIR)/bin/$(PROVIDER) -ldflags "$(LDFLAGS)" $(PROJECT)/$(PROVIDER_PATH)/cmd/$(PROVIDER))
-
-provider: tfgen provider_no_deps
+	$(call build_provider_cmd)
+bin/$(PROVIDER): .make/schema
+	$(call build_provider_cmd)
 
 test: export PATH := $(WORKING_DIR)/bin:$(PATH)
 test:

--- a/provider-ci/test-providers/aws/Makefile
+++ b/provider-ci/test-providers/aws/Makefile
@@ -36,11 +36,14 @@ LDFLAGS=$(LDFLAGS_PROJ_VERSION) $(LDFLAGS_UPSTREAM_VERSION) $(LDFLAGS_EXTRAS) $(
 # Ensure all directories exist before evaluating targets to avoid issues with `touch` creating directories.
 _ := $(shell mkdir -p .make bin .pulumi/bin)
 
+# Build the provider and all SDKs and install ready for testing
+build: install_plugins provider build_sdks install_sdks
 # Keep aliases for old targets to ensure backwards compatibility
 development: build
 only_build: build
-# Build the provider and all SDKs and install ready for testing
-build: install_plugins provider build_sdks install_sdks
+# Prepare the workspace for building the provider and SDKs
+# Importantly this is run by CI ahead of restoring the bin directory and resuming SDK builds
+prepare_local_workspace: install_plugins upstream
 # Creates all generated files which need to be committed
 generate: generate_sdks schema
 generate_sdks: generate_nodejs generate_python generate_dotnet generate_go generate_java
@@ -153,6 +156,7 @@ install_nodejs_sdk: .make/install_nodejs_sdk
 install_python_sdk:
 .PHONY: install_dotnet_sdk install_go_sdk install_java_sdk install_nodejs_sdk install_python_sdk
 
+# Install Pulumi plugins required for TFGen to resolve references
 install_plugins: .make/install_plugins
 .make/install_plugins: export PULUMI_HOME := $(WORKING_DIR)/.pulumi
 .make/install_plugins: export PATH := $(WORKING_DIR)/.pulumi/bin:$(PATH)
@@ -217,6 +221,7 @@ bin/$(TFGEN):
 	(cd provider && go build $(PULUMI_PROVIDER_BUILD_PARALLELISM) -o $(WORKING_DIR)/bin/$(TFGEN) -ldflags "$(LDFLAGS_PROJ_VERSION) $(LDFLAGS_EXTRAS)" $(PROJECT)/$(PROVIDER_PATH)/cmd/$(TFGEN))
 .PHONY: tfgen schema tfgen_no_deps tfgen_build_only
 
+# Apply patches to the upstream submodule, if it exists
 upstream: .make/upstream
 # Re-run if the upstream commit or the patches change
 .make/upstream: $(wildcard patches/*) $(wildcard .git/modules/upstream/HEAD)

--- a/provider-ci/test-providers/aws/Makefile
+++ b/provider-ci/test-providers/aws/Makefile
@@ -107,21 +107,24 @@ build_nodejs: .make/build_nodejs
 		cp ../../README.md ../../LICENSE* package.json yarn.lock ./bin/
 	@touch $@
 
-build_python: export PULUMI_HOME := $(WORKING_DIR)/.pulumi
-build_python: export PATH := $(WORKING_DIR)/.pulumi/bin:$(PATH)
-build_python: export PULUMI_CONVERT_EXAMPLES_CACHE_DIR := $(WORKING_DIR)/.pulumi/examples-cache
-build_python: .make/upstream
-	rm -rf sdk/python/
-	PULUMI_CONVERT=$(PULUMI_CONVERT) PULUMI_DISABLE_AUTOMATIC_PLUGIN_ACQUISITION=$(PULUMI_CONVERT) $(WORKING_DIR)/bin/$(TFGEN) python --out sdk/python/
+.PHONY: generate_python build_python
+generate_python: .make/generate_python
+build_python: .make/build_python
+.make/generate_python: export PATH := $(WORKING_DIR)/.pulumi/bin:$(PATH)
+.make/generate_python: bin/$(TFGEN)
+	$(GEN_ENVS) $(WORKING_DIR)/bin/$(TFGEN) python --out sdk/python/
+	printf "module fake_python_module // Exclude this directory from Go tools\n\ngo 1.17\n" > sdk/python/go.mod
+	cp README.md sdk/python/
+	@touch $@
+.make/build_python: .make/generate_python
 	cd sdk/python/ && \
-		printf "module fake_python_module // Exclude this directory from Go tools\n\ngo 1.17\n" > go.mod && \
-		cp ../../README.md . && \
 		rm -rf ./bin/ ../python.bin/ && cp -R . ../python.bin && mv ../python.bin ./bin && \
 		rm ./bin/go.mod && \
 		python3 -m venv venv && \
 		./venv/bin/python -m pip install build==1.2.1 && \
 		cd ./bin && \
 		../venv/bin/python -m build .
+	@touch $@
 
 .PHONY: clean
 clean:
@@ -251,7 +254,7 @@ ci-mgmt: .ci-mgmt.yaml
 debug_tfgen:
 	dlv  --listen=:2345 --headless=true --api-version=2  exec $(WORKING_DIR)/bin/$(TFGEN) -- schema --out provider/cmd/$(PROVIDER)
 
-.PHONY: development build build_sdks install_go_sdk install_java_sdk install_python_sdk install_sdks only_build build_java build_python install_dotnet_sdk install_nodejs_sdk lint_provider provider provider_no_deps test ci-mgmt test_provider debug_tfgen
+.PHONY: development build build_sdks install_go_sdk install_java_sdk install_python_sdk install_sdks only_build build_java install_dotnet_sdk install_nodejs_sdk lint_provider provider provider_no_deps test ci-mgmt test_provider debug_tfgen
 
 # Provider cross-platform build & packaging
 

--- a/provider-ci/test-providers/aws/Makefile
+++ b/provider-ci/test-providers/aws/Makefile
@@ -36,7 +36,6 @@ LDFLAGS=$(LDFLAGS_PROJ_VERSION) $(LDFLAGS_UPSTREAM_VERSION) $(LDFLAGS_EXTRAS) $(
 # Ensure all directories exist before evaluating targets to avoid issues with `touch` creating directories.
 _ := $(shell mkdir -p .make bin .pulumi/bin)
 
-.PHONY: development only_build build generate_sdks build_sdks install_sdks
 # Keep aliases for old targets to ensure backwards compatibility
 development: build
 only_build: build
@@ -44,12 +43,12 @@ build: install_plugins provider build_sdks install_sdks
 generate_sdks: generate_nodejs generate_python generate_dotnet generate_go generate_java
 build_sdks: build_nodejs build_python build_dotnet build_go build_java
 install_sdks: install_nodejs_sdk install_python_sdk install_dotnet_sdk install_go_sdk install_java_sdk
+.PHONY: development only_build build generate_sdks build_sdks install_sdks
 
 GEN_PULUMI_HOME := $(WORKING_DIR)/.pulumi
 GEN_PULUMI_CONVERT_EXAMPLES_CACHE_DIR := $(GEN_PULUMI_HOME)/examples-cache
 GEN_ENVS := PULUMI_HOME=$(GEN_PULUMI_HOME) PULUMI_CONVERT_EXAMPLES_CACHE_DIR=$(GEN_PULUMI_CONVERT_EXAMPLES_CACHE_DIR) PULUMI_CONVERT=$(PULUMI_CONVERT) PULUMI_DISABLE_AUTOMATIC_PLUGIN_ACQUISITION=$(PULUMI_CONVERT)
 
-.PHONY: generate_dotnet build_dotnet
 generate_dotnet: .make/generate_dotnet
 build_dotnet: .make/build_dotnet
 .make/generate_dotnet: export PATH := $(WORKING_DIR)/.pulumi/bin:$(PATH)
@@ -62,8 +61,8 @@ build_dotnet: .make/build_dotnet
 .make/build_dotnet: .make/generate_dotnet
 	cd sdk/dotnet/ && dotnet build
 	@touch $@
+.PHONY: generate_dotnet build_dotnet
 
-.PHONY: generate_go build_go
 generate_go: .make/generate_go
 build_go: .make/build_go
 .make/generate_go: export PATH := $(WORKING_DIR)/.pulumi/bin:$(PATH)
@@ -73,8 +72,8 @@ build_go: .make/build_go
 .make/build_go: .make/generate_go
 	cd sdk && go list "$$(grep -e "^module" go.mod | cut -d ' ' -f 2)/go/..." | xargs -I {} bash -c 'go build {} && go clean -i {}'
 	@touch $@
+.PHONY: generate_go build_go
 
-.PHONY: generate_java build_java
 generate_java: .make/generate_java
 build_java: .make/build_java
 .make/generate_java: export PATH := $(WORKING_DIR)/.pulumi/bin:$(PATH)
@@ -89,8 +88,8 @@ build_java: .make/build_java
 		gradle --console=plain build && \
 		gradle --console=plain javadoc
 	@touch $@
+.PHONY: generate_java build_java
 
-.PHONY: generate_nodejs build_nodejs
 generate_nodejs: .make/generate_nodejs
 build_nodejs: .make/build_nodejs
 .make/generate_nodejs: export PATH := $(WORKING_DIR)/.pulumi/bin:$(PATH)
@@ -104,8 +103,8 @@ build_nodejs: .make/build_nodejs
 		yarn run tsc && \
 		cp ../../README.md ../../LICENSE* package.json yarn.lock ./bin/
 	@touch $@
+.PHONY: generate_nodejs build_nodejs
 
-.PHONY: generate_python build_python
 generate_python: .make/generate_python
 build_python: .make/build_python
 .make/generate_python: export PATH := $(WORKING_DIR)/.pulumi/bin:$(PATH)
@@ -123,14 +122,14 @@ build_python: .make/build_python
 		cd ./bin && \
 		../venv/bin/python -m build .
 	@touch $@
+.PHONY: generate_python build_python
 
-.PHONY: clean
 clean:
 	rm -rf sdk/{dotnet,nodejs,go,python}
 	rm -rf bin/*
 	rm -rf .make/*
+.PHONY: clean
 
-.PHONY: install_dotnet_sdk install_go_sdk install_java_sdk install_nodejs_sdk install_python_sdk
 install_dotnet_sdk: .make/install_dotnet_sdk
 .make/install_dotnet_sdk: .make/build_dotnet
 	mkdir -p $(WORKING_DIR)/nuget
@@ -143,8 +142,8 @@ install_nodejs_sdk: .make/install_nodejs_sdk
 	yarn link --cwd $(WORKING_DIR)/sdk/nodejs/bin
 	@touch $@
 install_python_sdk:
+.PHONY: install_dotnet_sdk install_go_sdk install_java_sdk install_nodejs_sdk install_python_sdk
 
-.PHONY: install_plugins
 install_plugins: .make/install_plugins
 .make/install_plugins: export PULUMI_HOME := $(WORKING_DIR)/.pulumi
 .make/install_plugins: export PATH := $(WORKING_DIR)/.pulumi/bin:$(PATH)
@@ -160,42 +159,40 @@ install_plugins: .make/install_plugins
 	.pulumi/bin/pulumi plugin install resource std 1.6.2
 	.pulumi/bin/pulumi plugin install converter terraform 1.0.17
 	@touch $@
+.PHONY: install_plugins
 
 lint_provider: provider
 	cd provider && golangci-lint run --path-prefix provider -c ../.golangci.yml
-
 # `lint_provider.fix` is a utility target meant to be run manually
 # that will run the linter and fix errors when possible.
 lint_provider.fix:
 	cd provider && golangci-lint run --path-prefix provider -c ../.golangci.yml --fix
+.PHONY: lint_provider lint_provider.fix
 
 # `make provider_no_deps` builds the provider binary directly, without ensuring that
 # `cmd/pulumi-resource-aws/schema.json` is valid and up to date.
 # To create a release ready binary, you should use `make provider`.
-.PHONY: provider provider_no_deps
 build_provider_cmd = cd provider && go build $(PULUMI_PROVIDER_BUILD_PARALLELISM) -o $(WORKING_DIR)/bin/$(PROVIDER) -ldflags "$(LDFLAGS)" $(PROJECT)/$(PROVIDER_PATH)/cmd/$(PROVIDER)
 provider: bin/$(PROVIDER)
 provider_no_deps:
 	$(call build_provider_cmd)
 bin/$(PROVIDER): .make/schema
 	$(call build_provider_cmd)
+.PHONY: provider provider_no_deps
 
 test: export PATH := $(WORKING_DIR)/bin:$(PATH)
 test:
 	cd examples && go test -v -tags=all -parallel $(TESTPARALLELISM) -timeout 2h
+.PHONY: test
 
 test_provider:
-	@echo ""
-	@echo "== test_provider ==================================================================="
-	@echo ""
 	cd provider && go test -v -short ./... -parallel $(TESTPARALLELISM)
+.PHONY: test_provider
 
-.PHONY: tfgen schema tfgen_no_deps tfgen_build_only
 tfgen: schema
 schema: .make/schema 
 # This does actually have dependencies, but we're keeping it around for backwards compatibility for now
 tfgen_no_deps: .make/schema
-
 .make/schema: export PULUMI_HOME := $(WORKING_DIR)/.pulumi
 .make/schema: export PATH := $(WORKING_DIR)/.pulumi/bin:$(PATH)
 .make/schema: export PULUMI_CONVERT := $(PULUMI_CONVERT)
@@ -206,13 +203,11 @@ tfgen_no_deps: .make/schema
 	$(WORKING_DIR)/bin/$(TFGEN) schema --out provider/cmd/$(PROVIDER)
 	(cd provider && VERSION=$(VERSION_GENERIC) go generate cmd/$(PROVIDER)/main.go)
 	@touch $@
-
 tfgen_build_only: bin/$(TFGEN)
-
 bin/$(TFGEN):
 	(cd provider && go build $(PULUMI_PROVIDER_BUILD_PARALLELISM) -o $(WORKING_DIR)/bin/$(TFGEN) -ldflags "$(LDFLAGS_PROJ_VERSION) $(LDFLAGS_EXTRAS)" $(PROJECT)/$(PROVIDER_PATH)/cmd/$(TFGEN))
+.PHONY: tfgen schema tfgen_no_deps tfgen_build_only
 
-.PHONY: upstream
 upstream: .make/upstream
 # Re-run if the upstream commit or the patches change
 .make/upstream: $(wildcard patches/*) $(wildcard .git/modules/upstream/HEAD)
@@ -224,6 +219,7 @@ endif
 	# Apply all automated changes
 	cd upstream-tools && yarn --silent run apply
 	@touch $@
+.PHONY: upstream
 
 bin/pulumi-java-gen: .pulumi-java-gen.version
 	pulumictl download-binary -n pulumi-language-java -v v$(shell cat .pulumi-java-gen.version) -r pulumi/pulumi-java
@@ -235,6 +231,7 @@ bin/pulumi-java-gen: .pulumi-java-gen.version
 #
 ci-mgmt: .ci-mgmt.yaml
 	go run github.com/pulumi/ci-mgmt/provider-ci@master generate
+.PHONY: ci-mgmt
 
 # Because some codegen depends on the version of the CLI used, we install a local CLI
 # version pinned to the same version as `provider/go.mod`.
@@ -258,8 +255,7 @@ ci-mgmt: .ci-mgmt.yaml
 # Start debug server for tfgen
 debug_tfgen:
 	dlv  --listen=:2345 --headless=true --api-version=2  exec $(WORKING_DIR)/bin/$(TFGEN) -- schema --out provider/cmd/$(PROVIDER)
-
-.PHONY: lint_provider test ci-mgmt test_provider debug_tfgen
+.PHONY: debug_tfgen
 
 # Provider cross-platform build & packaging
 

--- a/provider-ci/test-providers/aws/Makefile
+++ b/provider-ci/test-providers/aws/Makefile
@@ -34,9 +34,9 @@ LDFLAGS=$(LDFLAGS_PROJ_VERSION) $(LDFLAGS_UPSTREAM_VERSION) $(LDFLAGS_EXTRAS) $(
 # At the end of each internal target we run `@touch $@` to update the file which is the name of the target.
 _ := $(shell mkdir -p .make)
 
-development: install_plugins provider build_sdks install_sdks
+development: .make/install_plugins provider build_sdks install_sdks
 
-build: install_plugins provider build_sdks install_sdks
+build: .make/install_plugins provider build_sdks install_sdks
 
 build_sdks: build_nodejs build_python build_dotnet build_go build_java 
 
@@ -124,9 +124,11 @@ install_dotnet_sdk:
 install_nodejs_sdk:
 	yarn link --cwd $(WORKING_DIR)/sdk/nodejs/bin
 
-install_plugins: export PULUMI_HOME := $(WORKING_DIR)/.pulumi
-install_plugins: export PATH := $(WORKING_DIR)/.pulumi/bin:$(PATH)
-install_plugins: .pulumi/bin/pulumi
+.PHONY: install_plugins
+install_plugins: .make/install_plugins
+.make/install_plugins: export PULUMI_HOME := $(WORKING_DIR)/.pulumi
+.make/install_plugins: export PATH := $(WORKING_DIR)/.pulumi/bin:$(PATH)
+.make/install_plugins: .pulumi/bin/pulumi
 	.pulumi/bin/pulumi plugin install resource archive 0.0.1
 	.pulumi/bin/pulumi plugin install resource tls 4.10.0
 	.pulumi/bin/pulumi plugin install resource github 4.10.0
@@ -137,6 +139,7 @@ install_plugins: .pulumi/bin/pulumi
 	.pulumi/bin/pulumi plugin install resource github 5.14.0
 	.pulumi/bin/pulumi plugin install resource std 1.6.2
 	.pulumi/bin/pulumi plugin install converter terraform 1.0.17
+	@touch $@
 
 lint_provider: provider
 	cd provider && golangci-lint run --path-prefix provider -c ../.golangci.yml
@@ -229,7 +232,7 @@ ci-mgmt: .ci-mgmt.yaml
 debug_tfgen:
 	dlv  --listen=:2345 --headless=true --api-version=2  exec $(WORKING_DIR)/bin/$(TFGEN) -- schema --out provider/cmd/$(PROVIDER)
 
-.PHONY: development build build_sdks install_go_sdk install_java_sdk install_python_sdk install_sdks only_build build_dotnet build_go build_java build_nodejs build_python clean cleanup help install_dotnet_sdk install_nodejs_sdk install_plugins lint_provider provider provider_no_deps test ci-mgmt test_provider debug_tfgen
+.PHONY: development build build_sdks install_go_sdk install_java_sdk install_python_sdk install_sdks only_build build_dotnet build_go build_java build_nodejs build_python clean cleanup help install_dotnet_sdk install_nodejs_sdk lint_provider provider provider_no_deps test ci-mgmt test_provider debug_tfgen
 
 # Provider cross-platform build & packaging
 

--- a/provider-ci/test-providers/aws/Makefile
+++ b/provider-ci/test-providers/aws/Makefile
@@ -36,21 +36,20 @@ LDFLAGS=$(LDFLAGS_PROJ_VERSION) $(LDFLAGS_UPSTREAM_VERSION) $(LDFLAGS_EXTRAS) $(
 # Ensure all directories exist before evaluating targets to avoid issues with `touch` creating directories.
 _ := $(shell mkdir -p .make bin .pulumi/bin)
 
-development: .make/install_plugins provider build_sdks install_sdks
-
-build: .make/install_plugins provider build_sdks install_sdks
-
-build_sdks: build_nodejs build_python build_dotnet build_go build_java 
+.PHONY: development only_build build generate_sdks build_sdks install_sdks
+# Keep aliases for old targets to ensure backwards compatibility
+development: build
+only_build: build
+build: install_plugins provider build_sdks install_sdks
+generate_sdks: generate_nodejs generate_python generate_dotnet generate_go generate_java
+build_sdks: build_nodejs build_python build_dotnet build_go build_java
+install_sdks: install_nodejs_sdk install_python_sdk install_dotnet_sdk install_go_sdk install_java_sdk
 
 install_go_sdk:
 
 install_java_sdk:
 
 install_python_sdk:
-
-install_sdks: install_dotnet_sdk install_python_sdk install_nodejs_sdk install_java_sdk
-
-only_build: build
 
 GEN_PULUMI_HOME := $(WORKING_DIR)/.pulumi
 GEN_PULUMI_CONVERT_EXAMPLES_CACHE_DIR := $(GEN_PULUMI_HOME)/examples-cache
@@ -259,7 +258,7 @@ ci-mgmt: .ci-mgmt.yaml
 debug_tfgen:
 	dlv  --listen=:2345 --headless=true --api-version=2  exec $(WORKING_DIR)/bin/$(TFGEN) -- schema --out provider/cmd/$(PROVIDER)
 
-.PHONY: development build build_sdks install_go_sdk install_java_sdk install_python_sdk install_sdks only_build install_dotnet_sdk install_nodejs_sdk lint_provider provider provider_no_deps test ci-mgmt test_provider debug_tfgen
+.PHONY: install_go_sdk install_java_sdk install_python_sdk install_sdks install_dotnet_sdk install_nodejs_sdk lint_provider test ci-mgmt test_provider debug_tfgen
 
 # Provider cross-platform build & packaging
 

--- a/provider-ci/test-providers/aws/Makefile
+++ b/provider-ci/test-providers/aws/Makefile
@@ -51,6 +51,43 @@ build_sdks: build_nodejs build_python build_dotnet build_go build_java
 install_sdks: install_nodejs_sdk install_python_sdk install_dotnet_sdk install_go_sdk install_java_sdk
 .PHONY: development only_build build generate generate_sdks build_sdks install_sdks
 
+help:
+	@echo "Usage: make [target]"
+	@echo ""
+	@echo "Main Targets"
+	@echo "  build (default)     Build the provider and all SDKs and install for testing"
+	@echo "  generate            Generate all SDKs, documentation and schema"
+	@echo "  provider            Build the local provider binary"
+	@echo "  lint_provider<.fix> Run the linter on the provider (& optionally fix)"
+	@echo "  test_provider       Run the provider tests"
+	@echo "  test                Run the example tests (must run 'build' first)"
+	@echo "  clean               Clean up generated files"
+	@echo ""
+	@echo "More Precise Targets"
+	@echo "  schema        Generate the schema"
+	@echo "  generate_sdks Generate all SDKs"
+	@echo "  build_sdks    Build all SDKs"
+	@echo "  install_sdks  Install all SDKs"
+	@echo "  provider_dist Build and package the provider for all platforms"
+	@echo ""
+	@echo "Tool Targets"
+	@echo "  ci-mgmt     Re-generate CI configuration from .ci-mgmt.yaml"
+	@echo "  debug_tfgen Start a debug server for tfgen"
+	@echo ""
+	@echo "Internal Targets (automatically run as dependencies of other targets)"
+	@echo "  prepare_local_workspace  Prepare for building"
+	@echo "  install_plugins          Install plugin dependencies"
+	@echo "  upstream                 Initialize the upstream submodule, if present"
+	@echo ""
+	@echo "Language-Specific Targets"
+	@echo "  generate_[language]    Generate the SDK files ready for committing"
+	@echo "  build_[language]       Build the SDK to check correctness"
+	@echo "  install_[language]_sdk Install the SDK ready for testing"
+	@echo ""
+	@echo "  [language] = nodejs python dotnet go java"
+	@echo ""
+.PHONY: help
+
 GEN_PULUMI_HOME := $(WORKING_DIR)/.pulumi
 GEN_PULUMI_CONVERT_EXAMPLES_CACHE_DIR := $(GEN_PULUMI_HOME)/examples-cache
 GEN_ENVS := PULUMI_HOME=$(GEN_PULUMI_HOME) PULUMI_CONVERT_EXAMPLES_CACHE_DIR=$(GEN_PULUMI_CONVERT_EXAMPLES_CACHE_DIR) PULUMI_CONVERT=$(PULUMI_CONVERT) PULUMI_DISABLE_AUTOMATIC_PLUGIN_ACQUISITION=$(PULUMI_CONVERT)

--- a/provider-ci/test-providers/aws/Makefile
+++ b/provider-ci/test-providers/aws/Makefile
@@ -70,12 +70,16 @@ build_dotnet: .make/build_dotnet
 	cd sdk/dotnet/ && dotnet build
 	@touch $@
 
-build_go: export PULUMI_HOME := $(WORKING_DIR)/.pulumi
-build_go: export PATH := $(WORKING_DIR)/.pulumi/bin:$(PATH)
-build_go: export PULUMI_CONVERT_EXAMPLES_CACHE_DIR := $(WORKING_DIR)/.pulumi/examples-cache
-build_go: .make/upstream
-	PULUMI_CONVERT=$(PULUMI_CONVERT) PULUMI_DISABLE_AUTOMATIC_PLUGIN_ACQUISITION=$(PULUMI_CONVERT) $(WORKING_DIR)/bin/$(TFGEN) go --out sdk/go/
+.PHONY: generate_go build_go
+generate_go: .make/generate_go
+build_go: .make/build_go
+.make/generate_go: export PATH := $(WORKING_DIR)/.pulumi/bin:$(PATH)
+.make/generate_go: bin/$(TFGEN)
+	$(GEN_ENVS) $(WORKING_DIR)/bin/$(TFGEN) go --out sdk/go/
+	@touch $@
+.make/build_go: .make/generate_go
 	cd sdk && go list "$$(grep -e "^module" go.mod | cut -d ' ' -f 2)/go/..." | xargs -I {} bash -c 'go build {} && go clean -i {}'
+	@touch $@
 
 build_java: PACKAGE_VERSION := $(VERSION_GENERIC)
 build_java: export PULUMI_HOME := $(WORKING_DIR)/.pulumi
@@ -243,7 +247,7 @@ ci-mgmt: .ci-mgmt.yaml
 debug_tfgen:
 	dlv  --listen=:2345 --headless=true --api-version=2  exec $(WORKING_DIR)/bin/$(TFGEN) -- schema --out provider/cmd/$(PROVIDER)
 
-.PHONY: development build build_sdks install_go_sdk install_java_sdk install_python_sdk install_sdks only_build build_go build_java build_nodejs build_python install_dotnet_sdk install_nodejs_sdk lint_provider provider provider_no_deps test ci-mgmt test_provider debug_tfgen
+.PHONY: development build build_sdks install_go_sdk install_java_sdk install_python_sdk install_sdks only_build build_java build_nodejs build_python install_dotnet_sdk install_nodejs_sdk lint_provider provider provider_no_deps test ci-mgmt test_provider debug_tfgen
 
 # Provider cross-platform build & packaging
 

--- a/provider-ci/test-providers/aws/Makefile
+++ b/provider-ci/test-providers/aws/Makefile
@@ -39,11 +39,14 @@ _ := $(shell mkdir -p .make bin .pulumi/bin)
 # Keep aliases for old targets to ensure backwards compatibility
 development: build
 only_build: build
+# Build the provider and all SDKs and install ready for testing
 build: install_plugins provider build_sdks install_sdks
+# Creates all generated files which need to be committed
+generate: generate_sdks schema
 generate_sdks: generate_nodejs generate_python generate_dotnet generate_go generate_java
 build_sdks: build_nodejs build_python build_dotnet build_go build_java
 install_sdks: install_nodejs_sdk install_python_sdk install_dotnet_sdk install_go_sdk install_java_sdk
-.PHONY: development only_build build generate_sdks build_sdks install_sdks
+.PHONY: development only_build build generate generate_sdks build_sdks install_sdks
 
 GEN_PULUMI_HOME := $(WORKING_DIR)/.pulumi
 GEN_PULUMI_CONVERT_EXAMPLES_CACHE_DIR := $(GEN_PULUMI_HOME)/examples-cache

--- a/provider-ci/test-providers/cloudflare/.github/workflows/build_provider.yml
+++ b/provider-ci/test-providers/cloudflare/.github/workflows/build_provider.yml
@@ -37,6 +37,8 @@ jobs:
         uses: ./.github/actions/setup-tools
         with:
           tools: pulumictl, go
+      - name: Prepare local workspace before restoring previously built
+        run: make prepare_local_workspace
       - name: Download schema-embed.json
         uses: actions/download-artifact@v4
         with:
@@ -45,9 +47,11 @@ jobs:
           # Avoid creating directories for each artifact
           merge-multiple: true
           path: provider/cmd/pulumi-resource-cloudflare/schema-embed.json
-      - name: Prepare for build
-        # This installs plugins and prepares upstream
-        run: make upstream
+      - name: Restore makefile progress
+        uses: actions/download-artifact@v4
+        with:
+          name: prerequisites.make
+          path: .make
       - name: Build & package provider
         run: make provider_dist-${{ matrix.platform.os }}-${{ matrix.platform.arch }}
       - name: Upload artifacts

--- a/provider-ci/test-providers/cloudflare/.github/workflows/build_sdk.yml
+++ b/provider-ci/test-providers/cloudflare/.github/workflows/build_sdk.yml
@@ -56,12 +56,17 @@ jobs:
         uses: ./.github/actions/setup-tools
         with:
           tools: pulumictl, pulumicli, ${{ matrix.language }}
+      - name: Prepare local workspace
+        run: make prepare_local_workspace
       - name: Download bin
         uses: ./.github/actions/download-bin
-      - name: Install plugins
-        run: make install_plugins
       - name: Update path
         run: echo "${{ github.workspace }}/bin" >> "$GITHUB_PATH"
+      - name: Restore makefile progress
+        uses: actions/download-artifact@v4
+        with:
+          name: prerequisites.make
+          path: .make
       - name: Build SDK
         run: make build_${{ matrix.language }}
       - name: Check worktree clean
@@ -77,3 +82,9 @@ jobs:
         uses: ./.github/actions/upload-sdk
         with:
           language: ${{ matrix.language }}
+      - name: Save makefile progress
+        uses: actions/upload-artifact@v4
+        with:
+          name: build_${{ matrix.language }}.make
+          path: .make
+          include-hidden-files: true

--- a/provider-ci/test-providers/cloudflare/.github/workflows/master.yml
+++ b/provider-ci/test-providers/cloudflare/.github/workflows/master.yml
@@ -148,9 +148,6 @@ jobs:
         tools: pulumictl, pulumicli, ${{ matrix.language }}
     - name: Download bin
       uses: ./.github/actions/download-bin
-    - name: Add NuGet source
-      if: matrix.language == 'dotnet'
-      run: dotnet nuget add source ${{ github.workspace }}/nuget
     - name: Download SDK
       uses: ./.github/actions/download-sdk
       with:

--- a/provider-ci/test-providers/cloudflare/.github/workflows/master.yml
+++ b/provider-ci/test-providers/cloudflare/.github/workflows/master.yml
@@ -155,6 +155,8 @@ jobs:
       uses: ./.github/actions/download-sdk
       with:
         language: ${{ matrix.language }}
+    - name: Mark SDK up to date
+      run: make --touch build_${{ matrix.language }}
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> "$GITHUB_PATH"
     - name: Install Python deps

--- a/provider-ci/test-providers/cloudflare/.github/workflows/master.yml
+++ b/provider-ci/test-providers/cloudflare/.github/workflows/master.yml
@@ -146,14 +146,19 @@ jobs:
       uses: ./.github/actions/setup-tools
       with:
         tools: pulumictl, pulumicli, ${{ matrix.language }}
+    - name: Prepare local workspace
+      run: make prepare_local_workspace
     - name: Download bin
       uses: ./.github/actions/download-bin
     - name: Download SDK
       uses: ./.github/actions/download-sdk
       with:
         language: ${{ matrix.language }}
-    - name: Mark SDK up to date
-      run: make --touch build_${{ matrix.language }}
+    - name: Restore makefile progress
+      uses: actions/download-artifact@v4
+      with:
+        name: build_${{ matrix.language }}.make
+        path: .make
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> "$GITHUB_PATH"
     - name: Install Python deps

--- a/provider-ci/test-providers/cloudflare/.github/workflows/prerelease.yml
+++ b/provider-ci/test-providers/cloudflare/.github/workflows/prerelease.yml
@@ -90,9 +90,6 @@ jobs:
         tools: pulumictl, pulumicli, nodejs, python, dotnet, go, java
     - name: Download bin
       uses: ./.github/actions/download-bin
-    - name: Add NuGet source
-      if: matrix.language == 'dotnet'
-      run: dotnet nuget add source ${{ github.workspace }}/nuget
     - name: Download SDK
       uses: ./.github/actions/download-sdk
       with:

--- a/provider-ci/test-providers/cloudflare/.github/workflows/prerelease.yml
+++ b/provider-ci/test-providers/cloudflare/.github/workflows/prerelease.yml
@@ -97,6 +97,8 @@ jobs:
       uses: ./.github/actions/download-sdk
       with:
         language: ${{ matrix.language }}
+    - name: Mark SDK up to date
+      run: make --touch build_${{ matrix.language }}
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> "$GITHUB_PATH"
     - name: Install Python deps

--- a/provider-ci/test-providers/cloudflare/.github/workflows/prerelease.yml
+++ b/provider-ci/test-providers/cloudflare/.github/workflows/prerelease.yml
@@ -88,14 +88,19 @@ jobs:
       uses: ./.github/actions/setup-tools
       with:
         tools: pulumictl, pulumicli, nodejs, python, dotnet, go, java
+    - name: Prepare local workspace
+      run: make prepare_local_workspace
     - name: Download bin
       uses: ./.github/actions/download-bin
     - name: Download SDK
       uses: ./.github/actions/download-sdk
       with:
         language: ${{ matrix.language }}
-    - name: Mark SDK up to date
-      run: make --touch build_${{ matrix.language }}
+    - name: Restore makefile progress
+      uses: actions/download-artifact@v4
+      with:
+        name: build_${{ matrix.language }}.make
+        path: .make
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> "$GITHUB_PATH"
     - name: Install Python deps

--- a/provider-ci/test-providers/cloudflare/.github/workflows/prerequisites.yml
+++ b/provider-ci/test-providers/cloudflare/.github/workflows/prerequisites.yml
@@ -58,20 +58,16 @@ jobs:
         path: |
           .pulumi/examples-cache
         key: ${{ runner.os }}-${{ hashFiles('provider/go.sum') }}
-    - name: Prepare upstream code
-      run: make upstream
     - name: Setup tools
       uses: ./.github/actions/setup-tools
       with:
         tools: go, pulumictl, pulumicli, schema-tools
-    - name: Build schema generator binary
-      run: make tfgen_build_only
-    - name: Install plugins
-      run: make install_plugins
+    - name: Prepare local workspace before restoring previously built files
+      run: make prepare_local_workspace
     - name: Generate schema
-      run: make tfgen_no_deps
+      run: make schema
     - name: Build provider binary
-      run: make provider_no_deps
+      run: make provider
     - name: Unit-test provider code
       run: make test_provider
     - if: inputs.is_pr
@@ -83,6 +79,12 @@ jobs:
           schema-tools compare -r github://api.github.com/pulumi -p cloudflare -o "${{ inputs.default_branch }}" -n --local-path=provider/cmd/pulumi-resource-cloudflare/schema.json;
           echo "$EOF";
         } >> "$GITHUB_ENV"
+    - name: Save makefile progress
+      uses: actions/upload-artifact@v4
+      with:
+        name: prerequisites.make
+        path: .make
+        include-hidden-files: true
     - if: inputs.is_pr && inputs.is_automated == false
       name: Comment on PR with Details of Schema Check
       uses: thollander/actions-comment-pull-request@v2

--- a/provider-ci/test-providers/cloudflare/.github/workflows/release.yml
+++ b/provider-ci/test-providers/cloudflare/.github/workflows/release.yml
@@ -96,9 +96,6 @@ jobs:
         tools: pulumictl, pulumicli, ${{ matrix.language }}
     - name: Download bin
       uses: ./.github/actions/download-bin
-    - name: Add NuGet source
-      if: matrix.language == 'dotnet'
-      run: dotnet nuget add source ${{ github.workspace }}/nuget
     - name: Download SDK
       uses: ./.github/actions/download-sdk
       with:

--- a/provider-ci/test-providers/cloudflare/.github/workflows/release.yml
+++ b/provider-ci/test-providers/cloudflare/.github/workflows/release.yml
@@ -103,6 +103,8 @@ jobs:
       uses: ./.github/actions/download-sdk
       with:
         language: ${{ matrix.language }}
+    - name: Mark SDK up to date
+      run: make --touch build_${{ matrix.language }}
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> "$GITHUB_PATH"
     - name: Install Python deps

--- a/provider-ci/test-providers/cloudflare/.github/workflows/release.yml
+++ b/provider-ci/test-providers/cloudflare/.github/workflows/release.yml
@@ -94,14 +94,19 @@ jobs:
       uses: ./.github/actions/setup-tools
       with:
         tools: pulumictl, pulumicli, ${{ matrix.language }}
+    - name: Prepare local workspace
+      run: make prepare_local_workspace
     - name: Download bin
       uses: ./.github/actions/download-bin
     - name: Download SDK
       uses: ./.github/actions/download-sdk
       with:
         language: ${{ matrix.language }}
-    - name: Mark SDK up to date
-      run: make --touch build_${{ matrix.language }}
+    - name: Restore makefile progress
+      uses: actions/download-artifact@v4
+      with:
+        name: build_${{ matrix.language }}.make
+        path: .make
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> "$GITHUB_PATH"
     - name: Install Python deps

--- a/provider-ci/test-providers/cloudflare/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/test-providers/cloudflare/.github/workflows/run-acceptance-tests.yml
@@ -145,9 +145,6 @@ jobs:
         tools: pulumictl, pulumicli, ${{ matrix.language }}
     - name: Download bin
       uses: ./.github/actions/download-bin
-    - name: Add NuGet source
-      if: matrix.language == 'dotnet'
-      run: dotnet nuget add source ${{ github.workspace }}/nuget
     - name: Download SDK
       uses: ./.github/actions/download-sdk
       with:

--- a/provider-ci/test-providers/cloudflare/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/test-providers/cloudflare/.github/workflows/run-acceptance-tests.yml
@@ -143,14 +143,19 @@ jobs:
       uses: ./.github/actions/setup-tools
       with:
         tools: pulumictl, pulumicli, ${{ matrix.language }}
+    - name: Prepare local workspace
+      run: make prepare_local_workspace
     - name: Download bin
       uses: ./.github/actions/download-bin
     - name: Download SDK
       uses: ./.github/actions/download-sdk
       with:
         language: ${{ matrix.language }}
-    - name: Mark SDK up to date
-      run: make --touch build_${{ matrix.language }}
+    - name: Restore makefile progress
+      uses: actions/download-artifact@v4
+      with:
+        name: build_${{ matrix.language }}.make
+        path: .make
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> "$GITHUB_PATH"
     - name: Install Python deps

--- a/provider-ci/test-providers/cloudflare/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/test-providers/cloudflare/.github/workflows/run-acceptance-tests.yml
@@ -152,6 +152,8 @@ jobs:
       uses: ./.github/actions/download-sdk
       with:
         language: ${{ matrix.language }}
+    - name: Mark SDK up to date
+      run: make --touch build_${{ matrix.language }}
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> "$GITHUB_PATH"
     - name: Install Python deps

--- a/provider-ci/test-providers/cloudflare/Makefile
+++ b/provider-ci/test-providers/cloudflare/Makefile
@@ -45,12 +45,6 @@ generate_sdks: generate_nodejs generate_python generate_dotnet generate_go gener
 build_sdks: build_nodejs build_python build_dotnet build_go build_java.make/build_registry_docs
 install_sdks: install_nodejs_sdk install_python_sdk install_dotnet_sdk install_go_sdk install_java_sdk
 
-install_go_sdk:
-
-install_java_sdk:
-
-install_python_sdk:
-
 GEN_PULUMI_HOME := $(WORKING_DIR)/.pulumi
 GEN_PULUMI_CONVERT_EXAMPLES_CACHE_DIR := $(GEN_PULUMI_HOME)/examples-cache
 GEN_ENVS := PULUMI_HOME=$(GEN_PULUMI_HOME) PULUMI_CONVERT_EXAMPLES_CACHE_DIR=$(GEN_PULUMI_CONVERT_EXAMPLES_CACHE_DIR) PULUMI_CONVERT=$(PULUMI_CONVERT) PULUMI_DISABLE_AUTOMATIC_PLUGIN_ACQUISITION=$(PULUMI_CONVERT)
@@ -142,12 +136,19 @@ clean:
 	rm -rf bin/*
 	rm -rf .make/*
 
-install_dotnet_sdk:
+.PHONY: install_dotnet_sdk install_go_sdk install_java_sdk install_nodejs_sdk install_python_sdk
+install_dotnet_sdk: .make/install_dotnet_sdk
+.make/install_dotnet_sdk: .make/build_dotnet
 	mkdir -p $(WORKING_DIR)/nuget
 	find . -name '*.nupkg' -print -exec cp -p {} $(WORKING_DIR)/nuget \;
-
-install_nodejs_sdk:
+	@touch $@
+install_go_sdk:
+install_java_sdk:
+install_nodejs_sdk: .make/install_nodejs_sdk
+.make/install_nodejs_sdk: .make/build_nodejs
 	yarn link --cwd $(WORKING_DIR)/sdk/nodejs/bin
+	@touch $@
+install_python_sdk:
 
 .PHONY: install_plugins
 install_plugins: .make/install_plugins
@@ -254,7 +255,7 @@ ci-mgmt: .ci-mgmt.yaml
 debug_tfgen:
 	dlv  --listen=:2345 --headless=true --api-version=2  exec $(WORKING_DIR)/bin/$(TFGEN) -- schema --out provider/cmd/$(PROVIDER)
 
-.PHONY: install_go_sdk install_java_sdk install_python_sdk install_sdks install_dotnet_sdk install_nodejs_sdk lint_provider test ci-mgmt test_provider debug_tfgen
+.PHONY: lint_provider test ci-mgmt test_provider debug_tfgen
 
 # Provider cross-platform build & packaging
 

--- a/provider-ci/test-providers/cloudflare/Makefile
+++ b/provider-ci/test-providers/cloudflare/Makefile
@@ -36,11 +36,14 @@ LDFLAGS=$(LDFLAGS_PROJ_VERSION) $(LDFLAGS_UPSTREAM_VERSION) $(LDFLAGS_EXTRAS) $(
 # Ensure all directories exist before evaluating targets to avoid issues with `touch` creating directories.
 _ := $(shell mkdir -p .make bin .pulumi/bin)
 
+# Build the provider and all SDKs and install ready for testing
+build: install_plugins provider build_sdks install_sdks build_registry_docs
 # Keep aliases for old targets to ensure backwards compatibility
 development: build
 only_build: build
-# Build the provider and all SDKs and install ready for testing
-build: install_plugins provider build_sdks install_sdks build_registry_docs
+# Prepare the workspace for building the provider and SDKs
+# Importantly this is run by CI ahead of restoring the bin directory and resuming SDK builds
+prepare_local_workspace: install_plugins upstream
 # Creates all generated files which need to be committed
 generate: generate_sdks schema build_registry_docs
 generate_sdks: generate_nodejs generate_python generate_dotnet generate_go generate_java
@@ -159,6 +162,7 @@ install_nodejs_sdk: .make/install_nodejs_sdk
 install_python_sdk:
 .PHONY: install_dotnet_sdk install_go_sdk install_java_sdk install_nodejs_sdk install_python_sdk
 
+# Install Pulumi plugins required for TFGen to resolve references
 install_plugins: .make/install_plugins
 .make/install_plugins: export PULUMI_HOME := $(WORKING_DIR)/.pulumi
 .make/install_plugins: export PATH := $(WORKING_DIR)/.pulumi/bin:$(PATH)
@@ -217,6 +221,7 @@ bin/$(TFGEN):
 	(cd provider && go build $(PULUMI_PROVIDER_BUILD_PARALLELISM) -o $(WORKING_DIR)/bin/$(TFGEN) -ldflags "$(LDFLAGS_PROJ_VERSION) $(LDFLAGS_EXTRAS)" $(PROJECT)/$(PROVIDER_PATH)/cmd/$(TFGEN))
 .PHONY: tfgen schema tfgen_no_deps tfgen_build_only
 
+# Apply patches to the upstream submodule, if it exists
 upstream: .make/upstream
 # Re-run if the upstream commit or the patches change
 .make/upstream: $(wildcard patches/*) $(wildcard .git/modules/upstream/HEAD)

--- a/provider-ci/test-providers/cloudflare/Makefile
+++ b/provider-ci/test-providers/cloudflare/Makefile
@@ -27,6 +27,13 @@ LDFLAGS_UPSTREAM_VERSION=
 LDFLAGS_EXTRAS=
 LDFLAGS=$(LDFLAGS_PROJ_VERSION) $(LDFLAGS_UPSTREAM_VERSION) $(LDFLAGS_EXTRAS) $(LDFLAGS_STRIP_SYMBOLS)
 
+# Create a `.make` directory for tracking targets which don't generate a single file output. This should be ignored by git.
+# For targets which either don't generate a single file output, or the output file is committed, we use a "sentinel"
+# file within `.make/` to track the staleness of the target and only rebuild when needed. 
+# For each phony target, we create an internal target with the same name, but prefixed with `.make/` where the work is performed.
+# At the end of each internal target we run `@touch $@` to update the file which is the name of the target.
+_ := $(shell mkdir -p .make)
+
 development: install_plugins provider build_sdks install_sdks
 
 build: install_plugins provider build_sdks install_sdks

--- a/provider-ci/test-providers/cloudflare/Makefile
+++ b/provider-ci/test-providers/cloudflare/Makefile
@@ -53,7 +53,7 @@ only_build: build
 build_dotnet: export PULUMI_HOME := $(WORKING_DIR)/.pulumi
 build_dotnet: export PATH := $(WORKING_DIR)/.pulumi/bin:$(PATH)
 build_dotnet: export PULUMI_CONVERT_EXAMPLES_CACHE_DIR := $(WORKING_DIR)/.pulumi/examples-cache
-build_dotnet: upstream
+build_dotnet: .make/upstream
 	PULUMI_CONVERT=$(PULUMI_CONVERT) PULUMI_DISABLE_AUTOMATIC_PLUGIN_ACQUISITION=$(PULUMI_CONVERT) $(WORKING_DIR)/bin/$(TFGEN) dotnet --out sdk/dotnet/
 	cd sdk/dotnet/ && \
 		printf "module fake_dotnet_module // Exclude this directory from Go tools\n\ngo 1.17\n" > go.mod && \
@@ -63,7 +63,7 @@ build_dotnet: upstream
 build_go: export PULUMI_HOME := $(WORKING_DIR)/.pulumi
 build_go: export PATH := $(WORKING_DIR)/.pulumi/bin:$(PATH)
 build_go: export PULUMI_CONVERT_EXAMPLES_CACHE_DIR := $(WORKING_DIR)/.pulumi/examples-cache
-build_go: upstream
+build_go: .make/upstream
 	PULUMI_CONVERT=$(PULUMI_CONVERT) PULUMI_DISABLE_AUTOMATIC_PLUGIN_ACQUISITION=$(PULUMI_CONVERT) $(WORKING_DIR)/bin/$(TFGEN) go --out sdk/go/
 	cd sdk && go list "$$(grep -e "^module" go.mod | cut -d ' ' -f 2)/go/..." | xargs -I {} bash -c 'go build {} && go clean -i {}'
 
@@ -71,7 +71,7 @@ build_java: PACKAGE_VERSION := $(VERSION_GENERIC)
 build_java: export PULUMI_HOME := $(WORKING_DIR)/.pulumi
 build_java: export PATH := $(WORKING_DIR)/.pulumi/bin:$(PATH)
 build_java: export PULUMI_CONVERT_EXAMPLES_CACHE_DIR := $(WORKING_DIR)/.pulumi/examples-cache
-build_java: bin/pulumi-java-gen upstream
+build_java: bin/pulumi-java-gen .make/upstream
 	$(WORKING_DIR)/bin/$(JAVA_GEN) generate --schema provider/cmd/$(PROVIDER)/schema.json --out sdk/java  --build gradle-nexus
 	cd sdk/java/ && \
 		printf "module fake_java_module // Exclude this directory from Go tools\n\ngo 1.17\n" > go.mod && \
@@ -81,7 +81,7 @@ build_java: bin/pulumi-java-gen upstream
 build_nodejs: export PULUMI_HOME := $(WORKING_DIR)/.pulumi
 build_nodejs: export PATH := $(WORKING_DIR)/.pulumi/bin:$(PATH)
 build_nodejs: export PULUMI_CONVERT_EXAMPLES_CACHE_DIR := $(WORKING_DIR)/.pulumi/examples-cache
-build_nodejs: upstream
+build_nodejs: .make/upstream
 	PULUMI_CONVERT=$(PULUMI_CONVERT) PULUMI_DISABLE_AUTOMATIC_PLUGIN_ACQUISITION=$(PULUMI_CONVERT) $(WORKING_DIR)/bin/$(TFGEN) nodejs --out sdk/nodejs/
 	cd sdk/nodejs/ && \
 		printf "module fake_nodejs_module // Exclude this directory from Go tools\n\ngo 1.17\n" > go.mod && \
@@ -92,7 +92,7 @@ build_nodejs: upstream
 build_python: export PULUMI_HOME := $(WORKING_DIR)/.pulumi
 build_python: export PATH := $(WORKING_DIR)/.pulumi/bin:$(PATH)
 build_python: export PULUMI_CONVERT_EXAMPLES_CACHE_DIR := $(WORKING_DIR)/.pulumi/examples-cache
-build_python: upstream
+build_python: .make/upstream
 	rm -rf sdk/python/
 	PULUMI_CONVERT=$(PULUMI_CONVERT) PULUMI_DISABLE_AUTOMATIC_PLUGIN_ACQUISITION=$(PULUMI_CONVERT) $(WORKING_DIR)/bin/$(TFGEN) python --out sdk/python/
 	cd sdk/python/ && \
@@ -180,10 +180,14 @@ tfgen_build_only: bin/$(TFGEN)
 bin/$(TFGEN):
 	(cd provider && go build $(PULUMI_PROVIDER_BUILD_PARALLELISM) -o $(WORKING_DIR)/bin/$(TFGEN) -ldflags "$(LDFLAGS_PROJ_VERSION) $(LDFLAGS_EXTRAS)" $(PROJECT)/$(PROVIDER_PATH)/cmd/$(TFGEN))
 
-upstream:
+.PHONY: upstream
+upstream: .make/upstream
+# Re-run if the upstream commit or the patches change
+.make/upstream: $(wildcard patches/*) $(wildcard .git/modules/upstream/HEAD)
 ifneq ("$(wildcard upstream)","")
 	./upstream.sh init
 endif
+	@touch $@
 
 bin/pulumi-java-gen: .pulumi-java-gen.version
 	pulumictl download-binary -n pulumi-language-java -v v$(shell cat .pulumi-java-gen.version) -r pulumi/pulumi-java
@@ -219,7 +223,7 @@ ci-mgmt: .ci-mgmt.yaml
 debug_tfgen:
 	dlv  --listen=:2345 --headless=true --api-version=2  exec $(WORKING_DIR)/bin/$(TFGEN) -- schema --out provider/cmd/$(PROVIDER)
 
-.PHONY: development build build_sdks install_go_sdk install_java_sdk install_python_sdk install_sdks only_build build_dotnet build_go build_java build_nodejs build_python clean cleanup help install_dotnet_sdk install_nodejs_sdk install_plugins lint_provider provider provider_no_deps test upstream ci-mgmt test_provider debug_tfgen
+.PHONY: development build build_sdks install_go_sdk install_java_sdk install_python_sdk install_sdks only_build build_dotnet build_go build_java build_nodejs build_python clean cleanup help install_dotnet_sdk install_nodejs_sdk install_plugins lint_provider provider provider_no_deps test ci-mgmt test_provider debug_tfgen
 
 # Provider cross-platform build & packaging
 

--- a/provider-ci/test-providers/cloudflare/Makefile
+++ b/provider-ci/test-providers/cloudflare/Makefile
@@ -216,6 +216,7 @@ ci-mgmt: .ci-mgmt.yaml
 .pulumi/bin/pulumi: .pulumi/version
 	@if [ -x .pulumi/bin/pulumi ] && [ "v$$(cat .pulumi/version)" = "$$(.pulumi/bin/pulumi version)" ]; then \
 		echo "pulumi/bin/pulumi version: v$$(cat .pulumi/version)"; \
+		touch $@; \
 	else \
 		curl -fsSL https://get.pulumi.com | \
 			HOME=$(WORKING_DIR) sh -s -- --version "$$(cat .pulumi/version)"; \

--- a/provider-ci/test-providers/cloudflare/Makefile
+++ b/provider-ci/test-providers/cloudflare/Makefile
@@ -34,9 +34,9 @@ LDFLAGS=$(LDFLAGS_PROJ_VERSION) $(LDFLAGS_UPSTREAM_VERSION) $(LDFLAGS_EXTRAS) $(
 # At the end of each internal target we run `@touch $@` to update the file which is the name of the target.
 _ := $(shell mkdir -p .make)
 
-development: install_plugins provider build_sdks install_sdks
+development: .make/install_plugins provider build_sdks install_sdks
 
-build: install_plugins provider build_sdks install_sdks
+build: .make/install_plugins provider build_sdks install_sdks
 
 build_sdks: build_nodejs build_python build_dotnet build_go build_java build_registry_docs
 
@@ -128,13 +128,16 @@ install_dotnet_sdk:
 install_nodejs_sdk:
 	yarn link --cwd $(WORKING_DIR)/sdk/nodejs/bin
 
-install_plugins: export PULUMI_HOME := $(WORKING_DIR)/.pulumi
-install_plugins: export PATH := $(WORKING_DIR)/.pulumi/bin:$(PATH)
-install_plugins: .pulumi/bin/pulumi
+.PHONY: install_plugins
+install_plugins: .make/install_plugins
+.make/install_plugins: export PULUMI_HOME := $(WORKING_DIR)/.pulumi
+.make/install_plugins: export PATH := $(WORKING_DIR)/.pulumi/bin:$(PATH)
+.make/install_plugins: .pulumi/bin/pulumi
 	.pulumi/bin/pulumi plugin install converter terraform 1.0.16
 	.pulumi/bin/pulumi plugin install resource std 1.6.2
 	.pulumi/bin/pulumi plugin install resource gcp 5.0.0
 	.pulumi/bin/pulumi plugin install resource tls 4.0.0
+	@touch $@
 
 lint_provider: provider
 	cd provider && golangci-lint run --path-prefix provider -c ../.golangci.yml
@@ -223,7 +226,7 @@ ci-mgmt: .ci-mgmt.yaml
 debug_tfgen:
 	dlv  --listen=:2345 --headless=true --api-version=2  exec $(WORKING_DIR)/bin/$(TFGEN) -- schema --out provider/cmd/$(PROVIDER)
 
-.PHONY: development build build_sdks install_go_sdk install_java_sdk install_python_sdk install_sdks only_build build_dotnet build_go build_java build_nodejs build_python clean cleanup help install_dotnet_sdk install_nodejs_sdk install_plugins lint_provider provider provider_no_deps test ci-mgmt test_provider debug_tfgen
+.PHONY: development build build_sdks install_go_sdk install_java_sdk install_python_sdk install_sdks only_build build_dotnet build_go build_java build_nodejs build_python clean cleanup help install_dotnet_sdk install_nodejs_sdk lint_provider provider provider_no_deps test ci-mgmt test_provider debug_tfgen
 
 # Provider cross-platform build & packaging
 

--- a/provider-ci/test-providers/cloudflare/Makefile
+++ b/provider-ci/test-providers/cloudflare/Makefile
@@ -40,7 +40,7 @@ development: .make/install_plugins provider build_sdks install_sdks
 
 build: .make/install_plugins provider build_sdks install_sdks
 
-build_sdks: build_nodejs build_python build_dotnet build_go build_java build_registry_docs
+build_sdks: build_nodejs build_python build_dotnet build_go build_java .make/build_registry_docs
 
 install_go_sdk:
 
@@ -106,10 +106,12 @@ build_python: .make/upstream
 		./venv/bin/python -m pip install build==1.2.1 && \
 		cd ./bin && \
 		../venv/bin/python -m build .
-
 # Run the bridge's registry-docs command to generated the content of the installation docs/ folder at provider repo root
-build_registry_docs:
-	$(WORKING_DIR)/bin/$(TFGEN) registry-docs --out $(WORKING_DIR)/docs
+.PHONY: build_registry_docs
+build_registry_docs: .make/build_registry_docs
+.make/build_registry_docs: bin/$(TFGEN)
+	bin/$(TFGEN) registry-docs --out $(WORKING_DIR)/docs
+	@touch $@
 
 .PHONY: clean
 clean:

--- a/provider-ci/test-providers/cloudflare/Makefile
+++ b/provider-ci/test-providers/cloudflare/Makefile
@@ -148,10 +148,13 @@ lint_provider.fix:
 # `make provider_no_deps` builds the provider binary directly, without ensuring that
 # `cmd/pulumi-resource-cloudflare/schema.json` is valid and up to date.
 # To create a release ready binary, you should use `make provider`.
+.PHONY: provider provider_no_deps
+build_provider_cmd = cd provider && go build $(PULUMI_PROVIDER_BUILD_PARALLELISM) -o $(WORKING_DIR)/bin/$(PROVIDER) -ldflags "$(LDFLAGS)" $(PROJECT)/$(PROVIDER_PATH)/cmd/$(PROVIDER)
+provider: bin/$(PROVIDER)
 provider_no_deps:
-	(cd provider && go build $(PULUMI_PROVIDER_BUILD_PARALLELISM) -o $(WORKING_DIR)/bin/$(PROVIDER) -ldflags "$(LDFLAGS)" $(PROJECT)/$(PROVIDER_PATH)/cmd/$(PROVIDER))
-
-provider: tfgen provider_no_deps
+	$(call build_provider_cmd)
+bin/$(PROVIDER): .make/schema
+	$(call build_provider_cmd)
 
 test: export PATH := $(WORKING_DIR)/bin:$(PATH)
 test:

--- a/provider-ci/test-providers/cloudflare/Makefile
+++ b/provider-ci/test-providers/cloudflare/Makefile
@@ -40,11 +40,11 @@ _ := $(shell mkdir -p .make bin .pulumi/bin)
 development: build
 only_build: build
 # Build the provider and all SDKs and install ready for testing
-build: install_plugins provider build_sdks install_sdks
+build: install_plugins provider build_sdks install_sdks build_registry_docs
 # Creates all generated files which need to be committed
 generate: generate_sdks schema build_registry_docs
 generate_sdks: generate_nodejs generate_python generate_dotnet generate_go generate_java
-build_sdks: build_nodejs build_python build_dotnet build_go build_javabuild_registry_docs
+build_sdks: build_nodejs build_python build_dotnet build_go build_java
 install_sdks: install_nodejs_sdk install_python_sdk install_dotnet_sdk install_go_sdk install_java_sdk
 .PHONY: development only_build build generate generate_sdks build_sdks install_sdks
 

--- a/provider-ci/test-providers/cloudflare/Makefile
+++ b/provider-ci/test-providers/cloudflare/Makefile
@@ -32,7 +32,9 @@ LDFLAGS=$(LDFLAGS_PROJ_VERSION) $(LDFLAGS_UPSTREAM_VERSION) $(LDFLAGS_EXTRAS) $(
 # file within `.make/` to track the staleness of the target and only rebuild when needed. 
 # For each phony target, we create an internal target with the same name, but prefixed with `.make/` where the work is performed.
 # At the end of each internal target we run `@touch $@` to update the file which is the name of the target.
-_ := $(shell mkdir -p .make)
+
+# Ensure all directories exist before evaluating targets to avoid issues with `touch` creating directories.
+_ := $(shell mkdir -p .make bin .pulumi/bin)
 
 development: .make/install_plugins provider build_sdks install_sdks
 
@@ -224,8 +226,7 @@ ci-mgmt: .ci-mgmt.yaml
 
 # Compute the version of Pulumi to use by inspecting the Go dependencies of the provider.
 .pulumi/version: provider/go.mod
-	@mkdir -p .pulumi
-	@cd provider && go list -f "{{slice .Version 1}}" -m github.com/pulumi/pulumi/pkg/v3 | tee ../$@
+	cd provider && go list -f "{{slice .Version 1}}" -m github.com/pulumi/pulumi/pkg/v3 | tee ../$@
 
 # Start debug server for tfgen
 debug_tfgen:

--- a/provider-ci/test-providers/cloudflare/Makefile
+++ b/provider-ci/test-providers/cloudflare/Makefile
@@ -52,15 +52,23 @@ install_sdks: install_dotnet_sdk install_python_sdk install_nodejs_sdk install_j
 
 only_build: build
 
-build_dotnet: export PULUMI_HOME := $(WORKING_DIR)/.pulumi
-build_dotnet: export PATH := $(WORKING_DIR)/.pulumi/bin:$(PATH)
-build_dotnet: export PULUMI_CONVERT_EXAMPLES_CACHE_DIR := $(WORKING_DIR)/.pulumi/examples-cache
-build_dotnet: .make/upstream
-	PULUMI_CONVERT=$(PULUMI_CONVERT) PULUMI_DISABLE_AUTOMATIC_PLUGIN_ACQUISITION=$(PULUMI_CONVERT) $(WORKING_DIR)/bin/$(TFGEN) dotnet --out sdk/dotnet/
+GEN_PULUMI_HOME := $(WORKING_DIR)/.pulumi
+GEN_PULUMI_CONVERT_EXAMPLES_CACHE_DIR := $(GEN_PULUMI_HOME)/examples-cache
+GEN_ENVS := PULUMI_HOME=$(GEN_PULUMI_HOME) PULUMI_CONVERT_EXAMPLES_CACHE_DIR=$(GEN_PULUMI_CONVERT_EXAMPLES_CACHE_DIR) PULUMI_CONVERT=$(PULUMI_CONVERT) PULUMI_DISABLE_AUTOMATIC_PLUGIN_ACQUISITION=$(PULUMI_CONVERT)
+
+.PHONY: generate_dotnet build_dotnet
+generate_dotnet: .make/generate_dotnet
+build_dotnet: .make/build_dotnet
+.make/generate_dotnet: export PATH := $(WORKING_DIR)/.pulumi/bin:$(PATH)
+.make/generate_dotnet: bin/$(TFGEN)
+	$(GEN_ENVS) $(WORKING_DIR)/bin/$(TFGEN) dotnet --out sdk/dotnet/
 	cd sdk/dotnet/ && \
 		printf "module fake_dotnet_module // Exclude this directory from Go tools\n\ngo 1.17\n" > go.mod && \
-		echo "$(VERSION_GENERIC)" >version.txt && \
-		dotnet build
+		echo "$(VERSION_GENERIC)" >version.txt
+	@touch $@
+.make/build_dotnet: .make/generate_dotnet
+	cd sdk/dotnet/ && dotnet build
+	@touch $@
 
 build_go: export PULUMI_HOME := $(WORKING_DIR)/.pulumi
 build_go: export PATH := $(WORKING_DIR)/.pulumi/bin:$(PATH)
@@ -231,7 +239,7 @@ ci-mgmt: .ci-mgmt.yaml
 debug_tfgen:
 	dlv  --listen=:2345 --headless=true --api-version=2  exec $(WORKING_DIR)/bin/$(TFGEN) -- schema --out provider/cmd/$(PROVIDER)
 
-.PHONY: development build build_sdks install_go_sdk install_java_sdk install_python_sdk install_sdks only_build build_dotnet build_go build_java build_nodejs build_python install_dotnet_sdk install_nodejs_sdk lint_provider provider provider_no_deps test ci-mgmt test_provider debug_tfgen
+.PHONY: development build build_sdks install_go_sdk install_java_sdk install_python_sdk install_sdks only_build build_go build_java build_nodejs build_python install_dotnet_sdk install_nodejs_sdk lint_provider provider provider_no_deps test ci-mgmt test_provider debug_tfgen
 
 # Provider cross-platform build & packaging
 

--- a/provider-ci/test-providers/cloudflare/Makefile
+++ b/provider-ci/test-providers/cloudflare/Makefile
@@ -162,6 +162,7 @@ test_provider:
 	@echo ""
 	cd provider && go test -v -short ./... -parallel $(TESTPARALLELISM)
 
+.PHONY: tfgen tfgen_no_deps tfgen_build_only
 tfgen: install_plugins upstream tfgen_no_deps
 
 tfgen_no_deps: export PULUMI_HOME := $(WORKING_DIR)/.pulumi
@@ -170,11 +171,13 @@ tfgen_no_deps: export PULUMI_CONVERT := $(PULUMI_CONVERT)
 tfgen_no_deps: export PULUMI_CONVERT_EXAMPLES_CACHE_DIR := $(WORKING_DIR)/.pulumi/examples-cache
 tfgen_no_deps: export PULUMI_DISABLE_AUTOMATIC_PLUGIN_ACQUISITION := $(PULUMI_CONVERT)
 tfgen_no_deps: export PULUMI_MISSING_DOCS_ERROR := $(PULUMI_MISSING_DOCS_ERROR)
-tfgen_no_deps: tfgen_build_only
+tfgen_no_deps: bin/$(TFGEN)
 	$(WORKING_DIR)/bin/$(TFGEN) schema --out provider/cmd/$(PROVIDER)
 	(cd provider && VERSION=$(VERSION_GENERIC) go generate cmd/$(PROVIDER)/main.go)
 
-tfgen_build_only:
+tfgen_build_only: bin/$(TFGEN)
+
+bin/$(TFGEN):
 	(cd provider && go build $(PULUMI_PROVIDER_BUILD_PARALLELISM) -o $(WORKING_DIR)/bin/$(TFGEN) -ldflags "$(LDFLAGS_PROJ_VERSION) $(LDFLAGS_EXTRAS)" $(PROJECT)/$(PROVIDER_PATH)/cmd/$(TFGEN))
 
 upstream:
@@ -216,7 +219,7 @@ ci-mgmt: .ci-mgmt.yaml
 debug_tfgen:
 	dlv  --listen=:2345 --headless=true --api-version=2  exec $(WORKING_DIR)/bin/$(TFGEN) -- schema --out provider/cmd/$(PROVIDER)
 
-.PHONY: development build build_sdks install_go_sdk install_java_sdk install_python_sdk install_sdks only_build build_dotnet build_go build_java build_nodejs build_python clean cleanup help install_dotnet_sdk install_nodejs_sdk install_plugins lint_provider provider provider_no_deps test tfgen upstream ci-mgmt test_provider debug_tfgen tfgen_build_only
+.PHONY: development build build_sdks install_go_sdk install_java_sdk install_python_sdk install_sdks only_build build_dotnet build_go build_java build_nodejs build_python clean cleanup help install_dotnet_sdk install_nodejs_sdk install_plugins lint_provider provider provider_no_deps test upstream ci-mgmt test_provider debug_tfgen
 
 # Provider cross-platform build & packaging
 

--- a/provider-ci/test-providers/cloudflare/Makefile
+++ b/provider-ci/test-providers/cloudflare/Makefile
@@ -36,7 +36,6 @@ LDFLAGS=$(LDFLAGS_PROJ_VERSION) $(LDFLAGS_UPSTREAM_VERSION) $(LDFLAGS_EXTRAS) $(
 # Ensure all directories exist before evaluating targets to avoid issues with `touch` creating directories.
 _ := $(shell mkdir -p .make bin .pulumi/bin)
 
-.PHONY: development only_build build generate_sdks build_sdks install_sdks
 # Keep aliases for old targets to ensure backwards compatibility
 development: build
 only_build: build
@@ -44,12 +43,12 @@ build: install_plugins provider build_sdks install_sdks
 generate_sdks: generate_nodejs generate_python generate_dotnet generate_go generate_java
 build_sdks: build_nodejs build_python build_dotnet build_go build_java.make/build_registry_docs
 install_sdks: install_nodejs_sdk install_python_sdk install_dotnet_sdk install_go_sdk install_java_sdk
+.PHONY: development only_build build generate_sdks build_sdks install_sdks
 
 GEN_PULUMI_HOME := $(WORKING_DIR)/.pulumi
 GEN_PULUMI_CONVERT_EXAMPLES_CACHE_DIR := $(GEN_PULUMI_HOME)/examples-cache
 GEN_ENVS := PULUMI_HOME=$(GEN_PULUMI_HOME) PULUMI_CONVERT_EXAMPLES_CACHE_DIR=$(GEN_PULUMI_CONVERT_EXAMPLES_CACHE_DIR) PULUMI_CONVERT=$(PULUMI_CONVERT) PULUMI_DISABLE_AUTOMATIC_PLUGIN_ACQUISITION=$(PULUMI_CONVERT)
 
-.PHONY: generate_dotnet build_dotnet
 generate_dotnet: .make/generate_dotnet
 build_dotnet: .make/build_dotnet
 .make/generate_dotnet: export PATH := $(WORKING_DIR)/.pulumi/bin:$(PATH)
@@ -62,8 +61,8 @@ build_dotnet: .make/build_dotnet
 .make/build_dotnet: .make/generate_dotnet
 	cd sdk/dotnet/ && dotnet build
 	@touch $@
+.PHONY: generate_dotnet build_dotnet
 
-.PHONY: generate_go build_go
 generate_go: .make/generate_go
 build_go: .make/build_go
 .make/generate_go: export PATH := $(WORKING_DIR)/.pulumi/bin:$(PATH)
@@ -73,8 +72,8 @@ build_go: .make/build_go
 .make/build_go: .make/generate_go
 	cd sdk && go list "$$(grep -e "^module" go.mod | cut -d ' ' -f 2)/go/..." | xargs -I {} bash -c 'go build {} && go clean -i {}'
 	@touch $@
+.PHONY: generate_go build_go
 
-.PHONY: generate_java build_java
 generate_java: .make/generate_java
 build_java: .make/build_java
 .make/generate_java: export PATH := $(WORKING_DIR)/.pulumi/bin:$(PATH)
@@ -89,8 +88,8 @@ build_java: .make/build_java
 		gradle --console=plain build && \
 		gradle --console=plain javadoc
 	@touch $@
+.PHONY: generate_java build_java
 
-.PHONY: generate_nodejs build_nodejs
 generate_nodejs: .make/generate_nodejs
 build_nodejs: .make/build_nodejs
 .make/generate_nodejs: export PATH := $(WORKING_DIR)/.pulumi/bin:$(PATH)
@@ -104,8 +103,8 @@ build_nodejs: .make/build_nodejs
 		yarn run tsc && \
 		cp ../../README.md ../../LICENSE* package.json yarn.lock ./bin/
 	@touch $@
+.PHONY: generate_nodejs build_nodejs
 
-.PHONY: generate_python build_python
 generate_python: .make/generate_python
 build_python: .make/build_python
 .make/generate_python: export PATH := $(WORKING_DIR)/.pulumi/bin:$(PATH)
@@ -123,20 +122,20 @@ build_python: .make/build_python
 		cd ./bin && \
 		../venv/bin/python -m build .
 	@touch $@
+.PHONY: generate_python build_python
 # Run the bridge's registry-docs command to generated the content of the installation docs/ folder at provider repo root
-.PHONY: build_registry_docs
 build_registry_docs: .make/build_registry_docs
 .make/build_registry_docs: bin/$(TFGEN)
 	bin/$(TFGEN) registry-docs --out $(WORKING_DIR)/docs
 	@touch $@
+.PHONY: build_registry_docs
 
-.PHONY: clean
 clean:
 	rm -rf sdk/{dotnet,nodejs,go,python}
 	rm -rf bin/*
 	rm -rf .make/*
+.PHONY: clean
 
-.PHONY: install_dotnet_sdk install_go_sdk install_java_sdk install_nodejs_sdk install_python_sdk
 install_dotnet_sdk: .make/install_dotnet_sdk
 .make/install_dotnet_sdk: .make/build_dotnet
 	mkdir -p $(WORKING_DIR)/nuget
@@ -149,8 +148,8 @@ install_nodejs_sdk: .make/install_nodejs_sdk
 	yarn link --cwd $(WORKING_DIR)/sdk/nodejs/bin
 	@touch $@
 install_python_sdk:
+.PHONY: install_dotnet_sdk install_go_sdk install_java_sdk install_nodejs_sdk install_python_sdk
 
-.PHONY: install_plugins
 install_plugins: .make/install_plugins
 .make/install_plugins: export PULUMI_HOME := $(WORKING_DIR)/.pulumi
 .make/install_plugins: export PATH := $(WORKING_DIR)/.pulumi/bin:$(PATH)
@@ -160,42 +159,40 @@ install_plugins: .make/install_plugins
 	.pulumi/bin/pulumi plugin install resource gcp 5.0.0
 	.pulumi/bin/pulumi plugin install resource tls 4.0.0
 	@touch $@
+.PHONY: install_plugins
 
 lint_provider: provider
 	cd provider && golangci-lint run --path-prefix provider -c ../.golangci.yml
-
 # `lint_provider.fix` is a utility target meant to be run manually
 # that will run the linter and fix errors when possible.
 lint_provider.fix:
 	cd provider && golangci-lint run --path-prefix provider -c ../.golangci.yml --fix
+.PHONY: lint_provider lint_provider.fix
 
 # `make provider_no_deps` builds the provider binary directly, without ensuring that
 # `cmd/pulumi-resource-cloudflare/schema.json` is valid and up to date.
 # To create a release ready binary, you should use `make provider`.
-.PHONY: provider provider_no_deps
 build_provider_cmd = cd provider && go build $(PULUMI_PROVIDER_BUILD_PARALLELISM) -o $(WORKING_DIR)/bin/$(PROVIDER) -ldflags "$(LDFLAGS)" $(PROJECT)/$(PROVIDER_PATH)/cmd/$(PROVIDER)
 provider: bin/$(PROVIDER)
 provider_no_deps:
 	$(call build_provider_cmd)
 bin/$(PROVIDER): .make/schema
 	$(call build_provider_cmd)
+.PHONY: provider provider_no_deps
 
 test: export PATH := $(WORKING_DIR)/bin:$(PATH)
 test:
 	cd examples && go test -v -tags=all -parallel $(TESTPARALLELISM) -timeout 2h
+.PHONY: test
 
 test_provider:
-	@echo ""
-	@echo "== test_provider ==================================================================="
-	@echo ""
 	cd provider && go test -v -short ./... -parallel $(TESTPARALLELISM)
+.PHONY: test_provider
 
-.PHONY: tfgen schema tfgen_no_deps tfgen_build_only
 tfgen: schema
 schema: .make/schema 
 # This does actually have dependencies, but we're keeping it around for backwards compatibility for now
 tfgen_no_deps: .make/schema
-
 .make/schema: export PULUMI_HOME := $(WORKING_DIR)/.pulumi
 .make/schema: export PATH := $(WORKING_DIR)/.pulumi/bin:$(PATH)
 .make/schema: export PULUMI_CONVERT := $(PULUMI_CONVERT)
@@ -206,13 +203,11 @@ tfgen_no_deps: .make/schema
 	$(WORKING_DIR)/bin/$(TFGEN) schema --out provider/cmd/$(PROVIDER)
 	(cd provider && VERSION=$(VERSION_GENERIC) go generate cmd/$(PROVIDER)/main.go)
 	@touch $@
-
 tfgen_build_only: bin/$(TFGEN)
-
 bin/$(TFGEN):
 	(cd provider && go build $(PULUMI_PROVIDER_BUILD_PARALLELISM) -o $(WORKING_DIR)/bin/$(TFGEN) -ldflags "$(LDFLAGS_PROJ_VERSION) $(LDFLAGS_EXTRAS)" $(PROJECT)/$(PROVIDER_PATH)/cmd/$(TFGEN))
+.PHONY: tfgen schema tfgen_no_deps tfgen_build_only
 
-.PHONY: upstream
 upstream: .make/upstream
 # Re-run if the upstream commit or the patches change
 .make/upstream: $(wildcard patches/*) $(wildcard .git/modules/upstream/HEAD)
@@ -220,6 +215,7 @@ ifneq ("$(wildcard upstream)","")
 	./upstream.sh init
 endif
 	@touch $@
+.PHONY: upstream
 
 bin/pulumi-java-gen: .pulumi-java-gen.version
 	pulumictl download-binary -n pulumi-language-java -v v$(shell cat .pulumi-java-gen.version) -r pulumi/pulumi-java
@@ -231,6 +227,7 @@ bin/pulumi-java-gen: .pulumi-java-gen.version
 #
 ci-mgmt: .ci-mgmt.yaml
 	go run github.com/pulumi/ci-mgmt/provider-ci@master generate
+.PHONY: ci-mgmt
 
 # Because some codegen depends on the version of the CLI used, we install a local CLI
 # version pinned to the same version as `provider/go.mod`.
@@ -254,8 +251,7 @@ ci-mgmt: .ci-mgmt.yaml
 # Start debug server for tfgen
 debug_tfgen:
 	dlv  --listen=:2345 --headless=true --api-version=2  exec $(WORKING_DIR)/bin/$(TFGEN) -- schema --out provider/cmd/$(PROVIDER)
-
-.PHONY: lint_provider test ci-mgmt test_provider debug_tfgen
+.PHONY: debug_tfgen
 
 # Provider cross-platform build & packaging
 

--- a/provider-ci/test-providers/cloudflare/Makefile
+++ b/provider-ci/test-providers/cloudflare/Makefile
@@ -81,16 +81,21 @@ build_go: .make/build_go
 	cd sdk && go list "$$(grep -e "^module" go.mod | cut -d ' ' -f 2)/go/..." | xargs -I {} bash -c 'go build {} && go clean -i {}'
 	@touch $@
 
-build_java: PACKAGE_VERSION := $(VERSION_GENERIC)
-build_java: export PULUMI_HOME := $(WORKING_DIR)/.pulumi
-build_java: export PATH := $(WORKING_DIR)/.pulumi/bin:$(PATH)
-build_java: export PULUMI_CONVERT_EXAMPLES_CACHE_DIR := $(WORKING_DIR)/.pulumi/examples-cache
-build_java: bin/pulumi-java-gen .make/upstream
-	$(WORKING_DIR)/bin/$(JAVA_GEN) generate --schema provider/cmd/$(PROVIDER)/schema.json --out sdk/java  --build gradle-nexus
+.PHONY: generate_java build_java
+generate_java: .make/generate_java
+build_java: .make/build_java
+.make/generate_java: export PATH := $(WORKING_DIR)/.pulumi/bin:$(PATH)
+.make/generate_java: PACKAGE_VERSION := $(VERSION_GENERIC)
+.make/generate_java: bin/pulumi-java-gen .make/schema
+	PULUMI_HOME=$(GEN_PULUMI_HOME) PULUMI_CONVERT_EXAMPLES_CACHE_DIR=$(GEN_PULUMI_CONVERT_EXAMPLES_CACHE_DIR) bin/$(JAVA_GEN) generate --schema provider/cmd/$(PROVIDER)/schema.json --out sdk/java  --build gradle-nexus
+	printf "module fake_java_module // Exclude this directory from Go tools\n\ngo 1.17\n" > sdk/java/go.mod
+	@touch $@
+.make/build_java: PACKAGE_VERSION := $(VERSION_GENERIC)
+.make/build_java: .make/generate_java
 	cd sdk/java/ && \
-		printf "module fake_java_module // Exclude this directory from Go tools\n\ngo 1.17\n" > go.mod && \
 		gradle --console=plain build && \
 		gradle --console=plain javadoc
+	@touch $@
 
 .PHONY: generate_nodejs build_nodejs
 generate_nodejs: .make/generate_nodejs
@@ -250,7 +255,7 @@ ci-mgmt: .ci-mgmt.yaml
 debug_tfgen:
 	dlv  --listen=:2345 --headless=true --api-version=2  exec $(WORKING_DIR)/bin/$(TFGEN) -- schema --out provider/cmd/$(PROVIDER)
 
-.PHONY: development build build_sdks install_go_sdk install_java_sdk install_python_sdk install_sdks only_build build_java install_dotnet_sdk install_nodejs_sdk lint_provider provider provider_no_deps test ci-mgmt test_provider debug_tfgen
+.PHONY: development build build_sdks install_go_sdk install_java_sdk install_python_sdk install_sdks only_build install_dotnet_sdk install_nodejs_sdk lint_provider provider provider_no_deps test ci-mgmt test_provider debug_tfgen
 
 # Provider cross-platform build & packaging
 

--- a/provider-ci/test-providers/cloudflare/Makefile
+++ b/provider-ci/test-providers/cloudflare/Makefile
@@ -39,11 +39,14 @@ _ := $(shell mkdir -p .make bin .pulumi/bin)
 # Keep aliases for old targets to ensure backwards compatibility
 development: build
 only_build: build
+# Build the provider and all SDKs and install ready for testing
 build: install_plugins provider build_sdks install_sdks
+# Creates all generated files which need to be committed
+generate: generate_sdks schema build_registry_docs
 generate_sdks: generate_nodejs generate_python generate_dotnet generate_go generate_java
-build_sdks: build_nodejs build_python build_dotnet build_go build_java.make/build_registry_docs
+build_sdks: build_nodejs build_python build_dotnet build_go build_javabuild_registry_docs
 install_sdks: install_nodejs_sdk install_python_sdk install_dotnet_sdk install_go_sdk install_java_sdk
-.PHONY: development only_build build generate_sdks build_sdks install_sdks
+.PHONY: development only_build build generate generate_sdks build_sdks install_sdks
 
 GEN_PULUMI_HOME := $(WORKING_DIR)/.pulumi
 GEN_PULUMI_CONVERT_EXAMPLES_CACHE_DIR := $(GEN_PULUMI_HOME)/examples-cache

--- a/provider-ci/test-providers/cloudflare/Makefile
+++ b/provider-ci/test-providers/cloudflare/Makefile
@@ -107,21 +107,24 @@ build_nodejs: .make/build_nodejs
 		cp ../../README.md ../../LICENSE* package.json yarn.lock ./bin/
 	@touch $@
 
-build_python: export PULUMI_HOME := $(WORKING_DIR)/.pulumi
-build_python: export PATH := $(WORKING_DIR)/.pulumi/bin:$(PATH)
-build_python: export PULUMI_CONVERT_EXAMPLES_CACHE_DIR := $(WORKING_DIR)/.pulumi/examples-cache
-build_python: .make/upstream
-	rm -rf sdk/python/
-	PULUMI_CONVERT=$(PULUMI_CONVERT) PULUMI_DISABLE_AUTOMATIC_PLUGIN_ACQUISITION=$(PULUMI_CONVERT) $(WORKING_DIR)/bin/$(TFGEN) python --out sdk/python/
+.PHONY: generate_python build_python
+generate_python: .make/generate_python
+build_python: .make/build_python
+.make/generate_python: export PATH := $(WORKING_DIR)/.pulumi/bin:$(PATH)
+.make/generate_python: bin/$(TFGEN)
+	$(GEN_ENVS) $(WORKING_DIR)/bin/$(TFGEN) python --out sdk/python/
+	printf "module fake_python_module // Exclude this directory from Go tools\n\ngo 1.17\n" > sdk/python/go.mod
+	cp README.md sdk/python/
+	@touch $@
+.make/build_python: .make/generate_python
 	cd sdk/python/ && \
-		printf "module fake_python_module // Exclude this directory from Go tools\n\ngo 1.17\n" > go.mod && \
-		cp ../../README.md . && \
 		rm -rf ./bin/ ../python.bin/ && cp -R . ../python.bin && mv ../python.bin ./bin && \
 		rm ./bin/go.mod && \
 		python3 -m venv venv && \
 		./venv/bin/python -m pip install build==1.2.1 && \
 		cd ./bin && \
 		../venv/bin/python -m build .
+	@touch $@
 # Run the bridge's registry-docs command to generated the content of the installation docs/ folder at provider repo root
 .PHONY: build_registry_docs
 build_registry_docs: .make/build_registry_docs
@@ -247,7 +250,7 @@ ci-mgmt: .ci-mgmt.yaml
 debug_tfgen:
 	dlv  --listen=:2345 --headless=true --api-version=2  exec $(WORKING_DIR)/bin/$(TFGEN) -- schema --out provider/cmd/$(PROVIDER)
 
-.PHONY: development build build_sdks install_go_sdk install_java_sdk install_python_sdk install_sdks only_build build_java build_python install_dotnet_sdk install_nodejs_sdk lint_provider provider provider_no_deps test ci-mgmt test_provider debug_tfgen
+.PHONY: development build build_sdks install_go_sdk install_java_sdk install_python_sdk install_sdks only_build build_java install_dotnet_sdk install_nodejs_sdk lint_provider provider provider_no_deps test ci-mgmt test_provider debug_tfgen
 
 # Provider cross-platform build & packaging
 

--- a/provider-ci/test-providers/cloudflare/Makefile
+++ b/provider-ci/test-providers/cloudflare/Makefile
@@ -36,21 +36,20 @@ LDFLAGS=$(LDFLAGS_PROJ_VERSION) $(LDFLAGS_UPSTREAM_VERSION) $(LDFLAGS_EXTRAS) $(
 # Ensure all directories exist before evaluating targets to avoid issues with `touch` creating directories.
 _ := $(shell mkdir -p .make bin .pulumi/bin)
 
-development: .make/install_plugins provider build_sdks install_sdks
-
-build: .make/install_plugins provider build_sdks install_sdks
-
-build_sdks: build_nodejs build_python build_dotnet build_go build_java .make/build_registry_docs
+.PHONY: development only_build build generate_sdks build_sdks install_sdks
+# Keep aliases for old targets to ensure backwards compatibility
+development: build
+only_build: build
+build: install_plugins provider build_sdks install_sdks
+generate_sdks: generate_nodejs generate_python generate_dotnet generate_go generate_java
+build_sdks: build_nodejs build_python build_dotnet build_go build_java.make/build_registry_docs
+install_sdks: install_nodejs_sdk install_python_sdk install_dotnet_sdk install_go_sdk install_java_sdk
 
 install_go_sdk:
 
 install_java_sdk:
 
 install_python_sdk:
-
-install_sdks: install_dotnet_sdk install_python_sdk install_nodejs_sdk install_java_sdk
-
-only_build: build
 
 GEN_PULUMI_HOME := $(WORKING_DIR)/.pulumi
 GEN_PULUMI_CONVERT_EXAMPLES_CACHE_DIR := $(GEN_PULUMI_HOME)/examples-cache
@@ -255,7 +254,7 @@ ci-mgmt: .ci-mgmt.yaml
 debug_tfgen:
 	dlv  --listen=:2345 --headless=true --api-version=2  exec $(WORKING_DIR)/bin/$(TFGEN) -- schema --out provider/cmd/$(PROVIDER)
 
-.PHONY: development build build_sdks install_go_sdk install_java_sdk install_python_sdk install_sdks only_build install_dotnet_sdk install_nodejs_sdk lint_provider provider provider_no_deps test ci-mgmt test_provider debug_tfgen
+.PHONY: install_go_sdk install_java_sdk install_python_sdk install_sdks install_dotnet_sdk install_nodejs_sdk lint_provider test ci-mgmt test_provider debug_tfgen
 
 # Provider cross-platform build & packaging
 

--- a/provider-ci/test-providers/cloudflare/Makefile
+++ b/provider-ci/test-providers/cloudflare/Makefile
@@ -51,6 +51,43 @@ build_sdks: build_nodejs build_python build_dotnet build_go build_java
 install_sdks: install_nodejs_sdk install_python_sdk install_dotnet_sdk install_go_sdk install_java_sdk
 .PHONY: development only_build build generate generate_sdks build_sdks install_sdks
 
+help:
+	@echo "Usage: make [target]"
+	@echo ""
+	@echo "Main Targets"
+	@echo "  build (default)     Build the provider and all SDKs and install for testing"
+	@echo "  generate            Generate all SDKs, documentation and schema"
+	@echo "  provider            Build the local provider binary"
+	@echo "  lint_provider<.fix> Run the linter on the provider (& optionally fix)"
+	@echo "  test_provider       Run the provider tests"
+	@echo "  test                Run the example tests (must run 'build' first)"
+	@echo "  clean               Clean up generated files"
+	@echo ""
+	@echo "More Precise Targets"
+	@echo "  schema        Generate the schema"
+	@echo "  generate_sdks Generate all SDKs"
+	@echo "  build_sdks    Build all SDKs"
+	@echo "  install_sdks  Install all SDKs"
+	@echo "  provider_dist Build and package the provider for all platforms"
+	@echo ""
+	@echo "Tool Targets"
+	@echo "  ci-mgmt     Re-generate CI configuration from .ci-mgmt.yaml"
+	@echo "  debug_tfgen Start a debug server for tfgen"
+	@echo ""
+	@echo "Internal Targets (automatically run as dependencies of other targets)"
+	@echo "  prepare_local_workspace  Prepare for building"
+	@echo "  install_plugins          Install plugin dependencies"
+	@echo "  upstream                 Initialize the upstream submodule, if present"
+	@echo ""
+	@echo "Language-Specific Targets"
+	@echo "  generate_[language]    Generate the SDK files ready for committing"
+	@echo "  build_[language]       Build the SDK to check correctness"
+	@echo "  install_[language]_sdk Install the SDK ready for testing"
+	@echo ""
+	@echo "  [language] = nodejs python dotnet go java"
+	@echo ""
+.PHONY: help
+
 GEN_PULUMI_HOME := $(WORKING_DIR)/.pulumi
 GEN_PULUMI_CONVERT_EXAMPLES_CACHE_DIR := $(GEN_PULUMI_HOME)/examples-cache
 GEN_ENVS := PULUMI_HOME=$(GEN_PULUMI_HOME) PULUMI_CONVERT_EXAMPLES_CACHE_DIR=$(GEN_PULUMI_CONVERT_EXAMPLES_CACHE_DIR) PULUMI_CONVERT=$(PULUMI_CONVERT) PULUMI_DISABLE_AUTOMATIC_PLUGIN_ACQUISITION=$(PULUMI_CONVERT)

--- a/provider-ci/test-providers/cloudflare/Makefile
+++ b/provider-ci/test-providers/cloudflare/Makefile
@@ -92,16 +92,20 @@ build_java: bin/pulumi-java-gen .make/upstream
 		gradle --console=plain build && \
 		gradle --console=plain javadoc
 
-build_nodejs: export PULUMI_HOME := $(WORKING_DIR)/.pulumi
-build_nodejs: export PATH := $(WORKING_DIR)/.pulumi/bin:$(PATH)
-build_nodejs: export PULUMI_CONVERT_EXAMPLES_CACHE_DIR := $(WORKING_DIR)/.pulumi/examples-cache
-build_nodejs: .make/upstream
-	PULUMI_CONVERT=$(PULUMI_CONVERT) PULUMI_DISABLE_AUTOMATIC_PLUGIN_ACQUISITION=$(PULUMI_CONVERT) $(WORKING_DIR)/bin/$(TFGEN) nodejs --out sdk/nodejs/
+.PHONY: generate_nodejs build_nodejs
+generate_nodejs: .make/generate_nodejs
+build_nodejs: .make/build_nodejs
+.make/generate_nodejs: export PATH := $(WORKING_DIR)/.pulumi/bin:$(PATH)
+.make/generate_nodejs: bin/$(TFGEN)
+	$(GEN_ENVS) $(WORKING_DIR)/bin/$(TFGEN) nodejs --out sdk/nodejs/
+	printf "module fake_nodejs_module // Exclude this directory from Go tools\n\ngo 1.17\n" > sdk/nodejs/go.mod
+	@touch $@
+.make/build_nodejs: .make/generate_nodejs
 	cd sdk/nodejs/ && \
-		printf "module fake_nodejs_module // Exclude this directory from Go tools\n\ngo 1.17\n" > go.mod && \
 		yarn install && \
 		yarn run tsc && \
 		cp ../../README.md ../../LICENSE* package.json yarn.lock ./bin/
+	@touch $@
 
 build_python: export PULUMI_HOME := $(WORKING_DIR)/.pulumi
 build_python: export PATH := $(WORKING_DIR)/.pulumi/bin:$(PATH)
@@ -243,7 +247,7 @@ ci-mgmt: .ci-mgmt.yaml
 debug_tfgen:
 	dlv  --listen=:2345 --headless=true --api-version=2  exec $(WORKING_DIR)/bin/$(TFGEN) -- schema --out provider/cmd/$(PROVIDER)
 
-.PHONY: development build build_sdks install_go_sdk install_java_sdk install_python_sdk install_sdks only_build build_java build_nodejs build_python install_dotnet_sdk install_nodejs_sdk lint_provider provider provider_no_deps test ci-mgmt test_provider debug_tfgen
+.PHONY: development build build_sdks install_go_sdk install_java_sdk install_python_sdk install_sdks only_build build_java build_python install_dotnet_sdk install_nodejs_sdk lint_provider provider provider_no_deps test ci-mgmt test_provider debug_tfgen
 
 # Provider cross-platform build & packaging
 

--- a/provider-ci/test-providers/cloudflare/Makefile
+++ b/provider-ci/test-providers/cloudflare/Makefile
@@ -111,12 +111,11 @@ build_python: .make/upstream
 build_registry_docs:
 	$(WORKING_DIR)/bin/$(TFGEN) registry-docs --out $(WORKING_DIR)/docs
 
+.PHONY: clean
 clean:
 	rm -rf sdk/{dotnet,nodejs,go,python}
-
-cleanup:
-	rm -r $(WORKING_DIR)/bin
-	rm -f provider/cmd/$(PROVIDER)/schema.go
+	rm -rf bin/*
+	rm -rf .make/*
 
 help:
 	@grep '^[^.#]\+:\s\+.*#' Makefile | \
@@ -232,7 +231,7 @@ ci-mgmt: .ci-mgmt.yaml
 debug_tfgen:
 	dlv  --listen=:2345 --headless=true --api-version=2  exec $(WORKING_DIR)/bin/$(TFGEN) -- schema --out provider/cmd/$(PROVIDER)
 
-.PHONY: development build build_sdks install_go_sdk install_java_sdk install_python_sdk install_sdks only_build build_dotnet build_go build_java build_nodejs build_python clean cleanup help install_dotnet_sdk install_nodejs_sdk lint_provider provider provider_no_deps test ci-mgmt test_provider debug_tfgen
+.PHONY: development build build_sdks install_go_sdk install_java_sdk install_python_sdk install_sdks only_build build_dotnet build_go build_java build_nodejs build_python help install_dotnet_sdk install_nodejs_sdk lint_provider provider provider_no_deps test ci-mgmt test_provider debug_tfgen
 
 # Provider cross-platform build & packaging
 

--- a/provider-ci/test-providers/cloudflare/Makefile
+++ b/provider-ci/test-providers/cloudflare/Makefile
@@ -70,12 +70,16 @@ build_dotnet: .make/build_dotnet
 	cd sdk/dotnet/ && dotnet build
 	@touch $@
 
-build_go: export PULUMI_HOME := $(WORKING_DIR)/.pulumi
-build_go: export PATH := $(WORKING_DIR)/.pulumi/bin:$(PATH)
-build_go: export PULUMI_CONVERT_EXAMPLES_CACHE_DIR := $(WORKING_DIR)/.pulumi/examples-cache
-build_go: .make/upstream
-	PULUMI_CONVERT=$(PULUMI_CONVERT) PULUMI_DISABLE_AUTOMATIC_PLUGIN_ACQUISITION=$(PULUMI_CONVERT) $(WORKING_DIR)/bin/$(TFGEN) go --out sdk/go/
+.PHONY: generate_go build_go
+generate_go: .make/generate_go
+build_go: .make/build_go
+.make/generate_go: export PATH := $(WORKING_DIR)/.pulumi/bin:$(PATH)
+.make/generate_go: bin/$(TFGEN)
+	$(GEN_ENVS) $(WORKING_DIR)/bin/$(TFGEN) go --out sdk/go/
+	@touch $@
+.make/build_go: .make/generate_go
 	cd sdk && go list "$$(grep -e "^module" go.mod | cut -d ' ' -f 2)/go/..." | xargs -I {} bash -c 'go build {} && go clean -i {}'
+	@touch $@
 
 build_java: PACKAGE_VERSION := $(VERSION_GENERIC)
 build_java: export PULUMI_HOME := $(WORKING_DIR)/.pulumi
@@ -239,7 +243,7 @@ ci-mgmt: .ci-mgmt.yaml
 debug_tfgen:
 	dlv  --listen=:2345 --headless=true --api-version=2  exec $(WORKING_DIR)/bin/$(TFGEN) -- schema --out provider/cmd/$(PROVIDER)
 
-.PHONY: development build build_sdks install_go_sdk install_java_sdk install_python_sdk install_sdks only_build build_go build_java build_nodejs build_python install_dotnet_sdk install_nodejs_sdk lint_provider provider provider_no_deps test ci-mgmt test_provider debug_tfgen
+.PHONY: development build build_sdks install_go_sdk install_java_sdk install_python_sdk install_sdks only_build build_java build_nodejs build_python install_dotnet_sdk install_nodejs_sdk lint_provider provider provider_no_deps test ci-mgmt test_provider debug_tfgen
 
 # Provider cross-platform build & packaging
 

--- a/provider-ci/test-providers/cloudflare/Makefile
+++ b/provider-ci/test-providers/cloudflare/Makefile
@@ -117,11 +117,6 @@ clean:
 	rm -rf bin/*
 	rm -rf .make/*
 
-help:
-	@grep '^[^.#]\+:\s\+.*#' Makefile | \
-	sed "s/\(.\+\):\s*\(.*\) #\s*\(.*\)/`printf "\033[93m"`\1`printf "\033[0m"`	\3 [\2]/" | \
-	expand -t20
-
 install_dotnet_sdk:
 	mkdir -p $(WORKING_DIR)/nuget
 	find . -name '*.nupkg' -print -exec cp -p {} $(WORKING_DIR)/nuget \;
@@ -231,7 +226,7 @@ ci-mgmt: .ci-mgmt.yaml
 debug_tfgen:
 	dlv  --listen=:2345 --headless=true --api-version=2  exec $(WORKING_DIR)/bin/$(TFGEN) -- schema --out provider/cmd/$(PROVIDER)
 
-.PHONY: development build build_sdks install_go_sdk install_java_sdk install_python_sdk install_sdks only_build build_dotnet build_go build_java build_nodejs build_python help install_dotnet_sdk install_nodejs_sdk lint_provider provider provider_no_deps test ci-mgmt test_provider debug_tfgen
+.PHONY: development build build_sdks install_go_sdk install_java_sdk install_python_sdk install_sdks only_build build_dotnet build_go build_java build_nodejs build_python install_dotnet_sdk install_nodejs_sdk lint_provider provider provider_no_deps test ci-mgmt test_provider debug_tfgen
 
 # Provider cross-platform build & packaging
 

--- a/provider-ci/test-providers/cloudflare/Makefile
+++ b/provider-ci/test-providers/cloudflare/Makefile
@@ -137,12 +137,18 @@ clean:
 	rm -rf sdk/{dotnet,nodejs,go,python}
 	rm -rf bin/*
 	rm -rf .make/*
+	if dotnet nuget list source | grep "$(WORKING_DIR)/nuget"; then \
+		dotnet nuget remove source "$(WORKING_DIR)/nuget" \
+	; fi
 .PHONY: clean
 
 install_dotnet_sdk: .make/install_dotnet_sdk
 .make/install_dotnet_sdk: .make/build_dotnet
-	mkdir -p $(WORKING_DIR)/nuget
-	find . -name '*.nupkg' -print -exec cp -p {} $(WORKING_DIR)/nuget \;
+	mkdir -p nuget
+	find sdk/dotnet/bin -name '*.nupkg' -print -exec cp -p "{}" ${WORKING_DIR}/nuget \;
+	if ! dotnet nuget list source | grep "${WORKING_DIR}/nuget"; then \
+		dotnet nuget add source "${WORKING_DIR}/nuget" --name "${WORKING_DIR}/nuget" \
+	; fi
 	@touch $@
 install_go_sdk:
 install_java_sdk:

--- a/provider-ci/test-providers/cloudflare/Makefile
+++ b/provider-ci/test-providers/cloudflare/Makefile
@@ -165,18 +165,22 @@ test_provider:
 	@echo ""
 	cd provider && go test -v -short ./... -parallel $(TESTPARALLELISM)
 
-.PHONY: tfgen tfgen_no_deps tfgen_build_only
-tfgen: install_plugins upstream tfgen_no_deps
+.PHONY: tfgen schema tfgen_no_deps tfgen_build_only
+tfgen: schema
+schema: .make/schema 
+# This does actually have dependencies, but we're keeping it around for backwards compatibility for now
+tfgen_no_deps: .make/schema
 
-tfgen_no_deps: export PULUMI_HOME := $(WORKING_DIR)/.pulumi
-tfgen_no_deps: export PATH := $(WORKING_DIR)/.pulumi/bin:$(PATH)
-tfgen_no_deps: export PULUMI_CONVERT := $(PULUMI_CONVERT)
-tfgen_no_deps: export PULUMI_CONVERT_EXAMPLES_CACHE_DIR := $(WORKING_DIR)/.pulumi/examples-cache
-tfgen_no_deps: export PULUMI_DISABLE_AUTOMATIC_PLUGIN_ACQUISITION := $(PULUMI_CONVERT)
-tfgen_no_deps: export PULUMI_MISSING_DOCS_ERROR := $(PULUMI_MISSING_DOCS_ERROR)
-tfgen_no_deps: bin/$(TFGEN)
+.make/schema: export PULUMI_HOME := $(WORKING_DIR)/.pulumi
+.make/schema: export PATH := $(WORKING_DIR)/.pulumi/bin:$(PATH)
+.make/schema: export PULUMI_CONVERT := $(PULUMI_CONVERT)
+.make/schema: export PULUMI_CONVERT_EXAMPLES_CACHE_DIR := $(WORKING_DIR)/.pulumi/examples-cache
+.make/schema: export PULUMI_DISABLE_AUTOMATIC_PLUGIN_ACQUISITION := $(PULUMI_CONVERT)
+.make/schema: export PULUMI_MISSING_DOCS_ERROR := $(PULUMI_MISSING_DOCS_ERROR)
+.make/schema: bin/$(TFGEN) provider/resources.go provider/go.mod .make/install_plugins .make/upstream
 	$(WORKING_DIR)/bin/$(TFGEN) schema --out provider/cmd/$(PROVIDER)
 	(cd provider && VERSION=$(VERSION_GENERIC) go generate cmd/$(PROVIDER)/main.go)
+	@touch $@
 
 tfgen_build_only: bin/$(TFGEN)
 

--- a/provider-ci/test-providers/docker/.github/workflows/build_provider.yml
+++ b/provider-ci/test-providers/docker/.github/workflows/build_provider.yml
@@ -37,6 +37,8 @@ jobs:
         uses: ./.github/actions/setup-tools
         with:
           tools: pulumictl, go
+      - name: Prepare local workspace before restoring previously built
+        run: make prepare_local_workspace
       - name: Download schema-embed.json
         uses: actions/download-artifact@v4
         with:
@@ -45,9 +47,11 @@ jobs:
           # Avoid creating directories for each artifact
           merge-multiple: true
           path: provider/cmd/pulumi-resource-docker/schema-embed.json
-      - name: Prepare for build
-        # This installs plugins and prepares upstream
-        run: make upstream
+      - name: Restore makefile progress
+        uses: actions/download-artifact@v4
+        with:
+          name: prerequisites.make
+          path: .make
       - name: Build & package provider
         run: make provider_dist-${{ matrix.platform.os }}-${{ matrix.platform.arch }}
       - name: Upload artifacts

--- a/provider-ci/test-providers/docker/.github/workflows/build_sdk.yml
+++ b/provider-ci/test-providers/docker/.github/workflows/build_sdk.yml
@@ -69,12 +69,17 @@ jobs:
         uses: ./.github/actions/setup-tools
         with:
           tools: pulumictl, pulumicli, ${{ matrix.language }}
+      - name: Prepare local workspace
+        run: make prepare_local_workspace
       - name: Download bin
         uses: ./.github/actions/download-bin
-      - name: Install plugins
-        run: make install_plugins
       - name: Update path
         run: echo "${{ github.workspace }}/bin" >> "$GITHUB_PATH"
+      - name: Restore makefile progress
+        uses: actions/download-artifact@v4
+        with:
+          name: prerequisites.make
+          path: .make
       - name: Build SDK
         run: make build_${{ matrix.language }}
       - name: Check worktree clean
@@ -90,3 +95,9 @@ jobs:
         uses: ./.github/actions/upload-sdk
         with:
           language: ${{ matrix.language }}
+      - name: Save makefile progress
+        uses: actions/upload-artifact@v4
+        with:
+          name: build_${{ matrix.language }}.make
+          path: .make
+          include-hidden-files: true

--- a/provider-ci/test-providers/docker/.github/workflows/master.yml
+++ b/provider-ci/test-providers/docker/.github/workflows/master.yml
@@ -161,9 +161,6 @@ jobs:
         tools: pulumictl, pulumicli, ${{ matrix.language }}
     - name: Download bin
       uses: ./.github/actions/download-bin
-    - name: Add NuGet source
-      if: matrix.language == 'dotnet'
-      run: dotnet nuget add source ${{ github.workspace }}/nuget
     - name: Download SDK
       uses: ./.github/actions/download-sdk
       with:

--- a/provider-ci/test-providers/docker/.github/workflows/master.yml
+++ b/provider-ci/test-providers/docker/.github/workflows/master.yml
@@ -168,6 +168,8 @@ jobs:
       uses: ./.github/actions/download-sdk
       with:
         language: ${{ matrix.language }}
+    - name: Mark SDK up to date
+      run: make --touch build_${{ matrix.language }}
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> "$GITHUB_PATH"
     - name: Install Python deps

--- a/provider-ci/test-providers/docker/.github/workflows/master.yml
+++ b/provider-ci/test-providers/docker/.github/workflows/master.yml
@@ -159,14 +159,19 @@ jobs:
       uses: ./.github/actions/setup-tools
       with:
         tools: pulumictl, pulumicli, ${{ matrix.language }}
+    - name: Prepare local workspace
+      run: make prepare_local_workspace
     - name: Download bin
       uses: ./.github/actions/download-bin
     - name: Download SDK
       uses: ./.github/actions/download-sdk
       with:
         language: ${{ matrix.language }}
-    - name: Mark SDK up to date
-      run: make --touch build_${{ matrix.language }}
+    - name: Restore makefile progress
+      uses: actions/download-artifact@v4
+      with:
+        name: build_${{ matrix.language }}.make
+        path: .make
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> "$GITHUB_PATH"
     - name: Install Python deps

--- a/provider-ci/test-providers/docker/.github/workflows/prerelease.yml
+++ b/provider-ci/test-providers/docker/.github/workflows/prerelease.yml
@@ -110,6 +110,8 @@ jobs:
       uses: ./.github/actions/download-sdk
       with:
         language: ${{ matrix.language }}
+    - name: Mark SDK up to date
+      run: make --touch build_${{ matrix.language }}
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> "$GITHUB_PATH"
     - name: Install Python deps

--- a/provider-ci/test-providers/docker/.github/workflows/prerelease.yml
+++ b/provider-ci/test-providers/docker/.github/workflows/prerelease.yml
@@ -101,14 +101,19 @@ jobs:
       uses: ./.github/actions/setup-tools
       with:
         tools: pulumictl, pulumicli, nodejs, python, dotnet, go, java
+    - name: Prepare local workspace
+      run: make prepare_local_workspace
     - name: Download bin
       uses: ./.github/actions/download-bin
     - name: Download SDK
       uses: ./.github/actions/download-sdk
       with:
         language: ${{ matrix.language }}
-    - name: Mark SDK up to date
-      run: make --touch build_${{ matrix.language }}
+    - name: Restore makefile progress
+      uses: actions/download-artifact@v4
+      with:
+        name: build_${{ matrix.language }}.make
+        path: .make
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> "$GITHUB_PATH"
     - name: Install Python deps

--- a/provider-ci/test-providers/docker/.github/workflows/prerelease.yml
+++ b/provider-ci/test-providers/docker/.github/workflows/prerelease.yml
@@ -103,9 +103,6 @@ jobs:
         tools: pulumictl, pulumicli, nodejs, python, dotnet, go, java
     - name: Download bin
       uses: ./.github/actions/download-bin
-    - name: Add NuGet source
-      if: matrix.language == 'dotnet'
-      run: dotnet nuget add source ${{ github.workspace }}/nuget
     - name: Download SDK
       uses: ./.github/actions/download-sdk
       with:

--- a/provider-ci/test-providers/docker/.github/workflows/prerequisites.yml
+++ b/provider-ci/test-providers/docker/.github/workflows/prerequisites.yml
@@ -71,20 +71,16 @@ jobs:
         path: |
           .pulumi/examples-cache
         key: ${{ runner.os }}-${{ hashFiles('provider/go.sum') }}
-    - name: Prepare upstream code
-      run: make upstream
     - name: Setup tools
       uses: ./.github/actions/setup-tools
       with:
         tools: go, pulumictl, pulumicli, schema-tools
-    - name: Build schema generator binary
-      run: make tfgen_build_only
-    - name: Install plugins
-      run: make install_plugins
+    - name: Prepare local workspace before restoring previously built files
+      run: make prepare_local_workspace
     - name: Generate schema
-      run: make tfgen_no_deps
+      run: make schema
     - name: Build provider binary
-      run: make provider_no_deps
+      run: make provider
     - name: Unit-test provider code
       run: make test_provider
     - if: inputs.is_pr
@@ -96,6 +92,12 @@ jobs:
           schema-tools compare -r github://api.github.com/pulumi -p docker -o "${{ inputs.default_branch }}" -n --local-path=provider/cmd/pulumi-resource-docker/schema.json;
           echo "$EOF";
         } >> "$GITHUB_ENV"
+    - name: Save makefile progress
+      uses: actions/upload-artifact@v4
+      with:
+        name: prerequisites.make
+        path: .make
+        include-hidden-files: true
     - if: inputs.is_pr && inputs.is_automated == false
       name: Comment on PR with Details of Schema Check
       uses: thollander/actions-comment-pull-request@v2

--- a/provider-ci/test-providers/docker/.github/workflows/release.yml
+++ b/provider-ci/test-providers/docker/.github/workflows/release.yml
@@ -107,14 +107,19 @@ jobs:
       uses: ./.github/actions/setup-tools
       with:
         tools: pulumictl, pulumicli, ${{ matrix.language }}
+    - name: Prepare local workspace
+      run: make prepare_local_workspace
     - name: Download bin
       uses: ./.github/actions/download-bin
     - name: Download SDK
       uses: ./.github/actions/download-sdk
       with:
         language: ${{ matrix.language }}
-    - name: Mark SDK up to date
-      run: make --touch build_${{ matrix.language }}
+    - name: Restore makefile progress
+      uses: actions/download-artifact@v4
+      with:
+        name: build_${{ matrix.language }}.make
+        path: .make
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> "$GITHUB_PATH"
     - name: Install Python deps

--- a/provider-ci/test-providers/docker/.github/workflows/release.yml
+++ b/provider-ci/test-providers/docker/.github/workflows/release.yml
@@ -109,9 +109,6 @@ jobs:
         tools: pulumictl, pulumicli, ${{ matrix.language }}
     - name: Download bin
       uses: ./.github/actions/download-bin
-    - name: Add NuGet source
-      if: matrix.language == 'dotnet'
-      run: dotnet nuget add source ${{ github.workspace }}/nuget
     - name: Download SDK
       uses: ./.github/actions/download-sdk
       with:

--- a/provider-ci/test-providers/docker/.github/workflows/release.yml
+++ b/provider-ci/test-providers/docker/.github/workflows/release.yml
@@ -116,6 +116,8 @@ jobs:
       uses: ./.github/actions/download-sdk
       with:
         language: ${{ matrix.language }}
+    - name: Mark SDK up to date
+      run: make --touch build_${{ matrix.language }}
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> "$GITHUB_PATH"
     - name: Install Python deps

--- a/provider-ci/test-providers/docker/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/test-providers/docker/.github/workflows/run-acceptance-tests.yml
@@ -158,9 +158,6 @@ jobs:
         tools: pulumictl, pulumicli, ${{ matrix.language }}
     - name: Download bin
       uses: ./.github/actions/download-bin
-    - name: Add NuGet source
-      if: matrix.language == 'dotnet'
-      run: dotnet nuget add source ${{ github.workspace }}/nuget
     - name: Download SDK
       uses: ./.github/actions/download-sdk
       with:

--- a/provider-ci/test-providers/docker/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/test-providers/docker/.github/workflows/run-acceptance-tests.yml
@@ -165,6 +165,8 @@ jobs:
       uses: ./.github/actions/download-sdk
       with:
         language: ${{ matrix.language }}
+    - name: Mark SDK up to date
+      run: make --touch build_${{ matrix.language }}
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> "$GITHUB_PATH"
     - name: Install Python deps

--- a/provider-ci/test-providers/docker/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/test-providers/docker/.github/workflows/run-acceptance-tests.yml
@@ -156,14 +156,19 @@ jobs:
       uses: ./.github/actions/setup-tools
       with:
         tools: pulumictl, pulumicli, ${{ matrix.language }}
+    - name: Prepare local workspace
+      run: make prepare_local_workspace
     - name: Download bin
       uses: ./.github/actions/download-bin
     - name: Download SDK
       uses: ./.github/actions/download-sdk
       with:
         language: ${{ matrix.language }}
-    - name: Mark SDK up to date
-      run: make --touch build_${{ matrix.language }}
+    - name: Restore makefile progress
+      uses: actions/download-artifact@v4
+      with:
+        name: build_${{ matrix.language }}.make
+        path: .make
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> "$GITHUB_PATH"
     - name: Install Python deps

--- a/provider-ci/test-providers/docker/Makefile
+++ b/provider-ci/test-providers/docker/Makefile
@@ -52,15 +52,23 @@ install_sdks: install_dotnet_sdk install_python_sdk install_nodejs_sdk install_j
 
 only_build: build
 
-build_dotnet: export PULUMI_HOME := $(WORKING_DIR)/.pulumi
-build_dotnet: export PATH := $(WORKING_DIR)/.pulumi/bin:$(PATH)
-build_dotnet: export PULUMI_CONVERT_EXAMPLES_CACHE_DIR := $(WORKING_DIR)/.pulumi/examples-cache
-build_dotnet: .make/upstream
-	PULUMI_CONVERT=$(PULUMI_CONVERT) PULUMI_DISABLE_AUTOMATIC_PLUGIN_ACQUISITION=$(PULUMI_CONVERT) $(WORKING_DIR)/bin/$(TFGEN) dotnet --out sdk/dotnet/
+GEN_PULUMI_HOME := $(WORKING_DIR)/.pulumi
+GEN_PULUMI_CONVERT_EXAMPLES_CACHE_DIR := $(GEN_PULUMI_HOME)/examples-cache
+GEN_ENVS := PULUMI_HOME=$(GEN_PULUMI_HOME) PULUMI_CONVERT_EXAMPLES_CACHE_DIR=$(GEN_PULUMI_CONVERT_EXAMPLES_CACHE_DIR) PULUMI_CONVERT=$(PULUMI_CONVERT) PULUMI_DISABLE_AUTOMATIC_PLUGIN_ACQUISITION=$(PULUMI_CONVERT)
+
+.PHONY: generate_dotnet build_dotnet
+generate_dotnet: .make/generate_dotnet
+build_dotnet: .make/build_dotnet
+.make/generate_dotnet: export PATH := $(WORKING_DIR)/.pulumi/bin:$(PATH)
+.make/generate_dotnet: bin/$(TFGEN)
+	$(GEN_ENVS) $(WORKING_DIR)/bin/$(TFGEN) dotnet --out sdk/dotnet/
 	cd sdk/dotnet/ && \
 		printf "module fake_dotnet_module // Exclude this directory from Go tools\n\ngo 1.17\n" > go.mod && \
-		echo "$(VERSION_GENERIC)" >version.txt && \
-		dotnet build
+		echo "$(VERSION_GENERIC)" >version.txt
+	@touch $@
+.make/build_dotnet: .make/generate_dotnet
+	cd sdk/dotnet/ && dotnet build
+	@touch $@
 
 build_go: export PULUMI_HOME := $(WORKING_DIR)/.pulumi
 build_go: export PATH := $(WORKING_DIR)/.pulumi/bin:$(PATH)
@@ -234,7 +242,7 @@ ci-mgmt: .ci-mgmt.yaml
 debug_tfgen:
 	dlv  --listen=:2345 --headless=true --api-version=2  exec $(WORKING_DIR)/bin/$(TFGEN) -- schema --out provider/cmd/$(PROVIDER)
 
-.PHONY: development build build_sdks install_go_sdk install_java_sdk install_python_sdk install_sdks only_build build_dotnet build_go build_java build_nodejs build_python install_dotnet_sdk install_nodejs_sdk lint_provider provider provider_no_deps test ci-mgmt test_provider debug_tfgen
+.PHONY: development build build_sdks install_go_sdk install_java_sdk install_python_sdk install_sdks only_build build_go build_java build_nodejs build_python install_dotnet_sdk install_nodejs_sdk lint_provider provider provider_no_deps test ci-mgmt test_provider debug_tfgen
 
 # Provider cross-platform build & packaging
 

--- a/provider-ci/test-providers/docker/Makefile
+++ b/provider-ci/test-providers/docker/Makefile
@@ -163,6 +163,7 @@ test_provider:
 	@echo ""
 	cd provider && go test -v -short ./... -parallel $(TESTPARALLELISM)
 
+.PHONY: tfgen tfgen_no_deps tfgen_build_only
 tfgen: install_plugins upstream docs tfgen_no_deps
 
 tfgen_no_deps: export PULUMI_HOME := $(WORKING_DIR)/.pulumi
@@ -171,11 +172,13 @@ tfgen_no_deps: export PULUMI_CONVERT := $(PULUMI_CONVERT)
 tfgen_no_deps: export PULUMI_CONVERT_EXAMPLES_CACHE_DIR := $(WORKING_DIR)/.pulumi/examples-cache
 tfgen_no_deps: export PULUMI_DISABLE_AUTOMATIC_PLUGIN_ACQUISITION := $(PULUMI_CONVERT)
 tfgen_no_deps: export PULUMI_MISSING_DOCS_ERROR := $(PULUMI_MISSING_DOCS_ERROR)
-tfgen_no_deps: tfgen_build_only
+tfgen_no_deps: bin/$(TFGEN)
 	$(WORKING_DIR)/bin/$(TFGEN) schema --out provider/cmd/$(PROVIDER)
 	(cd provider && VERSION=$(VERSION_GENERIC) go generate cmd/$(PROVIDER)/main.go)
 
-tfgen_build_only:
+tfgen_build_only: bin/$(TFGEN)
+
+bin/$(TFGEN):
 	(cd provider && go build $(PULUMI_PROVIDER_BUILD_PARALLELISM) -o $(WORKING_DIR)/bin/$(TFGEN) -ldflags "$(LDFLAGS_PROJ_VERSION) $(LDFLAGS_EXTRAS)" $(PROJECT)/$(PROVIDER_PATH)/cmd/$(TFGEN))
 
 upstream:
@@ -217,7 +220,7 @@ ci-mgmt: .ci-mgmt.yaml
 debug_tfgen:
 	dlv  --listen=:2345 --headless=true --api-version=2  exec $(WORKING_DIR)/bin/$(TFGEN) -- schema --out provider/cmd/$(PROVIDER)
 
-.PHONY: development build build_sdks install_go_sdk install_java_sdk install_python_sdk install_sdks only_build build_dotnet build_go build_java build_nodejs build_python clean cleanup docs help install_dotnet_sdk install_nodejs_sdk install_plugins lint_provider provider provider_no_deps test tfgen upstream ci-mgmt test_provider debug_tfgen tfgen_build_only
+.PHONY: development build build_sdks install_go_sdk install_java_sdk install_python_sdk install_sdks only_build build_dotnet build_go build_java build_nodejs build_python clean cleanup docs help install_dotnet_sdk install_nodejs_sdk install_plugins lint_provider provider provider_no_deps test upstream ci-mgmt test_provider debug_tfgen
 
 # Provider cross-platform build & packaging
 

--- a/provider-ci/test-providers/docker/Makefile
+++ b/provider-ci/test-providers/docker/Makefile
@@ -32,7 +32,9 @@ LDFLAGS=$(LDFLAGS_PROJ_VERSION) $(LDFLAGS_UPSTREAM_VERSION) $(LDFLAGS_EXTRAS) $(
 # file within `.make/` to track the staleness of the target and only rebuild when needed. 
 # For each phony target, we create an internal target with the same name, but prefixed with `.make/` where the work is performed.
 # At the end of each internal target we run `@touch $@` to update the file which is the name of the target.
-_ := $(shell mkdir -p .make)
+
+# Ensure all directories exist before evaluating targets to avoid issues with `touch` creating directories.
+_ := $(shell mkdir -p .make bin .pulumi/bin)
 
 development: .make/install_plugins provider build_sdks install_sdks
 
@@ -225,8 +227,7 @@ ci-mgmt: .ci-mgmt.yaml
 
 # Compute the version of Pulumi to use by inspecting the Go dependencies of the provider.
 .pulumi/version: provider/go.mod
-	@mkdir -p .pulumi
-	@cd provider && go list -f "{{slice .Version 1}}" -m github.com/pulumi/pulumi/pkg/v3 | tee ../$@
+	cd provider && go list -f "{{slice .Version 1}}" -m github.com/pulumi/pulumi/pkg/v3 | tee ../$@
 
 # Start debug server for tfgen
 debug_tfgen:

--- a/provider-ci/test-providers/docker/Makefile
+++ b/provider-ci/test-providers/docker/Makefile
@@ -122,11 +122,6 @@ docs: .make/docs
 	cd provider/pkg/docs-gen/examples/ && go run generate.go ./yaml ./
 	@touch $@
 
-help:
-	@grep '^[^.#]\+:\s\+.*#' Makefile | \
-	sed "s/\(.\+\):\s*\(.*\) #\s*\(.*\)/`printf "\033[93m"`\1`printf "\033[0m"`	\3 [\2]/" | \
-	expand -t20
-
 install_dotnet_sdk:
 	mkdir -p $(WORKING_DIR)/nuget
 	find . -name '*.nupkg' -print -exec cp -p {} $(WORKING_DIR)/nuget \;
@@ -234,7 +229,7 @@ ci-mgmt: .ci-mgmt.yaml
 debug_tfgen:
 	dlv  --listen=:2345 --headless=true --api-version=2  exec $(WORKING_DIR)/bin/$(TFGEN) -- schema --out provider/cmd/$(PROVIDER)
 
-.PHONY: development build build_sdks install_go_sdk install_java_sdk install_python_sdk install_sdks only_build build_dotnet build_go build_java build_nodejs build_python help install_dotnet_sdk install_nodejs_sdk lint_provider provider provider_no_deps test ci-mgmt test_provider debug_tfgen
+.PHONY: development build build_sdks install_go_sdk install_java_sdk install_python_sdk install_sdks only_build build_dotnet build_go build_java build_nodejs build_python install_dotnet_sdk install_nodejs_sdk lint_provider provider provider_no_deps test ci-mgmt test_provider debug_tfgen
 
 # Provider cross-platform build & packaging
 

--- a/provider-ci/test-providers/docker/Makefile
+++ b/provider-ci/test-providers/docker/Makefile
@@ -53,7 +53,7 @@ only_build: build
 build_dotnet: export PULUMI_HOME := $(WORKING_DIR)/.pulumi
 build_dotnet: export PATH := $(WORKING_DIR)/.pulumi/bin:$(PATH)
 build_dotnet: export PULUMI_CONVERT_EXAMPLES_CACHE_DIR := $(WORKING_DIR)/.pulumi/examples-cache
-build_dotnet: upstream
+build_dotnet: .make/upstream
 	PULUMI_CONVERT=$(PULUMI_CONVERT) PULUMI_DISABLE_AUTOMATIC_PLUGIN_ACQUISITION=$(PULUMI_CONVERT) $(WORKING_DIR)/bin/$(TFGEN) dotnet --out sdk/dotnet/
 	cd sdk/dotnet/ && \
 		printf "module fake_dotnet_module // Exclude this directory from Go tools\n\ngo 1.17\n" > go.mod && \
@@ -63,7 +63,7 @@ build_dotnet: upstream
 build_go: export PULUMI_HOME := $(WORKING_DIR)/.pulumi
 build_go: export PATH := $(WORKING_DIR)/.pulumi/bin:$(PATH)
 build_go: export PULUMI_CONVERT_EXAMPLES_CACHE_DIR := $(WORKING_DIR)/.pulumi/examples-cache
-build_go: upstream
+build_go: .make/upstream
 	PULUMI_CONVERT=$(PULUMI_CONVERT) PULUMI_DISABLE_AUTOMATIC_PLUGIN_ACQUISITION=$(PULUMI_CONVERT) $(WORKING_DIR)/bin/$(TFGEN) go --out sdk/go/
 	cd sdk && go list "$$(grep -e "^module" go.mod | cut -d ' ' -f 2)/go/..." | xargs -I {} bash -c 'go build {} && go clean -i {}'
 
@@ -71,7 +71,7 @@ build_java: PACKAGE_VERSION := $(VERSION_GENERIC)
 build_java: export PULUMI_HOME := $(WORKING_DIR)/.pulumi
 build_java: export PATH := $(WORKING_DIR)/.pulumi/bin:$(PATH)
 build_java: export PULUMI_CONVERT_EXAMPLES_CACHE_DIR := $(WORKING_DIR)/.pulumi/examples-cache
-build_java: bin/pulumi-java-gen upstream
+build_java: bin/pulumi-java-gen .make/upstream
 	$(WORKING_DIR)/bin/$(JAVA_GEN) generate --schema provider/cmd/$(PROVIDER)/schema.json --out sdk/java  --build gradle-nexus
 	cd sdk/java/ && \
 		printf "module fake_java_module // Exclude this directory from Go tools\n\ngo 1.17\n" > go.mod && \
@@ -81,7 +81,7 @@ build_java: bin/pulumi-java-gen upstream
 build_nodejs: export PULUMI_HOME := $(WORKING_DIR)/.pulumi
 build_nodejs: export PATH := $(WORKING_DIR)/.pulumi/bin:$(PATH)
 build_nodejs: export PULUMI_CONVERT_EXAMPLES_CACHE_DIR := $(WORKING_DIR)/.pulumi/examples-cache
-build_nodejs: upstream
+build_nodejs: .make/upstream
 	PULUMI_CONVERT=$(PULUMI_CONVERT) PULUMI_DISABLE_AUTOMATIC_PLUGIN_ACQUISITION=$(PULUMI_CONVERT) $(WORKING_DIR)/bin/$(TFGEN) nodejs --out sdk/nodejs/
 	cd sdk/nodejs/ && \
 		printf "module fake_nodejs_module // Exclude this directory from Go tools\n\ngo 1.17\n" > go.mod && \
@@ -92,7 +92,7 @@ build_nodejs: upstream
 build_python: export PULUMI_HOME := $(WORKING_DIR)/.pulumi
 build_python: export PATH := $(WORKING_DIR)/.pulumi/bin:$(PATH)
 build_python: export PULUMI_CONVERT_EXAMPLES_CACHE_DIR := $(WORKING_DIR)/.pulumi/examples-cache
-build_python: upstream
+build_python: .make/upstream
 	rm -rf sdk/python/
 	PULUMI_CONVERT=$(PULUMI_CONVERT) PULUMI_DISABLE_AUTOMATIC_PLUGIN_ACQUISITION=$(PULUMI_CONVERT) $(WORKING_DIR)/bin/$(TFGEN) python --out sdk/python/
 	cd sdk/python/ && \
@@ -181,10 +181,14 @@ tfgen_build_only: bin/$(TFGEN)
 bin/$(TFGEN):
 	(cd provider && go build $(PULUMI_PROVIDER_BUILD_PARALLELISM) -o $(WORKING_DIR)/bin/$(TFGEN) -ldflags "$(LDFLAGS_PROJ_VERSION) $(LDFLAGS_EXTRAS)" $(PROJECT)/$(PROVIDER_PATH)/cmd/$(TFGEN))
 
-upstream:
+.PHONY: upstream
+upstream: .make/upstream
+# Re-run if the upstream commit or the patches change
+.make/upstream: $(wildcard patches/*) $(wildcard .git/modules/upstream/HEAD)
 ifneq ("$(wildcard upstream)","")
 	./upstream.sh init
 endif
+	@touch $@
 
 bin/pulumi-java-gen: .pulumi-java-gen.version
 	pulumictl download-binary -n pulumi-language-java -v v$(shell cat .pulumi-java-gen.version) -r pulumi/pulumi-java
@@ -220,7 +224,7 @@ ci-mgmt: .ci-mgmt.yaml
 debug_tfgen:
 	dlv  --listen=:2345 --headless=true --api-version=2  exec $(WORKING_DIR)/bin/$(TFGEN) -- schema --out provider/cmd/$(PROVIDER)
 
-.PHONY: development build build_sdks install_go_sdk install_java_sdk install_python_sdk install_sdks only_build build_dotnet build_go build_java build_nodejs build_python clean cleanup docs help install_dotnet_sdk install_nodejs_sdk install_plugins lint_provider provider provider_no_deps test upstream ci-mgmt test_provider debug_tfgen
+.PHONY: development build build_sdks install_go_sdk install_java_sdk install_python_sdk install_sdks only_build build_dotnet build_go build_java build_nodejs build_python clean cleanup docs help install_dotnet_sdk install_nodejs_sdk install_plugins lint_provider provider provider_no_deps test ci-mgmt test_provider debug_tfgen
 
 # Provider cross-platform build & packaging
 

--- a/provider-ci/test-providers/docker/Makefile
+++ b/provider-ci/test-providers/docker/Makefile
@@ -27,6 +27,13 @@ LDFLAGS_UPSTREAM_VERSION=
 LDFLAGS_EXTRAS=
 LDFLAGS=$(LDFLAGS_PROJ_VERSION) $(LDFLAGS_UPSTREAM_VERSION) $(LDFLAGS_EXTRAS) $(LDFLAGS_STRIP_SYMBOLS)
 
+# Create a `.make` directory for tracking targets which don't generate a single file output. This should be ignored by git.
+# For targets which either don't generate a single file output, or the output file is committed, we use a "sentinel"
+# file within `.make/` to track the staleness of the target and only rebuild when needed. 
+# For each phony target, we create an internal target with the same name, but prefixed with `.make/` where the work is performed.
+# At the end of each internal target we run `@touch $@` to update the file which is the name of the target.
+_ := $(shell mkdir -p .make)
+
 development: install_plugins provider build_sdks install_sdks
 
 build: install_plugins provider build_sdks install_sdks

--- a/provider-ci/test-providers/docker/Makefile
+++ b/provider-ci/test-providers/docker/Makefile
@@ -166,18 +166,22 @@ test_provider:
 	@echo ""
 	cd provider && go test -v -short ./... -parallel $(TESTPARALLELISM)
 
-.PHONY: tfgen tfgen_no_deps tfgen_build_only
-tfgen: install_plugins upstream docs tfgen_no_deps
+.PHONY: tfgen schema tfgen_no_deps tfgen_build_only
+tfgen: schema
+schema: .make/schema  docs
+# This does actually have dependencies, but we're keeping it around for backwards compatibility for now
+tfgen_no_deps: .make/schema
 
-tfgen_no_deps: export PULUMI_HOME := $(WORKING_DIR)/.pulumi
-tfgen_no_deps: export PATH := $(WORKING_DIR)/.pulumi/bin:$(PATH)
-tfgen_no_deps: export PULUMI_CONVERT := $(PULUMI_CONVERT)
-tfgen_no_deps: export PULUMI_CONVERT_EXAMPLES_CACHE_DIR := $(WORKING_DIR)/.pulumi/examples-cache
-tfgen_no_deps: export PULUMI_DISABLE_AUTOMATIC_PLUGIN_ACQUISITION := $(PULUMI_CONVERT)
-tfgen_no_deps: export PULUMI_MISSING_DOCS_ERROR := $(PULUMI_MISSING_DOCS_ERROR)
-tfgen_no_deps: bin/$(TFGEN)
+.make/schema: export PULUMI_HOME := $(WORKING_DIR)/.pulumi
+.make/schema: export PATH := $(WORKING_DIR)/.pulumi/bin:$(PATH)
+.make/schema: export PULUMI_CONVERT := $(PULUMI_CONVERT)
+.make/schema: export PULUMI_CONVERT_EXAMPLES_CACHE_DIR := $(WORKING_DIR)/.pulumi/examples-cache
+.make/schema: export PULUMI_DISABLE_AUTOMATIC_PLUGIN_ACQUISITION := $(PULUMI_CONVERT)
+.make/schema: export PULUMI_MISSING_DOCS_ERROR := $(PULUMI_MISSING_DOCS_ERROR)
+.make/schema: bin/$(TFGEN) provider/resources.go provider/go.mod .make/install_plugins .make/upstream
 	$(WORKING_DIR)/bin/$(TFGEN) schema --out provider/cmd/$(PROVIDER)
 	(cd provider && VERSION=$(VERSION_GENERIC) go generate cmd/$(PROVIDER)/main.go)
+	@touch $@
 
 tfgen_build_only: bin/$(TFGEN)
 

--- a/provider-ci/test-providers/docker/Makefile
+++ b/provider-ci/test-providers/docker/Makefile
@@ -40,7 +40,7 @@ development: .make/install_plugins provider build_sdks install_sdks
 
 build: .make/install_plugins provider build_sdks install_sdks
 
-build_sdks: build_nodejs build_python build_dotnet build_go build_java build_registry_docs
+build_sdks: build_nodejs build_python build_dotnet build_go build_java .make/build_registry_docs
 
 install_go_sdk:
 
@@ -106,10 +106,12 @@ build_python: .make/upstream
 		./venv/bin/python -m pip install build==1.2.1 && \
 		cd ./bin && \
 		../venv/bin/python -m build .
-
 # Run the bridge's registry-docs command to generated the content of the installation docs/ folder at provider repo root
-build_registry_docs:
-	$(WORKING_DIR)/bin/$(TFGEN) registry-docs --out $(WORKING_DIR)/docs
+.PHONY: build_registry_docs
+build_registry_docs: .make/build_registry_docs
+.make/build_registry_docs: bin/$(TFGEN)
+	bin/$(TFGEN) registry-docs --out $(WORKING_DIR)/docs
+	@touch $@
 
 .PHONY: clean
 clean:

--- a/provider-ci/test-providers/docker/Makefile
+++ b/provider-ci/test-providers/docker/Makefile
@@ -34,9 +34,9 @@ LDFLAGS=$(LDFLAGS_PROJ_VERSION) $(LDFLAGS_UPSTREAM_VERSION) $(LDFLAGS_EXTRAS) $(
 # At the end of each internal target we run `@touch $@` to update the file which is the name of the target.
 _ := $(shell mkdir -p .make)
 
-development: install_plugins provider build_sdks install_sdks
+development: .make/install_plugins provider build_sdks install_sdks
 
-build: install_plugins provider build_sdks install_sdks
+build: .make/install_plugins provider build_sdks install_sdks
 
 build_sdks: build_nodejs build_python build_dotnet build_go build_java build_registry_docs
 
@@ -131,11 +131,14 @@ install_dotnet_sdk:
 install_nodejs_sdk:
 	yarn link --cwd $(WORKING_DIR)/sdk/nodejs/bin
 
-install_plugins: export PULUMI_HOME := $(WORKING_DIR)/.pulumi
-install_plugins: export PATH := $(WORKING_DIR)/.pulumi/bin:$(PATH)
-install_plugins: .pulumi/bin/pulumi
+.PHONY: install_plugins
+install_plugins: .make/install_plugins
+.make/install_plugins: export PULUMI_HOME := $(WORKING_DIR)/.pulumi
+.make/install_plugins: export PATH := $(WORKING_DIR)/.pulumi/bin:$(PATH)
+.make/install_plugins: .pulumi/bin/pulumi
 	.pulumi/bin/pulumi plugin install converter terraform 1.0.16
 	.pulumi/bin/pulumi plugin install resource aws 6.8.0
+	@touch $@
 
 lint_provider: provider
 	cd provider && golangci-lint run --path-prefix provider -c ../.golangci.yml
@@ -224,7 +227,7 @@ ci-mgmt: .ci-mgmt.yaml
 debug_tfgen:
 	dlv  --listen=:2345 --headless=true --api-version=2  exec $(WORKING_DIR)/bin/$(TFGEN) -- schema --out provider/cmd/$(PROVIDER)
 
-.PHONY: development build build_sdks install_go_sdk install_java_sdk install_python_sdk install_sdks only_build build_dotnet build_go build_java build_nodejs build_python clean cleanup docs help install_dotnet_sdk install_nodejs_sdk install_plugins lint_provider provider provider_no_deps test ci-mgmt test_provider debug_tfgen
+.PHONY: development build build_sdks install_go_sdk install_java_sdk install_python_sdk install_sdks only_build build_dotnet build_go build_java build_nodejs build_python clean cleanup docs help install_dotnet_sdk install_nodejs_sdk lint_provider provider provider_no_deps test ci-mgmt test_provider debug_tfgen
 
 # Provider cross-platform build & packaging
 

--- a/provider-ci/test-providers/docker/Makefile
+++ b/provider-ci/test-providers/docker/Makefile
@@ -40,11 +40,11 @@ _ := $(shell mkdir -p .make bin .pulumi/bin)
 development: build
 only_build: build
 # Build the provider and all SDKs and install ready for testing
-build: install_plugins provider build_sdks install_sdks
+build: install_plugins provider build_sdks install_sdks build_registry_docs
 # Creates all generated files which need to be committed
 generate: generate_sdks schema build_registry_docs
 generate_sdks: generate_nodejs generate_python generate_dotnet generate_go generate_java
-build_sdks: build_nodejs build_python build_dotnet build_go build_javabuild_registry_docs
+build_sdks: build_nodejs build_python build_dotnet build_go build_java
 install_sdks: install_nodejs_sdk install_python_sdk install_dotnet_sdk install_go_sdk install_java_sdk
 .PHONY: development only_build build generate generate_sdks build_sdks install_sdks
 

--- a/provider-ci/test-providers/docker/Makefile
+++ b/provider-ci/test-providers/docker/Makefile
@@ -36,21 +36,20 @@ LDFLAGS=$(LDFLAGS_PROJ_VERSION) $(LDFLAGS_UPSTREAM_VERSION) $(LDFLAGS_EXTRAS) $(
 # Ensure all directories exist before evaluating targets to avoid issues with `touch` creating directories.
 _ := $(shell mkdir -p .make bin .pulumi/bin)
 
-development: .make/install_plugins provider build_sdks install_sdks
-
-build: .make/install_plugins provider build_sdks install_sdks
-
-build_sdks: build_nodejs build_python build_dotnet build_go build_java .make/build_registry_docs
+.PHONY: development only_build build generate_sdks build_sdks install_sdks
+# Keep aliases for old targets to ensure backwards compatibility
+development: build
+only_build: build
+build: install_plugins provider build_sdks install_sdks
+generate_sdks: generate_nodejs generate_python generate_dotnet generate_go generate_java
+build_sdks: build_nodejs build_python build_dotnet build_go build_java.make/build_registry_docs
+install_sdks: install_nodejs_sdk install_python_sdk install_dotnet_sdk install_go_sdk install_java_sdk
 
 install_go_sdk:
 
 install_java_sdk:
 
 install_python_sdk:
-
-install_sdks: install_dotnet_sdk install_python_sdk install_nodejs_sdk install_java_sdk
-
-only_build: build
 
 GEN_PULUMI_HOME := $(WORKING_DIR)/.pulumi
 GEN_PULUMI_CONVERT_EXAMPLES_CACHE_DIR := $(GEN_PULUMI_HOME)/examples-cache
@@ -258,7 +257,7 @@ ci-mgmt: .ci-mgmt.yaml
 debug_tfgen:
 	dlv  --listen=:2345 --headless=true --api-version=2  exec $(WORKING_DIR)/bin/$(TFGEN) -- schema --out provider/cmd/$(PROVIDER)
 
-.PHONY: development build build_sdks install_go_sdk install_java_sdk install_python_sdk install_sdks only_build install_dotnet_sdk install_nodejs_sdk lint_provider provider provider_no_deps test ci-mgmt test_provider debug_tfgen
+.PHONY: install_go_sdk install_java_sdk install_python_sdk install_sdks install_dotnet_sdk install_nodejs_sdk lint_provider test ci-mgmt test_provider debug_tfgen
 
 # Provider cross-platform build & packaging
 

--- a/provider-ci/test-providers/docker/Makefile
+++ b/provider-ci/test-providers/docker/Makefile
@@ -39,11 +39,14 @@ _ := $(shell mkdir -p .make bin .pulumi/bin)
 # Keep aliases for old targets to ensure backwards compatibility
 development: build
 only_build: build
+# Build the provider and all SDKs and install ready for testing
 build: install_plugins provider build_sdks install_sdks
+# Creates all generated files which need to be committed
+generate: generate_sdks schema build_registry_docs
 generate_sdks: generate_nodejs generate_python generate_dotnet generate_go generate_java
-build_sdks: build_nodejs build_python build_dotnet build_go build_java.make/build_registry_docs
+build_sdks: build_nodejs build_python build_dotnet build_go build_javabuild_registry_docs
 install_sdks: install_nodejs_sdk install_python_sdk install_dotnet_sdk install_go_sdk install_java_sdk
-.PHONY: development only_build build generate_sdks build_sdks install_sdks
+.PHONY: development only_build build generate generate_sdks build_sdks install_sdks
 
 GEN_PULUMI_HOME := $(WORKING_DIR)/.pulumi
 GEN_PULUMI_CONVERT_EXAMPLES_CACHE_DIR := $(GEN_PULUMI_HOME)/examples-cache

--- a/provider-ci/test-providers/docker/Makefile
+++ b/provider-ci/test-providers/docker/Makefile
@@ -107,21 +107,24 @@ build_nodejs: .make/build_nodejs
 		cp ../../README.md ../../LICENSE* package.json yarn.lock ./bin/
 	@touch $@
 
-build_python: export PULUMI_HOME := $(WORKING_DIR)/.pulumi
-build_python: export PATH := $(WORKING_DIR)/.pulumi/bin:$(PATH)
-build_python: export PULUMI_CONVERT_EXAMPLES_CACHE_DIR := $(WORKING_DIR)/.pulumi/examples-cache
-build_python: .make/upstream
-	rm -rf sdk/python/
-	PULUMI_CONVERT=$(PULUMI_CONVERT) PULUMI_DISABLE_AUTOMATIC_PLUGIN_ACQUISITION=$(PULUMI_CONVERT) $(WORKING_DIR)/bin/$(TFGEN) python --out sdk/python/
+.PHONY: generate_python build_python
+generate_python: .make/generate_python
+build_python: .make/build_python
+.make/generate_python: export PATH := $(WORKING_DIR)/.pulumi/bin:$(PATH)
+.make/generate_python: bin/$(TFGEN)
+	$(GEN_ENVS) $(WORKING_DIR)/bin/$(TFGEN) python --out sdk/python/
+	printf "module fake_python_module // Exclude this directory from Go tools\n\ngo 1.17\n" > sdk/python/go.mod
+	cp README.md sdk/python/
+	@touch $@
+.make/build_python: .make/generate_python
 	cd sdk/python/ && \
-		printf "module fake_python_module // Exclude this directory from Go tools\n\ngo 1.17\n" > go.mod && \
-		cp ../../README.md . && \
 		rm -rf ./bin/ ../python.bin/ && cp -R . ../python.bin && mv ../python.bin ./bin && \
 		rm ./bin/go.mod && \
 		python3 -m venv venv && \
 		./venv/bin/python -m pip install build==1.2.1 && \
 		cd ./bin && \
 		../venv/bin/python -m build .
+	@touch $@
 # Run the bridge's registry-docs command to generated the content of the installation docs/ folder at provider repo root
 .PHONY: build_registry_docs
 build_registry_docs: .make/build_registry_docs
@@ -250,7 +253,7 @@ ci-mgmt: .ci-mgmt.yaml
 debug_tfgen:
 	dlv  --listen=:2345 --headless=true --api-version=2  exec $(WORKING_DIR)/bin/$(TFGEN) -- schema --out provider/cmd/$(PROVIDER)
 
-.PHONY: development build build_sdks install_go_sdk install_java_sdk install_python_sdk install_sdks only_build build_java build_python install_dotnet_sdk install_nodejs_sdk lint_provider provider provider_no_deps test ci-mgmt test_provider debug_tfgen
+.PHONY: development build build_sdks install_go_sdk install_java_sdk install_python_sdk install_sdks only_build build_java install_dotnet_sdk install_nodejs_sdk lint_provider provider provider_no_deps test ci-mgmt test_provider debug_tfgen
 
 # Provider cross-platform build & packaging
 

--- a/provider-ci/test-providers/docker/Makefile
+++ b/provider-ci/test-providers/docker/Makefile
@@ -217,6 +217,7 @@ ci-mgmt: .ci-mgmt.yaml
 .pulumi/bin/pulumi: .pulumi/version
 	@if [ -x .pulumi/bin/pulumi ] && [ "v$$(cat .pulumi/version)" = "$$(.pulumi/bin/pulumi version)" ]; then \
 		echo "pulumi/bin/pulumi version: v$$(cat .pulumi/version)"; \
+		touch $@; \
 	else \
 		curl -fsSL https://get.pulumi.com | \
 			HOME=$(WORKING_DIR) sh -s -- --version "$$(cat .pulumi/version)"; \

--- a/provider-ci/test-providers/docker/Makefile
+++ b/provider-ci/test-providers/docker/Makefile
@@ -92,16 +92,20 @@ build_java: bin/pulumi-java-gen .make/upstream
 		gradle --console=plain build && \
 		gradle --console=plain javadoc
 
-build_nodejs: export PULUMI_HOME := $(WORKING_DIR)/.pulumi
-build_nodejs: export PATH := $(WORKING_DIR)/.pulumi/bin:$(PATH)
-build_nodejs: export PULUMI_CONVERT_EXAMPLES_CACHE_DIR := $(WORKING_DIR)/.pulumi/examples-cache
-build_nodejs: .make/upstream
-	PULUMI_CONVERT=$(PULUMI_CONVERT) PULUMI_DISABLE_AUTOMATIC_PLUGIN_ACQUISITION=$(PULUMI_CONVERT) $(WORKING_DIR)/bin/$(TFGEN) nodejs --out sdk/nodejs/
+.PHONY: generate_nodejs build_nodejs
+generate_nodejs: .make/generate_nodejs
+build_nodejs: .make/build_nodejs
+.make/generate_nodejs: export PATH := $(WORKING_DIR)/.pulumi/bin:$(PATH)
+.make/generate_nodejs: bin/$(TFGEN)
+	$(GEN_ENVS) $(WORKING_DIR)/bin/$(TFGEN) nodejs --out sdk/nodejs/
+	printf "module fake_nodejs_module // Exclude this directory from Go tools\n\ngo 1.17\n" > sdk/nodejs/go.mod
+	@touch $@
+.make/build_nodejs: .make/generate_nodejs
 	cd sdk/nodejs/ && \
-		printf "module fake_nodejs_module // Exclude this directory from Go tools\n\ngo 1.17\n" > go.mod && \
 		yarn install && \
 		yarn run tsc && \
 		cp ../../README.md ../../LICENSE* package.json yarn.lock ./bin/
+	@touch $@
 
 build_python: export PULUMI_HOME := $(WORKING_DIR)/.pulumi
 build_python: export PATH := $(WORKING_DIR)/.pulumi/bin:$(PATH)
@@ -246,7 +250,7 @@ ci-mgmt: .ci-mgmt.yaml
 debug_tfgen:
 	dlv  --listen=:2345 --headless=true --api-version=2  exec $(WORKING_DIR)/bin/$(TFGEN) -- schema --out provider/cmd/$(PROVIDER)
 
-.PHONY: development build build_sdks install_go_sdk install_java_sdk install_python_sdk install_sdks only_build build_java build_nodejs build_python install_dotnet_sdk install_nodejs_sdk lint_provider provider provider_no_deps test ci-mgmt test_provider debug_tfgen
+.PHONY: development build build_sdks install_go_sdk install_java_sdk install_python_sdk install_sdks only_build build_java build_python install_dotnet_sdk install_nodejs_sdk lint_provider provider provider_no_deps test ci-mgmt test_provider debug_tfgen
 
 # Provider cross-platform build & packaging
 

--- a/provider-ci/test-providers/docker/Makefile
+++ b/provider-ci/test-providers/docker/Makefile
@@ -70,12 +70,16 @@ build_dotnet: .make/build_dotnet
 	cd sdk/dotnet/ && dotnet build
 	@touch $@
 
-build_go: export PULUMI_HOME := $(WORKING_DIR)/.pulumi
-build_go: export PATH := $(WORKING_DIR)/.pulumi/bin:$(PATH)
-build_go: export PULUMI_CONVERT_EXAMPLES_CACHE_DIR := $(WORKING_DIR)/.pulumi/examples-cache
-build_go: .make/upstream
-	PULUMI_CONVERT=$(PULUMI_CONVERT) PULUMI_DISABLE_AUTOMATIC_PLUGIN_ACQUISITION=$(PULUMI_CONVERT) $(WORKING_DIR)/bin/$(TFGEN) go --out sdk/go/
+.PHONY: generate_go build_go
+generate_go: .make/generate_go
+build_go: .make/build_go
+.make/generate_go: export PATH := $(WORKING_DIR)/.pulumi/bin:$(PATH)
+.make/generate_go: bin/$(TFGEN)
+	$(GEN_ENVS) $(WORKING_DIR)/bin/$(TFGEN) go --out sdk/go/
+	@touch $@
+.make/build_go: .make/generate_go
 	cd sdk && go list "$$(grep -e "^module" go.mod | cut -d ' ' -f 2)/go/..." | xargs -I {} bash -c 'go build {} && go clean -i {}'
+	@touch $@
 
 build_java: PACKAGE_VERSION := $(VERSION_GENERIC)
 build_java: export PULUMI_HOME := $(WORKING_DIR)/.pulumi
@@ -242,7 +246,7 @@ ci-mgmt: .ci-mgmt.yaml
 debug_tfgen:
 	dlv  --listen=:2345 --headless=true --api-version=2  exec $(WORKING_DIR)/bin/$(TFGEN) -- schema --out provider/cmd/$(PROVIDER)
 
-.PHONY: development build build_sdks install_go_sdk install_java_sdk install_python_sdk install_sdks only_build build_go build_java build_nodejs build_python install_dotnet_sdk install_nodejs_sdk lint_provider provider provider_no_deps test ci-mgmt test_provider debug_tfgen
+.PHONY: development build build_sdks install_go_sdk install_java_sdk install_python_sdk install_sdks only_build build_java build_nodejs build_python install_dotnet_sdk install_nodejs_sdk lint_provider provider provider_no_deps test ci-mgmt test_provider debug_tfgen
 
 # Provider cross-platform build & packaging
 

--- a/provider-ci/test-providers/docker/Makefile
+++ b/provider-ci/test-providers/docker/Makefile
@@ -36,11 +36,14 @@ LDFLAGS=$(LDFLAGS_PROJ_VERSION) $(LDFLAGS_UPSTREAM_VERSION) $(LDFLAGS_EXTRAS) $(
 # Ensure all directories exist before evaluating targets to avoid issues with `touch` creating directories.
 _ := $(shell mkdir -p .make bin .pulumi/bin)
 
+# Build the provider and all SDKs and install ready for testing
+build: install_plugins provider build_sdks install_sdks build_registry_docs
 # Keep aliases for old targets to ensure backwards compatibility
 development: build
 only_build: build
-# Build the provider and all SDKs and install ready for testing
-build: install_plugins provider build_sdks install_sdks build_registry_docs
+# Prepare the workspace for building the provider and SDKs
+# Importantly this is run by CI ahead of restoring the bin directory and resuming SDK builds
+prepare_local_workspace: install_plugins upstream
 # Creates all generated files which need to be committed
 generate: generate_sdks schema build_registry_docs
 generate_sdks: generate_nodejs generate_python generate_dotnet generate_go generate_java
@@ -164,6 +167,7 @@ install_nodejs_sdk: .make/install_nodejs_sdk
 install_python_sdk:
 .PHONY: install_dotnet_sdk install_go_sdk install_java_sdk install_nodejs_sdk install_python_sdk
 
+# Install Pulumi plugins required for TFGen to resolve references
 install_plugins: .make/install_plugins
 .make/install_plugins: export PULUMI_HOME := $(WORKING_DIR)/.pulumi
 .make/install_plugins: export PATH := $(WORKING_DIR)/.pulumi/bin:$(PATH)
@@ -220,6 +224,7 @@ bin/$(TFGEN):
 	(cd provider && go build $(PULUMI_PROVIDER_BUILD_PARALLELISM) -o $(WORKING_DIR)/bin/$(TFGEN) -ldflags "$(LDFLAGS_PROJ_VERSION) $(LDFLAGS_EXTRAS)" $(PROJECT)/$(PROVIDER_PATH)/cmd/$(TFGEN))
 .PHONY: tfgen schema tfgen_no_deps tfgen_build_only
 
+# Apply patches to the upstream submodule, if it exists
 upstream: .make/upstream
 # Re-run if the upstream commit or the patches change
 .make/upstream: $(wildcard patches/*) $(wildcard .git/modules/upstream/HEAD)

--- a/provider-ci/test-providers/docker/Makefile
+++ b/provider-ci/test-providers/docker/Makefile
@@ -36,7 +36,6 @@ LDFLAGS=$(LDFLAGS_PROJ_VERSION) $(LDFLAGS_UPSTREAM_VERSION) $(LDFLAGS_EXTRAS) $(
 # Ensure all directories exist before evaluating targets to avoid issues with `touch` creating directories.
 _ := $(shell mkdir -p .make bin .pulumi/bin)
 
-.PHONY: development only_build build generate_sdks build_sdks install_sdks
 # Keep aliases for old targets to ensure backwards compatibility
 development: build
 only_build: build
@@ -44,12 +43,12 @@ build: install_plugins provider build_sdks install_sdks
 generate_sdks: generate_nodejs generate_python generate_dotnet generate_go generate_java
 build_sdks: build_nodejs build_python build_dotnet build_go build_java.make/build_registry_docs
 install_sdks: install_nodejs_sdk install_python_sdk install_dotnet_sdk install_go_sdk install_java_sdk
+.PHONY: development only_build build generate_sdks build_sdks install_sdks
 
 GEN_PULUMI_HOME := $(WORKING_DIR)/.pulumi
 GEN_PULUMI_CONVERT_EXAMPLES_CACHE_DIR := $(GEN_PULUMI_HOME)/examples-cache
 GEN_ENVS := PULUMI_HOME=$(GEN_PULUMI_HOME) PULUMI_CONVERT_EXAMPLES_CACHE_DIR=$(GEN_PULUMI_CONVERT_EXAMPLES_CACHE_DIR) PULUMI_CONVERT=$(PULUMI_CONVERT) PULUMI_DISABLE_AUTOMATIC_PLUGIN_ACQUISITION=$(PULUMI_CONVERT)
 
-.PHONY: generate_dotnet build_dotnet
 generate_dotnet: .make/generate_dotnet
 build_dotnet: .make/build_dotnet
 .make/generate_dotnet: export PATH := $(WORKING_DIR)/.pulumi/bin:$(PATH)
@@ -62,8 +61,8 @@ build_dotnet: .make/build_dotnet
 .make/build_dotnet: .make/generate_dotnet
 	cd sdk/dotnet/ && dotnet build
 	@touch $@
+.PHONY: generate_dotnet build_dotnet
 
-.PHONY: generate_go build_go
 generate_go: .make/generate_go
 build_go: .make/build_go
 .make/generate_go: export PATH := $(WORKING_DIR)/.pulumi/bin:$(PATH)
@@ -73,8 +72,8 @@ build_go: .make/build_go
 .make/build_go: .make/generate_go
 	cd sdk && go list "$$(grep -e "^module" go.mod | cut -d ' ' -f 2)/go/..." | xargs -I {} bash -c 'go build {} && go clean -i {}'
 	@touch $@
+.PHONY: generate_go build_go
 
-.PHONY: generate_java build_java
 generate_java: .make/generate_java
 build_java: .make/build_java
 .make/generate_java: export PATH := $(WORKING_DIR)/.pulumi/bin:$(PATH)
@@ -89,8 +88,8 @@ build_java: .make/build_java
 		gradle --console=plain build && \
 		gradle --console=plain javadoc
 	@touch $@
+.PHONY: generate_java build_java
 
-.PHONY: generate_nodejs build_nodejs
 generate_nodejs: .make/generate_nodejs
 build_nodejs: .make/build_nodejs
 .make/generate_nodejs: export PATH := $(WORKING_DIR)/.pulumi/bin:$(PATH)
@@ -104,8 +103,8 @@ build_nodejs: .make/build_nodejs
 		yarn run tsc && \
 		cp ../../README.md ../../LICENSE* package.json yarn.lock ./bin/
 	@touch $@
+.PHONY: generate_nodejs build_nodejs
 
-.PHONY: generate_python build_python
 generate_python: .make/generate_python
 build_python: .make/build_python
 .make/generate_python: export PATH := $(WORKING_DIR)/.pulumi/bin:$(PATH)
@@ -123,25 +122,25 @@ build_python: .make/build_python
 		cd ./bin && \
 		../venv/bin/python -m build .
 	@touch $@
+.PHONY: generate_python build_python
 # Run the bridge's registry-docs command to generated the content of the installation docs/ folder at provider repo root
-.PHONY: build_registry_docs
 build_registry_docs: .make/build_registry_docs
 .make/build_registry_docs: bin/$(TFGEN)
 	bin/$(TFGEN) registry-docs --out $(WORKING_DIR)/docs
 	@touch $@
+.PHONY: build_registry_docs
 
-.PHONY: clean
 clean:
 	rm -rf sdk/{dotnet,nodejs,go,python}
 	rm -rf bin/*
 	rm -rf .make/*
-.PHONY: docs
+.PHONY: clean
 docs: .make/docs
 .make/docs:
 	cd provider/pkg/docs-gen/examples/ && go run generate.go ./yaml ./
 	@touch $@
+.PHONY: docs
 
-.PHONY: install_dotnet_sdk install_go_sdk install_java_sdk install_nodejs_sdk install_python_sdk
 install_dotnet_sdk: .make/install_dotnet_sdk
 .make/install_dotnet_sdk: .make/build_dotnet
 	mkdir -p $(WORKING_DIR)/nuget
@@ -154,8 +153,8 @@ install_nodejs_sdk: .make/install_nodejs_sdk
 	yarn link --cwd $(WORKING_DIR)/sdk/nodejs/bin
 	@touch $@
 install_python_sdk:
+.PHONY: install_dotnet_sdk install_go_sdk install_java_sdk install_nodejs_sdk install_python_sdk
 
-.PHONY: install_plugins
 install_plugins: .make/install_plugins
 .make/install_plugins: export PULUMI_HOME := $(WORKING_DIR)/.pulumi
 .make/install_plugins: export PATH := $(WORKING_DIR)/.pulumi/bin:$(PATH)
@@ -163,42 +162,40 @@ install_plugins: .make/install_plugins
 	.pulumi/bin/pulumi plugin install converter terraform 1.0.16
 	.pulumi/bin/pulumi plugin install resource aws 6.8.0
 	@touch $@
+.PHONY: install_plugins
 
 lint_provider: provider
 	cd provider && golangci-lint run --path-prefix provider -c ../.golangci.yml
-
 # `lint_provider.fix` is a utility target meant to be run manually
 # that will run the linter and fix errors when possible.
 lint_provider.fix:
 	cd provider && golangci-lint run --path-prefix provider -c ../.golangci.yml --fix
+.PHONY: lint_provider lint_provider.fix
 
 # `make provider_no_deps` builds the provider binary directly, without ensuring that
 # `cmd/pulumi-resource-docker/schema.json` is valid and up to date.
 # To create a release ready binary, you should use `make provider`.
-.PHONY: provider provider_no_deps
 build_provider_cmd = cd provider && go build $(PULUMI_PROVIDER_BUILD_PARALLELISM) -o $(WORKING_DIR)/bin/$(PROVIDER) -ldflags "$(LDFLAGS)" $(PROJECT)/$(PROVIDER_PATH)/cmd/$(PROVIDER)
 provider: bin/$(PROVIDER)
 provider_no_deps:
 	$(call build_provider_cmd)
 bin/$(PROVIDER): .make/schema
 	$(call build_provider_cmd)
+.PHONY: provider provider_no_deps
 
 test: export PATH := $(WORKING_DIR)/bin:$(PATH)
 test:
 	cd examples && go test -v -tags=all -parallel $(TESTPARALLELISM) -timeout 2h
+.PHONY: test
 
 test_provider:
-	@echo ""
-	@echo "== test_provider ==================================================================="
-	@echo ""
 	cd provider && go test -v -short ./... -parallel $(TESTPARALLELISM)
+.PHONY: test_provider
 
-.PHONY: tfgen schema tfgen_no_deps tfgen_build_only
 tfgen: schema
 schema: .make/schema  .make/docs
 # This does actually have dependencies, but we're keeping it around for backwards compatibility for now
 tfgen_no_deps: .make/schema
-
 .make/schema: export PULUMI_HOME := $(WORKING_DIR)/.pulumi
 .make/schema: export PATH := $(WORKING_DIR)/.pulumi/bin:$(PATH)
 .make/schema: export PULUMI_CONVERT := $(PULUMI_CONVERT)
@@ -209,13 +206,11 @@ tfgen_no_deps: .make/schema
 	$(WORKING_DIR)/bin/$(TFGEN) schema --out provider/cmd/$(PROVIDER)
 	(cd provider && VERSION=$(VERSION_GENERIC) go generate cmd/$(PROVIDER)/main.go)
 	@touch $@
-
 tfgen_build_only: bin/$(TFGEN)
-
 bin/$(TFGEN):
 	(cd provider && go build $(PULUMI_PROVIDER_BUILD_PARALLELISM) -o $(WORKING_DIR)/bin/$(TFGEN) -ldflags "$(LDFLAGS_PROJ_VERSION) $(LDFLAGS_EXTRAS)" $(PROJECT)/$(PROVIDER_PATH)/cmd/$(TFGEN))
+.PHONY: tfgen schema tfgen_no_deps tfgen_build_only
 
-.PHONY: upstream
 upstream: .make/upstream
 # Re-run if the upstream commit or the patches change
 .make/upstream: $(wildcard patches/*) $(wildcard .git/modules/upstream/HEAD)
@@ -223,6 +218,7 @@ ifneq ("$(wildcard upstream)","")
 	./upstream.sh init
 endif
 	@touch $@
+.PHONY: upstream
 
 bin/pulumi-java-gen: .pulumi-java-gen.version
 	pulumictl download-binary -n pulumi-language-java -v v$(shell cat .pulumi-java-gen.version) -r pulumi/pulumi-java
@@ -234,6 +230,7 @@ bin/pulumi-java-gen: .pulumi-java-gen.version
 #
 ci-mgmt: .ci-mgmt.yaml
 	go run github.com/pulumi/ci-mgmt/provider-ci@master generate
+.PHONY: ci-mgmt
 
 # Because some codegen depends on the version of the CLI used, we install a local CLI
 # version pinned to the same version as `provider/go.mod`.
@@ -257,8 +254,7 @@ ci-mgmt: .ci-mgmt.yaml
 # Start debug server for tfgen
 debug_tfgen:
 	dlv  --listen=:2345 --headless=true --api-version=2  exec $(WORKING_DIR)/bin/$(TFGEN) -- schema --out provider/cmd/$(PROVIDER)
-
-.PHONY: lint_provider test ci-mgmt test_provider debug_tfgen
+.PHONY: debug_tfgen
 
 # Provider cross-platform build & packaging
 

--- a/provider-ci/test-providers/docker/Makefile
+++ b/provider-ci/test-providers/docker/Makefile
@@ -81,16 +81,21 @@ build_go: .make/build_go
 	cd sdk && go list "$$(grep -e "^module" go.mod | cut -d ' ' -f 2)/go/..." | xargs -I {} bash -c 'go build {} && go clean -i {}'
 	@touch $@
 
-build_java: PACKAGE_VERSION := $(VERSION_GENERIC)
-build_java: export PULUMI_HOME := $(WORKING_DIR)/.pulumi
-build_java: export PATH := $(WORKING_DIR)/.pulumi/bin:$(PATH)
-build_java: export PULUMI_CONVERT_EXAMPLES_CACHE_DIR := $(WORKING_DIR)/.pulumi/examples-cache
-build_java: bin/pulumi-java-gen .make/upstream
-	$(WORKING_DIR)/bin/$(JAVA_GEN) generate --schema provider/cmd/$(PROVIDER)/schema.json --out sdk/java  --build gradle-nexus
+.PHONY: generate_java build_java
+generate_java: .make/generate_java
+build_java: .make/build_java
+.make/generate_java: export PATH := $(WORKING_DIR)/.pulumi/bin:$(PATH)
+.make/generate_java: PACKAGE_VERSION := $(VERSION_GENERIC)
+.make/generate_java: bin/pulumi-java-gen .make/schema
+	PULUMI_HOME=$(GEN_PULUMI_HOME) PULUMI_CONVERT_EXAMPLES_CACHE_DIR=$(GEN_PULUMI_CONVERT_EXAMPLES_CACHE_DIR) bin/$(JAVA_GEN) generate --schema provider/cmd/$(PROVIDER)/schema.json --out sdk/java  --build gradle-nexus
+	printf "module fake_java_module // Exclude this directory from Go tools\n\ngo 1.17\n" > sdk/java/go.mod
+	@touch $@
+.make/build_java: PACKAGE_VERSION := $(VERSION_GENERIC)
+.make/build_java: .make/generate_java
 	cd sdk/java/ && \
-		printf "module fake_java_module // Exclude this directory from Go tools\n\ngo 1.17\n" > go.mod && \
 		gradle --console=plain build && \
 		gradle --console=plain javadoc
+	@touch $@
 
 .PHONY: generate_nodejs build_nodejs
 generate_nodejs: .make/generate_nodejs
@@ -253,7 +258,7 @@ ci-mgmt: .ci-mgmt.yaml
 debug_tfgen:
 	dlv  --listen=:2345 --headless=true --api-version=2  exec $(WORKING_DIR)/bin/$(TFGEN) -- schema --out provider/cmd/$(PROVIDER)
 
-.PHONY: development build build_sdks install_go_sdk install_java_sdk install_python_sdk install_sdks only_build build_java install_dotnet_sdk install_nodejs_sdk lint_provider provider provider_no_deps test ci-mgmt test_provider debug_tfgen
+.PHONY: development build build_sdks install_go_sdk install_java_sdk install_python_sdk install_sdks only_build install_dotnet_sdk install_nodejs_sdk lint_provider provider provider_no_deps test ci-mgmt test_provider debug_tfgen
 
 # Provider cross-platform build & packaging
 

--- a/provider-ci/test-providers/docker/Makefile
+++ b/provider-ci/test-providers/docker/Makefile
@@ -51,6 +51,43 @@ build_sdks: build_nodejs build_python build_dotnet build_go build_java
 install_sdks: install_nodejs_sdk install_python_sdk install_dotnet_sdk install_go_sdk install_java_sdk
 .PHONY: development only_build build generate generate_sdks build_sdks install_sdks
 
+help:
+	@echo "Usage: make [target]"
+	@echo ""
+	@echo "Main Targets"
+	@echo "  build (default)     Build the provider and all SDKs and install for testing"
+	@echo "  generate            Generate all SDKs, documentation and schema"
+	@echo "  provider            Build the local provider binary"
+	@echo "  lint_provider<.fix> Run the linter on the provider (& optionally fix)"
+	@echo "  test_provider       Run the provider tests"
+	@echo "  test                Run the example tests (must run 'build' first)"
+	@echo "  clean               Clean up generated files"
+	@echo ""
+	@echo "More Precise Targets"
+	@echo "  schema        Generate the schema"
+	@echo "  generate_sdks Generate all SDKs"
+	@echo "  build_sdks    Build all SDKs"
+	@echo "  install_sdks  Install all SDKs"
+	@echo "  provider_dist Build and package the provider for all platforms"
+	@echo ""
+	@echo "Tool Targets"
+	@echo "  ci-mgmt     Re-generate CI configuration from .ci-mgmt.yaml"
+	@echo "  debug_tfgen Start a debug server for tfgen"
+	@echo ""
+	@echo "Internal Targets (automatically run as dependencies of other targets)"
+	@echo "  prepare_local_workspace  Prepare for building"
+	@echo "  install_plugins          Install plugin dependencies"
+	@echo "  upstream                 Initialize the upstream submodule, if present"
+	@echo ""
+	@echo "Language-Specific Targets"
+	@echo "  generate_[language]    Generate the SDK files ready for committing"
+	@echo "  build_[language]       Build the SDK to check correctness"
+	@echo "  install_[language]_sdk Install the SDK ready for testing"
+	@echo ""
+	@echo "  [language] = nodejs python dotnet go java"
+	@echo ""
+.PHONY: help
+
 GEN_PULUMI_HOME := $(WORKING_DIR)/.pulumi
 GEN_PULUMI_CONVERT_EXAMPLES_CACHE_DIR := $(GEN_PULUMI_HOME)/examples-cache
 GEN_ENVS := PULUMI_HOME=$(GEN_PULUMI_HOME) PULUMI_CONVERT_EXAMPLES_CACHE_DIR=$(GEN_PULUMI_CONVERT_EXAMPLES_CACHE_DIR) PULUMI_CONVERT=$(PULUMI_CONVERT) PULUMI_DISABLE_AUTOMATIC_PLUGIN_ACQUISITION=$(PULUMI_CONVERT)

--- a/provider-ci/test-providers/docker/Makefile
+++ b/provider-ci/test-providers/docker/Makefile
@@ -111,12 +111,11 @@ build_python: .make/upstream
 build_registry_docs:
 	$(WORKING_DIR)/bin/$(TFGEN) registry-docs --out $(WORKING_DIR)/docs
 
+.PHONY: clean
 clean:
 	rm -rf sdk/{dotnet,nodejs,go,python}
-
-cleanup:
-	rm -r $(WORKING_DIR)/bin
-	rm -f provider/cmd/$(PROVIDER)/schema.go
+	rm -rf bin/*
+	rm -rf .make/*
 
 docs:
 	cd provider/pkg/docs-gen/examples/ && go run generate.go ./yaml ./
@@ -233,7 +232,7 @@ ci-mgmt: .ci-mgmt.yaml
 debug_tfgen:
 	dlv  --listen=:2345 --headless=true --api-version=2  exec $(WORKING_DIR)/bin/$(TFGEN) -- schema --out provider/cmd/$(PROVIDER)
 
-.PHONY: development build build_sdks install_go_sdk install_java_sdk install_python_sdk install_sdks only_build build_dotnet build_go build_java build_nodejs build_python clean cleanup docs help install_dotnet_sdk install_nodejs_sdk lint_provider provider provider_no_deps test ci-mgmt test_provider debug_tfgen
+.PHONY: development build build_sdks install_go_sdk install_java_sdk install_python_sdk install_sdks only_build build_dotnet build_go build_java build_nodejs build_python docs help install_dotnet_sdk install_nodejs_sdk lint_provider provider provider_no_deps test ci-mgmt test_provider debug_tfgen
 
 # Provider cross-platform build & packaging
 

--- a/provider-ci/test-providers/docker/Makefile
+++ b/provider-ci/test-providers/docker/Makefile
@@ -45,12 +45,6 @@ generate_sdks: generate_nodejs generate_python generate_dotnet generate_go gener
 build_sdks: build_nodejs build_python build_dotnet build_go build_java.make/build_registry_docs
 install_sdks: install_nodejs_sdk install_python_sdk install_dotnet_sdk install_go_sdk install_java_sdk
 
-install_go_sdk:
-
-install_java_sdk:
-
-install_python_sdk:
-
 GEN_PULUMI_HOME := $(WORKING_DIR)/.pulumi
 GEN_PULUMI_CONVERT_EXAMPLES_CACHE_DIR := $(GEN_PULUMI_HOME)/examples-cache
 GEN_ENVS := PULUMI_HOME=$(GEN_PULUMI_HOME) PULUMI_CONVERT_EXAMPLES_CACHE_DIR=$(GEN_PULUMI_CONVERT_EXAMPLES_CACHE_DIR) PULUMI_CONVERT=$(PULUMI_CONVERT) PULUMI_DISABLE_AUTOMATIC_PLUGIN_ACQUISITION=$(PULUMI_CONVERT)
@@ -147,12 +141,19 @@ docs: .make/docs
 	cd provider/pkg/docs-gen/examples/ && go run generate.go ./yaml ./
 	@touch $@
 
-install_dotnet_sdk:
+.PHONY: install_dotnet_sdk install_go_sdk install_java_sdk install_nodejs_sdk install_python_sdk
+install_dotnet_sdk: .make/install_dotnet_sdk
+.make/install_dotnet_sdk: .make/build_dotnet
 	mkdir -p $(WORKING_DIR)/nuget
 	find . -name '*.nupkg' -print -exec cp -p {} $(WORKING_DIR)/nuget \;
-
-install_nodejs_sdk:
+	@touch $@
+install_go_sdk:
+install_java_sdk:
+install_nodejs_sdk: .make/install_nodejs_sdk
+.make/install_nodejs_sdk: .make/build_nodejs
 	yarn link --cwd $(WORKING_DIR)/sdk/nodejs/bin
+	@touch $@
+install_python_sdk:
 
 .PHONY: install_plugins
 install_plugins: .make/install_plugins
@@ -257,7 +258,7 @@ ci-mgmt: .ci-mgmt.yaml
 debug_tfgen:
 	dlv  --listen=:2345 --headless=true --api-version=2  exec $(WORKING_DIR)/bin/$(TFGEN) -- schema --out provider/cmd/$(PROVIDER)
 
-.PHONY: install_go_sdk install_java_sdk install_python_sdk install_sdks install_dotnet_sdk install_nodejs_sdk lint_provider test ci-mgmt test_provider debug_tfgen
+.PHONY: lint_provider test ci-mgmt test_provider debug_tfgen
 
 # Provider cross-platform build & packaging
 

--- a/provider-ci/test-providers/docker/Makefile
+++ b/provider-ci/test-providers/docker/Makefile
@@ -137,6 +137,9 @@ clean:
 	rm -rf sdk/{dotnet,nodejs,go,python}
 	rm -rf bin/*
 	rm -rf .make/*
+	if dotnet nuget list source | grep "$(WORKING_DIR)/nuget"; then \
+		dotnet nuget remove source "$(WORKING_DIR)/nuget" \
+	; fi
 .PHONY: clean
 docs: .make/docs
 .make/docs:
@@ -146,8 +149,11 @@ docs: .make/docs
 
 install_dotnet_sdk: .make/install_dotnet_sdk
 .make/install_dotnet_sdk: .make/build_dotnet
-	mkdir -p $(WORKING_DIR)/nuget
-	find . -name '*.nupkg' -print -exec cp -p {} $(WORKING_DIR)/nuget \;
+	mkdir -p nuget
+	find sdk/dotnet/bin -name '*.nupkg' -print -exec cp -p "{}" ${WORKING_DIR}/nuget \;
+	if ! dotnet nuget list source | grep "${WORKING_DIR}/nuget"; then \
+		dotnet nuget add source "${WORKING_DIR}/nuget" --name "${WORKING_DIR}/nuget" \
+	; fi
 	@touch $@
 install_go_sdk:
 install_java_sdk:

--- a/provider-ci/test-providers/docker/Makefile
+++ b/provider-ci/test-providers/docker/Makefile
@@ -116,9 +116,11 @@ clean:
 	rm -rf sdk/{dotnet,nodejs,go,python}
 	rm -rf bin/*
 	rm -rf .make/*
-
-docs:
+.PHONY: docs
+docs: .make/docs
+.make/docs:
 	cd provider/pkg/docs-gen/examples/ && go run generate.go ./yaml ./
+	@touch $@
 
 help:
 	@grep '^[^.#]\+:\s\+.*#' Makefile | \
@@ -169,7 +171,7 @@ test_provider:
 
 .PHONY: tfgen schema tfgen_no_deps tfgen_build_only
 tfgen: schema
-schema: .make/schema  docs
+schema: .make/schema  .make/docs
 # This does actually have dependencies, but we're keeping it around for backwards compatibility for now
 tfgen_no_deps: .make/schema
 
@@ -232,7 +234,7 @@ ci-mgmt: .ci-mgmt.yaml
 debug_tfgen:
 	dlv  --listen=:2345 --headless=true --api-version=2  exec $(WORKING_DIR)/bin/$(TFGEN) -- schema --out provider/cmd/$(PROVIDER)
 
-.PHONY: development build build_sdks install_go_sdk install_java_sdk install_python_sdk install_sdks only_build build_dotnet build_go build_java build_nodejs build_python docs help install_dotnet_sdk install_nodejs_sdk lint_provider provider provider_no_deps test ci-mgmt test_provider debug_tfgen
+.PHONY: development build build_sdks install_go_sdk install_java_sdk install_python_sdk install_sdks only_build build_dotnet build_go build_java build_nodejs build_python help install_dotnet_sdk install_nodejs_sdk lint_provider provider provider_no_deps test ci-mgmt test_provider debug_tfgen
 
 # Provider cross-platform build & packaging
 

--- a/provider-ci/test-providers/docker/Makefile
+++ b/provider-ci/test-providers/docker/Makefile
@@ -151,10 +151,13 @@ lint_provider.fix:
 # `make provider_no_deps` builds the provider binary directly, without ensuring that
 # `cmd/pulumi-resource-docker/schema.json` is valid and up to date.
 # To create a release ready binary, you should use `make provider`.
+.PHONY: provider provider_no_deps
+build_provider_cmd = cd provider && go build $(PULUMI_PROVIDER_BUILD_PARALLELISM) -o $(WORKING_DIR)/bin/$(PROVIDER) -ldflags "$(LDFLAGS)" $(PROJECT)/$(PROVIDER_PATH)/cmd/$(PROVIDER)
+provider: bin/$(PROVIDER)
 provider_no_deps:
-	(cd provider && go build $(PULUMI_PROVIDER_BUILD_PARALLELISM) -o $(WORKING_DIR)/bin/$(PROVIDER) -ldflags "$(LDFLAGS)" $(PROJECT)/$(PROVIDER_PATH)/cmd/$(PROVIDER))
-
-provider: tfgen provider_no_deps
+	$(call build_provider_cmd)
+bin/$(PROVIDER): .make/schema
+	$(call build_provider_cmd)
 
 test: export PATH := $(WORKING_DIR)/bin:$(PATH)
 test:


### PR DESCRIPTION
Allow targets to be up-to-date by using the "sentinel file" pattern where each unit of work is tracked via a file in the `.make` directory to indicate when it was last successfully completed. Replace dependencies on phony targets with these sentinel files.

Other improvements:
- Add `make schema` target as a generic replacement for `make tfgen`.
- Split out a generate phase from all the build sdk targets to allow skipping running the SDK builds locally.
- Add `make generate` target for generating all things which need to be committed without having to wait on build steps.
- Add `make prepare_local_workspace` which currently encompases installing plugins and preparing upstream.
- Group `.PHONY` declarations near the definition of the phony target rather than in one very long line. This allows us to see if we're missing declarations for specific targets more easily.
- Fix the `.pulumi/version` getting out of sync with the installed files.
- Fix the `clean` target to include the `bin` and `.make` directories (remove the duplicate `cleanup` target alongside).
- Replace the broken `help` target which hasn't been functional in many years AFAIK.
- Move nuget setup for install_dotnet_sdk into the makefile from CI.
- Use the new standard targets (schema & provider) instead of the internal targets (tfgen_build_only, tfgen_no_deps, provider_no_deps)
- Save and restore makefile progress via artifacts (prerequisites.make and build_[language].make). This maintains file timestamps between jobs.
 
Commits are structued to address one target at a time for review and history.

Preview of new help text:

```
Usage: make [target]

Main Targets
  build (default)     Build the provider and all SDKs and install for testing
  generate            Generate all SDKs, documentation and schema
  provider            Build the local provider binary
  lint_provider<.fix> Run the linter on the provider (& optionally fix)
  test_provider       Run the provider tests
  test                Run the example tests (must run 'build' first)
  clean               Clean up generated files

More Precise Targets
  schema        Generate the schema
  generate_sdks Generate all SDKs
  build_sdks    Build all SDKs
  install_sdks  Install all SDKs
  provider_dist Build and package the provider for all platforms

Tool Targets
  ci-mgmt     Re-generate CI configuration from .ci-mgmt.yaml
  debug_tfgen Start a debug server for tfgen

Internal Targets (automatically run as dependencies of other targets)
  prepare_local_workspace  Prepare for building
  install_plugins          Install plugin dependencies
  upstream                 Initialize the upstream submodule, if present

Language-Specific Targets
  generate_[language]    Generate the SDK files ready for committing
  build_[language]       Build the SDK to check correctness
  install_[language]_sdk Install the SDK ready for testing

  [language] = nodejs python dotnet go java

```