### PR TITLE
Include schema-embed in release artifacts

### DIFF
--- a/provider-ci/internal/pkg/templates/base/.github/workflows/publish.yml
+++ b/provider-ci/internal/pkg/templates/base/.github/workflows/publish.yml
@@ -66,6 +66,14 @@ jobs:
         path: dist
         # Don't create a directory for each artifact
         merge-multiple: true
+    - name: Download schema
+      uses: #{{ .Config.ActionVersions.DownloadArtifact }}#
+      with:
+        # Use a pattern to avoid failing if the artifact doesn't exist
+        pattern: schema-embed.*
+        # Avoid creating directories for each artifact
+        merge-multiple: true
+        path: dist
     - name: Calculate checksums
       working-directory: dist
       run: shasum ./*.tar.gz > "pulumi-#{{ .Config.Provider }}#_${{ inputs.version }}_checksums.txt"

--- a/provider-ci/test-providers/acme/.github/workflows/publish.yml
+++ b/provider-ci/test-providers/acme/.github/workflows/publish.yml
@@ -66,6 +66,14 @@ jobs:
         path: dist
         # Don't create a directory for each artifact
         merge-multiple: true
+    - name: Download schema
+      uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
+      with:
+        # Use a pattern to avoid failing if the artifact doesn't exist
+        pattern: schema-embed.*
+        # Avoid creating directories for each artifact
+        merge-multiple: true
+        path: dist
     - name: Calculate checksums
       working-directory: dist
       run: shasum ./*.tar.gz > "pulumi-acme_${{ inputs.version }}_checksums.txt"

--- a/provider-ci/test-providers/aws/.github/workflows/publish.yml
+++ b/provider-ci/test-providers/aws/.github/workflows/publish.yml
@@ -80,6 +80,14 @@ jobs:
         path: dist
         # Don't create a directory for each artifact
         merge-multiple: true
+    - name: Download schema
+      uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
+      with:
+        # Use a pattern to avoid failing if the artifact doesn't exist
+        pattern: schema-embed.*
+        # Avoid creating directories for each artifact
+        merge-multiple: true
+        path: dist
     - name: Calculate checksums
       working-directory: dist
       run: shasum ./*.tar.gz > "pulumi-aws_${{ inputs.version }}_checksums.txt"

--- a/provider-ci/test-providers/cloudflare/.github/workflows/publish.yml
+++ b/provider-ci/test-providers/cloudflare/.github/workflows/publish.yml
@@ -78,6 +78,14 @@ jobs:
         path: dist
         # Don't create a directory for each artifact
         merge-multiple: true
+    - name: Download schema
+      uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
+      with:
+        # Use a pattern to avoid failing if the artifact doesn't exist
+        pattern: schema-embed.*
+        # Avoid creating directories for each artifact
+        merge-multiple: true
+        path: dist
     - name: Calculate checksums
       working-directory: dist
       run: shasum ./*.tar.gz > "pulumi-cloudflare_${{ inputs.version }}_checksums.txt"

--- a/provider-ci/test-providers/docker/.github/workflows/publish.yml
+++ b/provider-ci/test-providers/docker/.github/workflows/publish.yml
@@ -91,6 +91,14 @@ jobs:
         path: dist
         # Don't create a directory for each artifact
         merge-multiple: true
+    - name: Download schema
+      uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
+      with:
+        # Use a pattern to avoid failing if the artifact doesn't exist
+        pattern: schema-embed.*
+        # Avoid creating directories for each artifact
+        merge-multiple: true
+        path: dist
     - name: Calculate checksums
       working-directory: dist
       run: shasum ./*.tar.gz > "pulumi-docker_${{ inputs.version }}_checksums.txt"

--- a/provider-ci/test-providers/eks/.github/workflows/publish.yml
+++ b/provider-ci/test-providers/eks/.github/workflows/publish.yml
@@ -83,6 +83,14 @@ jobs:
         path: dist
         # Don't create a directory for each artifact
         merge-multiple: true
+    - name: Download schema
+      uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
+      with:
+        # Use a pattern to avoid failing if the artifact doesn't exist
+        pattern: schema-embed.*
+        # Avoid creating directories for each artifact
+        merge-multiple: true
+        path: dist
     - name: Calculate checksums
       working-directory: dist
       run: shasum ./*.tar.gz > "pulumi-eks_${{ inputs.version }}_checksums.txt"


### PR DESCRIPTION
Upload to S3 and GH release so it's easily downloadable by systems like the registry and give the option of not requiring it to be committed.

Stacked on #1362 