### PR TITLE
Do not pollute workdir during pulumictl auto-installation

### DIFF
--- a/provider-ci/internal/pkg/defaults.go
+++ b/provider-ci/internal/pkg/defaults.go
@@ -1,5 +1,5 @@
 package pkg
 
 const (
-	defaultPulumiCTLVersion = "v0.0.46"
+	defaultPulumiCTLVersion = "v0.0.48"
 )

--- a/provider-ci/internal/pkg/templates/bridged-provider/Makefile
+++ b/provider-ci/internal/pkg/templates/bridged-provider/Makefile
@@ -34,8 +34,10 @@ PULUMI_MISSING_DOCS_ERROR := true
 PULUMICTL_VERSION := #{{ .Config.ToolVersions.PulumiCTL }}#
 PULUMICTL := $(shell which pulumictl || \
 	(test ! -e $(WORKING_DIR)/bin/pulumictl && \
-		GOPATH="$(WORKING_DIR)" go install "github.com/pulumi/pulumictl/cmd/pulumictl@$(PULUMICTL_VERSION)"; \
-	echo "$(WORKING_DIR)/bin/pulumictl"))
+		go install "github.com/pulumi/pulumictl/cmd/pulumictl@$(PULUMICTL_VERSION)" && \
+		mkdir -p "$(WORKING_DIR)/bin" && \
+		cp "$(shell go env GOPATH)/bin/pulumictl" "$(WORKING_DIR)/bin/pulumictl"; \
+		echo "$(WORKING_DIR)/bin/pulumictl"))
 
 # Override during CI using `make [TARGET] PROVIDER_VERSION=""` or by setting a PROVIDER_VERSION environment variable
 # Local & branch builds will just used this fixed default version unless specified

--- a/provider-ci/test-providers/acme/.github/actions/setup-tools/action.yml
+++ b/provider-ci/test-providers/acme/.github/actions/setup-tools/action.yml
@@ -42,7 +42,7 @@ runs:
       if: inputs.tools == 'all' || contains(inputs.tools, 'pulumictl')
       uses: jaxxstorm/action-install-gh-release@cd6b2b78ad38bdd294341cda064ec0692b06215b # v1.14.0
       with:
-        tag: v0.0.46
+        tag: v0.0.48
         repo: pulumi/pulumictl
 
     - name: Install Pulumi CLI

--- a/provider-ci/test-providers/acme/Makefile
+++ b/provider-ci/test-providers/acme/Makefile
@@ -15,11 +15,13 @@ PULUMI_PROVIDER_BUILD_PARALLELISM ?=
 PULUMI_CONVERT := 0
 PULUMI_MISSING_DOCS_ERROR := true
 
-PULUMICTL_VERSION := v0.0.46
+PULUMICTL_VERSION := v0.0.48
 PULUMICTL := $(shell which pulumictl || \
 	(test ! -e $(WORKING_DIR)/bin/pulumictl && \
-		GOPATH="$(WORKING_DIR)" go install "github.com/pulumi/pulumictl/cmd/pulumictl@$(PULUMICTL_VERSION)"; \
-	echo "$(WORKING_DIR)/bin/pulumictl"))
+		go install "github.com/pulumi/pulumictl/cmd/pulumictl@$(PULUMICTL_VERSION)" && \
+		mkdir -p "$(WORKING_DIR)/bin" && \
+		cp "$(shell go env GOPATH)/bin/pulumictl" "$(WORKING_DIR)/bin/pulumictl"; \
+		echo "$(WORKING_DIR)/bin/pulumictl"))
 
 # Override during CI using `make [TARGET] PROVIDER_VERSION=""` or by setting a PROVIDER_VERSION environment variable
 # Local & branch builds will just used this fixed default version unless specified

--- a/provider-ci/test-providers/aws/.github/actions/setup-tools/action.yml
+++ b/provider-ci/test-providers/aws/.github/actions/setup-tools/action.yml
@@ -42,7 +42,7 @@ runs:
       if: inputs.tools == 'all' || contains(inputs.tools, 'pulumictl')
       uses: jaxxstorm/action-install-gh-release@cd6b2b78ad38bdd294341cda064ec0692b06215b # v1.14.0
       with:
-        tag: v0.0.46
+        tag: v0.0.48
         repo: pulumi/pulumictl
 
     - name: Install Pulumi CLI

--- a/provider-ci/test-providers/aws/Makefile
+++ b/provider-ci/test-providers/aws/Makefile
@@ -15,11 +15,13 @@ PULUMI_PROVIDER_BUILD_PARALLELISM ?= -p 2
 PULUMI_CONVERT := 1
 PULUMI_MISSING_DOCS_ERROR := true
 
-PULUMICTL_VERSION := v0.0.46
+PULUMICTL_VERSION := v0.0.48
 PULUMICTL := $(shell which pulumictl || \
 	(test ! -e $(WORKING_DIR)/bin/pulumictl && \
-		GOPATH="$(WORKING_DIR)" go install "github.com/pulumi/pulumictl/cmd/pulumictl@$(PULUMICTL_VERSION)"; \
-	echo "$(WORKING_DIR)/bin/pulumictl"))
+		go install "github.com/pulumi/pulumictl/cmd/pulumictl@$(PULUMICTL_VERSION)" && \
+		mkdir -p "$(WORKING_DIR)/bin" && \
+		cp "$(shell go env GOPATH)/bin/pulumictl" "$(WORKING_DIR)/bin/pulumictl"; \
+		echo "$(WORKING_DIR)/bin/pulumictl"))
 
 # Override during CI using `make [TARGET] PROVIDER_VERSION=""` or by setting a PROVIDER_VERSION environment variable
 # Local & branch builds will just used this fixed default version unless specified

--- a/provider-ci/test-providers/cloudflare/.github/actions/setup-tools/action.yml
+++ b/provider-ci/test-providers/cloudflare/.github/actions/setup-tools/action.yml
@@ -42,7 +42,7 @@ runs:
       if: inputs.tools == 'all' || contains(inputs.tools, 'pulumictl')
       uses: jaxxstorm/action-install-gh-release@cd6b2b78ad38bdd294341cda064ec0692b06215b # v1.14.0
       with:
-        tag: v0.0.46
+        tag: v0.0.48
         repo: pulumi/pulumictl
 
     - name: Install Pulumi CLI

--- a/provider-ci/test-providers/cloudflare/Makefile
+++ b/provider-ci/test-providers/cloudflare/Makefile
@@ -15,11 +15,13 @@ PULUMI_PROVIDER_BUILD_PARALLELISM ?=
 PULUMI_CONVERT := 1
 PULUMI_MISSING_DOCS_ERROR := true
 
-PULUMICTL_VERSION := v0.0.46
+PULUMICTL_VERSION := v0.0.48
 PULUMICTL := $(shell which pulumictl || \
 	(test ! -e $(WORKING_DIR)/bin/pulumictl && \
-		GOPATH="$(WORKING_DIR)" go install "github.com/pulumi/pulumictl/cmd/pulumictl@$(PULUMICTL_VERSION)"; \
-	echo "$(WORKING_DIR)/bin/pulumictl"))
+		go install "github.com/pulumi/pulumictl/cmd/pulumictl@$(PULUMICTL_VERSION)" && \
+		mkdir -p "$(WORKING_DIR)/bin" && \
+		cp "$(shell go env GOPATH)/bin/pulumictl" "$(WORKING_DIR)/bin/pulumictl"; \
+		echo "$(WORKING_DIR)/bin/pulumictl"))
 
 # Override during CI using `make [TARGET] PROVIDER_VERSION=""` or by setting a PROVIDER_VERSION environment variable
 # Local & branch builds will just used this fixed default version unless specified

--- a/provider-ci/test-providers/docker/.github/actions/setup-tools/action.yml
+++ b/provider-ci/test-providers/docker/.github/actions/setup-tools/action.yml
@@ -42,7 +42,7 @@ runs:
       if: inputs.tools == 'all' || contains(inputs.tools, 'pulumictl')
       uses: jaxxstorm/action-install-gh-release@cd6b2b78ad38bdd294341cda064ec0692b06215b # v1.14.0
       with:
-        tag: v0.0.46
+        tag: v0.0.48
         repo: pulumi/pulumictl
 
     - name: Install Pulumi CLI

--- a/provider-ci/test-providers/docker/Makefile
+++ b/provider-ci/test-providers/docker/Makefile
@@ -15,11 +15,13 @@ PULUMI_PROVIDER_BUILD_PARALLELISM ?=
 PULUMI_CONVERT := 1
 PULUMI_MISSING_DOCS_ERROR := true
 
-PULUMICTL_VERSION := v0.0.46
+PULUMICTL_VERSION := v0.0.48
 PULUMICTL := $(shell which pulumictl || \
 	(test ! -e $(WORKING_DIR)/bin/pulumictl && \
-		GOPATH="$(WORKING_DIR)" go install "github.com/pulumi/pulumictl/cmd/pulumictl@$(PULUMICTL_VERSION)"; \
-	echo "$(WORKING_DIR)/bin/pulumictl"))
+		go install "github.com/pulumi/pulumictl/cmd/pulumictl@$(PULUMICTL_VERSION)" && \
+		mkdir -p "$(WORKING_DIR)/bin" && \
+		cp "$(shell go env GOPATH)/bin/pulumictl" "$(WORKING_DIR)/bin/pulumictl"; \
+		echo "$(WORKING_DIR)/bin/pulumictl"))
 
 # Override during CI using `make [TARGET] PROVIDER_VERSION=""` or by setting a PROVIDER_VERSION environment variable
 # Local & branch builds will just used this fixed default version unless specified

--- a/provider-ci/test-providers/eks/.github/actions/setup-tools/action.yml
+++ b/provider-ci/test-providers/eks/.github/actions/setup-tools/action.yml
@@ -42,7 +42,7 @@ runs:
       if: inputs.tools == 'all' || contains(inputs.tools, 'pulumictl')
       uses: jaxxstorm/action-install-gh-release@cd6b2b78ad38bdd294341cda064ec0692b06215b # v1.14.0
       with:
-        tag: v0.0.46
+        tag: v0.0.48
         repo: pulumi/pulumictl
 
     - name: Install Pulumi CLI

--- a/provider-ci/test-providers/eks/Makefile
+++ b/provider-ci/test-providers/eks/Makefile
@@ -15,11 +15,13 @@ PULUMI_PROVIDER_BUILD_PARALLELISM ?=
 PULUMI_CONVERT := 0
 PULUMI_MISSING_DOCS_ERROR := true
 
-PULUMICTL_VERSION := v0.0.46
+PULUMICTL_VERSION := v0.0.48
 PULUMICTL := $(shell which pulumictl || \
 	(test ! -e $(WORKING_DIR)/bin/pulumictl && \
-		GOPATH="$(WORKING_DIR)" go install "github.com/pulumi/pulumictl/cmd/pulumictl@$(PULUMICTL_VERSION)"; \
-	echo "$(WORKING_DIR)/bin/pulumictl"))
+		go install "github.com/pulumi/pulumictl/cmd/pulumictl@$(PULUMICTL_VERSION)" && \
+		mkdir -p "$(WORKING_DIR)/bin" && \
+		cp "$(shell go env GOPATH)/bin/pulumictl" "$(WORKING_DIR)/bin/pulumictl"; \
+		echo "$(WORKING_DIR)/bin/pulumictl"))
 
 # Override during CI using `make [TARGET] PROVIDER_VERSION=""` or by setting a PROVIDER_VERSION environment variable
 # Local & branch builds will just used this fixed default version unless specified


### PR DESCRIPTION
When pulumictl is not discovered in PATH it is auto-installed by the Makefile. 

Unfortunately the previous method used a GOPATH override to guide `go install` as to where install pulumictl. As a side effect of this, the auto-installation did not use the standard Go package cache and polluted the working dir with another copy of Go package cache.

After this change, auto installation happens against the standard Go package cache and the result is then copied into bin.

Users should prefer to have pulumictl in the environment than relying on the auto-installation.

Tested manually on pulumi-awsx.