### PR TITLE
Extract templates function to own file with docs

### DIFF
--- a/provider-ci/internal/cmd/listTemplates.go
+++ b/provider-ci/internal/cmd/listTemplates.go
@@ -17,7 +17,7 @@ var listTemplatesCmd = &cobra.Command{
 		if err != nil {
 			return err
 		}
-		out, err := yaml.Marshal(struct{ Templates []string }{Templates: templates})
+		out, err := yaml.Marshal(struct{ Templates []pkg.TemplateDir }{Templates: templates})
 		if err != nil {
 			return err
 		}

--- a/provider-ci/internal/pkg/generate.go
+++ b/provider-ci/internal/pkg/generate.go
@@ -99,29 +99,6 @@ func GeneratePackage(opts GenerateOpts) error {
 	return nil
 }
 
-// getTemplateDirs returns a list of directories in the embedded filesystem that form the overall template.
-// Each directory is rendered into the same output directory.
-// Care should be taken to ensure that the template files do not conflict with each other.
-func getTemplateDirs(templateName string) ([]string, error) {
-	// Available templates:
-	// - provider: the main template for any provider repository
-	// - pulumi-provider: a template for a Pulumi-managed provider. This folder consolidates files not needed for external providers.
-	// - bridged-provider: a template for a provider repository that uses tf-bridge & follows the boilerplate structure.
-	// - dev-container: a dev-container setup for any pulumi related project.
-	switch templateName {
-	case "bridged-provider":
-		// Render more specific templates last to allow them to override more general templates.
-		return []string{"dev-container", "provider", "pulumi-provider", "bridged-provider"}, nil
-	case "external-bridged-provider":
-		// Render more specific templates last to allow them to override more general templates.
-		return []string{"dev-container", "provider", "external-provider", "bridged-provider"}, nil
-	case "generic":
-		return []string{"provider", "pulumi-provider", "bridged-provider"}, nil
-	default:
-		return nil, fmt.Errorf("unknown template: %s", templateName)
-	}
-}
-
 func getDeletedFiles(templateName string) []string {
 	switch templateName {
 	case "bridged-provider":

--- a/provider-ci/internal/pkg/generate.go
+++ b/provider-ci/internal/pkg/generate.go
@@ -120,7 +120,7 @@ func getDeletedFiles(templateName string) []string {
 	}
 }
 
-func renderTemplateDir(template string, opts GenerateOpts) error {
+func renderTemplateDir(template TemplateDir, opts GenerateOpts) error {
 	// Template context is global and loaded from the file at opts.configPath
 	// The embedded filesystem templateFS should contain a subdirectory with the name of opts.templateName
 	// For each file in the subdirectory, apply templating and write to opts.outDir with the same relative path
@@ -144,7 +144,7 @@ func renderTemplateDir(template string, opts GenerateOpts) error {
 		Config:      config,
 	}
 
-	templateDir := filepath.Join("templates", template)
+	templateDir := filepath.Join("templates", string(template))
 
 	var err error
 	ctx.Splices, err = collectSplices(templateDir, ctx)
@@ -220,21 +220,21 @@ func collectSplices(templateDir string, tc templateContext) (map[string]string, 
 	return splices, nil
 }
 
-func ListTemplates() ([]string, error) {
+func ListTemplates() ([]TemplateDir, error) {
 	dirEntries, err := templateFS.ReadDir("templates")
 	if err != nil {
 		return nil, err
 	}
-	var templateNames []string
+	var templateNames []TemplateDir
 	for _, dirEntry := range dirEntries {
 		if dirEntry.IsDir() {
-			templateNames = append(templateNames, dirEntry.Name())
+			templateNames = append(templateNames, TemplateDir(dirEntry.Name()))
 		}
 	}
 	return templateNames, nil
 }
 
-func HasTemplate(name string) bool {
+func HasTemplate(name TemplateDir) bool {
 	templates, err := ListTemplates()
 	if err != nil {
 		return false

--- a/provider-ci/internal/pkg/templates.go
+++ b/provider-ci/internal/pkg/templates.go
@@ -1,0 +1,41 @@
+package pkg
+
+import (
+	"fmt"
+)
+
+// Template directories
+const (
+	// configuration to run the repository in a dev container
+	devContainer = "dev-container"
+	// git attributes, go config, CI reusable workflows
+	provider = "provider"
+	// CoC, upgrade-provider config, issue templates, command dispatch workflows
+	pulumiProvider = "pulumi-provider"
+	// ci-mgmt pull-based updates workflow
+	externalProvider = "external-provider"
+	// CI and Makefile for bridged providers (internal & external)
+	bridgedProvider = "bridged-provider"
+)
+
+// getTemplateDirs returns a list of directories in the embedded filesystem that form the overall template.
+// Templates are composed of one or more template folders within this directory.
+// Each directory is rendered into the same output directory.
+// Care should be taken to ensure that the template files do not conflict with each other.
+func getTemplateDirs(templateName string) ([]string, error) {
+	// Note: Render more specific templates last to allow them to override more general templates.
+	// The `.ci-mgmt.yaml` `template` property can be set to one of 3 values:
+	switch templateName {
+	case "bridged-provider":
+		// Any Pulumi-owned bridged provider
+		return []string{devContainer, provider, pulumiProvider, bridgedProvider}, nil
+	case "external-bridged-provider":
+		// third-party bridged providers
+		return []string{devContainer, provider, externalProvider, bridgedProvider}, nil
+	case "generic":
+		// currently almost identical to the bridged-provider template
+		return []string{provider, pulumiProvider, bridgedProvider}, nil
+	default:
+		return nil, fmt.Errorf("unknown template: %s", templateName)
+	}
+}

--- a/provider-ci/internal/pkg/templates.go
+++ b/provider-ci/internal/pkg/templates.go
@@ -4,37 +4,41 @@ import (
 	"fmt"
 )
 
+// TemplateDir is a directory in the embedded filesystem that contains files to be rendered into the output directory.
+// Multiple templates are combined together to form the overall template (see `getTemplateDirs`).
+type TemplateDir string
+
 // Template directories
 const (
 	// configuration to run the repository in a dev container
-	devContainer = "dev-container"
+	devContainer TemplateDir = "dev-container"
 	// git attributes, go config, CI reusable workflows
-	provider = "provider"
+	provider TemplateDir = "provider"
 	// CoC, upgrade-provider config, issue templates, command dispatch workflows
-	pulumiProvider = "pulumi-provider"
+	pulumiProvider TemplateDir = "pulumi-provider"
 	// ci-mgmt pull-based updates workflow
-	externalProvider = "external-provider"
+	externalProvider TemplateDir = "external-provider"
 	// CI and Makefile for bridged providers (internal & external)
-	bridgedProvider = "bridged-provider"
+	bridgedProvider TemplateDir = "bridged-provider"
 )
 
 // getTemplateDirs returns a list of directories in the embedded filesystem that form the overall template.
 // Templates are composed of one or more template folders within this directory.
 // Each directory is rendered into the same output directory.
 // Care should be taken to ensure that the template files do not conflict with each other.
-func getTemplateDirs(templateName string) ([]string, error) {
+func getTemplateDirs(templateName string) ([]TemplateDir, error) {
 	// Note: Render more specific templates last to allow them to override more general templates.
 	// The `.ci-mgmt.yaml` `template` property can be set to one of 3 values:
 	switch templateName {
 	case "bridged-provider":
 		// Any Pulumi-owned bridged provider
-		return []string{devContainer, provider, pulumiProvider, bridgedProvider}, nil
+		return []TemplateDir{devContainer, provider, pulumiProvider, bridgedProvider}, nil
 	case "external-bridged-provider":
 		// third-party bridged providers
-		return []string{devContainer, provider, externalProvider, bridgedProvider}, nil
+		return []TemplateDir{devContainer, provider, externalProvider, bridgedProvider}, nil
 	case "generic":
 		// currently almost identical to the bridged-provider template
-		return []string{provider, pulumiProvider, bridgedProvider}, nil
+		return []TemplateDir{provider, pulumiProvider, bridgedProvider}, nil
 	default:
 		return nil, fmt.Errorf("unknown template: %s", templateName)
 	}

--- a/provider-ci/internal/pkg/templates/defaults.config.yaml
+++ b/provider-ci/internal/pkg/templates/defaults.config.yaml
@@ -1,5 +1,5 @@
 # The default template name to apply
-# Possible template names can be found in the getTemplateDirs function in provider-ci/internal/pkg/generate.go file
+# Possible template names can be found in ../templates.go
 template: bridged-provider
 
 # provider is the name of the provider without the pulumi-prefix e.g. "aws"


### PR DESCRIPTION
1. Make it easier to find the key template composition code.
2. Add more documentation around the concepts and content.