### PR TITLE
Fix release verification to cover Mac OS appropriately

### DIFF
--- a/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/publish.yml
+++ b/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/publish.yml
@@ -211,6 +211,6 @@ jobs:
     with:
       providerVersion: ${{ inputs.version }}
       # Prelease is run often but we only have 5 concurrent macos runners, so we only test after the stable release.
-      enableMacosRunner: ${{ inputs.isPrerelease == false }}
+      enableMacRunner: ${{ inputs.isPrerelease == false }}
       skipGoSdk: ${{ inputs.skipGoSdk }}
       pythonVersion: ${{ needs.publish_sdk.outputs.python_version }}

--- a/provider-ci/internal/pkg/templates/provider/.github/workflows/verify-release.yml
+++ b/provider-ci/internal/pkg/templates/provider/.github/workflows/verify-release.yml
@@ -26,7 +26,7 @@ on:
         description: "The version of the provider to verify"
         required: true
         type: string
-      enableMacosRunner:
+      enableMacRunner:
         description: "Enable the macos-latest runner in addition to ubuntu-latest and windows-latest. Defaults to 'false'."
         required: false
         type: boolean

--- a/provider-ci/internal/pkg/templates/provider/.github/workflows/verify-release.yml
+++ b/provider-ci/internal/pkg/templates/provider/.github/workflows/verify-release.yml
@@ -64,7 +64,7 @@ jobs:
         # Expression expands to ["ubuntu-latest","windows-latest"] or ["ubuntu-latest","windows-latest","macos-latest"]
         # GitHub expressions don't have 'if' statements, so we use a ternary operator to conditionally include the MacOS runner suffix.
         # See the docs for a similar example to this: https://docs.github.com/en/actions/learn-github-actions/expressions#fromjson
-        runner: ${{ fromJSON(format('["ubuntu-latest","windows-latest"{0}]', github.event.inputs.enableMacRunner && ',"macos-latest"' || '')) }} #
+        runner: ${{ fromJSON(format('["ubuntu-latest","windows-latest"{0}]', inputs.enableMacRunner && ',"macos-latest"' || '')) }} #
 #{{- else }}#
         # We don't have any release verification configurations, so we only run on Linux to print warnings to help users configure the release verification.
         runner: ["ubuntu-latest"]

--- a/provider-ci/internal/pkg/templates/provider/.github/workflows/verify-release.yml
+++ b/provider-ci/internal/pkg/templates/provider/.github/workflows/verify-release.yml
@@ -64,7 +64,7 @@ jobs:
         # Expression expands to ["ubuntu-latest","windows-latest"] or ["ubuntu-latest","windows-latest","macos-latest"]
         # GitHub expressions don't have 'if' statements, so we use a ternary operator to conditionally include the MacOS runner suffix.
         # See the docs for a similar example to this: https://docs.github.com/en/actions/learn-github-actions/expressions#fromjson
-        runner: ${{ fromJSON(format('["ubuntu-latest","windows-latest"{0}]', inputs.enableMacRunner && ',"macos-latest"' || '')) }} #
+        runner: ${{ fromJSON(format('["ubuntu-latest","windows-latest"{0}]', inputs.enableMacRunner && ',"macos-latest"' || '')) }}
 #{{- else }}#
         # We don't have any release verification configurations, so we only run on Linux to print warnings to help users configure the release verification.
         runner: ["ubuntu-latest"]

--- a/provider-ci/internal/pkg/templates/provider/.github/workflows/verify-release.yml
+++ b/provider-ci/internal/pkg/templates/provider/.github/workflows/verify-release.yml
@@ -64,7 +64,7 @@ jobs:
         # Expression expands to ["ubuntu-latest","windows-latest"] or ["ubuntu-latest","windows-latest","macos-latest"]
         # GitHub expressions don't have 'if' statements, so we use a ternary operator to conditionally include the MacOS runner suffix.
         # See the docs for a similar example to this: https://docs.github.com/en/actions/learn-github-actions/expressions#fromjson
-        runner: ${{ fromJSON(format('["ubuntu-latest","windows-latest"{0}]', github.event.inputs.enableMacRunner == 'true' && ',"macos-latest"' || '')) }}
+        runner: ${{ fromJSON(format('["ubuntu-latest","windows-latest"{0}]', github.event.inputs.enableMacRunner && ',"macos-latest"' || '')) }} #
 #{{- else }}#
         # We don't have any release verification configurations, so we only run on Linux to print warnings to help users configure the release verification.
         runner: ["ubuntu-latest"]

--- a/provider-ci/test-providers/acme/.github/workflows/publish.yml
+++ b/provider-ci/test-providers/acme/.github/workflows/publish.yml
@@ -179,6 +179,6 @@ jobs:
     with:
       providerVersion: ${{ inputs.version }}
       # Prelease is run often but we only have 5 concurrent macos runners, so we only test after the stable release.
-      enableMacosRunner: ${{ inputs.isPrerelease == false }}
+      enableMacRunner: ${{ inputs.isPrerelease == false }}
       skipGoSdk: ${{ inputs.skipGoSdk }}
       pythonVersion: ${{ needs.publish_sdk.outputs.python_version }}

--- a/provider-ci/test-providers/acme/.github/workflows/verify-release.yml
+++ b/provider-ci/test-providers/acme/.github/workflows/verify-release.yml
@@ -26,7 +26,7 @@ on:
         description: "The version of the provider to verify"
         required: true
         type: string
-      enableMacosRunner:
+      enableMacRunner:
         description: "Enable the macos-latest runner in addition to ubuntu-latest and windows-latest. Defaults to 'false'."
         required: false
         type: boolean

--- a/provider-ci/test-providers/aws/.github/workflows/publish.yml
+++ b/provider-ci/test-providers/aws/.github/workflows/publish.yml
@@ -215,6 +215,6 @@ jobs:
     with:
       providerVersion: ${{ inputs.version }}
       # Prelease is run often but we only have 5 concurrent macos runners, so we only test after the stable release.
-      enableMacosRunner: ${{ inputs.isPrerelease == false }}
+      enableMacRunner: ${{ inputs.isPrerelease == false }}
       skipGoSdk: ${{ inputs.skipGoSdk }}
       pythonVersion: ${{ needs.publish_sdk.outputs.python_version }}

--- a/provider-ci/test-providers/aws/.github/workflows/verify-release.yml
+++ b/provider-ci/test-providers/aws/.github/workflows/verify-release.yml
@@ -26,7 +26,7 @@ on:
         description: "The version of the provider to verify"
         required: true
         type: string
-      enableMacosRunner:
+      enableMacRunner:
         description: "Enable the macos-latest runner in addition to ubuntu-latest and windows-latest. Defaults to 'false'."
         required: false
         type: boolean

--- a/provider-ci/test-providers/aws/.github/workflows/verify-release.yml
+++ b/provider-ci/test-providers/aws/.github/workflows/verify-release.yml
@@ -71,7 +71,7 @@ jobs:
         # Expression expands to ["ubuntu-latest","windows-latest"] or ["ubuntu-latest","windows-latest","macos-latest"]
         # GitHub expressions don't have 'if' statements, so we use a ternary operator to conditionally include the MacOS runner suffix.
         # See the docs for a similar example to this: https://docs.github.com/en/actions/learn-github-actions/expressions#fromjson
-        runner: ${{ fromJSON(format('["ubuntu-latest","windows-latest"{0}]', inputs.enableMacRunner && ',"macos-latest"' || '')) }} #
+        runner: ${{ fromJSON(format('["ubuntu-latest","windows-latest"{0}]', inputs.enableMacRunner && ',"macos-latest"' || '')) }}
     runs-on: ${{ matrix.runner }}
     steps:
       - name: Checkout Repo

--- a/provider-ci/test-providers/aws/.github/workflows/verify-release.yml
+++ b/provider-ci/test-providers/aws/.github/workflows/verify-release.yml
@@ -71,7 +71,7 @@ jobs:
         # Expression expands to ["ubuntu-latest","windows-latest"] or ["ubuntu-latest","windows-latest","macos-latest"]
         # GitHub expressions don't have 'if' statements, so we use a ternary operator to conditionally include the MacOS runner suffix.
         # See the docs for a similar example to this: https://docs.github.com/en/actions/learn-github-actions/expressions#fromjson
-        runner: ${{ fromJSON(format('["ubuntu-latest","windows-latest"{0}]', github.event.inputs.enableMacRunner == 'true' && ',"macos-latest"' || '')) }}
+        runner: ${{ fromJSON(format('["ubuntu-latest","windows-latest"{0}]', github.event.inputs.enableMacRunner && ',"macos-latest"' || '')) }} #
     runs-on: ${{ matrix.runner }}
     steps:
       - name: Checkout Repo

--- a/provider-ci/test-providers/aws/.github/workflows/verify-release.yml
+++ b/provider-ci/test-providers/aws/.github/workflows/verify-release.yml
@@ -71,7 +71,7 @@ jobs:
         # Expression expands to ["ubuntu-latest","windows-latest"] or ["ubuntu-latest","windows-latest","macos-latest"]
         # GitHub expressions don't have 'if' statements, so we use a ternary operator to conditionally include the MacOS runner suffix.
         # See the docs for a similar example to this: https://docs.github.com/en/actions/learn-github-actions/expressions#fromjson
-        runner: ${{ fromJSON(format('["ubuntu-latest","windows-latest"{0}]', github.event.inputs.enableMacRunner && ',"macos-latest"' || '')) }} #
+        runner: ${{ fromJSON(format('["ubuntu-latest","windows-latest"{0}]', inputs.enableMacRunner && ',"macos-latest"' || '')) }} #
     runs-on: ${{ matrix.runner }}
     steps:
       - name: Checkout Repo

--- a/provider-ci/test-providers/cloudflare/.github/workflows/publish.yml
+++ b/provider-ci/test-providers/cloudflare/.github/workflows/publish.yml
@@ -212,6 +212,6 @@ jobs:
     with:
       providerVersion: ${{ inputs.version }}
       # Prelease is run often but we only have 5 concurrent macos runners, so we only test after the stable release.
-      enableMacosRunner: ${{ inputs.isPrerelease == false }}
+      enableMacRunner: ${{ inputs.isPrerelease == false }}
       skipGoSdk: ${{ inputs.skipGoSdk }}
       pythonVersion: ${{ needs.publish_sdk.outputs.python_version }}

--- a/provider-ci/test-providers/cloudflare/.github/workflows/verify-release.yml
+++ b/provider-ci/test-providers/cloudflare/.github/workflows/verify-release.yml
@@ -26,7 +26,7 @@ on:
         description: "The version of the provider to verify"
         required: true
         type: string
-      enableMacosRunner:
+      enableMacRunner:
         description: "Enable the macos-latest runner in addition to ubuntu-latest and windows-latest. Defaults to 'false'."
         required: false
         type: boolean

--- a/provider-ci/test-providers/docker/.github/workflows/publish.yml
+++ b/provider-ci/test-providers/docker/.github/workflows/publish.yml
@@ -225,6 +225,6 @@ jobs:
     with:
       providerVersion: ${{ inputs.version }}
       # Prelease is run often but we only have 5 concurrent macos runners, so we only test after the stable release.
-      enableMacosRunner: ${{ inputs.isPrerelease == false }}
+      enableMacRunner: ${{ inputs.isPrerelease == false }}
       skipGoSdk: ${{ inputs.skipGoSdk }}
       pythonVersion: ${{ needs.publish_sdk.outputs.python_version }}

--- a/provider-ci/test-providers/docker/.github/workflows/verify-release.yml
+++ b/provider-ci/test-providers/docker/.github/workflows/verify-release.yml
@@ -26,7 +26,7 @@ on:
         description: "The version of the provider to verify"
         required: true
         type: string
-      enableMacosRunner:
+      enableMacRunner:
         description: "Enable the macos-latest runner in addition to ubuntu-latest and windows-latest. Defaults to 'false'."
         required: false
         type: boolean

--- a/provider-ci/test-providers/eks/.github/workflows/publish.yml
+++ b/provider-ci/test-providers/eks/.github/workflows/publish.yml
@@ -217,6 +217,6 @@ jobs:
     with:
       providerVersion: ${{ inputs.version }}
       # Prelease is run often but we only have 5 concurrent macos runners, so we only test after the stable release.
-      enableMacosRunner: ${{ inputs.isPrerelease == false }}
+      enableMacRunner: ${{ inputs.isPrerelease == false }}
       skipGoSdk: ${{ inputs.skipGoSdk }}
       pythonVersion: ${{ needs.publish_sdk.outputs.python_version }}

--- a/provider-ci/test-providers/eks/.github/workflows/verify-release.yml
+++ b/provider-ci/test-providers/eks/.github/workflows/verify-release.yml
@@ -26,7 +26,7 @@ on:
         description: "The version of the provider to verify"
         required: true
         type: string
-      enableMacosRunner:
+      enableMacRunner:
         description: "Enable the macos-latest runner in addition to ubuntu-latest and windows-latest. Defaults to 'false'."
         required: false
         type: boolean


### PR DESCRIPTION
This makes sure that release verification runs jobs on MacOS as intended.

Example release in https://github.com/pulumi/pulumi-xyz/pull/756 - see https://github.com/pulumi/pulumi-xyz/actions/runs/12817331557

Looks like there were a few bugs in the code:

- different variable naming
- treatment of boolean vs string
- github.event.inputs vs inputs - according to GitHub docs these treat booleans differently (!), but it has to be inputs.* I believe to be available in both workflow_call context and workflow_dispatch context