### PR TITLE
Fix default Renovate config path

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -1,6 +1,6 @@
 {
   $schema: "https://docs.renovatebot.com/renovate-schema.json",
-  extends: ["github>pulumi/renovate-config"],
+  extends: ["github>pulumi/renovate-config//default.json5"],
   postUpgradeTasks: {
     // Re-generate test workflows in case action versions have been bumped.
     commands: ["make build"],


### PR DESCRIPTION
https://docs.renovatebot.com/config-presets/#github

Renovate looks for `default.json` by default, but we use `default.json5` for its comment support.

Fixes https://github.com/pulumi/ci-mgmt/issues/1161