### PR TITLE
Allow customizing test folder directory and adding kubectl installation

### DIFF
--- a/provider-ci/internal/pkg/config.go
+++ b/provider-ci/internal/pkg/config.go
@@ -301,6 +301,9 @@ type Config struct {
 	// This function is called by the make renovate target after the Renovate bot has finished updating
 	// project dependencies in a PR. It is responsible for rebuilding any generated files as needed.
 	RenovateCmd string `yaml:"renovateCmd"`
+
+	// Kubectl determines if we need to install the kubectl CLI. Used in pulumi-eks currently.
+	Kubectl bool `yaml:"kubectl"`
 }
 
 // LoadLocalConfig loads the provider configuration at the given path with

--- a/provider-ci/internal/pkg/config.go
+++ b/provider-ci/internal/pkg/config.go
@@ -304,6 +304,10 @@ type Config struct {
 
 	// Kubectl determines if we need to install the kubectl CLI. Used in pulumi-eks currently.
 	Kubectl bool `yaml:"kubectl"`
+
+	// TestFolder defines where the test directory for integration tests is located.
+	// Defaults to "examples" if not set.
+	TestFolder string `yaml:"test-folder"`
 }
 
 // LoadLocalConfig loads the provider configuration at the given path with

--- a/provider-ci/internal/pkg/config.go
+++ b/provider-ci/internal/pkg/config.go
@@ -302,8 +302,9 @@ type Config struct {
 	// project dependencies in a PR. It is responsible for rebuilding any generated files as needed.
 	RenovateCmd string `yaml:"renovateCmd"`
 
-	// Kubectl determines if we need to install the kubectl CLI. Used in pulumi-eks currently.
-	Kubectl bool `yaml:"kubectl"`
+	// InstallKubectl determines if we need to install the kubectl CLI. This will use the latest stable version.
+	// Used in pulumi-eks currently.
+	InstallKubectl string `yaml:"install-kubectl"`
 
 	// TestFolder defines where the test directory for integration tests is located.
 	// Defaults to "examples" if not set.

--- a/provider-ci/internal/pkg/generate.go
+++ b/provider-ci/internal/pkg/generate.go
@@ -54,6 +54,10 @@ func GeneratePackage(opts GenerateOpts) error {
 		opts.Config.ToolVersions.PulumiCTL = defaultPulumiCTLVersion
 	}
 
+	if opts.Config.TestFolder == "" {
+		opts.Config.TestFolder = "examples"
+	}
+
 	// Clean up old workflows if requested
 	if opts.Config.CleanGithubWorkflows {
 		workflows, err := os.ReadDir(filepath.Join(opts.OutDir, ".github", "workflows"))

--- a/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/test.yml
+++ b/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/test.yml
@@ -139,14 +139,14 @@ jobs:
     #{{- end }}#
     - name: Run tests
       if: matrix.testTarget == 'local'
-      run: cd examples && go test -v -count=1 -cover -timeout 2h -tags=${{ matrix.language }} -skip TestPulumiExamples -parallel 4 .
+      run: cd #{{ .Config.TestFolder }}# && go test -v -count=1 -cover -timeout 2h -tags=${{ matrix.language }} -skip TestPulumiExamples -parallel 4 .
     - name: Run pulumi/examples tests
       if: matrix.testTarget == 'pulumiExamples'
       run: cd examples && go test -v -count=1 -cover -timeout 2h -tags=${{ matrix.language }} -run TestPulumiExamples -parallel 4 .
 #{{- else }}#
     - name: Generate test shards
       run: |-
-        cd examples
+        cd #{{ .Config.TestFolder }}#
         go run github.com/pulumi/shard@861c9ce4aa851e98c19f8376892bf7e47238fa1b \
             --total ${{ matrix.total-shards }} \
             --index ${{ matrix.current-shard }} \

--- a/provider-ci/internal/pkg/templates/bridged-provider/Makefile
+++ b/provider-ci/internal/pkg/templates/bridged-provider/Makefile
@@ -281,7 +281,7 @@ bin/$(PROVIDER): .make/schema
 
 test: export PATH := $(WORKING_DIR)/bin:$(PATH)
 test:
-	cd examples && go test -v -tags=all -parallel $(TESTPARALLELISM) -timeout 2h $(value GOTESTARGS)
+	cd #{{ .Config.TestFolder }}# && go test -v -tags=all -parallel $(TESTPARALLELISM) -timeout 2h $(value GOTESTARGS)
 .PHONY: test
 
 #{{- if .Config.TestProviderCmd }}#

--- a/provider-ci/internal/pkg/templates/provider/.github/actions/setup-tools/action.yml
+++ b/provider-ci/internal/pkg/templates/provider/.github/actions/setup-tools/action.yml
@@ -57,14 +57,13 @@ runs:
       with:
         repo: pulumi/schema-tools
     
-    #{{- if .Config.Kubectl }}#
+    #{{- if .Config.InstallKubectl }}#
 
-    - name: Install Kubectl
-      shell: bash
-      run: |
-        curl -LO "https://storage.googleapis.com/kubernetes-release/release/$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)/bin/linux/amd64/kubectl"
-        chmod +x ./kubectl
-        sudo mv kubectl /usr/local/bin
+    - name: Install kubectl
+      uses: azure/setup-kubectl@v4
+      with:
+        version: 'latest'
+      id: install
     #{{- end }}#
 
     - name: Setup Node

--- a/provider-ci/internal/pkg/templates/provider/.github/actions/setup-tools/action.yml
+++ b/provider-ci/internal/pkg/templates/provider/.github/actions/setup-tools/action.yml
@@ -56,6 +56,16 @@ runs:
       uses: jaxxstorm/action-install-gh-release@cd6b2b78ad38bdd294341cda064ec0692b06215b # v1.14.0
       with:
         repo: pulumi/schema-tools
+    
+    #{{- if .Config.Kubectl }}#
+
+    - name: Install Kubectl
+      shell: bash
+      run: |
+        curl -LO "https://storage.googleapis.com/kubernetes-release/release/$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)/bin/linux/amd64/kubectl"
+        chmod +x ./kubectl
+        sudo mv kubectl /usr/local/bin
+    #{{- end }}#
 
     - name: Setup Node
       if: inputs.tools == 'all' || contains(inputs.tools, 'nodejs')


### PR DESCRIPTION
This PR contains 2 changes that will not be squashed when merged to maintain their history.

Changes:

- Enable specifying if `kubectl` needs to be installed in a workflow
- Add a configuration option to specify where integration tests are located. Defaults to `examples` if unspecified