### PR TITLE
Don't install `gotestfmt` for bridged providers

### DIFF
--- a/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/test.yml
+++ b/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/test.yml
@@ -106,11 +106,6 @@ jobs:
     #{{- end }}#
     - name: Install dependencies
       run: make install_${{ matrix.language}}_sdk
-    - name: Install gotestfmt
-      uses: GoTestTools/gotestfmt-action@v2
-      with:
-        token: ${{ secrets.GITHUB_TOKEN }}
-        version: v2.5.0
 #{{- if .Config.Actions.PreTest }}#
 #{{ .Config.Actions.PreTest | toYaml | indent 4 }}#
 #{{- end }}#

--- a/provider-ci/test-providers/acme/.github/workflows/test.yml
+++ b/provider-ci/test-providers/acme/.github/workflows/test.yml
@@ -72,11 +72,6 @@ jobs:
         pip3 install pipenv
     - name: Install dependencies
       run: make install_${{ matrix.language}}_sdk
-    - name: Install gotestfmt
-      uses: GoTestTools/gotestfmt-action@v2
-      with:
-        token: ${{ secrets.GITHUB_TOKEN }}
-        version: v2.5.0
     - name: Run tests
       if: matrix.testTarget == 'local'
       run: cd examples && go test -v -count=1 -cover -timeout 2h -tags=${{ matrix.language }} -skip TestPulumiExamples -parallel 4 .

--- a/provider-ci/test-providers/aws/.github/workflows/test.yml
+++ b/provider-ci/test-providers/aws/.github/workflows/test.yml
@@ -83,11 +83,6 @@ jobs:
         pip3 install pipenv
     - name: Install dependencies
       run: make install_${{ matrix.language}}_sdk
-    - name: Install gotestfmt
-      uses: GoTestTools/gotestfmt-action@v2
-      with:
-        token: ${{ secrets.GITHUB_TOKEN }}
-        version: v2.5.0
     - name: Configure AWS Credentials
       uses: aws-actions/configure-aws-credentials@v4
       with:

--- a/provider-ci/test-providers/cloudflare/.github/workflows/test.yml
+++ b/provider-ci/test-providers/cloudflare/.github/workflows/test.yml
@@ -76,11 +76,6 @@ jobs:
       run: example/script.sh
     - name: Install dependencies
       run: make install_${{ matrix.language}}_sdk
-    - name: Install gotestfmt
-      uses: GoTestTools/gotestfmt-action@v2
-      with:
-        token: ${{ secrets.GITHUB_TOKEN }}
-        version: v2.5.0
     - name: make upstream
       run: |
         make upstream

--- a/provider-ci/test-providers/docker/.github/workflows/test.yml
+++ b/provider-ci/test-providers/docker/.github/workflows/test.yml
@@ -110,11 +110,6 @@ jobs:
       run: gcloud --quiet auth configure-docker
     - name: Install dependencies
       run: make install_${{ matrix.language}}_sdk
-    - name: Install gotestfmt
-      uses: GoTestTools/gotestfmt-action@v2
-      with:
-        token: ${{ secrets.GITHUB_TOKEN }}
-        version: v2.5.0
     - name: Setup SSH key
       uses: webfactory/ssh-agent@v0.7.0
       with:


### PR DESCRIPTION
Bridged providers no longer use `gotestfmt`, either during tests or during `actions.preTest`, so we no longer need to install `gotestfmt`.