### PR TITLE
Don't populate the Go cache from the license check job

### DIFF
--- a/provider-ci/internal/pkg/templates/provider/.github/actions/setup-tools/action.yml
+++ b/provider-ci/internal/pkg/templates/provider/.github/actions/setup-tools/action.yml
@@ -14,6 +14,12 @@ inputs:
         dotnet
         java
     default: all
+  cache-go:
+    description: |
+      Whether to enable the GitHub cache for Go. Appropriate for disabling in
+      smaller jobs that typically completely before the "real" job has an
+      opportunity to populate the cache.
+    default: "true"
 
 runs:
   using: "composite"
@@ -27,6 +33,8 @@ runs:
           provider/*.sum
           upstream/*.sum
           sdk/*.sum
+        # TODO(https://github.com/actions/setup-go/issues/316): Restore but don't save the cache.
+        cache: ${{ inputs.cache-go }}
 
     - name: Install pulumictl
       if: inputs.tools == 'all' || contains(inputs.tools, 'pulumictl')

--- a/provider-ci/internal/pkg/templates/provider/.github/workflows/license.yml
+++ b/provider-ci/internal/pkg/templates/provider/.github/workflows/license.yml
@@ -22,6 +22,7 @@ jobs:
         uses: ./.github/actions/setup-tools
         with:
           tools: go
+          cache-go: false
       - run: make upstream
       - uses: pulumi/license-check-action@main
         with:

--- a/provider-ci/test-providers/acme/.github/actions/setup-tools/action.yml
+++ b/provider-ci/test-providers/acme/.github/actions/setup-tools/action.yml
@@ -14,6 +14,12 @@ inputs:
         dotnet
         java
     default: all
+  cache-go:
+    description: |
+      Whether to enable the GitHub cache for Go. Appropriate for disabling in
+      smaller jobs that typically completely before the "real" job has an
+      opportunity to populate the cache.
+    default: "true"
 
 runs:
   using: "composite"
@@ -27,6 +33,8 @@ runs:
           provider/*.sum
           upstream/*.sum
           sdk/*.sum
+        # TODO(https://github.com/actions/setup-go/issues/316): Restore but don't save the cache.
+        cache: ${{ inputs.cache-go }}
 
     - name: Install pulumictl
       if: inputs.tools == 'all' || contains(inputs.tools, 'pulumictl')

--- a/provider-ci/test-providers/acme/.github/workflows/license.yml
+++ b/provider-ci/test-providers/acme/.github/workflows/license.yml
@@ -37,6 +37,7 @@ jobs:
         uses: ./.github/actions/setup-tools
         with:
           tools: go
+          cache-go: false
       - run: make upstream
       - uses: pulumi/license-check-action@main
         with:

--- a/provider-ci/test-providers/aws/.github/actions/setup-tools/action.yml
+++ b/provider-ci/test-providers/aws/.github/actions/setup-tools/action.yml
@@ -14,6 +14,12 @@ inputs:
         dotnet
         java
     default: all
+  cache-go:
+    description: |
+      Whether to enable the GitHub cache for Go. Appropriate for disabling in
+      smaller jobs that typically completely before the "real" job has an
+      opportunity to populate the cache.
+    default: "true"
 
 runs:
   using: "composite"
@@ -27,6 +33,8 @@ runs:
           provider/*.sum
           upstream/*.sum
           sdk/*.sum
+        # TODO(https://github.com/actions/setup-go/issues/316): Restore but don't save the cache.
+        cache: ${{ inputs.cache-go }}
 
     - name: Install pulumictl
       if: inputs.tools == 'all' || contains(inputs.tools, 'pulumictl')

--- a/provider-ci/test-providers/aws/.github/workflows/license.yml
+++ b/provider-ci/test-providers/aws/.github/workflows/license.yml
@@ -40,6 +40,7 @@ jobs:
         uses: ./.github/actions/setup-tools
         with:
           tools: go
+          cache-go: false
       - run: make upstream
       - uses: pulumi/license-check-action@main
         with:

--- a/provider-ci/test-providers/cloudflare/.github/actions/setup-tools/action.yml
+++ b/provider-ci/test-providers/cloudflare/.github/actions/setup-tools/action.yml
@@ -14,6 +14,12 @@ inputs:
         dotnet
         java
     default: all
+  cache-go:
+    description: |
+      Whether to enable the GitHub cache for Go. Appropriate for disabling in
+      smaller jobs that typically completely before the "real" job has an
+      opportunity to populate the cache.
+    default: "true"
 
 runs:
   using: "composite"
@@ -27,6 +33,8 @@ runs:
           provider/*.sum
           upstream/*.sum
           sdk/*.sum
+        # TODO(https://github.com/actions/setup-go/issues/316): Restore but don't save the cache.
+        cache: ${{ inputs.cache-go }}
 
     - name: Install pulumictl
       if: inputs.tools == 'all' || contains(inputs.tools, 'pulumictl')

--- a/provider-ci/test-providers/cloudflare/.github/workflows/license.yml
+++ b/provider-ci/test-providers/cloudflare/.github/workflows/license.yml
@@ -39,6 +39,7 @@ jobs:
         uses: ./.github/actions/setup-tools
         with:
           tools: go
+          cache-go: false
       - run: make upstream
       - uses: pulumi/license-check-action@main
         with:

--- a/provider-ci/test-providers/docker/.github/actions/setup-tools/action.yml
+++ b/provider-ci/test-providers/docker/.github/actions/setup-tools/action.yml
@@ -14,6 +14,12 @@ inputs:
         dotnet
         java
     default: all
+  cache-go:
+    description: |
+      Whether to enable the GitHub cache for Go. Appropriate for disabling in
+      smaller jobs that typically completely before the "real" job has an
+      opportunity to populate the cache.
+    default: "true"
 
 runs:
   using: "composite"
@@ -27,6 +33,8 @@ runs:
           provider/*.sum
           upstream/*.sum
           sdk/*.sum
+        # TODO(https://github.com/actions/setup-go/issues/316): Restore but don't save the cache.
+        cache: ${{ inputs.cache-go }}
 
     - name: Install pulumictl
       if: inputs.tools == 'all' || contains(inputs.tools, 'pulumictl')

--- a/provider-ci/test-providers/docker/.github/workflows/license.yml
+++ b/provider-ci/test-providers/docker/.github/workflows/license.yml
@@ -52,6 +52,7 @@ jobs:
         uses: ./.github/actions/setup-tools
         with:
           tools: go
+          cache-go: false
       - run: make upstream
       - uses: pulumi/license-check-action@main
         with:


### PR DESCRIPTION
GitHub cache artifacts are immutable, so the first job to write to the cache "wins" in the sense that all subsequent jobs will start with whatever that job happened to cache.

We currently use `setup-go` in the license check action, but this job is very quick (typically a couple minutes) and doesn't really build any artifacts or download modules. Subsequent jobs then need to re-download and re-compile all the provider's modules.

This PR disables caching for the license check job. This gives the `prerequisites` job an opportunity to more fully populate the cache.

Ideally we would only disable _writing_ to the cache, but there isn't an official way to do that yet (https://github.com/actions/setup-go/issues/316) and manually restoring the cache is fragile.