### PR TITLE
Sign bridged windows binaries

### DIFF
--- a/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/build_provider.yml
+++ b/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/build_provider.yml
@@ -87,7 +87,7 @@ jobs:
              --keystore "PulumiCodeSigning" \
              --url ${{ secrets.AZURE_SIGNING_KEY_VAULT_URI }} \
              --storepass "$(az account get-access-token --resource "https://vault.azure.net" | jq -r .accessToken)" \
-             bin/windows-amd64/pulumi-resource-#{{ .Config.Provider }}#.exe
+             bin/windows-amd64/pulumi-resource-#{{ .Config.Provider }}#.exe;
 
       - name: Package provider
         run: make provider_dist-${{ matrix.platform.os }}-${{ matrix.platform.arch }}

--- a/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/build_provider.yml
+++ b/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/build_provider.yml
@@ -62,8 +62,36 @@ jobs:
           path: provider/cmd/pulumi-resource-#{{ .Config.Provider }}#
       - name: Restore makefile progress
         run: make --touch provider schema
-      - name: Build & package provider
+
+      - name: Build provider
+        if: matrix.platform.os != 'windows'
+        run: make bin/${{ matrix.platform.os }}-${{ matrix.platform.arch }}/pulumi-resource-#{{ .Config.Provider }}#
+
+      - name: Build windows provider
+        if: matrix.platform.os == 'windows'
+        run: make bin/${{ matrix.platform.os }}-${{ matrix.platform.arch }}/pulumi-resource-#{{ .Config.Provider }}#.exe
+
+      - name: Sign windows provider
+        if: matrix.platform.os == 'windows'
+        run: |
+          az login --service-principal \
+            -u ${{ secrets.AZURE_SIGNING_CLIENT_ID }} \
+            -p ${{ secrets.AZURE_SIGNING_CLIENT_SECRET }} \
+            -t ${{ secrets.AZURE_SIGNING_TENANT_ID }} \
+            -o none;
+
+          wget https://github.com/ebourg/jsign/releases/download/6.0/jsign-6.0.jar;
+
+          java -jar jsign-6.0.jar \
+             --storetype AZUREKEYVAULT \
+             --keystore "PulumiCodeSigning" \
+             --url ${{ secrets.AZURE_SIGNING_KEY_VAULT_URI }} \
+             --storepass "$(az account get-access-token --resource "https://vault.azure.net" | jq -r .accessToken)" \
+             bin/windows-amd64/pulumi-resource-#{{ .Config.Provider }}#.exe
+
+      - name: Package provider
         run: make provider_dist-${{ matrix.platform.os }}-${{ matrix.platform.arch }}
+
       - name: Upload artifacts
         uses: #{{ .Config.ActionVersions.UploadArtifact }}#
         with:

--- a/provider-ci/test-providers/acme/.github/workflows/build_provider.yml
+++ b/provider-ci/test-providers/acme/.github/workflows/build_provider.yml
@@ -50,8 +50,36 @@ jobs:
           path: provider/cmd/pulumi-resource-acme
       - name: Restore makefile progress
         run: make --touch provider schema
-      - name: Build & package provider
+
+      - name: Build provider
+        if: matrix.platform.os != 'windows'
+        run: make bin/${{ matrix.platform.os }}-${{ matrix.platform.arch }}/pulumi-resource-acme
+
+      - name: Build windows provider
+        if: matrix.platform.os == 'windows'
+        run: make bin/${{ matrix.platform.os }}-${{ matrix.platform.arch }}/pulumi-resource-acme.exe
+
+      - name: Sign windows provider
+        if: matrix.platform.os == 'windows'
+        run: |
+          az login --service-principal \
+            -u ${{ secrets.AZURE_SIGNING_CLIENT_ID }} \
+            -p ${{ secrets.AZURE_SIGNING_CLIENT_SECRET }} \
+            -t ${{ secrets.AZURE_SIGNING_TENANT_ID }} \
+            -o none;
+
+          wget https://github.com/ebourg/jsign/releases/download/6.0/jsign-6.0.jar;
+
+          java -jar jsign-6.0.jar \
+             --storetype AZUREKEYVAULT \
+             --keystore "PulumiCodeSigning" \
+             --url ${{ secrets.AZURE_SIGNING_KEY_VAULT_URI }} \
+             --storepass "$(az account get-access-token --resource "https://vault.azure.net" | jq -r .accessToken)" \
+             bin/windows-amd64/pulumi-resource-acme.exe
+
+      - name: Package provider
         run: make provider_dist-${{ matrix.platform.os }}-${{ matrix.platform.arch }}
+
       - name: Upload artifacts
         uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3
         with:

--- a/provider-ci/test-providers/acme/.github/workflows/build_provider.yml
+++ b/provider-ci/test-providers/acme/.github/workflows/build_provider.yml
@@ -75,7 +75,7 @@ jobs:
              --keystore "PulumiCodeSigning" \
              --url ${{ secrets.AZURE_SIGNING_KEY_VAULT_URI }} \
              --storepass "$(az account get-access-token --resource "https://vault.azure.net" | jq -r .accessToken)" \
-             bin/windows-amd64/pulumi-resource-acme.exe
+             bin/windows-amd64/pulumi-resource-acme.exe;
 
       - name: Package provider
         run: make provider_dist-${{ matrix.platform.os }}-${{ matrix.platform.arch }}

--- a/provider-ci/test-providers/aws/.github/workflows/build_provider.yml
+++ b/provider-ci/test-providers/aws/.github/workflows/build_provider.yml
@@ -83,7 +83,7 @@ jobs:
              --keystore "PulumiCodeSigning" \
              --url ${{ secrets.AZURE_SIGNING_KEY_VAULT_URI }} \
              --storepass "$(az account get-access-token --resource "https://vault.azure.net" | jq -r .accessToken)" \
-             bin/windows-amd64/pulumi-resource-aws.exe
+             bin/windows-amd64/pulumi-resource-aws.exe;
 
       - name: Package provider
         run: make provider_dist-${{ matrix.platform.os }}-${{ matrix.platform.arch }}

--- a/provider-ci/test-providers/aws/.github/workflows/build_provider.yml
+++ b/provider-ci/test-providers/aws/.github/workflows/build_provider.yml
@@ -58,8 +58,36 @@ jobs:
           path: provider/cmd/pulumi-resource-aws
       - name: Restore makefile progress
         run: make --touch provider schema
-      - name: Build & package provider
+
+      - name: Build provider
+        if: matrix.platform.os != 'windows'
+        run: make bin/${{ matrix.platform.os }}-${{ matrix.platform.arch }}/pulumi-resource-aws
+
+      - name: Build windows provider
+        if: matrix.platform.os == 'windows'
+        run: make bin/${{ matrix.platform.os }}-${{ matrix.platform.arch }}/pulumi-resource-aws.exe
+
+      - name: Sign windows provider
+        if: matrix.platform.os == 'windows'
+        run: |
+          az login --service-principal \
+            -u ${{ secrets.AZURE_SIGNING_CLIENT_ID }} \
+            -p ${{ secrets.AZURE_SIGNING_CLIENT_SECRET }} \
+            -t ${{ secrets.AZURE_SIGNING_TENANT_ID }} \
+            -o none;
+
+          wget https://github.com/ebourg/jsign/releases/download/6.0/jsign-6.0.jar;
+
+          java -jar jsign-6.0.jar \
+             --storetype AZUREKEYVAULT \
+             --keystore "PulumiCodeSigning" \
+             --url ${{ secrets.AZURE_SIGNING_KEY_VAULT_URI }} \
+             --storepass "$(az account get-access-token --resource "https://vault.azure.net" | jq -r .accessToken)" \
+             bin/windows-amd64/pulumi-resource-aws.exe
+
+      - name: Package provider
         run: make provider_dist-${{ matrix.platform.os }}-${{ matrix.platform.arch }}
+
       - name: Upload artifacts
         uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3
         with:

--- a/provider-ci/test-providers/cloudflare/.github/workflows/build_provider.yml
+++ b/provider-ci/test-providers/cloudflare/.github/workflows/build_provider.yml
@@ -75,7 +75,7 @@ jobs:
              --keystore "PulumiCodeSigning" \
              --url ${{ secrets.AZURE_SIGNING_KEY_VAULT_URI }} \
              --storepass "$(az account get-access-token --resource "https://vault.azure.net" | jq -r .accessToken)" \
-             bin/windows-amd64/pulumi-resource-cloudflare.exe
+             bin/windows-amd64/pulumi-resource-cloudflare.exe;
 
       - name: Package provider
         run: make provider_dist-${{ matrix.platform.os }}-${{ matrix.platform.arch }}

--- a/provider-ci/test-providers/cloudflare/.github/workflows/build_provider.yml
+++ b/provider-ci/test-providers/cloudflare/.github/workflows/build_provider.yml
@@ -50,8 +50,36 @@ jobs:
           path: provider/cmd/pulumi-resource-cloudflare
       - name: Restore makefile progress
         run: make --touch provider schema
-      - name: Build & package provider
+
+      - name: Build provider
+        if: matrix.platform.os != 'windows'
+        run: make bin/${{ matrix.platform.os }}-${{ matrix.platform.arch }}/pulumi-resource-cloudflare
+
+      - name: Build windows provider
+        if: matrix.platform.os == 'windows'
+        run: make bin/${{ matrix.platform.os }}-${{ matrix.platform.arch }}/pulumi-resource-cloudflare.exe
+
+      - name: Sign windows provider
+        if: matrix.platform.os == 'windows'
+        run: |
+          az login --service-principal \
+            -u ${{ secrets.AZURE_SIGNING_CLIENT_ID }} \
+            -p ${{ secrets.AZURE_SIGNING_CLIENT_SECRET }} \
+            -t ${{ secrets.AZURE_SIGNING_TENANT_ID }} \
+            -o none;
+
+          wget https://github.com/ebourg/jsign/releases/download/6.0/jsign-6.0.jar;
+
+          java -jar jsign-6.0.jar \
+             --storetype AZUREKEYVAULT \
+             --keystore "PulumiCodeSigning" \
+             --url ${{ secrets.AZURE_SIGNING_KEY_VAULT_URI }} \
+             --storepass "$(az account get-access-token --resource "https://vault.azure.net" | jq -r .accessToken)" \
+             bin/windows-amd64/pulumi-resource-cloudflare.exe
+
+      - name: Package provider
         run: make provider_dist-${{ matrix.platform.os }}-${{ matrix.platform.arch }}
+
       - name: Upload artifacts
         uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3
         with:

--- a/provider-ci/test-providers/docker/.github/workflows/build_provider.yml
+++ b/provider-ci/test-providers/docker/.github/workflows/build_provider.yml
@@ -50,8 +50,36 @@ jobs:
           path: provider/cmd/pulumi-resource-docker
       - name: Restore makefile progress
         run: make --touch provider schema
-      - name: Build & package provider
+
+      - name: Build provider
+        if: matrix.platform.os != 'windows'
+        run: make bin/${{ matrix.platform.os }}-${{ matrix.platform.arch }}/pulumi-resource-docker
+
+      - name: Build windows provider
+        if: matrix.platform.os == 'windows'
+        run: make bin/${{ matrix.platform.os }}-${{ matrix.platform.arch }}/pulumi-resource-docker.exe
+
+      - name: Sign windows provider
+        if: matrix.platform.os == 'windows'
+        run: |
+          az login --service-principal \
+            -u ${{ secrets.AZURE_SIGNING_CLIENT_ID }} \
+            -p ${{ secrets.AZURE_SIGNING_CLIENT_SECRET }} \
+            -t ${{ secrets.AZURE_SIGNING_TENANT_ID }} \
+            -o none;
+
+          wget https://github.com/ebourg/jsign/releases/download/6.0/jsign-6.0.jar;
+
+          java -jar jsign-6.0.jar \
+             --storetype AZUREKEYVAULT \
+             --keystore "PulumiCodeSigning" \
+             --url ${{ secrets.AZURE_SIGNING_KEY_VAULT_URI }} \
+             --storepass "$(az account get-access-token --resource "https://vault.azure.net" | jq -r .accessToken)" \
+             bin/windows-amd64/pulumi-resource-docker.exe
+
+      - name: Package provider
         run: make provider_dist-${{ matrix.platform.os }}-${{ matrix.platform.arch }}
+
       - name: Upload artifacts
         uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3
         with:

--- a/provider-ci/test-providers/docker/.github/workflows/build_provider.yml
+++ b/provider-ci/test-providers/docker/.github/workflows/build_provider.yml
@@ -75,7 +75,7 @@ jobs:
              --keystore "PulumiCodeSigning" \
              --url ${{ secrets.AZURE_SIGNING_KEY_VAULT_URI }} \
              --storepass "$(az account get-access-token --resource "https://vault.azure.net" | jq -r .accessToken)" \
-             bin/windows-amd64/pulumi-resource-docker.exe
+             bin/windows-amd64/pulumi-resource-docker.exe;
 
       - name: Package provider
         run: make provider_dist-${{ matrix.platform.os }}-${{ matrix.platform.arch }}


### PR DESCRIPTION
This separates the provider build/packaging steps so we can add signatures before uploading.

Signing is done using [Jsign](https://ebourg.github.io/jsign/), which has the advantage of being able run on Ubuntu.

Confirmed the signature is OK on a Windows VM:

![image](https://github.com/user-attachments/assets/05c0181d-caa0-488c-94d4-fc760fe18748)

Refs https://github.com/pulumi/home/issues/3766