### PR TITLE
Fix the binary name to `pulumictl`

### DIFF
--- a/provider-ci/internal/pkg/templates/bridged-provider/Makefile
+++ b/provider-ci/internal/pkg/templates/bridged-provider/Makefile
@@ -35,7 +35,7 @@ PULUMICTL_VERSION := #{{ .Config.ToolVersions.PulumiCTL }}#
 PULUMICTL := $(shell which pulumictl || \
 	(test ! -e $(WORKING_DIR)/bin/pulumictl && \
 		GOPATH="$(WORKING_DIR)" go install "github.com/pulumi/pulumictl/cmd/pulumictl@$(PULUMICTL_VERSION)"; \
-	echo "$(WORKING_DIR)/bin/puluimctl"))
+	echo "$(WORKING_DIR)/bin/pulumictl"))
 
 # Override during CI using `make [TARGET] PROVIDER_VERSION=""` or by setting a PROVIDER_VERSION environment variable
 # Local & branch builds will just used this fixed default version unless specified

--- a/provider-ci/test-providers/acme/Makefile
+++ b/provider-ci/test-providers/acme/Makefile
@@ -19,7 +19,7 @@ PULUMICTL_VERSION := v0.0.46
 PULUMICTL := $(shell which pulumictl || \
 	(test ! -e $(WORKING_DIR)/bin/pulumictl && \
 		GOPATH="$(WORKING_DIR)" go install "github.com/pulumi/pulumictl/cmd/pulumictl@$(PULUMICTL_VERSION)"; \
-	echo "$(WORKING_DIR)/bin/puluimctl"))
+	echo "$(WORKING_DIR)/bin/pulumictl"))
 
 # Override during CI using `make [TARGET] PROVIDER_VERSION=""` or by setting a PROVIDER_VERSION environment variable
 # Local & branch builds will just used this fixed default version unless specified

--- a/provider-ci/test-providers/aws/Makefile
+++ b/provider-ci/test-providers/aws/Makefile
@@ -19,7 +19,7 @@ PULUMICTL_VERSION := v0.0.46
 PULUMICTL := $(shell which pulumictl || \
 	(test ! -e $(WORKING_DIR)/bin/pulumictl && \
 		GOPATH="$(WORKING_DIR)" go install "github.com/pulumi/pulumictl/cmd/pulumictl@$(PULUMICTL_VERSION)"; \
-	echo "$(WORKING_DIR)/bin/puluimctl"))
+	echo "$(WORKING_DIR)/bin/pulumictl"))
 
 # Override during CI using `make [TARGET] PROVIDER_VERSION=""` or by setting a PROVIDER_VERSION environment variable
 # Local & branch builds will just used this fixed default version unless specified

--- a/provider-ci/test-providers/cloudflare/Makefile
+++ b/provider-ci/test-providers/cloudflare/Makefile
@@ -19,7 +19,7 @@ PULUMICTL_VERSION := v0.0.46
 PULUMICTL := $(shell which pulumictl || \
 	(test ! -e $(WORKING_DIR)/bin/pulumictl && \
 		GOPATH="$(WORKING_DIR)" go install "github.com/pulumi/pulumictl/cmd/pulumictl@$(PULUMICTL_VERSION)"; \
-	echo "$(WORKING_DIR)/bin/puluimctl"))
+	echo "$(WORKING_DIR)/bin/pulumictl"))
 
 # Override during CI using `make [TARGET] PROVIDER_VERSION=""` or by setting a PROVIDER_VERSION environment variable
 # Local & branch builds will just used this fixed default version unless specified

--- a/provider-ci/test-providers/docker/Makefile
+++ b/provider-ci/test-providers/docker/Makefile
@@ -19,7 +19,7 @@ PULUMICTL_VERSION := v0.0.46
 PULUMICTL := $(shell which pulumictl || \
 	(test ! -e $(WORKING_DIR)/bin/pulumictl && \
 		GOPATH="$(WORKING_DIR)" go install "github.com/pulumi/pulumictl/cmd/pulumictl@$(PULUMICTL_VERSION)"; \
-	echo "$(WORKING_DIR)/bin/puluimctl"))
+	echo "$(WORKING_DIR)/bin/pulumictl"))
 
 # Override during CI using `make [TARGET] PROVIDER_VERSION=""` or by setting a PROVIDER_VERSION environment variable
 # Local & branch builds will just used this fixed default version unless specified

--- a/provider-ci/test-providers/eks/Makefile
+++ b/provider-ci/test-providers/eks/Makefile
@@ -19,7 +19,7 @@ PULUMICTL_VERSION := v0.0.46
 PULUMICTL := $(shell which pulumictl || \
 	(test ! -e $(WORKING_DIR)/bin/pulumictl && \
 		GOPATH="$(WORKING_DIR)" go install "github.com/pulumi/pulumictl/cmd/pulumictl@$(PULUMICTL_VERSION)"; \
-	echo "$(WORKING_DIR)/bin/puluimctl"))
+	echo "$(WORKING_DIR)/bin/pulumictl"))
 
 # Override during CI using `make [TARGET] PROVIDER_VERSION=""` or by setting a PROVIDER_VERSION environment variable
 # Local & branch builds will just used this fixed default version unless specified


### PR DESCRIPTION
Fixes: #1284

In Pulumiverse, all the providers that regenerate their workflows using ci-mgmt via a weekly pull based workflow failed last night.

It is because of a typo in the binary name to `pulumictl`.

Failing runs:

* https://github.com/pulumiverse/pulumi-grafana/actions/runs/12879415221/job/35906884734#step:3:12
* https://github.com/pulumiverse/pulumi-scaleway/actions/runs/12879402782/job/35906853723#step:3:12
* https://github.com/pulumiverse/pulumi-acme/actions/runs/12879415125/job/35906884423#step:3:12
* https://github.com/pulumiverse/pulumi-configcat/actions/runs/12879428726/job/35906918835#step:3:12
* https://github.com/pulumiverse/pulumi-unifi/actions/runs/12879450713/job/35906973576#step:3:12
* https://github.com/pulumiverse/pulumi-talos/actions/runs/12879451646/job/35906975981#step:3:12