### PR TITLE
Allow root-level go.mod for setup-go caching

### DIFF
--- a/provider-ci/internal/pkg/templates/provider/.github/actions/setup-tools/action.yml
+++ b/provider-ci/internal/pkg/templates/provider/.github/actions/setup-tools/action.yml
@@ -26,7 +26,9 @@ runs:
         cache-dependency-path: |
           provider/*.sum
           upstream/*.sum
+          sdk/go/*.sum
           sdk/*.sum
+          *.sum
 
     - name: Install pulumictl
       if: inputs.tools == 'all' || contains(inputs.tools, 'pulumictl')

--- a/provider-ci/test-providers/acme/.github/actions/setup-tools/action.yml
+++ b/provider-ci/test-providers/acme/.github/actions/setup-tools/action.yml
@@ -26,7 +26,9 @@ runs:
         cache-dependency-path: |
           provider/*.sum
           upstream/*.sum
+          sdk/go/*.sum
           sdk/*.sum
+          *.sum
 
     - name: Install pulumictl
       if: inputs.tools == 'all' || contains(inputs.tools, 'pulumictl')

--- a/provider-ci/test-providers/aws/.github/actions/setup-tools/action.yml
+++ b/provider-ci/test-providers/aws/.github/actions/setup-tools/action.yml
@@ -26,7 +26,9 @@ runs:
         cache-dependency-path: |
           provider/*.sum
           upstream/*.sum
+          sdk/go/*.sum
           sdk/*.sum
+          *.sum
 
     - name: Install pulumictl
       if: inputs.tools == 'all' || contains(inputs.tools, 'pulumictl')

--- a/provider-ci/test-providers/cloudflare/.github/actions/setup-tools/action.yml
+++ b/provider-ci/test-providers/cloudflare/.github/actions/setup-tools/action.yml
@@ -26,7 +26,9 @@ runs:
         cache-dependency-path: |
           provider/*.sum
           upstream/*.sum
+          sdk/go/*.sum
           sdk/*.sum
+          *.sum
 
     - name: Install pulumictl
       if: inputs.tools == 'all' || contains(inputs.tools, 'pulumictl')

--- a/provider-ci/test-providers/docker/.github/actions/setup-tools/action.yml
+++ b/provider-ci/test-providers/docker/.github/actions/setup-tools/action.yml
@@ -26,7 +26,9 @@ runs:
         cache-dependency-path: |
           provider/*.sum
           upstream/*.sum
+          sdk/go/*.sum
           sdk/*.sum
+          *.sum
 
     - name: Install pulumictl
       if: inputs.tools == 'all' || contains(inputs.tools, 'pulumictl')


### PR DESCRIPTION
It is valid (and [preferable](https://go.dev/wiki/Modules#should-i-have-multiple-modules-in-a-single-repository)) to have a root-level `go.mod`. If one is present we should use it as a cache key for setup-go.

Additionally since there is some talk of moving the SDK's module down a level we might as well handle that case gracefully as well, even if we're not doing it at the moment.

(I would prefer to use `**/*.sum`, but we don't want Go examples to bust the cache.)