### PR TITLE
Only sign the windows binary when the signing secrets are configured

### DIFF
--- a/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/build_provider.yml
+++ b/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/build_provider.yml
@@ -15,6 +15,7 @@ jobs:
     env:
       PROVIDER_VERSION: ${{ inputs.version }}
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      SIGN: ${{ secrets.AZURE_SIGNING_KEY_VAULT_URI != '' }}
     strategy:
       fail-fast: true
       matrix:
@@ -72,7 +73,7 @@ jobs:
         run: make bin/${{ matrix.platform.os }}-${{ matrix.platform.arch }}/pulumi-resource-#{{ .Config.Provider }}#.exe
 
       - name: Sign windows provider
-        if: matrix.platform.os == 'windows'
+        if: matrix.platform.os == 'windows' && env.SIGN == 'true'
         run: |
           az login --service-principal \
             -u ${{ secrets.AZURE_SIGNING_CLIENT_ID }} \

--- a/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/build_provider.yml
+++ b/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/build_provider.yml
@@ -15,7 +15,7 @@ jobs:
     env:
       PROVIDER_VERSION: ${{ inputs.version }}
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      SIGN: ${{ secrets.AZURE_SIGNING_KEY_VAULT_URI != '' }}
+      AZURE_SIGNING_CONFIGURED: ${{ secrets.AZURE_SIGNING_CLIENT_ID != '' && secrets.AZURE_SIGNING_CLIENT_SECRET != '' && secrets.AZURE_SIGNING_TENANT_ID != '' && secrets.AZURE_SIGNING_KEY_VAULT_URI != '' }}
     strategy:
       fail-fast: true
       matrix:
@@ -65,15 +65,10 @@ jobs:
         run: make --touch provider schema
 
       - name: Build provider
-        if: matrix.platform.os != 'windows'
-        run: make bin/${{ matrix.platform.os }}-${{ matrix.platform.arch }}/pulumi-resource-#{{ .Config.Provider }}#
-
-      - name: Build windows provider
-        if: matrix.platform.os == 'windows'
-        run: make bin/${{ matrix.platform.os }}-${{ matrix.platform.arch }}/pulumi-resource-#{{ .Config.Provider }}#.exe
+        run: make "provider-${{ matrix.platform.os }}-${{ matrix.platform.arch }}"
 
       - name: Sign windows provider
-        if: matrix.platform.os == 'windows' && env.SIGN == 'true'
+        if: matrix.platform.os == 'windows' && env.AZURE_SIGNING_CONFIGURED == 'true'
         run: |
           az login --service-principal \
             -u ${{ secrets.AZURE_SIGNING_CLIENT_ID }} \

--- a/provider-ci/internal/pkg/templates/bridged-provider/Makefile
+++ b/provider-ci/internal/pkg/templates/bridged-provider/Makefile
@@ -354,6 +354,13 @@ bin/%/$(PROVIDER) bin/%/$(PROVIDER).exe:
 		export CGO_ENABLED=0 && \
 		go build -o "${WORKING_DIR}/$@" $(PULUMI_PROVIDER_BUILD_PARALLELISM) -ldflags "$(LDFLAGS)" "$(PROJECT)/$(PROVIDER_PATH)/cmd/$(PROVIDER)"
 
+provider-linux-amd64: bin/linux-amd64/$(PROVIDER)
+provider-linux-arm64: bin/linux-arm64/$(PROVIDER)
+provider-darwin-amd64: bin/darwin-amd64/$(PROVIDER)
+provider-darwin-arm64: bin/darwin-arm64/$(PROVIDER)
+provider-windows-amd64: bin/windows-amd64/$(PROVIDER).exe
+.PHONY: provider-linux-amd64 provider-linux-arm64 provider-darwin-amd64 provider-darwin-arm64 provider-windows-amd64
+
 bin/$(PROVIDER)-v$(VERSION_GENERIC)-linux-amd64.tar.gz: bin/linux-amd64/$(PROVIDER)
 bin/$(PROVIDER)-v$(VERSION_GENERIC)-linux-arm64.tar.gz: bin/linux-arm64/$(PROVIDER)
 bin/$(PROVIDER)-v$(VERSION_GENERIC)-darwin-amd64.tar.gz: bin/darwin-amd64/$(PROVIDER)

--- a/provider-ci/test-providers/acme/.github/workflows/build_provider.yml
+++ b/provider-ci/test-providers/acme/.github/workflows/build_provider.yml
@@ -15,6 +15,7 @@ jobs:
     env:
       PROVIDER_VERSION: ${{ inputs.version }}
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      SIGN: ${{ secrets.AZURE_SIGNING_KEY_VAULT_URI != '' }}
     strategy:
       fail-fast: true
       matrix:
@@ -60,7 +61,7 @@ jobs:
         run: make bin/${{ matrix.platform.os }}-${{ matrix.platform.arch }}/pulumi-resource-acme.exe
 
       - name: Sign windows provider
-        if: matrix.platform.os == 'windows'
+        if: matrix.platform.os == 'windows' && env.SIGN == 'true'
         run: |
           az login --service-principal \
             -u ${{ secrets.AZURE_SIGNING_CLIENT_ID }} \

--- a/provider-ci/test-providers/acme/.github/workflows/build_provider.yml
+++ b/provider-ci/test-providers/acme/.github/workflows/build_provider.yml
@@ -15,7 +15,7 @@ jobs:
     env:
       PROVIDER_VERSION: ${{ inputs.version }}
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      SIGN: ${{ secrets.AZURE_SIGNING_KEY_VAULT_URI != '' }}
+      AZURE_SIGNING_CONFIGURED: ${{ secrets.AZURE_SIGNING_CLIENT_ID != '' && secrets.AZURE_SIGNING_CLIENT_SECRET != '' && secrets.AZURE_SIGNING_TENANT_ID != '' && secrets.AZURE_SIGNING_KEY_VAULT_URI != '' }}
     strategy:
       fail-fast: true
       matrix:
@@ -53,15 +53,10 @@ jobs:
         run: make --touch provider schema
 
       - name: Build provider
-        if: matrix.platform.os != 'windows'
-        run: make bin/${{ matrix.platform.os }}-${{ matrix.platform.arch }}/pulumi-resource-acme
-
-      - name: Build windows provider
-        if: matrix.platform.os == 'windows'
-        run: make bin/${{ matrix.platform.os }}-${{ matrix.platform.arch }}/pulumi-resource-acme.exe
+        run: make "provider-${{ matrix.platform.os }}-${{ matrix.platform.arch }}"
 
       - name: Sign windows provider
-        if: matrix.platform.os == 'windows' && env.SIGN == 'true'
+        if: matrix.platform.os == 'windows' && env.AZURE_SIGNING_CONFIGURED == 'true'
         run: |
           az login --service-principal \
             -u ${{ secrets.AZURE_SIGNING_CLIENT_ID }} \

--- a/provider-ci/test-providers/acme/Makefile
+++ b/provider-ci/test-providers/acme/Makefile
@@ -312,6 +312,13 @@ bin/%/$(PROVIDER) bin/%/$(PROVIDER).exe:
 		export CGO_ENABLED=0 && \
 		go build -o "${WORKING_DIR}/$@" $(PULUMI_PROVIDER_BUILD_PARALLELISM) -ldflags "$(LDFLAGS)" "$(PROJECT)/$(PROVIDER_PATH)/cmd/$(PROVIDER)"
 
+provider-linux-amd64: bin/linux-amd64/$(PROVIDER)
+provider-linux-arm64: bin/linux-arm64/$(PROVIDER)
+provider-darwin-amd64: bin/darwin-amd64/$(PROVIDER)
+provider-darwin-arm64: bin/darwin-arm64/$(PROVIDER)
+provider-windows-amd64: bin/windows-amd64/$(PROVIDER).exe
+.PHONY: provider-linux-amd64 provider-linux-arm64 provider-darwin-amd64 provider-darwin-arm64 provider-windows-amd64
+
 bin/$(PROVIDER)-v$(VERSION_GENERIC)-linux-amd64.tar.gz: bin/linux-amd64/$(PROVIDER)
 bin/$(PROVIDER)-v$(VERSION_GENERIC)-linux-arm64.tar.gz: bin/linux-arm64/$(PROVIDER)
 bin/$(PROVIDER)-v$(VERSION_GENERIC)-darwin-amd64.tar.gz: bin/darwin-amd64/$(PROVIDER)

--- a/provider-ci/test-providers/aws/.github/workflows/build_provider.yml
+++ b/provider-ci/test-providers/aws/.github/workflows/build_provider.yml
@@ -15,6 +15,7 @@ jobs:
     env:
       PROVIDER_VERSION: ${{ inputs.version }}
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      SIGN: ${{ secrets.AZURE_SIGNING_KEY_VAULT_URI != '' }}
     strategy:
       fail-fast: true
       matrix:
@@ -68,7 +69,7 @@ jobs:
         run: make bin/${{ matrix.platform.os }}-${{ matrix.platform.arch }}/pulumi-resource-aws.exe
 
       - name: Sign windows provider
-        if: matrix.platform.os == 'windows'
+        if: matrix.platform.os == 'windows' && env.SIGN == 'true'
         run: |
           az login --service-principal \
             -u ${{ secrets.AZURE_SIGNING_CLIENT_ID }} \

--- a/provider-ci/test-providers/aws/.github/workflows/build_provider.yml
+++ b/provider-ci/test-providers/aws/.github/workflows/build_provider.yml
@@ -15,7 +15,7 @@ jobs:
     env:
       PROVIDER_VERSION: ${{ inputs.version }}
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      SIGN: ${{ secrets.AZURE_SIGNING_KEY_VAULT_URI != '' }}
+      AZURE_SIGNING_CONFIGURED: ${{ secrets.AZURE_SIGNING_CLIENT_ID != '' && secrets.AZURE_SIGNING_CLIENT_SECRET != '' && secrets.AZURE_SIGNING_TENANT_ID != '' && secrets.AZURE_SIGNING_KEY_VAULT_URI != '' }}
     strategy:
       fail-fast: true
       matrix:
@@ -61,15 +61,10 @@ jobs:
         run: make --touch provider schema
 
       - name: Build provider
-        if: matrix.platform.os != 'windows'
-        run: make bin/${{ matrix.platform.os }}-${{ matrix.platform.arch }}/pulumi-resource-aws
-
-      - name: Build windows provider
-        if: matrix.platform.os == 'windows'
-        run: make bin/${{ matrix.platform.os }}-${{ matrix.platform.arch }}/pulumi-resource-aws.exe
+        run: make "provider-${{ matrix.platform.os }}-${{ matrix.platform.arch }}"
 
       - name: Sign windows provider
-        if: matrix.platform.os == 'windows' && env.SIGN == 'true'
+        if: matrix.platform.os == 'windows' && env.AZURE_SIGNING_CONFIGURED == 'true'
         run: |
           az login --service-principal \
             -u ${{ secrets.AZURE_SIGNING_CLIENT_ID }} \

--- a/provider-ci/test-providers/aws/Makefile
+++ b/provider-ci/test-providers/aws/Makefile
@@ -326,6 +326,13 @@ bin/%/$(PROVIDER) bin/%/$(PROVIDER).exe:
 		export CGO_ENABLED=0 && \
 		go build -o "${WORKING_DIR}/$@" $(PULUMI_PROVIDER_BUILD_PARALLELISM) -ldflags "$(LDFLAGS)" "$(PROJECT)/$(PROVIDER_PATH)/cmd/$(PROVIDER)"
 
+provider-linux-amd64: bin/linux-amd64/$(PROVIDER)
+provider-linux-arm64: bin/linux-arm64/$(PROVIDER)
+provider-darwin-amd64: bin/darwin-amd64/$(PROVIDER)
+provider-darwin-arm64: bin/darwin-arm64/$(PROVIDER)
+provider-windows-amd64: bin/windows-amd64/$(PROVIDER).exe
+.PHONY: provider-linux-amd64 provider-linux-arm64 provider-darwin-amd64 provider-darwin-arm64 provider-windows-amd64
+
 bin/$(PROVIDER)-v$(VERSION_GENERIC)-linux-amd64.tar.gz: bin/linux-amd64/$(PROVIDER)
 bin/$(PROVIDER)-v$(VERSION_GENERIC)-linux-arm64.tar.gz: bin/linux-arm64/$(PROVIDER)
 bin/$(PROVIDER)-v$(VERSION_GENERIC)-darwin-amd64.tar.gz: bin/darwin-amd64/$(PROVIDER)

--- a/provider-ci/test-providers/cloudflare/.github/workflows/build_provider.yml
+++ b/provider-ci/test-providers/cloudflare/.github/workflows/build_provider.yml
@@ -15,6 +15,7 @@ jobs:
     env:
       PROVIDER_VERSION: ${{ inputs.version }}
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      SIGN: ${{ secrets.AZURE_SIGNING_KEY_VAULT_URI != '' }}
     strategy:
       fail-fast: true
       matrix:
@@ -60,7 +61,7 @@ jobs:
         run: make bin/${{ matrix.platform.os }}-${{ matrix.platform.arch }}/pulumi-resource-cloudflare.exe
 
       - name: Sign windows provider
-        if: matrix.platform.os == 'windows'
+        if: matrix.platform.os == 'windows' && env.SIGN == 'true'
         run: |
           az login --service-principal \
             -u ${{ secrets.AZURE_SIGNING_CLIENT_ID }} \

--- a/provider-ci/test-providers/cloudflare/.github/workflows/build_provider.yml
+++ b/provider-ci/test-providers/cloudflare/.github/workflows/build_provider.yml
@@ -15,7 +15,7 @@ jobs:
     env:
       PROVIDER_VERSION: ${{ inputs.version }}
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      SIGN: ${{ secrets.AZURE_SIGNING_KEY_VAULT_URI != '' }}
+      AZURE_SIGNING_CONFIGURED: ${{ secrets.AZURE_SIGNING_CLIENT_ID != '' && secrets.AZURE_SIGNING_CLIENT_SECRET != '' && secrets.AZURE_SIGNING_TENANT_ID != '' && secrets.AZURE_SIGNING_KEY_VAULT_URI != '' }}
     strategy:
       fail-fast: true
       matrix:
@@ -53,15 +53,10 @@ jobs:
         run: make --touch provider schema
 
       - name: Build provider
-        if: matrix.platform.os != 'windows'
-        run: make bin/${{ matrix.platform.os }}-${{ matrix.platform.arch }}/pulumi-resource-cloudflare
-
-      - name: Build windows provider
-        if: matrix.platform.os == 'windows'
-        run: make bin/${{ matrix.platform.os }}-${{ matrix.platform.arch }}/pulumi-resource-cloudflare.exe
+        run: make "provider-${{ matrix.platform.os }}-${{ matrix.platform.arch }}"
 
       - name: Sign windows provider
-        if: matrix.platform.os == 'windows' && env.SIGN == 'true'
+        if: matrix.platform.os == 'windows' && env.AZURE_SIGNING_CONFIGURED == 'true'
         run: |
           az login --service-principal \
             -u ${{ secrets.AZURE_SIGNING_CLIENT_ID }} \

--- a/provider-ci/test-providers/cloudflare/Makefile
+++ b/provider-ci/test-providers/cloudflare/Makefile
@@ -322,6 +322,13 @@ bin/%/$(PROVIDER) bin/%/$(PROVIDER).exe:
 		export CGO_ENABLED=0 && \
 		go build -o "${WORKING_DIR}/$@" $(PULUMI_PROVIDER_BUILD_PARALLELISM) -ldflags "$(LDFLAGS)" "$(PROJECT)/$(PROVIDER_PATH)/cmd/$(PROVIDER)"
 
+provider-linux-amd64: bin/linux-amd64/$(PROVIDER)
+provider-linux-arm64: bin/linux-arm64/$(PROVIDER)
+provider-darwin-amd64: bin/darwin-amd64/$(PROVIDER)
+provider-darwin-arm64: bin/darwin-arm64/$(PROVIDER)
+provider-windows-amd64: bin/windows-amd64/$(PROVIDER).exe
+.PHONY: provider-linux-amd64 provider-linux-arm64 provider-darwin-amd64 provider-darwin-arm64 provider-windows-amd64
+
 bin/$(PROVIDER)-v$(VERSION_GENERIC)-linux-amd64.tar.gz: bin/linux-amd64/$(PROVIDER)
 bin/$(PROVIDER)-v$(VERSION_GENERIC)-linux-arm64.tar.gz: bin/linux-arm64/$(PROVIDER)
 bin/$(PROVIDER)-v$(VERSION_GENERIC)-darwin-amd64.tar.gz: bin/darwin-amd64/$(PROVIDER)

--- a/provider-ci/test-providers/docker/.github/workflows/build_provider.yml
+++ b/provider-ci/test-providers/docker/.github/workflows/build_provider.yml
@@ -15,7 +15,7 @@ jobs:
     env:
       PROVIDER_VERSION: ${{ inputs.version }}
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      SIGN: ${{ secrets.AZURE_SIGNING_KEY_VAULT_URI != '' }}
+      AZURE_SIGNING_CONFIGURED: ${{ secrets.AZURE_SIGNING_CLIENT_ID != '' && secrets.AZURE_SIGNING_CLIENT_SECRET != '' && secrets.AZURE_SIGNING_TENANT_ID != '' && secrets.AZURE_SIGNING_KEY_VAULT_URI != '' }}
     strategy:
       fail-fast: true
       matrix:
@@ -53,15 +53,10 @@ jobs:
         run: make --touch provider schema
 
       - name: Build provider
-        if: matrix.platform.os != 'windows'
-        run: make bin/${{ matrix.platform.os }}-${{ matrix.platform.arch }}/pulumi-resource-docker
-
-      - name: Build windows provider
-        if: matrix.platform.os == 'windows'
-        run: make bin/${{ matrix.platform.os }}-${{ matrix.platform.arch }}/pulumi-resource-docker.exe
+        run: make "provider-${{ matrix.platform.os }}-${{ matrix.platform.arch }}"
 
       - name: Sign windows provider
-        if: matrix.platform.os == 'windows' && env.SIGN == 'true'
+        if: matrix.platform.os == 'windows' && env.AZURE_SIGNING_CONFIGURED == 'true'
         run: |
           az login --service-principal \
             -u ${{ secrets.AZURE_SIGNING_CLIENT_ID }} \

--- a/provider-ci/test-providers/docker/.github/workflows/build_provider.yml
+++ b/provider-ci/test-providers/docker/.github/workflows/build_provider.yml
@@ -15,6 +15,7 @@ jobs:
     env:
       PROVIDER_VERSION: ${{ inputs.version }}
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      SIGN: ${{ secrets.AZURE_SIGNING_KEY_VAULT_URI != '' }}
     strategy:
       fail-fast: true
       matrix:
@@ -60,7 +61,7 @@ jobs:
         run: make bin/${{ matrix.platform.os }}-${{ matrix.platform.arch }}/pulumi-resource-docker.exe
 
       - name: Sign windows provider
-        if: matrix.platform.os == 'windows'
+        if: matrix.platform.os == 'windows' && env.SIGN == 'true'
         run: |
           az login --service-principal \
             -u ${{ secrets.AZURE_SIGNING_CLIENT_ID }} \

--- a/provider-ci/test-providers/docker/Makefile
+++ b/provider-ci/test-providers/docker/Makefile
@@ -325,6 +325,13 @@ bin/%/$(PROVIDER) bin/%/$(PROVIDER).exe:
 		export CGO_ENABLED=0 && \
 		go build -o "${WORKING_DIR}/$@" $(PULUMI_PROVIDER_BUILD_PARALLELISM) -ldflags "$(LDFLAGS)" "$(PROJECT)/$(PROVIDER_PATH)/cmd/$(PROVIDER)"
 
+provider-linux-amd64: bin/linux-amd64/$(PROVIDER)
+provider-linux-arm64: bin/linux-arm64/$(PROVIDER)
+provider-darwin-amd64: bin/darwin-amd64/$(PROVIDER)
+provider-darwin-arm64: bin/darwin-arm64/$(PROVIDER)
+provider-windows-amd64: bin/windows-amd64/$(PROVIDER).exe
+.PHONY: provider-linux-amd64 provider-linux-arm64 provider-darwin-amd64 provider-darwin-arm64 provider-windows-amd64
+
 bin/$(PROVIDER)-v$(VERSION_GENERIC)-linux-amd64.tar.gz: bin/linux-amd64/$(PROVIDER)
 bin/$(PROVIDER)-v$(VERSION_GENERIC)-linux-arm64.tar.gz: bin/linux-arm64/$(PROVIDER)
 bin/$(PROVIDER)-v$(VERSION_GENERIC)-darwin-amd64.tar.gz: bin/darwin-amd64/$(PROVIDER)


### PR DESCRIPTION
The addition of signing Windows binaries unconditionally broke the setup for non-Pulumi managed providers:

https://github.com/pulumi/ci-mgmt/pull/1202#issuecomment-2530623379

This PR checks if the signing secrets have been configured and skips the signing step when not configured, as is currently the case for the providers I manage.

This is tested for the `acme` provider:

* [commit](https://github.com/pulumiverse/pulumi-acme/pull/95/commits/16ad22e76f06a89290c19b2a453ba7e019acb708)
* [corresponding run which skips "Sign Windows provider"](https://github.com/pulumiverse/pulumi-acme/actions/runs/12251907770/job/34177631020)