### PR TITLE
Add linker flags for stripping debug symbols from binary

### DIFF
--- a/native-provider-ci/providers/aws-native/repo/.goreleaser.prerelease.yml
+++ b/native-provider-ci/providers/aws-native/repo/.goreleaser.prerelease.yml
@@ -20,6 +20,8 @@ builds:
   ignore: []
   main: ./cmd/pulumi-resource-aws-native/
   ldflags:
+  - -s
+  - -w
   - -X github.com/pulumi/pulumi-aws-native/provider/pkg/version.Version={{.Tag}}
   binary: pulumi-resource-aws-native
 archives:

--- a/native-provider-ci/providers/aws-native/repo/.goreleaser.yml
+++ b/native-provider-ci/providers/aws-native/repo/.goreleaser.yml
@@ -20,6 +20,8 @@ builds:
   ignore: []
   main: ./cmd/pulumi-resource-aws-native/
   ldflags:
+  - -s
+  - -w
   - -X github.com/pulumi/pulumi-aws-native/provider/pkg/version.Version={{.Tag}}
   binary: pulumi-resource-aws-native
 archives:

--- a/native-provider-ci/providers/command/repo/.goreleaser.prerelease.yml
+++ b/native-provider-ci/providers/command/repo/.goreleaser.prerelease.yml
@@ -19,6 +19,8 @@ builds:
   ignore: []
   main: ./cmd/pulumi-resource-command/
   ldflags:
+  - -s
+  - -w
   - -X github.com/pulumi/pulumi-command/provider/pkg/version.Version={{.Tag}}
   binary: pulumi-resource-command
 archives:

--- a/native-provider-ci/providers/command/repo/.goreleaser.yml
+++ b/native-provider-ci/providers/command/repo/.goreleaser.yml
@@ -19,6 +19,8 @@ builds:
   ignore: []
   main: ./cmd/pulumi-resource-command/
   ldflags:
+  - -s
+  - -w
   - -X github.com/pulumi/pulumi-command/provider/pkg/version.Version={{.Tag}}
   binary: pulumi-resource-command
 archives:

--- a/native-provider-ci/providers/docker-build/repo/.goreleaser.prerelease.yml
+++ b/native-provider-ci/providers/docker-build/repo/.goreleaser.prerelease.yml
@@ -16,6 +16,8 @@ builds:
   ignore: []
   main: ./cmd/pulumi-resource-docker-build/
   ldflags:
+  - -s
+  - -w
   - -X
     github.com/pulumi/pulumi-docker-build/provider/pkg/version.Version={{.Tag}}
   - -X github.com/pulumi/pulumi-docker-build/provider.Version={{.Tag}}

--- a/native-provider-ci/providers/docker-build/repo/.goreleaser.yml
+++ b/native-provider-ci/providers/docker-build/repo/.goreleaser.yml
@@ -16,6 +16,8 @@ builds:
   ignore: []
   main: ./cmd/pulumi-resource-docker-build/
   ldflags:
+  - -s
+  - -w
   - -X
     github.com/pulumi/pulumi-docker-build/provider/pkg/version.Version={{.Tag}}
   - -X github.com/pulumi/pulumi-docker-build/provider.Version={{.Tag}}

--- a/native-provider-ci/providers/google-native/repo/.goreleaser.prerelease.yml
+++ b/native-provider-ci/providers/google-native/repo/.goreleaser.prerelease.yml
@@ -21,6 +21,8 @@ builds:
   ignore: []
   main: ./cmd/pulumi-resource-google-native/
   ldflags:
+  - -s
+  - -w
   - -X
     github.com/pulumi/pulumi-google-native/provider/pkg/version.Version={{.Tag}}
   binary: pulumi-resource-google-native

--- a/native-provider-ci/providers/google-native/repo/.goreleaser.yml
+++ b/native-provider-ci/providers/google-native/repo/.goreleaser.yml
@@ -21,6 +21,8 @@ builds:
   ignore: []
   main: ./cmd/pulumi-resource-google-native/
   ldflags:
+  - -s
+  - -w
   - -X
     github.com/pulumi/pulumi-google-native/provider/pkg/version.Version={{.Tag}}
   binary: pulumi-resource-google-native

--- a/native-provider-ci/providers/kubernetes-cert-manager/repo/.goreleaser.prerelease.yml
+++ b/native-provider-ci/providers/kubernetes-cert-manager/repo/.goreleaser.prerelease.yml
@@ -16,6 +16,8 @@ builds:
   ignore: []
   main: ./cmd/pulumi-resource-kubernetes-cert-manager/
   ldflags:
+  - -s
+  - -w
   - -X
     github.com/pulumi/pulumi-kubernetes-cert-manager/provider/pkg/version.Version={{.Tag}}
   binary: pulumi-resource-kubernetes-cert-manager

--- a/native-provider-ci/providers/kubernetes-cert-manager/repo/.goreleaser.yml
+++ b/native-provider-ci/providers/kubernetes-cert-manager/repo/.goreleaser.yml
@@ -16,6 +16,8 @@ builds:
   ignore: []
   main: ./cmd/pulumi-resource-kubernetes-cert-manager/
   ldflags:
+  - -s
+  - -w
   - -X
     github.com/pulumi/pulumi-kubernetes-cert-manager/provider/pkg/version.Version={{.Tag}}
   binary: pulumi-resource-kubernetes-cert-manager

--- a/native-provider-ci/providers/kubernetes/repo/.goreleaser.prerelease.yml
+++ b/native-provider-ci/providers/kubernetes/repo/.goreleaser.prerelease.yml
@@ -22,6 +22,8 @@ builds:
   ignore: []
   main: ./cmd/pulumi-resource-kubernetes/
   ldflags:
+  - -s
+  - -w
   - -X
     github.com/pulumi/pulumi-kubernetes/provider/v4/pkg/version.Version={{.Tag}}
   binary: pulumi-resource-kubernetes

--- a/native-provider-ci/providers/kubernetes/repo/.goreleaser.yml
+++ b/native-provider-ci/providers/kubernetes/repo/.goreleaser.yml
@@ -22,6 +22,8 @@ builds:
   ignore: []
   main: ./cmd/pulumi-resource-kubernetes/
   ldflags:
+  - -s
+  - -w
   - -X
     github.com/pulumi/pulumi-kubernetes/provider/v4/pkg/version.Version={{.Tag}}
   binary: pulumi-resource-kubernetes

--- a/native-provider-ci/src/goreleaser.ts
+++ b/native-provider-ci/src/goreleaser.ts
@@ -107,7 +107,7 @@ export class PulumiGoreleaserPreConfig implements GoreleaserConfig {
   blobs: Blob[];
 
   constructor(opts: GoReleaserOpts) {
-    let ldflags: string[];
+    const ldflags = ["-s", "-w"];
     const ignores: Ignores[] = [];
 
     if (opts.skipWindowsArmBuild) {
@@ -115,13 +115,13 @@ export class PulumiGoreleaserPreConfig implements GoreleaserConfig {
     }
 
     if (opts["major-version"] > 1) {
-      ldflags = [
-        `-X github.com/pulumi/pulumi-${opts.provider}/provider/v${opts["major-version"]}/pkg/version.Version={{.Tag}}`,
-      ];
+      ldflags.push(
+        `-X github.com/pulumi/pulumi-${opts.provider}/provider/v${opts["major-version"]}/pkg/version.Version={{.Tag}}`
+      );
     } else {
-      ldflags = [
-        `-X github.com/pulumi/pulumi-${opts.provider}/provider/pkg/version.Version={{.Tag}}`,
-      ];
+      ldflags.push(
+        `-X github.com/pulumi/pulumi-${opts.provider}/provider/pkg/version.Version={{.Tag}}`
+      );
     }
 
     if (opts.providerVersion !== "") {


### PR DESCRIPTION
By stripping debug symbols in https://github.com/pulumi/ci-mgmt/pull/1145 we significantly decreased the size of bridged provider binaries (e.g. ~300MB for pulumi-aws). This adds the same optimizations to native providers. Panics and stack traces still contain all the necessary information.

In detail this adds the `-s` and `-w` linker flags which strip the symbol table, debug information and DWARF symbol table.