### PR TITLE
Automatically accept SDK changes for Renovate PRs

### DIFF
--- a/native-provider-ci/providers/aws-native/repo/.github/workflows/build.yml
+++ b/native-provider-ci/providers/aws-native/repo/.github/workflows/build.yml
@@ -108,6 +108,7 @@ jobs:
     - name: Build Provider
       run: make provider
     - name: Check worktree clean
+      id: worktreeClean
       uses: pulumi/git-status-check-action@54000b91124a8dd9fd6a872cb41f5dd246a46e7c # v1.1.1
       with:
         allowed-changes: |-
@@ -225,6 +226,7 @@ jobs:
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
+      id: worktreeClean
       uses: pulumi/git-status-check-action@54000b91124a8dd9fd6a872cb41f5dd246a46e7c # v1.1.1
       with:
         allowed-changes: |-
@@ -233,6 +235,44 @@ jobs:
           sdk/go/**/pulumiUtilities.go
           sdk/nodejs/package.json
           sdk/python/pyproject.toml
+    - name: Commit ${{ matrix.language }} SDK changes for Renovate
+      if: failure() && steps.worktreeClean.outcome == 'failure' &&
+        contains(github.actor, 'renovate')
+      shell: bash
+      run: >
+        git config --global user.email "bot@pulumi.com"
+
+        git config --global user.name "pulumi-bot"
+
+        # Stash local changes and check out the PR's branch directly.
+
+        git stash
+
+        git fetch
+
+        git checkout "origin/$HEAD_REF"
+
+
+        # Apply and add our changes, but don't commit any files we expect to
+
+        # always change due to versioning.
+
+        git stash pop
+
+        git add sdk
+
+        git reset     sdk/python/*/pulumi-plugin.json     sdk/dotnet/Pulumi.*.csproj     sdk/go/*/internal/pulumiUtilities.go     sdk/nodejs/package.json     sdk/python/pyproject.toml
+
+        git commit -m 'Commit ${{ matrix.language }} SDK for Renovate'
+
+
+        # Push with pulumi-bot credentials to trigger a re-run of the
+
+        # workflow. https://github.com/orgs/community/discussions/25702
+
+        git push https://pulumi-bot:${{ secrets.PULUMI_BOT_TOKEN }}@github.com/${{ github.repository }}     "HEAD:$HEAD_REF"
+      env:
+        HEAD_REF: ${{ github.head_ref }}
     - run: git status --porcelain
     - name: Tar SDK folder
       run: tar -zcf sdk/${{ matrix.language }}.tar.gz -C sdk/${{ matrix.language }} .

--- a/native-provider-ci/providers/aws-native/repo/.github/workflows/prerelease.yml
+++ b/native-provider-ci/providers/aws-native/repo/.github/workflows/prerelease.yml
@@ -100,6 +100,7 @@ jobs:
     - name: Build Provider
       run: make provider
     - name: Check worktree clean
+      id: worktreeClean
       uses: pulumi/git-status-check-action@54000b91124a8dd9fd6a872cb41f5dd246a46e7c # v1.1.1
       with:
         allowed-changes: |-
@@ -217,6 +218,7 @@ jobs:
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
+      id: worktreeClean
       uses: pulumi/git-status-check-action@54000b91124a8dd9fd6a872cb41f5dd246a46e7c # v1.1.1
       with:
         allowed-changes: |-
@@ -225,6 +227,44 @@ jobs:
           sdk/go/**/pulumiUtilities.go
           sdk/nodejs/package.json
           sdk/python/pyproject.toml
+    - name: Commit ${{ matrix.language }} SDK changes for Renovate
+      if: failure() && steps.worktreeClean.outcome == 'failure' &&
+        contains(github.actor, 'renovate')
+      shell: bash
+      run: >
+        git config --global user.email "bot@pulumi.com"
+
+        git config --global user.name "pulumi-bot"
+
+        # Stash local changes and check out the PR's branch directly.
+
+        git stash
+
+        git fetch
+
+        git checkout "origin/$HEAD_REF"
+
+
+        # Apply and add our changes, but don't commit any files we expect to
+
+        # always change due to versioning.
+
+        git stash pop
+
+        git add sdk
+
+        git reset     sdk/python/*/pulumi-plugin.json     sdk/dotnet/Pulumi.*.csproj     sdk/go/*/internal/pulumiUtilities.go     sdk/nodejs/package.json     sdk/python/pyproject.toml
+
+        git commit -m 'Commit ${{ matrix.language }} SDK for Renovate'
+
+
+        # Push with pulumi-bot credentials to trigger a re-run of the
+
+        # workflow. https://github.com/orgs/community/discussions/25702
+
+        git push https://pulumi-bot:${{ secrets.PULUMI_BOT_TOKEN }}@github.com/${{ github.repository }}     "HEAD:$HEAD_REF"
+      env:
+        HEAD_REF: ${{ github.head_ref }}
     - run: git status --porcelain
     - name: Tar SDK folder
       run: tar -zcf sdk/${{ matrix.language }}.tar.gz -C sdk/${{ matrix.language }} .

--- a/native-provider-ci/providers/aws-native/repo/.github/workflows/release.yml
+++ b/native-provider-ci/providers/aws-native/repo/.github/workflows/release.yml
@@ -100,6 +100,7 @@ jobs:
     - name: Build Provider
       run: make provider
     - name: Check worktree clean
+      id: worktreeClean
       uses: pulumi/git-status-check-action@54000b91124a8dd9fd6a872cb41f5dd246a46e7c # v1.1.1
       with:
         allowed-changes: |-
@@ -217,6 +218,7 @@ jobs:
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
+      id: worktreeClean
       uses: pulumi/git-status-check-action@54000b91124a8dd9fd6a872cb41f5dd246a46e7c # v1.1.1
       with:
         allowed-changes: |-
@@ -225,6 +227,44 @@ jobs:
           sdk/go/**/pulumiUtilities.go
           sdk/nodejs/package.json
           sdk/python/pyproject.toml
+    - name: Commit ${{ matrix.language }} SDK changes for Renovate
+      if: failure() && steps.worktreeClean.outcome == 'failure' &&
+        contains(github.actor, 'renovate')
+      shell: bash
+      run: >
+        git config --global user.email "bot@pulumi.com"
+
+        git config --global user.name "pulumi-bot"
+
+        # Stash local changes and check out the PR's branch directly.
+
+        git stash
+
+        git fetch
+
+        git checkout "origin/$HEAD_REF"
+
+
+        # Apply and add our changes, but don't commit any files we expect to
+
+        # always change due to versioning.
+
+        git stash pop
+
+        git add sdk
+
+        git reset     sdk/python/*/pulumi-plugin.json     sdk/dotnet/Pulumi.*.csproj     sdk/go/*/internal/pulumiUtilities.go     sdk/nodejs/package.json     sdk/python/pyproject.toml
+
+        git commit -m 'Commit ${{ matrix.language }} SDK for Renovate'
+
+
+        # Push with pulumi-bot credentials to trigger a re-run of the
+
+        # workflow. https://github.com/orgs/community/discussions/25702
+
+        git push https://pulumi-bot:${{ secrets.PULUMI_BOT_TOKEN }}@github.com/${{ github.repository }}     "HEAD:$HEAD_REF"
+      env:
+        HEAD_REF: ${{ github.head_ref }}
     - run: git status --porcelain
     - name: Tar SDK folder
       run: tar -zcf sdk/${{ matrix.language }}.tar.gz -C sdk/${{ matrix.language }} .

--- a/native-provider-ci/providers/aws-native/repo/.github/workflows/run-acceptance-tests.yml
+++ b/native-provider-ci/providers/aws-native/repo/.github/workflows/run-acceptance-tests.yml
@@ -122,6 +122,7 @@ jobs:
     - name: Build Provider
       run: make provider
     - name: Check worktree clean
+      id: worktreeClean
       uses: pulumi/git-status-check-action@54000b91124a8dd9fd6a872cb41f5dd246a46e7c # v1.1.1
       with:
         allowed-changes: |-
@@ -242,6 +243,7 @@ jobs:
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
+      id: worktreeClean
       uses: pulumi/git-status-check-action@54000b91124a8dd9fd6a872cb41f5dd246a46e7c # v1.1.1
       with:
         allowed-changes: |-
@@ -250,6 +252,44 @@ jobs:
           sdk/go/**/pulumiUtilities.go
           sdk/nodejs/package.json
           sdk/python/pyproject.toml
+    - name: Commit ${{ matrix.language }} SDK changes for Renovate
+      if: failure() && steps.worktreeClean.outcome == 'failure' &&
+        contains(github.actor, 'renovate')
+      shell: bash
+      run: >
+        git config --global user.email "bot@pulumi.com"
+
+        git config --global user.name "pulumi-bot"
+
+        # Stash local changes and check out the PR's branch directly.
+
+        git stash
+
+        git fetch
+
+        git checkout "origin/$HEAD_REF"
+
+
+        # Apply and add our changes, but don't commit any files we expect to
+
+        # always change due to versioning.
+
+        git stash pop
+
+        git add sdk
+
+        git reset     sdk/python/*/pulumi-plugin.json     sdk/dotnet/Pulumi.*.csproj     sdk/go/*/internal/pulumiUtilities.go     sdk/nodejs/package.json     sdk/python/pyproject.toml
+
+        git commit -m 'Commit ${{ matrix.language }} SDK for Renovate'
+
+
+        # Push with pulumi-bot credentials to trigger a re-run of the
+
+        # workflow. https://github.com/orgs/community/discussions/25702
+
+        git push https://pulumi-bot:${{ secrets.PULUMI_BOT_TOKEN }}@github.com/${{ github.repository }}     "HEAD:$HEAD_REF"
+      env:
+        HEAD_REF: ${{ github.head_ref }}
     - run: git status --porcelain
     - name: Tar SDK folder
       run: tar -zcf sdk/${{ matrix.language }}.tar.gz -C sdk/${{ matrix.language }} .

--- a/native-provider-ci/providers/command/repo/.github/workflows/build.yml
+++ b/native-provider-ci/providers/command/repo/.github/workflows/build.yml
@@ -73,6 +73,7 @@ jobs:
     - name: Build Provider
       run: make provider
     - name: Check worktree clean
+      id: worktreeClean
       uses: pulumi/git-status-check-action@54000b91124a8dd9fd6a872cb41f5dd246a46e7c # v1.1.1
       with:
         allowed-changes: |-
@@ -176,6 +177,7 @@ jobs:
     - name: Generate SDK
       run: make ${{ matrix.language }}_sdk
     - name: Check worktree clean
+      id: worktreeClean
       uses: pulumi/git-status-check-action@54000b91124a8dd9fd6a872cb41f5dd246a46e7c # v1.1.1
       with:
         allowed-changes: |-
@@ -184,6 +186,44 @@ jobs:
           sdk/go/**/pulumiUtilities.go
           sdk/nodejs/package.json
           sdk/python/pyproject.toml
+    - name: Commit ${{ matrix.language }} SDK changes for Renovate
+      if: failure() && steps.worktreeClean.outcome == 'failure' &&
+        contains(github.actor, 'renovate')
+      shell: bash
+      run: >
+        git config --global user.email "bot@pulumi.com"
+
+        git config --global user.name "pulumi-bot"
+
+        # Stash local changes and check out the PR's branch directly.
+
+        git stash
+
+        git fetch
+
+        git checkout "origin/$HEAD_REF"
+
+
+        # Apply and add our changes, but don't commit any files we expect to
+
+        # always change due to versioning.
+
+        git stash pop
+
+        git add sdk
+
+        git reset     sdk/python/*/pulumi-plugin.json     sdk/dotnet/Pulumi.*.csproj     sdk/go/*/internal/pulumiUtilities.go     sdk/nodejs/package.json     sdk/python/pyproject.toml
+
+        git commit -m 'Commit ${{ matrix.language }} SDK for Renovate'
+
+
+        # Push with pulumi-bot credentials to trigger a re-run of the
+
+        # workflow. https://github.com/orgs/community/discussions/25702
+
+        git push https://pulumi-bot:${{ secrets.PULUMI_BOT_TOKEN }}@github.com/${{ github.repository }}     "HEAD:$HEAD_REF"
+      env:
+        HEAD_REF: ${{ github.head_ref }}
     - run: git status --porcelain
     - name: Tar SDK folder
       run: tar -zcf sdk/${{ matrix.language }}.tar.gz -C sdk/${{ matrix.language }} .

--- a/native-provider-ci/providers/command/repo/.github/workflows/prerelease.yml
+++ b/native-provider-ci/providers/command/repo/.github/workflows/prerelease.yml
@@ -65,6 +65,7 @@ jobs:
     - name: Build Provider
       run: make provider
     - name: Check worktree clean
+      id: worktreeClean
       uses: pulumi/git-status-check-action@54000b91124a8dd9fd6a872cb41f5dd246a46e7c # v1.1.1
       with:
         allowed-changes: |-
@@ -168,6 +169,7 @@ jobs:
     - name: Generate SDK
       run: make ${{ matrix.language }}_sdk
     - name: Check worktree clean
+      id: worktreeClean
       uses: pulumi/git-status-check-action@54000b91124a8dd9fd6a872cb41f5dd246a46e7c # v1.1.1
       with:
         allowed-changes: |-
@@ -176,6 +178,44 @@ jobs:
           sdk/go/**/pulumiUtilities.go
           sdk/nodejs/package.json
           sdk/python/pyproject.toml
+    - name: Commit ${{ matrix.language }} SDK changes for Renovate
+      if: failure() && steps.worktreeClean.outcome == 'failure' &&
+        contains(github.actor, 'renovate')
+      shell: bash
+      run: >
+        git config --global user.email "bot@pulumi.com"
+
+        git config --global user.name "pulumi-bot"
+
+        # Stash local changes and check out the PR's branch directly.
+
+        git stash
+
+        git fetch
+
+        git checkout "origin/$HEAD_REF"
+
+
+        # Apply and add our changes, but don't commit any files we expect to
+
+        # always change due to versioning.
+
+        git stash pop
+
+        git add sdk
+
+        git reset     sdk/python/*/pulumi-plugin.json     sdk/dotnet/Pulumi.*.csproj     sdk/go/*/internal/pulumiUtilities.go     sdk/nodejs/package.json     sdk/python/pyproject.toml
+
+        git commit -m 'Commit ${{ matrix.language }} SDK for Renovate'
+
+
+        # Push with pulumi-bot credentials to trigger a re-run of the
+
+        # workflow. https://github.com/orgs/community/discussions/25702
+
+        git push https://pulumi-bot:${{ secrets.PULUMI_BOT_TOKEN }}@github.com/${{ github.repository }}     "HEAD:$HEAD_REF"
+      env:
+        HEAD_REF: ${{ github.head_ref }}
     - run: git status --porcelain
     - name: Tar SDK folder
       run: tar -zcf sdk/${{ matrix.language }}.tar.gz -C sdk/${{ matrix.language }} .

--- a/native-provider-ci/providers/command/repo/.github/workflows/release.yml
+++ b/native-provider-ci/providers/command/repo/.github/workflows/release.yml
@@ -65,6 +65,7 @@ jobs:
     - name: Build Provider
       run: make provider
     - name: Check worktree clean
+      id: worktreeClean
       uses: pulumi/git-status-check-action@54000b91124a8dd9fd6a872cb41f5dd246a46e7c # v1.1.1
       with:
         allowed-changes: |-
@@ -168,6 +169,7 @@ jobs:
     - name: Generate SDK
       run: make ${{ matrix.language }}_sdk
     - name: Check worktree clean
+      id: worktreeClean
       uses: pulumi/git-status-check-action@54000b91124a8dd9fd6a872cb41f5dd246a46e7c # v1.1.1
       with:
         allowed-changes: |-
@@ -176,6 +178,44 @@ jobs:
           sdk/go/**/pulumiUtilities.go
           sdk/nodejs/package.json
           sdk/python/pyproject.toml
+    - name: Commit ${{ matrix.language }} SDK changes for Renovate
+      if: failure() && steps.worktreeClean.outcome == 'failure' &&
+        contains(github.actor, 'renovate')
+      shell: bash
+      run: >
+        git config --global user.email "bot@pulumi.com"
+
+        git config --global user.name "pulumi-bot"
+
+        # Stash local changes and check out the PR's branch directly.
+
+        git stash
+
+        git fetch
+
+        git checkout "origin/$HEAD_REF"
+
+
+        # Apply and add our changes, but don't commit any files we expect to
+
+        # always change due to versioning.
+
+        git stash pop
+
+        git add sdk
+
+        git reset     sdk/python/*/pulumi-plugin.json     sdk/dotnet/Pulumi.*.csproj     sdk/go/*/internal/pulumiUtilities.go     sdk/nodejs/package.json     sdk/python/pyproject.toml
+
+        git commit -m 'Commit ${{ matrix.language }} SDK for Renovate'
+
+
+        # Push with pulumi-bot credentials to trigger a re-run of the
+
+        # workflow. https://github.com/orgs/community/discussions/25702
+
+        git push https://pulumi-bot:${{ secrets.PULUMI_BOT_TOKEN }}@github.com/${{ github.repository }}     "HEAD:$HEAD_REF"
+      env:
+        HEAD_REF: ${{ github.head_ref }}
     - run: git status --porcelain
     - name: Tar SDK folder
       run: tar -zcf sdk/${{ matrix.language }}.tar.gz -C sdk/${{ matrix.language }} .

--- a/native-provider-ci/providers/command/repo/.github/workflows/run-acceptance-tests.yml
+++ b/native-provider-ci/providers/command/repo/.github/workflows/run-acceptance-tests.yml
@@ -87,6 +87,7 @@ jobs:
     - name: Build Provider
       run: make provider
     - name: Check worktree clean
+      id: worktreeClean
       uses: pulumi/git-status-check-action@54000b91124a8dd9fd6a872cb41f5dd246a46e7c # v1.1.1
       with:
         allowed-changes: |-
@@ -193,6 +194,7 @@ jobs:
     - name: Generate SDK
       run: make ${{ matrix.language }}_sdk
     - name: Check worktree clean
+      id: worktreeClean
       uses: pulumi/git-status-check-action@54000b91124a8dd9fd6a872cb41f5dd246a46e7c # v1.1.1
       with:
         allowed-changes: |-
@@ -201,6 +203,44 @@ jobs:
           sdk/go/**/pulumiUtilities.go
           sdk/nodejs/package.json
           sdk/python/pyproject.toml
+    - name: Commit ${{ matrix.language }} SDK changes for Renovate
+      if: failure() && steps.worktreeClean.outcome == 'failure' &&
+        contains(github.actor, 'renovate')
+      shell: bash
+      run: >
+        git config --global user.email "bot@pulumi.com"
+
+        git config --global user.name "pulumi-bot"
+
+        # Stash local changes and check out the PR's branch directly.
+
+        git stash
+
+        git fetch
+
+        git checkout "origin/$HEAD_REF"
+
+
+        # Apply and add our changes, but don't commit any files we expect to
+
+        # always change due to versioning.
+
+        git stash pop
+
+        git add sdk
+
+        git reset     sdk/python/*/pulumi-plugin.json     sdk/dotnet/Pulumi.*.csproj     sdk/go/*/internal/pulumiUtilities.go     sdk/nodejs/package.json     sdk/python/pyproject.toml
+
+        git commit -m 'Commit ${{ matrix.language }} SDK for Renovate'
+
+
+        # Push with pulumi-bot credentials to trigger a re-run of the
+
+        # workflow. https://github.com/orgs/community/discussions/25702
+
+        git push https://pulumi-bot:${{ secrets.PULUMI_BOT_TOKEN }}@github.com/${{ github.repository }}     "HEAD:$HEAD_REF"
+      env:
+        HEAD_REF: ${{ github.head_ref }}
     - run: git status --porcelain
     - name: Tar SDK folder
       run: tar -zcf sdk/${{ matrix.language }}.tar.gz -C sdk/${{ matrix.language }} .

--- a/native-provider-ci/providers/docker-build/repo/.github/workflows/build.yml
+++ b/native-provider-ci/providers/docker-build/repo/.github/workflows/build.yml
@@ -118,6 +118,7 @@ jobs:
     - name: Build Provider
       run: make provider
     - name: Check worktree clean
+      id: worktreeClean
       uses: pulumi/git-status-check-action@54000b91124a8dd9fd6a872cb41f5dd246a46e7c # v1.1.1
       with:
         allowed-changes: |-
@@ -222,6 +223,7 @@ jobs:
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
+      id: worktreeClean
       uses: pulumi/git-status-check-action@54000b91124a8dd9fd6a872cb41f5dd246a46e7c # v1.1.1
       with:
         allowed-changes: |-
@@ -230,6 +232,44 @@ jobs:
           sdk/go/**/pulumiUtilities.go
           sdk/nodejs/package.json
           sdk/python/pyproject.toml
+    - name: Commit ${{ matrix.language }} SDK changes for Renovate
+      if: failure() && steps.worktreeClean.outcome == 'failure' &&
+        contains(github.actor, 'renovate')
+      shell: bash
+      run: >
+        git config --global user.email "bot@pulumi.com"
+
+        git config --global user.name "pulumi-bot"
+
+        # Stash local changes and check out the PR's branch directly.
+
+        git stash
+
+        git fetch
+
+        git checkout "origin/$HEAD_REF"
+
+
+        # Apply and add our changes, but don't commit any files we expect to
+
+        # always change due to versioning.
+
+        git stash pop
+
+        git add sdk
+
+        git reset     sdk/python/*/pulumi-plugin.json     sdk/dotnet/Pulumi.*.csproj     sdk/go/*/internal/pulumiUtilities.go     sdk/nodejs/package.json     sdk/python/pyproject.toml
+
+        git commit -m 'Commit ${{ matrix.language }} SDK for Renovate'
+
+
+        # Push with pulumi-bot credentials to trigger a re-run of the
+
+        # workflow. https://github.com/orgs/community/discussions/25702
+
+        git push https://pulumi-bot:${{ secrets.PULUMI_BOT_TOKEN }}@github.com/${{ github.repository }}     "HEAD:$HEAD_REF"
+      env:
+        HEAD_REF: ${{ github.head_ref }}
     - run: git status --porcelain
     - name: Tar SDK folder
       run: tar -zcf sdk/${{ matrix.language }}.tar.gz -C sdk/${{ matrix.language }} .

--- a/native-provider-ci/providers/docker-build/repo/.github/workflows/prerelease.yml
+++ b/native-provider-ci/providers/docker-build/repo/.github/workflows/prerelease.yml
@@ -110,6 +110,7 @@ jobs:
     - name: Build Provider
       run: make provider
     - name: Check worktree clean
+      id: worktreeClean
       uses: pulumi/git-status-check-action@54000b91124a8dd9fd6a872cb41f5dd246a46e7c # v1.1.1
       with:
         allowed-changes: |-
@@ -214,6 +215,7 @@ jobs:
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
+      id: worktreeClean
       uses: pulumi/git-status-check-action@54000b91124a8dd9fd6a872cb41f5dd246a46e7c # v1.1.1
       with:
         allowed-changes: |-
@@ -222,6 +224,44 @@ jobs:
           sdk/go/**/pulumiUtilities.go
           sdk/nodejs/package.json
           sdk/python/pyproject.toml
+    - name: Commit ${{ matrix.language }} SDK changes for Renovate
+      if: failure() && steps.worktreeClean.outcome == 'failure' &&
+        contains(github.actor, 'renovate')
+      shell: bash
+      run: >
+        git config --global user.email "bot@pulumi.com"
+
+        git config --global user.name "pulumi-bot"
+
+        # Stash local changes and check out the PR's branch directly.
+
+        git stash
+
+        git fetch
+
+        git checkout "origin/$HEAD_REF"
+
+
+        # Apply and add our changes, but don't commit any files we expect to
+
+        # always change due to versioning.
+
+        git stash pop
+
+        git add sdk
+
+        git reset     sdk/python/*/pulumi-plugin.json     sdk/dotnet/Pulumi.*.csproj     sdk/go/*/internal/pulumiUtilities.go     sdk/nodejs/package.json     sdk/python/pyproject.toml
+
+        git commit -m 'Commit ${{ matrix.language }} SDK for Renovate'
+
+
+        # Push with pulumi-bot credentials to trigger a re-run of the
+
+        # workflow. https://github.com/orgs/community/discussions/25702
+
+        git push https://pulumi-bot:${{ secrets.PULUMI_BOT_TOKEN }}@github.com/${{ github.repository }}     "HEAD:$HEAD_REF"
+      env:
+        HEAD_REF: ${{ github.head_ref }}
     - run: git status --porcelain
     - name: Tar SDK folder
       run: tar -zcf sdk/${{ matrix.language }}.tar.gz -C sdk/${{ matrix.language }} .

--- a/native-provider-ci/providers/docker-build/repo/.github/workflows/release.yml
+++ b/native-provider-ci/providers/docker-build/repo/.github/workflows/release.yml
@@ -110,6 +110,7 @@ jobs:
     - name: Build Provider
       run: make provider
     - name: Check worktree clean
+      id: worktreeClean
       uses: pulumi/git-status-check-action@54000b91124a8dd9fd6a872cb41f5dd246a46e7c # v1.1.1
       with:
         allowed-changes: |-
@@ -214,6 +215,7 @@ jobs:
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
+      id: worktreeClean
       uses: pulumi/git-status-check-action@54000b91124a8dd9fd6a872cb41f5dd246a46e7c # v1.1.1
       with:
         allowed-changes: |-
@@ -222,6 +224,44 @@ jobs:
           sdk/go/**/pulumiUtilities.go
           sdk/nodejs/package.json
           sdk/python/pyproject.toml
+    - name: Commit ${{ matrix.language }} SDK changes for Renovate
+      if: failure() && steps.worktreeClean.outcome == 'failure' &&
+        contains(github.actor, 'renovate')
+      shell: bash
+      run: >
+        git config --global user.email "bot@pulumi.com"
+
+        git config --global user.name "pulumi-bot"
+
+        # Stash local changes and check out the PR's branch directly.
+
+        git stash
+
+        git fetch
+
+        git checkout "origin/$HEAD_REF"
+
+
+        # Apply and add our changes, but don't commit any files we expect to
+
+        # always change due to versioning.
+
+        git stash pop
+
+        git add sdk
+
+        git reset     sdk/python/*/pulumi-plugin.json     sdk/dotnet/Pulumi.*.csproj     sdk/go/*/internal/pulumiUtilities.go     sdk/nodejs/package.json     sdk/python/pyproject.toml
+
+        git commit -m 'Commit ${{ matrix.language }} SDK for Renovate'
+
+
+        # Push with pulumi-bot credentials to trigger a re-run of the
+
+        # workflow. https://github.com/orgs/community/discussions/25702
+
+        git push https://pulumi-bot:${{ secrets.PULUMI_BOT_TOKEN }}@github.com/${{ github.repository }}     "HEAD:$HEAD_REF"
+      env:
+        HEAD_REF: ${{ github.head_ref }}
     - run: git status --porcelain
     - name: Tar SDK folder
       run: tar -zcf sdk/${{ matrix.language }}.tar.gz -C sdk/${{ matrix.language }} .

--- a/native-provider-ci/providers/docker-build/repo/.github/workflows/run-acceptance-tests.yml
+++ b/native-provider-ci/providers/docker-build/repo/.github/workflows/run-acceptance-tests.yml
@@ -132,6 +132,7 @@ jobs:
     - name: Build Provider
       run: make provider
     - name: Check worktree clean
+      id: worktreeClean
       uses: pulumi/git-status-check-action@54000b91124a8dd9fd6a872cb41f5dd246a46e7c # v1.1.1
       with:
         allowed-changes: |-
@@ -239,6 +240,7 @@ jobs:
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
+      id: worktreeClean
       uses: pulumi/git-status-check-action@54000b91124a8dd9fd6a872cb41f5dd246a46e7c # v1.1.1
       with:
         allowed-changes: |-
@@ -247,6 +249,44 @@ jobs:
           sdk/go/**/pulumiUtilities.go
           sdk/nodejs/package.json
           sdk/python/pyproject.toml
+    - name: Commit ${{ matrix.language }} SDK changes for Renovate
+      if: failure() && steps.worktreeClean.outcome == 'failure' &&
+        contains(github.actor, 'renovate')
+      shell: bash
+      run: >
+        git config --global user.email "bot@pulumi.com"
+
+        git config --global user.name "pulumi-bot"
+
+        # Stash local changes and check out the PR's branch directly.
+
+        git stash
+
+        git fetch
+
+        git checkout "origin/$HEAD_REF"
+
+
+        # Apply and add our changes, but don't commit any files we expect to
+
+        # always change due to versioning.
+
+        git stash pop
+
+        git add sdk
+
+        git reset     sdk/python/*/pulumi-plugin.json     sdk/dotnet/Pulumi.*.csproj     sdk/go/*/internal/pulumiUtilities.go     sdk/nodejs/package.json     sdk/python/pyproject.toml
+
+        git commit -m 'Commit ${{ matrix.language }} SDK for Renovate'
+
+
+        # Push with pulumi-bot credentials to trigger a re-run of the
+
+        # workflow. https://github.com/orgs/community/discussions/25702
+
+        git push https://pulumi-bot:${{ secrets.PULUMI_BOT_TOKEN }}@github.com/${{ github.repository }}     "HEAD:$HEAD_REF"
+      env:
+        HEAD_REF: ${{ github.head_ref }}
     - run: git status --porcelain
     - name: Tar SDK folder
       run: tar -zcf sdk/${{ matrix.language }}.tar.gz -C sdk/${{ matrix.language }} .

--- a/native-provider-ci/providers/google-native/repo/.github/workflows/build.yml
+++ b/native-provider-ci/providers/google-native/repo/.github/workflows/build.yml
@@ -112,6 +112,7 @@ jobs:
     - name: Build Provider
       run: make provider
     - name: Check worktree clean
+      id: worktreeClean
       uses: pulumi/git-status-check-action@54000b91124a8dd9fd6a872cb41f5dd246a46e7c # v1.1.1
       with:
         allowed-changes: |-
@@ -218,6 +219,7 @@ jobs:
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
+      id: worktreeClean
       uses: pulumi/git-status-check-action@54000b91124a8dd9fd6a872cb41f5dd246a46e7c # v1.1.1
       with:
         allowed-changes: |-
@@ -226,6 +228,44 @@ jobs:
           sdk/go/**/pulumiUtilities.go
           sdk/nodejs/package.json
           sdk/python/pyproject.toml
+    - name: Commit ${{ matrix.language }} SDK changes for Renovate
+      if: failure() && steps.worktreeClean.outcome == 'failure' &&
+        contains(github.actor, 'renovate')
+      shell: bash
+      run: >
+        git config --global user.email "bot@pulumi.com"
+
+        git config --global user.name "pulumi-bot"
+
+        # Stash local changes and check out the PR's branch directly.
+
+        git stash
+
+        git fetch
+
+        git checkout "origin/$HEAD_REF"
+
+
+        # Apply and add our changes, but don't commit any files we expect to
+
+        # always change due to versioning.
+
+        git stash pop
+
+        git add sdk
+
+        git reset     sdk/python/*/pulumi-plugin.json     sdk/dotnet/Pulumi.*.csproj     sdk/go/*/internal/pulumiUtilities.go     sdk/nodejs/package.json     sdk/python/pyproject.toml
+
+        git commit -m 'Commit ${{ matrix.language }} SDK for Renovate'
+
+
+        # Push with pulumi-bot credentials to trigger a re-run of the
+
+        # workflow. https://github.com/orgs/community/discussions/25702
+
+        git push https://pulumi-bot:${{ secrets.PULUMI_BOT_TOKEN }}@github.com/${{ github.repository }}     "HEAD:$HEAD_REF"
+      env:
+        HEAD_REF: ${{ github.head_ref }}
     - run: git status --porcelain
     - name: Tar SDK folder
       run: tar -zcf sdk/${{ matrix.language }}.tar.gz -C sdk/${{ matrix.language }} .

--- a/native-provider-ci/providers/google-native/repo/.github/workflows/prerelease.yml
+++ b/native-provider-ci/providers/google-native/repo/.github/workflows/prerelease.yml
@@ -104,6 +104,7 @@ jobs:
     - name: Build Provider
       run: make provider
     - name: Check worktree clean
+      id: worktreeClean
       uses: pulumi/git-status-check-action@54000b91124a8dd9fd6a872cb41f5dd246a46e7c # v1.1.1
       with:
         allowed-changes: |-
@@ -210,6 +211,7 @@ jobs:
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
+      id: worktreeClean
       uses: pulumi/git-status-check-action@54000b91124a8dd9fd6a872cb41f5dd246a46e7c # v1.1.1
       with:
         allowed-changes: |-
@@ -218,6 +220,44 @@ jobs:
           sdk/go/**/pulumiUtilities.go
           sdk/nodejs/package.json
           sdk/python/pyproject.toml
+    - name: Commit ${{ matrix.language }} SDK changes for Renovate
+      if: failure() && steps.worktreeClean.outcome == 'failure' &&
+        contains(github.actor, 'renovate')
+      shell: bash
+      run: >
+        git config --global user.email "bot@pulumi.com"
+
+        git config --global user.name "pulumi-bot"
+
+        # Stash local changes and check out the PR's branch directly.
+
+        git stash
+
+        git fetch
+
+        git checkout "origin/$HEAD_REF"
+
+
+        # Apply and add our changes, but don't commit any files we expect to
+
+        # always change due to versioning.
+
+        git stash pop
+
+        git add sdk
+
+        git reset     sdk/python/*/pulumi-plugin.json     sdk/dotnet/Pulumi.*.csproj     sdk/go/*/internal/pulumiUtilities.go     sdk/nodejs/package.json     sdk/python/pyproject.toml
+
+        git commit -m 'Commit ${{ matrix.language }} SDK for Renovate'
+
+
+        # Push with pulumi-bot credentials to trigger a re-run of the
+
+        # workflow. https://github.com/orgs/community/discussions/25702
+
+        git push https://pulumi-bot:${{ secrets.PULUMI_BOT_TOKEN }}@github.com/${{ github.repository }}     "HEAD:$HEAD_REF"
+      env:
+        HEAD_REF: ${{ github.head_ref }}
     - run: git status --porcelain
     - name: Tar SDK folder
       run: tar -zcf sdk/${{ matrix.language }}.tar.gz -C sdk/${{ matrix.language }} .

--- a/native-provider-ci/providers/google-native/repo/.github/workflows/release.yml
+++ b/native-provider-ci/providers/google-native/repo/.github/workflows/release.yml
@@ -104,6 +104,7 @@ jobs:
     - name: Build Provider
       run: make provider
     - name: Check worktree clean
+      id: worktreeClean
       uses: pulumi/git-status-check-action@54000b91124a8dd9fd6a872cb41f5dd246a46e7c # v1.1.1
       with:
         allowed-changes: |-
@@ -210,6 +211,7 @@ jobs:
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
+      id: worktreeClean
       uses: pulumi/git-status-check-action@54000b91124a8dd9fd6a872cb41f5dd246a46e7c # v1.1.1
       with:
         allowed-changes: |-
@@ -218,6 +220,44 @@ jobs:
           sdk/go/**/pulumiUtilities.go
           sdk/nodejs/package.json
           sdk/python/pyproject.toml
+    - name: Commit ${{ matrix.language }} SDK changes for Renovate
+      if: failure() && steps.worktreeClean.outcome == 'failure' &&
+        contains(github.actor, 'renovate')
+      shell: bash
+      run: >
+        git config --global user.email "bot@pulumi.com"
+
+        git config --global user.name "pulumi-bot"
+
+        # Stash local changes and check out the PR's branch directly.
+
+        git stash
+
+        git fetch
+
+        git checkout "origin/$HEAD_REF"
+
+
+        # Apply and add our changes, but don't commit any files we expect to
+
+        # always change due to versioning.
+
+        git stash pop
+
+        git add sdk
+
+        git reset     sdk/python/*/pulumi-plugin.json     sdk/dotnet/Pulumi.*.csproj     sdk/go/*/internal/pulumiUtilities.go     sdk/nodejs/package.json     sdk/python/pyproject.toml
+
+        git commit -m 'Commit ${{ matrix.language }} SDK for Renovate'
+
+
+        # Push with pulumi-bot credentials to trigger a re-run of the
+
+        # workflow. https://github.com/orgs/community/discussions/25702
+
+        git push https://pulumi-bot:${{ secrets.PULUMI_BOT_TOKEN }}@github.com/${{ github.repository }}     "HEAD:$HEAD_REF"
+      env:
+        HEAD_REF: ${{ github.head_ref }}
     - run: git status --porcelain
     - name: Tar SDK folder
       run: tar -zcf sdk/${{ matrix.language }}.tar.gz -C sdk/${{ matrix.language }} .

--- a/native-provider-ci/providers/google-native/repo/.github/workflows/run-acceptance-tests.yml
+++ b/native-provider-ci/providers/google-native/repo/.github/workflows/run-acceptance-tests.yml
@@ -126,6 +126,7 @@ jobs:
     - name: Build Provider
       run: make provider
     - name: Check worktree clean
+      id: worktreeClean
       uses: pulumi/git-status-check-action@54000b91124a8dd9fd6a872cb41f5dd246a46e7c # v1.1.1
       with:
         allowed-changes: |-
@@ -235,6 +236,7 @@ jobs:
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
+      id: worktreeClean
       uses: pulumi/git-status-check-action@54000b91124a8dd9fd6a872cb41f5dd246a46e7c # v1.1.1
       with:
         allowed-changes: |-
@@ -243,6 +245,44 @@ jobs:
           sdk/go/**/pulumiUtilities.go
           sdk/nodejs/package.json
           sdk/python/pyproject.toml
+    - name: Commit ${{ matrix.language }} SDK changes for Renovate
+      if: failure() && steps.worktreeClean.outcome == 'failure' &&
+        contains(github.actor, 'renovate')
+      shell: bash
+      run: >
+        git config --global user.email "bot@pulumi.com"
+
+        git config --global user.name "pulumi-bot"
+
+        # Stash local changes and check out the PR's branch directly.
+
+        git stash
+
+        git fetch
+
+        git checkout "origin/$HEAD_REF"
+
+
+        # Apply and add our changes, but don't commit any files we expect to
+
+        # always change due to versioning.
+
+        git stash pop
+
+        git add sdk
+
+        git reset     sdk/python/*/pulumi-plugin.json     sdk/dotnet/Pulumi.*.csproj     sdk/go/*/internal/pulumiUtilities.go     sdk/nodejs/package.json     sdk/python/pyproject.toml
+
+        git commit -m 'Commit ${{ matrix.language }} SDK for Renovate'
+
+
+        # Push with pulumi-bot credentials to trigger a re-run of the
+
+        # workflow. https://github.com/orgs/community/discussions/25702
+
+        git push https://pulumi-bot:${{ secrets.PULUMI_BOT_TOKEN }}@github.com/${{ github.repository }}     "HEAD:$HEAD_REF"
+      env:
+        HEAD_REF: ${{ github.head_ref }}
     - run: git status --porcelain
     - name: Tar SDK folder
       run: tar -zcf sdk/${{ matrix.language }}.tar.gz -C sdk/${{ matrix.language }} .

--- a/native-provider-ci/providers/kubernetes-cert-manager/repo/.github/workflows/build.yml
+++ b/native-provider-ci/providers/kubernetes-cert-manager/repo/.github/workflows/build.yml
@@ -111,6 +111,7 @@ jobs:
     - name: Build Provider
       run: make provider
     - name: Check worktree clean
+      id: worktreeClean
       uses: pulumi/git-status-check-action@54000b91124a8dd9fd6a872cb41f5dd246a46e7c # v1.1.1
       with:
         allowed-changes: |-
@@ -217,6 +218,7 @@ jobs:
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
+      id: worktreeClean
       uses: pulumi/git-status-check-action@54000b91124a8dd9fd6a872cb41f5dd246a46e7c # v1.1.1
       with:
         allowed-changes: |-
@@ -225,6 +227,44 @@ jobs:
           sdk/go/**/pulumiUtilities.go
           sdk/nodejs/package.json
           sdk/python/pyproject.toml
+    - name: Commit ${{ matrix.language }} SDK changes for Renovate
+      if: failure() && steps.worktreeClean.outcome == 'failure' &&
+        contains(github.actor, 'renovate')
+      shell: bash
+      run: >
+        git config --global user.email "bot@pulumi.com"
+
+        git config --global user.name "pulumi-bot"
+
+        # Stash local changes and check out the PR's branch directly.
+
+        git stash
+
+        git fetch
+
+        git checkout "origin/$HEAD_REF"
+
+
+        # Apply and add our changes, but don't commit any files we expect to
+
+        # always change due to versioning.
+
+        git stash pop
+
+        git add sdk
+
+        git reset     sdk/python/*/pulumi-plugin.json     sdk/dotnet/Pulumi.*.csproj     sdk/go/*/internal/pulumiUtilities.go     sdk/nodejs/package.json     sdk/python/pyproject.toml
+
+        git commit -m 'Commit ${{ matrix.language }} SDK for Renovate'
+
+
+        # Push with pulumi-bot credentials to trigger a re-run of the
+
+        # workflow. https://github.com/orgs/community/discussions/25702
+
+        git push https://pulumi-bot:${{ secrets.PULUMI_BOT_TOKEN }}@github.com/${{ github.repository }}     "HEAD:$HEAD_REF"
+      env:
+        HEAD_REF: ${{ github.head_ref }}
     - run: git status --porcelain
     - name: Tar SDK folder
       run: tar -zcf sdk/${{ matrix.language }}.tar.gz -C sdk/${{ matrix.language }} .

--- a/native-provider-ci/providers/kubernetes-cert-manager/repo/.github/workflows/prerelease.yml
+++ b/native-provider-ci/providers/kubernetes-cert-manager/repo/.github/workflows/prerelease.yml
@@ -103,6 +103,7 @@ jobs:
     - name: Build Provider
       run: make provider
     - name: Check worktree clean
+      id: worktreeClean
       uses: pulumi/git-status-check-action@54000b91124a8dd9fd6a872cb41f5dd246a46e7c # v1.1.1
       with:
         allowed-changes: |-
@@ -209,6 +210,7 @@ jobs:
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
+      id: worktreeClean
       uses: pulumi/git-status-check-action@54000b91124a8dd9fd6a872cb41f5dd246a46e7c # v1.1.1
       with:
         allowed-changes: |-
@@ -217,6 +219,44 @@ jobs:
           sdk/go/**/pulumiUtilities.go
           sdk/nodejs/package.json
           sdk/python/pyproject.toml
+    - name: Commit ${{ matrix.language }} SDK changes for Renovate
+      if: failure() && steps.worktreeClean.outcome == 'failure' &&
+        contains(github.actor, 'renovate')
+      shell: bash
+      run: >
+        git config --global user.email "bot@pulumi.com"
+
+        git config --global user.name "pulumi-bot"
+
+        # Stash local changes and check out the PR's branch directly.
+
+        git stash
+
+        git fetch
+
+        git checkout "origin/$HEAD_REF"
+
+
+        # Apply and add our changes, but don't commit any files we expect to
+
+        # always change due to versioning.
+
+        git stash pop
+
+        git add sdk
+
+        git reset     sdk/python/*/pulumi-plugin.json     sdk/dotnet/Pulumi.*.csproj     sdk/go/*/internal/pulumiUtilities.go     sdk/nodejs/package.json     sdk/python/pyproject.toml
+
+        git commit -m 'Commit ${{ matrix.language }} SDK for Renovate'
+
+
+        # Push with pulumi-bot credentials to trigger a re-run of the
+
+        # workflow. https://github.com/orgs/community/discussions/25702
+
+        git push https://pulumi-bot:${{ secrets.PULUMI_BOT_TOKEN }}@github.com/${{ github.repository }}     "HEAD:$HEAD_REF"
+      env:
+        HEAD_REF: ${{ github.head_ref }}
     - run: git status --porcelain
     - name: Tar SDK folder
       run: tar -zcf sdk/${{ matrix.language }}.tar.gz -C sdk/${{ matrix.language }} .

--- a/native-provider-ci/providers/kubernetes-cert-manager/repo/.github/workflows/release.yml
+++ b/native-provider-ci/providers/kubernetes-cert-manager/repo/.github/workflows/release.yml
@@ -103,6 +103,7 @@ jobs:
     - name: Build Provider
       run: make provider
     - name: Check worktree clean
+      id: worktreeClean
       uses: pulumi/git-status-check-action@54000b91124a8dd9fd6a872cb41f5dd246a46e7c # v1.1.1
       with:
         allowed-changes: |-
@@ -209,6 +210,7 @@ jobs:
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
+      id: worktreeClean
       uses: pulumi/git-status-check-action@54000b91124a8dd9fd6a872cb41f5dd246a46e7c # v1.1.1
       with:
         allowed-changes: |-
@@ -217,6 +219,44 @@ jobs:
           sdk/go/**/pulumiUtilities.go
           sdk/nodejs/package.json
           sdk/python/pyproject.toml
+    - name: Commit ${{ matrix.language }} SDK changes for Renovate
+      if: failure() && steps.worktreeClean.outcome == 'failure' &&
+        contains(github.actor, 'renovate')
+      shell: bash
+      run: >
+        git config --global user.email "bot@pulumi.com"
+
+        git config --global user.name "pulumi-bot"
+
+        # Stash local changes and check out the PR's branch directly.
+
+        git stash
+
+        git fetch
+
+        git checkout "origin/$HEAD_REF"
+
+
+        # Apply and add our changes, but don't commit any files we expect to
+
+        # always change due to versioning.
+
+        git stash pop
+
+        git add sdk
+
+        git reset     sdk/python/*/pulumi-plugin.json     sdk/dotnet/Pulumi.*.csproj     sdk/go/*/internal/pulumiUtilities.go     sdk/nodejs/package.json     sdk/python/pyproject.toml
+
+        git commit -m 'Commit ${{ matrix.language }} SDK for Renovate'
+
+
+        # Push with pulumi-bot credentials to trigger a re-run of the
+
+        # workflow. https://github.com/orgs/community/discussions/25702
+
+        git push https://pulumi-bot:${{ secrets.PULUMI_BOT_TOKEN }}@github.com/${{ github.repository }}     "HEAD:$HEAD_REF"
+      env:
+        HEAD_REF: ${{ github.head_ref }}
     - run: git status --porcelain
     - name: Tar SDK folder
       run: tar -zcf sdk/${{ matrix.language }}.tar.gz -C sdk/${{ matrix.language }} .

--- a/native-provider-ci/providers/kubernetes-cert-manager/repo/.github/workflows/run-acceptance-tests.yml
+++ b/native-provider-ci/providers/kubernetes-cert-manager/repo/.github/workflows/run-acceptance-tests.yml
@@ -125,6 +125,7 @@ jobs:
     - name: Build Provider
       run: make provider
     - name: Check worktree clean
+      id: worktreeClean
       uses: pulumi/git-status-check-action@54000b91124a8dd9fd6a872cb41f5dd246a46e7c # v1.1.1
       with:
         allowed-changes: |-
@@ -234,6 +235,7 @@ jobs:
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
+      id: worktreeClean
       uses: pulumi/git-status-check-action@54000b91124a8dd9fd6a872cb41f5dd246a46e7c # v1.1.1
       with:
         allowed-changes: |-
@@ -242,6 +244,44 @@ jobs:
           sdk/go/**/pulumiUtilities.go
           sdk/nodejs/package.json
           sdk/python/pyproject.toml
+    - name: Commit ${{ matrix.language }} SDK changes for Renovate
+      if: failure() && steps.worktreeClean.outcome == 'failure' &&
+        contains(github.actor, 'renovate')
+      shell: bash
+      run: >
+        git config --global user.email "bot@pulumi.com"
+
+        git config --global user.name "pulumi-bot"
+
+        # Stash local changes and check out the PR's branch directly.
+
+        git stash
+
+        git fetch
+
+        git checkout "origin/$HEAD_REF"
+
+
+        # Apply and add our changes, but don't commit any files we expect to
+
+        # always change due to versioning.
+
+        git stash pop
+
+        git add sdk
+
+        git reset     sdk/python/*/pulumi-plugin.json     sdk/dotnet/Pulumi.*.csproj     sdk/go/*/internal/pulumiUtilities.go     sdk/nodejs/package.json     sdk/python/pyproject.toml
+
+        git commit -m 'Commit ${{ matrix.language }} SDK for Renovate'
+
+
+        # Push with pulumi-bot credentials to trigger a re-run of the
+
+        # workflow. https://github.com/orgs/community/discussions/25702
+
+        git push https://pulumi-bot:${{ secrets.PULUMI_BOT_TOKEN }}@github.com/${{ github.repository }}     "HEAD:$HEAD_REF"
+      env:
+        HEAD_REF: ${{ github.head_ref }}
     - run: git status --porcelain
     - name: Tar SDK folder
       run: tar -zcf sdk/${{ matrix.language }}.tar.gz -C sdk/${{ matrix.language }} .

--- a/native-provider-ci/providers/kubernetes-ingress-nginx/repo/.github/workflows/build.yml
+++ b/native-provider-ci/providers/kubernetes-ingress-nginx/repo/.github/workflows/build.yml
@@ -111,6 +111,7 @@ jobs:
     - name: Build Provider
       run: make provider
     - name: Check worktree clean
+      id: worktreeClean
       uses: pulumi/git-status-check-action@54000b91124a8dd9fd6a872cb41f5dd246a46e7c # v1.1.1
       with:
         allowed-changes: |-
@@ -217,6 +218,7 @@ jobs:
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
+      id: worktreeClean
       uses: pulumi/git-status-check-action@54000b91124a8dd9fd6a872cb41f5dd246a46e7c # v1.1.1
       with:
         allowed-changes: |-
@@ -225,6 +227,44 @@ jobs:
           sdk/go/**/pulumiUtilities.go
           sdk/nodejs/package.json
           sdk/python/pyproject.toml
+    - name: Commit ${{ matrix.language }} SDK changes for Renovate
+      if: failure() && steps.worktreeClean.outcome == 'failure' &&
+        contains(github.actor, 'renovate')
+      shell: bash
+      run: >
+        git config --global user.email "bot@pulumi.com"
+
+        git config --global user.name "pulumi-bot"
+
+        # Stash local changes and check out the PR's branch directly.
+
+        git stash
+
+        git fetch
+
+        git checkout "origin/$HEAD_REF"
+
+
+        # Apply and add our changes, but don't commit any files we expect to
+
+        # always change due to versioning.
+
+        git stash pop
+
+        git add sdk
+
+        git reset     sdk/python/*/pulumi-plugin.json     sdk/dotnet/Pulumi.*.csproj     sdk/go/*/internal/pulumiUtilities.go     sdk/nodejs/package.json     sdk/python/pyproject.toml
+
+        git commit -m 'Commit ${{ matrix.language }} SDK for Renovate'
+
+
+        # Push with pulumi-bot credentials to trigger a re-run of the
+
+        # workflow. https://github.com/orgs/community/discussions/25702
+
+        git push https://pulumi-bot:${{ secrets.PULUMI_BOT_TOKEN }}@github.com/${{ github.repository }}     "HEAD:$HEAD_REF"
+      env:
+        HEAD_REF: ${{ github.head_ref }}
     - run: git status --porcelain
     - name: Tar SDK folder
       run: tar -zcf sdk/${{ matrix.language }}.tar.gz -C sdk/${{ matrix.language }} .

--- a/native-provider-ci/providers/kubernetes-ingress-nginx/repo/.github/workflows/prerelease.yml
+++ b/native-provider-ci/providers/kubernetes-ingress-nginx/repo/.github/workflows/prerelease.yml
@@ -103,6 +103,7 @@ jobs:
     - name: Build Provider
       run: make provider
     - name: Check worktree clean
+      id: worktreeClean
       uses: pulumi/git-status-check-action@54000b91124a8dd9fd6a872cb41f5dd246a46e7c # v1.1.1
       with:
         allowed-changes: |-
@@ -209,6 +210,7 @@ jobs:
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
+      id: worktreeClean
       uses: pulumi/git-status-check-action@54000b91124a8dd9fd6a872cb41f5dd246a46e7c # v1.1.1
       with:
         allowed-changes: |-
@@ -217,6 +219,44 @@ jobs:
           sdk/go/**/pulumiUtilities.go
           sdk/nodejs/package.json
           sdk/python/pyproject.toml
+    - name: Commit ${{ matrix.language }} SDK changes for Renovate
+      if: failure() && steps.worktreeClean.outcome == 'failure' &&
+        contains(github.actor, 'renovate')
+      shell: bash
+      run: >
+        git config --global user.email "bot@pulumi.com"
+
+        git config --global user.name "pulumi-bot"
+
+        # Stash local changes and check out the PR's branch directly.
+
+        git stash
+
+        git fetch
+
+        git checkout "origin/$HEAD_REF"
+
+
+        # Apply and add our changes, but don't commit any files we expect to
+
+        # always change due to versioning.
+
+        git stash pop
+
+        git add sdk
+
+        git reset     sdk/python/*/pulumi-plugin.json     sdk/dotnet/Pulumi.*.csproj     sdk/go/*/internal/pulumiUtilities.go     sdk/nodejs/package.json     sdk/python/pyproject.toml
+
+        git commit -m 'Commit ${{ matrix.language }} SDK for Renovate'
+
+
+        # Push with pulumi-bot credentials to trigger a re-run of the
+
+        # workflow. https://github.com/orgs/community/discussions/25702
+
+        git push https://pulumi-bot:${{ secrets.PULUMI_BOT_TOKEN }}@github.com/${{ github.repository }}     "HEAD:$HEAD_REF"
+      env:
+        HEAD_REF: ${{ github.head_ref }}
     - run: git status --porcelain
     - name: Tar SDK folder
       run: tar -zcf sdk/${{ matrix.language }}.tar.gz -C sdk/${{ matrix.language }} .

--- a/native-provider-ci/providers/kubernetes-ingress-nginx/repo/.github/workflows/release.yml
+++ b/native-provider-ci/providers/kubernetes-ingress-nginx/repo/.github/workflows/release.yml
@@ -103,6 +103,7 @@ jobs:
     - name: Build Provider
       run: make provider
     - name: Check worktree clean
+      id: worktreeClean
       uses: pulumi/git-status-check-action@54000b91124a8dd9fd6a872cb41f5dd246a46e7c # v1.1.1
       with:
         allowed-changes: |-
@@ -209,6 +210,7 @@ jobs:
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
+      id: worktreeClean
       uses: pulumi/git-status-check-action@54000b91124a8dd9fd6a872cb41f5dd246a46e7c # v1.1.1
       with:
         allowed-changes: |-
@@ -217,6 +219,44 @@ jobs:
           sdk/go/**/pulumiUtilities.go
           sdk/nodejs/package.json
           sdk/python/pyproject.toml
+    - name: Commit ${{ matrix.language }} SDK changes for Renovate
+      if: failure() && steps.worktreeClean.outcome == 'failure' &&
+        contains(github.actor, 'renovate')
+      shell: bash
+      run: >
+        git config --global user.email "bot@pulumi.com"
+
+        git config --global user.name "pulumi-bot"
+
+        # Stash local changes and check out the PR's branch directly.
+
+        git stash
+
+        git fetch
+
+        git checkout "origin/$HEAD_REF"
+
+
+        # Apply and add our changes, but don't commit any files we expect to
+
+        # always change due to versioning.
+
+        git stash pop
+
+        git add sdk
+
+        git reset     sdk/python/*/pulumi-plugin.json     sdk/dotnet/Pulumi.*.csproj     sdk/go/*/internal/pulumiUtilities.go     sdk/nodejs/package.json     sdk/python/pyproject.toml
+
+        git commit -m 'Commit ${{ matrix.language }} SDK for Renovate'
+
+
+        # Push with pulumi-bot credentials to trigger a re-run of the
+
+        # workflow. https://github.com/orgs/community/discussions/25702
+
+        git push https://pulumi-bot:${{ secrets.PULUMI_BOT_TOKEN }}@github.com/${{ github.repository }}     "HEAD:$HEAD_REF"
+      env:
+        HEAD_REF: ${{ github.head_ref }}
     - run: git status --porcelain
     - name: Tar SDK folder
       run: tar -zcf sdk/${{ matrix.language }}.tar.gz -C sdk/${{ matrix.language }} .

--- a/native-provider-ci/providers/kubernetes-ingress-nginx/repo/.github/workflows/run-acceptance-tests.yml
+++ b/native-provider-ci/providers/kubernetes-ingress-nginx/repo/.github/workflows/run-acceptance-tests.yml
@@ -125,6 +125,7 @@ jobs:
     - name: Build Provider
       run: make provider
     - name: Check worktree clean
+      id: worktreeClean
       uses: pulumi/git-status-check-action@54000b91124a8dd9fd6a872cb41f5dd246a46e7c # v1.1.1
       with:
         allowed-changes: |-
@@ -234,6 +235,7 @@ jobs:
     - name: Build SDK
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
+      id: worktreeClean
       uses: pulumi/git-status-check-action@54000b91124a8dd9fd6a872cb41f5dd246a46e7c # v1.1.1
       with:
         allowed-changes: |-
@@ -242,6 +244,44 @@ jobs:
           sdk/go/**/pulumiUtilities.go
           sdk/nodejs/package.json
           sdk/python/pyproject.toml
+    - name: Commit ${{ matrix.language }} SDK changes for Renovate
+      if: failure() && steps.worktreeClean.outcome == 'failure' &&
+        contains(github.actor, 'renovate')
+      shell: bash
+      run: >
+        git config --global user.email "bot@pulumi.com"
+
+        git config --global user.name "pulumi-bot"
+
+        # Stash local changes and check out the PR's branch directly.
+
+        git stash
+
+        git fetch
+
+        git checkout "origin/$HEAD_REF"
+
+
+        # Apply and add our changes, but don't commit any files we expect to
+
+        # always change due to versioning.
+
+        git stash pop
+
+        git add sdk
+
+        git reset     sdk/python/*/pulumi-plugin.json     sdk/dotnet/Pulumi.*.csproj     sdk/go/*/internal/pulumiUtilities.go     sdk/nodejs/package.json     sdk/python/pyproject.toml
+
+        git commit -m 'Commit ${{ matrix.language }} SDK for Renovate'
+
+
+        # Push with pulumi-bot credentials to trigger a re-run of the
+
+        # workflow. https://github.com/orgs/community/discussions/25702
+
+        git push https://pulumi-bot:${{ secrets.PULUMI_BOT_TOKEN }}@github.com/${{ github.repository }}     "HEAD:$HEAD_REF"
+      env:
+        HEAD_REF: ${{ github.head_ref }}
     - run: git status --porcelain
     - name: Tar SDK folder
       run: tar -zcf sdk/${{ matrix.language }}.tar.gz -C sdk/${{ matrix.language }} .

--- a/native-provider-ci/providers/kubernetes/repo/.github/workflows/build.yml
+++ b/native-provider-ci/providers/kubernetes/repo/.github/workflows/build.yml
@@ -113,6 +113,7 @@ jobs:
         number: ${{ github.event.issue.number }}
         github_token: ${{ secrets.GITHUB_TOKEN }}
     - name: Check worktree clean
+      id: worktreeClean
       uses: pulumi/git-status-check-action@54000b91124a8dd9fd6a872cb41f5dd246a46e7c # v1.1.1
       with:
         allowed-changes: |-
@@ -217,6 +218,7 @@ jobs:
     - name: Generate SDK
       run: make ${{ matrix.language }}_sdk
     - name: Check worktree clean
+      id: worktreeClean
       uses: pulumi/git-status-check-action@54000b91124a8dd9fd6a872cb41f5dd246a46e7c # v1.1.1
       with:
         allowed-changes: |-
@@ -225,6 +227,44 @@ jobs:
           sdk/go/**/pulumiUtilities.go
           sdk/nodejs/package.json
           sdk/python/pyproject.toml
+    - name: Commit ${{ matrix.language }} SDK changes for Renovate
+      if: failure() && steps.worktreeClean.outcome == 'failure' &&
+        contains(github.actor, 'renovate')
+      shell: bash
+      run: >
+        git config --global user.email "bot@pulumi.com"
+
+        git config --global user.name "pulumi-bot"
+
+        # Stash local changes and check out the PR's branch directly.
+
+        git stash
+
+        git fetch
+
+        git checkout "origin/$HEAD_REF"
+
+
+        # Apply and add our changes, but don't commit any files we expect to
+
+        # always change due to versioning.
+
+        git stash pop
+
+        git add sdk
+
+        git reset     sdk/python/*/pulumi-plugin.json     sdk/dotnet/Pulumi.*.csproj     sdk/go/*/internal/pulumiUtilities.go     sdk/nodejs/package.json     sdk/python/pyproject.toml
+
+        git commit -m 'Commit ${{ matrix.language }} SDK for Renovate'
+
+
+        # Push with pulumi-bot credentials to trigger a re-run of the
+
+        # workflow. https://github.com/orgs/community/discussions/25702
+
+        git push https://pulumi-bot:${{ secrets.PULUMI_BOT_TOKEN }}@github.com/${{ github.repository }}     "HEAD:$HEAD_REF"
+      env:
+        HEAD_REF: ${{ github.head_ref }}
     - run: git status --porcelain
     - name: Tar SDK folder
       run: tar -zcf sdk/${{ matrix.language }}.tar.gz -C sdk/${{ matrix.language }} .

--- a/native-provider-ci/providers/kubernetes/repo/.github/workflows/prerelease.yml
+++ b/native-provider-ci/providers/kubernetes/repo/.github/workflows/prerelease.yml
@@ -105,6 +105,7 @@ jobs:
         number: ${{ github.event.issue.number }}
         github_token: ${{ secrets.GITHUB_TOKEN }}
     - name: Check worktree clean
+      id: worktreeClean
       uses: pulumi/git-status-check-action@54000b91124a8dd9fd6a872cb41f5dd246a46e7c # v1.1.1
       with:
         allowed-changes: |-
@@ -209,6 +210,7 @@ jobs:
     - name: Generate SDK
       run: make ${{ matrix.language }}_sdk
     - name: Check worktree clean
+      id: worktreeClean
       uses: pulumi/git-status-check-action@54000b91124a8dd9fd6a872cb41f5dd246a46e7c # v1.1.1
       with:
         allowed-changes: |-
@@ -217,6 +219,44 @@ jobs:
           sdk/go/**/pulumiUtilities.go
           sdk/nodejs/package.json
           sdk/python/pyproject.toml
+    - name: Commit ${{ matrix.language }} SDK changes for Renovate
+      if: failure() && steps.worktreeClean.outcome == 'failure' &&
+        contains(github.actor, 'renovate')
+      shell: bash
+      run: >
+        git config --global user.email "bot@pulumi.com"
+
+        git config --global user.name "pulumi-bot"
+
+        # Stash local changes and check out the PR's branch directly.
+
+        git stash
+
+        git fetch
+
+        git checkout "origin/$HEAD_REF"
+
+
+        # Apply and add our changes, but don't commit any files we expect to
+
+        # always change due to versioning.
+
+        git stash pop
+
+        git add sdk
+
+        git reset     sdk/python/*/pulumi-plugin.json     sdk/dotnet/Pulumi.*.csproj     sdk/go/*/internal/pulumiUtilities.go     sdk/nodejs/package.json     sdk/python/pyproject.toml
+
+        git commit -m 'Commit ${{ matrix.language }} SDK for Renovate'
+
+
+        # Push with pulumi-bot credentials to trigger a re-run of the
+
+        # workflow. https://github.com/orgs/community/discussions/25702
+
+        git push https://pulumi-bot:${{ secrets.PULUMI_BOT_TOKEN }}@github.com/${{ github.repository }}     "HEAD:$HEAD_REF"
+      env:
+        HEAD_REF: ${{ github.head_ref }}
     - run: git status --porcelain
     - name: Tar SDK folder
       run: tar -zcf sdk/${{ matrix.language }}.tar.gz -C sdk/${{ matrix.language }} .

--- a/native-provider-ci/providers/kubernetes/repo/.github/workflows/release.yml
+++ b/native-provider-ci/providers/kubernetes/repo/.github/workflows/release.yml
@@ -105,6 +105,7 @@ jobs:
         number: ${{ github.event.issue.number }}
         github_token: ${{ secrets.GITHUB_TOKEN }}
     - name: Check worktree clean
+      id: worktreeClean
       uses: pulumi/git-status-check-action@54000b91124a8dd9fd6a872cb41f5dd246a46e7c # v1.1.1
       with:
         allowed-changes: |-
@@ -209,6 +210,7 @@ jobs:
     - name: Generate SDK
       run: make ${{ matrix.language }}_sdk
     - name: Check worktree clean
+      id: worktreeClean
       uses: pulumi/git-status-check-action@54000b91124a8dd9fd6a872cb41f5dd246a46e7c # v1.1.1
       with:
         allowed-changes: |-
@@ -217,6 +219,44 @@ jobs:
           sdk/go/**/pulumiUtilities.go
           sdk/nodejs/package.json
           sdk/python/pyproject.toml
+    - name: Commit ${{ matrix.language }} SDK changes for Renovate
+      if: failure() && steps.worktreeClean.outcome == 'failure' &&
+        contains(github.actor, 'renovate')
+      shell: bash
+      run: >
+        git config --global user.email "bot@pulumi.com"
+
+        git config --global user.name "pulumi-bot"
+
+        # Stash local changes and check out the PR's branch directly.
+
+        git stash
+
+        git fetch
+
+        git checkout "origin/$HEAD_REF"
+
+
+        # Apply and add our changes, but don't commit any files we expect to
+
+        # always change due to versioning.
+
+        git stash pop
+
+        git add sdk
+
+        git reset     sdk/python/*/pulumi-plugin.json     sdk/dotnet/Pulumi.*.csproj     sdk/go/*/internal/pulumiUtilities.go     sdk/nodejs/package.json     sdk/python/pyproject.toml
+
+        git commit -m 'Commit ${{ matrix.language }} SDK for Renovate'
+
+
+        # Push with pulumi-bot credentials to trigger a re-run of the
+
+        # workflow. https://github.com/orgs/community/discussions/25702
+
+        git push https://pulumi-bot:${{ secrets.PULUMI_BOT_TOKEN }}@github.com/${{ github.repository }}     "HEAD:$HEAD_REF"
+      env:
+        HEAD_REF: ${{ github.head_ref }}
     - run: git status --porcelain
     - name: Tar SDK folder
       run: tar -zcf sdk/${{ matrix.language }}.tar.gz -C sdk/${{ matrix.language }} .

--- a/native-provider-ci/providers/kubernetes/repo/.github/workflows/run-acceptance-tests.yml
+++ b/native-provider-ci/providers/kubernetes/repo/.github/workflows/run-acceptance-tests.yml
@@ -127,6 +127,7 @@ jobs:
         number: ${{ github.event.issue.number }}
         github_token: ${{ secrets.GITHUB_TOKEN }}
     - name: Check worktree clean
+      id: worktreeClean
       uses: pulumi/git-status-check-action@54000b91124a8dd9fd6a872cb41f5dd246a46e7c # v1.1.1
       with:
         allowed-changes: |-
@@ -234,6 +235,7 @@ jobs:
     - name: Generate SDK
       run: make ${{ matrix.language }}_sdk
     - name: Check worktree clean
+      id: worktreeClean
       uses: pulumi/git-status-check-action@54000b91124a8dd9fd6a872cb41f5dd246a46e7c # v1.1.1
       with:
         allowed-changes: |-
@@ -242,6 +244,44 @@ jobs:
           sdk/go/**/pulumiUtilities.go
           sdk/nodejs/package.json
           sdk/python/pyproject.toml
+    - name: Commit ${{ matrix.language }} SDK changes for Renovate
+      if: failure() && steps.worktreeClean.outcome == 'failure' &&
+        contains(github.actor, 'renovate')
+      shell: bash
+      run: >
+        git config --global user.email "bot@pulumi.com"
+
+        git config --global user.name "pulumi-bot"
+
+        # Stash local changes and check out the PR's branch directly.
+
+        git stash
+
+        git fetch
+
+        git checkout "origin/$HEAD_REF"
+
+
+        # Apply and add our changes, but don't commit any files we expect to
+
+        # always change due to versioning.
+
+        git stash pop
+
+        git add sdk
+
+        git reset     sdk/python/*/pulumi-plugin.json     sdk/dotnet/Pulumi.*.csproj     sdk/go/*/internal/pulumiUtilities.go     sdk/nodejs/package.json     sdk/python/pyproject.toml
+
+        git commit -m 'Commit ${{ matrix.language }} SDK for Renovate'
+
+
+        # Push with pulumi-bot credentials to trigger a re-run of the
+
+        # workflow. https://github.com/orgs/community/discussions/25702
+
+        git push https://pulumi-bot:${{ secrets.PULUMI_BOT_TOKEN }}@github.com/${{ github.repository }}     "HEAD:$HEAD_REF"
+      env:
+        HEAD_REF: ${{ github.head_ref }}
     - run: git status --porcelain
     - name: Tar SDK folder
       run: tar -zcf sdk/${{ matrix.language }}.tar.gz -C sdk/${{ matrix.language }} .

--- a/native-provider-ci/src/workflows.ts
+++ b/native-provider-ci/src/workflows.ts
@@ -463,6 +463,7 @@ export class BuildSdkJob implements NormalJob {
       steps.GenerateSDKs(opts.provider),
       steps.BuildSDKs(opts.provider),
       steps.CheckCleanWorkTree(),
+      steps.CommitSDKChangesForRenovate(),
       steps.Porcelain(),
       steps.ZipSDKsStep(),
       steps.UploadSDKs(tag),

--- a/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/build_sdk.yml
+++ b/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/build_sdk.yml
@@ -18,7 +18,9 @@ jobs:
     name: build_sdk
     runs-on: #{{ if .Config.Runner.BuildSDK }}##{{- .Config.Runner.BuildSDK }}##{{ else }}##{{- .Config.Runner.Default }}##{{ end }}#
     strategy:
-      fail-fast: true
+      # We normally fail fast unless this is a PR from Renovate in which case
+      # we'll always build all SDKs in case there are any changes to commit.
+      fail-fast: ${{ ! contains(github.actor, 'renovate') }}
       matrix:
         language:
 #{{ .Config.Languages | toYaml | indent 8 }}#
@@ -60,14 +62,52 @@ jobs:
       - name: Build SDK
         run: make build_${{ matrix.language }}
       - name: Check worktree clean
+        id: worktreeClean
         uses: pulumi/git-status-check-action@v1
         with:
+          # Keep these in sync with the Renovate step below to avoid them getting checked in.
           allowed-changes: |
             sdk/**/pulumi-plugin.json
             sdk/dotnet/*.csproj
             sdk/go/**/pulumiUtilities.go
             sdk/nodejs/package.json
             sdk/python/pyproject.toml
+      - name: Commit ${{ matrix.language }} SDK changes for Renovate
+        # If the worktree is dirty and this is a Renovate PR to bump
+        # dependencies, commit the updated SDK and push it back to the PR. The
+        # job will still be marked as a failure.
+        if: failure() && steps.worktreeClean.outcome == 'failure' && contains(github.actor, 'renovate')
+        shell: bash
+        run: |
+          git config --global user.email "bot@pulumi.com"
+          git config --global user.name "pulumi-bot"
+
+          # Stash local changes and check out the PR's branch directly.
+          git stash
+          git fetch
+          git checkout "origin/$HEAD_REF"
+
+          # Apply and add our changes, but don't commit any files we expect to
+          # always change due to versioning.
+          git stash pop
+          git add sdk
+          git reset \
+              sdk/python/*/pulumi-plugin.json \
+              sdk/dotnet/Pulumi.*.csproj \
+              sdk/go/*/internal/pulumiUtilities.go \
+              sdk/nodejs/package.json \
+              sdk/python/pyproject.toml
+          git commit -m 'Commit ${{ matrix.language }} SDK for Renovate'
+
+          # Push with pulumi-bot credentials to trigger a re-run of the
+          # workflow. https://github.com/orgs/community/discussions/25702
+          git push https://pulumi-bot:${{ secrets.PULUMI_BOT_TOKEN }}@github.com/${{ github.repository }} \
+              "HEAD:$HEAD_REF"
+        env:
+          # head_ref is untrusted so it's recommended to pass via env var to
+          # avoid injections.
+          HEAD_REF: ${{ github.head_ref }}
+
       - name: Upload SDK
         uses: ./.github/actions/upload-sdk
         with:

--- a/provider-ci/test-providers/acme/.github/workflows/build_sdk.yml
+++ b/provider-ci/test-providers/acme/.github/workflows/build_sdk.yml
@@ -33,7 +33,9 @@ jobs:
     name: build_sdk
     runs-on: ubuntu-latest
     strategy:
-      fail-fast: true
+      # We normally fail fast unless this is a PR from Renovate in which case
+      # we'll always build all SDKs in case there are any changes to commit.
+      fail-fast: ${{ ! contains(github.actor, 'renovate') }}
       matrix:
         language:
         - dotnet
@@ -66,14 +68,52 @@ jobs:
       - name: Build SDK
         run: make build_${{ matrix.language }}
       - name: Check worktree clean
+        id: worktreeClean
         uses: pulumi/git-status-check-action@v1
         with:
+          # Keep these in sync with the Renovate step below to avoid them getting checked in.
           allowed-changes: |
             sdk/**/pulumi-plugin.json
             sdk/dotnet/*.csproj
             sdk/go/**/pulumiUtilities.go
             sdk/nodejs/package.json
             sdk/python/pyproject.toml
+      - name: Commit ${{ matrix.language }} SDK changes for Renovate
+        # If the worktree is dirty and this is a Renovate PR to bump
+        # dependencies, commit the updated SDK and push it back to the PR. The
+        # job will still be marked as a failure.
+        if: failure() && steps.worktreeClean.outcome == 'failure' && contains(github.actor, 'renovate')
+        shell: bash
+        run: |
+          git config --global user.email "bot@pulumi.com"
+          git config --global user.name "pulumi-bot"
+
+          # Stash local changes and check out the PR's branch directly.
+          git stash
+          git fetch
+          git checkout "origin/$HEAD_REF"
+
+          # Apply and add our changes, but don't commit any files we expect to
+          # always change due to versioning.
+          git stash pop
+          git add sdk
+          git reset \
+              sdk/python/*/pulumi-plugin.json \
+              sdk/dotnet/Pulumi.*.csproj \
+              sdk/go/*/internal/pulumiUtilities.go \
+              sdk/nodejs/package.json \
+              sdk/python/pyproject.toml
+          git commit -m 'Commit ${{ matrix.language }} SDK for Renovate'
+
+          # Push with pulumi-bot credentials to trigger a re-run of the
+          # workflow. https://github.com/orgs/community/discussions/25702
+          git push https://pulumi-bot:${{ secrets.PULUMI_BOT_TOKEN }}@github.com/${{ github.repository }} \
+              "HEAD:$HEAD_REF"
+        env:
+          # head_ref is untrusted so it's recommended to pass via env var to
+          # avoid injections.
+          HEAD_REF: ${{ github.head_ref }}
+
       - name: Upload SDK
         uses: ./.github/actions/upload-sdk
         with:

--- a/provider-ci/test-providers/aws/.github/workflows/build_sdk.yml
+++ b/provider-ci/test-providers/aws/.github/workflows/build_sdk.yml
@@ -36,7 +36,9 @@ jobs:
     name: build_sdk
     runs-on: ubuntu-latest
     strategy:
-      fail-fast: true
+      # We normally fail fast unless this is a PR from Renovate in which case
+      # we'll always build all SDKs in case there are any changes to commit.
+      fail-fast: ${{ ! contains(github.actor, 'renovate') }}
       matrix:
         language:
         - nodejs
@@ -78,14 +80,52 @@ jobs:
       - name: Build SDK
         run: make build_${{ matrix.language }}
       - name: Check worktree clean
+        id: worktreeClean
         uses: pulumi/git-status-check-action@v1
         with:
+          # Keep these in sync with the Renovate step below to avoid them getting checked in.
           allowed-changes: |
             sdk/**/pulumi-plugin.json
             sdk/dotnet/*.csproj
             sdk/go/**/pulumiUtilities.go
             sdk/nodejs/package.json
             sdk/python/pyproject.toml
+      - name: Commit ${{ matrix.language }} SDK changes for Renovate
+        # If the worktree is dirty and this is a Renovate PR to bump
+        # dependencies, commit the updated SDK and push it back to the PR. The
+        # job will still be marked as a failure.
+        if: failure() && steps.worktreeClean.outcome == 'failure' && contains(github.actor, 'renovate')
+        shell: bash
+        run: |
+          git config --global user.email "bot@pulumi.com"
+          git config --global user.name "pulumi-bot"
+
+          # Stash local changes and check out the PR's branch directly.
+          git stash
+          git fetch
+          git checkout "origin/$HEAD_REF"
+
+          # Apply and add our changes, but don't commit any files we expect to
+          # always change due to versioning.
+          git stash pop
+          git add sdk
+          git reset \
+              sdk/python/*/pulumi-plugin.json \
+              sdk/dotnet/Pulumi.*.csproj \
+              sdk/go/*/internal/pulumiUtilities.go \
+              sdk/nodejs/package.json \
+              sdk/python/pyproject.toml
+          git commit -m 'Commit ${{ matrix.language }} SDK for Renovate'
+
+          # Push with pulumi-bot credentials to trigger a re-run of the
+          # workflow. https://github.com/orgs/community/discussions/25702
+          git push https://pulumi-bot:${{ secrets.PULUMI_BOT_TOKEN }}@github.com/${{ github.repository }} \
+              "HEAD:$HEAD_REF"
+        env:
+          # head_ref is untrusted so it's recommended to pass via env var to
+          # avoid injections.
+          HEAD_REF: ${{ github.head_ref }}
+
       - name: Upload SDK
         uses: ./.github/actions/upload-sdk
         with:

--- a/provider-ci/test-providers/cloudflare/.github/workflows/build_sdk.yml
+++ b/provider-ci/test-providers/cloudflare/.github/workflows/build_sdk.yml
@@ -35,7 +35,9 @@ jobs:
     name: build_sdk
     runs-on: ubuntu-latest
     strategy:
-      fail-fast: true
+      # We normally fail fast unless this is a PR from Renovate in which case
+      # we'll always build all SDKs in case there are any changes to commit.
+      fail-fast: ${{ ! contains(github.actor, 'renovate') }}
       matrix:
         language:
         - nodejs
@@ -69,14 +71,52 @@ jobs:
       - name: Build SDK
         run: make build_${{ matrix.language }}
       - name: Check worktree clean
+        id: worktreeClean
         uses: pulumi/git-status-check-action@v1
         with:
+          # Keep these in sync with the Renovate step below to avoid them getting checked in.
           allowed-changes: |
             sdk/**/pulumi-plugin.json
             sdk/dotnet/*.csproj
             sdk/go/**/pulumiUtilities.go
             sdk/nodejs/package.json
             sdk/python/pyproject.toml
+      - name: Commit ${{ matrix.language }} SDK changes for Renovate
+        # If the worktree is dirty and this is a Renovate PR to bump
+        # dependencies, commit the updated SDK and push it back to the PR. The
+        # job will still be marked as a failure.
+        if: failure() && steps.worktreeClean.outcome == 'failure' && contains(github.actor, 'renovate')
+        shell: bash
+        run: |
+          git config --global user.email "bot@pulumi.com"
+          git config --global user.name "pulumi-bot"
+
+          # Stash local changes and check out the PR's branch directly.
+          git stash
+          git fetch
+          git checkout "origin/$HEAD_REF"
+
+          # Apply and add our changes, but don't commit any files we expect to
+          # always change due to versioning.
+          git stash pop
+          git add sdk
+          git reset \
+              sdk/python/*/pulumi-plugin.json \
+              sdk/dotnet/Pulumi.*.csproj \
+              sdk/go/*/internal/pulumiUtilities.go \
+              sdk/nodejs/package.json \
+              sdk/python/pyproject.toml
+          git commit -m 'Commit ${{ matrix.language }} SDK for Renovate'
+
+          # Push with pulumi-bot credentials to trigger a re-run of the
+          # workflow. https://github.com/orgs/community/discussions/25702
+          git push https://pulumi-bot:${{ secrets.PULUMI_BOT_TOKEN }}@github.com/${{ github.repository }} \
+              "HEAD:$HEAD_REF"
+        env:
+          # head_ref is untrusted so it's recommended to pass via env var to
+          # avoid injections.
+          HEAD_REF: ${{ github.head_ref }}
+
       - name: Upload SDK
         uses: ./.github/actions/upload-sdk
         with:

--- a/provider-ci/test-providers/docker/.github/workflows/build_sdk.yml
+++ b/provider-ci/test-providers/docker/.github/workflows/build_sdk.yml
@@ -48,7 +48,9 @@ jobs:
     name: build_sdk
     runs-on: ubuntu-latest
     strategy:
-      fail-fast: true
+      # We normally fail fast unless this is a PR from Renovate in which case
+      # we'll always build all SDKs in case there are any changes to commit.
+      fail-fast: ${{ ! contains(github.actor, 'renovate') }}
       matrix:
         language:
         - nodejs
@@ -82,14 +84,52 @@ jobs:
       - name: Build SDK
         run: make build_${{ matrix.language }}
       - name: Check worktree clean
+        id: worktreeClean
         uses: pulumi/git-status-check-action@v1
         with:
+          # Keep these in sync with the Renovate step below to avoid them getting checked in.
           allowed-changes: |
             sdk/**/pulumi-plugin.json
             sdk/dotnet/*.csproj
             sdk/go/**/pulumiUtilities.go
             sdk/nodejs/package.json
             sdk/python/pyproject.toml
+      - name: Commit ${{ matrix.language }} SDK changes for Renovate
+        # If the worktree is dirty and this is a Renovate PR to bump
+        # dependencies, commit the updated SDK and push it back to the PR. The
+        # job will still be marked as a failure.
+        if: failure() && steps.worktreeClean.outcome == 'failure' && contains(github.actor, 'renovate')
+        shell: bash
+        run: |
+          git config --global user.email "bot@pulumi.com"
+          git config --global user.name "pulumi-bot"
+
+          # Stash local changes and check out the PR's branch directly.
+          git stash
+          git fetch
+          git checkout "origin/$HEAD_REF"
+
+          # Apply and add our changes, but don't commit any files we expect to
+          # always change due to versioning.
+          git stash pop
+          git add sdk
+          git reset \
+              sdk/python/*/pulumi-plugin.json \
+              sdk/dotnet/Pulumi.*.csproj \
+              sdk/go/*/internal/pulumiUtilities.go \
+              sdk/nodejs/package.json \
+              sdk/python/pyproject.toml
+          git commit -m 'Commit ${{ matrix.language }} SDK for Renovate'
+
+          # Push with pulumi-bot credentials to trigger a re-run of the
+          # workflow. https://github.com/orgs/community/discussions/25702
+          git push https://pulumi-bot:${{ secrets.PULUMI_BOT_TOKEN }}@github.com/${{ github.repository }} \
+              "HEAD:$HEAD_REF"
+        env:
+          # head_ref is untrusted so it's recommended to pass via env var to
+          # avoid injections.
+          HEAD_REF: ${{ github.head_ref }}
+
       - name: Upload SDK
         uses: ./.github/actions/upload-sdk
         with:


### PR DESCRIPTION
We have a problem right now where automated dependency upgrades can change our generated code, and this causes tests to fail because we expect no changes in CI.

The "right" way to do this is with a hermetic `make renovate` step which can re-generate this code during the Renovate job, as @t0yv0 has started doing for EKS (e.g. https://github.com/pulumi/pulumi-eks/pull/1552). But we don't have hermetic builds so we don't yet have an easy way to get this to work across all providers.

This PR implements a suggestion from Daniel to help address the long tail. Essentially right before we fail a build for containing SDK changes, we will commit those changes and push them back to the PR -- _but only if it came from Renovate._ The build will still fail, but tests will be re-tried against the updated SDK.

Renovate has already been configured to "ignore" updates from pulumi-bot (https://github.com/pulumi/renovate-config/commit/82931a62d50a9b7a628032bdefbf3c6f64a4e895), so if tests pass it will still automatically squash and merge.

Here's an example where I manually modified the SDK and the PR was automatically corrected:

![image](https://github.com/user-attachments/assets/0f0f4912-5962-4cfc-b7b5-2e991334ea36)

Refs https://github.com/pulumi/ci-mgmt/issues/1101
Refs https://github.com/pulumi/ci-mgmt/issues/936