### PR TITLE
Setup GCloud Auth with correct id-token permission for release verification

### DIFF
--- a/provider-ci/internal/pkg/templates/provider/.github/workflows/verify-release.yml
+++ b/provider-ci/internal/pkg/templates/provider/.github/workflows/verify-release.yml
@@ -70,6 +70,11 @@ jobs:
         runner: ["ubuntu-latest"]
 #{{- end }}#
     runs-on: ${{ matrix.runner }}
+#{{- if and .Config.ReleaseVerification .Config.GCP }}#
+    permissions:
+      contents: 'read'
+      id-token: 'write'
+#{{- end }}#
     steps:
       - name: Checkout Repo
         uses: #{{ .Config.ActionVersions.Checkout }}#


### PR DESCRIPTION
This pull request adds permissions for the google-github-action on pulumi-gcp when release verification is enabled.
