### PR TITLE
Fix upstream not refreshing after pull

### DIFF
--- a/provider-ci/internal/pkg/templates/bridged-provider/Makefile
+++ b/provider-ci/internal/pkg/templates/bridged-provider/Makefile
@@ -291,7 +291,7 @@ bin/$(TFGEN): provider/*.go provider/go.* .make/upstream
 # Apply patches to the upstream submodule, if it exists
 upstream: .make/upstream
 # Re-run if the upstream commit or the patches change
-.make/upstream: $(wildcard patches/*) $(wildcard .git/modules/upstream/HEAD)
+.make/upstream: $(wildcard patches/*) $(shell ./upstream.sh file_target)
 ifneq ("$(wildcard upstream)","")
 	./upstream.sh init
 endif

--- a/provider-ci/internal/pkg/templates/bridged-provider/upstream.sh
+++ b/provider-ci/internal/pkg/templates/bridged-provider/upstream.sh
@@ -23,6 +23,7 @@ COMMANDS
   check_in              Write checkedout commits back to patches, add upstream
                         and patches changes to the git staging area and exit
                         checkout mode.
+  file_target           Print a file path to depend on in make.
   help                  Print this help message, plus examples.
 
 OPTIONS
@@ -334,6 +335,21 @@ re-initializing using updated patches and updated upstream base.
 EOF
 }
 
+file_target() {
+  path=.git/modules/upstream/HEAD
+  # Don't print a file if it doesn't exist - it's probably not initialized yet.
+  if [[ ! -f "${path}" ]]; then
+    exit 0
+  fi
+  # If the submodule is changed, touch the file to trigger a re-init.
+  desired_commit=$(git ls-tree HEAD upstream | cut -d ' ' -f3 | cut -f1 || true)
+  current_commit=$(cat "${path}")
+  if [[ "${desired_commit}" != "${current_commit}" ]]; then
+    touch "${path}"
+  fi
+  echo "${path}"
+}
+
 if [[ -z ${original_cmd} ]]; then
   echo "Error: command is required."
   echo
@@ -371,6 +387,9 @@ case ${original_cmd} in
     ;;
   check_in|checkin)
     check_in "$@"
+    ;;
+  file_target)
+    file_target "$@"
     ;;
   *)
     echo "Error: unknown command \"${original_cmd}\"."

--- a/provider-ci/internal/pkg/templates/bridged-provider/upstream.sh
+++ b/provider-ci/internal/pkg/templates/bridged-provider/upstream.sh
@@ -335,6 +335,8 @@ re-initializing using updated patches and updated upstream base.
 EOF
 }
 
+# file_target prints a file path to depend on in make to trigger an init when required.
+# Also updates the file timestamp if the submodule needs updating.
 file_target() {
   path=.git/modules/upstream/HEAD
   # Don't print a file if it doesn't exist - it's probably not initialized yet.

--- a/provider-ci/test-providers/acme/Makefile
+++ b/provider-ci/test-providers/acme/Makefile
@@ -255,7 +255,7 @@ bin/$(TFGEN): provider/*.go provider/go.* .make/upstream
 # Apply patches to the upstream submodule, if it exists
 upstream: .make/upstream
 # Re-run if the upstream commit or the patches change
-.make/upstream: $(wildcard patches/*) $(wildcard .git/modules/upstream/HEAD)
+.make/upstream: $(wildcard patches/*) $(shell ./upstream.sh file_target)
 ifneq ("$(wildcard upstream)","")
 	./upstream.sh init
 endif

--- a/provider-ci/test-providers/acme/upstream.sh
+++ b/provider-ci/test-providers/acme/upstream.sh
@@ -23,6 +23,7 @@ COMMANDS
   check_in              Write checkedout commits back to patches, add upstream
                         and patches changes to the git staging area and exit
                         checkout mode.
+  file_target           Print a file path to depend on in make.
   help                  Print this help message, plus examples.
 
 OPTIONS
@@ -334,6 +335,21 @@ re-initializing using updated patches and updated upstream base.
 EOF
 }
 
+file_target() {
+  path=.git/modules/upstream/HEAD
+  # Don't print a file if it doesn't exist - it's probably not initialized yet.
+  if [[ ! -f "${path}" ]]; then
+    exit 0
+  fi
+  # If the submodule is changed, touch the file to trigger a re-init.
+  desired_commit=$(git ls-tree HEAD upstream | cut -d ' ' -f3 | cut -f1 || true)
+  current_commit=$(cat "${path}")
+  if [[ "${desired_commit}" != "${current_commit}" ]]; then
+    touch "${path}"
+  fi
+  echo "${path}"
+}
+
 if [[ -z ${original_cmd} ]]; then
   echo "Error: command is required."
   echo
@@ -371,6 +387,9 @@ case ${original_cmd} in
     ;;
   check_in|checkin)
     check_in "$@"
+    ;;
+  file_target)
+    file_target "$@"
     ;;
   *)
     echo "Error: unknown command \"${original_cmd}\"."

--- a/provider-ci/test-providers/acme/upstream.sh
+++ b/provider-ci/test-providers/acme/upstream.sh
@@ -335,6 +335,8 @@ re-initializing using updated patches and updated upstream base.
 EOF
 }
 
+# file_target prints a file path to depend on in make to trigger an init when required.
+# Also updates the file timestamp if the submodule needs updating.
 file_target() {
   path=.git/modules/upstream/HEAD
   # Don't print a file if it doesn't exist - it's probably not initialized yet.

--- a/provider-ci/test-providers/aws/Makefile
+++ b/provider-ci/test-providers/aws/Makefile
@@ -265,7 +265,7 @@ bin/$(TFGEN): provider/*.go provider/go.* .make/upstream
 # Apply patches to the upstream submodule, if it exists
 upstream: .make/upstream
 # Re-run if the upstream commit or the patches change
-.make/upstream: $(wildcard patches/*) $(wildcard .git/modules/upstream/HEAD)
+.make/upstream: $(wildcard patches/*) $(shell ./upstream.sh file_target)
 ifneq ("$(wildcard upstream)","")
 	./upstream.sh init
 endif

--- a/provider-ci/test-providers/aws/upstream.sh
+++ b/provider-ci/test-providers/aws/upstream.sh
@@ -23,6 +23,7 @@ COMMANDS
   check_in              Write checkedout commits back to patches, add upstream
                         and patches changes to the git staging area and exit
                         checkout mode.
+  file_target           Print a file path to depend on in make.
   help                  Print this help message, plus examples.
 
 OPTIONS
@@ -334,6 +335,21 @@ re-initializing using updated patches and updated upstream base.
 EOF
 }
 
+file_target() {
+  path=.git/modules/upstream/HEAD
+  # Don't print a file if it doesn't exist - it's probably not initialized yet.
+  if [[ ! -f "${path}" ]]; then
+    exit 0
+  fi
+  # If the submodule is changed, touch the file to trigger a re-init.
+  desired_commit=$(git ls-tree HEAD upstream | cut -d ' ' -f3 | cut -f1 || true)
+  current_commit=$(cat "${path}")
+  if [[ "${desired_commit}" != "${current_commit}" ]]; then
+    touch "${path}"
+  fi
+  echo "${path}"
+}
+
 if [[ -z ${original_cmd} ]]; then
   echo "Error: command is required."
   echo
@@ -371,6 +387,9 @@ case ${original_cmd} in
     ;;
   check_in|checkin)
     check_in "$@"
+    ;;
+  file_target)
+    file_target "$@"
     ;;
   *)
     echo "Error: unknown command \"${original_cmd}\"."

--- a/provider-ci/test-providers/aws/upstream.sh
+++ b/provider-ci/test-providers/aws/upstream.sh
@@ -335,6 +335,8 @@ re-initializing using updated patches and updated upstream base.
 EOF
 }
 
+# file_target prints a file path to depend on in make to trigger an init when required.
+# Also updates the file timestamp if the submodule needs updating.
 file_target() {
   path=.git/modules/upstream/HEAD
   # Don't print a file if it doesn't exist - it's probably not initialized yet.

--- a/provider-ci/test-providers/cloudflare/Makefile
+++ b/provider-ci/test-providers/cloudflare/Makefile
@@ -265,7 +265,7 @@ bin/$(TFGEN): provider/*.go provider/go.* .make/upstream
 # Apply patches to the upstream submodule, if it exists
 upstream: .make/upstream
 # Re-run if the upstream commit or the patches change
-.make/upstream: $(wildcard patches/*) $(wildcard .git/modules/upstream/HEAD)
+.make/upstream: $(wildcard patches/*) $(shell ./upstream.sh file_target)
 ifneq ("$(wildcard upstream)","")
 	./upstream.sh init
 endif

--- a/provider-ci/test-providers/cloudflare/upstream.sh
+++ b/provider-ci/test-providers/cloudflare/upstream.sh
@@ -23,6 +23,7 @@ COMMANDS
   check_in              Write checkedout commits back to patches, add upstream
                         and patches changes to the git staging area and exit
                         checkout mode.
+  file_target           Print a file path to depend on in make.
   help                  Print this help message, plus examples.
 
 OPTIONS
@@ -334,6 +335,21 @@ re-initializing using updated patches and updated upstream base.
 EOF
 }
 
+file_target() {
+  path=.git/modules/upstream/HEAD
+  # Don't print a file if it doesn't exist - it's probably not initialized yet.
+  if [[ ! -f "${path}" ]]; then
+    exit 0
+  fi
+  # If the submodule is changed, touch the file to trigger a re-init.
+  desired_commit=$(git ls-tree HEAD upstream | cut -d ' ' -f3 | cut -f1 || true)
+  current_commit=$(cat "${path}")
+  if [[ "${desired_commit}" != "${current_commit}" ]]; then
+    touch "${path}"
+  fi
+  echo "${path}"
+}
+
 if [[ -z ${original_cmd} ]]; then
   echo "Error: command is required."
   echo
@@ -371,6 +387,9 @@ case ${original_cmd} in
     ;;
   check_in|checkin)
     check_in "$@"
+    ;;
+  file_target)
+    file_target "$@"
     ;;
   *)
     echo "Error: unknown command \"${original_cmd}\"."

--- a/provider-ci/test-providers/cloudflare/upstream.sh
+++ b/provider-ci/test-providers/cloudflare/upstream.sh
@@ -335,6 +335,8 @@ re-initializing using updated patches and updated upstream base.
 EOF
 }
 
+# file_target prints a file path to depend on in make to trigger an init when required.
+# Also updates the file timestamp if the submodule needs updating.
 file_target() {
   path=.git/modules/upstream/HEAD
   # Don't print a file if it doesn't exist - it's probably not initialized yet.

--- a/provider-ci/test-providers/docker/Makefile
+++ b/provider-ci/test-providers/docker/Makefile
@@ -268,7 +268,7 @@ bin/$(TFGEN): provider/*.go provider/go.* .make/upstream
 # Apply patches to the upstream submodule, if it exists
 upstream: .make/upstream
 # Re-run if the upstream commit or the patches change
-.make/upstream: $(wildcard patches/*) $(wildcard .git/modules/upstream/HEAD)
+.make/upstream: $(wildcard patches/*) $(shell ./upstream.sh file_target)
 ifneq ("$(wildcard upstream)","")
 	./upstream.sh init
 endif

--- a/provider-ci/test-providers/docker/upstream.sh
+++ b/provider-ci/test-providers/docker/upstream.sh
@@ -23,6 +23,7 @@ COMMANDS
   check_in              Write checkedout commits back to patches, add upstream
                         and patches changes to the git staging area and exit
                         checkout mode.
+  file_target           Print a file path to depend on in make.
   help                  Print this help message, plus examples.
 
 OPTIONS
@@ -334,6 +335,21 @@ re-initializing using updated patches and updated upstream base.
 EOF
 }
 
+file_target() {
+  path=.git/modules/upstream/HEAD
+  # Don't print a file if it doesn't exist - it's probably not initialized yet.
+  if [[ ! -f "${path}" ]]; then
+    exit 0
+  fi
+  # If the submodule is changed, touch the file to trigger a re-init.
+  desired_commit=$(git ls-tree HEAD upstream | cut -d ' ' -f3 | cut -f1 || true)
+  current_commit=$(cat "${path}")
+  if [[ "${desired_commit}" != "${current_commit}" ]]; then
+    touch "${path}"
+  fi
+  echo "${path}"
+}
+
 if [[ -z ${original_cmd} ]]; then
   echo "Error: command is required."
   echo
@@ -371,6 +387,9 @@ case ${original_cmd} in
     ;;
   check_in|checkin)
     check_in "$@"
+    ;;
+  file_target)
+    file_target "$@"
     ;;
   *)
     echo "Error: unknown command \"${original_cmd}\"."

--- a/provider-ci/test-providers/docker/upstream.sh
+++ b/provider-ci/test-providers/docker/upstream.sh
@@ -335,6 +335,8 @@ re-initializing using updated patches and updated upstream base.
 EOF
 }
 
+# file_target prints a file path to depend on in make to trigger an init when required.
+# Also updates the file timestamp if the submodule needs updating.
 file_target() {
   path=.git/modules/upstream/HEAD
   # Don't print a file if it doesn't exist - it's probably not initialized yet.


### PR DESCRIPTION
When running `git pull`, the upstream HEAD will not be updated if recursive submodule checkout is not enabled (as is the default).

1. Add `./upstream.sh file_target` command which just prints the upstream HEAD file path, if it exists (mimicking the existing wildcard statement).
2. Before printing, mark the file as updated if it doesn't match the new desired commit which will then trigger the upstream init to run and update the submodule.