### PR TITLE
Auto-merge provider upgrades

### DIFF
--- a/provider-ci/internal/pkg/templates/defaults.config.yaml
+++ b/provider-ci/internal/pkg/templates/defaults.config.yaml
@@ -237,7 +237,7 @@ checkUpstreamUpgrade: true
 clean-github-workflows: true
 
 # Whether we automatically merge upstream provider upgrades.
-autoMergeProviderUpgrades: false
+autoMergeProviderUpgrades: true
 
 # Whether we allow missing docs in the provider.
 allowMissingDocs: false

--- a/provider-ci/test-providers/acme/.github/workflows/upgrade-provider.yml
+++ b/provider-ci/test-providers/acme/.github/workflows/upgrade-provider.yml
@@ -76,7 +76,7 @@ jobs:
           kind: all
           email: bot@pulumi.com
           username: pulumi-bot
-          automerge: false
+          automerge: true
           target-version: ${{ steps.target_version.outputs.version }}
           allow-missing-docs: false
       - name: Comment on upgrade issue if automated PR failed

--- a/provider-ci/test-providers/aws/.ci-mgmt.yaml
+++ b/provider-ci/test-providers/aws/.ci-mgmt.yaml
@@ -66,3 +66,4 @@ releaseVerification:
   python: examples/webserver-py
   dotnet: examples/webserver-cs
   go: examples/webserver-go
+autoMergeProviderUpgrades: false

--- a/provider-ci/test-providers/aws/.github/workflows/upgrade-provider.yml
+++ b/provider-ci/test-providers/aws/.github/workflows/upgrade-provider.yml
@@ -84,7 +84,7 @@ jobs:
           kind: all
           email: bot@pulumi.com
           username: pulumi-bot
-          automerge: false
+          automerge: true
           target-version: ${{ steps.target_version.outputs.version }}
           allow-missing-docs: false
       - name: Comment on upgrade issue if automated PR failed

--- a/provider-ci/test-providers/aws/.github/workflows/upgrade-provider.yml
+++ b/provider-ci/test-providers/aws/.github/workflows/upgrade-provider.yml
@@ -84,7 +84,7 @@ jobs:
           kind: all
           email: bot@pulumi.com
           username: pulumi-bot
-          automerge: true
+          automerge: false
           target-version: ${{ steps.target_version.outputs.version }}
           allow-missing-docs: false
       - name: Comment on upgrade issue if automated PR failed

--- a/provider-ci/test-providers/docker/.github/workflows/upgrade-provider.yml
+++ b/provider-ci/test-providers/docker/.github/workflows/upgrade-provider.yml
@@ -76,7 +76,7 @@ jobs:
           kind: all
           email: bot@pulumi.com
           username: pulumi-bot
-          automerge: false
+          automerge: true
           target-version: ${{ steps.target_version.outputs.version }}
           allow-missing-docs: false
       - name: Comment on upgrade issue if automated PR failed


### PR DESCRIPTION
This PR changes all Tier2+ providers to auto-merge upstream provider upgrades. This will save us a lot of clicking.

Fixes https://github.com/pulumi/ci-mgmt/issues/1344

Tier 1 providers are exempt as the config is explicitly false there:
https://github.com/pulumi/pulumi-gcp/pull/2970
https://github.com/pulumi/pulumi-aws/pull/5192
https://github.com/pulumi/pulumi-azure/pull/3002
https://github.com/pulumi/pulumi-azuread/pull/1876