### PR TITLE
Configure Git to checkout files with long names

### DIFF
--- a/provider-ci/internal/pkg/templates/provider/.github/workflows/verify-release.yml
+++ b/provider-ci/internal/pkg/templates/provider/.github/workflows/verify-release.yml
@@ -71,6 +71,8 @@ jobs:
 #{{- end }}#
     runs-on: ${{ matrix.runner }}
     steps:
+      - name: Configure Git to checkout files with long names
+        run: git config --global core.longpaths true
       - name: Checkout Repo
         uses: #{{ .Config.ActionVersions.Checkout }}#
         with:

--- a/provider-ci/test-providers/acme/.github/workflows/verify-release.yml
+++ b/provider-ci/test-providers/acme/.github/workflows/verify-release.yml
@@ -76,6 +76,8 @@ jobs:
         runner: ["ubuntu-latest"]
     runs-on: ${{ matrix.runner }}
     steps:
+      - name: Configure Git to checkout files with long names
+        run: git config --global core.longpaths true
       - name: Checkout Repo
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:

--- a/provider-ci/test-providers/aws/.github/workflows/verify-release.yml
+++ b/provider-ci/test-providers/aws/.github/workflows/verify-release.yml
@@ -74,6 +74,8 @@ jobs:
         runner: ${{ fromJSON(format('["ubuntu-latest","windows-latest"{0}]', inputs.enableMacRunner && ',"macos-latest"' || '')) }}
     runs-on: ${{ matrix.runner }}
     steps:
+      - name: Configure Git to checkout files with long names
+        run: git config --global core.longpaths true
       - name: Checkout Repo
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:

--- a/provider-ci/test-providers/cloudflare/.github/workflows/verify-release.yml
+++ b/provider-ci/test-providers/cloudflare/.github/workflows/verify-release.yml
@@ -78,6 +78,8 @@ jobs:
         runner: ["ubuntu-latest"]
     runs-on: ${{ matrix.runner }}
     steps:
+      - name: Configure Git to checkout files with long names
+        run: git config --global core.longpaths true
       - name: Checkout Repo
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:

--- a/provider-ci/test-providers/docker/.github/workflows/verify-release.yml
+++ b/provider-ci/test-providers/docker/.github/workflows/verify-release.yml
@@ -91,6 +91,8 @@ jobs:
         runner: ["ubuntu-latest"]
     runs-on: ${{ matrix.runner }}
     steps:
+      - name: Configure Git to checkout files with long names
+        run: git config --global core.longpaths true
       - name: Checkout Repo
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:

--- a/provider-ci/test-providers/eks/.github/workflows/verify-release.yml
+++ b/provider-ci/test-providers/eks/.github/workflows/verify-release.yml
@@ -83,6 +83,8 @@ jobs:
         runner: ["ubuntu-latest"]
     runs-on: ${{ matrix.runner }}
     steps:
+      - name: Configure Git to checkout files with long names
+        run: git config --global core.longpaths true
       - name: Checkout Repo
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:


### PR DESCRIPTION
On windows Action runners, the actions/checkout action needs extra configuration to be able to handle long file names.

This pull request adds this setting for the release-verification job, which uses both Linux and Windows runners.

While this was discovered while trying to enact release verification for pulumi-gcp, as it is just a configuration setting it's probably worth it to enable nonconditionally (on every provider) so we don't have to re-discover that we need to twist this knob when we enable release verification elsewhere.

Fixes https://github.com/pulumi/ci-mgmt/issues/1322
