### PR TITLE
Split up Go provider build caches by platform-arch

### DIFF
--- a/provider-ci/internal/pkg/templates/base/.github/workflows/build_provider.yml
+++ b/provider-ci/internal/pkg/templates/base/.github/workflows/build_provider.yml
@@ -58,6 +58,7 @@ jobs:
         uses: ./.github/actions/setup-tools
         with:
           tools: pulumictl, go
+          # use per-platform/arch caches instead since we are doing cross-builds
           cache-go: false
       # Based on https://github.com/actions/cache/blob/main/examples.md#go---modules
       - name: Get GOCACHE

--- a/provider-ci/internal/pkg/templates/base/.github/workflows/build_provider.yml
+++ b/provider-ci/internal/pkg/templates/base/.github/workflows/build_provider.yml
@@ -76,7 +76,7 @@ jobs:
           path: |
             ${{ steps.gocache.outputs.path }}
             ${{ steps.gomodcache.outputs.path }}
-          key: go-provider-${{ matrix.platform.os }}-${{ matrix.platform.arch }}-${{ hashFiles('provider/go.sum') }}
+          key: go-provider-${{ matrix.platform.os }}-${{ matrix.platform.arch }}-${{ hashFiles('#{{ .Config.ModulePath }}#/go.sum') }}
           restore-keys: |
             go-provider-${{ matrix.platform.os }}-${{ matrix.platform.arch }}-
       - name: Prepare local workspace before restoring previously built

--- a/provider-ci/internal/pkg/templates/base/.github/workflows/build_provider.yml
+++ b/provider-ci/internal/pkg/templates/base/.github/workflows/build_provider.yml
@@ -58,6 +58,27 @@ jobs:
         uses: ./.github/actions/setup-tools
         with:
           tools: pulumictl, go
+          cache-go: false
+      # Based on https://github.com/actions/cache/blob/main/examples.md#go---modules
+      - name: Get GOCACHE
+        id: gocache
+        shell: bash
+        run: |
+          echo "path=$(go env GOCACHE)" >> ${GITHUB_OUTPUT}
+      - name: Get GOMODCACHE
+        id: gomodcache
+        shell: bash
+        run: |
+          echo "path=$(go env GOMODCACHE)" >> ${GITHUB_OUTPUT}
+      - name: Go Cache
+        uses: actions/cache@v4
+        with:
+          path: |
+            ${{ steps.gocache.outputs.path }}
+            ${{ steps.gomodcache.outputs.path }}
+          key: go-provider-${{ matrix.platform.os }}-${{ matrix.platform.arch }}-${{ hashFiles('provider/go.sum') }}
+          restore-keys: |
+            go-provider-${{ matrix.platform.os }}-${{ matrix.platform.arch }}-
       - name: Prepare local workspace before restoring previously built
         run: make prepare_local_workspace
       - name: Restore prerequisites

--- a/provider-ci/internal/pkg/templates/base/.github/workflows/build_provider.yml
+++ b/provider-ci/internal/pkg/templates/base/.github/workflows/build_provider.yml
@@ -64,12 +64,12 @@ jobs:
         id: gocache
         shell: bash
         run: |
-          echo "path=$(go env GOCACHE)" >> ${GITHUB_OUTPUT}
+          echo "path=$(go env GOCACHE)" >> "${GITHUB_OUTPUT}"
       - name: Get GOMODCACHE
         id: gomodcache
         shell: bash
         run: |
-          echo "path=$(go env GOMODCACHE)" >> ${GITHUB_OUTPUT}
+          echo "path=$(go env GOMODCACHE)" >> "${GITHUB_OUTPUT}"
       - name: Go Cache
         uses: actions/cache@v4
         with:

--- a/provider-ci/test-providers/acme/.github/workflows/build_provider.yml
+++ b/provider-ci/test-providers/acme/.github/workflows/build_provider.yml
@@ -45,6 +45,7 @@ jobs:
         uses: ./.github/actions/setup-tools
         with:
           tools: pulumictl, go
+          # use per-platform/arch caches instead since we are doing cross-builds
           cache-go: false
       # Based on https://github.com/actions/cache/blob/main/examples.md#go---modules
       - name: Get GOCACHE

--- a/provider-ci/test-providers/acme/.github/workflows/build_provider.yml
+++ b/provider-ci/test-providers/acme/.github/workflows/build_provider.yml
@@ -51,12 +51,12 @@ jobs:
         id: gocache
         shell: bash
         run: |
-          echo "path=$(go env GOCACHE)" >> ${GITHUB_OUTPUT}
+          echo "path=$(go env GOCACHE)" >> "${GITHUB_OUTPUT}"
       - name: Get GOMODCACHE
         id: gomodcache
         shell: bash
         run: |
-          echo "path=$(go env GOMODCACHE)" >> ${GITHUB_OUTPUT}
+          echo "path=$(go env GOMODCACHE)" >> "${GITHUB_OUTPUT}"
       - name: Go Cache
         uses: actions/cache@v4
         with:

--- a/provider-ci/test-providers/acme/.github/workflows/build_provider.yml
+++ b/provider-ci/test-providers/acme/.github/workflows/build_provider.yml
@@ -45,6 +45,27 @@ jobs:
         uses: ./.github/actions/setup-tools
         with:
           tools: pulumictl, go
+          cache-go: false
+      # Based on https://github.com/actions/cache/blob/main/examples.md#go---modules
+      - name: Get GOCACHE
+        id: gocache
+        shell: bash
+        run: |
+          echo "path=$(go env GOCACHE)" >> ${GITHUB_OUTPUT}
+      - name: Get GOMODCACHE
+        id: gomodcache
+        shell: bash
+        run: |
+          echo "path=$(go env GOMODCACHE)" >> ${GITHUB_OUTPUT}
+      - name: Go Cache
+        uses: actions/cache@v4
+        with:
+          path: |
+            ${{ steps.gocache.outputs.path }}
+            ${{ steps.gomodcache.outputs.path }}
+          key: go-provider-${{ matrix.platform.os }}-${{ matrix.platform.arch }}-${{ hashFiles('provider/go.sum') }}
+          restore-keys: |
+            go-provider-${{ matrix.platform.os }}-${{ matrix.platform.arch }}-
       - name: Prepare local workspace before restoring previously built
         run: make prepare_local_workspace
       - name: Restore prerequisites

--- a/provider-ci/test-providers/aws/.github/workflows/build_provider.yml
+++ b/provider-ci/test-providers/aws/.github/workflows/build_provider.yml
@@ -54,6 +54,27 @@ jobs:
         uses: ./.github/actions/setup-tools
         with:
           tools: pulumictl, go
+          cache-go: false
+      # Based on https://github.com/actions/cache/blob/main/examples.md#go---modules
+      - name: Get GOCACHE
+        id: gocache
+        shell: bash
+        run: |
+          echo "path=$(go env GOCACHE)" >> ${GITHUB_OUTPUT}
+      - name: Get GOMODCACHE
+        id: gomodcache
+        shell: bash
+        run: |
+          echo "path=$(go env GOMODCACHE)" >> ${GITHUB_OUTPUT}
+      - name: Go Cache
+        uses: actions/cache@v4
+        with:
+          path: |
+            ${{ steps.gocache.outputs.path }}
+            ${{ steps.gomodcache.outputs.path }}
+          key: go-provider-${{ matrix.platform.os }}-${{ matrix.platform.arch }}-${{ hashFiles('provider/go.sum') }}
+          restore-keys: |
+            go-provider-${{ matrix.platform.os }}-${{ matrix.platform.arch }}-
       - name: Prepare local workspace before restoring previously built
         run: make prepare_local_workspace
       - name: Restore prerequisites

--- a/provider-ci/test-providers/aws/.github/workflows/build_provider.yml
+++ b/provider-ci/test-providers/aws/.github/workflows/build_provider.yml
@@ -60,12 +60,12 @@ jobs:
         id: gocache
         shell: bash
         run: |
-          echo "path=$(go env GOCACHE)" >> ${GITHUB_OUTPUT}
+          echo "path=$(go env GOCACHE)" >> "${GITHUB_OUTPUT}"
       - name: Get GOMODCACHE
         id: gomodcache
         shell: bash
         run: |
-          echo "path=$(go env GOMODCACHE)" >> ${GITHUB_OUTPUT}
+          echo "path=$(go env GOMODCACHE)" >> "${GITHUB_OUTPUT}"
       - name: Go Cache
         uses: actions/cache@v4
         with:

--- a/provider-ci/test-providers/aws/.github/workflows/build_provider.yml
+++ b/provider-ci/test-providers/aws/.github/workflows/build_provider.yml
@@ -54,6 +54,7 @@ jobs:
         uses: ./.github/actions/setup-tools
         with:
           tools: pulumictl, go
+          # use per-platform/arch caches instead since we are doing cross-builds
           cache-go: false
       # Based on https://github.com/actions/cache/blob/main/examples.md#go---modules
       - name: Get GOCACHE

--- a/provider-ci/test-providers/cloudflare/.github/workflows/build_provider.yml
+++ b/provider-ci/test-providers/cloudflare/.github/workflows/build_provider.yml
@@ -45,6 +45,7 @@ jobs:
         uses: ./.github/actions/setup-tools
         with:
           tools: pulumictl, go
+          # use per-platform/arch caches instead since we are doing cross-builds
           cache-go: false
       # Based on https://github.com/actions/cache/blob/main/examples.md#go---modules
       - name: Get GOCACHE

--- a/provider-ci/test-providers/cloudflare/.github/workflows/build_provider.yml
+++ b/provider-ci/test-providers/cloudflare/.github/workflows/build_provider.yml
@@ -51,12 +51,12 @@ jobs:
         id: gocache
         shell: bash
         run: |
-          echo "path=$(go env GOCACHE)" >> ${GITHUB_OUTPUT}
+          echo "path=$(go env GOCACHE)" >> "${GITHUB_OUTPUT}"
       - name: Get GOMODCACHE
         id: gomodcache
         shell: bash
         run: |
-          echo "path=$(go env GOMODCACHE)" >> ${GITHUB_OUTPUT}
+          echo "path=$(go env GOMODCACHE)" >> "${GITHUB_OUTPUT}"
       - name: Go Cache
         uses: actions/cache@v4
         with:

--- a/provider-ci/test-providers/cloudflare/.github/workflows/build_provider.yml
+++ b/provider-ci/test-providers/cloudflare/.github/workflows/build_provider.yml
@@ -45,6 +45,27 @@ jobs:
         uses: ./.github/actions/setup-tools
         with:
           tools: pulumictl, go
+          cache-go: false
+      # Based on https://github.com/actions/cache/blob/main/examples.md#go---modules
+      - name: Get GOCACHE
+        id: gocache
+        shell: bash
+        run: |
+          echo "path=$(go env GOCACHE)" >> ${GITHUB_OUTPUT}
+      - name: Get GOMODCACHE
+        id: gomodcache
+        shell: bash
+        run: |
+          echo "path=$(go env GOMODCACHE)" >> ${GITHUB_OUTPUT}
+      - name: Go Cache
+        uses: actions/cache@v4
+        with:
+          path: |
+            ${{ steps.gocache.outputs.path }}
+            ${{ steps.gomodcache.outputs.path }}
+          key: go-provider-${{ matrix.platform.os }}-${{ matrix.platform.arch }}-${{ hashFiles('provider/go.sum') }}
+          restore-keys: |
+            go-provider-${{ matrix.platform.os }}-${{ matrix.platform.arch }}-
       - name: Prepare local workspace before restoring previously built
         run: make prepare_local_workspace
       - name: Restore prerequisites

--- a/provider-ci/test-providers/docker/.github/workflows/build_provider.yml
+++ b/provider-ci/test-providers/docker/.github/workflows/build_provider.yml
@@ -45,6 +45,7 @@ jobs:
         uses: ./.github/actions/setup-tools
         with:
           tools: pulumictl, go
+          # use per-platform/arch caches instead since we are doing cross-builds
           cache-go: false
       # Based on https://github.com/actions/cache/blob/main/examples.md#go---modules
       - name: Get GOCACHE

--- a/provider-ci/test-providers/docker/.github/workflows/build_provider.yml
+++ b/provider-ci/test-providers/docker/.github/workflows/build_provider.yml
@@ -51,12 +51,12 @@ jobs:
         id: gocache
         shell: bash
         run: |
-          echo "path=$(go env GOCACHE)" >> ${GITHUB_OUTPUT}
+          echo "path=$(go env GOCACHE)" >> "${GITHUB_OUTPUT}"
       - name: Get GOMODCACHE
         id: gomodcache
         shell: bash
         run: |
-          echo "path=$(go env GOMODCACHE)" >> ${GITHUB_OUTPUT}
+          echo "path=$(go env GOMODCACHE)" >> "${GITHUB_OUTPUT}"
       - name: Go Cache
         uses: actions/cache@v4
         with:

--- a/provider-ci/test-providers/docker/.github/workflows/build_provider.yml
+++ b/provider-ci/test-providers/docker/.github/workflows/build_provider.yml
@@ -45,6 +45,27 @@ jobs:
         uses: ./.github/actions/setup-tools
         with:
           tools: pulumictl, go
+          cache-go: false
+      # Based on https://github.com/actions/cache/blob/main/examples.md#go---modules
+      - name: Get GOCACHE
+        id: gocache
+        shell: bash
+        run: |
+          echo "path=$(go env GOCACHE)" >> ${GITHUB_OUTPUT}
+      - name: Get GOMODCACHE
+        id: gomodcache
+        shell: bash
+        run: |
+          echo "path=$(go env GOMODCACHE)" >> ${GITHUB_OUTPUT}
+      - name: Go Cache
+        uses: actions/cache@v4
+        with:
+          path: |
+            ${{ steps.gocache.outputs.path }}
+            ${{ steps.gomodcache.outputs.path }}
+          key: go-provider-${{ matrix.platform.os }}-${{ matrix.platform.arch }}-${{ hashFiles('provider/go.sum') }}
+          restore-keys: |
+            go-provider-${{ matrix.platform.os }}-${{ matrix.platform.arch }}-
       - name: Prepare local workspace before restoring previously built
         run: make prepare_local_workspace
       - name: Restore prerequisites

--- a/provider-ci/test-providers/eks/.github/workflows/build_provider.yml
+++ b/provider-ci/test-providers/eks/.github/workflows/build_provider.yml
@@ -45,6 +45,7 @@ jobs:
         uses: ./.github/actions/setup-tools
         with:
           tools: pulumictl, go
+          # use per-platform/arch caches instead since we are doing cross-builds
           cache-go: false
       # Based on https://github.com/actions/cache/blob/main/examples.md#go---modules
       - name: Get GOCACHE

--- a/provider-ci/test-providers/eks/.github/workflows/build_provider.yml
+++ b/provider-ci/test-providers/eks/.github/workflows/build_provider.yml
@@ -51,12 +51,12 @@ jobs:
         id: gocache
         shell: bash
         run: |
-          echo "path=$(go env GOCACHE)" >> ${GITHUB_OUTPUT}
+          echo "path=$(go env GOCACHE)" >> "${GITHUB_OUTPUT}"
       - name: Get GOMODCACHE
         id: gomodcache
         shell: bash
         run: |
-          echo "path=$(go env GOMODCACHE)" >> ${GITHUB_OUTPUT}
+          echo "path=$(go env GOMODCACHE)" >> "${GITHUB_OUTPUT}"
       - name: Go Cache
         uses: actions/cache@v4
         with:

--- a/provider-ci/test-providers/eks/.github/workflows/build_provider.yml
+++ b/provider-ci/test-providers/eks/.github/workflows/build_provider.yml
@@ -45,6 +45,27 @@ jobs:
         uses: ./.github/actions/setup-tools
         with:
           tools: pulumictl, go
+          cache-go: false
+      # Based on https://github.com/actions/cache/blob/main/examples.md#go---modules
+      - name: Get GOCACHE
+        id: gocache
+        shell: bash
+        run: |
+          echo "path=$(go env GOCACHE)" >> ${GITHUB_OUTPUT}
+      - name: Get GOMODCACHE
+        id: gomodcache
+        shell: bash
+        run: |
+          echo "path=$(go env GOMODCACHE)" >> ${GITHUB_OUTPUT}
+      - name: Go Cache
+        uses: actions/cache@v4
+        with:
+          path: |
+            ${{ steps.gocache.outputs.path }}
+            ${{ steps.gomodcache.outputs.path }}
+          key: go-provider-${{ matrix.platform.os }}-${{ matrix.platform.arch }}-${{ hashFiles('provider/go.sum') }}
+          restore-keys: |
+            go-provider-${{ matrix.platform.os }}-${{ matrix.platform.arch }}-
       - name: Prepare local workspace before restoring previously built
         run: make prepare_local_workspace
       - name: Restore prerequisites

--- a/provider-ci/test-providers/terraform-module/.github/workflows/build_provider.yml
+++ b/provider-ci/test-providers/terraform-module/.github/workflows/build_provider.yml
@@ -45,6 +45,7 @@ jobs:
         uses: ./.github/actions/setup-tools
         with:
           tools: pulumictl, go
+          # use per-platform/arch caches instead since we are doing cross-builds
           cache-go: false
       # Based on https://github.com/actions/cache/blob/main/examples.md#go---modules
       - name: Get GOCACHE

--- a/provider-ci/test-providers/terraform-module/.github/workflows/build_provider.yml
+++ b/provider-ci/test-providers/terraform-module/.github/workflows/build_provider.yml
@@ -63,7 +63,7 @@ jobs:
           path: |
             ${{ steps.gocache.outputs.path }}
             ${{ steps.gomodcache.outputs.path }}
-          key: go-provider-${{ matrix.platform.os }}-${{ matrix.platform.arch }}-${{ hashFiles('provider/go.sum') }}
+          key: go-provider-${{ matrix.platform.os }}-${{ matrix.platform.arch }}-${{ hashFiles('./go.sum') }}
           restore-keys: |
             go-provider-${{ matrix.platform.os }}-${{ matrix.platform.arch }}-
       - name: Prepare local workspace before restoring previously built

--- a/provider-ci/test-providers/terraform-module/.github/workflows/build_provider.yml
+++ b/provider-ci/test-providers/terraform-module/.github/workflows/build_provider.yml
@@ -51,12 +51,12 @@ jobs:
         id: gocache
         shell: bash
         run: |
-          echo "path=$(go env GOCACHE)" >> ${GITHUB_OUTPUT}
+          echo "path=$(go env GOCACHE)" >> "${GITHUB_OUTPUT}"
       - name: Get GOMODCACHE
         id: gomodcache
         shell: bash
         run: |
-          echo "path=$(go env GOMODCACHE)" >> ${GITHUB_OUTPUT}
+          echo "path=$(go env GOMODCACHE)" >> "${GITHUB_OUTPUT}"
       - name: Go Cache
         uses: actions/cache@v4
         with:

--- a/provider-ci/test-providers/terraform-module/.github/workflows/build_provider.yml
+++ b/provider-ci/test-providers/terraform-module/.github/workflows/build_provider.yml
@@ -45,6 +45,27 @@ jobs:
         uses: ./.github/actions/setup-tools
         with:
           tools: pulumictl, go
+          cache-go: false
+      # Based on https://github.com/actions/cache/blob/main/examples.md#go---modules
+      - name: Get GOCACHE
+        id: gocache
+        shell: bash
+        run: |
+          echo "path=$(go env GOCACHE)" >> ${GITHUB_OUTPUT}
+      - name: Get GOMODCACHE
+        id: gomodcache
+        shell: bash
+        run: |
+          echo "path=$(go env GOMODCACHE)" >> ${GITHUB_OUTPUT}
+      - name: Go Cache
+        uses: actions/cache@v4
+        with:
+          path: |
+            ${{ steps.gocache.outputs.path }}
+            ${{ steps.gomodcache.outputs.path }}
+          key: go-provider-${{ matrix.platform.os }}-${{ matrix.platform.arch }}-${{ hashFiles('provider/go.sum') }}
+          restore-keys: |
+            go-provider-${{ matrix.platform.os }}-${{ matrix.platform.arch }}-
       - name: Prepare local workspace before restoring previously built
         run: make prepare_local_workspace
       - name: Restore prerequisites


### PR DESCRIPTION
In large providers like AWS we have cache stability issues - we run out of 10GB cache space, and we also have jobs failing when they hit out-of-disk issues on the runners, such as build_provider. One problem is that Go caches are very monolithic with one big file combining all architectures and platforms (in build_provider) job.

This PR looks at breaking down the caches per platform and architecture. Smaller caches should use less disk space on the runner. They also should evict more easily.

Relates https://github.com/pulumi/ci-mgmt/issues/1031

