### PR TITLE
Update yarn command in bridge Makefile

### DIFF
--- a/provider-ci/internal/pkg/templates/bridged-provider/Makefile
+++ b/provider-ci/internal/pkg/templates/bridged-provider/Makefile
@@ -231,7 +231,7 @@ install_go_sdk:
 install_java_sdk:
 install_nodejs_sdk: .make/install_nodejs_sdk
 .make/install_nodejs_sdk: .make/build_nodejs
-	yarn link --cwd $(WORKING_DIR)/sdk/nodejs/bin
+	yarn --cwd link $(WORKING_DIR)/sdk/nodejs/bin
 	@touch $@
 install_python_sdk:
 .PHONY: install_dotnet_sdk install_go_sdk install_java_sdk install_nodejs_sdk install_python_sdk


### PR DESCRIPTION
This might have changed in a recent version of `yarn`, but I ran into an issue where `--cwd` was required to be the first argument after the `yarn` command to work, otherwise it would throw an error:

```
Usage Error: The --cwd option is ambiguous when used anywhere else than the very first 
parameter provided in the command line, before even the command path
```