### PR TITLE
Don't create a `schema-embed.json` directory

### DIFF
--- a/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/build_provider.yml
+++ b/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/build_provider.yml
@@ -58,7 +58,7 @@ jobs:
           pattern: schema-embed.*
           # Avoid creating directories for each artifact
           merge-multiple: true
-          path: provider/cmd/pulumi-resource-#{{ .Config.Provider }}#/schema-embed.json
+          path: provider/cmd/pulumi-resource-#{{ .Config.Provider }}#
       - name: Restore makefile progress
         run: make --touch provider schema
       - name: Build & package provider

--- a/provider-ci/test-providers/acme/.github/workflows/build_provider.yml
+++ b/provider-ci/test-providers/acme/.github/workflows/build_provider.yml
@@ -46,7 +46,7 @@ jobs:
           pattern: schema-embed.*
           # Avoid creating directories for each artifact
           merge-multiple: true
-          path: provider/cmd/pulumi-resource-acme/schema-embed.json
+          path: provider/cmd/pulumi-resource-acme
       - name: Restore makefile progress
         run: make --touch provider schema
       - name: Build & package provider

--- a/provider-ci/test-providers/aws/.github/workflows/build_provider.yml
+++ b/provider-ci/test-providers/aws/.github/workflows/build_provider.yml
@@ -54,7 +54,7 @@ jobs:
           pattern: schema-embed.*
           # Avoid creating directories for each artifact
           merge-multiple: true
-          path: provider/cmd/pulumi-resource-aws/schema-embed.json
+          path: provider/cmd/pulumi-resource-aws
       - name: Restore makefile progress
         run: make --touch provider schema
       - name: Build & package provider

--- a/provider-ci/test-providers/cloudflare/.github/workflows/build_provider.yml
+++ b/provider-ci/test-providers/cloudflare/.github/workflows/build_provider.yml
@@ -46,7 +46,7 @@ jobs:
           pattern: schema-embed.*
           # Avoid creating directories for each artifact
           merge-multiple: true
-          path: provider/cmd/pulumi-resource-cloudflare/schema-embed.json
+          path: provider/cmd/pulumi-resource-cloudflare
       - name: Restore makefile progress
         run: make --touch provider schema
       - name: Build & package provider

--- a/provider-ci/test-providers/docker/.github/workflows/build_provider.yml
+++ b/provider-ci/test-providers/docker/.github/workflows/build_provider.yml
@@ -46,7 +46,7 @@ jobs:
           pattern: schema-embed.*
           # Avoid creating directories for each artifact
           merge-multiple: true
-          path: provider/cmd/pulumi-resource-docker/schema-embed.json
+          path: provider/cmd/pulumi-resource-docker
       - name: Restore makefile progress
         run: make --touch provider schema
       - name: Build & package provider


### PR DESCRIPTION
This PR downloads our `schema-embed.json` artifact to a more appropriate path:

```diff
-provider/cmd/pulumi-resource-foo/schema-embed.json/schema-embed.json
+provider/cmd/pulumi-resource-foo/schema-embed.json
```

The current directory format happens to work due to a quirk of `go:embed`:

> If a pattern names a directory, all files in the subtree rooted at that directory are
> embedded (recursively), except that files with names beginning with ‘.’ or ‘_’
> are excluded.

Normally this is invalid for `[]byte` types, but it succeeds when there is a single file.

Refs https://github.com/pulumi/pulumi-aws/issues/4863