### PR TITLE
Unconditional id-token permissions

### DIFF
--- a/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/main.yml
+++ b/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/main.yml
@@ -87,9 +87,7 @@ jobs:
     name: publish
     permissions:
       contents: write
-      #{{- if .Config.GCP }}#
       id-token: write
-      #{{- end }}#
     needs:
       - prerequisites
       - build_provider

--- a/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/prerelease.yml
+++ b/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/prerelease.yml
@@ -43,9 +43,7 @@ jobs:
     name: publish
     permissions:
       contents: write
-      #{{- if .Config.GCP }}#
       id-token: write
-      #{{- end }}#
     needs:
       - prerequisites
       - build_provider

--- a/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/publish.yml
+++ b/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/publish.yml
@@ -206,10 +206,9 @@ jobs:
   verify_release:
     name: verify_release
     needs: publish_sdk
-    #{{- if .Config.GCP }}#
     permissions:
+      contents: write
       id-token: write
-    #{{- end }}#
     uses: ./.github/workflows/verify-release.yml
     secrets: inherit
     with:

--- a/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/release.yml
+++ b/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/release.yml
@@ -52,9 +52,7 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
-      #{{- if .Config.GCP }}#
       id-token: write
-      #{{- end }}#
     needs:
       - prerequisites
       - build_provider

--- a/provider-ci/internal/pkg/templates/provider/.github/workflows/verify-release.yml
+++ b/provider-ci/internal/pkg/templates/provider/.github/workflows/verify-release.yml
@@ -70,7 +70,7 @@ jobs:
         runner: ["ubuntu-latest"]
 #{{- end }}#
     runs-on: ${{ matrix.runner }}
-#{{- if and .Config.ReleaseVerification .Config.GCP }}#
+#{{- if .Config.ReleaseVerification }}#
     permissions:
       contents: 'read'
       id-token: 'write'

--- a/provider-ci/test-providers/acme/.github/workflows/main.yml
+++ b/provider-ci/test-providers/acme/.github/workflows/main.yml
@@ -94,6 +94,7 @@ jobs:
     name: publish
     permissions:
       contents: write
+      id-token: write
     needs:
       - prerequisites
       - build_provider

--- a/provider-ci/test-providers/acme/.github/workflows/prerelease.yml
+++ b/provider-ci/test-providers/acme/.github/workflows/prerelease.yml
@@ -55,6 +55,7 @@ jobs:
     name: publish
     permissions:
       contents: write
+      id-token: write
     needs:
       - prerequisites
       - build_provider

--- a/provider-ci/test-providers/acme/.github/workflows/publish.yml
+++ b/provider-ci/test-providers/acme/.github/workflows/publish.yml
@@ -174,6 +174,9 @@ jobs:
   verify_release:
     name: verify_release
     needs: publish_sdk
+    permissions:
+      contents: write
+      id-token: write
     uses: ./.github/workflows/verify-release.yml
     secrets: inherit
     with:

--- a/provider-ci/test-providers/acme/.github/workflows/release.yml
+++ b/provider-ci/test-providers/acme/.github/workflows/release.yml
@@ -61,6 +61,7 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
+      id-token: write
     needs:
       - prerequisites
       - build_provider

--- a/provider-ci/test-providers/aws/.github/workflows/master.yml
+++ b/provider-ci/test-providers/aws/.github/workflows/master.yml
@@ -94,6 +94,7 @@ jobs:
     name: publish
     permissions:
       contents: write
+      id-token: write
     needs:
       - prerequisites
       - build_provider

--- a/provider-ci/test-providers/aws/.github/workflows/prerelease.yml
+++ b/provider-ci/test-providers/aws/.github/workflows/prerelease.yml
@@ -54,6 +54,7 @@ jobs:
     name: publish
     permissions:
       contents: write
+      id-token: write
     needs:
       - prerequisites
       - build_provider

--- a/provider-ci/test-providers/aws/.github/workflows/publish.yml
+++ b/provider-ci/test-providers/aws/.github/workflows/publish.yml
@@ -210,6 +210,9 @@ jobs:
   verify_release:
     name: verify_release
     needs: publish_sdk
+    permissions:
+      contents: write
+      id-token: write
     uses: ./.github/workflows/verify-release.yml
     secrets: inherit
     with:

--- a/provider-ci/test-providers/aws/.github/workflows/release.yml
+++ b/provider-ci/test-providers/aws/.github/workflows/release.yml
@@ -60,6 +60,7 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
+      id-token: write
     needs:
       - prerequisites
       - build_provider

--- a/provider-ci/test-providers/aws/.github/workflows/verify-release.yml
+++ b/provider-ci/test-providers/aws/.github/workflows/verify-release.yml
@@ -73,6 +73,9 @@ jobs:
         # See the docs for a similar example to this: https://docs.github.com/en/actions/learn-github-actions/expressions#fromjson
         runner: ${{ fromJSON(format('["ubuntu-latest","windows-latest"{0}]', inputs.enableMacRunner && ',"macos-latest"' || '')) }}
     runs-on: ${{ matrix.runner }}
+    permissions:
+      contents: 'read'
+      id-token: 'write'
     steps:
       - name: Configure Git to checkout files with long names
         run: git config --global core.longpaths true

--- a/provider-ci/test-providers/cloudflare/.github/workflows/master.yml
+++ b/provider-ci/test-providers/cloudflare/.github/workflows/master.yml
@@ -96,6 +96,7 @@ jobs:
     name: publish
     permissions:
       contents: write
+      id-token: write
     needs:
       - prerequisites
       - build_provider

--- a/provider-ci/test-providers/cloudflare/.github/workflows/prerelease.yml
+++ b/provider-ci/test-providers/cloudflare/.github/workflows/prerelease.yml
@@ -57,6 +57,7 @@ jobs:
     name: publish
     permissions:
       contents: write
+      id-token: write
     needs:
       - prerequisites
       - build_provider

--- a/provider-ci/test-providers/cloudflare/.github/workflows/publish.yml
+++ b/provider-ci/test-providers/cloudflare/.github/workflows/publish.yml
@@ -207,6 +207,9 @@ jobs:
   verify_release:
     name: verify_release
     needs: publish_sdk
+    permissions:
+      contents: write
+      id-token: write
     uses: ./.github/workflows/verify-release.yml
     secrets: inherit
     with:

--- a/provider-ci/test-providers/cloudflare/.github/workflows/release.yml
+++ b/provider-ci/test-providers/cloudflare/.github/workflows/release.yml
@@ -63,6 +63,7 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
+      id-token: write
     needs:
       - prerequisites
       - build_provider

--- a/provider-ci/test-providers/docker/.github/workflows/publish.yml
+++ b/provider-ci/test-providers/docker/.github/workflows/publish.yml
@@ -221,6 +221,7 @@ jobs:
     name: verify_release
     needs: publish_sdk
     permissions:
+      contents: write
       id-token: write
     uses: ./.github/workflows/verify-release.yml
     secrets: inherit

--- a/provider-ci/test-providers/eks/.github/workflows/master.yml
+++ b/provider-ci/test-providers/eks/.github/workflows/master.yml
@@ -62,6 +62,7 @@ jobs:
     name: publish
     permissions:
       contents: write
+      id-token: write
     needs:
       - prerequisites
       - build_provider

--- a/provider-ci/test-providers/eks/.github/workflows/prerelease.yml
+++ b/provider-ci/test-providers/eks/.github/workflows/prerelease.yml
@@ -62,6 +62,7 @@ jobs:
     name: publish
     permissions:
       contents: write
+      id-token: write
     needs:
       - prerequisites
       - build_provider

--- a/provider-ci/test-providers/eks/.github/workflows/publish.yml
+++ b/provider-ci/test-providers/eks/.github/workflows/publish.yml
@@ -212,6 +212,9 @@ jobs:
   verify_release:
     name: verify_release
     needs: publish_sdk
+    permissions:
+      contents: write
+      id-token: write
     uses: ./.github/workflows/verify-release.yml
     secrets: inherit
     with:

--- a/provider-ci/test-providers/eks/.github/workflows/release.yml
+++ b/provider-ci/test-providers/eks/.github/workflows/release.yml
@@ -68,6 +68,7 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
+      id-token: write
     needs:
       - prerequisites
       - build_provider


### PR DESCRIPTION
If we limit permissions via template conditionals, it means that our test proivder xyz cannot validate that code path, leading us to guess in the dark at valid workflow configurations.
This pull request implements the suggestion from here: https://github.com/pulumi/ci-mgmt/pull/1332#discussion_r1935180350.
- **Set contents: write and id-token: write unconditionally, so we can validate the workflows**
- **test providers**
