### PR TITLE
Allow missing docs config

### DIFF
--- a/provider-ci/internal/pkg/config.go
+++ b/provider-ci/internal/pkg/config.go
@@ -1,9 +1,8 @@
 package pkg
 
 import (
-	_ "embed" // For embedding action versions.
-
 	"bytes"
+	_ "embed" // For embedding action versions.
 	"fmt"
 	"os"
 	"path/filepath"
@@ -312,6 +311,10 @@ type Config struct {
 
 	// AutoMergeProviderUpgrades controls whether we automatically merge upstream provider upgrades.
 	AutoMergeProviderUpgrades bool `yaml:"autoMergeProviderUpgrades"`
+
+	// AllowMissingDocs controls whether we allow missing docs in the provider.
+	// Defaults to false.
+	AllowMissingDocs bool `yaml:"allowMissingDocs"`
 }
 
 // LoadLocalConfig loads the provider configuration at the given path with

--- a/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/upgrade-provider.yml
+++ b/provider-ci/internal/pkg/templates/bridged-provider/.github/workflows/upgrade-provider.yml
@@ -91,6 +91,7 @@ jobs:
           username: pulumi-bot
           automerge: #{{ .Config.AutoMergeProviderUpgrades }}#
           target-version: ${{ steps.target_version.outputs.version }}
+          allow-missing-docs: #{{ .Config.AllowMissingDocs }}#
           #{{- if .Config.JavaGenVersion }}#
           target-java-version: #{{ .Config.JavaGenVersion }}#
           #{{- end }}#

--- a/provider-ci/internal/pkg/templates/defaults.config.yaml
+++ b/provider-ci/internal/pkg/templates/defaults.config.yaml
@@ -234,3 +234,6 @@ clean-github-workflows: true
 
 # Whether we automatically merge upstream provider upgrades.
 autoMergeProviderUpgrades: false
+
+# Whether we allow missing docs in the provider.
+allowMissingDocs: false

--- a/provider-ci/test-providers/acme/.github/workflows/upgrade-provider.yml
+++ b/provider-ci/test-providers/acme/.github/workflows/upgrade-provider.yml
@@ -78,6 +78,7 @@ jobs:
           username: pulumi-bot
           automerge: false
           target-version: ${{ steps.target_version.outputs.version }}
+          allow-missing-docs: false
       - name: Comment on upgrade issue if automated PR failed
         if: steps.upgrade_provider.outcome == 'failure'
         shell: bash

--- a/provider-ci/test-providers/aws/.github/workflows/upgrade-provider.yml
+++ b/provider-ci/test-providers/aws/.github/workflows/upgrade-provider.yml
@@ -86,6 +86,7 @@ jobs:
           username: pulumi-bot
           automerge: false
           target-version: ${{ steps.target_version.outputs.version }}
+          allow-missing-docs: false
       - name: Comment on upgrade issue if automated PR failed
         if: steps.upgrade_provider.outcome == 'failure'
         shell: bash

--- a/provider-ci/test-providers/docker/.github/workflows/upgrade-provider.yml
+++ b/provider-ci/test-providers/docker/.github/workflows/upgrade-provider.yml
@@ -78,6 +78,7 @@ jobs:
           username: pulumi-bot
           automerge: false
           target-version: ${{ steps.target_version.outputs.version }}
+          allow-missing-docs: false
       - name: Comment on upgrade issue if automated PR failed
         if: steps.upgrade_provider.outcome == 'failure'
         shell: bash


### PR DESCRIPTION
This config will allow us to opt-out Tier 1 providers and opt-in Tier2+ providers.

Currently defaults to False, will flip to True once we opt-out Tier 1 providers.

Related to https://github.com/pulumi/upgrade-provider/issues/303