### PR TITLE
Revert "Run preTest actions during release verification workflow"

### DIFF
--- a/provider-ci/internal/pkg/templates/provider/.github/workflows/verify-release.yml
+++ b/provider-ci/internal/pkg/templates/provider/.github/workflows/verify-release.yml
@@ -80,9 +80,6 @@ jobs:
         with:
           tools: pulumicli, #{{ range $index, $element := .Config.Languages }}##{{if $index}}#, #{{end}}##{{ $element }}##{{end}}#
 #{{- if .Config.ReleaseVerification }}#
-#{{- if .Config.Actions.PreTest }}#
-#{{ .Config.Actions.PreTest | toYaml | indent 6 }}#
-#{{- end }}#
 #{{- if .Config.ReleaseVerification.Nodejs }}#
       - name: Verify nodejs release
         uses: pulumi/verify-provider-release@v1

--- a/provider-ci/test-providers/aws/.ci-mgmt.yaml
+++ b/provider-ci/test-providers/aws/.ci-mgmt.yaml
@@ -61,8 +61,3 @@ actions:
         role-duration-seconds: 7200
         role-session-name: aws@githubActions
         role-to-assume: ${{ secrets.AWS_CI_ROLE_ARN }}
-releaseVerification:
-  nodejs: examples/bucket
-  python: examples/webserver-py
-  dotnet: examples/webserver-cs
-  go: examples/webserver-go

--- a/provider-ci/test-providers/aws/.github/workflows/verify-release.yml
+++ b/provider-ci/test-providers/aws/.github/workflows/verify-release.yml
@@ -65,13 +65,18 @@ env:
 jobs:
   verify-release:
     name: verify-release
+    # We don't have any release verification configurations, so we never run this workflow.
+    # Configure your .ci-mgmt.yaml files to include the release verification configurations e.g.
+    # releaseVerification:
+    #   nodejs: path/to/nodejs/project
+    #   python: path/to/python/project
+    #   dotnet: path/to/dotnet/project
+    #   go: path/to/go/project
+    if: false
     strategy:
       matrix:
-        # We always run on Linux and Windows, and optionally on MacOS. This is because MacOS runners have limited availability.
-        # Expression expands to ["ubuntu-latest","windows-latest"] or ["ubuntu-latest","windows-latest","macos-latest"]
-        # GitHub expressions don't have 'if' statements, so we use a ternary operator to conditionally include the MacOS runner suffix.
-        # See the docs for a similar example to this: https://docs.github.com/en/actions/learn-github-actions/expressions#fromjson
-        runner: ${{ fromJSON(format('["ubuntu-latest","windows-latest"{0}]', github.event.inputs.enableMacRunner == 'true' && ',"macos-latest"' || '')) }}
+        # We don't have any release verification configurations, so we only run on Linux to print warnings to help users configure the release verification.
+        runner: ["ubuntu-latest"]
     runs-on: ${{ matrix.runner }}
     steps:
       - name: Checkout Repo
@@ -82,42 +87,3 @@ jobs:
         uses: ./.github/actions/setup-tools
         with:
           tools: pulumicli, nodejs, python, dotnet, go, java
-      - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v4
-        with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-region: ${{ env.AWS_REGION }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          role-duration-seconds: 7200
-          role-session-name: aws@githubActions
-          role-to-assume: ${{ secrets.AWS_CI_ROLE_ARN }}
-      - name: Verify nodejs release
-        uses: pulumi/verify-provider-release@v1
-        with:
-          runtime: nodejs
-          directory: examples/bucket
-          provider: aws
-          providerVersion: ${{ inputs.providerVersion }}
-      - name: Verify python release
-        uses: pulumi/verify-provider-release@v1
-        with:
-          runtime: python
-          directory: examples/webserver-py
-          provider: aws
-          providerVersion: ${{ inputs.providerVersion }}
-          packageVersion: ${{ inputs.pythonVersion || inputs.providerVersion }}
-      - name: Verify dotnet release
-        uses: pulumi/verify-provider-release@v1
-        with:
-          runtime: dotnet
-          directory: examples/webserver-cs
-          provider: aws
-          providerVersion: ${{ inputs.providerVersion }}
-      - name: Verify go release
-        uses: pulumi/verify-provider-release@v1
-        if: inputs.skipGoSdk == false
-        with:
-          runtime: go
-          directory: examples/webserver-go
-          provider: aws
-          providerVersion: ${{ inputs.providerVersion }}


### PR DESCRIPTION
Reverts pulumi/ci-mgmt#1274

This caused a P1 in the pulumi-azure provider:
- https://github.com/pulumi/pulumi-azure/issues/2895

We can revisit an alternative way of setting up required credentials for AWS. See: https://github.com/pulumi/ci-mgmt/pull/1274#issuecomment-2582085346