### PR TITLE
Fix GH CLI bug breaking weekly pulumi upgrade

### DIFF
--- a/native-provider-ci/providers/aws-native/repo/.github/workflows/weekly-pulumi-update.yml
+++ b/native-provider-ci/providers/aws-native/repo/.github/workflows/weekly-pulumi-update.yml
@@ -117,10 +117,14 @@ jobs:
     - name: Create PR
       id: create-pr
       if: steps.gomod.outputs.changes != 0
-      run: |
+      run: >
         ver=$(cat .pulumi.version)
+
         msg="Automated upgrade: bump pulumi/pulumi to ${ver}"
-        gh pr create -t "$msg" -b "$msg" -B master
+
+        # See https://github.com/cli/cli/issues/6485#issuecomment-2560935183 for --head workaround
+
+        gh pr create -t "$msg" -b "$msg" --head $(git branch --show-current)
       env:
         GITHUB_TOKEN: ${{ secrets.PULUMI_BOT_TOKEN }}
     name: weekly-pulumi-update

--- a/native-provider-ci/providers/command/repo/.github/workflows/weekly-pulumi-update.yml
+++ b/native-provider-ci/providers/command/repo/.github/workflows/weekly-pulumi-update.yml
@@ -115,10 +115,14 @@ jobs:
     - name: Create PR
       id: create-pr
       if: steps.gomod.outputs.changes != 0
-      run: |
+      run: >
         ver=$(cat .pulumi.version)
+
         msg="Automated upgrade: bump pulumi/pulumi to ${ver}"
-        gh pr create -t "$msg" -b "$msg" -B master
+
+        # See https://github.com/cli/cli/issues/6485#issuecomment-2560935183 for --head workaround
+
+        gh pr create -t "$msg" -b "$msg" --head $(git branch --show-current)
       env:
         GITHUB_TOKEN: ${{ secrets.PULUMI_BOT_TOKEN }}
     name: weekly-pulumi-update

--- a/native-provider-ci/providers/docker-build/repo/.github/workflows/weekly-pulumi-update.yml
+++ b/native-provider-ci/providers/docker-build/repo/.github/workflows/weekly-pulumi-update.yml
@@ -127,10 +127,14 @@ jobs:
     - name: Create PR
       id: create-pr
       if: steps.gomod.outputs.changes != 0
-      run: |
+      run: >
         ver=$(cat .pulumi.version)
+
         msg="Automated upgrade: bump pulumi/pulumi to ${ver}"
-        gh pr create -t "$msg" -b "$msg" -B main
+
+        # See https://github.com/cli/cli/issues/6485#issuecomment-2560935183 for --head workaround
+
+        gh pr create -t "$msg" -b "$msg" --head $(git branch --show-current)
       env:
         GITHUB_TOKEN: ${{ secrets.PULUMI_BOT_TOKEN }}
     name: weekly-pulumi-update

--- a/native-provider-ci/providers/google-native/repo/.github/workflows/weekly-pulumi-update.yml
+++ b/native-provider-ci/providers/google-native/repo/.github/workflows/weekly-pulumi-update.yml
@@ -121,10 +121,14 @@ jobs:
     - name: Create PR
       id: create-pr
       if: steps.gomod.outputs.changes != 0
-      run: |
+      run: >
         ver=$(cat .pulumi.version)
+
         msg="Automated upgrade: bump pulumi/pulumi to ${ver}"
-        gh pr create -t "$msg" -b "$msg" -B master
+
+        # See https://github.com/cli/cli/issues/6485#issuecomment-2560935183 for --head workaround
+
+        gh pr create -t "$msg" -b "$msg" --head $(git branch --show-current)
       env:
         GITHUB_TOKEN: ${{ secrets.PULUMI_BOT_TOKEN }}
     name: weekly-pulumi-update

--- a/native-provider-ci/providers/kubernetes-cert-manager/repo/.github/workflows/weekly-pulumi-update.yml
+++ b/native-provider-ci/providers/kubernetes-cert-manager/repo/.github/workflows/weekly-pulumi-update.yml
@@ -120,10 +120,14 @@ jobs:
     - name: Create PR
       id: create-pr
       if: steps.gomod.outputs.changes != 0
-      run: |
+      run: >
         ver=$(cat .pulumi.version)
+
         msg="Automated upgrade: bump pulumi/pulumi to ${ver}"
-        gh pr create -t "$msg" -b "$msg" -B master
+
+        # See https://github.com/cli/cli/issues/6485#issuecomment-2560935183 for --head workaround
+
+        gh pr create -t "$msg" -b "$msg" --head $(git branch --show-current)
       env:
         GITHUB_TOKEN: ${{ secrets.PULUMI_BOT_TOKEN }}
     name: weekly-pulumi-update

--- a/native-provider-ci/providers/kubernetes-coredns/repo/.github/workflows/weekly-pulumi-update.yml
+++ b/native-provider-ci/providers/kubernetes-coredns/repo/.github/workflows/weekly-pulumi-update.yml
@@ -120,10 +120,14 @@ jobs:
     - name: Create PR
       id: create-pr
       if: steps.gomod.outputs.changes != 0
-      run: |
+      run: >
         ver=$(cat .pulumi.version)
+
         msg="Automated upgrade: bump pulumi/pulumi to ${ver}"
-        gh pr create -t "$msg" -b "$msg" -B master
+
+        # See https://github.com/cli/cli/issues/6485#issuecomment-2560935183 for --head workaround
+
+        gh pr create -t "$msg" -b "$msg" --head $(git branch --show-current)
       env:
         GITHUB_TOKEN: ${{ secrets.PULUMI_BOT_TOKEN }}
     name: weekly-pulumi-update

--- a/native-provider-ci/providers/kubernetes-ingress-nginx/repo/.github/workflows/weekly-pulumi-update.yml
+++ b/native-provider-ci/providers/kubernetes-ingress-nginx/repo/.github/workflows/weekly-pulumi-update.yml
@@ -120,10 +120,14 @@ jobs:
     - name: Create PR
       id: create-pr
       if: steps.gomod.outputs.changes != 0
-      run: |
+      run: >
         ver=$(cat .pulumi.version)
+
         msg="Automated upgrade: bump pulumi/pulumi to ${ver}"
-        gh pr create -t "$msg" -b "$msg" -B master
+
+        # See https://github.com/cli/cli/issues/6485#issuecomment-2560935183 for --head workaround
+
+        gh pr create -t "$msg" -b "$msg" --head $(git branch --show-current)
       env:
         GITHUB_TOKEN: ${{ secrets.PULUMI_BOT_TOKEN }}
     name: weekly-pulumi-update

--- a/native-provider-ci/providers/kubernetes/repo/.github/workflows/weekly-pulumi-update.yml
+++ b/native-provider-ci/providers/kubernetes/repo/.github/workflows/weekly-pulumi-update.yml
@@ -120,10 +120,14 @@ jobs:
     - name: Create PR
       id: create-pr
       if: steps.gomod.outputs.changes != 0
-      run: |
+      run: >
         ver=$(cat .pulumi.version)
+
         msg="Automated upgrade: bump pulumi/pulumi to ${ver}"
-        gh pr create -t "$msg" -b "$msg" -B master
+
+        # See https://github.com/cli/cli/issues/6485#issuecomment-2560935183 for --head workaround
+
+        gh pr create -t "$msg" -b "$msg" --head $(git branch --show-current)
       env:
         GITHUB_TOKEN: ${{ secrets.PULUMI_BOT_TOKEN }}
     name: weekly-pulumi-update

--- a/native-provider-ci/providers/pulumistack/repo/.github/workflows/weekly-pulumi-update.yml
+++ b/native-provider-ci/providers/pulumistack/repo/.github/workflows/weekly-pulumi-update.yml
@@ -111,10 +111,14 @@ jobs:
     - name: Create PR
       id: create-pr
       if: steps.gomod.outputs.changes != 0
-      run: |
+      run: >
         ver=$(cat .pulumi.version)
+
         msg="Automated upgrade: bump pulumi/pulumi to ${ver}"
-        gh pr create -t "$msg" -b "$msg" -B master
+
+        # See https://github.com/cli/cli/issues/6485#issuecomment-2560935183 for --head workaround
+
+        gh pr create -t "$msg" -b "$msg" --head $(git branch --show-current)
       env:
         GITHUB_TOKEN: ${{ secrets.PULUMI_BOT_TOKEN }}
     name: weekly-pulumi-update

--- a/native-provider-ci/src/steps.ts
+++ b/native-provider-ci/src/steps.ts
@@ -1030,7 +1030,7 @@ export function ProviderWithPulumiUpgrade(provider: string): Step {
   };
 }
 
-export function CreateUpdatePulumiPR(branch: string): Step {
+export function CreateUpdatePulumiPR(): Step {
   return {
     name: "Create PR",
     id: "create-pr",
@@ -1040,8 +1040,9 @@ export function CreateUpdatePulumiPR(branch: string): Step {
       "\n" +
       'msg="Automated upgrade: bump pulumi/pulumi to ${ver}"' +
       "\n" +
-      'gh pr create -t "$msg" -b "$msg" -B ' +
-      branch +
+      "# See https://github.com/cli/cli/issues/6485#issuecomment-2560935183 for --head workaround" +
+      "\n" +
+      'gh pr create -t "$msg" -b "$msg" --head $(git branch --show-current)' +
       "\n",
     env: {
       GITHUB_TOKEN: "${{ secrets.PULUMI_BOT_TOKEN }}",

--- a/native-provider-ci/src/workflows.ts
+++ b/native-provider-ci/src/workflows.ts
@@ -965,7 +965,7 @@ export class WeeklyPulumiUpdate implements NormalJob {
       steps.UpdatePulumi(),
       steps.InitializeSubModules(opts.submodules),
       steps.ProviderWithPulumiUpgrade(opts.provider),
-      steps.CreateUpdatePulumiPR(opts.defaultBranch),
+      steps.CreateUpdatePulumiPR(),
       // steps.SetPRAutoMerge(opts.provider),
     ].filter((step: Step) => step.uses !== undefined || step.run !== undefined);
     Object.assign(this, { name });


### PR DESCRIPTION
A recent update to the GitHub CLI introduced a bug that prevents creating PRs in workflows. This change applies a known workaround for this issue (see https://github.com/cli/cli/issues/6485#issuecomment-2560935183).

Fixes workflow P1s for native providers (like https://github.com/pulumi/pulumi-aws-native/issues/1994, https://github.com/pulumi/pulumi-kubernetes-ingress-nginx/issues/88, etc.).