### PR TITLE
Remove `.Config.Publish.PublisherAction` in favor of renovate

### DIFF
--- a/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/publish.yml
+++ b/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/publish.yml
@@ -121,13 +121,13 @@ jobs:
         tools: pulumictl, pulumicli, #{{ range $index, $element := .Config.Languages }}##{{if $index}}#, #{{end}}##{{ $element }}##{{end}}#
     - name: Publish SDKs
       if: inputs.skipJavaSdk == false
-      uses: #{{ .Config.Publish.PublisherAction }}#
+      uses: pulumi/pulumi-package-publisher@696a0fe98f86d86ada2a842d1859f3e8c40d6cd7 # v0.0.21
       with:
         sdk: #{{ .Config.Publish.SDK }}#
         version: ${{ inputs.version }}
     - name: Publish SDKs (except Java)
       if: inputs.skipJavaSdk == true
-      uses: #{{ .Config.Publish.PublisherAction }}#
+      uses: pulumi/pulumi-package-publisher@696a0fe98f86d86ada2a842d1859f3e8c40d6cd7 # v0.0.21
       with:
         sdk: #{{ .Config.Publish.SDK }}#,!java
         version: ${{ inputs.version }}

--- a/provider-ci/internal/pkg/templates/defaults.config.yaml
+++ b/provider-ci/internal/pkg/templates/defaults.config.yaml
@@ -160,9 +160,6 @@ runner:
 # publish contains multiple properties relating to the publish jobs.
 # Used by 2 providers: https://github.com/search?q=org%3Apulumi+path%3A.ci-mgmt.yaml+%22publish%3A%22&type=code
 publish:
-  # publisherAction is the version of the pulumi-package-publisher action to use.
-  # This should be pinned to just the major version once v1 is released.
-  publisherAction: "pulumi/pulumi-package-publisher@696a0fe98f86d86ada2a842d1859f3e8c40d6cd7 # v0.0.21"
   # passed to the sdk input of pulumi-package-publisher
   # This is overridden in pulumi-local to disable python
   sdk: all


### PR DESCRIPTION
Follow-up on https://github.com/pulumi/ci-mgmt/pull/1228.

This PR removes the `.Config.Publish.PublisherAction` option. It looks like .Config.Publisher.PublisherAction hasn't worked in the last 6 months: #1007. Given that it hasn't worked (presumably by accident) and that we have heard no complaints, it seems safe to remove the option and reduce the configuration complexity in `ci-mgmt`.