### PR TITLE
Allow missing resource docs for Tier2+ providers

### DIFF
--- a/provider-ci/internal/pkg/templates/defaults.config.yaml
+++ b/provider-ci/internal/pkg/templates/defaults.config.yaml
@@ -240,4 +240,4 @@ clean-github-workflows: true
 autoMergeProviderUpgrades: false
 
 # Whether we allow missing docs in the provider.
-allowMissingDocs: false
+allowMissingDocs: true

--- a/provider-ci/test-providers/acme/.github/workflows/upgrade-provider.yml
+++ b/provider-ci/test-providers/acme/.github/workflows/upgrade-provider.yml
@@ -78,7 +78,7 @@ jobs:
           username: pulumi-bot
           automerge: false
           target-version: ${{ steps.target_version.outputs.version }}
-          allow-missing-docs: false
+          allow-missing-docs: true
       - name: Comment on upgrade issue if automated PR failed
         if: steps.upgrade_provider.outcome == 'failure'
         shell: bash

--- a/provider-ci/test-providers/aws/.ci-mgmt.yaml
+++ b/provider-ci/test-providers/aws/.ci-mgmt.yaml
@@ -49,6 +49,7 @@ plugins:
     kind: converter
 # Use `pulumi convert` for translating examples from TF to Pulumi.
 pulumiConvert: 1
+allowMissingDocs: false
 goBuildParallelism: 2
 actions:
   preTest:

--- a/provider-ci/test-providers/aws/.github/workflows/upgrade-provider.yml
+++ b/provider-ci/test-providers/aws/.github/workflows/upgrade-provider.yml
@@ -86,7 +86,7 @@ jobs:
           username: pulumi-bot
           automerge: false
           target-version: ${{ steps.target_version.outputs.version }}
-          allow-missing-docs: true
+          allow-missing-docs: false
       - name: Comment on upgrade issue if automated PR failed
         if: steps.upgrade_provider.outcome == 'failure'
         shell: bash

--- a/provider-ci/test-providers/aws/.github/workflows/upgrade-provider.yml
+++ b/provider-ci/test-providers/aws/.github/workflows/upgrade-provider.yml
@@ -86,7 +86,7 @@ jobs:
           username: pulumi-bot
           automerge: false
           target-version: ${{ steps.target_version.outputs.version }}
-          allow-missing-docs: false
+          allow-missing-docs: true
       - name: Comment on upgrade issue if automated PR failed
         if: steps.upgrade_provider.outcome == 'failure'
         shell: bash

--- a/provider-ci/test-providers/docker/.github/workflows/upgrade-provider.yml
+++ b/provider-ci/test-providers/docker/.github/workflows/upgrade-provider.yml
@@ -78,7 +78,7 @@ jobs:
           username: pulumi-bot
           automerge: false
           target-version: ${{ steps.target_version.outputs.version }}
-          allow-missing-docs: false
+          allow-missing-docs: true
       - name: Comment on upgrade issue if automated PR failed
         if: steps.upgrade_provider.outcome == 'failure'
         shell: bash


### PR DESCRIPTION
This PR changes all Tier2+ providers to allow missing resource docs when running a provider upgrade. This is a common issue which happens and we have to manually work around.

Fixes https://github.com/pulumi/upgrade-provider/issues/303

Tier 1 providers are exempt as the config is explicitly false there:
https://github.com/pulumi/pulumi-gcp/pull/2971
https://github.com/pulumi/pulumi-aws/pull/5193
https://github.com/pulumi/pulumi-azure/pull/3003
https://github.com/pulumi/pulumi-azuread/pull/1877