### PR TITLE
Allow testing of 3rd party contributions

### DIFF
--- a/provider-ci/internal/pkg/templates/base/.github/workflows/pull-request.yml
+++ b/provider-ci/internal/pkg/templates/base/.github/workflows/pull-request.yml
@@ -8,21 +8,16 @@ jobs:
     name: comment-on-pr
     runs-on: #{{ .Config.Runner.Default }}#
     steps:
-    - name: Checkout Repo
-      uses: #{{ .Config.ActionVersions.Checkout }}#
-      with:
-        #{{- if .Config.CheckoutSubmodules }}#
-        submodules: #{{ .Config.CheckoutSubmodules }}#
-        #{{- end }}#
-        persist-credentials: false
-    - name: Comment PR
-      uses: #{{ .Config.ActionVersions.PrComment }}#
-      with:
-        github-token: ${{ secrets.GITHUB_TOKEN }}
-        message: >
-          PR is now waiting for a maintainer to run the acceptance tests.
+      - name: Comment PR
+        uses: #{{ .Config.ActionVersions.PrComment }}#
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          message: >
+            PR is now waiting for a maintainer to run the acceptance tests.
 
-          **Note for the maintainer:** To run the acceptance tests, please comment */run-acceptance-tests* on the PR
+            **Note for the maintainer:** To run the acceptance tests, go to the 
+            [run-acceptance-tests workflow in the Actions tab](${{ github.server_url }}/${{ github.repository }}/actions/workflows/run-acceptance-tests.yml)
+            and click the "Run workflow" button. Make sure to select the `${{ github.head_ref }}` branch.
 name: pull-request
 on:
   pull_request_target: {}

--- a/provider-ci/internal/pkg/templates/base/.github/workflows/pull-request.yml
+++ b/provider-ci/internal/pkg/templates/base/.github/workflows/pull-request.yml
@@ -18,6 +18,7 @@ jobs:
             **Note for the maintainer:** To run the acceptance tests, go to the 
             [run-acceptance-tests workflow in the Actions tab](${{ github.server_url }}/${{ github.repository }}/actions/workflows/run-acceptance-tests.yml)
             and click the "Run workflow" button. Make sure to select the `${{ github.head_ref }}` branch.
+            Alternatively, run `gh workflow run acceptance-test.yml --repo "${{ github.repository }}" --ref "${{ github.head_ref }}" on your local machine.`
 name: pull-request
 on:
   pull_request_target: {}

--- a/provider-ci/internal/pkg/templates/base/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/internal/pkg/templates/base/.github/workflows/run-acceptance-tests.yml
@@ -9,6 +9,7 @@ on:
   repository_dispatch:
     types:
     - run-acceptance-tests-command
+  workflow_dispatch: {}
 
 env:
   PR_COMMIT_SHA: ${{ github.event.client_payload.pull_request.head.sha }}

--- a/provider-ci/test-providers/acme/.github/workflows/pull-request.yml
+++ b/provider-ci/test-providers/acme/.github/workflows/pull-request.yml
@@ -33,6 +33,7 @@ jobs:
             **Note for the maintainer:** To run the acceptance tests, go to the 
             [run-acceptance-tests workflow in the Actions tab](${{ github.server_url }}/${{ github.repository }}/actions/workflows/run-acceptance-tests.yml)
             and click the "Run workflow" button. Make sure to select the `${{ github.head_ref }}` branch.
+            Alternatively, run `gh workflow run acceptance-test.yml --repo "${{ github.repository }}" --ref "${{ github.head_ref }}" on your local machine.`
 name: pull-request
 on:
   pull_request_target: {}

--- a/provider-ci/test-providers/acme/.github/workflows/pull-request.yml
+++ b/provider-ci/test-providers/acme/.github/workflows/pull-request.yml
@@ -23,18 +23,16 @@ jobs:
     name: comment-on-pr
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout Repo
-      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-      with:
-        persist-credentials: false
-    - name: Comment PR
-      uses: thollander/actions-comment-pull-request@24bffb9b452ba05a4f3f77933840a6a841d1b32b # v3.0.1
-      with:
-        github-token: ${{ secrets.GITHUB_TOKEN }}
-        message: >
-          PR is now waiting for a maintainer to run the acceptance tests.
+      - name: Comment PR
+        uses: thollander/actions-comment-pull-request@24bffb9b452ba05a4f3f77933840a6a841d1b32b # v3.0.1
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          message: >
+            PR is now waiting for a maintainer to run the acceptance tests.
 
-          **Note for the maintainer:** To run the acceptance tests, please comment */run-acceptance-tests* on the PR
+            **Note for the maintainer:** To run the acceptance tests, go to the 
+            [run-acceptance-tests workflow in the Actions tab](${{ github.server_url }}/${{ github.repository }}/actions/workflows/run-acceptance-tests.yml)
+            and click the "Run workflow" button. Make sure to select the `${{ github.head_ref }}` branch.
 name: pull-request
 on:
   pull_request_target: {}

--- a/provider-ci/test-providers/acme/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/test-providers/acme/.github/workflows/run-acceptance-tests.yml
@@ -9,6 +9,7 @@ on:
   repository_dispatch:
     types:
     - run-acceptance-tests-command
+  workflow_dispatch: {}
 
 env:
   PR_COMMIT_SHA: ${{ github.event.client_payload.pull_request.head.sha }}

--- a/provider-ci/test-providers/aws/.github/workflows/pull-request.yml
+++ b/provider-ci/test-providers/aws/.github/workflows/pull-request.yml
@@ -26,19 +26,16 @@ jobs:
     name: comment-on-pr
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout Repo
-      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-      with:
-        submodules: true
-        persist-credentials: false
-    - name: Comment PR
-      uses: thollander/actions-comment-pull-request@24bffb9b452ba05a4f3f77933840a6a841d1b32b # v3.0.1
-      with:
-        github-token: ${{ secrets.GITHUB_TOKEN }}
-        message: >
-          PR is now waiting for a maintainer to run the acceptance tests.
+      - name: Comment PR
+        uses: thollander/actions-comment-pull-request@24bffb9b452ba05a4f3f77933840a6a841d1b32b # v3.0.1
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          message: >
+            PR is now waiting for a maintainer to run the acceptance tests.
 
-          **Note for the maintainer:** To run the acceptance tests, please comment */run-acceptance-tests* on the PR
+            **Note for the maintainer:** To run the acceptance tests, go to the 
+            [run-acceptance-tests workflow in the Actions tab](${{ github.server_url }}/${{ github.repository }}/actions/workflows/run-acceptance-tests.yml)
+            and click the "Run workflow" button. Make sure to select the `${{ github.head_ref }}` branch.
 name: pull-request
 on:
   pull_request_target: {}

--- a/provider-ci/test-providers/aws/.github/workflows/pull-request.yml
+++ b/provider-ci/test-providers/aws/.github/workflows/pull-request.yml
@@ -36,6 +36,7 @@ jobs:
             **Note for the maintainer:** To run the acceptance tests, go to the 
             [run-acceptance-tests workflow in the Actions tab](${{ github.server_url }}/${{ github.repository }}/actions/workflows/run-acceptance-tests.yml)
             and click the "Run workflow" button. Make sure to select the `${{ github.head_ref }}` branch.
+            Alternatively, run `gh workflow run acceptance-test.yml --repo "${{ github.repository }}" --ref "${{ github.head_ref }}" on your local machine.`
 name: pull-request
 on:
   pull_request_target: {}

--- a/provider-ci/test-providers/aws/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/test-providers/aws/.github/workflows/run-acceptance-tests.yml
@@ -9,6 +9,7 @@ on:
   repository_dispatch:
     types:
     - run-acceptance-tests-command
+  workflow_dispatch: {}
 
 env:
   PR_COMMIT_SHA: ${{ github.event.client_payload.pull_request.head.sha }}

--- a/provider-ci/test-providers/cloudflare/.github/workflows/pull-request.yml
+++ b/provider-ci/test-providers/cloudflare/.github/workflows/pull-request.yml
@@ -25,18 +25,16 @@ jobs:
     name: comment-on-pr
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout Repo
-      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-      with:
-        persist-credentials: false
-    - name: Comment PR
-      uses: thollander/actions-comment-pull-request@24bffb9b452ba05a4f3f77933840a6a841d1b32b # v3.0.1
-      with:
-        github-token: ${{ secrets.GITHUB_TOKEN }}
-        message: >
-          PR is now waiting for a maintainer to run the acceptance tests.
+      - name: Comment PR
+        uses: thollander/actions-comment-pull-request@24bffb9b452ba05a4f3f77933840a6a841d1b32b # v3.0.1
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          message: >
+            PR is now waiting for a maintainer to run the acceptance tests.
 
-          **Note for the maintainer:** To run the acceptance tests, please comment */run-acceptance-tests* on the PR
+            **Note for the maintainer:** To run the acceptance tests, go to the 
+            [run-acceptance-tests workflow in the Actions tab](${{ github.server_url }}/${{ github.repository }}/actions/workflows/run-acceptance-tests.yml)
+            and click the "Run workflow" button. Make sure to select the `${{ github.head_ref }}` branch.
 name: pull-request
 on:
   pull_request_target: {}

--- a/provider-ci/test-providers/cloudflare/.github/workflows/pull-request.yml
+++ b/provider-ci/test-providers/cloudflare/.github/workflows/pull-request.yml
@@ -35,6 +35,7 @@ jobs:
             **Note for the maintainer:** To run the acceptance tests, go to the 
             [run-acceptance-tests workflow in the Actions tab](${{ github.server_url }}/${{ github.repository }}/actions/workflows/run-acceptance-tests.yml)
             and click the "Run workflow" button. Make sure to select the `${{ github.head_ref }}` branch.
+            Alternatively, run `gh workflow run acceptance-test.yml --repo "${{ github.repository }}" --ref "${{ github.head_ref }}" on your local machine.`
 name: pull-request
 on:
   pull_request_target: {}

--- a/provider-ci/test-providers/cloudflare/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/test-providers/cloudflare/.github/workflows/run-acceptance-tests.yml
@@ -9,6 +9,7 @@ on:
   repository_dispatch:
     types:
     - run-acceptance-tests-command
+  workflow_dispatch: {}
 
 env:
   PR_COMMIT_SHA: ${{ github.event.client_payload.pull_request.head.sha }}

--- a/provider-ci/test-providers/docker/.github/workflows/pull-request.yml
+++ b/provider-ci/test-providers/docker/.github/workflows/pull-request.yml
@@ -38,18 +38,16 @@ jobs:
     name: comment-on-pr
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout Repo
-      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-      with:
-        persist-credentials: false
-    - name: Comment PR
-      uses: thollander/actions-comment-pull-request@24bffb9b452ba05a4f3f77933840a6a841d1b32b # v3.0.1
-      with:
-        github-token: ${{ secrets.GITHUB_TOKEN }}
-        message: >
-          PR is now waiting for a maintainer to run the acceptance tests.
+      - name: Comment PR
+        uses: thollander/actions-comment-pull-request@24bffb9b452ba05a4f3f77933840a6a841d1b32b # v3.0.1
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          message: >
+            PR is now waiting for a maintainer to run the acceptance tests.
 
-          **Note for the maintainer:** To run the acceptance tests, please comment */run-acceptance-tests* on the PR
+            **Note for the maintainer:** To run the acceptance tests, go to the 
+            [run-acceptance-tests workflow in the Actions tab](${{ github.server_url }}/${{ github.repository }}/actions/workflows/run-acceptance-tests.yml)
+            and click the "Run workflow" button. Make sure to select the `${{ github.head_ref }}` branch.
 name: pull-request
 on:
   pull_request_target: {}

--- a/provider-ci/test-providers/docker/.github/workflows/pull-request.yml
+++ b/provider-ci/test-providers/docker/.github/workflows/pull-request.yml
@@ -48,6 +48,7 @@ jobs:
             **Note for the maintainer:** To run the acceptance tests, go to the 
             [run-acceptance-tests workflow in the Actions tab](${{ github.server_url }}/${{ github.repository }}/actions/workflows/run-acceptance-tests.yml)
             and click the "Run workflow" button. Make sure to select the `${{ github.head_ref }}` branch.
+            Alternatively, run `gh workflow run acceptance-test.yml --repo "${{ github.repository }}" --ref "${{ github.head_ref }}" on your local machine.`
 name: pull-request
 on:
   pull_request_target: {}

--- a/provider-ci/test-providers/docker/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/test-providers/docker/.github/workflows/run-acceptance-tests.yml
@@ -9,6 +9,7 @@ on:
   repository_dispatch:
     types:
     - run-acceptance-tests-command
+  workflow_dispatch: {}
 
 env:
   PR_COMMIT_SHA: ${{ github.event.client_payload.pull_request.head.sha }}

--- a/provider-ci/test-providers/eks/.github/workflows/pull-request.yml
+++ b/provider-ci/test-providers/eks/.github/workflows/pull-request.yml
@@ -30,18 +30,16 @@ jobs:
     name: comment-on-pr
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout Repo
-      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-      with:
-        persist-credentials: false
-    - name: Comment PR
-      uses: thollander/actions-comment-pull-request@24bffb9b452ba05a4f3f77933840a6a841d1b32b # v3.0.1
-      with:
-        github-token: ${{ secrets.GITHUB_TOKEN }}
-        message: >
-          PR is now waiting for a maintainer to run the acceptance tests.
+      - name: Comment PR
+        uses: thollander/actions-comment-pull-request@24bffb9b452ba05a4f3f77933840a6a841d1b32b # v3.0.1
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          message: >
+            PR is now waiting for a maintainer to run the acceptance tests.
 
-          **Note for the maintainer:** To run the acceptance tests, please comment */run-acceptance-tests* on the PR
+            **Note for the maintainer:** To run the acceptance tests, go to the 
+            [run-acceptance-tests workflow in the Actions tab](${{ github.server_url }}/${{ github.repository }}/actions/workflows/run-acceptance-tests.yml)
+            and click the "Run workflow" button. Make sure to select the `${{ github.head_ref }}` branch.
 name: pull-request
 on:
   pull_request_target: {}

--- a/provider-ci/test-providers/eks/.github/workflows/pull-request.yml
+++ b/provider-ci/test-providers/eks/.github/workflows/pull-request.yml
@@ -40,6 +40,7 @@ jobs:
             **Note for the maintainer:** To run the acceptance tests, go to the 
             [run-acceptance-tests workflow in the Actions tab](${{ github.server_url }}/${{ github.repository }}/actions/workflows/run-acceptance-tests.yml)
             and click the "Run workflow" button. Make sure to select the `${{ github.head_ref }}` branch.
+            Alternatively, run `gh workflow run acceptance-test.yml --repo "${{ github.repository }}" --ref "${{ github.head_ref }}" on your local machine.`
 name: pull-request
 on:
   pull_request_target: {}

--- a/provider-ci/test-providers/eks/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/test-providers/eks/.github/workflows/run-acceptance-tests.yml
@@ -9,6 +9,7 @@ on:
   repository_dispatch:
     types:
     - run-acceptance-tests-command
+  workflow_dispatch: {}
 
 env:
   PR_COMMIT_SHA: ${{ github.event.client_payload.pull_request.head.sha }}

--- a/provider-ci/test-providers/terraform-module/.github/workflows/pull-request.yml
+++ b/provider-ci/test-providers/terraform-module/.github/workflows/pull-request.yml
@@ -34,6 +34,7 @@ jobs:
             **Note for the maintainer:** To run the acceptance tests, go to the 
             [run-acceptance-tests workflow in the Actions tab](${{ github.server_url }}/${{ github.repository }}/actions/workflows/run-acceptance-tests.yml)
             and click the "Run workflow" button. Make sure to select the `${{ github.head_ref }}` branch.
+            Alternatively, run `gh workflow run acceptance-test.yml --repo "${{ github.repository }}" --ref "${{ github.head_ref }}" on your local machine.`
 name: pull-request
 on:
   pull_request_target: {}

--- a/provider-ci/test-providers/terraform-module/.github/workflows/pull-request.yml
+++ b/provider-ci/test-providers/terraform-module/.github/workflows/pull-request.yml
@@ -24,18 +24,16 @@ jobs:
     name: comment-on-pr
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout Repo
-      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-      with:
-        persist-credentials: false
-    - name: Comment PR
-      uses: thollander/actions-comment-pull-request@24bffb9b452ba05a4f3f77933840a6a841d1b32b # v3.0.1
-      with:
-        github-token: ${{ secrets.GITHUB_TOKEN }}
-        message: >
-          PR is now waiting for a maintainer to run the acceptance tests.
+      - name: Comment PR
+        uses: thollander/actions-comment-pull-request@24bffb9b452ba05a4f3f77933840a6a841d1b32b # v3.0.1
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          message: >
+            PR is now waiting for a maintainer to run the acceptance tests.
 
-          **Note for the maintainer:** To run the acceptance tests, please comment */run-acceptance-tests* on the PR
+            **Note for the maintainer:** To run the acceptance tests, go to the 
+            [run-acceptance-tests workflow in the Actions tab](${{ github.server_url }}/${{ github.repository }}/actions/workflows/run-acceptance-tests.yml)
+            and click the "Run workflow" button. Make sure to select the `${{ github.head_ref }}` branch.
 name: pull-request
 on:
   pull_request_target: {}

--- a/provider-ci/test-providers/terraform-module/.github/workflows/run-acceptance-tests.yml
+++ b/provider-ci/test-providers/terraform-module/.github/workflows/run-acceptance-tests.yml
@@ -9,6 +9,7 @@ on:
   repository_dispatch:
     types:
     - run-acceptance-tests-command
+  workflow_dispatch: {}
 
 env:
   PR_COMMIT_SHA: ${{ github.event.client_payload.pull_request.head.sha }}


### PR DESCRIPTION
Fixes #1409 

1. Allow the run-acceptance-tests workflow to be run manually.
2. Instruct the user to run the workflow via the UI.

See issue for discusson of alternative approaches and their drawbacks.