### PR TITLE
Fix path gen/tfgen typo

### DIFF
--- a/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/prerequisites.yml
+++ b/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/prerequisites.yml
@@ -130,10 +130,11 @@ jobs:
       with:
         #{{- if .Config.NoUpstream }}#
         name: pulumi-gen-#{{ .Config.Provider }}#
+        path: ${{ github.workspace }}/bin/pulumi-gen-#{{ .Config.Provider }}#
         #{{- else }}#
         name: pulumi-tfgen-#{{ .Config.Provider }}#
-        #{{- end }}#
         path: ${{ github.workspace }}/bin/pulumi-tfgen-#{{ .Config.Provider }}#
+        #{{- end }}#
         retention-days: 30
 
     - name: Upload schema-embed.json

--- a/provider-ci/test-providers/eks/.github/workflows/prerequisites.yml
+++ b/provider-ci/test-providers/eks/.github/workflows/prerequisites.yml
@@ -106,7 +106,7 @@ jobs:
       uses: actions/upload-artifact@6f51ac03b9356f520e9adb1b1b7802705f340c2b # v4.5.0
       with:
         name: pulumi-gen-eks
-        path: ${{ github.workspace }}/bin/pulumi-tfgen-eks
+        path: ${{ github.workspace }}/bin/pulumi-gen-eks
         retention-days: 30
 
     - name: Upload schema-embed.json


### PR DESCRIPTION
Not only name: but path: also must respect the gen/tfgen distinction.