### PR TITLE
Set gcloud auth permissions on each publish step 

### DIFF
--- a/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/main.yml
+++ b/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/main.yml
@@ -87,6 +87,9 @@ jobs:
     name: publish
     permissions:
       contents: write
+      #{{- if .Config.GCP }}#
+      id-token: write
+      #{{- end }}#
     needs:
       - prerequisites
       - build_provider

--- a/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/prerelease.yml
+++ b/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/prerelease.yml
@@ -43,6 +43,9 @@ jobs:
     name: publish
     permissions:
       contents: write
+      #{{- if .Config.GCP }}#
+      id-token: write
+      #{{- end }}#
     needs:
       - prerequisites
       - build_provider

--- a/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/release.yml
+++ b/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/release.yml
@@ -52,6 +52,9 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
+      #{{- if .Config.GCP }}#
+      id-token: write
+      #{{- end }}#
     needs:
       - prerequisites
       - build_provider

--- a/provider-ci/test-providers/docker/.github/workflows/master.yml
+++ b/provider-ci/test-providers/docker/.github/workflows/master.yml
@@ -109,6 +109,7 @@ jobs:
     name: publish
     permissions:
       contents: write
+      id-token: write
     needs:
       - prerequisites
       - build_provider

--- a/provider-ci/test-providers/docker/.github/workflows/prerelease.yml
+++ b/provider-ci/test-providers/docker/.github/workflows/prerelease.yml
@@ -70,6 +70,7 @@ jobs:
     name: publish
     permissions:
       contents: write
+      id-token: write
     needs:
       - prerequisites
       - build_provider

--- a/provider-ci/test-providers/docker/.github/workflows/release.yml
+++ b/provider-ci/test-providers/docker/.github/workflows/release.yml
@@ -76,6 +76,7 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
+      id-token: write
     needs:
       - prerequisites
       - build_provider


### PR DESCRIPTION
Followup to https://github.com/pulumi/ci-mgmt/pull/1331 which was supposed to fix https://github.com/pulumi/pulumi-gcp/issues/2919 but instead pushed the permissions problem up into the next parent Workflow.
Upshot is that the "invalid Workflow" error happens in a different file: https://github.com/pulumi/pulumi-gcp/actions/runs/13042448162/workflow#L101 

I believe this is all of the places where we need to tell Actions to inherit slightly elevated permissions.

