### PR TITLE
Apply .gitignore migration to external providers too

### DIFF
--- a/provider-ci/internal/pkg/migrations/ignoreMakeDir.go
+++ b/provider-ci/internal/pkg/migrations/ignoreMakeDir.go
@@ -14,7 +14,7 @@ func (ignoreMakeDir) Name() string {
 	return "Add .make directory to .gitignore"
 }
 func (ignoreMakeDir) ShouldRun(templateName string) bool {
-	return templateName == "bridged-provider"
+	return templateName == "bridged-provider" || templateName == "external-bridged-provider"
 }
 func (ignoreMakeDir) Migrate(templateName, outDir string) error {
 	gitignorePath := filepath.Join(outDir, ".gitignore")


### PR DESCRIPTION
External providers get a generated makefile too, so need the new git-ignore rule for `.make`.