### PR TITLE
Verify actual published Python SDK version

### DIFF
--- a/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/publish.yml
+++ b/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/publish.yml
@@ -104,6 +104,8 @@ jobs:
     name: publish_sdk
     needs: publish
     runs-on: #{{ .Config.Runner.Default }}#
+    outputs:
+      python_version: ${{ steps.python_version.outputs.version }}
     steps:
     - name: Checkout Repo
       uses: #{{ .Config.ActionVersions.Checkout }}#
@@ -147,6 +149,13 @@ jobs:
           go.*
           go/**
           !*.tar.gz
+    - name: Extract python version
+      id: python_version
+      working-directory: sdk/python
+      run: |
+        pip install toml-cli==0.7.0
+        version=$(toml get --toml-path pyproject.toml project.version)
+        echo "version=${version}" >> "$GITHUB_OUTPUT"
 
 #{{- if .Config.PublishRegistry }}#
   create_docs_build:
@@ -204,3 +213,4 @@ jobs:
       # Prelease is run often but we only have 5 concurrent macos runners, so we only test after the stable release.
       enableMacosRunner: ${{ inputs.isPrerelease == false }}
       skipGoSdk: ${{ inputs.skipGoSdk }}
+      pythonVersion: ${{ needs.publish_sdk.outputs.python_version }}

--- a/provider-ci/internal/pkg/templates/provider/.github/workflows/verify-release.yml
+++ b/provider-ci/internal/pkg/templates/provider/.github/workflows/verify-release.yml
@@ -96,7 +96,8 @@ jobs:
           runtime: python
           directory: #{{ .Config.ReleaseVerification.Python }}#
           provider: #{{ .Config.Provider }}#
-          providerVersion: ${{ inputs.pythonVersion || inputs.providerVersion }}
+          providerVersion: ${{ inputs.providerVersion }}
+          packageVersion: ${{ inputs.pythonVersion || inputs.providerVersion }}
 #{{- end }}#
 #{{- if .Config.ReleaseVerification.Dotnet }}#
       - name: Verify dotnet release

--- a/provider-ci/internal/pkg/templates/provider/.github/workflows/verify-release.yml
+++ b/provider-ci/internal/pkg/templates/provider/.github/workflows/verify-release.yml
@@ -16,6 +16,10 @@ on:
         required: false
         type: boolean
         default: false
+      pythonVersion:
+        description: "Optional python SDK version to verify. Defaults to inputs.providerVersion."
+        type: string
+        required: false
   workflow_call:
     inputs:
       providerVersion:
@@ -32,6 +36,10 @@ on:
         required: false
         type: boolean
         default: false
+      pythonVersion:
+        description: "Optional python SDK version to verify. Defaults to inputs.providerVersion."
+        type: string
+        required: false
 
 env:
 #{{ .Config.Env | toYaml | indent 2 }}#
@@ -88,7 +96,7 @@ jobs:
           runtime: python
           directory: #{{ .Config.ReleaseVerification.Python }}#
           provider: #{{ .Config.Provider }}#
-          providerVersion: ${{ inputs.providerVersion }}
+          providerVersion: ${{ inputs.pythonVersion || inputs.providerVersion }}
 #{{- end }}#
 #{{- if .Config.ReleaseVerification.Dotnet }}#
       - name: Verify dotnet release

--- a/provider-ci/test-providers/acme/.github/workflows/publish.yml
+++ b/provider-ci/test-providers/acme/.github/workflows/publish.yml
@@ -100,6 +100,8 @@ jobs:
     name: publish_sdk
     needs: publish
     runs-on: ubuntu-latest
+    outputs:
+      python_version: ${{ steps.python_version.outputs.version }}
     steps:
     - name: Checkout Repo
       uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -140,6 +142,13 @@ jobs:
           go.*
           go/**
           !*.tar.gz
+    - name: Extract python version
+      id: python_version
+      working-directory: sdk/python
+      run: |
+        pip install toml-cli==0.7.0
+        version=$(toml get --toml-path pyproject.toml project.version)
+        echo "version=${version}" >> "$GITHUB_OUTPUT"
 
   clean_up_release_labels:
     name: Clean up release labels
@@ -172,3 +181,4 @@ jobs:
       # Prelease is run often but we only have 5 concurrent macos runners, so we only test after the stable release.
       enableMacosRunner: ${{ inputs.isPrerelease == false }}
       skipGoSdk: ${{ inputs.skipGoSdk }}
+      pythonVersion: ${{ needs.publish_sdk.outputs.python_version }}

--- a/provider-ci/test-providers/acme/.github/workflows/verify-release.yml
+++ b/provider-ci/test-providers/acme/.github/workflows/verify-release.yml
@@ -16,6 +16,10 @@ on:
         required: false
         type: boolean
         default: false
+      pythonVersion:
+        description: "Optional python SDK version to verify. Defaults to inputs.providerVersion."
+        type: string
+        required: false
   workflow_call:
     inputs:
       providerVersion:
@@ -32,6 +36,10 @@ on:
         required: false
         type: boolean
         default: false
+      pythonVersion:
+        description: "Optional python SDK version to verify. Defaults to inputs.providerVersion."
+        type: string
+        required: false
 
 env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/provider-ci/test-providers/aws/.github/workflows/publish.yml
+++ b/provider-ci/test-providers/aws/.github/workflows/publish.yml
@@ -116,6 +116,8 @@ jobs:
     name: publish_sdk
     needs: publish
     runs-on: ubuntu-latest
+    outputs:
+      python_version: ${{ steps.python_version.outputs.version }}
     steps:
     - name: Checkout Repo
       uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -157,6 +159,13 @@ jobs:
           go.*
           go/**
           !*.tar.gz
+    - name: Extract python version
+      id: python_version
+      working-directory: sdk/python
+      run: |
+        pip install toml-cli==0.7.0
+        version=$(toml get --toml-path pyproject.toml project.version)
+        echo "version=${version}" >> "$GITHUB_OUTPUT"
   create_docs_build:
     name: create_docs_build
     needs: publish_sdk
@@ -208,3 +217,4 @@ jobs:
       # Prelease is run often but we only have 5 concurrent macos runners, so we only test after the stable release.
       enableMacosRunner: ${{ inputs.isPrerelease == false }}
       skipGoSdk: ${{ inputs.skipGoSdk }}
+      pythonVersion: ${{ needs.publish_sdk.outputs.python_version }}

--- a/provider-ci/test-providers/aws/.github/workflows/verify-release.yml
+++ b/provider-ci/test-providers/aws/.github/workflows/verify-release.yml
@@ -16,6 +16,10 @@ on:
         required: false
         type: boolean
         default: false
+      pythonVersion:
+        description: "Optional python SDK version to verify. Defaults to inputs.providerVersion."
+        type: string
+        required: false
   workflow_call:
     inputs:
       providerVersion:
@@ -32,6 +36,10 @@ on:
         required: false
         type: boolean
         default: false
+      pythonVersion:
+        description: "Optional python SDK version to verify. Defaults to inputs.providerVersion."
+        type: string
+        required: false
 
 env:
   AWS_REGION: us-west-2

--- a/provider-ci/test-providers/cloudflare/.github/workflows/publish.yml
+++ b/provider-ci/test-providers/cloudflare/.github/workflows/publish.yml
@@ -114,6 +114,8 @@ jobs:
     name: publish_sdk
     needs: publish
     runs-on: ubuntu-latest
+    outputs:
+      python_version: ${{ steps.python_version.outputs.version }}
     steps:
     - name: Checkout Repo
       uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -154,6 +156,13 @@ jobs:
           go.*
           go/**
           !*.tar.gz
+    - name: Extract python version
+      id: python_version
+      working-directory: sdk/python
+      run: |
+        pip install toml-cli==0.7.0
+        version=$(toml get --toml-path pyproject.toml project.version)
+        echo "version=${version}" >> "$GITHUB_OUTPUT"
   create_docs_build:
     name: create_docs_build
     needs: publish_sdk
@@ -205,3 +214,4 @@ jobs:
       # Prelease is run often but we only have 5 concurrent macos runners, so we only test after the stable release.
       enableMacosRunner: ${{ inputs.isPrerelease == false }}
       skipGoSdk: ${{ inputs.skipGoSdk }}
+      pythonVersion: ${{ needs.publish_sdk.outputs.python_version }}

--- a/provider-ci/test-providers/cloudflare/.github/workflows/verify-release.yml
+++ b/provider-ci/test-providers/cloudflare/.github/workflows/verify-release.yml
@@ -16,6 +16,10 @@ on:
         required: false
         type: boolean
         default: false
+      pythonVersion:
+        description: "Optional python SDK version to verify. Defaults to inputs.providerVersion."
+        type: string
+        required: false
   workflow_call:
     inputs:
       providerVersion:
@@ -32,6 +36,10 @@ on:
         required: false
         type: boolean
         default: false
+      pythonVersion:
+        description: "Optional python SDK version to verify. Defaults to inputs.providerVersion."
+        type: string
+        required: false
 
 env:
   CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}

--- a/provider-ci/test-providers/docker/.github/workflows/publish.yml
+++ b/provider-ci/test-providers/docker/.github/workflows/publish.yml
@@ -127,6 +127,8 @@ jobs:
     name: publish_sdk
     needs: publish
     runs-on: ubuntu-latest
+    outputs:
+      python_version: ${{ steps.python_version.outputs.version }}
     steps:
     - name: Checkout Repo
       uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -167,6 +169,13 @@ jobs:
           go.*
           go/**
           !*.tar.gz
+    - name: Extract python version
+      id: python_version
+      working-directory: sdk/python
+      run: |
+        pip install toml-cli==0.7.0
+        version=$(toml get --toml-path pyproject.toml project.version)
+        echo "version=${version}" >> "$GITHUB_OUTPUT"
   create_docs_build:
     name: create_docs_build
     needs: publish_sdk
@@ -218,3 +227,4 @@ jobs:
       # Prelease is run often but we only have 5 concurrent macos runners, so we only test after the stable release.
       enableMacosRunner: ${{ inputs.isPrerelease == false }}
       skipGoSdk: ${{ inputs.skipGoSdk }}
+      pythonVersion: ${{ needs.publish_sdk.outputs.python_version }}

--- a/provider-ci/test-providers/docker/.github/workflows/verify-release.yml
+++ b/provider-ci/test-providers/docker/.github/workflows/verify-release.yml
@@ -16,6 +16,10 @@ on:
         required: false
         type: boolean
         default: false
+      pythonVersion:
+        description: "Optional python SDK version to verify. Defaults to inputs.providerVersion."
+        type: string
+        required: false
   workflow_call:
     inputs:
       providerVersion:
@@ -32,6 +36,10 @@ on:
         required: false
         type: boolean
         default: false
+      pythonVersion:
+        description: "Optional python SDK version to verify. Defaults to inputs.providerVersion."
+        type: string
+        required: false
 
 env:
   ARM_CLIENT_ID: 30e520fa-12b4-4e21-b473-9426c5ac2e1e


### PR DESCRIPTION
Fixes #1219

Extract SDK version after publishing the Python SDK. The SDK is downloaded internally by the pulumi-package-publisher action.

The xyz provider does not have a python example so we will need to manually test this against another provider.