### PR TITLE
Correct github-status-action-v2 version

### DIFF
--- a/native-provider-ci/providers/aws-native/repo/.github/workflows/run-acceptance-tests.yml
+++ b/native-provider-ci/providers/aws-native/repo/.github/workflows/run-acceptance-tests.yml
@@ -386,7 +386,7 @@ jobs:
     name: sentinel
     steps:
     - name: Mark workflow as successful
-      uses: guibranco/github-status-action-v2@1.1.13
+      uses: guibranco/github-status-action-v2@v1.1.13
       with:
         authToken: ${{ secrets.GITHUB_TOKEN }}
         context: Sentinel

--- a/native-provider-ci/providers/command/repo/.github/workflows/run-acceptance-tests.yml
+++ b/native-provider-ci/providers/command/repo/.github/workflows/run-acceptance-tests.yml
@@ -346,7 +346,7 @@ jobs:
     name: sentinel
     steps:
     - name: Mark workflow as successful
-      uses: guibranco/github-status-action-v2@1.1.13
+      uses: guibranco/github-status-action-v2@v1.1.13
       with:
         authToken: ${{ secrets.GITHUB_TOKEN }}
         context: Sentinel

--- a/native-provider-ci/providers/docker-build/repo/.github/workflows/run-acceptance-tests.yml
+++ b/native-provider-ci/providers/docker-build/repo/.github/workflows/run-acceptance-tests.yml
@@ -402,7 +402,7 @@ jobs:
     name: sentinel
     steps:
     - name: Mark workflow as successful
-      uses: guibranco/github-status-action-v2@1.1.13
+      uses: guibranco/github-status-action-v2@v1.1.13
       with:
         authToken: ${{ secrets.GITHUB_TOKEN }}
         context: Sentinel

--- a/native-provider-ci/providers/google-native/repo/.github/workflows/run-acceptance-tests.yml
+++ b/native-provider-ci/providers/google-native/repo/.github/workflows/run-acceptance-tests.yml
@@ -389,7 +389,7 @@ jobs:
     name: sentinel
     steps:
     - name: Mark workflow as successful
-      uses: guibranco/github-status-action-v2@1.1.13
+      uses: guibranco/github-status-action-v2@v1.1.13
       with:
         authToken: ${{ secrets.GITHUB_TOKEN }}
         context: Sentinel

--- a/native-provider-ci/providers/kubernetes-cert-manager/repo/.github/workflows/run-acceptance-tests.yml
+++ b/native-provider-ci/providers/kubernetes-cert-manager/repo/.github/workflows/run-acceptance-tests.yml
@@ -378,7 +378,7 @@ jobs:
     name: sentinel
     steps:
     - name: Mark workflow as successful
-      uses: guibranco/github-status-action-v2@1.1.13
+      uses: guibranco/github-status-action-v2@v1.1.13
       with:
         authToken: ${{ secrets.GITHUB_TOKEN }}
         context: Sentinel

--- a/native-provider-ci/providers/kubernetes/repo/.github/workflows/run-acceptance-tests.yml
+++ b/native-provider-ci/providers/kubernetes/repo/.github/workflows/run-acceptance-tests.yml
@@ -418,7 +418,7 @@ jobs:
     name: sentinel
     steps:
     - name: Mark workflow as successful
-      uses: guibranco/github-status-action-v2@1.1.13
+      uses: guibranco/github-status-action-v2@v1.1.13
       with:
         authToken: ${{ secrets.GITHUB_TOKEN }}
         context: Sentinel

--- a/provider-ci/internal/pkg/action-versions.yml
+++ b/provider-ci/internal/pkg/action-versions.yml
@@ -115,4 +115,4 @@ jobs:
         uses: helm/kind-action@0025e74a8c7512023d06dc019c617aa3cf561fde # v1.10.0
 
       - name: guibranco/github-status-action-v2
-        uses: guibranco/github-status-action-v2@1.1.13
+        uses: guibranco/github-status-action-v2@v1.1.13


### PR DESCRIPTION
The version of `github-status-action-v2` was missing the `v` prefix. This caused failures in sentinel jobs (e.g. https://github.com/pulumi/pulumi-aws-native/actions/runs/12048854301/job/33595172277?pr=1865).

Fixes https://github.com/pulumi/ci-mgmt/issues/1182
