### PR TITLE
Removes libvirt from maintained provider list

### DIFF
--- a/.github/ISSUE_TEMPLATE/0-ecosystem-providers.md
+++ b/.github/ISSUE_TEMPLATE/0-ecosystem-providers.md
@@ -75,7 +75,6 @@ assignees: ''
 - [ ] [kafka](https://github.com/pulumi/pulumi-kafka)
 - [ ] [keycloak](https://github.com/pulumi/pulumi-keycloak)
 - [ ] [kong](https://github.com/pulumi/pulumi-kong)
-- [ ] [libvirt](https://github.com/pulumi/pulumi-libvirt)
 - [ ] [linode](https://github.com/pulumi/pulumi-linode)
 - [ ] [local](https://github.com/pulumi/pulumi-local)
 - [ ] [mailgun](https://github.com/pulumi/pulumi-mailgun)

--- a/provider-ci/providers.json
+++ b/provider-ci/providers.json
@@ -39,7 +39,6 @@
     "kafka",
     "keycloak",
     "kong",
-    "libvirt",
     "linode",
     "local",
     "mailgun",


### PR DESCRIPTION
Part of https://github.com/pulumi/home/issues/3879.

Removes Libvirt from managed CI.
