### PR TITLE
Update sentinel job for native providers

### DIFF
--- a/native-provider-ci/providers/aws-native/repo/.github/workflows/run-acceptance-tests.yml
+++ b/native-provider-ci/providers/aws-native/repo/.github/workflows/run-acceptance-tests.yml
@@ -393,7 +393,10 @@ jobs:
         state: success
         description: Sentinel checks passed
         sha: ${{ github.event.pull_request.head.sha || github.sha }}
+    permissions:
+      statuses: write
     if: github.event_name == 'repository_dispatch' ||
       github.event.pull_request.head.repo.full_name == github.repository
     needs:
     - test
+    - prerequisites

--- a/native-provider-ci/providers/command/repo/.github/workflows/run-acceptance-tests.yml
+++ b/native-provider-ci/providers/command/repo/.github/workflows/run-acceptance-tests.yml
@@ -353,10 +353,13 @@ jobs:
         state: success
         description: Sentinel checks passed
         sha: ${{ github.event.pull_request.head.sha || github.sha }}
+    permissions:
+      statuses: write
     if: github.event_name == 'repository_dispatch' ||
       github.event.pull_request.head.repo.full_name == github.repository
     needs:
     - test
+    - prerequisites
     - lint
   lint:
     runs-on: ubuntu-latest

--- a/native-provider-ci/providers/docker-build/repo/.github/workflows/run-acceptance-tests.yml
+++ b/native-provider-ci/providers/docker-build/repo/.github/workflows/run-acceptance-tests.yml
@@ -409,10 +409,13 @@ jobs:
         state: success
         description: Sentinel checks passed
         sha: ${{ github.event.pull_request.head.sha || github.sha }}
+    permissions:
+      statuses: write
     if: github.event_name == 'repository_dispatch' ||
       github.event.pull_request.head.repo.full_name == github.repository
     needs:
     - test
+    - prerequisites
     - lint
   lint:
     runs-on: ubuntu-latest

--- a/native-provider-ci/providers/google-native/repo/.github/workflows/run-acceptance-tests.yml
+++ b/native-provider-ci/providers/google-native/repo/.github/workflows/run-acceptance-tests.yml
@@ -396,7 +396,10 @@ jobs:
         state: success
         description: Sentinel checks passed
         sha: ${{ github.event.pull_request.head.sha || github.sha }}
+    permissions:
+      statuses: write
     if: github.event_name == 'repository_dispatch' ||
       github.event.pull_request.head.repo.full_name == github.repository
     needs:
     - test
+    - prerequisites

--- a/native-provider-ci/providers/kubernetes-cert-manager/repo/.github/workflows/run-acceptance-tests.yml
+++ b/native-provider-ci/providers/kubernetes-cert-manager/repo/.github/workflows/run-acceptance-tests.yml
@@ -390,10 +390,13 @@ jobs:
         state: success
         description: Sentinel checks passed
         sha: ${{ github.event.pull_request.head.sha || github.sha }}
+    permissions:
+      statuses: write
     if: github.event_name == 'repository_dispatch' ||
       github.event.pull_request.head.repo.full_name == github.repository
     needs:
     - test
+    - prerequisites
     - lint
   lint:
     runs-on: ubuntu-latest

--- a/native-provider-ci/providers/kubernetes-ingress-nginx/repo/.github/workflows/run-acceptance-tests.yml
+++ b/native-provider-ci/providers/kubernetes-ingress-nginx/repo/.github/workflows/run-acceptance-tests.yml
@@ -390,10 +390,13 @@ jobs:
         state: success
         description: Sentinel checks passed
         sha: ${{ github.event.pull_request.head.sha || github.sha }}
+    permissions:
+      statuses: write
     if: github.event_name == 'repository_dispatch' ||
       github.event.pull_request.head.repo.full_name == github.repository
     needs:
     - test
+    - prerequisites
     - lint
   lint:
     runs-on: ubuntu-latest

--- a/native-provider-ci/providers/kubernetes/repo/.github/workflows/run-acceptance-tests.yml
+++ b/native-provider-ci/providers/kubernetes/repo/.github/workflows/run-acceptance-tests.yml
@@ -425,10 +425,13 @@ jobs:
         state: success
         description: Sentinel checks passed
         sha: ${{ github.event.pull_request.head.sha || github.sha }}
+    permissions:
+      statuses: write
     if: github.event_name == 'repository_dispatch' ||
       github.event.pull_request.head.repo.full_name == github.repository
     needs:
     - test
+    - prerequisites
     - lint
   lint:
     runs-on: ubuntu-latest

--- a/native-provider-ci/src/workflows.ts
+++ b/native-provider-ci/src/workflows.ts
@@ -144,6 +144,7 @@ export function RunAcceptanceTestsWorkflow(
         .addRunsOn(opts.provider),
       test: new TestsJob(name, "test", opts).addDispatchConditional(true),
       sentinel: new EmptyJob("sentinel")
+        .addPermissions({ statuses: "write" })
         .addConditional(
           "github.event_name == 'repository_dispatch' || github.event.pull_request.head.repo.full_name == github.repository"
         )
@@ -164,7 +165,7 @@ function calculateSentinelNeeds(
   requiresLint: boolean,
   provider: string
 ): string[] {
-  const needs: string[] = ["test"];
+  const needs: string[] = ["test", "prerequisites"];
 
   if (requiresLint) {
     needs.push("lint");
@@ -1009,6 +1010,7 @@ export class EmptyJob implements NormalJob {
   name: string;
   if?: string;
   needs?: string[];
+  permissions?: any;
 
   constructor(name: string, params?: Partial<NormalJob>) {
     this.name = name;
@@ -1033,6 +1035,11 @@ export class EmptyJob implements NormalJob {
 
   addNeeds(name: string[]) {
     this.needs = name;
+    return this;
+  }
+
+  addPermissions(permissions: any) {
+    this.permissions = permissions;
     return this;
   }
 }


### PR DESCRIPTION
p-k has a weird bug https://github.com/pulumi/pulumi-kubernetes/issues/3382 where we aren't able to depend on the correct "Sentinel" check.

This updates the native sentinel job to more closely match the bridged one:
https://github.com/pulumi/ci-mgmt/blob/1243b9e2dff8ae4d4391591bcec61a38daeac0af/provider-ci/test-providers/aws/.github/workflows/run-acceptance-tests.yml#L87-L109

Other native providers don't have this problem, so I don't actually think this will resolve the issue, but it should at least help rule out any permission weirdness.

Edit: OK I ran this against p-k here https://github.com/pulumi/pulumi-kubernetes/pull/3383 and suddenly the Sentinel check is available to us! So it does seem there's something wonky about the job's settings.

Before
![image](https://github.com/user-attachments/assets/f7f48998-275a-4d40-9a5b-1be669f3d9b0)

After
![image](https://github.com/user-attachments/assets/9b85be85-2093-4435-b975-4acc2c5a75ee)
