### PR TITLE
Add conflict resolution instructions to upstream tool

### DIFF
--- a/provider-ci/internal/pkg/templates/bridged-provider/upstream.sh
+++ b/provider-ci/internal/pkg/templates/bridged-provider/upstream.sh
@@ -286,7 +286,7 @@ rebase() {
     interactive_flag="--interactive"
   fi
   if ! git rebase --onto "${onto}" ${interactive_flag}; then
-    echo "Rebase failed. Please resolve the conflicts and run 'git rebase --continue' in the upstream directory."
+    echo "Rebase failed. Please resolve the conflicts and run 'git rebase --continue' in the upstream directory. Once the rebase is complete, run '${original_exec} check_in' to write to commits back to patches."
     exit 1
   fi
   cd ..

--- a/provider-ci/test-providers/acme/upstream.sh
+++ b/provider-ci/test-providers/acme/upstream.sh
@@ -286,7 +286,7 @@ rebase() {
     interactive_flag="--interactive"
   fi
   if ! git rebase --onto "${onto}" ${interactive_flag}; then
-    echo "Rebase failed. Please resolve the conflicts and run 'git rebase --continue' in the upstream directory."
+    echo "Rebase failed. Please resolve the conflicts and run 'git rebase --continue' in the upstream directory. Once the rebase is complete, run '${original_exec} check_in' to write to commits back to patches."
     exit 1
   fi
   cd ..

--- a/provider-ci/test-providers/aws/upstream.sh
+++ b/provider-ci/test-providers/aws/upstream.sh
@@ -286,7 +286,7 @@ rebase() {
     interactive_flag="--interactive"
   fi
   if ! git rebase --onto "${onto}" ${interactive_flag}; then
-    echo "Rebase failed. Please resolve the conflicts and run 'git rebase --continue' in the upstream directory."
+    echo "Rebase failed. Please resolve the conflicts and run 'git rebase --continue' in the upstream directory. Once the rebase is complete, run '${original_exec} check_in' to write to commits back to patches."
     exit 1
   fi
   cd ..

--- a/provider-ci/test-providers/cloudflare/upstream.sh
+++ b/provider-ci/test-providers/cloudflare/upstream.sh
@@ -286,7 +286,7 @@ rebase() {
     interactive_flag="--interactive"
   fi
   if ! git rebase --onto "${onto}" ${interactive_flag}; then
-    echo "Rebase failed. Please resolve the conflicts and run 'git rebase --continue' in the upstream directory."
+    echo "Rebase failed. Please resolve the conflicts and run 'git rebase --continue' in the upstream directory. Once the rebase is complete, run '${original_exec} check_in' to write to commits back to patches."
     exit 1
   fi
   cd ..

--- a/provider-ci/test-providers/docker/upstream.sh
+++ b/provider-ci/test-providers/docker/upstream.sh
@@ -286,7 +286,7 @@ rebase() {
     interactive_flag="--interactive"
   fi
   if ! git rebase --onto "${onto}" ${interactive_flag}; then
-    echo "Rebase failed. Please resolve the conflicts and run 'git rebase --continue' in the upstream directory."
+    echo "Rebase failed. Please resolve the conflicts and run 'git rebase --continue' in the upstream directory. Once the rebase is complete, run '${original_exec} check_in' to write to commits back to patches."
     exit 1
   fi
   cd ..


### PR DESCRIPTION
Add instructions for running `./upstream.sh check_in` after fixing conflicts during rebase.