### PR TITLE
Upgrade to dotnet 8

### DIFF
--- a/provider-ci/internal/pkg/templates/defaults.config.yaml
+++ b/provider-ci/internal/pkg/templates/defaults.config.yaml
@@ -80,7 +80,7 @@ freeDiskSpaceBeforeSdkBuild: false
 # Used for centrally managing tool versions.
 # This is not currently overridden by any providers: https://github.com/search?q=org%3Apulumi+path%3A.ci-mgmt.yaml+%22toolVersions%22&type=code
 toolVersions:
-  dotnet: "6.0.x"
+  dotnet: "8.0.x"
   go: "1.21.x"
   java: "11"
   gradle: "7.6"

--- a/provider-ci/test-providers/acme/.github/actions/setup-tools/action.yml
+++ b/provider-ci/test-providers/acme/.github/actions/setup-tools/action.yml
@@ -68,7 +68,7 @@ runs:
       if: inputs.tools == 'all' || contains(inputs.tools, 'dotnet')
       uses: actions/setup-dotnet@3951f0dfe7a07e2313ec93c75700083e2005cbab # v4.3.0
       with:
-        dotnet-version: 6.0.x
+        dotnet-version: 8.0.x
 
     - name: Setup Python
       if: inputs.tools == 'all' || contains(inputs.tools, 'python')

--- a/provider-ci/test-providers/acme/devbox.json
+++ b/provider-ci/test-providers/acme/devbox.json
@@ -5,7 +5,7 @@
     "go@1.21.",
     "nodejs@20.",
     "python3@3.11.8",
-    "dotnet-sdk@6.0.",
+    "dotnet-sdk@8.0.",
     "gradle_7@7.6",
     "curl@8"
   ],

--- a/provider-ci/test-providers/cloudflare/.github/actions/setup-tools/action.yml
+++ b/provider-ci/test-providers/cloudflare/.github/actions/setup-tools/action.yml
@@ -68,7 +68,7 @@ runs:
       if: inputs.tools == 'all' || contains(inputs.tools, 'dotnet')
       uses: actions/setup-dotnet@3951f0dfe7a07e2313ec93c75700083e2005cbab # v4.3.0
       with:
-        dotnet-version: 6.0.x
+        dotnet-version: 8.0.x
 
     - name: Setup Python
       if: inputs.tools == 'all' || contains(inputs.tools, 'python')

--- a/provider-ci/test-providers/cloudflare/devbox.json
+++ b/provider-ci/test-providers/cloudflare/devbox.json
@@ -5,7 +5,7 @@
     "go@1.21.",
     "nodejs@20.",
     "python3@3.11.8",
-    "dotnet-sdk@6.0.",
+    "dotnet-sdk@8.0.",
     "gradle_7@7.6",
     "curl@8"
   ],

--- a/provider-ci/test-providers/docker/.github/actions/setup-tools/action.yml
+++ b/provider-ci/test-providers/docker/.github/actions/setup-tools/action.yml
@@ -68,7 +68,7 @@ runs:
       if: inputs.tools == 'all' || contains(inputs.tools, 'dotnet')
       uses: actions/setup-dotnet@3951f0dfe7a07e2313ec93c75700083e2005cbab # v4.3.0
       with:
-        dotnet-version: 6.0.x
+        dotnet-version: 8.0.x
 
     - name: Setup Python
       if: inputs.tools == 'all' || contains(inputs.tools, 'python')

--- a/provider-ci/test-providers/docker/devbox.json
+++ b/provider-ci/test-providers/docker/devbox.json
@@ -5,7 +5,7 @@
     "go@1.21.",
     "nodejs@20.",
     "python3@3.11.8",
-    "dotnet-sdk@6.0.",
+    "dotnet-sdk@8.0.",
     "gradle_7@7.6",
     "curl@8"
   ],

--- a/provider-ci/test-providers/eks/.github/actions/setup-tools/action.yml
+++ b/provider-ci/test-providers/eks/.github/actions/setup-tools/action.yml
@@ -68,7 +68,7 @@ runs:
       if: inputs.tools == 'all' || contains(inputs.tools, 'dotnet')
       uses: actions/setup-dotnet@3951f0dfe7a07e2313ec93c75700083e2005cbab # v4.3.0
       with:
-        dotnet-version: 6.0.x
+        dotnet-version: 8.0.x
 
     - name: Setup Python
       if: inputs.tools == 'all' || contains(inputs.tools, 'python')

--- a/provider-ci/test-providers/eks/devbox.json
+++ b/provider-ci/test-providers/eks/devbox.json
@@ -5,7 +5,7 @@
     "go@1.21.",
     "nodejs@20.",
     "python3@3.11.8",
-    "dotnet-sdk@6.0.",
+    "dotnet-sdk@8.0.",
     "gradle_7@7.6",
     "curl@8"
   ],

--- a/provider-ci/test-providers/terraform-module/.github/actions/setup-tools/action.yml
+++ b/provider-ci/test-providers/terraform-module/.github/actions/setup-tools/action.yml
@@ -68,7 +68,7 @@ runs:
       if: inputs.tools == 'all' || contains(inputs.tools, 'dotnet')
       uses: actions/setup-dotnet@3951f0dfe7a07e2313ec93c75700083e2005cbab # v4.3.0
       with:
-        dotnet-version: 6.0.x
+        dotnet-version: 8.0.x
 
     - name: Setup Python
       if: inputs.tools == 'all' || contains(inputs.tools, 'python')

--- a/provider-ci/test-providers/terraform-module/devbox.json
+++ b/provider-ci/test-providers/terraform-module/devbox.json
@@ -5,7 +5,7 @@
     "go@1.21.",
     "nodejs@20.",
     "python3@3.11.8",
-    "dotnet-sdk@6.0.",
+    "dotnet-sdk@8.0.",
     "gradle_7@7.6",
     "curl@8"
   ],


### PR DESCRIPTION
.NET 6 is now out of support and the Pulumi .NET SDK is needing to move to .NET 8. Therefore we should use version 8 when building too.