### PR TITLE
Always spin up KinD cluster for pulumi-kubernetes-* providers in test step

### DIFF
--- a/native-provider-ci/providers/kubernetes-cert-manager/repo/.github/workflows/build.yml
+++ b/native-provider-ci/providers/kubernetes-cert-manager/repo/.github/workflows/build.yml
@@ -339,6 +339,11 @@ jobs:
       with:
         version: v2.5.0
         token: ${{ secrets.GITHUB_TOKEN }}
+    - name: Setup KinD cluster
+      uses: helm/kind-action@0025e74a8c7512023d06dc019c617aa3cf561fde # v1.10.0
+      with:
+        cluster_name: kind-integration-tests-${{ matrix.language }}
+        node_image: kindest/node:v1.29.2
     - name: Run tests
       run: >-
         set -euo pipefail

--- a/native-provider-ci/providers/kubernetes-cert-manager/repo/.github/workflows/prerelease.yml
+++ b/native-provider-ci/providers/kubernetes-cert-manager/repo/.github/workflows/prerelease.yml
@@ -330,6 +330,11 @@ jobs:
       with:
         version: v2.5.0
         token: ${{ secrets.GITHUB_TOKEN }}
+    - name: Setup KinD cluster
+      uses: helm/kind-action@0025e74a8c7512023d06dc019c617aa3cf561fde # v1.10.0
+      with:
+        cluster_name: kind-integration-tests-${{ matrix.language }}
+        node_image: kindest/node:v1.29.2
     - name: Run tests
       run: >-
         set -euo pipefail

--- a/native-provider-ci/providers/kubernetes-cert-manager/repo/.github/workflows/release.yml
+++ b/native-provider-ci/providers/kubernetes-cert-manager/repo/.github/workflows/release.yml
@@ -330,6 +330,11 @@ jobs:
       with:
         version: v2.5.0
         token: ${{ secrets.GITHUB_TOKEN }}
+    - name: Setup KinD cluster
+      uses: helm/kind-action@0025e74a8c7512023d06dc019c617aa3cf561fde # v1.10.0
+      with:
+        cluster_name: kind-integration-tests-${{ matrix.language }}
+        node_image: kindest/node:v1.29.2
     - name: Run tests
       run: >-
         set -euo pipefail

--- a/native-provider-ci/providers/kubernetes-ingress-nginx/repo/.github/workflows/build.yml
+++ b/native-provider-ci/providers/kubernetes-ingress-nginx/repo/.github/workflows/build.yml
@@ -132,7 +132,7 @@ jobs:
     - name: Test Provider Library
       run: make test_provider
     - name: Upload coverage reports to Codecov
-      uses: codecov/codecov-action@015f24e6818733317a2da2edd6290ab26238649a # v5.0.7
+      uses: codecov/codecov-action@7f8b4b4bde536c465e797be725718b88c5d95e0e # v5.1.1
       env:
         CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
     - if: failure() && github.event_name == 'push'
@@ -339,6 +339,11 @@ jobs:
       with:
         version: v2.5.0
         token: ${{ secrets.GITHUB_TOKEN }}
+    - name: Setup KinD cluster
+      uses: helm/kind-action@0025e74a8c7512023d06dc019c617aa3cf561fde # v1.10.0
+      with:
+        cluster_name: kind-integration-tests-${{ matrix.language }}
+        node_image: kindest/node:v1.29.2
     - name: Run tests
       run: >-
         set -euo pipefail

--- a/native-provider-ci/providers/kubernetes-ingress-nginx/repo/.github/workflows/prerelease.yml
+++ b/native-provider-ci/providers/kubernetes-ingress-nginx/repo/.github/workflows/prerelease.yml
@@ -124,7 +124,7 @@ jobs:
     - name: Test Provider Library
       run: make test_provider
     - name: Upload coverage reports to Codecov
-      uses: codecov/codecov-action@015f24e6818733317a2da2edd6290ab26238649a # v5.0.7
+      uses: codecov/codecov-action@7f8b4b4bde536c465e797be725718b88c5d95e0e # v5.1.1
       env:
         CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
     - if: failure() && github.event_name == 'push'
@@ -330,6 +330,11 @@ jobs:
       with:
         version: v2.5.0
         token: ${{ secrets.GITHUB_TOKEN }}
+    - name: Setup KinD cluster
+      uses: helm/kind-action@0025e74a8c7512023d06dc019c617aa3cf561fde # v1.10.0
+      with:
+        cluster_name: kind-integration-tests-${{ matrix.language }}
+        node_image: kindest/node:v1.29.2
     - name: Run tests
       run: >-
         set -euo pipefail

--- a/native-provider-ci/providers/kubernetes-ingress-nginx/repo/.github/workflows/release.yml
+++ b/native-provider-ci/providers/kubernetes-ingress-nginx/repo/.github/workflows/release.yml
@@ -124,7 +124,7 @@ jobs:
     - name: Test Provider Library
       run: make test_provider
     - name: Upload coverage reports to Codecov
-      uses: codecov/codecov-action@015f24e6818733317a2da2edd6290ab26238649a # v5.0.7
+      uses: codecov/codecov-action@7f8b4b4bde536c465e797be725718b88c5d95e0e # v5.1.1
       env:
         CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
     - if: failure() && github.event_name == 'push'
@@ -330,6 +330,11 @@ jobs:
       with:
         version: v2.5.0
         token: ${{ secrets.GITHUB_TOKEN }}
+    - name: Setup KinD cluster
+      uses: helm/kind-action@0025e74a8c7512023d06dc019c617aa3cf561fde # v1.10.0
+      with:
+        cluster_name: kind-integration-tests-${{ matrix.language }}
+        node_image: kindest/node:v1.29.2
     - name: Run tests
       run: >-
         set -euo pipefail

--- a/native-provider-ci/providers/kubernetes-ingress-nginx/repo/.github/workflows/run-acceptance-tests.yml
+++ b/native-provider-ci/providers/kubernetes-ingress-nginx/repo/.github/workflows/run-acceptance-tests.yml
@@ -146,7 +146,7 @@ jobs:
     - name: Test Provider Library
       run: make test_provider
     - name: Upload coverage reports to Codecov
-      uses: codecov/codecov-action@015f24e6818733317a2da2edd6290ab26238649a # v5.0.7
+      uses: codecov/codecov-action@7f8b4b4bde536c465e797be725718b88c5d95e0e # v5.1.1
       env:
         CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
     - if: failure() && github.event_name == 'push'

--- a/native-provider-ci/src/steps.ts
+++ b/native-provider-ci/src/steps.ts
@@ -1270,20 +1270,24 @@ export function FreeDiskSpace(runner: string): Step {
 }
 
 export function CreateKindCluster(provider: string, name: string): Step {
-  if (
-    (provider === "kubernetes" ||
-      provider == "kubernetes-cert-manager" ||
-      provider == "kubernetes-ingress-nginx") &&
-    name === "run-acceptance-tests"
-  ) {
-    return {
-      name: "Setup KinD cluster",
-      uses: action.createKindCluster,
-      with: {
-        cluster_name: "kind-integration-tests-${{ matrix.language }}",
-        node_image: "kindest/node:v1.29.2",
-      },
-    };
+  // We always want to create a KinD cluster for any jobs in the "kubernetes-*" providers.
+  // For "kubernetes" provider, we only create a KinD cluster for the "run-acceptance-tests" job,
+  // as the other jobs will spin up GKE clusteres for testing.
+  const step = {
+    name: "Setup KinD cluster",
+    uses: action.createKindCluster,
+    with: {
+      cluster_name: "kind-integration-tests-${{ matrix.language }}",
+      node_image: "kindest/node:v1.29.2",
+    },
+  };
+
+  switch (provider) {
+    case "kubernetes":
+      return name === "run-acceptance-tests" ? step : {};
+    case "kubernetes-cert-manager":
+    case "kubernetes-ingress-nginx":
+      return step;
   }
 
   return {};

--- a/native-provider-ci/src/steps.ts
+++ b/native-provider-ci/src/steps.ts
@@ -1270,9 +1270,9 @@ export function FreeDiskSpace(runner: string): Step {
 }
 
 export function CreateKindCluster(provider: string, name: string): Step {
-  // We always want to create a KinD cluster for any jobs in the "kubernetes-*" providers.
-  // For "kubernetes" provider, we only create a KinD cluster for the "run-acceptance-tests" job,
-  // as the other jobs will spin up GKE clusteres for testing.
+  // Always create a KinD cluster for any jobs in "kubernetes-*" providers.
+  // For the "kubernetes" provider, create a KinD cluster only for the "run-acceptance-tests" job,
+  // as other jobs will use GKE clusters for testing.
   const step = {
     name: "Setup KinD cluster",
     uses: action.createKindCluster,


### PR DESCRIPTION
We need to create the KinD cluster in all workflows that run tests, not just the `run-acceptance` workflow. For the pulumi-kubernetes provider, we don't need to create a KinD cluster as we create a GKE cluster for testing instead.

Closes: https://github.com/pulumi/pulumi-kubernetes-cert-manager/issues/254