### PR TITLE
Remove Civo from provider list

### DIFF
--- a/.github/ISSUE_TEMPLATE/0-ecosystem-providers.md
+++ b/.github/ISSUE_TEMPLATE/0-ecosystem-providers.md
@@ -54,7 +54,6 @@ assignees: ''
 - [ ] [archive](https://github.com/pulumi/pulumi-archive)
 - [ ] [artifactory](https://github.com/pulumi/pulumi-artifactory)
 - [ ] [azuredevops](https://github.com/pulumi/pulumi-azuredevops)
-- [ ] [civo](https://github.com/pulumi/pulumi-civo)
 - [ ] [cloudamqp](https://github.com/pulumi/pulumi-cloudamqp)
 - [ ] [cloudinit](https://github.com/pulumi/pulumi-cloudinit)
 - [ ] [cloudngfwaws](https://github.com/pulumi/pulumi-cloudngfwaws)

--- a/provider-ci/providers.json
+++ b/provider-ci/providers.json
@@ -11,7 +11,6 @@
     "azure",
     "azuread",
     "azuredevops",
-    "civo",
     "cloudamqp",
     "cloudflare",
     "cloudinit",


### PR DESCRIPTION
This pull request removes Civo from the list of managed providers.

Part of https://github.com/pulumi/pulumi-civo/issues/696.
