### PR TITLE
Remove unused sshPrivateKey config

### DIFF
--- a/provider-ci/internal/pkg/config.go
+++ b/provider-ci/internal/pkg/config.go
@@ -205,12 +205,6 @@ type Config struct {
 	// https://github.com/search?q=org%3Apulumi+path%3A.ci-mgmt.yaml+%22docker%3A%22&type=code
 	Docker bool `yaml:"docker"`
 
-	// SSHPrivateKey sets up SSH with specified private key before running
-	// tests in CI job. This should be provided from a secret. Used by the
-	// docker provider only:
-	// https://github.com/search?q=org%3Apulumi+path%3A.ci-mgmt.yaml+%22sshPrivateKey%3A%22&type=code
-	SSHPrivateKey string `yaml:"sshPrivateKey"`
-
 	// GCP authenticates with GCP before running tests in CI job. Used in gcp
 	// and docker:
 	// https://github.com/search?q=org%3Apulumi+path%3A.ci-mgmt.yaml+%22gcp%3A%22&type=code

--- a/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/main.yml
+++ b/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/main.yml
@@ -200,12 +200,6 @@ jobs:
     - name: Login to Google Cloud Registry
       run: gcloud --quiet auth configure-docker
     #{{- end }}#
-    #{{- if .Config.SSHPrivateKey }}#
-    - name: Setup SSH key
-      uses: webfactory/ssh-agent@836c84ec59a0e7bc0eabc79988384eb567561ee2 # v0.7.0
-      with:
-        ssh-private-key: #{{ .Config.SSHPrivateKey }}#
-    #{{- end }}#
     #{{- if index .Config.SetupScript }}#
     - name: Run setup script
       run: #{{ index .Config.SetupScript }}#

--- a/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/nightly-test.yml
+++ b/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/nightly-test.yml
@@ -109,12 +109,6 @@ jobs:
     - name: Login to Google Cloud Registry
       run: gcloud --quiet auth configure-docker
     #{{- end }}#
-    #{{- if .Config.SSHPrivateKey }}#
-    - name: Setup SSH key
-      uses: webfactory/ssh-agent@836c84ec59a0e7bc0eabc79988384eb567561ee2 # v0.7.0
-      with:
-        ssh-private-key: #{{ .Config.SSHPrivateKey }}#
-    #{{- end }}#
     #{{- if index .Config.SetupScript }}#
     - name: Run setup script
       run: #{{ index .Config.SetupScript }}#

--- a/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/prerelease.yml
+++ b/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/prerelease.yml
@@ -139,12 +139,6 @@ jobs:
     - name: Login to Google Cloud Registry
       run: gcloud --quiet auth configure-docker
     #{{- end }}#
-    #{{- if .Config.SSHPrivateKey }}#
-    - name: Setup SSH key
-      uses: webfactory/ssh-agent@836c84ec59a0e7bc0eabc79988384eb567561ee2 # v0.7.0
-      with:
-        ssh-private-key: #{{ .Config.SSHPrivateKey }}#
-    #{{- end }}#
     #{{- if index .Config.SetupScript }}#
     - name: Run setup script
       run: #{{ index .Config.SetupScript }}#

--- a/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/release.yml
+++ b/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/release.yml
@@ -148,12 +148,6 @@ jobs:
     - name: Login to Google Cloud Registry
       run: gcloud --quiet auth configure-docker
     #{{- end }}#
-    #{{- if .Config.SSHPrivateKey }}#
-    - name: Setup SSH key
-      uses: webfactory/ssh-agent@836c84ec59a0e7bc0eabc79988384eb567561ee2 # v0.7.0
-      with:
-        ssh-private-key: #{{ .Config.SSHPrivateKey }}#
-    #{{- end }}#
     #{{- if index .Config.SetupScript }}#
     - name: Run setup script
       run: #{{ index .Config.SetupScript }}#

--- a/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/run-acceptance-tests.yml
@@ -196,12 +196,6 @@ jobs:
     - name: Login to Google Cloud Registry
       run: gcloud --quiet auth configure-docker
     #{{- end }}#
-    #{{- if .Config.SSHPrivateKey }}#
-    - name: Setup SSH key
-      uses: webfactory/ssh-agent@836c84ec59a0e7bc0eabc79988384eb567561ee2 # v0.7.0
-      with:
-        ssh-private-key: #{{ .Config.SSHPrivateKey }}#
-    #{{- end }}#
     #{{- if index .Config.SetupScript }}#
     - name: Run setup script
       run: #{{ index .Config.SetupScript }}#

--- a/provider-ci/internal/pkg/templates/defaults.config.yaml
+++ b/provider-ci/internal/pkg/templates/defaults.config.yaml
@@ -210,11 +210,6 @@ checkUpstreamUpgrade: true
 # Used in 9 providers: https://github.com/search?q=org%3Apulumi+path%3A.ci-mgmt.yaml+%22docker%3A%22&type=code
 #docker: false
 
-# Setup SSH with specified private key before running tests in CI job.
-# This should be provided from a secret
-# Used by the docker provider only: https://github.com/search?q=org%3Apulumi+path%3A.ci-mgmt.yaml+%22sshPrivateKey%3A%22&type=code
-#sshPrivateKey: ${{ secrets.PRIVATE_SSH_KEY_FOR_DIGITALOCEAN }}
-
 # Authenticate with GCP before running tests in CI job
 # Used in gcp and docker: https://github.com/search?q=org%3Apulumi+path%3A.ci-mgmt.yaml+%22gcp%3A%22&type=code
 #gcp: false


### PR DESCRIPTION
Only the Docker provider uses the `webfactory/ssh-agent` action, and that's configured via [`preTest`](https://github.com/pulumi/pulumi-docker/blob/master/.ci-mgmt.yaml#L35-L39) instead of the special-purpose `sshPrivateKey` option.

Nothing else [appears](https://github.com/search?q=org%3Apulumi%20path%3A.ci-mgmt.yml%20sshPrivateKey&type=code) to use this, so we can remove it.