### PR TITLE
Fix: do not add pulumi-eks yet

### DIFF
--- a/provider-ci/providers.json
+++ b/provider-ci/providers.json
@@ -23,7 +23,6 @@
     "dnsimple",
     "docker",
     "ec",
-    "eks",
     "external",
     "f5bigip",
     "fastly",


### PR DESCRIPTION
In https://github.com/pulumi/ci-mgmt/pull/1278 we added pulumi-eks as a test provider which is good but we also added it to providers.json - it is not quite ready for this since the repo has not been fully onboarded. One observable failure is that ci-mgmt started applying branch protections to the repository and failed to override hand-rolled branch protections. It is better to avoid doing this for now.