### PR TITLE
Allow auto-merging upstream provider upgrades

### DIFF
--- a/provider-ci/internal/pkg/config.go
+++ b/provider-ci/internal/pkg/config.go
@@ -309,6 +309,9 @@ type Config struct {
 	// TestFolder defines where the test directory for integration tests is located.
 	// Defaults to "examples" if not set.
 	TestFolder string `yaml:"test-folder"`
+
+	// AutoMergeProviderUpgrades controls whether we automatically merge upstream provider upgrades.
+	AutoMergeProviderUpgrades bool `yaml:"autoMergeProviderUpgrades"`
 }
 
 // LoadLocalConfig loads the provider configuration at the given path with

--- a/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/upgrade-provider.yml
+++ b/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/upgrade-provider.yml
@@ -80,14 +80,20 @@ jobs:
         # upstream_version will be empty if the provider is up-to-date
         run: echo "version=${{ github.event.inputs.version || steps.upstream_version.outputs.latest_version }}" >> "$GITHUB_OUTPUT"
         shell: bash
-      - name: Attempt provider upgrade
+      - name: Call upgrade provider action
         id: upgrade_provider
-        # Only attempt the upgrade if we have a target version
         if: steps.target_version.outputs.version != ''
-        # Don't mark the build as failed if we can't auto-open a PR as we've already opened the upgrade issue for tracking
         continue-on-error: true
-        run: upgrade-provider "${{ github.repository }}" --kind="all" --target-version="${{ steps.target_version.outputs.version }}" #{{ if .Config.JavaGenVersion }}#--java-version="#{{ .Config.JavaGenVersion }}#"#{{ end }}#
-        shell: bash
+        uses: #{{ .Config.ActionVersions.UpgradeProviderAction }}#
+        with:
+          kind: all
+          email: bot@pulumi.com
+          username: pulumi-bot
+          automerge: #{{ .Config.AutoMergeProviderUpgrades }}#
+          target-version: ${{ steps.target_version.outputs.version }}
+          #{{- if .Config.JavaGenVersion }}#
+          target-java-version: #{{ .Config.JavaGenVersion }}#
+          #{{- end }}#
       - name: Comment on upgrade issue if automated PR failed
         if: steps.upgrade_provider.outcome == 'failure'
         shell: bash

--- a/provider-ci/internal/pkg/templates/defaults.config.yaml
+++ b/provider-ci/internal/pkg/templates/defaults.config.yaml
@@ -231,3 +231,6 @@ checkUpstreamUpgrade: true
 # (e.g. `aws-*`) which are considered provider-specific workflows. This will likely change to false in the future once
 # we've made the process of cleaning up removed and renamed workflows more reliable.
 clean-github-workflows: true
+
+# Whether we automatically merge upstream provider upgrades.
+autoMergeProviderUpgrades: false

--- a/provider-ci/test-providers/acme/.github/workflows/upgrade-provider.yml
+++ b/provider-ci/test-providers/acme/.github/workflows/upgrade-provider.yml
@@ -67,14 +67,17 @@ jobs:
         # upstream_version will be empty if the provider is up-to-date
         run: echo "version=${{ github.event.inputs.version || steps.upstream_version.outputs.latest_version }}" >> "$GITHUB_OUTPUT"
         shell: bash
-      - name: Attempt provider upgrade
+      - name: Call upgrade provider action
         id: upgrade_provider
-        # Only attempt the upgrade if we have a target version
         if: steps.target_version.outputs.version != ''
-        # Don't mark the build as failed if we can't auto-open a PR as we've already opened the upgrade issue for tracking
         continue-on-error: true
-        run: upgrade-provider "${{ github.repository }}" --kind="all" --target-version="${{ steps.target_version.outputs.version }}" 
-        shell: bash
+        uses: pulumi/pulumi-upgrade-provider-action@a1d9f03fbfd923f787427c1d9e99c2356711d483 # v0.0.13
+        with:
+          kind: all
+          email: bot@pulumi.com
+          username: pulumi-bot
+          automerge: false
+          target-version: ${{ steps.target_version.outputs.version }}
       - name: Comment on upgrade issue if automated PR failed
         if: steps.upgrade_provider.outcome == 'failure'
         shell: bash

--- a/provider-ci/test-providers/aws/.github/workflows/upgrade-provider.yml
+++ b/provider-ci/test-providers/aws/.github/workflows/upgrade-provider.yml
@@ -75,14 +75,17 @@ jobs:
         # upstream_version will be empty if the provider is up-to-date
         run: echo "version=${{ github.event.inputs.version || steps.upstream_version.outputs.latest_version }}" >> "$GITHUB_OUTPUT"
         shell: bash
-      - name: Attempt provider upgrade
+      - name: Call upgrade provider action
         id: upgrade_provider
-        # Only attempt the upgrade if we have a target version
         if: steps.target_version.outputs.version != ''
-        # Don't mark the build as failed if we can't auto-open a PR as we've already opened the upgrade issue for tracking
         continue-on-error: true
-        run: upgrade-provider "${{ github.repository }}" --kind="all" --target-version="${{ steps.target_version.outputs.version }}" 
-        shell: bash
+        uses: pulumi/pulumi-upgrade-provider-action@a1d9f03fbfd923f787427c1d9e99c2356711d483 # v0.0.13
+        with:
+          kind: all
+          email: bot@pulumi.com
+          username: pulumi-bot
+          automerge: false
+          target-version: ${{ steps.target_version.outputs.version }}
       - name: Comment on upgrade issue if automated PR failed
         if: steps.upgrade_provider.outcome == 'failure'
         shell: bash

--- a/provider-ci/test-providers/docker/.github/workflows/upgrade-provider.yml
+++ b/provider-ci/test-providers/docker/.github/workflows/upgrade-provider.yml
@@ -67,14 +67,17 @@ jobs:
         # upstream_version will be empty if the provider is up-to-date
         run: echo "version=${{ github.event.inputs.version || steps.upstream_version.outputs.latest_version }}" >> "$GITHUB_OUTPUT"
         shell: bash
-      - name: Attempt provider upgrade
+      - name: Call upgrade provider action
         id: upgrade_provider
-        # Only attempt the upgrade if we have a target version
         if: steps.target_version.outputs.version != ''
-        # Don't mark the build as failed if we can't auto-open a PR as we've already opened the upgrade issue for tracking
         continue-on-error: true
-        run: upgrade-provider "${{ github.repository }}" --kind="all" --target-version="${{ steps.target_version.outputs.version }}" 
-        shell: bash
+        uses: pulumi/pulumi-upgrade-provider-action@a1d9f03fbfd923f787427c1d9e99c2356711d483 # v0.0.13
+        with:
+          kind: all
+          email: bot@pulumi.com
+          username: pulumi-bot
+          automerge: false
+          target-version: ${{ steps.target_version.outputs.version }}
       - name: Comment on upgrade issue if automated PR failed
         if: steps.upgrade_provider.outcome == 'failure'
         shell: bash


### PR DESCRIPTION
This PR adds a config `autoMergeProviderUpgrades` which will mark upstream provider upgrades to be auto-merged. I've also moved the upgrade-provider call to use the upgrade-provider action like we do with bridge upgrades.

Related to https://github.com/pulumi/ci-mgmt/issues/1344