### PR TITLE
Remove two references to `make upstream`

### DIFF
--- a/provider-ci/internal/pkg/templates/provider/.github/workflows/license.yml
+++ b/provider-ci/internal/pkg/templates/provider/.github/workflows/license.yml
@@ -23,7 +23,8 @@ jobs:
         with:
           tools: go
           cache-go: false
-      - run: make upstream
+      - run: make prepare_local_workspace
+        continue-on-error: true
       - uses: pulumi/license-check-action@main
         with:
           module-path: provider

--- a/provider-ci/internal/pkg/templates/provider/.github/workflows/lint.yml
+++ b/provider-ci/internal/pkg/templates/provider/.github/workflows/lint.yml
@@ -32,9 +32,9 @@ jobs:
       continue-on-error: true # this fails if there are no go:embed directives
       run: |
         git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
-    - name: prepare upstream
+    - name: prepare workspace
       continue-on-error: true
-      run: make upstream
+      run: make prepare_local_workspace
     - name: golangci-lint
       uses: golangci/golangci-lint-action@971e284b6050e8a5849b72094c50ab08da042db8 # v6
       with:

--- a/provider-ci/test-providers/acme/.github/workflows/license.yml
+++ b/provider-ci/test-providers/acme/.github/workflows/license.yml
@@ -38,7 +38,8 @@ jobs:
         with:
           tools: go
           cache-go: false
-      - run: make upstream
+      - run: make prepare_local_workspace
+        continue-on-error: true
       - uses: pulumi/license-check-action@main
         with:
           module-path: provider

--- a/provider-ci/test-providers/acme/.github/workflows/lint.yml
+++ b/provider-ci/test-providers/acme/.github/workflows/lint.yml
@@ -44,9 +44,9 @@ jobs:
       continue-on-error: true # this fails if there are no go:embed directives
       run: |
         git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
-    - name: prepare upstream
+    - name: prepare workspace
       continue-on-error: true
-      run: make upstream
+      run: make prepare_local_workspace
     - name: golangci-lint
       uses: golangci/golangci-lint-action@971e284b6050e8a5849b72094c50ab08da042db8 # v6
       with:

--- a/provider-ci/test-providers/aws/.ci-mgmt.yaml
+++ b/provider-ci/test-providers/aws/.ci-mgmt.yaml
@@ -61,5 +61,3 @@ actions:
         role-duration-seconds: 7200
         role-session-name: aws@githubActions
         role-to-assume: ${{ secrets.AWS_CI_ROLE_ARN }}
-    - name: Make upstream
-      run: make upstream

--- a/provider-ci/test-providers/aws/.github/workflows/license.yml
+++ b/provider-ci/test-providers/aws/.github/workflows/license.yml
@@ -41,7 +41,8 @@ jobs:
         with:
           tools: go
           cache-go: false
-      - run: make upstream
+      - run: make prepare_local_workspace
+        continue-on-error: true
       - uses: pulumi/license-check-action@main
         with:
           module-path: provider

--- a/provider-ci/test-providers/aws/.github/workflows/lint.yml
+++ b/provider-ci/test-providers/aws/.github/workflows/lint.yml
@@ -48,9 +48,9 @@ jobs:
       continue-on-error: true # this fails if there are no go:embed directives
       run: |
         git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
-    - name: prepare upstream
+    - name: prepare workspace
       continue-on-error: true
-      run: make upstream
+      run: make prepare_local_workspace
     - name: golangci-lint
       uses: golangci/golangci-lint-action@971e284b6050e8a5849b72094c50ab08da042db8 # v6
       with:

--- a/provider-ci/test-providers/aws/.github/workflows/test.yml
+++ b/provider-ci/test-providers/aws/.github/workflows/test.yml
@@ -97,8 +97,6 @@ jobs:
         role-duration-seconds: 7200
         role-session-name: aws@githubActions
         role-to-assume: ${{ secrets.AWS_CI_ROLE_ARN }}
-    - name: Make upstream
-      run: make upstream
     - name: Run tests
       if: matrix.testTarget == 'local'
       run: cd examples && go test -v -count=1 -cover -timeout 2h -tags=${{ matrix.language }} -skip TestPulumiExamples -parallel 4 .

--- a/provider-ci/test-providers/cloudflare/.github/workflows/license.yml
+++ b/provider-ci/test-providers/cloudflare/.github/workflows/license.yml
@@ -40,7 +40,8 @@ jobs:
         with:
           tools: go
           cache-go: false
-      - run: make upstream
+      - run: make prepare_local_workspace
+        continue-on-error: true
       - uses: pulumi/license-check-action@main
         with:
           module-path: provider

--- a/provider-ci/test-providers/cloudflare/.github/workflows/lint.yml
+++ b/provider-ci/test-providers/cloudflare/.github/workflows/lint.yml
@@ -46,9 +46,9 @@ jobs:
       continue-on-error: true # this fails if there are no go:embed directives
       run: |
         git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
-    - name: prepare upstream
+    - name: prepare workspace
       continue-on-error: true
-      run: make upstream
+      run: make prepare_local_workspace
     - name: golangci-lint
       uses: golangci/golangci-lint-action@971e284b6050e8a5849b72094c50ab08da042db8 # v6
       with:

--- a/provider-ci/test-providers/docker/.github/workflows/license.yml
+++ b/provider-ci/test-providers/docker/.github/workflows/license.yml
@@ -53,7 +53,8 @@ jobs:
         with:
           tools: go
           cache-go: false
-      - run: make upstream
+      - run: make prepare_local_workspace
+        continue-on-error: true
       - uses: pulumi/license-check-action@main
         with:
           module-path: provider

--- a/provider-ci/test-providers/docker/.github/workflows/lint.yml
+++ b/provider-ci/test-providers/docker/.github/workflows/lint.yml
@@ -59,9 +59,9 @@ jobs:
       continue-on-error: true # this fails if there are no go:embed directives
       run: |
         git grep -l 'go:embed' -- provider | xargs sed -i 's/go:embed/ goembed/g'
-    - name: prepare upstream
+    - name: prepare workspace
       continue-on-error: true
-      run: make upstream
+      run: make prepare_local_workspace
     - name: golangci-lint
       uses: golangci/golangci-lint-action@971e284b6050e8a5849b72094c50ab08da042db8 # v6
       with:


### PR DESCRIPTION
The `provider` template is already intended to be a generic base for other templates, so it shouldn't contain references to "upstream".

This changes the template to use the `prepare_local_workspace` target instead, which includes `upstream` for bridged providers.

Fixes https://github.com/pulumi/ci-mgmt/issues/1133