### PR TITLE
Always download schema-embed.json prior to building SDKs

### DIFF
--- a/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/build_sdk.yml
+++ b/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/build_sdk.yml
@@ -57,6 +57,14 @@ jobs:
         uses: ./.github/actions/download-codegen
       - name: Update path
         run: echo "${{ github.workspace }}/bin" >> "$GITHUB_PATH"
+      - name: Download schema-embed.json
+        uses: #{{ .Config.ActionVersions.DownloadArtifact }}#
+        with:
+          # Use a pattern to avoid failing if the artifact doesn't exist
+          pattern: schema-embed.*
+          # Avoid creating directories for each artifact
+          merge-multiple: true
+          path: provider/cmd/pulumi-resource-#{{ .Config.Provider }}#
       - name: Restore makefile progress
         run: make --touch provider schema
       - name: Build SDK

--- a/provider-ci/test-providers/acme/.github/workflows/build_sdk.yml
+++ b/provider-ci/test-providers/acme/.github/workflows/build_sdk.yml
@@ -63,6 +63,14 @@ jobs:
         uses: ./.github/actions/download-codegen
       - name: Update path
         run: echo "${{ github.workspace }}/bin" >> "$GITHUB_PATH"
+      - name: Download schema-embed.json
+        uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
+        with:
+          # Use a pattern to avoid failing if the artifact doesn't exist
+          pattern: schema-embed.*
+          # Avoid creating directories for each artifact
+          merge-multiple: true
+          path: provider/cmd/pulumi-resource-acme
       - name: Restore makefile progress
         run: make --touch provider schema
       - name: Build SDK

--- a/provider-ci/test-providers/aws/.github/workflows/build_sdk.yml
+++ b/provider-ci/test-providers/aws/.github/workflows/build_sdk.yml
@@ -75,6 +75,14 @@ jobs:
         uses: ./.github/actions/download-codegen
       - name: Update path
         run: echo "${{ github.workspace }}/bin" >> "$GITHUB_PATH"
+      - name: Download schema-embed.json
+        uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
+        with:
+          # Use a pattern to avoid failing if the artifact doesn't exist
+          pattern: schema-embed.*
+          # Avoid creating directories for each artifact
+          merge-multiple: true
+          path: provider/cmd/pulumi-resource-aws
       - name: Restore makefile progress
         run: make --touch provider schema
       - name: Build SDK

--- a/provider-ci/test-providers/cloudflare/.github/workflows/build_sdk.yml
+++ b/provider-ci/test-providers/cloudflare/.github/workflows/build_sdk.yml
@@ -66,6 +66,14 @@ jobs:
         uses: ./.github/actions/download-codegen
       - name: Update path
         run: echo "${{ github.workspace }}/bin" >> "$GITHUB_PATH"
+      - name: Download schema-embed.json
+        uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
+        with:
+          # Use a pattern to avoid failing if the artifact doesn't exist
+          pattern: schema-embed.*
+          # Avoid creating directories for each artifact
+          merge-multiple: true
+          path: provider/cmd/pulumi-resource-cloudflare
       - name: Restore makefile progress
         run: make --touch provider schema
       - name: Build SDK

--- a/provider-ci/test-providers/docker/.github/workflows/build_sdk.yml
+++ b/provider-ci/test-providers/docker/.github/workflows/build_sdk.yml
@@ -79,6 +79,14 @@ jobs:
         uses: ./.github/actions/download-codegen
       - name: Update path
         run: echo "${{ github.workspace }}/bin" >> "$GITHUB_PATH"
+      - name: Download schema-embed.json
+        uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
+        with:
+          # Use a pattern to avoid failing if the artifact doesn't exist
+          pattern: schema-embed.*
+          # Avoid creating directories for each artifact
+          merge-multiple: true
+          path: provider/cmd/pulumi-resource-docker
       - name: Restore makefile progress
         run: make --touch provider schema
       - name: Build SDK

--- a/provider-ci/test-providers/eks/.github/workflows/build_sdk.yml
+++ b/provider-ci/test-providers/eks/.github/workflows/build_sdk.yml
@@ -71,6 +71,14 @@ jobs:
         uses: ./.github/actions/download-codegen
       - name: Update path
         run: echo "${{ github.workspace }}/bin" >> "$GITHUB_PATH"
+      - name: Download schema-embed.json
+        uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
+        with:
+          # Use a pattern to avoid failing if the artifact doesn't exist
+          pattern: schema-embed.*
+          # Avoid creating directories for each artifact
+          merge-multiple: true
+          path: provider/cmd/pulumi-resource-eks
       - name: Restore makefile progress
         run: make --touch provider schema
       - name: Build SDK


### PR DESCRIPTION
A local copy of the schema is required when building SDKs using `pulumi package gen-sdk`. This PR ensures that this file is always available when building SDKs.