### PR TITLE
Run build_registry_docs as part of SDK build

### DIFF
--- a/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/prerequisites.yml
+++ b/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/prerequisites.yml
@@ -64,6 +64,10 @@ jobs:
 #{{- end }}#
     - name: Generate schema
       run: make schema
+    #{{- if .Config.RegistryDocs }}#
+    - name: Build registry docs
+      run: make build_registry_docs
+    #{{- end }}#
     - name: Build provider binary
       run: make provider
     - name: Unit-test provider code

--- a/provider-ci/test-providers/cloudflare/.github/workflows/prerequisites.yml
+++ b/provider-ci/test-providers/cloudflare/.github/workflows/prerequisites.yml
@@ -66,6 +66,8 @@ jobs:
       run: make prepare_local_workspace
     - name: Generate schema
       run: make schema
+    - name: Build registry docs
+      run: make build_registry_docs
     - name: Build provider binary
       run: make provider
     - name: Unit-test provider code

--- a/provider-ci/test-providers/docker/.github/workflows/prerequisites.yml
+++ b/provider-ci/test-providers/docker/.github/workflows/prerequisites.yml
@@ -79,6 +79,8 @@ jobs:
       run: make prepare_local_workspace
     - name: Generate schema
       run: make schema
+    - name: Build registry docs
+      run: make build_registry_docs
     - name: Build provider binary
       run: make provider
     - name: Unit-test provider code


### PR DESCRIPTION
https://github.com/pulumi/pulumi-snowflake/issues/752 revealed that we weren't running registry docs build on pull requests.
This addresses that issue. Index docs will now be built on pull requests in CI.

