### PR TITLE
Upgrade provider should be upgrading upstream only

### DIFF
--- a/provider-ci/internal/pkg/templates/bridged/.github/workflows/upgrade-provider.yml
+++ b/provider-ci/internal/pkg/templates/bridged/.github/workflows/upgrade-provider.yml
@@ -86,7 +86,7 @@ jobs:
         continue-on-error: true
         uses: #{{ .Config.ActionVersions.UpgradeProviderAction }}#
         with:
-          kind: all
+          kind: upstream
           email: bot@pulumi.com
           username: pulumi-bot
           automerge: #{{ .Config.AutoMergeProviderUpgrades }}#

--- a/provider-ci/internal/pkg/templates/bridged/.github/workflows/upgrade-provider.yml
+++ b/provider-ci/internal/pkg/templates/bridged/.github/workflows/upgrade-provider.yml
@@ -86,7 +86,7 @@ jobs:
         continue-on-error: true
         uses: #{{ .Config.ActionVersions.UpgradeProviderAction }}#
         with:
-          kind: upstream
+          kind: provider
           email: bot@pulumi.com
           username: pulumi-bot
           automerge: #{{ .Config.AutoMergeProviderUpgrades }}#

--- a/provider-ci/test-providers/acme/.github/workflows/upgrade-provider.yml
+++ b/provider-ci/test-providers/acme/.github/workflows/upgrade-provider.yml
@@ -73,7 +73,7 @@ jobs:
         continue-on-error: true
         uses: pulumi/pulumi-upgrade-provider-action@ff5cb5907aecba099e61146c4d4d074c7fd6ca99 # v0.0.15
         with:
-          kind: upstream
+          kind: provider
           email: bot@pulumi.com
           username: pulumi-bot
           automerge: true

--- a/provider-ci/test-providers/acme/.github/workflows/upgrade-provider.yml
+++ b/provider-ci/test-providers/acme/.github/workflows/upgrade-provider.yml
@@ -73,7 +73,7 @@ jobs:
         continue-on-error: true
         uses: pulumi/pulumi-upgrade-provider-action@ff5cb5907aecba099e61146c4d4d074c7fd6ca99 # v0.0.15
         with:
-          kind: all
+          kind: upstream
           email: bot@pulumi.com
           username: pulumi-bot
           automerge: true

--- a/provider-ci/test-providers/aws/.github/workflows/upgrade-provider.yml
+++ b/provider-ci/test-providers/aws/.github/workflows/upgrade-provider.yml
@@ -81,7 +81,7 @@ jobs:
         continue-on-error: true
         uses: pulumi/pulumi-upgrade-provider-action@ff5cb5907aecba099e61146c4d4d074c7fd6ca99 # v0.0.15
         with:
-          kind: upstream
+          kind: provider
           email: bot@pulumi.com
           username: pulumi-bot
           automerge: false

--- a/provider-ci/test-providers/aws/.github/workflows/upgrade-provider.yml
+++ b/provider-ci/test-providers/aws/.github/workflows/upgrade-provider.yml
@@ -81,7 +81,7 @@ jobs:
         continue-on-error: true
         uses: pulumi/pulumi-upgrade-provider-action@ff5cb5907aecba099e61146c4d4d074c7fd6ca99 # v0.0.15
         with:
-          kind: all
+          kind: upstream
           email: bot@pulumi.com
           username: pulumi-bot
           automerge: false

--- a/provider-ci/test-providers/docker/.github/workflows/upgrade-provider.yml
+++ b/provider-ci/test-providers/docker/.github/workflows/upgrade-provider.yml
@@ -73,7 +73,7 @@ jobs:
         continue-on-error: true
         uses: pulumi/pulumi-upgrade-provider-action@ff5cb5907aecba099e61146c4d4d074c7fd6ca99 # v0.0.15
         with:
-          kind: upstream
+          kind: provider
           email: bot@pulumi.com
           username: pulumi-bot
           automerge: true

--- a/provider-ci/test-providers/docker/.github/workflows/upgrade-provider.yml
+++ b/provider-ci/test-providers/docker/.github/workflows/upgrade-provider.yml
@@ -73,7 +73,7 @@ jobs:
         continue-on-error: true
         uses: pulumi/pulumi-upgrade-provider-action@ff5cb5907aecba099e61146c4d4d074c7fd6ca99 # v0.0.15
         with:
-          kind: all
+          kind: upstream
           email: bot@pulumi.com
           username: pulumi-bot
           automerge: true


### PR DESCRIPTION
Fixes https://github.com/pulumi/ci-mgmt/issues/1141

As a concrete example, https://github.com/pulumi/pulumi-gcp/pull/3004 fails because it starts hitting .NET 8.0 issues. This brings us close to violating SLA on upstream upgrades for no good reason.  I do believe we are better off with separate PRs for upstream upgrades vs Pulumi internal dependencies.
