### PR TITLE
Configure gcloud auth id-token permissions for nested workflow

### DIFF
--- a/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/publish.yml
+++ b/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/publish.yml
@@ -206,6 +206,10 @@ jobs:
   verify_release:
     name: verify_release
     needs: publish_sdk
+    #{{- if .Config.GCP }}#
+    permissions:
+      id-token: write
+    #{{- end }}#
     uses: ./.github/workflows/verify-release.yml
     secrets: inherit
     with:

--- a/provider-ci/test-providers/docker/.github/workflows/publish.yml
+++ b/provider-ci/test-providers/docker/.github/workflows/publish.yml
@@ -220,6 +220,8 @@ jobs:
   verify_release:
     name: verify_release
     needs: publish_sdk
+    permissions:
+      id-token: write
     uses: ./.github/workflows/verify-release.yml
     secrets: inherit
     with:


### PR DESCRIPTION
Fixes https://github.com/pulumi/pulumi-gcp/issues/2919. 

It looks like when you nest Workflows, you also need to state elevated permissions at the parent Workflow level.

- **Ensure correct id-token permission for GCP auth action**
- **Generate correct GCP auth for docker test provider**
