### PR TITLE
Pin the major version explicitly in CI

### DIFF
--- a/provider-ci/internal/pkg/templates/base/.github/workflows/prerequisites.yml
+++ b/provider-ci/internal/pkg/templates/base/.github/workflows/prerequisites.yml
@@ -48,6 +48,7 @@ jobs:
     - uses: #{{ .Config.ActionVersions.ProviderVersionAction }}#
       id: provider-version
       with:
+        major-version: #{{ .Config.MajorVersion }}#
         set-env: 'PROVIDER_VERSION'
     - name: Cache examples generation
       uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4

--- a/provider-ci/test-providers/acme/.github/workflows/prerequisites.yml
+++ b/provider-ci/test-providers/acme/.github/workflows/prerequisites.yml
@@ -51,6 +51,7 @@ jobs:
     - uses: pulumi/provider-version-action@f96d032a2758fdda7939e5728eff6c0d980ae894 # v1.6.0
       id: provider-version
       with:
+        major-version: 0
         set-env: 'PROVIDER_VERSION'
     - name: Cache examples generation
       uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4

--- a/provider-ci/test-providers/aws/.github/workflows/prerequisites.yml
+++ b/provider-ci/test-providers/aws/.github/workflows/prerequisites.yml
@@ -62,6 +62,7 @@ jobs:
     - uses: pulumi/provider-version-action@f96d032a2758fdda7939e5728eff6c0d980ae894 # v1.6.0
       id: provider-version
       with:
+        major-version: 6
         set-env: 'PROVIDER_VERSION'
     - name: Cache examples generation
       uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4

--- a/provider-ci/test-providers/cloudflare/.github/workflows/prerequisites.yml
+++ b/provider-ci/test-providers/cloudflare/.github/workflows/prerequisites.yml
@@ -53,6 +53,7 @@ jobs:
     - uses: pulumi/provider-version-action@f96d032a2758fdda7939e5728eff6c0d980ae894 # v1.6.0
       id: provider-version
       with:
+        major-version: 5
         set-env: 'PROVIDER_VERSION'
     - name: Cache examples generation
       uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4

--- a/provider-ci/test-providers/docker/.github/workflows/prerequisites.yml
+++ b/provider-ci/test-providers/docker/.github/workflows/prerequisites.yml
@@ -66,6 +66,7 @@ jobs:
     - uses: pulumi/provider-version-action@f96d032a2758fdda7939e5728eff6c0d980ae894 # v1.6.0
       id: provider-version
       with:
+        major-version: 4
         set-env: 'PROVIDER_VERSION'
     - name: Cache examples generation
       uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4

--- a/provider-ci/test-providers/eks/.github/workflows/prerequisites.yml
+++ b/provider-ci/test-providers/eks/.github/workflows/prerequisites.yml
@@ -58,6 +58,7 @@ jobs:
     - uses: pulumi/provider-version-action@f96d032a2758fdda7939e5728eff6c0d980ae894 # v1.6.0
       id: provider-version
       with:
+        major-version: 3
         set-env: 'PROVIDER_VERSION'
     - name: Cache examples generation
       uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4


### PR DESCRIPTION
This ensures the major version always matches the major version generated into the makefile too - based on the .ci-mgmt.yaml config.

This is much more predictable behaviour than inferring from the branch name or PR labels. This utilises the new feature https://github.com/pulumi/provider-version-action/pull/15, released in v1.6.0 of pulumi/provider-version-action

Stacked on #1363 