### PR TITLE
Configure credentials for release verification

### DIFF
--- a/provider-ci/internal/pkg/templates/provider/.github/workflows/verify-release.yml
+++ b/provider-ci/internal/pkg/templates/provider/.github/workflows/verify-release.yml
@@ -80,6 +80,35 @@ jobs:
         with:
           tools: pulumicli, #{{ range $index, $element := .Config.Languages }}##{{if $index}}#, #{{end}}##{{ $element }}##{{end}}#
 #{{- if .Config.ReleaseVerification }}#
+    #{{- if .Config.AWS }}#
+    - name: Configure AWS Credentials
+      uses: #{{ .Config.ActionVersions.ConfigureAwsCredentials }}#
+      with:
+        aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+        aws-region: ${{ env.AWS_REGION }}
+        aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        role-duration-seconds: 7200
+        role-session-name: #{{ .Config.Provider }}#@githubActions
+        role-to-assume: ${{ secrets.AWS_CI_ROLE_ARN }}
+    #{{- end }}#
+    #{{- if .Config.GCP }}#
+    - name: Authenticate to Google Cloud
+      uses: #{{ .Config.ActionVersions.GoogleAuth }}#
+      with:
+        service_account: ${{ env.GOOGLE_CI_SERVICE_ACCOUNT_EMAIL }}
+        workload_identity_provider: projects/${{ env.GOOGLE_PROJECT_NUMBER
+          }}/locations/global/workloadIdentityPools/${{
+          env.GOOGLE_CI_WORKLOAD_IDENTITY_POOL }}/providers/${{
+          env.GOOGLE_CI_WORKLOAD_IDENTITY_PROVIDER }}
+    - name: Setup gcloud auth
+      uses: #{{ .Config.ActionVersions.SetupGcloud }}#
+      with:
+        install_components: gke-gcloud-auth-plugin
+    #{{- end }}#
+    #{{- if .Config.GCPRegistry }}#
+    - name: Login to Google Cloud Registry
+      run: gcloud --quiet auth configure-docker
+    #{{- end }}#
 #{{- if .Config.Actions.PreTest }}#
 #{{ .Config.Actions.PreTest | toYaml | indent 6 }}#
 #{{- end }}#

--- a/provider-ci/internal/pkg/templates/provider/.github/workflows/verify-release.yml
+++ b/provider-ci/internal/pkg/templates/provider/.github/workflows/verify-release.yml
@@ -80,35 +80,35 @@ jobs:
         with:
           tools: pulumicli, #{{ range $index, $element := .Config.Languages }}##{{if $index}}#, #{{end}}##{{ $element }}##{{end}}#
 #{{- if .Config.ReleaseVerification }}#
-    #{{- if .Config.AWS }}#
-    - name: Configure AWS Credentials
-      uses: #{{ .Config.ActionVersions.ConfigureAwsCredentials }}#
-      with:
-        aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-        aws-region: ${{ env.AWS_REGION }}
-        aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-        role-duration-seconds: 7200
-        role-session-name: #{{ .Config.Provider }}#@githubActions
-        role-to-assume: ${{ secrets.AWS_CI_ROLE_ARN }}
-    #{{- end }}#
-    #{{- if .Config.GCP }}#
-    - name: Authenticate to Google Cloud
-      uses: #{{ .Config.ActionVersions.GoogleAuth }}#
-      with:
-        service_account: ${{ env.GOOGLE_CI_SERVICE_ACCOUNT_EMAIL }}
-        workload_identity_provider: projects/${{ env.GOOGLE_PROJECT_NUMBER
-          }}/locations/global/workloadIdentityPools/${{
-          env.GOOGLE_CI_WORKLOAD_IDENTITY_POOL }}/providers/${{
-          env.GOOGLE_CI_WORKLOAD_IDENTITY_PROVIDER }}
-    - name: Setup gcloud auth
-      uses: #{{ .Config.ActionVersions.SetupGcloud }}#
-      with:
-        install_components: gke-gcloud-auth-plugin
-    #{{- end }}#
-    #{{- if .Config.GCPRegistry }}#
-    - name: Login to Google Cloud Registry
-      run: gcloud --quiet auth configure-docker
-    #{{- end }}#
+      #{{- if .Config.AWS }}#
+      - name: Configure AWS Credentials
+        uses: #{{ .Config.ActionVersions.ConfigureAwsCredentials }}#
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-region: ${{ env.AWS_REGION }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          role-duration-seconds: 7200
+          role-session-name: #{{ .Config.Provider }}#@githubActions
+          role-to-assume: ${{ secrets.AWS_CI_ROLE_ARN }}
+      #{{- end }}#
+      #{{- if .Config.GCP }}#
+      - name: Authenticate to Google Cloud
+        uses: #{{ .Config.ActionVersions.GoogleAuth }}#
+        with:
+          service_account: ${{ env.GOOGLE_CI_SERVICE_ACCOUNT_EMAIL }}
+          workload_identity_provider: projects/${{ env.GOOGLE_PROJECT_NUMBER
+            }}/locations/global/workloadIdentityPools/${{
+            env.GOOGLE_CI_WORKLOAD_IDENTITY_POOL }}/providers/${{
+            env.GOOGLE_CI_WORKLOAD_IDENTITY_PROVIDER }}
+      - name: Setup gcloud auth
+        uses: #{{ .Config.ActionVersions.SetupGcloud }}#
+        with:
+          install_components: gke-gcloud-auth-plugin
+      #{{- end }}#
+      #{{- if .Config.GCPRegistry }}#
+      - name: Login to Google Cloud Registry
+        run: gcloud --quiet auth configure-docker
+      #{{- end }}#
 #{{- if .Config.Actions.PreTest }}#
 #{{ .Config.Actions.PreTest | toYaml | indent 6 }}#
 #{{- end }}#


### PR DESCRIPTION
This permits providers such as pulumi-awsx to simply state this in .ci-mgmt.yaml:

    aws: true

And have release verification authorized for AWS.

Without this change release verification does not work as it lacks credentials.

The template bits got copied from https://github.com/pulumi/ci-mgmt/blob/3beca112a1943089e2fea1e63f7fd9dbb2ec8007/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/test.yml#L74